### PR TITLE
fix(ui): prompt variables must be only letters or underscore

### DIFF
--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -41,6 +41,7 @@ import {
   type NewPromptFormSchemaType,
   PromptContentSchema,
   type PromptContentType,
+  getIsCharOrUnderscore,
 } from "./validation";
 import { Input } from "@/src/components/ui/input";
 import Link from "next/link";
@@ -95,7 +96,7 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
     currentType === PromptType.Text
       ? form.watch("textPrompt")
       : JSON.stringify(form.watch("chatPrompt"), null, 2),
-  );
+  ).filter(getIsCharOrUnderscore);
 
   const createPromptMutation = api.prompts.create.useMutation({
     onSuccess: () => utils.prompts.invalidate(),

--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -276,6 +276,8 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
           <p className="text-sm text-gray-500">
             You can use <code className="text-xs">{"{{variable}}"}</code> to
             insert variables into your prompt.
+            <b className="font-semibold"> Note:</b> Variables must be
+            alphabetical characters or underscores.
             {currentExtractedVariables.length > 0
               ? " The following variables are available:"
               : ""}

--- a/web/src/features/prompts/components/NewPromptForm/validation.ts
+++ b/web/src/features/prompts/components/NewPromptForm/validation.ts
@@ -61,11 +61,14 @@ export const PromptContentSchema = z.union([
 ]);
 export type PromptContentType = z.infer<typeof PromptContentSchema>;
 
-function validateVariables(content: string): boolean {
-  const variables = extractVariables(content);
+export function getIsCharOrUnderscore(value: string): boolean {
   const charOrUnderscore = /^[A-Za-z_]+$/;
 
-  return variables.every((variable) => charOrUnderscore.test(variable));
+  return charOrUnderscore.test(value);
+}
+
+function validateVariables(content: string): boolean {
+  return extractVariables(content).every(getIsCharOrUnderscore);
 }
 
 function validateJson(content: string): boolean {


### PR DESCRIPTION
Implements that UI displayed prompt variables must be only letters or underscore.