### PR TITLE
fix: add labels to fern definition for prompt return types

### DIFF
--- a/fern/apis/server/definition/prompts.yml
+++ b/fern/apis/server/definition/prompts.yml
@@ -89,6 +89,7 @@ types:
       name: string
       version: integer
       config: unknown
+      labels: list<string>
 
   ChatMessage:
     properties:

--- a/web/generated/openapi-server/openapi.yml
+++ b/web/generated/openapi-server/openapi.yml
@@ -2693,10 +2693,15 @@ components:
         version:
           type: integer
         config: {}
+        labels:
+          type: array
+          items:
+            type: string
       required:
         - name
         - version
         - config
+        - labels
     ChatMessage:
       title: ChatMessage
       type: object


### PR DESCRIPTION
Add labels to fern definition for prompt return types.