### PR TITLE
fix: adds error handling to chat completion calls

### DIFF
--- a/web/src/features/playground/client/context/index.tsx
+++ b/web/src/features/playground/client/context/index.tsx
@@ -268,7 +268,9 @@ async function* getChatCompletionStream(
   });
 
   if (!result.ok) {
-    throw new Error("Failed to fetch data: " + result.statusText);
+    const errorData = await result.json();
+
+    throw new Error(`Completion failed: ${errorData.message}`);
   }
 
   const reader = result.body?.getReader();

--- a/web/src/features/playground/server/chatCompletionHandler.ts
+++ b/web/src/features/playground/server/chatCompletionHandler.ts
@@ -30,6 +30,8 @@ export default async function chatCompletionHandler(req: NextRequest) {
   try {
     body = validateChatCompletionBody(await req.json());
   } catch (err) {
+    console.error(err);
+
     return NextResponse.json(
       {
         message: "Invalid request body",
@@ -39,13 +41,29 @@ export default async function chatCompletionHandler(req: NextRequest) {
     );
   }
 
-  const { messages, modelParams } = body;
-  const stream = await fetchLLMCompletion({
-    messages,
-    modelParams,
-    streaming: true,
-    functionCall: undefined,
-  });
+  try {
+    const { messages, modelParams } = body;
+    const stream = await fetchLLMCompletion({
+      messages,
+      modelParams,
+      streaming: true,
+      functionCall: undefined,
+    });
 
-  return new StreamingTextResponse(stream);
+    return new StreamingTextResponse(stream);
+  } catch (err) {
+    console.error(err);
+
+    if (err instanceof Error) {
+      return NextResponse.json(
+        {
+          message: err.message,
+          error: err,
+        },
+        { status: 500 },
+      );
+    }
+
+    throw err;
+  }
 }


### PR DESCRIPTION
Adds error handling to chat completion calls.

For example, Anthropic requires at least one message excluding the system message. (OpenAI is fine with a system message only). With this PR, users will see the error message from Anthropic in the UI when attempting an invalid completion.