### PR TITLE
chore: fixes flaky vitest suite by running in child process

### DIFF
--- a/worker/package.json
+++ b/worker/package.json
@@ -8,7 +8,7 @@
     "node": ">=20"
   },
   "scripts": {
-    "test": "dotenv -e ../.env -- vitest run --reporter=basic ",
+    "test": "dotenv -e ../.env -- vitest run --reporter=basic --pool=forks",
     "coverage": "vitest run --coverage",
     "start": "dotenv -e ../.env -- node dist/index.js",
     "build": "tsc",


### PR DESCRIPTION
Fixes flaky vitest suite by running in child process.

Saw error `free(): invalid next size (fast)` when running vitest, issue mentioned here: https://github.com/vitest-dev/vitest/issues/4882