### PR TITLE
fix: remove `Expires` from S3 PutObject

### DIFF
--- a/src/server/api/routers/generations.ts
+++ b/src/server/api/routers/generations.ts
@@ -476,7 +476,6 @@ export const generationsRouter = createTRPCRouter({
             Key: fileName,
             Body: output,
             ContentType: exportOptions[input.fileFormat].fileType,
-            Expires: new Date(Date.now() + 60 * 60 * 1000), // in 1 hour, file will be deleted
           }),
         );
         const signedUrl = await getSignedUrl(


### PR DESCRIPTION
Fixes #1046