### PR TITLE
feat: add new /ready endpoint to separate liveness from readiness

### DIFF
--- a/web/src/pages/api/public/health.ts
+++ b/web/src/pages/api/public/health.ts
@@ -1,7 +1,6 @@
 import { VERSION } from "@/src/constants";
 import { cors, runMiddleware } from "@/src/features/public-api/server/cors";
 import { telemetry } from "@/src/features/telemetry";
-import { isSigtermReceived } from "@/src/utils/shutdown";
 import { prisma } from "@langfuse/shared/src/db";
 import { traceException } from "@langfuse/shared/src/server";
 import { type NextApiRequest, type NextApiResponse } from "next";
@@ -16,15 +15,6 @@ export default async function handler(
     const failIfNoRecentEvents = req.query.failIfNoRecentEvents === "true";
 
     try {
-      if (isSigtermReceived()) {
-        console.log(
-          "Health check failed: SIGTERM / SIGINT received, shutting down.",
-        );
-        return res.status(500).json({
-          status: "SIGTERM / SIGINT received, shutting down",
-          version: VERSION.replace("v", ""),
-        });
-      }
       await prisma.$queryRaw`SELECT 1;`;
 
       if (failIfNoRecentEvents) {

--- a/web/src/pages/api/public/ready.ts
+++ b/web/src/pages/api/public/ready.ts
@@ -1,0 +1,37 @@
+import { VERSION } from "@/src/constants";
+import { cors, runMiddleware } from "@/src/features/public-api/server/cors";
+import { telemetry } from "@/src/features/telemetry";
+import { isSigtermReceived } from "@/src/utils/shutdown";
+import { traceException } from "@langfuse/shared/src/server";
+import { type NextApiRequest, type NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  try {
+    await runMiddleware(req, res, cors);
+    await telemetry();
+
+    if (isSigtermReceived()) {
+      console.log(
+        "Readiness check failed: SIGTERM / SIGINT received, shutting down.",
+      );
+      return res.status(500).json({
+        status: "SIGTERM / SIGINT received, shutting down",
+        version: VERSION.replace("v", ""),
+      });
+    }
+  } catch (e) {
+    traceException(e);
+    console.log("Readiness check failed: ", e);
+    return res.status(503).json({
+      status: "Readiness check failed",
+      version: VERSION.replace("v", ""),
+    });
+  }
+  return res.status(200).json({
+    status: "OK",
+    version: VERSION.replace("v", ""),
+  });
+}

--- a/worker/src/features/health/index.ts
+++ b/worker/src/features/health/index.ts
@@ -3,10 +3,17 @@ import { redis } from "@langfuse/shared/src/server";
 import { Response } from "express";
 import logger from "../../logger";
 
-export const checkContainerHealth = async (res: Response) => {
-  if (isSigtermReceived()) {
+/**
+ * Check the health of the container.
+ * If failOnSigterm is true, the health check will fail if a SIGTERM signal has been received.
+ */
+export const checkContainerHealth = async (
+  res: Response,
+  failOnSigterm: boolean,
+) => {
+  if (failOnSigterm && isSigtermReceived()) {
     logger.info(
-      "Health check failed: SIGTERM / SIGINT received, shutting down."
+      "Health check failed: SIGTERM / SIGINT received, shutting down.",
     );
     return res.status(500).json({
       status: "SIGTERM / SIGINT received, shutting down",
@@ -25,8 +32,8 @@ export const checkContainerHealth = async (res: Response) => {
     new Promise((_, reject) =>
       setTimeout(
         () => reject(new Error("Redis ping timeout after 2 seconds")),
-        2000
-      )
+        2000,
+      ),
     ),
   ]);
 


### PR DESCRIPTION
## What does this PR do?

Adds a new /ready endpoint to track whether the service should accept traffic. We use this to stop receiving traffic after a SIGTERM has been received.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update