### PR TITLE
fix(ui): populate default prompt data for chat prompts with custom role

### DIFF
--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -22,6 +22,8 @@ export enum ChatMessageRole {
   Assistant = "assistant",
 }
 
+export const ChatMessageDefaultRoleSchema = z.nativeEnum(ChatMessageRole);
+
 export type ModelParams = {
   provider: string;
   adapter: LLMAdapter;

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -4,7 +4,7 @@ import z from "zod";
 export type PromptVariable = { name: string; value: string; isUsed: boolean };
 
 export type ChatMessage = {
-  role: ChatMessageRole;
+  role: ChatMessageRole | string; // Users may ingest any string as role via API/SDK
   content: string;
 };
 

--- a/web/src/components/ChatMessages/ChatMessageComponent.tsx
+++ b/web/src/components/ChatMessages/ChatMessageComponent.tsx
@@ -25,7 +25,8 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
   const toggleRole = () => {
     if (message.role === ChatMessageRole.System) return;
 
-    if (!!availableRoles) {
+    // if user has set custom roles, available roles will be non-empty and we toggle through custom and default roles (assistant, user)
+    if (!!availableRoles && Boolean(availableRoles.length)) {
       let randomRole = availableRoles[roleIndex % availableRoles.length];
       if (randomRole === message.role) {
         randomRole = availableRoles[(roleIndex + 1) % availableRoles.length];
@@ -33,6 +34,7 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
       updateMessage(message.id, "role", randomRole);
       setRoleIndex(roleIndex + 1);
     } else {
+      // if user has not set custom roles, we toggle through default roles (assistant, user)
       updateMessage(
         message.id,
         "role",

--- a/web/src/components/ChatMessages/ChatMessageComponent.tsx
+++ b/web/src/components/ChatMessages/ChatMessageComponent.tsx
@@ -9,27 +9,38 @@ import type { MessagesContext } from "./types";
 
 type ChatMessageProps = Pick<
   MessagesContext,
-  "deleteMessage" | "updateMessage"
+  "deleteMessage" | "updateMessage" | "availableRoles"
 > & { message: ChatMessageWithId };
 
 export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
   message,
   updateMessage,
   deleteMessage,
+  availableRoles,
 }) => {
   const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
   const [textAreaRows, setTextAreaRows] = useState(1);
+  const [roleIndex, setRoleIndex] = useState(1);
 
   const toggleRole = () => {
     if (message.role === ChatMessageRole.System) return;
 
-    updateMessage(
-      message.id,
-      "role",
-      message.role === ChatMessageRole.User
-        ? ChatMessageRole.Assistant
-        : ChatMessageRole.User,
-    );
+    if (!!availableRoles) {
+      let randomRole = availableRoles[roleIndex % availableRoles.length];
+      if (randomRole === message.role) {
+        randomRole = availableRoles[(roleIndex + 1) % availableRoles.length];
+      }
+      updateMessage(message.id, "role", randomRole);
+      setRoleIndex(roleIndex + 1);
+    } else {
+      updateMessage(
+        message.id,
+        "role",
+        message.role === ChatMessageRole.User
+          ? ChatMessageRole.Assistant
+          : ChatMessageRole.User,
+      );
+    }
   };
 
   const handleContentChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
@@ -64,7 +75,7 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
         <Textarea
           ref={textAreaRef}
           id={message.id}
-          className="height-[auto] min-h-6 w-full  font-mono text-xs focus:outline-none"
+          className="height-[auto] min-h-6 w-full font-mono text-xs focus:outline-none"
           placeholder={placeholder}
           value={message.content}
           onChange={handleContentChange}

--- a/web/src/components/ChatMessages/types.ts
+++ b/web/src/components/ChatMessages/types.ts
@@ -1,6 +1,5 @@
 import type { ChatMessageRole, ChatMessageWithId } from "@langfuse/shared";
 
-
 export type MessagesContext = {
   messages: ChatMessageWithId[];
   addMessage: (role: ChatMessageRole, content?: string) => ChatMessageWithId;
@@ -8,6 +7,7 @@ export type MessagesContext = {
   updateMessage: <Key extends keyof ChatMessageWithId>(
     id: string,
     key: Key,
-    value: ChatMessageWithId[Key]
+    value: ChatMessageWithId[Key],
   ) => void;
+  availableRoles?: string[]; // Only defined if user has extended default roles (ChatMessageRole) with custom roles via SDK/API
 };

--- a/web/src/features/prompts/components/NewPromptForm/PromptChatMessages.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/PromptChatMessages.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 
 import { ChatMessages } from "@/src/components/ChatMessages";

--- a/web/src/features/prompts/components/NewPromptForm/PromptChatMessages.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/PromptChatMessages.tsx
@@ -1,9 +1,13 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 
 import { ChatMessages } from "@/src/components/ChatMessages";
 import { createEmptyMessage } from "@/src/components/ChatMessages/utils/createEmptyMessage";
-import { ChatMessageRole, type ChatMessageWithId } from "@langfuse/shared";
+import {
+  ChatMessageRole,
+  ChatMessageDefaultRoleSchema,
+  type ChatMessageWithId,
+} from "@langfuse/shared";
 
 import {
   ChatMessageListSchema,
@@ -23,6 +27,7 @@ export const PromptChatMessages: React.FC<PromptChatMessagesProps> = ({
   initialMessages,
 }) => {
   const [messages, setMessages] = useState<ChatMessageWithId[]>([]);
+  const [availableRoles, setAvailableRoles] = useState<string[]>([]);
 
   useEffect(() => {
     const parsedMessages = ChatMessageListSchema.safeParse(initialMessages);
@@ -39,6 +44,21 @@ export const PromptChatMessages: React.FC<PromptChatMessagesProps> = ({
         id: uuidv4(),
       })),
     );
+
+    const customRoles = parsedMessages.data.reduce((acc, message) => {
+      const { role } = message;
+      if (ChatMessageDefaultRoleSchema.safeParse(role).error) {
+        acc.add(role);
+      }
+      return acc;
+    }, new Set<string>());
+    if (customRoles.size) {
+      setAvailableRoles([
+        ...customRoles,
+        ChatMessageRole.Assistant,
+        ChatMessageRole.User,
+      ]);
+    }
   }, [initialMessages]);
 
   const addMessage: MessagesContext["addMessage"] = (role, content) => {
@@ -65,6 +85,14 @@ export const PromptChatMessages: React.FC<PromptChatMessagesProps> = ({
   }, [messages, onChange]);
 
   return (
-    <ChatMessages {...{ messages, addMessage, deleteMessage, updateMessage }} />
+    <ChatMessages
+      {...{
+        messages,
+        addMessage,
+        deleteMessage,
+        updateMessage,
+        availableRoles,
+      }}
+    />
   );
 };

--- a/web/src/features/prompts/components/NewPromptForm/validation.ts
+++ b/web/src/features/prompts/components/NewPromptForm/validation.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 import { PromptType } from "@/src/features/prompts/server/utils/validation";
-import { ChatMessageRole } from "@langfuse/shared";
+import { ChatMessageDefaultRoleSchema } from "@langfuse/shared";
 
 const ChatMessageSchema = z.object({
-  role: z.union([z.nativeEnum(ChatMessageRole), z.string()]), // Users may ingest any string as role via API/SDK
+  role: z.union([ChatMessageDefaultRoleSchema, z.string()]), // Users may ingest any string as role via API/SDK
   content: z.string(),
 });
 

--- a/web/src/features/prompts/components/NewPromptForm/validation.ts
+++ b/web/src/features/prompts/components/NewPromptForm/validation.ts
@@ -3,7 +3,7 @@ import { PromptType } from "@/src/features/prompts/server/utils/validation";
 import { ChatMessageRole } from "@langfuse/shared";
 
 const ChatMessageSchema = z.object({
-  role: z.nativeEnum(ChatMessageRole),
+  role: z.union([z.nativeEnum(ChatMessageRole), z.string()]), // Users may ingest any string as role via API/SDK
   content: z.string(),
 });
 


### PR DESCRIPTION
- populate default prompt data for chat prompts with custom roles 
   - note: the langfuse API/SDKs allow to ingest prompts with any string as user defined role, see [API reference for details](https://api.reference.langfuse.com/#post-/api/public/v2/prompts)  
- allow to toggle between all available roles (ie `assistant`, `user`) and any custom role given a custom role was present in the original message body 