### PR TITLE
feat(ui): add navigation to datasets and dataset items

### DIFF
--- a/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/src/features/datasets/components/DatasetItemsTable.tsx
@@ -15,6 +15,8 @@ import { Button } from "@/src/components/ui/button";
 import { DatasetStatus, type DatasetItem } from "@prisma/client";
 import { cn } from "@/src/utils/tailwind";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
+import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
+import { useEffect } from "react";
 
 type RowData = {
   id: string;
@@ -31,11 +33,22 @@ export function DatasetItemsTable({
   projectId: string;
   datasetId: string;
 }) {
+  const { setDetailPageList } = useDetailPageLists();
   const utils = api.useUtils();
   const items = api.datasets.itemsByDatasetId.useQuery({
     projectId,
     datasetId,
   });
+
+  useEffect(() => {
+    if (items.isSuccess) {
+      setDetailPageList(
+        "datasetItems",
+        items.data.map((t) => t.id),
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [items.isSuccess, items.data]);
 
   const mutUpdate = api.datasets.updateDatasetItem.useMutation({
     onSuccess: () => utils.datasets.invalidate(),

--- a/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/src/features/datasets/components/DatasetRunsTable.tsx
@@ -2,9 +2,11 @@ import { GroupedScoreBadges } from "@/src/components/grouped-score-badge";
 import { DataTable } from "@/src/components/table/data-table";
 import TableLink from "@/src/components/table/table-link";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
+import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
 import { api } from "@/src/utils/api";
 import { formatInterval } from "@/src/utils/dates";
 import { type RouterOutput } from "@/src/utils/types";
+import { useEffect } from "react";
 
 type RowData = {
   key: {
@@ -25,7 +27,16 @@ export function DatasetRunsTable(props: {
     projectId: props.projectId,
     datasetId: props.datasetId,
   });
-
+  const { setDetailPageList } = useDetailPageLists();
+  useEffect(() => {
+    if (runs.isSuccess) {
+      setDetailPageList(
+        "datasetRuns",
+        runs.data.map((t) => t.id),
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runs.isSuccess, runs.data]);
   const columns: LangfuseColumnDef<RowData>[] = [
     {
       accessorKey: "key",

--- a/src/features/datasets/components/DatasetsTable.tsx
+++ b/src/features/datasets/components/DatasetsTable.tsx
@@ -10,9 +10,11 @@ import {
   DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
 import { NewDatasetButton } from "@/src/features/datasets/components/NewDatasetButton";
+import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
 import { api } from "@/src/utils/api";
 import { type RouterOutput } from "@/src/utils/types";
 import { MoreVertical, Trash } from "lucide-react";
+import { useEffect } from "react";
 
 type RowData = {
   key: {
@@ -26,6 +28,7 @@ type RowData = {
 };
 
 export function DatasetsTable(props: { projectId: string }) {
+  const { setDetailPageList } = useDetailPageLists();
   const utils = api.useUtils();
   const datasets = api.datasets.allDatasets.useQuery({
     projectId: props.projectId,
@@ -33,6 +36,15 @@ export function DatasetsTable(props: { projectId: string }) {
   const mutDelete = api.datasets.deleteDataset.useMutation({
     onSuccess: () => utils.datasets.invalidate(),
   });
+    useEffect(() => {
+    if (datasets.isSuccess) {
+      setDetailPageList(
+        "datasets",
+        datasets.data.map((t) => t.id),
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [datasets.isSuccess, datasets.data]);
 
   const columns: LangfuseColumnDef<RowData>[] = [
     {

--- a/src/features/navigate-detail-pages/DetailPageNav.tsx
+++ b/src/features/navigate-detail-pages/DetailPageNav.tsx
@@ -50,7 +50,7 @@ export const DetailPageNav = (props: {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [previousPageId, nextPageId, router, props]);
 
-  if (ids.length > 0)
+  if (ids.length > 1)
     return (
       <div>
         <Tooltip>

--- a/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
+++ b/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
@@ -4,6 +4,7 @@ import { api } from "@/src/utils/api";
 import { useRouter } from "next/router";
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
 import Link from "next/link";
+import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 
 export default function Dataset() {
   const router = useRouter();
@@ -23,6 +24,13 @@ export default function Dataset() {
           { name: "Datasets", href: `/project/${projectId}/datasets` },
           { name: dataset.data?.name ?? datasetId },
         ]}
+        actionButtons={
+          <DetailPageNav
+            currentId={datasetId}
+            path={(id) => `/project/${projectId}/datasets/${id}`}
+            listKey="datasets"
+          />
+        }
       />
       <Tabs value="runs" className="mb-3">
         <TabsList>

--- a/src/pages/project/[projectId]/datasets/[datasetId]/items.tsx
+++ b/src/pages/project/[projectId]/datasets/[datasetId]/items.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
 import Link from "next/link";
 import { DatasetItemsTable } from "@/src/features/datasets/components/DatasetItemsTable";
+import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 
 export default function DatasetItems() {
   const router = useRouter();
@@ -23,6 +24,13 @@ export default function DatasetItems() {
           { name: "Datasets", href: `/project/${projectId}/datasets` },
           { name: dataset.data?.name ?? datasetId },
         ]}
+        actionButtons={
+          <DetailPageNav
+            currentId={datasetId}
+            path={(id) => `/project/${projectId}/datasets/${id}/items/`}
+            listKey="datasets"
+          />
+        }
       />
       <Tabs value="items" className="mb-3">
         <TabsList>

--- a/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId].tsx
+++ b/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId].tsx
@@ -1,6 +1,7 @@
 import Header from "@/src/components/layouts/header";
 import { DatasetRunItemsTable } from "@/src/features/datasets/components/DatasetRunItemsTable";
 import { EditDatasetItem } from "@/src/features/datasets/components/EditDatasetItem";
+import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 import { api } from "@/src/utils/api";
 import { useRouter } from "next/router";
 
@@ -27,6 +28,15 @@ export default function Dataset() {
           },
           { name: "Item: " + itemId },
         ]}
+        actionButtons={
+          <DetailPageNav
+            currentId={itemId}
+            path={(id) =>
+              `/project/${projectId}/datasets/${datasetId}/items/${id}`
+            }
+            listKey="datasetItems"
+          />
+        }
       />
       <EditDatasetItem
         projectId={projectId}

--- a/src/pages/project/[projectId]/datasets/[datasetId]/runs/[runId].tsx
+++ b/src/pages/project/[projectId]/datasets/[datasetId]/runs/[runId].tsx
@@ -1,5 +1,6 @@
 import Header from "@/src/components/layouts/header";
 import { DatasetRunItemsTable } from "@/src/features/datasets/components/DatasetRunItemsTable";
+import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 import { api } from "@/src/utils/api";
 import { useRouter } from "next/router";
 
@@ -26,6 +27,15 @@ export default function Dataset() {
           },
           { name: "Run: " + runId },
         ]}
+        actionButtons={
+          <DetailPageNav
+            currentId={runId}
+            path={(id) =>
+              `/project/${projectId}/datasets/${datasetId}/runs/${id}`
+            }
+            listKey="datasetRuns"
+          />
+        }
       />
       <DatasetRunItemsTable
         projectId={projectId}


### PR DESCRIPTION
- Add navigation for datasets
- Add navigation for dataset items
- Add navigation for dataset runs
- Seed db with two datasets each with two runs
- Log completed seeding (e.g. Seeding 100 of 100) in CL