### PR TITLE
feat: front-end cloud admin flag for clickhouse

### DIFF
--- a/web/src/components/layouts/ClickhouseAdminToggle.tsx
+++ b/web/src/components/layouts/ClickhouseAdminToggle.tsx
@@ -6,7 +6,7 @@ export const useClickhouse = () => {
   const session = useSession();
   const [isEnabled] = useLocalStorage<boolean>("useClickhouseQueries", false);
 
-  return (isEnabled && session.data?.user?.admin === true).toString();
+  return isEnabled && session.data?.user?.admin === true;
 };
 
 export function ClickhouseAdminToggle() {

--- a/web/src/components/layouts/ClickhouseAdminToggle.tsx
+++ b/web/src/components/layouts/ClickhouseAdminToggle.tsx
@@ -1,0 +1,40 @@
+import { Switch } from "@/src/components/ui/switch";
+import useLocalStorage from "@/src/components/useLocalStorage";
+import { useSession } from "next-auth/react";
+
+export const useClickhouse = () => {
+  const session = useSession();
+  const [isEnabled] = useLocalStorage<boolean>("useClickhouseQueries", false);
+
+  return (isEnabled && session.data?.user?.admin === true).toString();
+};
+
+export function ClickhouseAdminToggle() {
+  const [isEnabled, setIsEnabled] = useLocalStorage<boolean>(
+    "useClickhouseQueries",
+    false,
+  );
+
+  const handleToggle = () => {
+    setIsEnabled((prev) => !prev);
+    // You can add any additional logic here, such as API calls or analytics tracking
+  };
+
+  return (
+    <div className="ml-auto flex items-center space-x-1">
+      <div
+        title={
+          isEnabled ? "Disable Clickhouse Queries" : "Enable Clickhouse Queries"
+        }
+      >
+        <Switch
+          id="clickhouse-toggle"
+          checked={isEnabled}
+          onCheckedChange={() => {
+            handleToggle();
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -34,6 +34,7 @@ import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { useOrgEntitlements } from "@/src/features/entitlements/hooks";
 import { useUiCustomization } from "@/src/ee/features/ui-customization/useUiCustomization";
 import { hasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
+import { ClickhouseAdminToggle } from "@/src/components/layouts/ClickhouseAdminToggle";
 
 const signOutUser = async () => {
   localStorage.clear();
@@ -42,17 +43,32 @@ const signOutUser = async () => {
   await signOut();
 };
 
-const userNavigation = [
-  {
-    name: "Theme",
-    onClick: () => {},
-    content: <ThemeToggle />,
-  },
-  {
-    name: "Sign out",
-    onClick: signOutUser,
-  },
-];
+const getUserNavigation = (isAdmin: boolean) => {
+  const navigationItems = [
+    {
+      name: "Theme",
+      onClick: () => {},
+      content: <ThemeToggle />,
+    },
+    {
+      name: "Sign out",
+      onClick: signOutUser,
+    },
+  ];
+
+  console.log("isAdmin", isAdmin);
+
+  return isAdmin
+    ? [
+        {
+          name: "CH Query",
+          onClick: () => {},
+          content: <ClickhouseAdminToggle />,
+        },
+        ...navigationItems,
+      ]
+    : navigationItems;
+};
 
 const pathsWithoutNavigation: string[] = [
   "/onboarding",
@@ -186,7 +202,7 @@ export default function Layout(props: PropsWithChildren) {
 
     const href = (
       route.customizableHref
-        ? uiCustomization?.[route.customizableHref] ?? route.pathname
+        ? (uiCustomization?.[route.customizableHref] ?? route.pathname)
         : route.pathname
     )
       ?.replace("[projectId]", routerProjectId ?? "")
@@ -448,22 +464,24 @@ export default function Layout(props: PropsWithChildren) {
                   >
                     {session.data?.user?.email}
                   </span>
-                  {userNavigation.map((item) => (
-                    <Menu.Item key={item.name}>
-                      {({ active }) => (
-                        <a
-                          onClick={() => void item.onClick()}
-                          className={cn(
-                            active ? "bg-primary-foreground" : "",
-                            "flex cursor-pointer items-center justify-between px-2 py-0.5 text-sm leading-6 text-primary",
-                          )}
-                        >
-                          {item.name}
-                          {item.content}
-                        </a>
-                      )}
-                    </Menu.Item>
-                  ))}
+                  {getUserNavigation(session.data?.user?.admin === true).map(
+                    (item) => (
+                      <Menu.Item key={item.name}>
+                        {({ active }) => (
+                          <a
+                            onClick={() => void item.onClick()}
+                            className={cn(
+                              active ? "bg-primary-foreground" : "",
+                              "flex cursor-pointer items-center justify-between px-2 py-0.5 text-sm leading-6 text-primary",
+                            )}
+                          >
+                            {item.name}
+                            {item.content}
+                          </a>
+                        )}
+                      </Menu.Item>
+                    ),
+                  )}
                 </Menu.Items>
               </Transition>
             </Menu>
@@ -516,22 +534,24 @@ export default function Layout(props: PropsWithChildren) {
                 >
                   {session.data?.user?.email}
                 </span>
-                {userNavigation.map((item) => (
-                  <Menu.Item key={item.name}>
-                    {({ active }) => (
-                      <a
-                        onClick={() => void item.onClick()}
-                        className={cn(
-                          active ? "bg-primary-foreground" : "",
-                          "flex cursor-pointer items-center justify-between px-2 py-1 text-sm leading-6 text-primary",
-                        )}
-                      >
-                        {item.name}
-                        {item.content}
-                      </a>
-                    )}
-                  </Menu.Item>
-                ))}
+                {getUserNavigation(session.data?.user?.admin === true).map(
+                  (item) => (
+                    <Menu.Item key={item.name}>
+                      {({ active }) => (
+                        <a
+                          onClick={() => void item.onClick()}
+                          className={cn(
+                            active ? "bg-primary-foreground" : "",
+                            "flex cursor-pointer items-center justify-between px-2 py-1 text-sm leading-6 text-primary",
+                          )}
+                        >
+                          {item.name}
+                          {item.content}
+                        </a>
+                      )}
+                    </Menu.Item>
+                  ),
+                )}
               </Menu.Items>
             </Transition>
           </Menu>

--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -56,8 +56,6 @@ const getUserNavigation = (isAdmin: boolean) => {
     },
   ];
 
-  console.log("isAdmin", isAdmin);
-
   return isAdmin
     ? [
         {
@@ -457,31 +455,29 @@ export default function Layout(props: PropsWithChildren) {
                 leaveFrom="transform opacity-100 scale-100"
                 leaveTo="transform opacity-0 scale-95"
               >
-                <Menu.Items className="absolute -top-full bottom-1 right-0 z-10 overflow-hidden rounded-md bg-background py-2 shadow-lg ring-1 ring-border focus:outline-none">
+                <Menu.Items className="absolute bottom-1 right-0 z-10 overflow-hidden rounded-md bg-background py-2 shadow-lg ring-1 ring-border focus:outline-none">
                   <span
                     className="block max-w-52 overflow-hidden truncate border-b px-3 pb-2 text-sm leading-6 text-muted-foreground"
                     title={session.data?.user?.email ?? undefined}
                   >
                     {session.data?.user?.email}
                   </span>
-                  {getUserNavigation(session.data?.user?.admin === true).map(
-                    (item) => (
-                      <Menu.Item key={item.name}>
-                        {({ active }) => (
-                          <a
-                            onClick={() => void item.onClick()}
-                            className={cn(
-                              active ? "bg-primary-foreground" : "",
-                              "flex cursor-pointer items-center justify-between px-2 py-0.5 text-sm leading-6 text-primary",
-                            )}
-                          >
-                            {item.name}
-                            {item.content}
-                          </a>
-                        )}
-                      </Menu.Item>
-                    ),
-                  )}
+                  {getUserNavigation(cloudAdmin).map((item) => (
+                    <Menu.Item key={item.name}>
+                      {({ active }) => (
+                        <a
+                          onClick={() => void item.onClick()}
+                          className={cn(
+                            active ? "bg-primary-foreground" : "",
+                            "flex cursor-pointer items-center justify-between px-2 py-0.5 text-sm leading-6 text-primary",
+                          )}
+                        >
+                          {item.name}
+                          {item.content}
+                        </a>
+                      )}
+                    </Menu.Item>
+                  ))}
                 </Menu.Items>
               </Transition>
             </Menu>
@@ -534,24 +530,22 @@ export default function Layout(props: PropsWithChildren) {
                 >
                   {session.data?.user?.email}
                 </span>
-                {getUserNavigation(session.data?.user?.admin === true).map(
-                  (item) => (
-                    <Menu.Item key={item.name}>
-                      {({ active }) => (
-                        <a
-                          onClick={() => void item.onClick()}
-                          className={cn(
-                            active ? "bg-primary-foreground" : "",
-                            "flex cursor-pointer items-center justify-between px-2 py-1 text-sm leading-6 text-primary",
-                          )}
-                        >
-                          {item.name}
-                          {item.content}
-                        </a>
-                      )}
-                    </Menu.Item>
-                  ),
-                )}
+                {getUserNavigation(cloudAdmin).map((item) => (
+                  <Menu.Item key={item.name}>
+                    {({ active }) => (
+                      <a
+                        onClick={() => void item.onClick()}
+                        className={cn(
+                          active ? "bg-primary-foreground" : "",
+                          "flex cursor-pointer items-center justify-between px-2 py-1 text-sm leading-6 text-primary",
+                        )}
+                      >
+                        {item.name}
+                        {item.content}
+                      </a>
+                    )}
+                  </Menu.Item>
+                ))}
               </Menu.Items>
             </Transition>
           </Menu>

--- a/web/src/pages/support.tsx
+++ b/web/src/pages/support.tsx
@@ -1,5 +1,4 @@
 import { SupportChannels } from "@/src/components/Support";
-import { useClickhouse } from "@/src/components/layouts/ClickhouseAdminToggle";
 import Header from "@/src/components/layouts/header";
 
 export default function SupportPage() {
@@ -8,7 +7,6 @@ export default function SupportPage() {
       <Header title="Support" />
 
       <div className="flex flex-col gap-10">
-        {useClickhouse()}
         <p>
           We are here to help in case of questions or issues. Pick the channel
           that is most convenient for you!

--- a/web/src/pages/support.tsx
+++ b/web/src/pages/support.tsx
@@ -1,11 +1,14 @@
 import { SupportChannels } from "@/src/components/Support";
+import { useClickhouse } from "@/src/components/layouts/ClickhouseAdminToggle";
 import Header from "@/src/components/layouts/header";
 
 export default function SupportPage() {
   return (
     <div className="md:container">
       <Header title="Support" />
+
       <div className="flex flex-col gap-10">
+        {useClickhouse()}
         <p>
           We are here to help in case of questions or issues. Pick the channel
           that is most convenient for you!


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a `ClickhouseAdminToggle` component for admin users to toggle Clickhouse queries, integrated into the user navigation.
> 
>   - **Feature**:
>     - Adds `ClickhouseAdminToggle` component in `ClickhouseAdminToggle.tsx` for admin users to toggle Clickhouse queries.
>     - Integrates `ClickhouseAdminToggle` into user navigation in `layout.tsx` for admin users.
>   - **Hooks**:
>     - Introduces `useClickhouse` hook in `ClickhouseAdminToggle.tsx` to check if Clickhouse queries are enabled based on local storage and admin status.
>   - **Misc**:
>     - Updates `support.tsx` to use `useClickhouse` hook.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cd0502e4dd3e5ea59caf37ed245bce4cb85693f7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->