### PR TITLE
feat(api): add `lastConfig` attribute and `fromUpdatedAt` and `toUpdatedAt` query params to `GET /v2/prompts`

### DIFF
--- a/fern/apis/server/definition/prompts.yml
+++ b/fern/apis/server/definition/prompts.yml
@@ -41,6 +41,12 @@ service:
           limit:
             type: optional<integer>
             docs: limit of items per page
+          fromUpdatedAt:
+            type: optional<datetime>
+            docs: Optional filter to only include prompt versions created/updated on or after a certain datetime (ISO 8601)
+          toUpdatedAt:
+            type: optional<datetime>
+            docs: Optional filter to only include prompt versions created/updated before a certain datetime (ISO 8601)
 
       response: PromptMetaListResponse
 

--- a/fern/apis/server/definition/prompts.yml
+++ b/fern/apis/server/definition/prompts.yml
@@ -64,6 +64,9 @@ types:
       labels: list<string>
       tags: list<string>
       lastUpdatedAt: datetime
+      lastConfig:
+        type: unknown
+        docs: Config object of the most recent prompt version that matches the filters (if any are provided)
 
   CreatePromptRequest:
     union:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -1188,6 +1188,26 @@ paths:
           schema:
             type: integer
             nullable: true
+        - name: fromUpdatedAt
+          in: query
+          description: >-
+            Optional filter to only include prompt versions created/updated on
+            or after a certain datetime (ISO 8601)
+          required: false
+          schema:
+            type: string
+            format: date-time
+            nullable: true
+        - name: toUpdatedAt
+          in: query
+          description: >-
+            Optional filter to only include prompt versions created/updated
+            before a certain datetime (ISO 8601)
+          required: false
+          schema:
+            type: string
+            format: date-time
+            nullable: true
       responses:
         '200':
           description: ''

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3690,12 +3690,17 @@ components:
         lastUpdatedAt:
           type: string
           format: date-time
+        lastConfig:
+          description: >-
+            Config object of the most recent prompt version that matches the
+            filters (if any are provided)
       required:
         - name
         - versions
         - labels
         - tags
         - lastUpdatedAt
+        - lastConfig
     CreatePromptRequest:
       title: CreatePromptRequest
       oneOf:

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -877,7 +877,7 @@
           "request": {
             "description": "Get a list of prompt names with versions and labels",
             "url": {
-              "raw": "{{baseUrl}}/api/public/v2/prompts?name=&label=&tag=&page=&limit=",
+              "raw": "{{baseUrl}}/api/public/v2/prompts?name=&label=&tag=&page=&limit=&fromUpdatedAt=&toUpdatedAt=",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -912,6 +912,16 @@
                   "key": "limit",
                   "value": "",
                   "description": "limit of items per page"
+                },
+                {
+                  "key": "fromUpdatedAt",
+                  "value": "",
+                  "description": "Optional filter to only include prompt versions created/updated on or after a certain datetime (ISO 8601)"
+                },
+                {
+                  "key": "toUpdatedAt",
+                  "value": "",
+                  "description": "Optional filter to only include prompt versions created/updated before a certain datetime (ISO 8601)"
                 }
               ],
               "variable": []

--- a/web/src/features/prompts/server/actions/getPromptsMeta.ts
+++ b/web/src/features/prompts/server/actions/getPromptsMeta.ts
@@ -14,26 +14,55 @@ export const getPromptsMeta = async (
   const { projectId, page, limit } = params;
 
   const promptsMeta = (await prisma.$queryRaw`
-    SELECT
+    WITH latest_version_config AS (
+      SELECT
+          p.name,
+          p.config
+      FROM
+          prompts p
+      WHERE
+          (p.name, p.version) IN (
+              SELECT
+                  p.name,
+                  MAX(p.version)
+              FROM
+                  prompts p -- needs to be p for filter conditions
+              WHERE
+                  p."project_id" = ${projectId}
+                  ${getPromptsFilterCondition(params)}
+              GROUP BY
+                  p.name
+        )
+      AND p."project_id" = ${projectId}
+    ), versions AS (
+      SELECT
         p.name AS name,
         MAX(p.tags) AS tags,  -- use max to get tags, they are the same for all versions of a prompt
         MAX(p.updated_at) as "lastUpdatedAt",
         array_agg(DISTINCT p.version) AS versions,
         COALESCE(array_agg(DISTINCT label) FILTER (WHERE label IS NOT NULL), '{}'::text[]) AS labels --- COALESCE is necessary to return an empty array if there are no labels and remove NULLs
+      FROM
+          prompts p -- needs to be p for filter conditions
+      LEFT JOIN LATERAL unnest(p.labels) AS label ON true
+      WHERE 
+          p."project_id" = ${projectId} 
+          ${getPromptsFilterCondition(params)}
+      GROUP BY
+          p.name
+      ORDER BY
+          p.name --- necessary for consistent pagination
+      LIMIT
+          ${limit}
+      OFFSET
+          ${limit * (page - 1)}
+    )
+
+    SELECT
+      v.*,
+      l.config AS "lastConfig"
     FROM
-        prompts p
-    LEFT JOIN LATERAL unnest(p.labels) AS label ON true
-    WHERE 
-        p."project_id" = ${projectId} 
-        ${getPromptsFilterCondition(params)}
-    GROUP BY
-        p.name
-    ORDER BY
-        p.name --- necessary for consistent pagination
-    LIMIT
-        ${limit}
-    OFFSET
-        ${limit * (page - 1)}
+      versions v
+    LEFT JOIN latest_version_config l ON v.name = l.name
   `) as PromptsMeta[];
 
   const [{ count: totalItemsCount }] = (await prisma.$queryRaw`
@@ -62,6 +91,7 @@ type PromptsMeta = {
   labels: string[];
   tags: string[];
   lastUpdatedAt: Date;
+  lastConfig: unknown; // json object
 };
 
 export type PromptsMetaResponse = {

--- a/web/src/features/prompts/server/actions/getPromptsMeta.ts
+++ b/web/src/features/prompts/server/actions/getPromptsMeta.ts
@@ -113,7 +113,7 @@ export type PromptsMetaResponse = {
 };
 
 const getPromptsFilterCondition = (params: GetPromptsMetaType) => {
-  const { name, version, label, tag } = params;
+  const { name, version, label, tag, fromUpdatedAt, toUpdatedAt } = params;
   const filters: FilterState = [];
 
   if (name) {
@@ -149,6 +149,24 @@ const getPromptsFilterCondition = (params: GetPromptsMetaType) => {
       type: "arrayOptions",
       operator: "any of",
       value: [tag],
+    });
+  }
+
+  if (fromUpdatedAt) {
+    filters.push({
+      column: "updatedAt",
+      type: "datetime",
+      operator: ">=",
+      value: new Date(fromUpdatedAt),
+    });
+  }
+
+  if (toUpdatedAt) {
+    filters.push({
+      column: "updatedAt",
+      type: "datetime",
+      operator: "<",
+      value: new Date(toUpdatedAt),
     });
   }
 

--- a/web/src/features/prompts/server/utils/validation.ts
+++ b/web/src/features/prompts/server/utils/validation.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { jsonSchema } from "@langfuse/shared";
 import type { Prompt } from "@langfuse/shared";
-import { stringDateTime } from "@langfuse/shared/src/server";
 
 export const ChatMessageSchema = z.object({
   role: z.string(),
@@ -68,8 +67,8 @@ export const GetPromptsMetaSchema = z.object({
   tag: z.string().optional(),
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(100).default(10),
-  fromUpdatedAt: stringDateTime.nullish(),
-  toUpdatedAt: stringDateTime.nullish(),
+  fromUpdatedAt: z.string().datetime({ offset: true }).nullish(),
+  toUpdatedAt: z.string().datetime({ offset: true }).nullish(),
 });
 
 export type GetPromptsMetaType = z.infer<typeof GetPromptsMetaSchema>;

--- a/web/src/features/prompts/server/utils/validation.ts
+++ b/web/src/features/prompts/server/utils/validation.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { jsonSchema } from "@langfuse/shared";
 import type { Prompt } from "@langfuse/shared";
+import { stringDateTime } from "@langfuse/shared/src/server";
 
 export const ChatMessageSchema = z.object({
   role: z.string(),
@@ -67,6 +68,8 @@ export const GetPromptsMetaSchema = z.object({
   tag: z.string().optional(),
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(100).default(10),
+  fromUpdatedAt: stringDateTime.nullish(),
+  toUpdatedAt: stringDateTime.nullish(),
 });
 
 export type GetPromptsMetaType = z.infer<typeof GetPromptsMetaSchema>;

--- a/web/src/server/api/definitions/promptsTable.ts
+++ b/web/src/server/api/definitions/promptsTable.ts
@@ -24,6 +24,12 @@ export const promptsTableCols: ColumnDefinition[] = [
     internal: 'p."created_at"',
   },
   {
+    name: "Updated At",
+    id: "updatedAt",
+    type: "datetime",
+    internal: 'p."updated_at"',
+  },
+  {
     name: "Type",
     id: "type",
     type: "stringOptions",


### PR DESCRIPTION
based on discussion: #2684 