### PR TITLE
fix: make latest label a reserved label

### DIFF
--- a/packages/shared/prisma/seed.ts
+++ b/packages/shared/prisma/seed.ts
@@ -72,7 +72,7 @@ async function main() {
       name: "summary-prompt",
       project: { connect: { id: seedProjectId } },
       prompt: "prompt {{variable}} {{anotherVariable}}",
-      labels: ["production"],
+      labels: ["production", "latest"],
       version: 1,
       createdBy: "user-1",
     },
@@ -764,7 +764,7 @@ async function generatePrompts(project: Project) {
       prompt: "Prompt 1 content",
       name: "Prompt 1",
       version: 1,
-      labels: ["production"],
+      labels: ["production", "latest"],
     },
     {
       id: `prompt-${v4()}`,
@@ -773,7 +773,7 @@ async function generatePrompts(project: Project) {
       prompt: "Prompt 2 content",
       name: "Prompt 2",
       version: 1,
-      labels: ["production"],
+      labels: ["production", "latest"],
     },
     {
       id: `prompt-${v4()}`,
@@ -782,7 +782,7 @@ async function generatePrompts(project: Project) {
       prompt: "Prompt 3 content",
       name: "Prompt 3 by API",
       version: 1,
-      labels: ["production"],
+      labels: ["production", "latest"],
     },
     {
       id: `prompt-${v4()}`,
@@ -791,7 +791,7 @@ async function generatePrompts(project: Project) {
       prompt: "Prompt 4 content",
       name: "Prompt 4",
       version: 1,
-      labels: ["production"],
+      labels: ["production", "latest"],
       tags: ["tag1", "tag2"],
     },
   ];
@@ -859,6 +859,7 @@ async function generatePrompts(project: Project) {
         frequencyPenalty: 0.5,
       },
       version: 3,
+      labels: ["production", "latest"],
     },
   ];
 
@@ -908,7 +909,7 @@ async function generatePrompts(project: Project) {
         prompt: `${promptName} version ${i} content`,
         name: promptName,
         version: i,
-        labels: i === 20 ? ["production"] : [],
+        labels: i === 20 ? ["production", "latest"] : [],
       },
       update: {
         id: promptId,

--- a/web/src/features/prompts/components/SetPromptVersionLabels/AddLabelForm.tsx
+++ b/web/src/features/prompts/components/SetPromptVersionLabels/AddLabelForm.tsx
@@ -14,9 +14,13 @@ import { Input } from "@/src/components/ui/input";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { PromptLabelSchema } from "@/src/features/prompts/server/utils/validation";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { isReservedPromptLabel } from "@/src/features/prompts/utils";
 
 const AddLabelFormSchema = z.object({
-  newLabel: PromptLabelSchema,
+  newLabel: PromptLabelSchema.refine(
+    (val) => !isReservedPromptLabel(val),
+    "Custom label cannot be 'latest' or 'production'",
+  ),
 });
 
 type AddLabelFromSchemaType = z.infer<typeof AddLabelFormSchema>;

--- a/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
+++ b/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
@@ -22,6 +22,7 @@ import { AddLabelForm } from "./AddLabelForm";
 import { LabelCommandItem } from "./LabelCommandItem";
 import { PRODUCTION_LABEL } from "@/src/features/prompts/constants";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { isReservedPromptLabel } from "@/src/features/prompts/utils";
 
 export function SetPromptVersionLabels({ prompt }: { prompt: Prompt }) {
   const projectId = useProjectIdFromURL();
@@ -128,7 +129,7 @@ export function SetPromptVersionLabels({ prompt }: { prompt: Prompt }) {
                 ref={customLabelScrollRef}
               >
                 {labels
-                  .filter((l) => l !== PRODUCTION_LABEL)
+                  .filter((l) => !isReservedPromptLabel(l))
                   .map((label) => (
                     <LabelCommandItem
                       key={label}

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -19,6 +19,7 @@ import {
   singleFilter,
   tableColumnsToSqlFilterAndPrefix,
 } from "@langfuse/shared";
+import { LATEST_PROMPT_LABEL } from "@/src/features/prompts/constants";
 
 const PromptFilterOptions = z.object({
   projectId: z.string(), // Required for protectedProjectProcedure
@@ -312,12 +313,44 @@ export const promptRouter = createTRPCRouter({
           ctx.prisma,
         );
 
-        await ctx.prisma.prompt.delete({
-          where: {
-            id: input.promptVersionId,
-            projectId: input.projectId,
-          },
-        });
+        const transaction = [
+          ctx.prisma.prompt.delete({
+            where: {
+              id: input.promptVersionId,
+              projectId: input.projectId,
+            },
+          }),
+        ];
+
+        // If the deleted prompt was the latest version, update the latest prompt
+        if (promptVersion.labels.includes(LATEST_PROMPT_LABEL)) {
+          const newLatestPrompt = await ctx.prisma.prompt.findFirst({
+            where: {
+              projectId: input.projectId,
+              name: promptVersion.name,
+              id: { not: input.promptVersionId },
+            },
+            orderBy: [{ version: "desc" }],
+          });
+
+          if (newLatestPrompt) {
+            transaction.push(
+              ctx.prisma.prompt.update({
+                where: {
+                  id: newLatestPrompt.id,
+                  projectId: input.projectId,
+                },
+                data: {
+                  labels: {
+                    push: LATEST_PROMPT_LABEL,
+                  },
+                },
+              }),
+            );
+          }
+        }
+
+        await ctx.prisma.$transaction(transaction);
       } catch (e) {
         console.log(e);
         throw e;

--- a/web/src/features/prompts/utils.ts
+++ b/web/src/features/prompts/utils.ts
@@ -1,0 +1,8 @@
+import {
+  LATEST_PROMPT_LABEL,
+  PRODUCTION_LABEL,
+} from "@/src/features/prompts/constants";
+
+export const isReservedPromptLabel = (label: string) => {
+  return [PRODUCTION_LABEL, LATEST_PROMPT_LABEL].includes(label);
+};


### PR DESCRIPTION
- Do not allow setting / unsetting 'latest' label in UI
- If latest prompt version is getting deleted, set the 'latest' label on the next prompt version if any