### PR TITLE
perf: optimize indices

### DIFF
--- a/packages/shared/prisma/migrations/20240618164950_drop_observations_parent_observation_id_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20240618164950_drop_observations_parent_observation_id_idx/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX IF EXISTS "observations_parent_observation_id_idx";

--- a/packages/shared/prisma/migrations/20240618164950_drop_observations_parent_observation_id_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20240618164950_drop_observations_parent_observation_id_idx/migration.sql
@@ -1,2 +1,2 @@
 -- DropIndex
-DROP INDEX IF EXISTS "observations_parent_observation_id_idx";
+DROP INDEX CONCURRENTLY IF EXISTS "observations_parent_observation_id_idx";

--- a/packages/shared/prisma/migrations/20240618164951_drop_observations_updated_at_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20240618164951_drop_observations_updated_at_idx/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX IF EXISTS "observations_updated_at_idx";

--- a/packages/shared/prisma/migrations/20240618164951_drop_observations_updated_at_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20240618164951_drop_observations_updated_at_idx/migration.sql
@@ -1,2 +1,2 @@
 -- DropIndex
-DROP INDEX IF EXISTS "observations_updated_at_idx";
+DROP INDEX CONCURRENTLY IF EXISTS "observations_updated_at_idx";

--- a/packages/shared/prisma/migrations/20240618164952_drop_scores_updated_at_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20240618164952_drop_scores_updated_at_idx/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX IF EXISTS "scores_updated_at_idx";

--- a/packages/shared/prisma/migrations/20240618164952_drop_scores_updated_at_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20240618164952_drop_scores_updated_at_idx/migration.sql
@@ -1,2 +1,2 @@
 -- DropIndex
-DROP INDEX IF EXISTS "scores_updated_at_idx";
+DROP INDEX CONCURRENTLY IF EXISTS "scores_updated_at_idx";

--- a/packages/shared/prisma/migrations/20240618164953_drop_traces_external_id_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20240618164953_drop_traces_external_id_idx/migration.sql
@@ -1,2 +1,2 @@
 -- DropIndex
-DROP INDEX IF EXISTS "traces_external_id_idx";
+DROP INDEX CONCURRENTLY IF EXISTS "traces_external_id_idx";

--- a/packages/shared/prisma/migrations/20240618164953_drop_traces_external_id_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20240618164953_drop_traces_external_id_idx/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX IF EXISTS "traces_external_id_idx";

--- a/packages/shared/prisma/migrations/20240618164954_drop_traces_release_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20240618164954_drop_traces_release_idx/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX IF EXISTS "traces_release_idx";

--- a/packages/shared/prisma/migrations/20240618164954_drop_traces_release_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20240618164954_drop_traces_release_idx/migration.sql
@@ -1,2 +1,2 @@
 -- DropIndex
-DROP INDEX IF EXISTS "traces_release_idx";
+DROP INDEX CONCURRENTLY IF EXISTS "traces_release_idx";

--- a/packages/shared/prisma/migrations/20240618164955_drop_traces_updated_at_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20240618164955_drop_traces_updated_at_idx/migration.sql
@@ -1,2 +1,2 @@
 -- DropIndex
-DROP INDEX IF EXISTS "traces_updated_at_idx";
+DROP INDEX CONCURRENTLY IF EXISTS "traces_updated_at_idx";

--- a/packages/shared/prisma/migrations/20240618164955_drop_traces_updated_at_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20240618164955_drop_traces_updated_at_idx/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX IF EXISTS "traces_updated_at_idx";

--- a/packages/shared/prisma/migrations/20240618164956_create_traces_project_id_timestamp_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20240618164956_create_traces_project_id_timestamp_idx/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY "traces_project_id_timestamp_idx" ON "traces"("project_id", "timestamp");

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -242,14 +242,12 @@ model Trace {
     JobExecution JobExecution[]
 
     @@index([projectId])
+    @@index([projectId, timestamp])
     @@index([sessionId])
     @@index([name])
     @@index([userId])
     @@index([id, userId])
-    @@index([externalId])
     @@index(timestamp)
-    @@index(release)
-    @@index(updatedAt)
     @@index(createdAt)
     @@index([tags(ops: ArrayOps)], type: Gin)
     @@map("traces")
@@ -328,9 +326,7 @@ model Observation {
     @@index([type])
     @@index(startTime)
     @@index(createdAt)
-    @@index(updatedAt)
     @@index(projectId)
-    @@index(parentObservationId)
     @@index(model)
     @@index(internalModel)
     @@index([projectId, promptId])
@@ -429,7 +425,6 @@ model Score {
     @@index([observationId], type: Hash)
     @@index([source])
     @@index([createdAt])
-    @@index([updatedAt])
     @@map("scores")
 }
 


### PR DESCRIPTION
Remove the following indices:

- observations_updated_at_idx
- observations_parent_observation_id_idx
- traces_release_idx
- traces_external_id_idx
- traces_updated_at_idx
- scores_updated_at_idx

Add the following index:

- traces: timestamp + project_id