### PR TITLE
fix: keep more failed jobs in bullmq

### DIFF
--- a/packages/shared/src/server/redis/batch-export.ts
+++ b/packages/shared/src/server/redis/batch-export.ts
@@ -15,7 +15,7 @@ export const getBatchExportQueue = () => {
         connection: connection,
         defaultJobOptions: {
           removeOnComplete: true,
-          removeOnFail: 100,
+          removeOnFail: 10000,
           attempts: 2,
         },
       })

--- a/packages/shared/src/server/redis/batch-export.ts
+++ b/packages/shared/src/server/redis/batch-export.ts
@@ -15,7 +15,7 @@ export const getBatchExportQueue = () => {
         connection: connection,
         defaultJobOptions: {
           removeOnComplete: true,
-          removeOnFail: 10000,
+          removeOnFail: 10_000,
           attempts: 2,
         },
       })

--- a/packages/shared/src/server/redis/batch-export.ts
+++ b/packages/shared/src/server/redis/batch-export.ts
@@ -17,6 +17,10 @@ export const getBatchExportQueue = () => {
           removeOnComplete: true,
           removeOnFail: 10_000,
           attempts: 2,
+          backoff: {
+            type: "exponential",
+            delay: 5000,
+          },
         },
       })
     : null;

--- a/packages/shared/src/server/redis/ingestionFlushQueue.ts
+++ b/packages/shared/src/server/redis/ingestionFlushQueue.ts
@@ -18,7 +18,7 @@ export const getIngestionFlushQueue = () => {
         connection: connection,
         defaultJobOptions: {
           removeOnComplete: true, // Important: If not true, new jobs for that ID would be ignored as jobs in the complete set are still considered as part of the queue
-          removeOnFail: 100000,
+          removeOnFail: 100_000,
           delay: env.LANGFUSE_INGESTION_FLUSH_DELAY_MS,
           attempts: env.LANGFUSE_INGESTION_FLUSH_ATTEMPTS,
         },

--- a/packages/shared/src/server/redis/ingestionFlushQueue.ts
+++ b/packages/shared/src/server/redis/ingestionFlushQueue.ts
@@ -21,6 +21,10 @@ export const getIngestionFlushQueue = () => {
           removeOnFail: 100_000,
           delay: env.LANGFUSE_INGESTION_FLUSH_DELAY_MS,
           attempts: env.LANGFUSE_INGESTION_FLUSH_ATTEMPTS,
+          backoff: {
+            type: "exponential",
+            delay: 5000,
+          },
         },
       })
     : null;

--- a/packages/shared/src/server/redis/ingestionFlushQueue.ts
+++ b/packages/shared/src/server/redis/ingestionFlushQueue.ts
@@ -18,7 +18,7 @@ export const getIngestionFlushQueue = () => {
         connection: connection,
         defaultJobOptions: {
           removeOnComplete: true, // Important: If not true, new jobs for that ID would be ignored as jobs in the complete set are still considered as part of the queue
-          removeOnFail: 1_000,
+          removeOnFail: 100000,
           delay: env.LANGFUSE_INGESTION_FLUSH_DELAY_MS,
           attempts: env.LANGFUSE_INGESTION_FLUSH_ATTEMPTS,
         },

--- a/packages/shared/src/server/redis/legacy-ingestion.ts
+++ b/packages/shared/src/server/redis/legacy-ingestion.ts
@@ -23,6 +23,10 @@ export class LegacyIngestionQueue {
               removeOnComplete: true,
               removeOnFail: 100_000,
               attempts: 5,
+              backoff: {
+                type: "exponential",
+                delay: 5000,
+              },
             },
           },
         )

--- a/packages/shared/src/server/redis/legacy-ingestion.ts
+++ b/packages/shared/src/server/redis/legacy-ingestion.ts
@@ -21,7 +21,7 @@ export class LegacyIngestionQueue {
             connection: newRedis,
             defaultJobOptions: {
               removeOnComplete: true,
-              removeOnFail: 100,
+              removeOnFail: 100000,
               attempts: 5,
             },
           },

--- a/packages/shared/src/server/redis/legacy-ingestion.ts
+++ b/packages/shared/src/server/redis/legacy-ingestion.ts
@@ -21,7 +21,7 @@ export class LegacyIngestionQueue {
             connection: newRedis,
             defaultJobOptions: {
               removeOnComplete: true,
-              removeOnFail: 100000,
+              removeOnFail: 100_000,
               attempts: 5,
             },
           },

--- a/packages/shared/src/server/redis/trace-upsert.ts
+++ b/packages/shared/src/server/redis/trace-upsert.ts
@@ -22,6 +22,11 @@ export const getTraceUpsertQueue = () => {
         defaultJobOptions: {
           removeOnComplete: 100, // Important: If not true, new jobs for that ID would be ignored as jobs in the complete set are still considered as part of the queue
           removeOnFail: 100_000,
+          attempts: 5,
+          backoff: {
+            type: "exponential",
+            delay: 5000,
+          },
         },
       })
     : null;

--- a/packages/shared/src/server/redis/trace-upsert.ts
+++ b/packages/shared/src/server/redis/trace-upsert.ts
@@ -21,7 +21,7 @@ export const getTraceUpsertQueue = () => {
         connection: connection,
         defaultJobOptions: {
           removeOnComplete: 100, // Important: If not true, new jobs for that ID would be ignored as jobs in the complete set are still considered as part of the queue
-          removeOnFail: 100000,
+          removeOnFail: 100_000,
         },
       })
     : null;

--- a/packages/shared/src/server/redis/trace-upsert.ts
+++ b/packages/shared/src/server/redis/trace-upsert.ts
@@ -21,7 +21,7 @@ export const getTraceUpsertQueue = () => {
         connection: connection,
         defaultJobOptions: {
           removeOnComplete: 100, // Important: If not true, new jobs for that ID would be ignored as jobs in the complete set are still considered as part of the queue
-          removeOnFail: 1_000,
+          removeOnFail: 100000,
         },
       })
     : null;
@@ -30,7 +30,7 @@ export const getTraceUpsertQueue = () => {
 };
 
 export function convertTraceUpsertEventsToRedisEvents(
-  events: TraceUpsertEventType[]
+  events: TraceUpsertEventType[],
 ) {
   const uniqueTracesPerProject = events.reduce((acc, event) => {
     if (!acc.get(event.projectId)) {


### PR DESCRIPTION
## What does this PR do?

Increase the number of failed jobs that are kept in bullmq for debugging and replay.