### PR TITLE
fix(ui): disable sign-in and sso buttons while email/pw are empty

### DIFF
--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -440,8 +440,10 @@ export default function SignIn({ authProviders, signUpDisabled }: PageProps) {
                     className="w-full"
                     loading={credentialsForm.formState.isSubmitting}
                     disabled={
-                      env.NEXT_PUBLIC_TURNSTILE_SITE_KEY !== undefined &&
-                      turnstileToken === undefined
+                      (env.NEXT_PUBLIC_TURNSTILE_SITE_KEY !== undefined &&
+                        turnstileToken === undefined) ||
+                      credentialsForm.watch("email") === "" ||
+                      credentialsForm.watch("password") === ""
                     }
                     onClick={credentialsForm.handleSubmit(onCredentialsSubmit)}
                     data-testid="submit-email-password-sign-in-form"
@@ -455,8 +457,9 @@ export default function SignIn({ authProviders, signUpDisabled }: PageProps) {
                     variant="secondary"
                     loading={ssoLoading}
                     disabled={
-                      env.NEXT_PUBLIC_TURNSTILE_SITE_KEY !== undefined &&
-                      turnstileToken === undefined
+                      (env.NEXT_PUBLIC_TURNSTILE_SITE_KEY !== undefined &&
+                        turnstileToken === undefined) ||
+                      credentialsForm.watch("email") === ""
                     }
                     onClick={handleSsoSignIn}
                   >


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance form validation in `sign-in.tsx` by disabling submit buttons when email or password fields are empty.
> 
>   - **Behavior**:
>     - In `sign-in.tsx`, disable the "Sign in" button if email or password fields are empty.
>     - Disable the SSO button if the email field is empty.
>   - **Validation**:
>     - Added checks for empty email and password fields before enabling the submit button for credentials.
>     - Added check for empty email field before enabling the SSO button.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 967a1bfa492b7db505ecd98473ac2e677930d269. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->