### PR TITLE
fix(ui): prevents email address overflow in user menu box

### DIFF
--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -388,8 +388,11 @@ export default function Layout(props: PropsWithChildren) {
                 leaveFrom="transform opacity-100 scale-100"
                 leaveTo="transform opacity-0 scale-95"
               >
-                <Menu.Items className="absolute -top-full bottom-1 right-0 z-10 grid overflow-hidden rounded-md bg-background pt-2 shadow-lg ring-1 ring-border focus:outline-none">
-                  <span className="block overflow-hidden text-ellipsis border-b px-3 pb-2 text-sm leading-6 text-muted-foreground">
+                <Menu.Items className="absolute -top-full bottom-1 right-0 z-10 overflow-hidden rounded-md bg-background py-2 shadow-lg ring-1 ring-border focus:outline-none">
+                  <span
+                    className="block max-w-44 overflow-hidden text-ellipsis border-b px-3 pb-2 text-sm leading-6 text-muted-foreground"
+                    title={session.data?.user?.email ?? undefined}
+                  >
                     {session.data?.user?.email}
                   </span>
                   {userNavigation.map((item) => (
@@ -454,7 +457,10 @@ export default function Layout(props: PropsWithChildren) {
               leaveTo="transform opacity-0 scale-95"
             >
               <Menu.Items className="absolute right-0 z-10 mt-2.5 rounded-md bg-background py-2 pb-1 shadow-lg ring-1 ring-border focus:outline-none">
-                <span className="mb-1 block border-b px-3 pb-2 text-sm leading-6 text-muted-foreground">
+                <span
+                  className="mb-1 block max-w-44 overflow-hidden text-ellipsis whitespace-nowrap border-b px-3 pb-2 text-sm leading-6 text-muted-foreground"
+                  title={session.data?.user?.email ?? undefined}
+                >
                   {session.data?.user?.email}
                 </span>
                 {userNavigation.map((item) => (

--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -388,8 +388,8 @@ export default function Layout(props: PropsWithChildren) {
                 leaveFrom="transform opacity-100 scale-100"
                 leaveTo="transform opacity-0 scale-95"
               >
-                <Menu.Items className="absolute -top-full bottom-1 right-0 z-10 overflow-hidden rounded-md bg-background py-2 shadow-lg ring-1 ring-border focus:outline-none">
-                  <span className="block border-b px-3 pb-2 text-sm leading-6 text-muted-foreground">
+                <Menu.Items className="absolute -top-full bottom-1 right-0 z-10 grid overflow-hidden rounded-md bg-background pt-2 shadow-lg ring-1 ring-border focus:outline-none">
+                  <span className="block overflow-hidden text-ellipsis border-b px-3 pb-2 text-sm leading-6 text-muted-foreground">
                     {session.data?.user?.email}
                   </span>
                   {userNavigation.map((item) => (

--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -458,7 +458,7 @@ export default function Layout(props: PropsWithChildren) {
             >
               <Menu.Items className="absolute right-0 z-10 mt-2.5 rounded-md bg-background py-2 pb-1 shadow-lg ring-1 ring-border focus:outline-none">
                 <span
-                  className="mb-1 block max-w-44 overflow-hidden text-ellipsis whitespace-nowrap border-b px-3 pb-2 text-sm leading-6 text-muted-foreground"
+                  className="mb-1 block max-w-44 overflow-hidden text-ellipsis border-b px-3 pb-2 text-sm leading-6 text-muted-foreground"
                   title={session.data?.user?.email ?? undefined}
                 >
                   {session.data?.user?.email}


### PR DESCRIPTION
## What does this PR do?

This PR simply fixes the user email position in the menu box, inside the sidebar, preventing text overflow on the page when the user's email is quite long, as shown in this screenshot:

![image](https://github.com/user-attachments/assets/256576df-533a-4160-ab41-912a0f37ce9b)

Fixes # (issue)

https://github.com/user-attachments/assets/976330ed-b884-4cb7-a384-6348370b84bc


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
