### PR TITLE
fix: allow bearer auth for score ingestion via /api/public/ingestion

### DIFF
--- a/src/__tests__/test-utils.ts
+++ b/src/__tests__/test-utils.ts
@@ -27,21 +27,38 @@ export function createBasicAuthHeader(
   return `Basic ${base64Credentials}`;
 }
 
+export type IngestionAPIResponse = {
+  errors: ErrorIngestion[];
+  successes: SuccessfulIngestion[];
+};
+
+export type SuccessfulIngestion = {
+  id: string;
+  status: number;
+};
+
+export type ErrorIngestion = {
+  id: string;
+  status: number;
+  message: string;
+  error: string;
+};
+
 export async function makeAPICall(
   method: "POST" | "GET" | "PUT" | "DELETE" | "PATCH",
   url: string,
   body?: unknown,
+  auth?: string,
 ) {
   const finalUrl = `http://localhost:3000/${url}`;
+  const authorization =
+    auth || createBasicAuthHeader("pk-lf-1234567890", "sk-lf-1234567890");
   const options = {
     method: method,
     headers: {
       Accept: "application/json",
       "Content-Type": "application/json;charset=UTF-8",
-      Authorization: createBasicAuthHeader(
-        "pk-lf-1234567890",
-        "sk-lf-1234567890",
-      ),
+      Authorization: authorization,
     },
     // Conditionally include the body property if the method is not "GET"
     ...(method !== "GET" &&
@@ -50,7 +67,7 @@ export async function makeAPICall(
   const a = await fetch(finalUrl, options);
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  return { body: await a.json(), status: a.status };
+  return { body: (await a.json()) as IngestionAPIResponse, status: a.status };
 }
 
 export const setupUserAndProject = async () => {


### PR DESCRIPTION
## What does this PR do?

Currently, the `/api/public/ingestion` endpoint rejects all requests with `apiScope != 'all'`. For Score ingestions, Bearer auth is used with the `public_key` as the token, where the server only grants `apiScope = 'scores'`. This PR enables score ingestion via the ingestion endpoint for that source of traffic. 

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't added tests that prove my fix is effective or that my feature works
