### PR TITLE
fix: skip git hooks in release-it

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,13 @@
   "release-it": {
     "git": {
       "commitMessage": "chore: release v${version}",
-      "tagName": "v${version}"
+      "tagName": "v${version}",
+      "commitArgs": [
+        "--no-verify"
+      ],
+      "pushArgs": [
+        "--no-verify"
+      ]
     },
     "plugins": {
       "@release-it/bumper": {


### PR DESCRIPTION
Release it is not showing prompts from git hooks. Skip git hooks via the `--no-verify` flag.