### PR TITLE
fix(auth): Cannot read properties of undefined, GoogleProfile.hd

### DIFF
--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -445,10 +445,11 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             env.AUTH_GOOGLE_ALLOWED_DOMAINS?.split(",").map((domain) =>
               domain.trim().toLowerCase(),
             ) ?? [];
+          
           if (allowedDomains.length > 0) {
             return await Promise.resolve(
               allowedDomains.includes(
-                (profile as GoogleProfile).hd.toLowerCase(),
+                (profile as GoogleProfile).hd?.toLowerCase(),
               ),
             );
           }


### PR DESCRIPTION
Fix: cannot read properties of undefined (reading 'toLowerCase') whe accessing GoogleProfile.hd.

As mentioned by the documentation (https://developers.google.com/identity/openid-connect/openid-connect#an-id-tokens-payload), GoogleProfile.hd can be null, hence, I have changed the code to check that before trying to run `toLowerCase()` 

## What does this PR do?
Fixes # ([issue](https://github.com/langfuse/langfuse/issues/3017))

<img width="1020" alt="Screenshot 2024-08-22 at 17 29 08" src="https://github.com/user-attachments/assets/5e05f944-b8ec-498f-bec6-2d7cf0cf90ae">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.