### PR TITLE
fix: correctly return 500 and 400 API errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,8 @@ Requirements
 
 6. Run the migrations
 
+   The `schema.prisma` file is in the `web` directory and hence, migrations are applied from there.
+
    ```bash
    npm run db:migrate
 

--- a/web/src/__tests__/ingestion.servertest.ts
+++ b/web/src/__tests__/ingestion.servertest.ts
@@ -1763,4 +1763,47 @@ IB Home   /   . . .   /   News   /   News about the IB   /   Why ChatGPT is an o
 
     expect(dbScore).toBeNull();
   });
+
+  it("should error on wrong input", async () => {
+    const traceId = "trace_id";
+    const bearerAuth = "Bearer pk-lf-1234567890";
+
+    const scoreId = "score_id";
+    const scoreEventId = "score_event_id";
+    const scoreName = "score-name";
+    const scoreValue = 100.5;
+
+    const response = await makeAPICall(
+      "POST",
+      "/api/public/ingestion",
+      {
+        // sending data instead of batch
+        data: [
+          {
+            id: scoreEventId,
+            type: "score-create",
+            timestamp: new Date().toISOString(),
+            body: {
+              id: scoreId,
+              name: scoreName,
+              value: scoreValue,
+              traceId: traceId,
+            },
+          },
+        ],
+      },
+      bearerAuth,
+    );
+
+    expect(response.status).toBe(400);
+    expect(await prisma.trace.count()).toBe(0);
+
+    const dbScore = await prisma.score.findUnique({
+      where: {
+        id: scoreId,
+      },
+    });
+
+    expect(dbScore).toBeNull();
+  });
 });

--- a/web/src/features/feedback/server/feedbackHandler.ts
+++ b/web/src/features/feedback/server/feedbackHandler.ts
@@ -19,6 +19,6 @@ export default async function feedbackApiHandler(
     }
   } catch (error) {
     console.error(error);
-    res.status(400).json({ status: "Error" });
+    res.status(500).json({ status: "Error" });
   }
 }

--- a/web/src/pages/api/public/dataset-items.ts
+++ b/web/src/pages/api/public/dataset-items.ts
@@ -85,13 +85,13 @@ export default async function handler(
       });
     }
   } catch (error: unknown) {
+    console.error(error);
     if (error instanceof z.ZodError) {
       return res.status(400).json({
         message: "Invalid request data",
         error: error.errors,
       });
     }
-    console.error(error);
     if (isPrismaException(error)) {
       return res.status(500).json({
         error: "Internal Server Error",

--- a/web/src/pages/api/public/dataset-items.ts
+++ b/web/src/pages/api/public/dataset-items.ts
@@ -85,6 +85,12 @@ export default async function handler(
       });
     }
   } catch (error: unknown) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({
+        message: "Invalid request data",
+        error: error.errors,
+      });
+    }
     console.error(error);
     if (isPrismaException(error)) {
       return res.status(500).json({
@@ -93,7 +99,7 @@ export default async function handler(
     }
     const errorMessage =
       error instanceof Error ? error.message : "An unknown error occurred";
-    res.status(400).json({
+    res.status(500).json({
       message: "Invalid request data",
       error: errorMessage,
     });

--- a/web/src/pages/api/public/dataset-items/[datasetItemId].ts
+++ b/web/src/pages/api/public/dataset-items/[datasetItemId].ts
@@ -71,9 +71,15 @@ export default async function handler(
         error: "Internal Server Error",
       });
     }
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({
+        message: "Invalid request data",
+        error: error.errors,
+      });
+    }
     const errorMessage =
       error instanceof Error ? error.message : "An unknown error occurred";
-    res.status(400).json({
+    res.status(500).json({
       message: "Invalid request data",
       error: errorMessage,
     });

--- a/web/src/pages/api/public/dataset-run-items.ts
+++ b/web/src/pages/api/public/dataset-run-items.ts
@@ -102,6 +102,12 @@ export default async function handler(
       return res.status(200).json(runItem);
     } catch (error: unknown) {
       console.error(error);
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({
+          message: "Invalid request data",
+          error: error.errors,
+        });
+      }
       if (isPrismaException(error)) {
         return res.status(500).json({
           error: "Internal Server Error",
@@ -109,7 +115,7 @@ export default async function handler(
       }
       const errorMessage =
         error instanceof Error ? error.message : "An unknown error occurred";
-      res.status(400).json({
+      res.status(500).json({
         message: "Invalid request data",
         error: errorMessage,
       });

--- a/web/src/pages/api/public/datasets.ts
+++ b/web/src/pages/api/public/datasets.ts
@@ -61,6 +61,12 @@ export default async function handler(
     }
   } catch (error: unknown) {
     console.error(error);
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({
+        message: "Invalid request data",
+        error: error.errors,
+      });
+    }
     if (isPrismaException(error)) {
       return res.status(500).json({
         error: "Internal Server Error",
@@ -68,7 +74,7 @@ export default async function handler(
     }
     const errorMessage =
       error instanceof Error ? error.message : "An unknown error occurred";
-    res.status(400).json({
+    res.status(500).json({
       message: "Invalid request data",
       error: errorMessage,
     });

--- a/web/src/pages/api/public/datasets/[name]/runs/[runName].ts
+++ b/web/src/pages/api/public/datasets/[name]/runs/[runName].ts
@@ -83,9 +83,15 @@ export default async function handler(
           error: "Internal Server Error",
         });
       }
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({
+          message: "Invalid request data",
+          error: error.errors,
+        });
+      }
       const errorMessage =
         error instanceof Error ? error.message : "An unknown error occurred";
-      res.status(400).json({
+      res.status(500).json({
         message: "Invalid request data",
         error: errorMessage,
       });

--- a/web/src/pages/api/public/events.ts
+++ b/web/src/pages/api/public/events.ts
@@ -11,7 +11,7 @@ import {
   handleBatch,
   handleBatchResultLegacy,
 } from "@/src/pages/api/public/ingestion";
-import { type z } from "zod";
+import { z } from "zod";
 import { isPrismaException } from "@/src/utils/exceptions";
 
 export default async function handler(
@@ -67,6 +67,12 @@ export default async function handler(
     handleBatchResultLegacy(result.errors, result.results, res);
   } catch (error: unknown) {
     console.error(error);
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({
+        message: "Invalid request data",
+        error: error.errors,
+      });
+    }
     if (isPrismaException(error)) {
       return res.status(500).json({
         error: "Internal Server Error",
@@ -74,7 +80,7 @@ export default async function handler(
     }
     const errorMessage =
       error instanceof Error ? error.message : "An unknown error occurred";
-    res.status(400).json({
+    res.status(500).json({
       message: "Invalid request data",
       error: errorMessage,
     });

--- a/web/src/pages/api/public/generations.ts
+++ b/web/src/pages/api/public/generations.ts
@@ -13,7 +13,7 @@ import {
   handleBatch,
   handleBatchResultLegacy,
 } from "@/src/pages/api/public/ingestion";
-import { type z } from "zod";
+import { z } from "zod";
 import { isPrismaException } from "@/src/utils/exceptions";
 
 export default async function handler(
@@ -70,6 +70,12 @@ export default async function handler(
       handleBatchResultLegacy(result.errors, result.results, res);
     } catch (error: unknown) {
       console.error(error);
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({
+          message: "Invalid request data",
+          error: error.errors,
+        });
+      }
       if (isPrismaException(error)) {
         return res.status(500).json({
           error: "Internal Server Error",
@@ -77,7 +83,7 @@ export default async function handler(
       }
       const errorMessage =
         error instanceof Error ? error.message : "An unknown error occurred";
-      res.status(400).json({
+      res.status(500).json({
         message: "Invalid request data",
         error: errorMessage,
       });
@@ -129,6 +135,12 @@ export default async function handler(
       handleBatchResultLegacy(result.errors, result.results, res);
     } catch (error: unknown) {
       console.error(error);
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({
+          message: "Invalid request data",
+          error: error.errors,
+        });
+      }
       if (isPrismaException(error)) {
         return res.status(500).json({
           error: "Internal Server Error",
@@ -143,7 +155,7 @@ export default async function handler(
 
       const errorMessage =
         error instanceof Error ? error.message : "An unknown error occurred";
-      res.status(400).json({
+      res.status(500).json({
         message: "Invalid request data",
         error: errorMessage,
       });

--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -107,16 +107,23 @@ export default async function handler(
 
     handleBatchResult([...errors, ...result.errors], result.results, res);
   } catch (error: unknown) {
+    console.error(error);
+
     if (isPrismaException(error)) {
       return res.status(500).json({
         error: "Internal Server Error",
       });
     }
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({
+        message: "Invalid request data",
+        error: error.errors,
+      });
+    }
 
-    console.error(error);
     const errorMessage =
       error instanceof Error ? error.message : "An unknown error occurred";
-    res.status(400).json({
+    res.status(500).json({
       message: "Invalid request data",
       errors: [errorMessage],
     });

--- a/web/src/pages/api/public/metrics/daily.ts
+++ b/web/src/pages/api/public/metrics/daily.ts
@@ -156,9 +156,15 @@ export default async function handler(
         error: "Internal Server Error",
       });
     }
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({
+        message: "Invalid request data",
+        error: error.errors,
+      });
+    }
     const errorMessage =
       error instanceof Error ? error.message : "An unknown error occurred";
-    res.status(400).json({
+    res.status(500).json({
       message: "Invalid request data",
       error: errorMessage,
     });

--- a/web/src/pages/api/public/observations/[observationId].ts
+++ b/web/src/pages/api/public/observations/[observationId].ts
@@ -63,9 +63,15 @@ export default async function handler(
         error: "Internal Server Error",
       });
     }
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({
+        message: "Invalid request data",
+        error: error.errors,
+      });
+    }
     const errorMessage =
       error instanceof Error ? error.message : "An unknown error occurred";
-    res.status(400).json({
+    res.status(500).json({
       message: "Invalid request data",
       error: errorMessage,
     });

--- a/web/src/pages/api/public/observations/index.ts
+++ b/web/src/pages/api/public/observations/index.ts
@@ -80,9 +80,15 @@ export default async function handler(
         error: "Internal Server Error",
       });
     }
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({
+        message: "Invalid request data",
+        error: error.errors,
+      });
+    }
     const errorMessage =
       error instanceof Error ? error.message : "An unknown error occurred";
-    res.status(400).json({
+    res.status(500).json({
       message: "Invalid request data",
       error: errorMessage,
     });

--- a/web/src/pages/api/public/prompts.ts
+++ b/web/src/pages/api/public/prompts.ts
@@ -78,9 +78,15 @@ export default async function handler(
           error: "Internal Server Error",
         });
       }
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({
+          message: "Invalid request data",
+          error: error.errors,
+        });
+      }
       const errorMessage =
         error instanceof Error ? error.message : "An unknown error occurred";
-      res.status(400).json({
+      res.status(500).json({
         message: "Invalid request data",
         error: errorMessage,
       });
@@ -131,9 +137,15 @@ export default async function handler(
           error: "Internal Server Error",
         });
       }
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({
+          message: "Invalid request data",
+          error: error.errors,
+        });
+      }
       const errorMessage =
         error instanceof Error ? error.message : "An unknown error occurred";
-      res.status(400).json({
+      res.status(500).json({
         message: "Invalid request data",
         error: errorMessage,
       });

--- a/web/src/pages/api/public/scores.ts
+++ b/web/src/pages/api/public/scores.ts
@@ -70,9 +70,15 @@ export default async function handler(
           error: "Internal Server Error",
         });
       }
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({
+          message: "Invalid request data",
+          error: error.errors,
+        });
+      }
       const errorMessage =
         error instanceof Error ? error.message : "An unknown error occurred";
-      res.status(400).json({
+      res.status(500).json({
         message: "Invalid request data",
         error: errorMessage,
       });
@@ -134,13 +140,19 @@ export default async function handler(
     } catch (error: unknown) {
       console.error(error);
       if (isPrismaException(error)) {
-        return res.status(400).json({
+        return res.status(500).json({
           error: "Internal Server Error",
+        });
+      }
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({
+          message: "Invalid request data",
+          error: error.errors,
         });
       }
       const errorMessage =
         error instanceof Error ? error.message : "An unknown error occurred";
-      res.status(400).json({
+      res.status(500).json({
         message: "Invalid request data",
         error: errorMessage,
       });

--- a/web/src/pages/api/public/scores/[scoreId].ts
+++ b/web/src/pages/api/public/scores/[scoreId].ts
@@ -70,9 +70,15 @@ export default async function handler(
           error: "Internal Server Error",
         });
       }
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({
+          message: "Invalid request data",
+          error: error.errors,
+        });
+      }
       const errorMessage =
         error instanceof Error ? error.message : "An unknown error occurred";
-      res.status(400).json({
+      res.status(500).json({
         message: "Invalid request data",
         error: errorMessage,
       });
@@ -123,9 +129,15 @@ export default async function handler(
           error: "Internal Server Error",
         });
       }
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({
+          message: "Invalid request data",
+          error: error.errors,
+        });
+      }
       const errorMessage =
         error instanceof Error ? error.message : "An unknown error occurred";
-      res.status(400).json({
+      res.status(500).json({
         message: "Invalid request data",
         error: errorMessage,
       });

--- a/web/src/pages/api/public/sessions/[sessionId].ts
+++ b/web/src/pages/api/public/sessions/[sessionId].ts
@@ -69,9 +69,15 @@ export default async function handler(
         error: "Internal Server Error",
       });
     }
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({
+        message: "Invalid request data",
+        error: error.errors,
+      });
+    }
     const errorMessage =
       error instanceof Error ? error.message : "An unknown error occurred";
-    res.status(400).json({
+    res.status(500).json({
       message: "Invalid request data",
       error: errorMessage,
     });

--- a/web/src/pages/api/public/spans.ts
+++ b/web/src/pages/api/public/spans.ts
@@ -13,7 +13,7 @@ import {
   handleBatch,
   handleBatchResultLegacy,
 } from "@/src/pages/api/public/ingestion";
-import { type z } from "zod";
+import { z } from "zod";
 import { isPrismaException } from "@/src/utils/exceptions";
 
 export default async function handler(
@@ -70,10 +70,16 @@ export default async function handler(
           error: "Internal Server Error",
         });
       }
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({
+          message: "Invalid request data",
+          error: error.errors,
+        });
+      }
       const errorMessage =
         error instanceof Error ? error.message : "An unknown error occurred";
       console.error(error, req.body);
-      res.status(400).json({
+      res.status(500).json({
         message: "Invalid request data",
         error: errorMessage,
       });
@@ -120,7 +126,12 @@ export default async function handler(
           error: "Internal Server Error",
         });
       }
-
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({
+          message: "Invalid request data",
+          error: error.errors,
+        });
+      }
       if (error instanceof ResourceNotFoundError) {
         return res.status(404).json({
           message: "Span not found",
@@ -128,7 +139,7 @@ export default async function handler(
       }
       const errorMessage =
         error instanceof Error ? error.message : "An unknown error occurred";
-      res.status(400).json({
+      res.status(500).json({
         message: "Invalid request data",
         error: errorMessage,
       });

--- a/web/src/pages/api/public/traces.ts
+++ b/web/src/pages/api/public/traces.ts
@@ -168,9 +168,15 @@ export default async function handler(
         errors: ["Internal Server Error"],
       });
     }
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({
+        message: "Invalid request data",
+        error: error.errors,
+      });
+    }
     const errorMessage =
       error instanceof Error ? error.message : "An unknown error occurred";
-    res.status(400).json({
+    res.status(500).json({
       message: "Invalid request data",
       error: errorMessage,
     });

--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -85,9 +85,15 @@ export default async function handler(
         error: "Internal Server Error",
       });
     }
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({
+        message: "Invalid request data",
+        error: error.errors,
+      });
+    }
     const errorMessage =
       error instanceof Error ? error.message : "An unknown error occurred";
-    res.status(400).json({
+    res.status(500).json({
       message: "Invalid request data",
       error: errorMessage,
     });

--- a/web/src/pages/api/public/users.ts
+++ b/web/src/pages/api/public/users.ts
@@ -119,15 +119,21 @@ export default async function handler(
       return res.status(405).json({ message: "Method not allowed" });
     }
   } catch (error: unknown) {
+    console.error(error);
     if (isPrismaException(error)) {
       return res.status(500).json({
         errors: ["Internal Server Error"],
       });
     }
-    console.error(error);
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({
+        message: "Invalid request data",
+        error: error.errors,
+      });
+    }
     const errorMessage =
       error instanceof Error ? error.message : "An unknown error occurred";
-    res.status(400).json({
+    res.status(500).json({
       message: "Invalid request data",
       error: errorMessage,
     });


### PR DESCRIPTION
this ensures that:
- we will always return 400 errors if zod throws
- otherwise we return 500