### PR TITLE
chore: removing 'version' from docker-compose.yml file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   langfuse-server:
     image: langfuse/langfuse:2


### PR DESCRIPTION
## What does this PR do?

removed 'version' tag from docker-compose.yml file as 'version' was made obsolete
[reference](https://forums.docker.com/t/docker-compose-yml-version-is-obsolete/141313/2)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.