### PR TITLE
fix: ordering of ingestion events by timestamp

### DIFF
--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -165,21 +165,24 @@ export default async function handler(
   }
 }
 
+/**
+ * Sorts a batch of ingestion events. Orders by: updating events last, sorted by timestamp asc.
+ */
+
 const sortBatch = (batch: Array<z.infer<typeof ingestionEvent>>) => {
-  // keep the order of events as they are. Order events in a way that types containing updates come last
-  // Filter out OBSERVATION_UPDATE events
+  const updateEvents: (typeof eventTypes)[keyof typeof eventTypes][] = [
+    eventTypes.GENERATION_UPDATE,
+    eventTypes.SPAN_UPDATE,
+    eventTypes.OBSERVATION_UPDATE, // legacy event type
+  ];
   const updates = batch
-    .filter((event) => event.type === eventTypes.OBSERVATION_UPDATE)
+    .filter((event) => updateEvents.includes(event.type))
     .sort((a, b) => {
-      // Sort updates by timestamp ascending
       return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
     });
-
-  // Keep all other events in their original order
   const others = batch
-    .filter((event) => event.type !== eventTypes.OBSERVATION_UPDATE)
+    .filter((event) => !updateEvents.includes(event.type))
     .sort((a, b) => {
-      // Sort updates by timestamp ascending
       return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
     });
 

--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -171,7 +171,7 @@ const sortBatch = (batch: Array<z.infer<typeof ingestionEvent>>) => {
   const updates = batch
     .filter((event) => event.type === eventTypes.OBSERVATION_UPDATE)
     .sort((a, b) => {
-      // Sort updates by timestamp
+      // Sort updates by timestamp ascending
       return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
     });
 
@@ -179,7 +179,7 @@ const sortBatch = (batch: Array<z.infer<typeof ingestionEvent>>) => {
   const others = batch
     .filter((event) => event.type !== eventTypes.OBSERVATION_UPDATE)
     .sort((a, b) => {
-      // Sort updates by timestamp
+      // Sort updates by timestamp ascending
       return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
     });
 

--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -168,14 +168,20 @@ export default async function handler(
 const sortBatch = (batch: Array<z.infer<typeof ingestionEvent>>) => {
   // keep the order of events as they are. Order events in a way that types containing updates come last
   // Filter out OBSERVATION_UPDATE events
-  const updates = batch.filter(
-    (event) => event.type === eventTypes.OBSERVATION_UPDATE,
-  );
+  const updates = batch
+    .filter((event) => event.type === eventTypes.OBSERVATION_UPDATE)
+    .sort((a, b) => {
+      // Sort updates by timestamp
+      return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+    });
 
   // Keep all other events in their original order
-  const others = batch.filter(
-    (event) => event.type !== eventTypes.OBSERVATION_UPDATE,
-  );
+  const others = batch
+    .filter((event) => event.type !== eventTypes.OBSERVATION_UPDATE)
+    .sort((a, b) => {
+      // Sort updates by timestamp
+      return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+    });
 
   // Return the array with non-update events first, followed by update events
   return [...others, ...updates];


### PR DESCRIPTION
In case integrations send events out of order, they shall be ordered by timestamp again in the ingestion pipeline