### PR TITLE
feat: fallback to synchronous ingestion if queue unavailable

### DIFF
--- a/packages/shared/src/server/redis/legacy-ingestion.ts
+++ b/packages/shared/src/server/redis/legacy-ingestion.ts
@@ -2,28 +2,32 @@ import { Queue } from "bullmq";
 import { QueueName, TQueueJobTypes } from "../queues";
 import { createNewRedisInstance } from "./redis";
 
-let legacyIngestionQueue: Queue<
-  TQueueJobTypes[QueueName.LegacyIngestionQueue]
-> | null = null;
+export class LegacyIngestionQueue {
+  private static instance: Queue<
+    TQueueJobTypes[QueueName.LegacyIngestionQueue]
+  > | null = null;
 
-export const getLegacyIngestionQueue = () => {
-  if (legacyIngestionQueue) return legacyIngestionQueue;
+  public static getInstance(): Queue<
+    TQueueJobTypes[QueueName.LegacyIngestionQueue]
+  > | null {
+    if (LegacyIngestionQueue.instance) return LegacyIngestionQueue.instance;
 
-  const newRedis = createNewRedisInstance();
+    const newRedis = createNewRedisInstance({ enableOfflineQueue: false });
 
-  legacyIngestionQueue = newRedis
-    ? new Queue<TQueueJobTypes[QueueName.LegacyIngestionQueue]>(
-        QueueName.LegacyIngestionQueue,
-        {
-          connection: newRedis,
-          defaultJobOptions: {
-            removeOnComplete: true,
-            removeOnFail: 100,
-            attempts: 5,
+    LegacyIngestionQueue.instance = newRedis
+      ? new Queue<TQueueJobTypes[QueueName.LegacyIngestionQueue]>(
+          QueueName.LegacyIngestionQueue,
+          {
+            connection: newRedis,
+            defaultJobOptions: {
+              removeOnComplete: true,
+              removeOnFail: 100,
+              attempts: 5,
+            },
           },
-        }
-      )
-    : null;
+        )
+      : null;
 
-  return legacyIngestionQueue;
-};
+    return LegacyIngestionQueue.instance;
+  }
+}

--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -1,11 +1,14 @@
-import Redis from "ioredis";
+import Redis, { RedisOptions } from "ioredis";
 import { env } from "../../env";
 
-export const createNewRedisInstance = () => {
+export const createNewRedisInstance = (
+  additionalOptions: Partial<RedisOptions> = {},
+) => {
   return env.REDIS_CONNECTION_STRING
     ? new Redis(env.REDIS_CONNECTION_STRING, {
         maxRetriesPerRequest: null,
         enableAutoPipelining: env.REDIS_ENABLE_AUTO_PIPELINING === "true",
+        ...additionalOptions,
       })
     : env.REDIS_HOST
       ? new Redis({
@@ -14,6 +17,7 @@ export const createNewRedisInstance = () => {
           password: String(env.REDIS_AUTH),
           maxRetriesPerRequest: null, // Set to `null` to disable retrying
           enableAutoPipelining: env.REDIS_ENABLE_AUTO_PIPELINING === "true",
+          ...additionalOptions,
         })
       : null;
 };

--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -15,7 +15,7 @@ import {
 import { type NextApiResponse } from "next";
 
 // Business Logic
-// - rate limit strategy is based on org-id, org plan, and resources. Rate limits are appliead in buckets of minutes.
+// - rate limit strategy is based on org-id, org plan, and resources. Rate limits are applied in buckets of minutes.
 // - rate limits are not applied for self hosters and are also not applied when Redis is not available
 // - infos for rate-limits are taken from the API access scope. Info for this scope is stored alongside API Keys in Redis for efficient access.
 // - isRateLimited returns false for self-hosters

--- a/web/src/features/telemetry/index.ts
+++ b/web/src/features/telemetry/index.ts
@@ -13,7 +13,7 @@ export async function telemetry() {
   try {
     // Only run in prod
     if (process.env.NODE_ENV !== "production") return;
-    // Do not run in Lanfuse cloud, separate telemetry is used
+    // Do not run in Langfuse cloud, separate telemetry is used
     if (process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== undefined) return;
     // Check if telemetry is not disabled, except for EE
     if (

--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -3,7 +3,6 @@ import { type NextApiRequest, type NextApiResponse } from "next";
 import { z } from "zod";
 import { LangfuseNotFoundError, InternalServerError } from "@langfuse/shared";
 import {
-  getLegacyIngestionQueue,
   eventTypes,
   ingestionEvent,
   traceException,
@@ -13,6 +12,7 @@ import {
   handleBatch,
   recordIncrement,
   getCurrentSpan,
+  LegacyIngestionQueue,
 } from "@langfuse/shared/src/server";
 import {
   SdkLogProcessor,
@@ -141,43 +141,54 @@ export default async function handler(
 
     if (env.LANGFUSE_ASYNC_INGESTION_PROCESSING === "true" && redis) {
       // this function MUST NOT return but send the HTTP response directly
-      const queue = getLegacyIngestionQueue();
+      const queue = LegacyIngestionQueue.getInstance();
 
       if (queue) {
         // still need to check auth scope for all events individually
 
         const failedAccessScope = accessCheckPerEvent(sortedBatch, authCheck);
 
-        await queue.add(
-          QueueJobs.LegacyIngestionJob,
-          {
-            payload: { data: sortedBatch, authCheck: authCheck },
-            id: randomUUID(),
-            timestamp: new Date(),
-            name: QueueJobs.LegacyIngestionJob as const,
-          },
-          {
-            removeOnFail: 1_000_000,
-            removeOnComplete: true,
-            attempts: 5,
-            backoff: {
-              type: "exponential",
-              delay: 1000,
+        let addToQueueFailed = false;
+        try {
+          await queue.add(
+            QueueJobs.LegacyIngestionJob,
+            {
+              payload: { data: sortedBatch, authCheck: authCheck },
+              id: randomUUID(),
+              timestamp: new Date(),
+              name: QueueJobs.LegacyIngestionJob as const,
             },
-          },
-        );
+            {
+              removeOnFail: 1_000_000,
+              removeOnComplete: true,
+              attempts: 5,
+              backoff: {
+                type: "exponential",
+                delay: 1000,
+              },
+            },
+          );
+        } catch (e: unknown) {
+          console.warn(
+            "Failed to add message to queue. Falling back to synchronous ingestion",
+            e,
+          );
+          addToQueueFailed = true;
+        }
 
-        return handleBatchResult(
-          [
-            ...validationErrors,
-            ...failedAccessScope.map((e) => ({
-              id: e.id,
-              error: "Access Scope Denied",
-            })),
-          ], // we are not sending additional server errors to the client in case of early return
-          sortedBatch.map((event) => ({ id: event.id, result: event })),
-          res,
-        );
+        if (!addToQueueFailed) {
+          return handleBatchResult(
+            [
+              ...validationErrors,
+              ...failedAccessScope.map((e) => ({
+                id: e.id,
+                error: "Access Scope Denied",
+              })),
+            ], // we are not sending additional server errors to the client in case of early return
+            sortedBatch.map((event) => ({ id: event.id, result: event })),
+            res,
+          );
+        }
       } else {
         console.error(
           "Ingestion queue not initialized, falling back to sync processing",

--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -170,7 +170,7 @@ export default async function handler(
           );
         } catch (e: unknown) {
           console.warn(
-            "Failed to add message to queue. Falling back to synchronous ingestion",
+            "Failed to add batch to queue, falling back to sync processing",
             e,
           );
           addToQueueFailed = true;


### PR DESCRIPTION
## What does this PR do?

- Fallback to synchronous ingestion pipeline if Redis is unavailable and adding messages into the queue fails.
- Refactor queue creation into a singleton class to remove global variable.
- Fix a couple typos and apply prettier.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
