### PR TITLE
Adding deploy with stitch to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
       <a href="https://github.com/langfuse/langfuse/pkgs/container/langfuse"><img alt="Docker Image" src="https://img.shields.io/badge/docker-langfuse-blue?logo=Docker&logoColor=white&style=flat-square"></a>
       <a href="https://www.npmjs.com/package/langfuse"><img src="https://img.shields.io/npm/v/langfuse?style=flat-square&label=npm+langfuse" alt="langfuse npm package"></a>
       <a href="https://pypi.python.org/pypi/langfuse"><img src="https://img.shields.io/pypi/v/langfuse.svg?style=flat-square&label=pypi+langfuse" alt="langfuse Python package on PyPi"></a>
+      <a href="https://deploy.stitch.tech/langfuse/langfuse"><img src="https://img.shields.io/badge/deploy_with-Stitch-%23E369F7?logo=amazonaws&color=%23E369F7" alt="Deploy to aws using Stitch"></a>      
    </div>
 </div>
 </br>


### PR DESCRIPTION
## What does this PR do?

Adds a deploy with Stitch badge to the README.
<img width="811" alt="image" src="https://github.com/langfuse/langfuse/assets/8139394/7b3b2198-dea1-4c1b-80b1-95aa588a95fe">

Hey I'm Raj from Stitch (YC W24) and we are building installers for opensource software. After speaking to @clemra we feel like Langfuse could really make use of this.

Here is a short video demo: https://www.loom.com/share/89de0a8a55024c189d99c47bbad36167?sid=68dbb816-fa36-41c4-969c-d71eef472396

The Stitch installer essentially creates infra on the user's cloud and runs a script to install langfuse. We have written the install script using the instructions on the readme. We will be fully opensourcing the Stitch installer so that it is transparent to users exactly what is being run on their cloud.

Please let me know if you have any questions.
## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
