### PR TITLE
fix(ingestion): allow nested objects in modelParams

### DIFF
--- a/packages/shared/src/features/ingestion/types.ts
+++ b/packages/shared/src/features/ingestion/types.ts
@@ -108,7 +108,13 @@ export const CreateGenerationBody = CreateSpanBody.extend({
     .record(
       z.string(),
       z
-        .union([z.string(), z.number(), z.boolean(), z.array(z.string())])
+        .union([
+          z.string(),
+          z.number(),
+          z.boolean(),
+          z.array(z.string()),
+          z.record(z.string()),
+        ])
         .nullish()
     )
     .nullish(),
@@ -130,7 +136,13 @@ export const UpdateGenerationBody = UpdateSpanBody.extend({
     .record(
       z.string(),
       z
-        .union([z.string(), z.number(), z.boolean(), z.array(z.string())])
+        .union([
+          z.string(),
+          z.number(),
+          z.boolean(),
+          z.array(z.string()),
+          z.record(z.string()),
+        ])
         .nullish()
     )
     .nullish(),

--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -148,7 +148,11 @@ export const ObservationPreview = (props: {
                     .filter(Boolean)
                     .map(([key, value]) => (
                       <Badge variant="outline" key={key}>
-                        {key}: {value?.toString()}
+                        {key}:{" "}
+                        {Object.prototype.toString.call(value) ===
+                        "[object Object]"
+                          ? JSON.stringify(value)
+                          : value?.toString()}
                       </Badge>
                     ))
                 : null}


### PR DESCRIPTION
OpenAI passes a nested object with key `response_format` if that option is used. Allow it on the ingestion endpoint.