### PR TITLE
feat: cache bookmark state in component

### DIFF
--- a/src/components/bookmark-trace.tsx
+++ b/src/components/bookmark-trace.tsx
@@ -3,6 +3,7 @@ import { StarIcon } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import { api } from "@/src/utils/api";
 import { useHasAccess } from "@/src/features/rbac/utils/checkAccess";
+import { useEffect, useState } from "react";
 
 export function BookmarkTrace({
   traceId,
@@ -16,19 +17,28 @@ export function BookmarkTrace({
   size?: "sm" | "xs";
 }) {
   const utils = api.useUtils();
+  const [cacheIsBookmarked, setCacheIsBookmarked] = useState<boolean | null>(
+    null,
+  );
+  const localIsBookmarked = cacheIsBookmarked ?? isBookmarked;
   const hasAccess = useHasAccess({ projectId, scope: "traces:bookmark" });
   const mutBookmarkTrace = api.traces.bookmark.useMutation({
     onSuccess: () => {
+      setCacheIsBookmarked(!localIsBookmarked);
       void utils.traces.invalidate();
     },
   });
+
+  useEffect(() => {
+    setCacheIsBookmarked(null);
+  }, [isBookmarked]);
 
   const handleBookmarkClick = () => {
     if (!hasAccess) return;
     void mutBookmarkTrace.mutateAsync({
       traceId,
       projectId,
-      bookmarked: !isBookmarked,
+      bookmarked: !localIsBookmarked,
     });
   };
 
@@ -42,7 +52,7 @@ export function BookmarkTrace({
     >
       <StarIcon
         className={`h-4 w-4 ${
-          isBookmarked ? "fill-current text-yellow-500" : "text-gray-500"
+          localIsBookmarked ? "fill-current text-yellow-500" : "text-gray-500"
         }`}
       />
     </Button>


### PR DESCRIPTION
## What does this PR do?

With large tables, refreshing the whole table is expensive. With this change, the bookmark state in the UI changes once the mutation is completed and does not wait for the refresh of the whole table.