### PR TITLE
perf: no `refetchOnMount` for I/O previews in tables

### DIFF
--- a/web/src/components/table/use-cases/generations.tsx
+++ b/web/src/components/table/use-cases/generations.tsx
@@ -695,6 +695,7 @@ const GenerationsIOCell = ({
           skipBatch: true,
         },
       },
+      refetchOnMount: false, // prevents refetching loops
     },
   );
   return (

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -661,6 +661,7 @@ const TracesIOCell = ({
           skipBatch: true,
         },
       },
+      refetchOnMount: false, // prevents refetching loops
     },
   );
   return (

--- a/web/src/features/datasets/components/DatasetRunItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsTable.tsx
@@ -255,12 +255,13 @@ const TraceObservationIOCell = ({
   const trace = api.traces.byId.useQuery(
     { traceId: traceId },
     {
-      enabled: !!traceId && !!!observationId,
+      enabled: observationId === undefined,
       trpc: {
         context: {
           skipBatch: true,
         },
       },
+      refetchOnMount: false, // prevents refetching loops
     },
   );
   const observation = api.observations.byId.useQuery(
@@ -269,12 +270,13 @@ const TraceObservationIOCell = ({
       traceId: traceId,
     },
     {
-      enabled: !!traceId && !!observationId,
+      enabled: observationId !== undefined,
       trpc: {
         context: {
           skipBatch: true,
         },
       },
+      refetchOnMount: false, // prevents refetching loops
     },
   );
 
@@ -311,6 +313,7 @@ const DatasetItemIOCell = ({
           skipBatch: true,
         },
       },
+      refetchOnMount: false, // prevents refetching loops
     },
   );
 


### PR DESCRIPTION
In some cases, this reduces the number of requests a lot and blocks potential looping state refreshes