### PR TITLE
fix(ui): add missing array polyfills for better browser compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "cmdk": "^0.2.0",
+        "core-js": "^3.34.0",
         "cors": "^2.8.5",
         "date-fns": "^2.30.0",
         "decimal.js": "^10.4.3",
@@ -7863,6 +7864,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.34.0.tgz",
+      "integrity": "sha512-aDdvlDder8QmY91H88GzNi9EtQi2TjvQhpCX6B1v/dAZHU1AuLgHvRh54RiOerpEhEW46Tkf+vgAViB/CWC0ag==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/cors": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "cmdk": "^0.2.0",
+    "core-js": "^3.34.0",
     "cors": "^2.8.5",
     "date-fns": "^2.30.0",
     "decimal.js": "^10.4.3",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -19,6 +19,13 @@ import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
 import { CrispWidget, chatSetUser } from "@/src/features/support-chat";
 
+// Custom polyfills not yet available in `next-core`:
+// https://github.com/vercel/next.js/issues/58242
+// https://nextjs.org/docs/architecture/supported-browsers#custom-polyfills
+import "core-js/features/array/to-reversed";
+import "core-js/features/array/to-spliced";
+import "core-js/features/array/to-sorted";
+
 // Other CSS
 import "react18-json-view/src/style.css";
 import { DetailPageListsProvider } from "@/src/features/navigate-detail-pages/context";


### PR DESCRIPTION
- Fixes #653
- methods: .toReversed, .toSorted, .toSpliced
- Fix until they are included in next-core: https://github.com/vercel/next.js/issues/58242