### PR TITLE
fix: remove unit default TOKENS

### DIFF
--- a/scripts/model-match.ts
+++ b/scripts/model-match.ts
@@ -28,7 +28,7 @@ export async function modelMatch() {
   let totalObservations = 0;
 
   while (continueLoop) {
-    type SelectedType = {
+    type ObservationSelect = {
       model: string | null;
       id: string;
       projectId: string;
@@ -50,20 +50,16 @@ export async function modelMatch() {
       where: {
         internalModel: null,
         type: "GENERATION",
-        // TODO: remove start time filter
-        startTime: {
-          lt: new Date("2020-01-24"),
-        },
       },
-      take: 100_000,
-      skip: index * 100_000,
+      take: 50_000,
+      skip: index * 50_000,
     });
     console.log("Observations: ", observations[0]?.id);
 
     console.log(`Found ${observations.length} observations to migrate`);
 
     interface GroupedObservations {
-      [key: string]: SelectedType[];
+      [key: string]: ObservationSelect[];
     }
 
     const groupedObservations = observations.reduce<GroupedObservations>(

--- a/src/__tests__/generations.servertest.ts
+++ b/src/__tests__/generations.servertest.ts
@@ -34,7 +34,7 @@ describe("/api/public/generations API Endpoint", () => {
       usage: {
         total: 100,
       },
-      expectedUnit: "TOKENS",
+      expectedUnit: null,
       expectedPromptTokens: 0,
       expectedCompletionTokens: 0,
       expectedTotalTokens: 100,
@@ -64,21 +64,21 @@ describe("/api/public/generations API Endpoint", () => {
       expectedPromptTokens: 0,
       expectedCompletionTokens: 0,
       expectedTotalTokens: 0,
-      expectedUnit: "TOKENS",
+      expectedUnit: null,
     },
     {
       usage: null,
       expectedPromptTokens: 0,
       expectedCompletionTokens: 0,
       expectedTotalTokens: 0,
-      expectedUnit: "TOKENS",
+      expectedUnit: null,
     },
     {
       usage: {},
       expectedPromptTokens: 0,
       expectedCompletionTokens: 0,
       expectedTotalTokens: 0,
-      expectedUnit: "TOKENS",
+      expectedUnit: null,
     },
   ].forEach((testConfig) => {
     it(`should create generation after trace 1 ${JSON.stringify(

--- a/src/__tests__/ingestion.servertest.ts
+++ b/src/__tests__/ingestion.servertest.ts
@@ -38,7 +38,7 @@ describe("/api/public/ingestion API Endpoint", () => {
       usage: {
         total: 100,
       },
-      expectedUnit: "TOKENS",
+      expectedUnit: null,
       expectedPromptTokens: 0,
       expectedCompletionTokens: 0,
       expectedTotalTokens: 100,
@@ -68,21 +68,21 @@ describe("/api/public/ingestion API Endpoint", () => {
       expectedPromptTokens: 0,
       expectedCompletionTokens: 0,
       expectedTotalTokens: 0,
-      expectedUnit: "TOKENS",
+      expectedUnit: null,
     },
     {
       usage: null,
       expectedPromptTokens: 0,
       expectedCompletionTokens: 0,
       expectedTotalTokens: 0,
-      expectedUnit: "TOKENS",
+      expectedUnit: null,
     },
     {
       usage: {},
       expectedPromptTokens: 0,
       expectedCompletionTokens: 0,
       expectedTotalTokens: 0,
-      expectedUnit: "TOKENS",
+      expectedUnit: null,
     },
   ].forEach((testConfig) => {
     it(`should create trace, generation and score without matching models ${JSON.stringify(

--- a/src/__tests__/observations.servertest.ts
+++ b/src/__tests__/observations.servertest.ts
@@ -59,6 +59,7 @@ describe("/api/public/observations API Endpoint", () => {
           connect: { id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a" },
         },
         internalModel: "gpt-3.5-turbo",
+        unit: "TOKENS",
       },
     });
 
@@ -71,7 +72,10 @@ describe("/api/public/observations API Endpoint", () => {
     expect(fetchedObservations.status).toBe(200);
 
     if (!isObservationList(fetchedObservations.body)) {
-      throw new Error("Expected body to be an array of observations");
+      throw new Error(
+        "Expected body to be an array of observations" +
+          JSON.stringify(fetchedObservations.body),
+      );
     }
 
     expect(fetchedObservations.body.data.length).toBe(1);

--- a/src/features/public-api/server/ingestion-api-schema.ts
+++ b/src/features/public-api/server/ingestion-api-schema.ts
@@ -34,6 +34,7 @@ export const usage = MixedUsage.nullish()
     if (!v) {
       return null;
     }
+    // if we get the openai format, we default to TOKENS unit
     if ("promptTokens" in v || "completionTokens" in v || "totalTokens" in v) {
       return {
         input: v.promptTokens,
@@ -42,17 +43,19 @@ export const usage = MixedUsage.nullish()
         unit: "TOKENS",
       };
     }
+    // if we get the new generic format, we do not set a defualt
     if ("input" in v || "output" in v || "total" in v || "unit" in v) {
-      const unit = v.unit ?? "TOKENS";
+      const unit = v.unit;
       return { ...v, unit };
     }
 
+    // if the object is empty, we return undefined
     if (lodash.isEmpty(v)) {
-      return { unit: "TOKENS" };
+      return undefined;
     }
   })
   // ensure output is always of new usage model
-  .pipe(Usage.nullable());
+  .pipe(Usage.nullish());
 
 export const TraceBody = z.object({
   id: z.string().nullish(),

--- a/src/features/public-api/server/ingestion-api-schema.ts
+++ b/src/features/public-api/server/ingestion-api-schema.ts
@@ -7,7 +7,7 @@ export const Usage = z.object({
   input: z.number().int().nullish(),
   output: z.number().int().nullish(),
   total: z.number().int().nullish(),
-  unit: z.enum(["TOKENS", "CHARACTERS"]).nullable(),
+  unit: z.enum(["TOKENS", "CHARACTERS"]).nullish(),
   inputCost: z.number().nullish(),
   outputCost: z.number().nullish(),
   totalCost: z.number().nullish(),


### PR DESCRIPTION
Behavior
- User provides open standard (prompttokens, completiontokens, totaltokens)
    - Match to tokens by default on server side always
- User provides non openai standard
    - If unit not provided, derive from matched model. Model is found without matching unit
    - If unit provided, match model with unit + use that unit for the observation


Python SDk
- converts openai model to new langfuse standard: https://github.com/langfuse/langfuse-python/blob/c864a74a0d6038781740d40c244d991dc0843565/langfuse/utils.py#L68

JS SDK
- does not do any conversion, just takes the ingestion api type
