### PR TITLE
docs: fix link to db schema

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ flowchart TB
 
 The diagram below may not show all relationships if the foreign key is not defined in the database schema. For instance, `trace_id` in the `observation` table is not defined as a foreign key to the `trace` table to allow unordered ingestion of these objects, but it is still a foreign key in the application code.
 
-Full database schema: [prisma/schema.prisma](prisma/schema.prisma)
+Full database schema: [web/prisma/schema.prisma](web/prisma/schema.prisma)
 
 <img src="./web/prisma/database.svg">
 


### PR DESCRIPTION
## What does this PR do?

I realized that the link to the db schema in the contributing docs was broken so I fixed it :) 

