### PR TITLE
Auth: case-insensitive emails

### DIFF
--- a/prisma/migrations/20231021182825_user_emails_all_lowercase/migration.sql
+++ b/prisma/migrations/20231021182825_user_emails_all_lowercase/migration.sql
@@ -1,0 +1,5 @@
+-- Due to the unique constraint on the email column, we need to make sure that all emails are in lowercase.
+-- This migration will update all existing emails to be lowercase.
+-- This migration fails if there are duplicate emails in the database.
+
+UPDATE "users" SET "email" = LOWER("email");

--- a/src/__e2e__/auth.spec.ts
+++ b/src/__e2e__/auth.spec.ts
@@ -37,10 +37,23 @@ test("Successfully sign up & able to go to homepage", async ({ page }) => {
   await expect(page).toHaveURL("/?getStarted=1");
 });
 
-test("Signup validation", async ({ page }) => {
+test("Successfully sign up & able to go to homepage with uppercase email", async ({
+  page,
+}) => {
+  await page.goto("auth/sign-up");
+  await page.fill('input[name="name"]', "demo lang");
+  await page.fill('input[name="email"]', "A" + randomEmailAddress());
+  await page.fill('input[type="password"]', "password3");
+  await page.click('button[type="submit"]');
+  await page.waitForTimeout(2000);
+  // see get started page
+  await expect(page).toHaveURL("/?getStarted=1");
+});
+
+test("Signup input validation", async ({ page }) => {
   await page.goto("auth/sign-up");
   await page.fill('input[name="email"]', "notanemail");
-  await page.fill('input[type="password"]', "pass3");
+  await page.fill('input[type="password"]', "shortPw");
   await page.click('button[type="submit"]');
   await page.waitForTimeout(2000);
   await expect(page.getByText("Invalid email")).toBeVisible();

--- a/src/features/auth/lib/emailPassword.ts
+++ b/src/features/auth/lib/emailPassword.ts
@@ -23,7 +23,7 @@ export async function createUserEmailPassword(
   // check that no user exists with this email
   const user = await prisma.user.findUnique({
     where: {
-      email,
+      email: email.toLowerCase(),
     },
   });
   if (user !== null) {
@@ -43,7 +43,7 @@ export async function createUserEmailPassword(
 
   const newUser = await prisma.user.create({
     data: {
-      email,
+      email: email.toLowerCase(),
       password: hashedPassword,
       name,
       // if demo project id is set grant user access to it

--- a/src/features/auth/lib/signupSchema.ts
+++ b/src/features/auth/lib/signupSchema.ts
@@ -1,7 +1,9 @@
 import * as z from "zod";
 
 export const signupSchema = z.object({
-  name: z.string(),
+  name: z.string().min(1, {
+    message: "Name is required",
+  }),
   email: z.string().email(),
   password: z.string().min(8, {
     message: "Password must be at least 8 characters long",

--- a/src/features/rbac/server/projectMembersRouter.ts
+++ b/src/features/rbac/server/projectMembersRouter.ts
@@ -88,7 +88,7 @@ export const projectMembersRouter = createTRPCRouter({
 
       const user = await ctx.prisma.user.findUnique({
         where: {
-          email: input.email,
+          email: input.email.toLowerCase(),
         },
       });
       if (!user) throw new Error("User not found");

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -47,7 +47,7 @@ export const authOptions: NextAuthOptions = {
       const dbUser = await prisma.user.findUnique({
         where: {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          email: token.email!,
+          email: token.email!.toLowerCase(),
         },
         select: {
           id: true,


### PR DESCRIPTION
Users reported authentication issues when using non-all-lowercase emails.

- [x] Change auth to treat emails case-insensitively to resolve next-auth errors.
- [x] Add an E2E test to check for handling of uppercase emails.
- [x] Migrate emails of users who previously signed up using an uppercase email.