### PR TITLE
feat: allows to link runItem to a trace

### DIFF
--- a/web/prisma/generated/types.ts
+++ b/web/prisma/generated/types.ts
@@ -108,7 +108,8 @@ export type DatasetRunItems = {
     id: string;
     dataset_run_id: string;
     dataset_item_id: string;
-    observation_id: string;
+    observation_id: string | null;
+    run_id: string | null;
     created_at: Generated<Timestamp>;
     updated_at: Generated<Timestamp>;
 };

--- a/web/prisma/migrations/20240309094911_link_run_item_to_trace/migration.sql
+++ b/web/prisma/migrations/20240309094911_link_run_item_to_trace/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "dataset_run_items" ADD COLUMN     "run_id" TEXT,
+ALTER COLUMN "observation_id" DROP NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "dataset_run_items_run_id_idx" ON "dataset_run_items" USING HASH ("run_id");
+
+-- AddForeignKey
+ALTER TABLE "dataset_run_items" ADD CONSTRAINT "dataset_run_items_run_id_fkey" FOREIGN KEY ("run_id") REFERENCES "traces"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -210,7 +210,8 @@ model Trace {
     sessionId  String?       @map("session_id")
     session    TraceSession? @relation(fields: [sessionId, projectId], references: [id, projectId])
 
-    scores Score[]
+    scores          Score[]
+    DatasetRunItems DatasetRunItems[]
 
     @@index([projectId])
     @@index([sessionId])
@@ -395,19 +396,22 @@ model DatasetRuns {
 }
 
 model DatasetRunItems {
-    id            String      @id @default(cuid())
-    datasetRunId  String      @map("dataset_run_id")
-    datasetRun    DatasetRuns @relation(fields: [datasetRunId], references: [id], onDelete: Cascade)
-    datasetItemId String      @map("dataset_item_id")
-    datasetItem   DatasetItem @relation(fields: [datasetItemId], references: [id], onDelete: Cascade)
-    observationId String      @map("observation_id")
-    observation   Observation @relation(fields: [observationId], references: [id], onDelete: Cascade)
-    createdAt     DateTime    @default(now()) @map("created_at")
-    updatedAt     DateTime    @default(now()) @updatedAt @map("updated_at")
+    id            String       @id @default(cuid())
+    datasetRunId  String       @map("dataset_run_id")
+    datasetRun    DatasetRuns  @relation(fields: [datasetRunId], references: [id], onDelete: Cascade)
+    datasetItemId String       @map("dataset_item_id")
+    datasetItem   DatasetItem  @relation(fields: [datasetItemId], references: [id], onDelete: Cascade)
+    observationId String?      @map("observation_id")
+    observation   Observation? @relation(fields: [observationId], references: [id], onDelete: Cascade)
+    traceId       String?      @map("run_id")
+    trace         Trace?       @relation(fields: [traceId], references: [id], onDelete: Cascade)
+    createdAt     DateTime     @default(now()) @map("created_at")
+    updatedAt     DateTime     @default(now()) @updatedAt @map("updated_at")
 
     @@index([datasetRunId], type: Hash)
     @@index([datasetItemId], type: Hash)
     @@index([observationId], type: Hash)
+    @@index([traceId], type: Hash)
     @@map("dataset_run_items")
 }
 

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -283,10 +283,19 @@ export function TracePage({ traceId }: { traceId: string }) {
 }
 
 export const calculateDisplayTotalCost = (
-  observations: ObservationReturnType[],
+  observations: Pick<
+    ObservationReturnType,
+    "calculatedInputCost" | "calculatedOutputCost" | "calculatedTotalCost"
+  >[],
 ) => {
   return observations.reduce(
-    (prev: Decimal | undefined, curr: ObservationReturnType) => {
+    (
+      prev: Decimal | undefined,
+      curr: Pick<
+        ObservationReturnType,
+        "calculatedInputCost" | "calculatedOutputCost" | "calculatedTotalCost"
+      >,
+    ) => {
       // if we don't have any calculated costs, we can't do anything
       if (
         !curr.calculatedTotalCost &&

--- a/worker/generated/types.ts
+++ b/worker/generated/types.ts
@@ -108,7 +108,8 @@ export type DatasetRunItems = {
     id: string;
     dataset_run_id: string;
     dataset_item_id: string;
-    observation_id: string;
+    observation_id: string | null;
+    run_id: string | null;
     created_at: Generated<Timestamp>;
     updated_at: Generated<Timestamp>;
 };


### PR DESCRIPTION
## What does this PR do?

Currently, a `runItem` can only be linked to an `observation`.
The goal of this PRs is to allow to link a `runItem` to a trace. 

I still have some issues on this PR so I'm open to some feedback:
- the latency shown is wrong. I reused some code I found in the codebase but I was unable to figure out what I'm doing wrong here
- I think there is maybe some things to update in the sdk too but I'm don't now how to do it

## Type of change

<!-- Please delete bullets that are not relevant. -->


- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist