### PR TITLE
chore: trpc useUtils instead of useContext (deprecated)

### DIFF
--- a/src/components/delete-trace.tsx
+++ b/src/components/delete-trace.tsx
@@ -20,7 +20,7 @@ export function DeleteTrace({
   isTableAction?: boolean;
 }) {
   const router = useRouter();
-  const utils = api.useContext();
+  const utils = api.useUtils();
 
   const hasAccess = useHasAccess({ projectId, scope: "traces:delete" });
 

--- a/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/src/features/datasets/components/DatasetItemsTable.tsx
@@ -31,7 +31,7 @@ export function DatasetItemsTable({
   projectId: string;
   datasetId: string;
 }) {
-  const utils = api.useContext();
+  const utils = api.useUtils();
   const items = api.datasets.itemsByDatasetId.useQuery({
     projectId,
     datasetId,
@@ -156,16 +156,16 @@ export function DatasetItemsTable({
           items.isLoading
             ? { isLoading: true, isError: false }
             : items.isError
-            ? {
-                isLoading: false,
-                isError: true,
-                error: items.error.message,
-              }
-            : {
-                isLoading: false,
-                isError: false,
-                data: items.data?.map((t) => convertToTableRow(t)),
-              }
+              ? {
+                  isLoading: false,
+                  isError: true,
+                  error: items.error.message,
+                }
+              : {
+                  isLoading: false,
+                  isError: false,
+                  data: items.data?.map((t) => convertToTableRow(t)),
+                }
         }
       />
       <NewDatasetItemButton

--- a/src/features/datasets/components/DatasetsTable.tsx
+++ b/src/features/datasets/components/DatasetsTable.tsx
@@ -29,7 +29,7 @@ type RowData = {
 };
 
 export function DatasetsTable(props: { projectId: string }) {
-  const utils = api.useContext();
+  const utils = api.useUtils();
   const datasets = api.datasets.allDatasets.useQuery({
     projectId: props.projectId,
   });
@@ -146,16 +146,16 @@ export function DatasetsTable(props: { projectId: string }) {
           datasets.isLoading
             ? { isLoading: true, isError: false }
             : datasets.isError
-            ? {
-                isLoading: false,
-                isError: true,
-                error: datasets.error.message,
-              }
-            : {
-                isLoading: false,
-                isError: false,
-                data: datasets.data?.map((t) => convertToTableRow(t)),
-              }
+              ? {
+                  isLoading: false,
+                  isError: true,
+                  error: datasets.error.message,
+                }
+              : {
+                  isLoading: false,
+                  isError: false,
+                  data: datasets.data?.map((t) => convertToTableRow(t)),
+                }
         }
       />
       <NewDatasetButton projectId={props.projectId} className="mt-4" />

--- a/src/features/datasets/components/EditDatasetItem.tsx
+++ b/src/features/datasets/components/EditDatasetItem.tsx
@@ -56,7 +56,7 @@ export const EditDatasetItem = ({
     projectId: projectId,
     scope: "datasets:CUD",
   });
-  const utils = api.useContext();
+  const utils = api.useUtils();
   const item = api.datasets.itemById.useQuery({
     datasetId,
     projectId,

--- a/src/features/datasets/components/NewDatasetForm.tsx
+++ b/src/features/datasets/components/NewDatasetForm.tsx
@@ -32,7 +32,7 @@ export const NewDatasetForm = (props: {
     },
   });
 
-  const utils = api.useContext();
+  const utils = api.useUtils();
   const createDatasetMutation = api.datasets.createDataset.useMutation({
     onSuccess: () => utils.datasets.invalidate(),
     onError: (error) => setFormError(error.message),

--- a/src/features/datasets/components/NewDatasetItemForm.tsx
+++ b/src/features/datasets/components/NewDatasetItemForm.tsx
@@ -83,7 +83,7 @@ export const NewDatasetItemForm = (props: {
     projectId: props.projectId,
   });
 
-  const utils = api.useContext();
+  const utils = api.useUtils();
   const createDatasetItemMutation = api.datasets.createDatasetItem.useMutation({
     onSuccess: () => utils.datasets.invalidate(),
     onError: (error) => setFormError(error.message),

--- a/src/features/manual-scoring/components/index.tsx
+++ b/src/features/manual-scoring/components/index.tsx
@@ -58,7 +58,7 @@ export function ManualScoreButton({
         : s.observationId === null),
   );
 
-  const utils = api.useContext();
+  const utils = api.useUtils();
   const onSuccess = async () => {
     await Promise.all([utils.scores.invalidate(), utils.traces.invalidate()]);
   };
@@ -179,8 +179,8 @@ export function ManualScoreButton({
                 {form.formState.isSubmitting
                   ? "Loading ..."
                   : score
-                  ? "Update"
-                  : "Create"}
+                    ? "Update"
+                    : "Create"}
               </Button>
               {score && (
                 <Button

--- a/src/features/projects/components/DeleteProjectButton.tsx
+++ b/src/features/projects/components/DeleteProjectButton.tsx
@@ -25,7 +25,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 export function DeleteProjectButton(props: { projectId: string }) {
-  const utils = api.useContext();
+  const utils = api.useUtils();
   const router = useRouter();
   const session = useSession();
   const posthog = usePostHog();

--- a/src/features/projects/components/NewProjectButton.tsx
+++ b/src/features/projects/components/NewProjectButton.tsx
@@ -44,7 +44,7 @@ export function NewProjectButton({ size = "default" }: NewProjectButtonProps) {
       name: "",
     },
   });
-  const utils = api.useContext();
+  const utils = api.useUtils();
   const router = useRouter();
   const posthog = usePostHog();
   const createProjectMutation = api.projects.create.useMutation({

--- a/src/features/projects/components/TransferOwnershipButton.tsx
+++ b/src/features/projects/components/TransferOwnershipButton.tsx
@@ -29,7 +29,7 @@ const formSchema = z.object({
   newOwnerEmail: z.string().email(),
 });
 export function TransferOwnershipButton(props: { projectId: string }) {
-  const utils = api.useContext();
+  const utils = api.useUtils();
   const router = useRouter();
   const posthog = usePostHog();
 

--- a/src/features/public-api/components/ApiKeyList.tsx
+++ b/src/features/public-api/components/ApiKeyList.tsx
@@ -104,7 +104,7 @@ function DeleteApiKeyButton(props: { projectId: string; apiKeyId: string }) {
     scope: "apiKeys:delete",
   });
 
-  const utils = api.useContext();
+  const utils = api.useUtils();
   const mutDeleteApiKey = api.apiKeys.delete.useMutation({
     onSuccess: () => utils.apiKeys.invalidate(),
   });

--- a/src/features/public-api/components/CreateApiKeyButton.tsx
+++ b/src/features/public-api/components/CreateApiKeyButton.tsx
@@ -14,7 +14,7 @@ import { useHasAccess } from "@/src/features/rbac/utils/checkAccess";
 import { usePostHog } from "posthog-js/react";
 
 export function CreateApiKeyButton(props: { projectId: string }) {
-  const utils = api.useContext();
+  const utils = api.useUtils();
   const posthog = usePostHog();
   const hasAccess = useHasAccess({
     projectId: props.projectId,

--- a/src/features/public-traces/components/PublishTraceSwitch.tsx
+++ b/src/features/public-traces/components/PublishTraceSwitch.tsx
@@ -15,7 +15,7 @@ export const PublishTraceSwitch = (props: {
     projectId: props.projectId,
     scope: "traces:publish",
   });
-  const utils = api.useContext();
+  const utils = api.useUtils();
   const mut = api.publishTraces.update.useMutation({
     onSuccess: () => utils.traces.invalidate(),
   });

--- a/src/features/rbac/components/CreateProjectMemberButton.tsx
+++ b/src/features/rbac/components/CreateProjectMemberButton.tsx
@@ -51,7 +51,7 @@ export function CreateProjectMemberButton(props: { projectId: string }) {
     scope: "members:create",
   });
 
-  const utils = api.useContext();
+  const utils = api.useUtils();
   const mutCreateProjectMember = api.projectMembers.create.useMutation({
     onSuccess: () => utils.projectMembers.invalidate(),
   });

--- a/src/features/rbac/components/ProjectMembersTable.tsx
+++ b/src/features/rbac/components/ProjectMembersTable.tsx
@@ -26,7 +26,7 @@ export function ProjectMembersTable({ projectId }: { projectId: string }) {
 
   const session = useSession();
 
-  const utils = api.useContext();
+  const utils = api.useUtils();
   const memberships = api.projectMembers.get.useQuery(
     {
       projectId: projectId,


### PR DESCRIPTION
## What does this PR do?

Replace trpc useContext with useUtils.

useContext will be deprecated.

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)