### PR TITLE
fix: properly split tags when passed as a string (#3621)

### DIFF
--- a/web/src/pages/api/public/metrics/daily.ts
+++ b/web/src/pages/api/public/metrics/daily.ts
@@ -23,7 +23,7 @@ export default withMiddlewares({
         : Prisma.empty;
       const tagsCondition = query.tags
         ? Prisma.sql`AND ARRAY[${Prisma.join(
-            (Array.isArray(query.tags) ? query.tags : [query.tags]).map(
+            (Array.isArray(query.tags) ? query.tags : query.tags.split(',')).map(
               (v) => Prisma.sql`${v}`,
             ),
             ", ",

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -61,7 +61,7 @@ export default withMiddlewares({
         : Prisma.empty;
       const tagsCondition = query.tags
         ? Prisma.sql`AND ARRAY[${Prisma.join(
-            (Array.isArray(query.tags) ? query.tags : [query.tags]).map(
+            (Array.isArray(query.tags) ? query.tags : query.tags.split(',')).map(
               (v) => Prisma.sql`${v}`,
             ),
             ", ",
@@ -169,7 +169,7 @@ export default withMiddlewares({
           },
           tags: query.tags
             ? {
-                hasEvery: Array.isArray(query.tags) ? query.tags : [query.tags],
+                hasEvery: Array.isArray(query.tags) ? query.tags : query.tags.split(','),
               }
             : undefined,
         },


### PR DESCRIPTION
authored by @JorisAndrade
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes tag processing in `daily.ts` and `index.ts` by splitting string tags into arrays for SQL queries.
> 
>   - **Behavior**:
>     - Fixes tag processing in `daily.ts` and `index.ts` by splitting string tags using `split(',')`.
>     - Ensures tags are correctly handled as arrays in SQL queries.
>   - **Files Affected**:
>     - `daily.ts`: Adjusts tag handling in SQL condition.
>     - `index.ts`: Adjusts tag handling in SQL condition and `count` query.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e0ccf48e87cd748b1b73be043f3afd0ae9d5e41e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->