### PR TITLE
fix: keep the tmp col on backfill script

### DIFF
--- a/web/scripts/observations-backfill-calculated-cost.ts
+++ b/web/scripts/observations-backfill-calculated-cost.ts
@@ -123,10 +123,10 @@ const backfillCalculatedGenerationCost = async () => {
 
     log("✅ Finished batch update loop.");
 
-    // Drop the temporary column
-    log("Dropping temporary column...");
-    await prisma.$executeRaw`ALTER TABLE observations DROP COLUMN IF EXISTS tmp_has_calculated_cost;`;
-    log("✅ Dropped temporary column");
+    // // Drop the temporary column
+    // log("Dropping temporary column...");
+    // await prisma.$executeRaw`ALTER TABLE observations DROP COLUMN IF EXISTS tmp_has_calculated_cost;`;
+    // log("✅ Dropped temporary column");
 
     log("✅ Finished backfillCalculatedGenerationCost");
   } catch (err) {


### PR DESCRIPTION
Keep the tmp col on backfill script