### PR TITLE
feat: add crisp events in posthog

### DIFF
--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -128,6 +128,7 @@ const events = {
   ],
   help_popup: ["opened", "href_clicked"],
   navigate_detail_pages: ["button_click_prev_or_next"],
+  support_chat: ["initiated", "opened", "message_sent"],
 } as const;
 
 // type that represents all possible event names, e.g. "traces:bookmark"

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -128,7 +128,7 @@ const events = {
   ],
   help_popup: ["opened", "href_clicked"],
   navigate_detail_pages: ["button_click_prev_or_next"],
-  support_chat: ["initiated", "opened", "message_sent"],
+  support_chat: ["initiated", "opened", "message_sent"], // also used on landing page for consistency
 } as const;
 
 // type that represents all possible event names, e.g. "traces:bookmark"

--- a/web/src/features/support-chat/chat.tsx
+++ b/web/src/features/support-chat/chat.tsx
@@ -3,11 +3,29 @@
 import { useEffect } from "react";
 import { Crisp } from "crisp-sdk-web";
 import { env } from "@/src/env.mjs";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 const CrispChat = () => {
+  const capture = usePostHogClientCapture();
+
   useEffect(() => {
-    if (env.NEXT_PUBLIC_CRISP_WEBSITE_ID)
+    if (env.NEXT_PUBLIC_CRISP_WEBSITE_ID) {
       Crisp.configure(env.NEXT_PUBLIC_CRISP_WEBSITE_ID);
+      Crisp.chat.onChatInitiated(() => {
+        capture("support_chat:initiated");
+      });
+      Crisp.chat.onChatOpened(() => {
+        capture("support_chat:opened");
+      });
+      Crisp.message.onMessageSent(() => {
+        capture("support_chat:message_sent");
+      });
+      return () => {
+        Crisp.chat.offChatInitiated();
+        Crisp.chat.offChatOpened();
+        Crisp.message.offMessageSent();
+      };
+    }
   });
 
   return null;

--- a/web/src/features/support-chat/chat.tsx
+++ b/web/src/features/support-chat/chat.tsx
@@ -26,7 +26,7 @@ const CrispChat = () => {
         Crisp.message.offMessageSent();
       };
     }
-  });
+  }, [capture]);
 
   return null;
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Integrate PostHog analytics with Crisp by capturing and logging chat events in `usePostHogClientCapture.ts` and `chat.tsx`.
> 
>   - **Behavior**:
>     - Add `support_chat` events (`initiated`, `opened`, `message_sent`) to `events` in `usePostHogClientCapture.ts`.
>     - Capture Crisp chat events (`onChatInitiated`, `onChatOpened`, `onMessageSent`) in `chat.tsx` using `usePostHogClientCapture`.
>   - **Functions**:
>     - `capture()` in `usePostHogClientCapture.ts` now supports `support_chat` events.
>     - `CrispChat` component in `chat.tsx` uses `capture()` to log chat events.
>   - **Misc**:
>     - Add cleanup for Crisp event listeners in `chat.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e1ef54bbad151219ba9fd643680adc829894b406. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->