### PR TITLE
chore: make credentials for export bucket optional

### DIFF
--- a/web/src/server/api/routers/generations/exportQuery/index.ts
+++ b/web/src/server/api/routers/generations/exportQuery/index.ts
@@ -4,6 +4,7 @@ import { env } from "@/src/env.mjs";
 import { BatchExportFileFormat, exportOptions } from "@langfuse/shared";
 import {
   type FullObservations,
+  logger,
   S3StorageService,
 } from "@langfuse/shared/src/server";
 import { protectedProjectProcedure } from "@/src/server/api/trpc";
@@ -72,7 +73,9 @@ export const generationsExportQuery = protectedProjectProcedure
     const endpoint = env.S3_ENDPOINT;
     const region = env.S3_REGION;
 
-    if (accessKeyId && secretAccessKey && bucketName && endpoint && region) {
+    // If bucketName is configured, we expect that the user has some valid S3 setup.
+    if (bucketName) {
+      logger.info(`Preparing export for ${fileName} on S3`);
       const { signedUrl } = await new S3StorageService({
         accessKeyId,
         secretAccessKey,
@@ -93,6 +96,7 @@ export const generationsExportQuery = protectedProjectProcedure
       };
     }
 
+    logger.info(`Preparing export for ${fileName} in memory`);
     // Fall back to returning the data directly. This might fail for large exports due to memory constraints.
     // Self-hosted instances should always run with sufficient memory or have S3 configured to avoid this.
     let fileOutputString = "";


### PR DESCRIPTION
## What does this PR do?

Makes accessKeyId, accessKeySecret, region, and endpoint optional for all export bucket interactions. This has the advantage that we can skip them in our own setup and instead fallback to the default credential provider chain which would use an IAM role that we assign to our service. That way, we can remove long-living credentials from our stack that we've previously used to authenticate with a S3 compliant interface.