### PR TITLE
chore: add web/src/ee

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,9 +2,9 @@ Copyright (c) 2023 Finto Technologies GmbH
 
 Portions of this software are licensed as follows:
 
-* All content that resides under the "ee/" directory of this repository, if that directory exists, is licensed under the license defined in "ee/LICENSE".
-* All third party components incorporated into the Finto Technologies Software are licensed under the original license provided by the owner of the applicable component.
-* Content outside of the above mentioned directories or restrictions above is available under the "MIT Expat" license as defined below.
+- All content that resides under the "ee/" and/or "web/src/ee" directories of this repository, if these directories exist, is licensed under the license defined in "ee/LICENSE".
+- All third party components incorporated into the Finto Technologies Software are licensed under the original license provided by the owner of the applicable component.
+- Content outside of the above mentioned directories or restrictions above is available under the "MIT Expat" license as defined below.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@ See the [→ Quickstart](https://langfuse.com/docs/get-started) to integrate Lan
 
 ### Integrations
 
-| Integration                                                      | Supports      | Description                                                      |
-| ---------------------------------------------------------------- | ------------- | ---------------------------------------------------------------- |
-| [**SDK** - _recommended_](https://langfuse.com/docs/sdk)         | Python, JS/TS | Manual instrumentation using the SDKs for full flexibility.      |
-| [OpenAI SDK](https://langfuse.com/docs/integrations/openai)      | Python, JS/TS | Automated instrumentation of OpenAI SDK.                         |
-| [Langchain](https://langfuse.com/docs/integrations/langchain)    | Python, JS/TS | Instrumentation via Langchain callbacks.                         |
-| [LlamaIndex](https://langfuse.com/docs/integrations/llama-index) | Python        | Automated instrumentation via LlamaIndex callback system.        |
-| [API](https://langfuse.com/docs/api)                             |               | Directly call the public API. OpenAPI spec available.            |
+| Integration                                                      | Supports      | Description                                                 |
+| ---------------------------------------------------------------- | ------------- | ----------------------------------------------------------- |
+| [**SDK** - _recommended_](https://langfuse.com/docs/sdk)         | Python, JS/TS | Manual instrumentation using the SDKs for full flexibility. |
+| [OpenAI SDK](https://langfuse.com/docs/integrations/openai)      | Python, JS/TS | Automated instrumentation of OpenAI SDK.                    |
+| [Langchain](https://langfuse.com/docs/integrations/langchain)    | Python, JS/TS | Instrumentation via Langchain callbacks.                    |
+| [LlamaIndex](https://langfuse.com/docs/integrations/llama-index) | Python        | Automated instrumentation via LlamaIndex callback system.   |
+| [API](https://langfuse.com/docs/api)                             |               | Directly call the public API. OpenAPI spec available.       |
 
 External projects/packages that integrate with Langfuse:
 
@@ -142,7 +142,7 @@ In order of preference the best way to communicate with us:
 
 ## License
 
-This repository is MIT licensed, except for the `ee/` folder. See [LICENSE](LICENSE) and [docs](https://langfuse.com/docs/open-source) for more details.
+This repository is MIT licensed, except for the `ee` folders. See [LICENSE](LICENSE) and [docs](https://langfuse.com/docs/open-source) for more details.
 
 ## Misc
 

--- a/web/src/ee/README.md
+++ b/web/src/ee/README.md
@@ -2,4 +2,4 @@
 
 This folder includes features that are only available in the Enterprise Edition of Langfuse and on Langfuse Cloud.
 
-See [LICENSE](../LICENSE) and [docs](https://langfuse.com/docs/open-source) for more details.
+See [LICENSE](../../../LICENSE) and [docs](https://langfuse.com/docs/open-source) for more details.


### PR DESCRIPTION
This change adds a second folder (`/web/src/ee`) to store `ee` content. Previously all was in `/ee`.

This change helps to ship new `ee` frontend features faster without requiring a big refactoring.