### PR TITLE
feat(models): add new `REQUESTS` unit

### DIFF
--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -292,6 +292,7 @@ types:
       - MILLISECONDS
       - SECONDS
       - IMAGES
+      - REQUESTS
   ObservationLevel:
     enum:
       - DEBUG

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -632,7 +632,7 @@ model Model {
     inputPrice      Decimal?  @map("input_price")
     outputPrice     Decimal?  @map("output_price")
     totalPrice      Decimal?  @map("total_price")
-    unit            String // TOKENS, CHARACTERS, MILLISECONDS, SECONDS, or IMAGES
+    unit            String // TOKENS, CHARACTERS, MILLISECONDS, SECONDS, REQUESTS, or IMAGES
     tokenizerId     String?   @map("tokenizer_id")
     tokenizerConfig Json?     @map("tokenizer_config")
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -6,4 +6,5 @@ export enum ModelUsageUnit {
   Seconds = "SECONDS",
   Milliseconds = "MILLISECONDS",
   Images = "IMAGES",
+  Requests = "REQUESTS",
 }

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -2650,6 +2650,7 @@ components:
         - MILLISECONDS
         - SECONDS
         - IMAGES
+        - REQUESTS
       description: Unit of usage in Langfuse
     ObservationLevel:
       title: ObservationLevel

--- a/web/src/__tests__/ingestion.servertest.ts
+++ b/web/src/__tests__/ingestion.servertest.ts
@@ -59,6 +59,17 @@ describe("/api/public/ingestion API Endpoint", () => {
     },
     {
       usage: {
+        input: 1,
+        output: 2,
+        unit: ModelUsageUnit.Requests,
+      },
+      expectedUnit: ModelUsageUnit.Requests,
+      expectedPromptTokens: 1,
+      expectedCompletionTokens: 2,
+      expectedTotalTokens: 3,
+    },
+    {
+      usage: {
         input: 30,
         output: 10,
         unit: ModelUsageUnit.Seconds,

--- a/web/src/components/table/use-cases/models.tsx
+++ b/web/src/components/table/use-cases/models.tsx
@@ -43,7 +43,7 @@ const modelConfigDescriptions = {
   outputPrice: "Price per 1000 units of output",
   totalPrice:
     "Price per 1000 units, for models that don't have input/output specific prices",
-  unit: "Unit of measurement for generative model, can be TOKENS, CHARACTERS, SECONDS, MILLISECONDS, or IMAGES.",
+  unit: "Unit of measurement for generative model, can be TOKENS, CHARACTERS, SECONDS, MILLISECONDS, REQUESTS or IMAGES.",
   tokenizerId:
     "Tokenizer used for this model to calculate token counts if none are ingested. Pick from list of supported tokenizers.",
   config:

--- a/web/src/features/public-api/types/models.ts
+++ b/web/src/features/public-api/types/models.ts
@@ -1,5 +1,5 @@
 import {
-  type ModelUsageUnit,
+  type ModelUsageUnit as PrismaModelUsageUnit,
   paginationMetaResponseZod,
   paginationZod,
   type Model as PrismaModel,
@@ -11,7 +11,16 @@ import { z } from "zod";
  * Objects
  */
 
-const ModelDefinition = z
+const APIModelUsageUnit = z.enum([
+  "TOKENS",
+  "CHARACTERS",
+  "MILLISECONDS",
+  "SECONDS",
+  "REQUESTS",
+  "IMAGES",
+]);
+
+const APIModelDefinition = z
   .object({
     id: z.string(),
     modelName: z.string(),
@@ -20,7 +29,7 @@ const ModelDefinition = z
     inputPrice: z.number().nonnegative().nullable(),
     outputPrice: z.number().nonnegative().nullable(),
     totalPrice: z.number().nonnegative().nullable(),
-    unit: z.enum(["TOKENS", "CHARACTERS", "MILLISECONDS", "SECONDS", "IMAGES"]),
+    unit: APIModelUsageUnit,
     tokenizerId: z.string().nullable(),
     tokenizerConfig: z.any(), // Assuming Prisma.JsonValue is any type
     isLangfuseManaged: z.boolean(),
@@ -41,10 +50,10 @@ export function prismaToApiModelDefinition({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   updatedAt,
   ...model
-}: PrismaModel): z.infer<typeof ModelDefinition> {
+}: PrismaModel): z.infer<typeof APIModelDefinition> {
   return {
     ...model,
-    unit: unit as ModelUsageUnit,
+    unit: unit as PrismaModelUsageUnit,
     inputPrice: inputPrice?.toNumber() ?? null,
     outputPrice: outputPrice?.toNumber() ?? null,
     totalPrice: totalPrice?.toNumber() ?? null,
@@ -62,7 +71,7 @@ export const GetModelsV1Query = z.object({
 });
 export const GetModelsV1Response = z
   .object({
-    data: z.array(ModelDefinition),
+    data: z.array(APIModelDefinition),
     meta: paginationMetaResponseZod,
   })
   .strict();
@@ -76,7 +85,7 @@ export const PostModelsV1Body = z
     inputPrice: z.number().nonnegative().nullish(),
     outputPrice: z.number().nonnegative().nullish(),
     totalPrice: z.number().nonnegative().nullish(),
-    unit: z.enum(["TOKENS", "CHARACTERS", "MILLISECONDS", "SECONDS", "IMAGES"]),
+    unit: APIModelUsageUnit,
     tokenizerId: z.enum(["openai", "claude"]).nullish(),
     tokenizerConfig: jsonSchema.nullish(), // Assuming Prisma.JsonValue is any type
   })
@@ -92,13 +101,13 @@ export const PostModelsV1Body = z
       message: "If input and/or output price is set, total price must be null",
     },
   );
-export const PostModelsV1Response = ModelDefinition.strict();
+export const PostModelsV1Response = APIModelDefinition.strict();
 
 // GET /models/{modelId}
 export const GetModelV1Query = z.object({
   modelId: z.string(),
 });
-export const GetModelV1Response = ModelDefinition.strict();
+export const GetModelV1Response = APIModelDefinition.strict();
 
 // DELETE /models/{modelId}
 export const DeleteModelV1Query = z.object({


### PR DESCRIPTION
Why include this unit? For example, to account for the pricing of APIs used as tools.

Context ([discord](https://discord.com/channels/1111061815649124414/1111063505563562064/1262545690723221617))

> I'd like to be able to have a "custom-model" that is priced per API call(s), to support costing in function calls during a trace
> - it seem possible today to "hack" this in by adding a "custom model" and abusing one of the current unit types
> - would it be possible to add a unit for CALLS or REQUESTS?
>
> example trace:
> 1. generate routing LLM response
> 2. call Bing Search API
> 3. N calls to proxy/scrape API
> 4. generate "real-time" RAG response
> 
> 2 & 3 would be the kind of thing I'd like to capture. For something like execution seconds for running generated code in a python container, the existing time units seem to have that covered