### PR TITLE
fix: allow null values returned for cost values in sessions table

### DIFF
--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -208,8 +208,8 @@ export default function SessionsTable({
       enableHiding: true,
       defaultHidden: true,
       cell: ({ row }) => {
-        const value: Decimal | undefined = row.getValue("inputCost");
-        return value !== undefined ? (
+        const value: Decimal | null | undefined = row.getValue("inputCost");
+        return value ? (
           <span>{usdFormatter(value.toNumber())}</span>
         ) : undefined;
       },
@@ -221,9 +221,9 @@ export default function SessionsTable({
       enableHiding: true,
       defaultHidden: true,
       cell: ({ row }) => {
-        const value: Decimal | undefined = row.getValue("outputCost");
+        const value: Decimal | null | undefined = row.getValue("outputCost");
 
-        return value !== undefined ? (
+        return value ? (
           <span>{usdFormatter(value.toNumber())}</span>
         ) : undefined;
       },
@@ -235,9 +235,9 @@ export default function SessionsTable({
       enableHiding: true,
       enableSorting: true,
       cell: ({ row }) => {
-        const value: Decimal | undefined = row.getValue("totalCost");
+        const value: Decimal | null | undefined = row.getValue("totalCost");
 
-        return value !== undefined ? (
+        return value ? (
           <span>{usdFormatter(value.toNumber())}</span>
         ) : undefined;
       },
@@ -251,7 +251,7 @@ export default function SessionsTable({
       cell: ({ row }) => {
         const value: number | undefined = row.getValue("inputTokens");
 
-        return value !== undefined ? <span>{Number(value)}</span> : undefined;
+        return value ? <span>{Number(value)}</span> : undefined;
       },
     },
     {
@@ -263,7 +263,7 @@ export default function SessionsTable({
       cell: ({ row }) => {
         const value = row.getValue("outputTokens");
 
-        return value !== undefined ? <span>{Number(value)}</span> : undefined;
+        return value ? <span>{Number(value)}</span> : undefined;
       },
     },
     {
@@ -274,7 +274,7 @@ export default function SessionsTable({
       defaultHidden: true,
       cell: ({ row }) => {
         const value = row.getValue("totalTokens");
-        return value !== undefined ? <span>{Number(value)}</span> : undefined;
+        return value ? <span>{Number(value)}</span> : undefined;
       },
     },
     {

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -96,12 +96,12 @@ export const sessionRouter = createTRPCRouter({
         t."userIds",
         t."countTraces",
         o."sessionDuration",
-        o."totalCost",
-        o."inputCost",
-        o."outputCost",
-        o."promptTokens",
-        o."completionTokens",
-        o."totalTokens",
+        COALESCE(o."totalCost", 0) AS "totalCost",
+        COALESCE(o."inputCost", 0) AS "inputCost",
+        COALESCE(o."outputCost", 0) AS "outputCost",
+        COALESCE(o."promptTokens", 0) AS "promptTokens",
+        COALESCE(o."completionTokens", 0) AS "completionTokens",
+        COALESCE(o."totalTokens", 0) AS "totalTokens",
         (count(*) OVER ())::int AS "totalCount"
       FROM trace_sessions s
       LEFT JOIN trace_metrics t ON t.session_id = s.id


### PR DESCRIPTION
Fix: handle null values returned from sessions all TRPC query for inputCost, outputCost and totalCost