### PR TITLE
fix: use actual singletons for db clients

### DIFF
--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -32,7 +32,6 @@ import "react18-json-view/src/style.css";
 import { DetailPageListsProvider } from "@/src/features/navigate-detail-pages/context";
 import { env } from "@/src/env.mjs";
 import { ThemeProvider } from "@/src/features/theming/ThemeProvider";
-import { shutdown } from "@/src/utils/shutdown";
 import { MarkdownContextProvider } from "@/src/features/theming/useMarkdownContext";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 
@@ -230,7 +229,11 @@ function UserTracking() {
   return null;
 }
 
-if (process.env.NEXT_MANUAL_SIG_HANDLE) {
+if (
+  process.env.NEXT_RUNTIME === "nodejs" &&
+  process.env.NEXT_MANUAL_SIG_HANDLE
+) {
+  const { shutdown } = await import("@/src/utils/shutdown");
   prexit(async (signal) => {
     console.log("Signal: ", signal);
     return await shutdown(signal);

--- a/web/src/utils/shutdown.ts
+++ b/web/src/utils/shutdown.ts
@@ -2,12 +2,12 @@
 // There is no official best way to gracefully shutdown a Next.js app in Docker.
 // This here is a workaround to handle SIGTERM and SIGINT signals.
 // NEVER call process.exit() in this process. Kubernetes should kill the container: https://kostasbariotis.com/why-you-should-not-use-process-exit/
-// We wait for 20 seconds to allow the app to finish processing requests. There is no native way to do this in Next.js.
+// We wait for 110 seconds to allow the app to finish processing requests. There is no native way to do this in Next.js.
 
 import { logger, redis } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 
-const TIMEOUT = 200_000;
+const TIMEOUT = 110_000;
 
 declare global {
   // eslint-disable-next-line no-var

--- a/web/src/utils/shutdown.ts
+++ b/web/src/utils/shutdown.ts
@@ -4,6 +4,8 @@
 // NEVER call process.exit() in this process. Kubernetes should kill the container: https://kostasbariotis.com/why-you-should-not-use-process-exit/
 // We wait for 20 seconds to allow the app to finish processing requests. There is no native way to do this in Next.js.
 
+import { prisma } from "@langfuse/shared/src/db";
+
 const TIMEOUT = 200_000;
 
 declare global {
@@ -43,6 +45,9 @@ export const shutdown = async (signal: PrexitSignal) => {
             return;
           }
           redis?.disconnect();
+
+          await prisma.$disconnect();
+          console.log("Prisma connection has been closed.");
         }
         console.log("Shutdown complete");
         resolve();

--- a/worker/src/utils/shutdown.ts
+++ b/worker/src/utils/shutdown.ts
@@ -6,6 +6,7 @@ import { setSigtermReceived } from "../features/health";
 import { server } from "../index";
 import { freeAllTokenizers } from "../features/tokenisation/usage";
 import { WorkerManager } from "../queues/workerManager";
+import { prisma } from "@langfuse/shared/src/db";
 
 export const onShutdown: NodeJS.SignalsListener = async (signal) => {
   logger.info(`Received ${signal}, closing server...`);
@@ -24,6 +25,9 @@ export const onShutdown: NodeJS.SignalsListener = async (signal) => {
 
   redis?.disconnect();
   logger.info("Redis connection has been closed.");
+
+  await prisma.$disconnect();
+  logger.info("Prisma connection has been closed.");
 
   freeAllTokenizers();
   logger.info("All tokenizers are cleaned up from memory.");


### PR DESCRIPTION
## What

We assume that each import created a new DB client which leads to a connection exhaustion on our DB. With this change, we use true singletons for the prisma and kysely client which should reduce the total number of connections in use.