### PR TITLE
fix(api): align get/v2/prompts meta response with api spec

### DIFF
--- a/web/src/__tests__/prompts.v2.servertest.ts
+++ b/web/src/__tests__/prompts.v2.servertest.ts
@@ -784,10 +784,10 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       expect(promptMeta3.tags).toEqual(["tag-1"]);
 
       // Validate pagination
-      expect(body.pagination.page).toBe(1);
-      expect(body.pagination.limit).toBe(10);
-      expect(body.pagination.totalPages).toBe(1);
-      expect(body.pagination.totalItems).toBe(3);
+      expect(body.meta.page).toBe(1);
+      expect(body.meta.limit).toBe(10);
+      expect(body.meta.totalPages).toBe(1);
+      expect(body.meta.totalItems).toBe(3);
     });
 
     it("should fetch a prompt meta list with name filter", async () => {
@@ -802,10 +802,10 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       expect(body.data[0].tags).toEqual([]);
 
       // Validate pagination
-      expect(body.pagination.page).toBe(1);
-      expect(body.pagination.limit).toBe(10);
-      expect(body.pagination.totalPages).toBe(1);
-      expect(body.pagination.totalItems).toBe(1);
+      expect(body.meta.page).toBe(1);
+      expect(body.meta.limit).toBe(10);
+      expect(body.meta.totalPages).toBe(1);
+      expect(body.meta.totalItems).toBe(1);
 
       // Test with a different name
       const response2 = await makeAPICall("GET", `${baseURI}?name=prompt-2`);
@@ -819,10 +819,10 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       expect(body2.data[0].tags).toEqual([]);
 
       // Validate pagination
-      expect(body2.pagination.page).toBe(1);
-      expect(body2.pagination.limit).toBe(10);
-      expect(body2.pagination.totalPages).toBe(1);
-      expect(body2.pagination.totalItems).toBe(1);
+      expect(body2.meta.page).toBe(1);
+      expect(body2.meta.limit).toBe(10);
+      expect(body2.meta.totalPages).toBe(1);
+      expect(body2.meta.totalItems).toBe(1);
 
       // Return 200 with empty list if name does not exist
       const response3 = await makeAPICall(
@@ -846,10 +846,10 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       expect(body.data[0].tags).toEqual(["tag-1"]);
 
       // Validate pagination
-      expect(body.pagination.page).toBe(1);
-      expect(body.pagination.limit).toBe(10);
-      expect(body.pagination.totalPages).toBe(1);
-      expect(body.pagination.totalItems).toBe(1);
+      expect(body.meta.page).toBe(1);
+      expect(body.meta.limit).toBe(10);
+      expect(body.meta.totalPages).toBe(1);
+      expect(body.meta.totalItems).toBe(1);
 
       // Return 200 with empty list if tag does not exist
       const response3 = await makeAPICall("GET", `${baseURI}?tag=non-existent`);
@@ -875,10 +875,10 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       ).toBe(true);
 
       // Validate pagination
-      expect(body.pagination.page).toBe(1);
-      expect(body.pagination.limit).toBe(10);
-      expect(body.pagination.totalPages).toBe(1);
-      expect(body.pagination.totalItems).toBe(3);
+      expect(body.meta.page).toBe(1);
+      expect(body.meta.limit).toBe(10);
+      expect(body.meta.totalPages).toBe(1);
+      expect(body.meta.totalItems).toBe(3);
 
       // Test with a different label
       const response2 = await makeAPICall("GET", `${baseURI}?label=dev`);
@@ -892,10 +892,10 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       expect(body2.data[0].tags).toEqual([]);
 
       // Validate pagination
-      expect(body2.pagination.page).toBe(1);
-      expect(body2.pagination.limit).toBe(10);
-      expect(body2.pagination.totalPages).toBe(1);
-      expect(body2.pagination.totalItems).toBe(1);
+      expect(body2.meta.page).toBe(1);
+      expect(body2.meta.limit).toBe(10);
+      expect(body2.meta.totalPages).toBe(1);
+      expect(body2.meta.totalItems).toBe(1);
 
       // Return 200 with empty list if label does not exist
       const response3 = await makeAPICall(
@@ -914,10 +914,10 @@ describe("/api/public/v2/prompts API Endpoint", () => {
     const body = response.body as unknown as PromptsMetaResponse;
 
     expect(body.data).toHaveLength(1);
-    expect(body.pagination.page).toBe(1);
-    expect(body.pagination.limit).toBe(1);
-    expect(body.pagination.totalPages).toBe(3);
-    expect(body.pagination.totalItems).toBe(3);
+    expect(body.meta.page).toBe(1);
+    expect(body.meta.limit).toBe(1);
+    expect(body.meta.totalPages).toBe(3);
+    expect(body.meta.totalItems).toBe(3);
   });
 });
 

--- a/web/src/__tests__/prompts.v2.servertest.ts
+++ b/web/src/__tests__/prompts.v2.servertest.ts
@@ -788,6 +788,13 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       expect(body.meta.limit).toBe(10);
       expect(body.meta.totalPages).toBe(1);
       expect(body.meta.totalItems).toBe(3);
+
+      // Validate pagination backwards compatibility
+      // https://github.com/langfuse/langfuse/issues/2068
+      expect(body.pagination?.page).toBe(1);
+      expect(body.pagination?.limit).toBe(10);
+      expect(body.pagination?.totalPages).toBe(1);
+      expect(body.pagination?.totalItems).toBe(3);
     });
 
     it("should fetch a prompt meta list with name filter", async () => {

--- a/web/src/features/prompts/server/actions/getPromptsMeta.ts
+++ b/web/src/features/prompts/server/actions/getPromptsMeta.ts
@@ -47,7 +47,7 @@ export const getPromptsMeta = async (
 
   return {
     data: promptsMeta,
-    pagination: { page, limit, totalPages, totalItems },
+    meta: { page, limit, totalPages, totalItems },
   };
 };
 
@@ -60,7 +60,7 @@ type PromptsMeta = {
 
 export type PromptsMetaResponse = {
   data: PromptsMeta[];
-  pagination: {
+  meta: {
     page: number;
     limit: number;
     totalPages: number;

--- a/web/src/features/prompts/server/actions/getPromptsMeta.ts
+++ b/web/src/features/prompts/server/actions/getPromptsMeta.ts
@@ -72,7 +72,7 @@ export type PromptsMetaResponse = {
   };
   // necessary for backwards compatibility as we initially released the /v2/prompts endpoint with this structure which did not match the api spec
   // https://github.com/langfuse/langfuse/issues/2068
-  pagination?: {
+  pagination: {
     page: number;
     limit: number;
     totalPages: number;

--- a/web/src/features/prompts/server/actions/getPromptsMeta.ts
+++ b/web/src/features/prompts/server/actions/getPromptsMeta.ts
@@ -48,7 +48,10 @@ export const getPromptsMeta = async (
   return {
     data: promptsMeta,
     meta: { page, limit, totalPages, totalItems },
-    pagination: { page, limit, totalPages, totalItems }, // backwards compatibility
+
+    // necessary for backwards compatibility as we initially released the /v2/prompts endpoint with this structure which did not match the api spec
+    // https://github.com/langfuse/langfuse/issues/2068
+    pagination: { page, limit, totalPages, totalItems },
   };
 };
 
@@ -68,6 +71,7 @@ export type PromptsMetaResponse = {
     totalItems: number;
   };
   // necessary for backwards compatibility as we initially released the /v2/prompts endpoint with this structure which did not match the api spec
+  // https://github.com/langfuse/langfuse/issues/2068
   pagination?: {
     page: number;
     limit: number;

--- a/web/src/features/prompts/server/actions/getPromptsMeta.ts
+++ b/web/src/features/prompts/server/actions/getPromptsMeta.ts
@@ -48,6 +48,7 @@ export const getPromptsMeta = async (
   return {
     data: promptsMeta,
     meta: { page, limit, totalPages, totalItems },
+    pagination: { page, limit, totalPages, totalItems }, // backwards compatibility
   };
 };
 
@@ -61,6 +62,13 @@ type PromptsMeta = {
 export type PromptsMetaResponse = {
   data: PromptsMeta[];
   meta: {
+    page: number;
+    limit: number;
+    totalPages: number;
+    totalItems: number;
+  };
+  // necessary for backwards compatibility as we initially released the /v2/prompts endpoint with this structure which did not match the api spec
+  pagination?: {
     page: number;
     limit: number;
     totalPages: number;


### PR DESCRIPTION
Fixes #2068

Keep `pagination` for backwards compatibility