### PR TITLE
chore: bump to node20

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.7.0",
   "author": "engineering@langfuse.com",
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "infra:dev:up": "docker-compose -f ./docker-compose.dev.yml up -d",

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,9 @@
   "version": "2.12.1",
   "private": true,
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "prebuild": "cp generated/openapi-client/openapi.yml public/openapi-client.yml && cp generated/openapi-server/openapi.yml public/openapi-server.yml",
     "build": "dotenv -e ../.env -- next build",


### PR DESCRIPTION
update package.json to require node20, non-breaking as all docker containers run on node20 anyways