### PR TITLE
perf(dashboards): read directly from observations table for costs

### DIFF
--- a/web/src/features/dashboard/components/MetricTable.tsx
+++ b/web/src/features/dashboard/components/MetricTable.tsx
@@ -23,7 +23,7 @@ export const MetricTable = ({
     {
       projectId,
       from: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION // Langfuse Cloud has already completed the cost backfill job, thus cost can be pulled directly from obs. table
-        ? "traces_observations"
+        ? "observations"
         : "traces_observationsview",
       select: [
         { column: "calculatedTotalCost", agg: "SUM" },

--- a/web/src/features/dashboard/components/ModelUsageChart.tsx
+++ b/web/src/features/dashboard/components/ModelUsageChart.tsx
@@ -37,7 +37,7 @@ export const ModelUsageChart = ({
     {
       projectId,
       from: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION // Langfuse Cloud has already completed the cost backfill job, thus cost can be pulled directly from obs. table
-        ? "traces_observations"
+        ? "observations"
         : "traces_observationsview",
       select: [
         { column: "totalTokens", agg: "SUM" },


### PR DESCRIPTION
Read directly from observations table for costs to make efficient use of indices