### PR TITLE
fix(sessions): composite ids

### DIFF
--- a/prisma/migrations/20240124140443_session_composite_key/migration.sql
+++ b/prisma/migrations/20240124140443_session_composite_key/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - The primary key for the `trace_sessions` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- DropForeignKey
+ALTER TABLE "traces" DROP CONSTRAINT "traces_session_id_fkey";
+
+-- DropIndex
+DROP INDEX "trace_sessions_id_project_id_key";
+
+-- AlterTable
+ALTER TABLE "trace_sessions" DROP CONSTRAINT "trace_sessions_pkey",
+ADD CONSTRAINT "trace_sessions_pkey" PRIMARY KEY ("id", "project_id");
+
+-- AddForeignKey
+ALTER TABLE "traces" ADD CONSTRAINT "traces_session_id_project_id_fkey" FOREIGN KEY ("session_id", "project_id") REFERENCES "trace_sessions"("id", "project_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -163,7 +163,7 @@ enum MembershipRole {
 }
 
 model TraceSession {
-    id         String   @id @default(cuid())
+    id         String   @default(cuid())
     createdAt  DateTime @default(now()) @map("created_at")
     updatedAt  DateTime @default(now()) @updatedAt @map("updated_at")
     projectId  String   @map("project_id")
@@ -172,7 +172,7 @@ model TraceSession {
     public     Boolean  @default(false)
     traces     Trace[]
 
-    @@unique([id, projectId])
+    @@id([id, projectId])
     @@index([projectId])
     @@index([createdAt])
     @@map("trace_sessions")
@@ -195,7 +195,7 @@ model Trace {
     input      Json?
     output     Json?
     sessionId  String?       @map("session_id")
-    session    TraceSession? @relation(fields: [sessionId], references: [id], onDelete: SetNull)
+    session    TraceSession? @relation(fields: [sessionId, projectId], references: [id, projectId])
 
     scores Score[]
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -144,6 +144,8 @@ async function main() {
 
       const tags = [envTag, colorTag].filter((tag) => tag !== null);
 
+      const projectId = [project1.id, project2.id][i % 2] as string;
+
       const trace = await prisma.trace.create({
         data: {
           id: `trace-${Math.floor(Math.random() * 1000000000)}`,
@@ -156,9 +158,7 @@ async function main() {
           },
           tags: tags as string[],
           project: {
-            connect: {
-              id: [project1.id, project2.id][i % 2],
-            },
+            connect: { id: projectId },
           },
           userId: `user-${i % 10}`,
           session:
@@ -166,13 +166,14 @@ async function main() {
               ? {
                   connectOrCreate: {
                     where: {
-                      id: `session-${i % 10}`,
+                      id_projectId: {
+                        id: `session-${i % 10}`,
+                        projectId: projectId,
+                      },
                     },
                     create: {
                       id: `session-${i % 10}`,
-                      project: {
-                        connect: { id: [project1.id, project2.id][i % 2] },
-                      },
+                      projectId: projectId,
                     },
                   },
                 }

--- a/src/pages/api/public/sessions/[sessionId].ts
+++ b/src/pages/api/public/sessions/[sessionId].ts
@@ -45,8 +45,10 @@ export default async function handler(
 
     const session = await prisma.traceSession.findUnique({
       where: {
-        id: sessionId,
-        projectId: authCheck.scope.projectId,
+        id_projectId: {
+          id: sessionId,
+          projectId: authCheck.scope.projectId,
+        },
       },
       include: {
         traces: true,

--- a/src/server/api/routers/sessions.ts
+++ b/src/server/api/routers/sessions.ts
@@ -163,8 +163,10 @@ export const sessionRouter = createTRPCRouter({
 
         const session = await ctx.prisma.traceSession.update({
           where: {
-            id: input.sessionId,
-            projectId: input.projectId,
+            id_projectId: {
+              id: input.sessionId,
+              projectId: input.projectId,
+            },
           },
           data: {
             bookmarked: input.bookmarked,
@@ -205,8 +207,10 @@ export const sessionRouter = createTRPCRouter({
         });
         return ctx.prisma.traceSession.update({
           where: {
-            id: input.sessionId,
-            projectId: input.projectId,
+            id_projectId: {
+              id: input.sessionId,
+              projectId: input.projectId,
+            },
           },
           data: {
             public: input.public,


### PR DESCRIPTION
sessions should be unique on a project level, currently the @id config on the session table forces them to be unique across projects in a langfuse instance.

https://github.com/langfuse/langfuse/blob/d87432cce3d475e6cf383f0b801ce014af048366/prisma/schema.prisma#L166

This PR fixes this.