### PR TITLE
fix: missing tokenizer model in isTiktokenModel

### DIFF
--- a/web/src/utils/types.ts
+++ b/web/src/utils/types.ts
@@ -127,5 +127,6 @@ export const isTiktokenModel = (model: string): model is TiktokenModel => {
     "gpt-3.5-turbo-16k-0613",
     "gpt-4-1106-preview",
     "gpt-4-vision-preview",
+    "gpt-4-turbo-2024-04-09",
   ].includes(model);
 };


### PR DESCRIPTION
## What does this PR do?

Usage and total cost are missing in traces using the `gpt-4-turbo-2024-04-09` model because its `tokenizerModel` was changed in https://github.com/langfuse/langfuse/pull/1807 but the new one was not added in `isTiktokenModel()` resulting in the following error:
```
Invalid tokenizer config for model cluv2t5k3000508ih5kve9zag: {"tokensPerName":1,"tokenizerModel":"gpt-4-turbo-2024-04-09","tokensPerMessage":3}, {"issues":[{"code":"custom","message":"Unknown tiktoken model","path":["tokenizerModel"]}],"name":"ZodError"}
```

I tested my change locally and it works :tm: 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)