### PR TITLE
chore: add worker entrypoint to handle alternative database config

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -61,9 +61,14 @@ RUN addgroup --system --gid 1001 expressjs
 RUN adduser --system --uid 1001 expressjs
 USER expressjs
 COPY --from=builder --chown=expressjs:expressjs /app .
+COPY --chown=expressjs:expressjs ./worker/entrypoint.sh ./worker/entrypoint.sh
+RUN chmod +x ./worker/entrypoint.sh
 
 EXPOSE 3030
 ENV PORT=3030
 
-ENTRYPOINT ["dumb-init", "--", "node", "worker/dist/index.js"]
+ENTRYPOINT ["dumb-init", "--", "./worker/entrypoint.sh"]
+
+# startup command
+CMD ["node", "worker/dist/index.js"]
 

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Run cleanup script before running migrations
+# Check if DATABASE_URL is not set
+if [ -z "$DATABASE_URL" ]; then
+    # Check if all required variables are provided
+    if [ -n "$DATABASE_HOST" ] && [ -n "$DATABASE_USERNAME" ] && [ -n "$DATABASE_PASSWORD" ]  && [ -n "$DATABASE_NAME" ]; then
+        # Construct DATABASE_URL from the provided variables
+        DATABASE_URL="postgresql://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}"
+        export DATABASE_URL
+    else
+        echo "Error: Required database environment variables are not set. Provide a postgres url for DATABASE_URL."
+        exit 1
+    fi
+fi
+
+# Run the command passed to the docker image on start
+exec "$@"


### PR DESCRIPTION
## What does this PR do?

Add an entrypoint script to the worker, comparable to the web container, which instantiates the DATABASE_URL if alternative database config method is used.