### PR TITLE
fix(ui): overflow of long strings in sessions view

### DIFF
--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -196,7 +196,7 @@ const SessionIO = ({
     },
   );
   return (
-    <div className="col-span-2 grid grid-flow-row gap-2 p-0">
+    <div className="col-span-2 flex flex-col gap-2 p-0">
       {!trace.data ? (
         <JsonSkeleton
           className="h-full w-full overflow-hidden px-2 py-1"


### PR DESCRIPTION
before
![CleanShot 2024-09-06 at 19 07 13](https://github.com/user-attachments/assets/90c697af-97fe-424a-a1ec-a4650309f4c5)

after
![CleanShot 2024-09-06 at 19 07 29](https://github.com/user-attachments/assets/58b1bc71-ec40-4632-b82b-722d2dbd0cd9)