### PR TITLE
feat: add separate db variables as alternative to connection string

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,18 @@
 #!/bin/sh
 
+# Check if DATABASE_URL is not set
+if [ -z "$DATABASE_URL" ]; then
+    # Check if all required variables are provided
+    if [ -n "$DATABASE_HOST" ] && [ -n "$DATABASE_USERNAME" ] && [ -n "$DATABASE_PASSWORD" ]  && [ -n "$DATABASE_NAME" ]; then
+        # Construct DATABASE_URL from the provided variables
+        DATABASE_URL="postgresql://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}"
+        export DATABASE_URL
+    else
+        echo "Error: Required DATABASE_* variables are not set."
+        exit 1
+    fi
+fi
+
 # Set DIRECT_URL to the value of DATABASE_URL, required for migrations
 export DIRECT_URL=$DATABASE_URL
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ if [ -z "$DATABASE_URL" ]; then
         DATABASE_URL="postgresql://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}"
         export DATABASE_URL
     else
-        echo "Error: Required DATABASE_* variables are not set."
+        echo "Error: Required database environment variables are not set. Provide a postgres url for DATABASE_URL."
         exit 1
     fi
 fi


### PR DESCRIPTION
## What does this PR do?

This PR enables to provide the database connection to the docker container in four separate variables:
- `DATABASE_HOST`
- `DATABASE_NAME`
- `DATABASE_USERNAME`
- `DATABASE_PASSWORD`

which are used if present and `DATABASE_URL` **not being present**. 

> Warning: This creates a new dependency that future users could depend on.


<img width="607" alt="image" src="https://github.com/langfuse/langfuse/assets/2428581/c1c64351-4224-41de-907e-623cc73bf49a">

Working as expected

<img width="486" alt="image" src="https://github.com/langfuse/langfuse/assets/2428581/ea595c68-489c-435f-a812-02217f650910">

if no `DATABASE_` env var present

<img width="608" alt="image" src="https://github.com/langfuse/langfuse/assets/2428581/39a34413-ee3c-4712-91ba-2ef0c3a8d7e1">

`DATABASE_URL` takes precedence over the other `DATABASE` vars.

Fixes #492 

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist



- I haven't added tests that prove my fix is effective or that my feature works 
- I haven't checked if new and existing unit tests pass locally with my changes
