### PR TITLE
Remove hard coded ref to public schema

### DIFF
--- a/packages/shared/prisma/migrations/20240530212419_model_price_anthropic_via_google_vertex/migration.sql
+++ b/packages/shared/prisma/migrations/20240530212419_model_price_anthropic_via_google_vertex/migration.sql
@@ -1,7 +1,7 @@
 -- Google Vertex uses @ to separate model name and version
 
-UPDATE "public"."models" SET "match_pattern" = '(?i)^(claude-3-haiku(-|@)?20240307)$' WHERE "id" = 'cltr0w45b000008k1407o9qv1';
+UPDATE models SET "match_pattern" = '(?i)^(claude-3-haiku(-|@)?20240307)$' WHERE "id" = 'cltr0w45b000008k1407o9qv1';
 
-UPDATE "public"."models" SET "match_pattern" = '(?i)^(claude-3-opus(-|@)?20240229)$' WHERE "id" = 'cltgy0iuw000008le3vod1hhy';
+UPDATE models SET "match_pattern" = '(?i)^(claude-3-opus(-|@)?20240229)$' WHERE "id" = 'cltgy0iuw000008le3vod1hhy';
 
-UPDATE "public"."models" SET "match_pattern" = '(?i)^(claude-3-sonnet(-|@)?20240229)$' WHERE "id" = 'cltgy0pp6000108le56se7bl3';
+UPDATE models SET "match_pattern" = '(?i)^(claude-3-sonnet(-|@)?20240229)$' WHERE "id" = 'cltgy0pp6000108le56se7bl3';

--- a/packages/shared/prisma/migrations/20240606090858_pricings_add_latest_gemini_models/migration.sql
+++ b/packages/shared/prisma/migrations/20240606090858_pricings_add_latest_gemini_models/migration.sql
@@ -1,5 +1,5 @@
 -- does not include pricing yet, will be added as soon as it is calculated at ingestion time
 
-INSERT INTO "public"."models" ("id", "model_name", "match_pattern", "unit") VALUES ('clx30djsn0000w9mzebiv41we', 'gemini-1.5-flash', '(?i)^(gemini-1.5-flash)(@[a-zA-Z0-9]+)?$', 'CHARACTERS');
+INSERT INTO models ("id", "model_name", "match_pattern", "unit") VALUES ('clx30djsn0000w9mzebiv41we', 'gemini-1.5-flash', '(?i)^(gemini-1.5-flash)(@[a-zA-Z0-9]+)?$', 'CHARACTERS');
 
-INSERT INTO "public"."models" ("id", "model_name", "match_pattern", "unit") VALUES ('clx30hkrx0000w9mz7lqi0ial', 'gemini-1.5-pro', '(?i)^(gemini-1.5-pro)(@[a-zA-Z0-9]+)?$', 'CHARACTERS');
+INSERT INTO models ("id", "model_name", "match_pattern", "unit") VALUES ('clx30hkrx0000w9mz7lqi0ial', 'gemini-1.5-pro', '(?i)^(gemini-1.5-pro)(@[a-zA-Z0-9]+)?$', 'CHARACTERS');


### PR DESCRIPTION
Prevents errors when using a custom schema

## What does this PR do?

When using a custom schema the table `"public"."models"` does not exist so these migrations will error. This PR changes the two files that use this format so that they instead reference the table as `models`, consistent with other migrations.

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [ x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
