### PR TITLE
ci: run tests on node 20 only

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [20]
     steps:
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master


### PR DESCRIPTION
previously cloud functions on aws/vercel ran on node 18, after upgrading to node20 across the whole project, we can drop the node18 ci