### PR TITLE
feat: invalidate API keys via cloud admin api

### DIFF
--- a/web/src/pages/api/admin/api-keys/index.ts
+++ b/web/src/pages/api/admin/api-keys/index.ts
@@ -111,7 +111,6 @@ export default async function handler(
           },
         },
       });
-      console.log(apiKeysToBeInvalidated);
 
       // then delete from the cache
       await new ApiAuthService(prisma, redis).invalidate(

--- a/web/src/pages/api/admin/api-keys/index.ts
+++ b/web/src/pages/api/admin/api-keys/index.ts
@@ -101,7 +101,7 @@ export default async function handler(
         `Removed API keys for projects ${body.data.projectIds.join(", ")}`,
       );
 
-      res.status(200).json({ message: "API keys deleted" });
+      return res.status(200).json({ message: "API keys deleted" });
     } else if (body.data.action === "invalidate") {
       // delete the API keys in the database first
       const apiKeysToBeInvalidated = await prisma.apiKey.findMany({
@@ -111,6 +111,7 @@ export default async function handler(
           },
         },
       });
+      console.log(apiKeysToBeInvalidated);
 
       // then delete from the cache
       await new ApiAuthService(prisma, redis).invalidate(
@@ -119,9 +120,9 @@ export default async function handler(
       );
 
       logger.info(
-        `Removed API keys for projects ${body.data.projectIds.join(", ")}`,
+        `Invalidated API keys for projects ${body.data.projectIds.join(", ")}`,
       );
-      res.status(200).json({ message: "API keys invalidated" });
+      return res.status(200).json({ message: "API keys invalidated" });
     }
 
     // return not implemented error

--- a/web/src/pages/api/admin/api-keys/index.ts
+++ b/web/src/pages/api/admin/api-keys/index.ts
@@ -31,7 +31,7 @@ export default async function handler(
 ) {
   try {
     // allow only POST requests
-    if (req.method !== "DELETE") {
+    if (req.method !== "POST") {
       res.status(405).json({ error: "Method Not Allowed" });
       return;
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds API key invalidation functionality to admin API in `index.ts`, updating handler to support both delete and invalidate actions.
> 
>   - **Behavior**:
>     - Adds `InvalidateApiKeySchema` for invalidating API keys in `index.ts`.
>     - Updates `handler` function to process `delete` and `invalidate` actions.
>     - Logs actions and returns success messages for both actions.
>   - **Schema**:
>     - Introduces `ApiKeyAction` as a discriminated union of `DeleteApiKeySchema` and `InvalidateApiKeySchema`.
>   - **Error Handling**:
>     - Returns 404 error if action does not exist in `handler`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 513001b21b08efbf94bb7647b8af3e899dda602b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->