### PR TITLE
fix: include scores with missing traces in ui and api

### DIFF
--- a/web/src/pages/api/public/scores.ts
+++ b/web/src/pages/api/public/scores.ts
@@ -144,7 +144,7 @@ export default async function handler(
             s.observation_id as "observationId",
             json_build_object('userId', t.user_id) as "trace"
           FROM "scores" AS s
-          JOIN "traces" AS t ON t.id = s.trace_id AND t.project_id = ${authCheck.scope.projectId}
+          LEFT JOIN "traces" AS t ON t.id = s.trace_id AND t.project_id = ${authCheck.scope.projectId}
           WHERE s.project_id = ${authCheck.scope.projectId}
           ${userCondition}
           ${nameCondition}
@@ -160,7 +160,7 @@ export default async function handler(
         Prisma.sql`
           SELECT COUNT(*) as count
           FROM "scores" AS s
-          JOIN "traces" AS t ON t.id = s.trace_id AND t.project_id = ${authCheck.scope.projectId}
+          LEFT JOIN "traces" AS t ON t.id = s.trace_id AND t.project_id = ${authCheck.scope.projectId}
           WHERE s.project_id = ${authCheck.scope.projectId}
           ${userCondition}
           ${nameCondition}

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -331,7 +331,7 @@ const generateScoresQuery = (
   SELECT
    ${select}
   FROM scores s
-  JOIN traces t ON t.id = s.trace_id AND t.project_id = ${projectId}
+  LEFT JOIN traces t ON t.id = s.trace_id AND t.project_id = ${projectId}
   LEFT JOIN job_executions je ON je.job_output_score_id = s.id AND je.project_id = ${projectId}
   LEFT JOIN users u ON u.id = s.author_user_id
   WHERE s.project_id = ${projectId}


### PR DESCRIPTION
since recently, traceids on scores are not verified at ingestion time to increase ingestion throughput and avoid requiring ordering of requests. however, the scores were not shown in tables due to a JOIN on traces. fixed with this pr.