### PR TITLE
chore: update metric name for eval exec queue length

### DIFF
--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -309,7 +309,6 @@ export default async function handler(
      *******************/
     const result = await handleBatch(sortedBatch, authCheck, tokenCount);
 
-    // send out REST requests to worker for all trace types
     await addTracesToTraceUpsertQueue(
       result.results,
       authCheck.scope.projectId,

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -94,7 +94,7 @@ export const evalJobExecutorQueueProcessor = async (
       ?.count()
       .then((count) => {
         logger.debug(`Eval execution queue length: ${count}`);
-        recordGauge("eval_execution_queue_length", count, {
+        recordGauge("langfuse.queue.evaluation_execution.length", count, {
           unit: "records",
         });
         return count;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename metric in `evalQueue.ts` and remove comment in `ingestion.ts`.
> 
>   - **Metrics**:
>     - Rename metric in `evalJobExecutorQueueProcessor` from `eval_execution_queue_length` to `langfuse.queue.evaluation_execution.length` in `evalQueue.ts`.
>   - **Comments**:
>     - Remove comment about REST requests in `ingestion.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bc18ab19a20d61f39da2c7bf9a760d368f263b16. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->