### PR TITLE
perf: increase chatCompletion function timeout

### DIFF
--- a/web/src/app/api/chatCompletion/route.ts
+++ b/web/src/app/api/chatCompletion/route.ts
@@ -1,6 +1,6 @@
 import chatCompletionHandler from "@/src/ee/features/playground/server/chatCompletionHandler";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 60;
+export const maxDuration = 120;
 
 export const POST = chatCompletionHandler;


### PR DESCRIPTION
Increase chatcompletion handler timeout to avoid truncated responses for long generations.