### PR TITLE
fix: fern api types for public scores endpoint

### DIFF
--- a/fern/apis/server/definition/score.yml
+++ b/fern/apis/server/definition/score.yml
@@ -31,7 +31,7 @@ service:
             type: optional<datetime>
             docs: Retrieve only scores newer than this datetime (ISO 8601).
           source:
-            type: commons.ScoreSource
+            type: optional<commons.ScoreSource>
             docs: Retrieve only scores from a specific source.
           operator:
             type: optional<string>
@@ -40,7 +40,7 @@ service:
             type: optional<double>
             docs: Retrieve only scores with <operator> value.
           scoreIds:
-            type: optional<list<string>>
+            type: optional<string>
             docs: Comma-separated list of score IDs to limit the results to.
       response: Scores
     get-by-id:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -997,9 +997,10 @@ paths:
         - name: source
           in: query
           description: Retrieve only scores from a specific source.
-          required: true
+          required: false
           schema:
             $ref: '#/components/schemas/ScoreSource'
+            nullable: true
         - name: operator
           in: query
           description: Retrieve only scores with <operator> value.

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -808,7 +808,7 @@
                 {
                   "key": "scoreIds",
                   "value": "",
-                  "description": "Retrieve only scores with the given ids."
+                  "description": "Comma-separated list of score IDs to limit the results to."
                 }
               ],
               "variable": []


### PR DESCRIPTION
Fix Fern api types for public scores endpoint