### PR TITLE
 fix: build shared package before running `models:migrate`

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -17,7 +17,7 @@
     "db:push": {},
     "db:seed": {},
     "models:migrate": {
-      "dependsOn": ["db:generate"]
+      "dependsOn": ["db:generate", "@langfuse/shared#build"]
     },
     "db:seed:examples": {},
     "dev": {


### PR DESCRIPTION
Fixes #2702