### PR TITLE
fix: encode all links to objects with user-provided ids

### DIFF
--- a/web/src/components/table/use-cases/generations.tsx
+++ b/web/src/components/table/use-cases/generations.tsx
@@ -284,7 +284,7 @@ export default function GenerationsTable({
         return typeof observationId === "string" &&
           typeof traceId === "string" ? (
           <TableLink
-            path={`/project/${projectId}/traces/${traceId}?observation=${observationId}`}
+            path={`/project/${projectId}/traces/${encodeURIComponent(traceId)}?observation=${encodeURIComponent(observationId)}`}
             value={observationId}
           />
         ) : null;

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -174,7 +174,7 @@ export default function ScoresTable({
         return typeof value === "string" ? (
           <>
             <TableLink
-              path={`/project/${projectId}/traces/${value}`}
+              path={`/project/${projectId}/traces/${encodeURIComponent(value)}`}
               value={value}
             />
           </>
@@ -194,7 +194,7 @@ export default function ScoresTable({
         const traceId = row.getValue("traceId") as ScoresTableRow["traceId"];
         return traceId && observationId ? (
           <TableLink
-            path={`/project/${projectId}/traces/${traceId}?observation=${observationId}`}
+            path={`/project/${projectId}/traces/${encodeURIComponent(traceId)}?observation=${encodeURIComponent(observationId)}`}
             value={observationId}
           />
         ) : undefined;
@@ -236,7 +236,7 @@ export default function ScoresTable({
         return typeof value === "string" ? (
           <>
             <TableLink
-              path={`/project/${projectId}/users/${value}`}
+              path={`/project/${projectId}/users/${encodeURIComponent(value)}`}
               value={value}
             />
           </>
@@ -396,7 +396,7 @@ export default function ScoresTable({
           ? score.value % 1 === 0
             ? String(score.value)
             : score.value.toFixed(4)
-          : score.stringValue ?? "",
+          : (score.stringValue ?? ""),
       author: {
         userId: score.authorUserId ?? undefined,
         image: score.authorUserImage ?? undefined,

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -291,7 +291,7 @@ export default function TracesTable({
         const value: TracesTableRow["id"] = row.getValue("id");
         return value && typeof value === "string" ? (
           <TableLink
-            path={`/project/${projectId}/traces/${value}`}
+            path={`/project/${projectId}/traces/${encodeURIComponent(value)}`}
             value={value}
           />
         ) : undefined;
@@ -692,7 +692,7 @@ export default function TracesTable({
 
   const rows = useMemo(() => {
     return traces.isSuccess
-      ? traceRowData?.rows?.map((trace) => {
+      ? (traceRowData?.rows?.map((trace) => {
           return {
             bookmarked: trace.bookmarked,
             id: trace.id,
@@ -721,7 +721,7 @@ export default function TracesTable({
             outputCost: trace.calculatedOutputCost ?? undefined,
             totalCost: trace.calculatedTotalCost ?? undefined,
           };
-        }) ?? []
+        }) ?? [])
       : [];
   }, [traces, traceRowData, scoreKeysAndProps]);
 

--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -112,13 +112,13 @@ export function DatasetItemsTable({
         if (!source) return null;
         return source.observationId ? (
           <TableLink
-            path={`/project/${projectId}/traces/${source.traceId}?observation=${source.observationId}`}
+            path={`/project/${projectId}/traces/${encodeURIComponent(source.traceId)}?observation=${encodeURIComponent(source.observationId)}`}
             value={source.observationId}
             icon={<ListTree className="h-4 w-4" />}
           />
         ) : (
           <TableLink
-            path={`/project/${projectId}/traces/${source.traceId}`}
+            path={`/project/${projectId}/traces/${encodeURIComponent(source.traceId)}`}
             value={source.traceId}
             icon={<ListTree className="h-4 w-4" />}
           />

--- a/web/src/features/datasets/components/DatasetRunItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsTable.tsx
@@ -120,13 +120,13 @@ export function DatasetRunItemsTable(
         if (!trace) return null;
         return trace.observationId ? (
           <TableLink
-            path={`/project/${props.projectId}/traces/${trace.traceId}?observation=${trace.observationId}`}
+            path={`/project/${props.projectId}/traces/${encodeURIComponent(trace.traceId)}?observation=${encodeURIComponent(trace.observationId)}`}
             value={`Trace: ${trace.traceId}, Observation: ${trace.observationId}`}
             icon={<ListTree className="h-4 w-4" />}
           />
         ) : (
           <TableLink
-            path={`/project/${props.projectId}/traces/${trace.traceId}`}
+            path={`/project/${props.projectId}/traces/${encodeURIComponent(trace.traceId)}`}
             value={`Trace: ${trace.traceId}`}
             icon={<ListTree className="h-4 w-4" />}
           />

--- a/web/src/pages/project/[projectId]/traces/[traceId].tsx
+++ b/web/src/pages/project/[projectId]/traces/[traceId].tsx
@@ -3,7 +3,7 @@ import { TracePage } from "@/src/components/trace";
 
 export default function Trace() {
   const router = useRouter();
-  const traceId = router.query.traceId as string;
+  const traceId = decodeURIComponent(router.query.traceId as string);
 
   return <TracePage traceId={traceId} />;
 }

--- a/web/src/pages/project/[projectId]/users.tsx
+++ b/web/src/pages/project/[projectId]/users.tsx
@@ -239,8 +239,8 @@ export default function UsersPage() {
                 <TableLink
                   path={
                     value.observationId
-                      ? `/project/${projectId}/traces/${value.traceId}?observation=${value.observationId}`
-                      : `/project/${projectId}/traces/${value.traceId}`
+                      ? `/project/${projectId}/traces/${encodeURIComponent(value.traceId)}?observation=${encodeURIComponent(value.observationId)}`
+                      : `/project/${projectId}/traces/${encodeURIComponent(value.traceId)}`
                   }
                   value={value.traceId}
                 />

--- a/web/src/pages/project/[projectId]/users/[userId].tsx
+++ b/web/src/pages/project/[projectId]/users/[userId].tsx
@@ -188,8 +188,8 @@ function OverviewTab({ userId, projectId }: TabProps) {
                 <TableLink
                   path={
                     user.data.lastScore.observationId
-                      ? `/project/${projectId}/traces/${user.data.lastScore.traceId}?observation=${user.data.lastScore.observationId}`
-                      : `/project/${projectId}/traces/${user.data.lastScore.traceId}`
+                      ? `/project/${projectId}/traces/${encodeURIComponent(user.data.lastScore.traceId)}?observation=${encodeURIComponent(user.data.lastScore.observationId)}`
+                      : `/project/${projectId}/traces/${encodeURIComponent(user.data.lastScore.traceId)}`
                   }
                   value={user.data.lastScore.traceId}
                 />


### PR DESCRIPTION
Fixes #3669 

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Encode URL parameters for trace and observation IDs across multiple components to ensure proper URL handling.
> 
>   - **Behavior**:
>     - Encode `traceId` and `observationId` in URLs using `encodeURIComponent()` in `generations.tsx`, `scores.tsx`, `traces.tsx`, `DatasetItemsTable.tsx`, and `DatasetRunItemsTable.tsx`.
>     - Decode `traceId` in `traces/[traceId].tsx` and `users/[userId].tsx` using `decodeURIComponent()`.
>   - **Misc**:
>     - Minor formatting change in `scores.tsx` to add parentheses around a ternary operation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3fa8f4eb99b6f4da6143a3cb41bf3d74b7800b53. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->