### PR TITLE
Api to delete a score issue No. 1148

### DIFF
--- a/src/pages/api/public/scores.ts
+++ b/src/pages/api/public/scores.ts
@@ -140,6 +140,7 @@ export default async function handler(
     }
   } else if (req.method === "DELETE") {
     try {
+      console.log("deleting score......");
       console.log(authCheck.scope.accessLevel);
       if (authCheck.scope.accessLevel !== "all") {
         return res.status(401).json({
@@ -148,14 +149,14 @@ export default async function handler(
         });
       }
 
-      const scoreId = ScoresDeleteSchema.parse(req.query);
+      const scoreId = ScoresDeleteSchema.parse(req.query.scoreId);
 
       const result = await prisma.$queryRaw(
         Prisma.sql`DELETE from scores WHERE id=${scoreId}`,
       );
       res.status(200).send(result);
     } catch (error) {
-      console.log(error);
+      console.log("Error ", error);
     }
   } else {
     return res.status(405).json({ message: "Method not allowed" });

--- a/src/pages/api/public/scores.ts
+++ b/src/pages/api/public/scores.ts
@@ -22,6 +22,10 @@ const ScoresGetSchema = z.object({
   name: z.string().nullish(),
 });
 
+const ScoresDeleteSchema = z.object({
+  scoreId: z.string(),
+});
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
@@ -133,6 +137,25 @@ export default async function handler(
         message: "Invalid request data",
         error: errorMessage,
       });
+    }
+  } else if (req.method === "DELETE") {
+    try {
+      console.log(authCheck.scope.accessLevel);
+      if (authCheck.scope.accessLevel !== "all") {
+        return res.status(401).json({
+          message:
+            "Access denied - need to use basic auth with secret key to GET scores",
+        });
+      }
+
+      const scoreId = ScoresDeleteSchema.parse(req.query);
+
+      const result = await prisma.$queryRaw(
+        Prisma.sql`DELETE from scores WHERE id=${scoreId}`,
+      );
+      res.status(200).send(result);
+    } catch (error) {
+      console.log(error);
     }
   } else {
     return res.status(405).json({ message: "Method not allowed" });


### PR DESCRIPTION
Added the Delete API to delete a Score at ```/api/public/score/[scoreId]```. Test is pending because I have problem with authentication headers. 