### PR TITLE
feat(ui): improve trace view: collapse/expand observation tree + color coding of observation types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ yarn-error.log*
 
 # openapi spec that is copied during build
 /public/openapi*.yml
+
+
+# vscode
+.devcontainer

--- a/src/components/trace/ObservationTree.tsx
+++ b/src/components/trace/ObservationTree.tsx
@@ -155,9 +155,13 @@ const ObservationTreeNode = (props: {
                         ev.stopPropagation(),
                         props.toggleCollapsedObservation(observation.id)
                       )}
-                      variant={collapsed ? "default" : "outline"}
+                      variant="default"
+                      pressed={collapsed}
                       size="xs"
-                      title="Toggle children"
+                      className="w-7"
+                      title={
+                        collapsed ? "Expand children" : "Collapse children"
+                      }
                     >
                       {collapsed ? (
                         <PlusIcon className="h-4 w-4" />
@@ -248,9 +252,10 @@ const ColorCodedObservationType = (props: {
 
   return (
     <span
-      className={`${
-        colors[props.observationType]
-      } self-start rounded-sm p-1 text-xs`}
+      className={cn(
+        "self-start rounded-sm p-1 text-xs",
+        colors[props.observationType],
+      )}
     >
       {props.observationType}
     </span>

--- a/src/components/trace/ObservationTree.tsx
+++ b/src/components/trace/ObservationTree.tsx
@@ -6,8 +6,9 @@ import { Fragment } from "react";
 import { type ObservationReturnType } from "@/src/server/api/routers/traces";
 import { LevelColors } from "@/src/components/level-colors";
 import { formatInterval } from "@/src/utils/dates";
-import { ChevronsDownUp, ChevronsUpDown } from "lucide-react";
+import { MinusCircle, MinusIcon, PlusCircleIcon, PlusIcon } from "lucide-react";
 import { Toggle } from "@/src/components/ui/toggle";
+import { Button } from "@/src/components/ui/button";
 
 export const ObservationTree = (props: {
   observations: ObservationReturnType[];
@@ -74,16 +75,22 @@ const ObservationTreeTraceNode = (props: {
     <div className="flex gap-2">
       <span className={cn("rounded-sm bg-gray-200 p-1 text-xs")}>TRACE</span>
       <span className="flex-1 text-sm">{props.trace.name}</span>
-      <Toggle onPressedChange={props.expandAll} size="xs" title="Expand all">
-        <ChevronsUpDown className="h-4 w-4" />
-      </Toggle>
-      <Toggle
-        onPressedChange={props.collapseAll}
+      <Button
+        onClick={(ev) => (ev.stopPropagation(), props.expandAll())}
         size="xs"
+        variant="ghost"
+        title="Expand all"
+      >
+        <PlusCircleIcon className="h-4 w-4" />
+      </Button>
+      <Button
+        onClick={(ev) => (ev.stopPropagation(), props.collapseAll())}
+        size="xs"
+        variant="ghost"
         title="Collapse all"
       >
-        <ChevronsDownUp className="h-4 w-4" />
-      </Toggle>
+        <MinusCircle className="h-4 w-4" />
+      </Button>
     </div>
 
     {props.showMetrics && props.trace.latency ? (
@@ -144,16 +151,18 @@ const ObservationTreeNode = (props: {
                   </span>
                   {observation.children.length === 0 ? null : (
                     <Toggle
-                      onPressedChange={() =>
+                      onClick={(ev) => (
+                        ev.stopPropagation(),
                         props.toggleCollapsedObservation(observation.id)
-                      }
+                      )}
+                      variant={collapsed ? "default" : "outline"}
                       size="xs"
-                      title="Toggle collapsed"
+                      title="Toggle children"
                     >
                       {collapsed ? (
-                        <ChevronsUpDown className="h-4 w-4" />
+                        <PlusIcon className="h-4 w-4" />
                       ) : (
-                        <ChevronsDownUp className="h-4 w-4" />
+                        <MinusIcon className="h-4 w-4" />
                       )}
                     </Toggle>
                   )}

--- a/src/components/trace/ObservationTree.tsx
+++ b/src/components/trace/ObservationTree.tsx
@@ -1,14 +1,20 @@
 import { type NestedObservation } from "@/src/utils/types";
 import { cn } from "@/src/utils/tailwind";
-import { type Trace, type Score } from "@prisma/client";
+import { type Trace, type Score, $Enums } from "@prisma/client";
 import { GroupedScoreBadges } from "@/src/components/grouped-score-badge";
 import { Fragment } from "react";
 import { type ObservationReturnType } from "@/src/server/api/routers/traces";
 import { LevelColors } from "@/src/components/level-colors";
 import { formatInterval } from "@/src/utils/dates";
+import { ChevronsDownUp, ChevronsUpDown } from "lucide-react";
+import { Toggle } from "@/src/components/ui/toggle";
 
 export const ObservationTree = (props: {
   observations: ObservationReturnType[];
+  collapsedObservations: string[];
+  toggleCollapsedObservation: (id: string) => void;
+  collapseAll: () => void;
+  expandAll: () => void;
   trace: Trace;
   scores: Score[];
   currentObservationId: string | undefined;
@@ -21,6 +27,8 @@ export const ObservationTree = (props: {
   return (
     <div className={props.className}>
       <ObservationTreeTraceNode
+        expandAll={props.expandAll}
+        collapseAll={props.collapseAll}
         trace={props.trace}
         scores={props.scores}
         currentObservationId={props.currentObservationId}
@@ -30,6 +38,8 @@ export const ObservationTree = (props: {
       />
       <ObservationTreeNode
         observations={nestedObservations}
+        collapsedObservations={props.collapsedObservations}
+        toggleCollapsedObservation={props.toggleCollapsedObservation}
         scores={props.scores}
         indentationLevel={1}
         currentObservationId={props.currentObservationId}
@@ -40,8 +50,11 @@ export const ObservationTree = (props: {
     </div>
   );
 };
+
 const ObservationTreeTraceNode = (props: {
   trace: Trace & { latency?: number };
+  expandAll: () => void;
+  collapseAll: () => void;
   scores: Score[];
   currentObservationId: string | undefined;
   setCurrentObservationId: (id: string | undefined) => void;
@@ -50,7 +63,7 @@ const ObservationTreeTraceNode = (props: {
 }) => (
   <div
     className={cn(
-      "group mb-0.5 flex cursor-pointer flex-col gap-1 rounded-sm p-1.5",
+      "group mb-0.5 flex cursor-pointer flex-col gap-1 rounded-sm p-1",
       props.currentObservationId === undefined ||
         props.currentObservationId === ""
         ? "bg-gray-100"
@@ -60,7 +73,17 @@ const ObservationTreeTraceNode = (props: {
   >
     <div className="flex gap-2">
       <span className={cn("rounded-sm bg-gray-200 p-1 text-xs")}>TRACE</span>
-      <span className="text-sm">{props.trace.name}</span>
+      <span className="flex-1 text-sm">{props.trace.name}</span>
+      <Toggle onPressedChange={props.expandAll} size="xs" title="Expand all">
+        <ChevronsUpDown className="h-4 w-4" />
+      </Toggle>
+      <Toggle
+        onPressedChange={props.collapseAll}
+        size="xs"
+        title="Collapse all"
+      >
+        <ChevronsDownUp className="h-4 w-4" />
+      </Toggle>
     </div>
 
     {props.showMetrics && props.trace.latency ? (
@@ -79,8 +102,11 @@ const ObservationTreeTraceNode = (props: {
     ) : null}
   </div>
 );
+
 const ObservationTreeNode = (props: {
   observations: NestedObservation[];
+  collapsedObservations: string[];
+  toggleCollapsedObservation: (id: string) => void;
   scores: Score[];
   indentationLevel: number;
   currentObservationId: string | undefined;
@@ -91,95 +117,136 @@ const ObservationTreeNode = (props: {
   <>
     {props.observations
       .sort((a, b) => a.startTime.getTime() - b.startTime.getTime())
-      .map((observation) => (
-        <Fragment key={observation.id}>
-          <div className="flex">
-            {Array.from({ length: props.indentationLevel }, (_, i) => (
-              <div className="mx-2 border-r" key={i} />
-            ))}
-            <div
-              className={cn(
-                "group my-0.5 flex flex-1 cursor-pointer flex-col gap-1 rounded-sm p-1.5",
-                props.currentObservationId === observation.id
-                  ? "bg-gray-100"
-                  : "hover:bg-gray-50",
-              )}
-              onClick={() => props.setCurrentObservationId(observation.id)}
-            >
-              <div className="flex gap-2">
-                <span
-                  className={cn(
-                    "self-start rounded-sm bg-gray-200 p-1 text-xs",
-                  )}
-                >
-                  {observation.type}
-                </span>
-                <span className="line-clamp-1 text-sm">{observation.name}</span>
-              </div>
-              {props.showMetrics &&
-                (observation.promptTokens ||
-                  observation.completionTokens ||
-                  observation.totalTokens ||
-                  observation.endTime) && (
-                  <div className="flex gap-2">
-                    {observation.endTime ? (
-                      <span className="text-xs text-gray-500">
-                        {formatInterval(
-                          (observation.endTime.getTime() -
-                            observation.startTime.getTime()) /
-                            1000,
-                        )}
-                      </span>
-                    ) : null}
-                    {observation.promptTokens ||
-                    observation.completionTokens ||
-                    observation.totalTokens ? (
-                      <span className="text-xs text-gray-500">
-                        {observation.promptTokens} →{" "}
-                        {observation.completionTokens} (∑{" "}
-                        {observation.totalTokens})
-                      </span>
-                    ) : null}
-                  </div>
+      .map((observation) => {
+        const collapsed = props.collapsedObservations.includes(observation.id);
+
+        return (
+          <Fragment key={observation.id}>
+            <div className="flex">
+              {Array.from({ length: props.indentationLevel }, (_, i) => (
+                <div className="mx-2 border-r" key={i} />
+              ))}
+              <div
+                className={cn(
+                  "group my-0.5 flex flex-1 cursor-pointer flex-col gap-1 rounded-sm p-1",
+                  props.currentObservationId === observation.id
+                    ? "bg-gray-100"
+                    : "hover:bg-gray-50",
                 )}
-              {observation.level !== "DEFAULT" ? (
-                <div className="flex">
-                  <span
-                    className={cn(
-                      "rounded-sm p-0.5 text-xs",
-                      LevelColors[observation.level].bg,
-                      LevelColors[observation.level].text,
-                    )}
-                  >
-                    {observation.level}
-                  </span>
-                </div>
-              ) : null}
-              {props.showScores &&
-              props.scores.find((s) => s.observationId === observation.id) ? (
-                <div className="flex flex-wrap gap-1">
-                  <GroupedScoreBadges
-                    scores={props.scores.filter(
-                      (s) => s.observationId === observation.id,
-                    )}
+                onClick={() => props.setCurrentObservationId(observation.id)}
+              >
+                <div className="flex gap-2">
+                  <ColorCodedObservationType
+                    observationType={observation.type}
                   />
+                  <span className="line-clamp-1 flex-1 text-sm">
+                    {observation.name}
+                  </span>
+                  {observation.children.length === 0 ? null : (
+                    <Toggle
+                      onPressedChange={() =>
+                        props.toggleCollapsedObservation(observation.id)
+                      }
+                      size="xs"
+                      title="Toggle collapsed"
+                    >
+                      {collapsed ? (
+                        <ChevronsUpDown className="h-4 w-4" />
+                      ) : (
+                        <ChevronsDownUp className="h-4 w-4" />
+                      )}
+                    </Toggle>
+                  )}
                 </div>
-              ) : null}
+                {props.showMetrics &&
+                  (observation.promptTokens ||
+                    observation.completionTokens ||
+                    observation.totalTokens ||
+                    observation.endTime) && (
+                    <div className="flex gap-2">
+                      {observation.endTime ? (
+                        <span className="text-xs text-gray-500">
+                          {formatInterval(
+                            (observation.endTime.getTime() -
+                              observation.startTime.getTime()) /
+                              1000,
+                          )}
+                        </span>
+                      ) : null}
+                      {observation.promptTokens ||
+                      observation.completionTokens ||
+                      observation.totalTokens ? (
+                        <span className="text-xs text-gray-500">
+                          {observation.promptTokens} →{" "}
+                          {observation.completionTokens} (∑{" "}
+                          {observation.totalTokens})
+                        </span>
+                      ) : null}
+                    </div>
+                  )}
+                {observation.level !== "DEFAULT" ? (
+                  <div className="flex">
+                    <span
+                      className={cn(
+                        "rounded-sm p-0.5 text-xs",
+                        LevelColors[observation.level].bg,
+                        LevelColors[observation.level].text,
+                      )}
+                    >
+                      {observation.level}
+                    </span>
+                  </div>
+                ) : null}
+                {props.showScores &&
+                props.scores.find((s) => s.observationId === observation.id) ? (
+                  <div className="flex flex-wrap gap-1">
+                    <GroupedScoreBadges
+                      scores={props.scores.filter(
+                        (s) => s.observationId === observation.id,
+                      )}
+                    />
+                  </div>
+                ) : null}
+              </div>
             </div>
-          </div>
-          <ObservationTreeNode
-            observations={observation.children}
-            scores={props.scores}
-            indentationLevel={props.indentationLevel + 1}
-            currentObservationId={props.currentObservationId}
-            setCurrentObservationId={props.setCurrentObservationId}
-            showMetrics={props.showMetrics}
-            showScores={props.showScores}
-          />
-        </Fragment>
-      ))}
+            {!collapsed && (
+              <ObservationTreeNode
+                observations={observation.children}
+                collapsedObservations={props.collapsedObservations}
+                toggleCollapsedObservation={props.toggleCollapsedObservation}
+                scores={props.scores}
+                indentationLevel={props.indentationLevel + 1}
+                currentObservationId={props.currentObservationId}
+                setCurrentObservationId={props.setCurrentObservationId}
+                showMetrics={props.showMetrics}
+                showScores={props.showScores}
+              />
+            )}
+          </Fragment>
+        );
+      })}
   </>
 );
+
+const ColorCodedObservationType = (props: {
+  observationType: $Enums.ObservationType;
+}) => {
+  const colors: Record<$Enums.ObservationType, string> = {
+    [$Enums.ObservationType.SPAN]: "bg-blue-200",
+    [$Enums.ObservationType.GENERATION]: "bg-orange-200",
+    [$Enums.ObservationType.EVENT]: "bg-green-200",
+  };
+
+  return (
+    <span
+      className={`${
+        colors[props.observationType]
+      } self-start rounded-sm p-1 text-xs`}
+    >
+      {props.observationType}
+    </span>
+  );
+};
 
 export function nestObservations(
   list: ObservationReturnType[],

--- a/src/components/trace/index.tsx
+++ b/src/components/trace/index.tsx
@@ -58,11 +58,10 @@ export function Trace(props: {
   );
 
   const collapseAll = useCallback(() => {
-    // loop through observations to find all parents until the list of parents does not change anymore
+    // exlude all parents of the current observation
     let excludeParentObservations = new Set<string>();
     let newExcludeParentObservations = new Set<string>();
     do {
-      // combine both sets
       excludeParentObservations = new Set<string>([
         ...excludeParentObservations,
         ...newExcludeParentObservations,

--- a/src/components/trace/index.tsx
+++ b/src/components/trace/index.tsx
@@ -58,10 +58,32 @@ export function Trace(props: {
   );
 
   const collapseAll = useCallback(() => {
+    // loop through observations to find all parents until the list of parents does not change anymore
+    let excludeParentObservations = new Set<string>();
+    let newExcludeParentObservations = new Set<string>();
+    do {
+      // combine both sets
+      excludeParentObservations = new Set<string>([
+        ...excludeParentObservations,
+        ...newExcludeParentObservations,
+      ]);
+      newExcludeParentObservations = new Set<string>(
+        props.observations
+          .filter(
+            (o) =>
+              o.parentObservationId !== null &&
+              (o.id === currentObservationId ||
+                excludeParentObservations.has(o.id)),
+          )
+          .map((o) => o.parentObservationId as string)
+          .filter((id) => !excludeParentObservations.has(id)),
+      );
+    } while (newExcludeParentObservations.size > 0);
+
     setCollapsedObservations(
       props.observations
         .map((o) => o.id)
-        .filter((id) => id !== currentObservationId),
+        .filter((id) => !excludeParentObservations.has(id)),
     );
   }, [props.observations, currentObservationId]);
 

--- a/src/components/trace/index.tsx
+++ b/src/components/trace/index.tsx
@@ -58,7 +58,7 @@ export function Trace(props: {
   );
 
   const collapseAll = useCallback(() => {
-    // exlude all parents of the current observation
+    // exclude all parents of the current observation
     let excludeParentObservations = new Set<string>();
     let newExcludeParentObservations = new Set<string>();
     do {

--- a/src/components/trace/index.tsx
+++ b/src/components/trace/index.tsx
@@ -23,6 +23,7 @@ import { Award, ChevronsDownUp, ChevronsUpDown } from "lucide-react";
 import { ScrollArea } from "@/src/components/ui/scroll-area";
 import { usdFormatter } from "@/src/utils/numbers";
 import Decimal from "decimal.js";
+import { useCallback, useState } from "react";
 
 export function Trace(props: {
   observations: Array<ObservationReturnType>;
@@ -41,9 +42,36 @@ export function Trace(props: {
     true,
   );
 
+  const [collapsedObservations, setCollapsedObservations] = useState<string[]>(
+    [],
+  );
+
+  const toggleCollapsedObservation = useCallback(
+    (id: string) => {
+      if (collapsedObservations.includes(id)) {
+        setCollapsedObservations(collapsedObservations.filter((i) => i !== id));
+      } else {
+        setCollapsedObservations([...collapsedObservations, id]);
+      }
+    },
+    [collapsedObservations],
+  );
+
+  const collapseAll = useCallback(() => {
+    setCollapsedObservations(
+      props.observations
+        .map((o) => o.id)
+        .filter((id) => id !== currentObservationId),
+    );
+  }, [props.observations, currentObservationId]);
+
+  const expandAll = useCallback(() => {
+    setCollapsedObservations([]);
+  }, [setCollapsedObservations]);
+
   return (
-    <div className="grid gap-4 md:h-full md:grid-cols-3">
-      <ScrollArea className="md:col-span-2 md:h-full">
+    <div className="grid gap-4 md:h-full md:grid-cols-5">
+      <ScrollArea className="md:col-span-3 md:h-full">
         {currentObservationId === undefined ||
         currentObservationId === "" ||
         currentObservationId === null ? (
@@ -62,7 +90,7 @@ export function Trace(props: {
           />
         )}
       </ScrollArea>
-      <div className="md:flex md:h-full md:flex-col md:overflow-hidden">
+      <div className="md:col-span-2 md:flex md:h-full md:flex-col md:overflow-hidden">
         <div className="mb-2 flex flex-shrink-0 flex-row justify-end gap-2">
           <Toggle
             pressed={scoresOnObservationTree}
@@ -92,6 +120,10 @@ export function Trace(props: {
         <ScrollArea className="flex flex-grow">
           <ObservationTree
             observations={props.observations}
+            collapsedObservations={collapsedObservations}
+            toggleCollapsedObservation={toggleCollapsedObservation}
+            collapseAll={collapseAll}
+            expandAll={expandAll}
             trace={props.trace}
             scores={props.scores}
             currentObservationId={currentObservationId ?? undefined}

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -18,6 +18,7 @@ const toggleVariants = cva(
       size: {
         default: "h-10 px-3",
         sm: "h-9 px-2.5",
+        xs: "h-6 px-1.5",
         lg: "h-11 px-5",
       },
     },

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -17,8 +17,8 @@ const toggleVariants = cva(
       },
       size: {
         default: "h-10 px-3",
-        sm: "h-9 px-2.5",
         xs: "h-6 px-1.5",
+        sm: "h-9 px-2.5",
         lg: "h-11 px-5",
       },
     },


### PR DESCRIPTION
## What does this PR do?

This PR initiates a suggestion for some changes to the Trace view that I consider to improve the readability of traces. These suggested changes include:

* Color coding of Observation Type
* Ability to collapse child traces
* Ability to collapse and expand all traces
* Makes the trace view a little bit wider
* Make the padding a little bit smaller, to retrieve some more space for viewing traces

At this point I just want to have a conversation and get some feedback to see if changes in this line is desired by the maintainers.

Going forward I would be open to making more significant changes:

* Adding fuzzy search to make it easier to find deeply nested traces by run-name
* Being able to focus on a sub-trace-tree, allowing to render that sub-tree with the full space of the container
* Seek to send more useful data from the langchain integration to provide richer information in the trace view, especially better handling of run-names

![2024-01-20-18-20-02-scrot](https://github.com/langfuse/langfuse/assets/17207277/32ef04b5-5fa1-4d16-a8ab-3bfe38415dca)


## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
