### PR TITLE
chore: improve date picker formatting

### DIFF
--- a/web/src/components/date-picker.tsx
+++ b/web/src/components/date-picker.tsx
@@ -171,8 +171,8 @@ export function DatePickerWithRange({
             {internalDateRange?.from ? (
               internalDateRange.to ? (
                 <>
-                  {format(internalDateRange.from, "LLL dd, yy : hh:mm")} -{" "}
-                  {format(internalDateRange.to, "LLL dd, yy : hh:mm")}
+                  {format(internalDateRange.from, "LLL dd, yy : HH:mm")} -{" "}
+                  {format(internalDateRange.to, "LLL dd, yy : HH:mm")}
                 </>
               ) : (
                 format(internalDateRange.from, "LLL dd, y")


### PR DESCRIPTION
## What does this PR do?

The date picker only used a 1-12 hour format which could lead to confusion.


![CleanShot 2024-02-28 at 17 11 47@2x](https://github.com/langfuse/langfuse/assets/17188508/8065d91e-86b2-439b-903a-2620e3220ea7)


In this PR I changed it to military format: 
![CleanShot 2024-02-28 at 17 23 59@2x](https://github.com/langfuse/langfuse/assets/17188508/15e6f3b6-b7ef-439e-8a7f-710b94c92191)

Alternatively happy to change it to am/pm if that is preferred

 
![CleanShot 2024-02-28 at 17 39 30@2x](https://github.com/langfuse/langfuse/assets/17188508/f360ab7e-ffb6-4291-87e9-857f4a169963)
