### PR TITLE
chore: reduce local psql connection issues

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -3,8 +3,8 @@
 
 # Prisma
 # https://www.prisma.io/docs/reference/database-reference/connection-urls#env
-DIRECT_URL="postgresql://postgres:postgres@localhost:5432/postgres"
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres"
+DIRECT_URL="postgresql://postgres:postgres@localhost:5432/postgres?connection_limit=1"
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres?connection_limit=1"
 
 # Clickhouse
 CLICKHOUSE_MIGRATION_URL="clickhouse://localhost:9000"

--- a/.env.local.example
+++ b/.env.local.example
@@ -3,8 +3,8 @@
 
 # Prisma
 # https://www.prisma.io/docs/reference/database-reference/connection-urls#env
-DIRECT_URL="postgresql://postgres:postgres@db:5432/postgres"
-DATABASE_URL="postgresql://postgres:postgres@db:5432/postgres"
+DIRECT_URL="postgresql://postgres:postgres@db:5432/postgres?connection_limit=1"
+DATABASE_URL="postgresql://postgres:postgres@db:5432/postgres?connection_limit=1"
 # Next Auth
 NEXTAUTH_SECRET="secret"
 NEXTAUTH_URL="http://localhost:3000"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,7 +28,7 @@ services:
   postgres:
     image: postgres:${POSTGRES_VERSION:-latest}
     restart: always
-    command: ["postgres", "-c", "log_statement=all"]
+    command: ["postgres", "-c", "log_statement=all", "-c", "max_connections=500"]
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres


### PR DESCRIPTION
## What does this PR do?

Reduces the connection pool limit on local runs to 1 and increases the max_connections of the development database. Nextjs in local mode has a poor way of handling connections and reinstantiates a client for each recompilation. With this approach, we reduce the impact of this behaviour by limiting the connections that are being blocked per instantiation.