### PR TITLE
feat(api): upsert scores

### DIFF
--- a/fern/apis/client/definition/score.yml
+++ b/fern/apis/client/definition/score.yml
@@ -5,7 +5,7 @@ service:
   base-path: /api/public
   endpoints:
     create:
-      docs: Add a score to the database
+      docs: Add a score to the database, upserts on id
       method: POST
       path: /scores
       request: CreateScoreRequest

--- a/fern/apis/server/definition/score.yml
+++ b/fern/apis/server/definition/score.yml
@@ -7,7 +7,7 @@ service:
   base-path: /api/public
   endpoints:
     create:
-      docs: Add a score to the database
+      docs: Add a score to the database, upserts on id
       method: POST
       path: /scores
       request: CreateScoreRequest

--- a/generated/openapi-client/openapi.yml
+++ b/generated/openapi-client/openapi.yml
@@ -5,7 +5,7 @@ info:
 paths:
   /api/public/scores:
     post:
-      description: Add a score to the database
+      description: Add a score to the database, upserts on id
       operationId: score_create
       tags:
         - Score

--- a/generated/openapi-server/openapi.yml
+++ b/generated/openapi-server/openapi.yml
@@ -612,7 +612,7 @@ paths:
       security: *ref_0
   /api/public/scores:
     post:
-      description: Add a score to the database
+      description: Add a score to the database, upserts on id
       operationId: score_create
       tags:
         - Score

--- a/generated/postman/collection.json
+++ b/generated/postman/collection.json
@@ -490,7 +490,7 @@
           "_type": "endpoint",
           "name": "Create",
           "request": {
-            "description": "Add a score to the database",
+            "description": "Add a score to the database, upserts on id",
             "url": {
               "raw": "{{baseUrl}}/api/public/scores",
               "host": [

--- a/prisma/migrations/20231116005353_scores_unique_id_projectid/migration.sql
+++ b/prisma/migrations/20231116005353_scores_unique_id_projectid/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[id,trace_id]` on the table `scores` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "scores_id_trace_id_key" ON "scores"("id", "trace_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -217,6 +217,7 @@ model Score {
     observationId String?      @map("observation_id")
     observation   Observation? @relation(fields: [observationId], references: [id], onDelete: SetNull)
 
+    @@unique([id, traceId]) // used for upsert
     @@index([value])
     @@index([traceId], type: Hash)
     @@index([observationId], type: Hash)

--- a/src/__tests__/scores.servertest.ts
+++ b/src/__tests__/scores.servertest.ts
@@ -38,6 +38,7 @@ describe("/api/public/scores API Endpoint", () => {
       name: "score-name",
       value: 100.5,
       traceId: traceId,
+      comment: "comment",
     });
 
     expect(createScore.status).toBe(200);
@@ -52,6 +53,7 @@ describe("/api/public/scores API Endpoint", () => {
     expect(dbScore?.name).toBe("score-name");
     expect(dbScore?.value).toBe(100.5);
     expect(dbScore?.observationId).toBeNull();
+    expect(dbScore?.comment).toBe("comment");
   });
 
   it("should create score for a trace with int", async () => {
@@ -147,5 +149,86 @@ describe("/api/public/scores API Endpoint", () => {
     expect(dbScore?.observationId).toBe(dbGeneration[0]!.id);
     expect(dbScore?.name).toBe("score-name");
     expect(dbScore?.value).toBe(100);
+  });
+
+  it("should upsert a score", async () => {
+    await pruneDatabase();
+
+    const traceId = uuidv4();
+
+    await makeAPICall("POST", "/api/public/traces", {
+      id: traceId,
+      name: "trace-name",
+      userId: "user-1",
+      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      metadata: { key: "value" },
+      release: "1.0.0",
+      version: "2.0.0",
+    });
+
+    const dbTrace = await prisma.trace.findMany({
+      where: {
+        id: traceId,
+      },
+    });
+
+    expect(dbTrace.length).toBeGreaterThan(0);
+    expect(dbTrace[0]?.id).toBe(traceId);
+
+    const generationId = uuidv4();
+    await makeAPICall("POST", "/api/public/generations", {
+      id: generationId,
+      name: "generation-name",
+      traceId,
+      startTime: "2021-01-01T00:00:00.000Z",
+      endTime: "2021-01-01T00:00:00.000Z",
+      model: "model-name",
+      modelParameters: { key: "value" },
+      prompt: { key: "value" },
+      metadata: { key: "value" },
+      version: "2.0.0",
+    });
+
+    const dbGeneration = await prisma.observation.findMany({
+      where: {
+        id: generationId,
+      },
+    });
+
+    expect(dbGeneration.length).toBeGreaterThan(0);
+    expect(dbGeneration[0]?.id).toBe(generationId);
+
+    const scoreId = uuidv4();
+    const createScore = await makeAPICall("POST", "/api/public/scores", {
+      id: scoreId,
+      name: "score-name",
+      value: 100,
+      traceId: traceId,
+      comment: "comment",
+    });
+    expect(createScore.status).toBe(200);
+
+    const upsertScore = await makeAPICall("POST", "/api/public/scores", {
+      id: scoreId,
+      traceId: traceId,
+      name: "score-name-updated",
+      value: 200,
+      comment: "comment-updated",
+      observationId: dbGeneration[0]!.id,
+    });
+    expect(upsertScore.status).toBe(200);
+
+    const dbScore = await prisma.score.findUnique({
+      where: {
+        id: scoreId,
+      },
+    });
+
+    expect(dbScore?.id).toBe(scoreId);
+    expect(dbScore?.traceId).toBe(traceId);
+    expect(dbScore?.name).toBe("score-name-updated");
+    expect(dbScore?.value).toBe(200);
+    expect(dbScore?.comment).toBe("comment-updated");
+    expect(dbScore?.observationId).toBe(dbGeneration[0]!.id);
   });
 });

--- a/src/server/api/services/EventProcessor.ts
+++ b/src/server/api/services/EventProcessor.ts
@@ -292,14 +292,32 @@ export class ScoreProcessor implements EventProcessor {
     if (!accessCheck)
       throw new AuthenticationError("Access denied for score creation");
 
-    return await prisma.score.create({
-      data: {
-        id: body.id ?? v4(),
+    const id = body.id ?? v4();
+
+    // access control via traceId
+    return await prisma.score.upsert({
+      where: {
+        id_traceId: {
+          id,
+          traceId: body.traceId,
+        },
+      },
+      create: {
+        id,
+        trace: { connect: { id: body.traceId } },
         timestamp: new Date(),
         value: body.value,
         name: body.name,
         comment: body.comment,
-        trace: { connect: { id: body.traceId } },
+        ...(body.observationId && {
+          observation: { connect: { id: body.observationId } },
+        }),
+      },
+      update: {
+        timestamp: new Date(),
+        value: body.value,
+        name: body.name,
+        comment: body.comment,
         ...(body.observationId && {
           observation: { connect: { id: body.observationId } },
         }),


### PR DESCRIPTION
Closes #483.
-  Update scores based on id and traceId.
-  Include tests.