### PR TITLE
 feat(ui): extend max prompt label length to 36 characters

### DIFF
--- a/web/src/features/prompts/server/utils/validation.ts
+++ b/web/src/features/prompts/server/utils/validation.ts
@@ -15,7 +15,7 @@ export enum PromptType {
 export const PromptLabelSchema = z
   .string()
   .min(1)
-  .max(20)
+  .max(36)
   .regex(
     /^[a-z0-9_\-.]+$/,
     "Label must be lowercase alphanumeric with optional underscores, hyphens, or periods",


### PR DESCRIPTION
Ad discussed here: https://github.com/orgs/langfuse/discussions/2812