### PR TITLE
chore: run arm builds on tagged commits only

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -292,7 +292,7 @@ jobs:
           labels: ${{ steps.meta-web.outputs.labels }}
           platforms: |
             linux/amd64
-            linux/arm64
+            ${{ startsWith(github.ref, 'refs/tags/') && 'linux/arm64' || '' }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta-worker
@@ -319,4 +319,4 @@ jobs:
           labels: ${{ steps.meta-worker.outputs.labels }}
           platforms: |
             linux/amd64
-            linux/arm64
+            ${{ startsWith(github.ref, 'refs/tags/') && 'linux/arm64' || '' }}


### PR DESCRIPTION
linux/arm64 builds take 60 min in GitHub actions. This PR runs these builds only on tagged releases instead of on every commit on main in order to conserve GitHub actions resources.