### PR TITLE
fix(ui): do not run llm api key query when it is not available

### DIFF
--- a/web/src/features/public-api/components/LLMApiKeyList.tsx
+++ b/web/src/features/public-api/components/LLMApiKeyList.tsx
@@ -59,7 +59,7 @@ export function LlmApiKeyList(props: { projectId: string }) {
       projectId: props.projectId,
     },
     {
-      enabled: hasAccess,
+      enabled: hasAccess && env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== undefined,
     },
   );
 


### PR DESCRIPTION
this error message showed up when self-hosting langfuse as this route is currently only used on langfuse cloud (preview features which are in public beta and will be released with v3)

![CleanShot 2024-06-02 at 01 31 34](https://github.com/langfuse/langfuse/assets/2834609/5da2c4d9-c99b-423c-84e5-093d2724e233)
