### PR TITLE
fix: do not retry when api key is missing for evals and normalise wait time metric

### DIFF
--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -28,7 +28,7 @@ export const LegacyIngestionEventMeta = z.object({
       type: z.nativeEnum(eventTypes),
       eventBodyId: z.string(),
       eventId: z.string(),
-    }),
+    })
   ),
   authCheck: z.object({
     validKey: z.literal(true),
@@ -55,6 +55,7 @@ export const TraceUpsertEventSchema = z.object({
 export const EvalExecutionEvent = z.object({
   projectId: z.string(),
   jobExecutionId: z.string(),
+  delay: z.number().nullish(),
 });
 
 export type BatchExportJobType = z.infer<typeof BatchExportJobSchema>;

--- a/worker/src/__tests__/eval-service.test.ts
+++ b/worker/src/__tests__/eval-service.test.ts
@@ -24,7 +24,7 @@ vi.mock("../redis/consumer", () => ({
     add: vi.fn().mockImplementation((jobName, jobData) => {
       logger.info(
         `Mock evalQueue.add called with jobName: ${jobName} and jobData:`,
-        jobData,
+        jobData
       );
       // Simulate the job being processed immediately by calling the job's processing function
       // Note: You would replace `processJobFunction` with the actual function that processes the job
@@ -485,6 +485,7 @@ describe("execute evals", () => {
     const payload = {
       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
       jobExecutionId: jobExecutionId,
+      delay: 1000,
     };
 
     await evaluate({ event: payload });
@@ -587,12 +588,13 @@ describe("execute evals", () => {
     const payload = {
       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
       jobExecutionId: jobExecutionId,
+      delay: 1000,
     };
 
     await expect(evaluate({ event: payload })).rejects.toThrowError(
       new LangfuseNotFoundError(
-        "API key for provider openai and project 7a88fb47-b4e2-43b8-a06c-a5ce950dc53a not found.",
-      ),
+        "API key for provider openai and project 7a88fb47-b4e2-43b8-a06c-a5ce950dc53a not found."
+      )
     );
 
     const jobs = await kyselyPrisma.$kysely
@@ -680,6 +682,7 @@ describe("execute evals", () => {
     const payload = {
       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
       jobExecutionId: jobExecutionId,
+      delay: 1000,
     };
 
     await evaluate({ event: payload });
@@ -727,7 +730,7 @@ describe("test variable extraction", () => {
       "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
       ["input", "output"],
       traceId,
-      variableMapping,
+      variableMapping
     );
 
     expect(result).toEqual([
@@ -789,7 +792,7 @@ describe("test variable extraction", () => {
       "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
       ["input", "output"],
       traceId,
-      variableMapping,
+      variableMapping
     );
 
     expect(result).toEqual([
@@ -839,12 +842,12 @@ describe("test variable extraction", () => {
         "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
         ["input", "output"],
         traceId,
-        variableMapping,
-      ),
+        variableMapping
+      )
     ).rejects.toThrowError(
       new LangfuseNotFoundError(
-        `Observation great-llm-name for trace ${traceId} not found. Please ensure the mapped data exists and consider extending the job delay.`,
-      ),
+        `Observation great-llm-name for trace ${traceId} not found. Please ensure the mapped data exists and consider extending the job delay.`
+      )
     );
   }, 10_000);
 
@@ -894,7 +897,7 @@ describe("test variable extraction", () => {
       "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
       ["input", "output"],
       traceId,
-      variableMapping,
+      variableMapping
     );
 
     expect(result).toEqual([
@@ -970,7 +973,7 @@ describe("test variable extraction", () => {
       "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
       ["input", "output"],
       traceId,
-      variableMapping,
+      variableMapping
     );
 
     expect(result).toEqual([

--- a/worker/src/features/evaluation/eval-service.ts
+++ b/worker/src/features/evaluation/eval-service.ts
@@ -139,6 +139,7 @@ export const createEvalJobs = async ({
           payload: {
             projectId: event.projectId,
             jobExecutionId: jobExecutionId,
+            delay: config.delay,
           },
         },
         {

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -127,6 +127,7 @@ export const evalJobExecutorQueueProcessor = async (
     if (
       !(e instanceof BaseError && e.message.includes("API key for provider"))
     ) {
+      traceException(e);
       logger.error(
         `Failed Evaluation_Execution job for id ${job.data.payload.jobExecutionId}`,
         e

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -123,15 +123,19 @@ export const evalJobExecutorQueueProcessor = async (
       .execute();
 
     // do not log expected errors (api failures + missing api keys not provided by the user)
+    traceException(e);
     if (
-      !(e instanceof ApiError) &&
       !(e instanceof BaseError && e.message.includes("API key for provider"))
     ) {
-      traceException(e);
       logger.error(
         `Failed Evaluation_Execution job for id ${job.data.payload.jobExecutionId}`,
         e
       );
+    }
+
+    // for missing API keys, we do not want to retry.
+    if (e instanceof BaseError && e.message.includes("API key for provider")) {
+      return;
     }
 
     throw e;

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -136,9 +136,8 @@ export const evalJobExecutorQueueProcessor = async (
       .execute();
 
     // do not log expected errors (api failures + missing api keys not provided by the user)
-    traceException(e);
     if (
-      !(e instanceof BaseError && e.message.includes("API key for provider")) &&
+      !(e instanceof BaseError && e.message.includes("API key for provider")) ||
       !(
         e instanceof BaseError &&
         e.message.includes(

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -137,7 +137,7 @@ export const evalJobExecutorQueueProcessor = async (
 
     // do not log expected errors (api failures + missing api keys not provided by the user)
     if (
-      !(e instanceof BaseError && e.message.includes("API key for provider")) ||
+      !(e instanceof BaseError && e.message.includes("API key for provider")) &&
       !(
         e instanceof BaseError &&
         e.message.includes(

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -84,11 +84,24 @@ export const evalJobExecutorQueueProcessor = async (
 
     // reduce the delay from the time to get the actual wait time
     // from the point where the job was ready to be processed
-    const waitTime = Date.now() - job.timestamp - job.delay;
+    // reduce the delay by expo backoff: 2 ^ (attempts - 1) * delay, delay: 1000ms
+    const estimatedBackoffTime =
+      job.attemptsMade > 0 ? 1000 * Math.pow(2, job.attemptsMade - 1) : 0;
+
+    const normalisedWaitTime =
+      Date.now() -
+      job.timestamp -
+      (job.data.payload.delay ?? 0) -
+      estimatedBackoffTime;
+
     recordIncrement("langfuse.queue.evaluation_execution.request");
-    recordHistogram("langfuse.queue.evaluation_execution.wait_time", waitTime, {
-      unit: "milliseconds",
-    });
+    recordHistogram(
+      "langfuse.queue.evaluation_execution.wait_time",
+      normalisedWaitTime,
+      {
+        unit: "milliseconds",
+      }
+    );
 
     await evaluate({ event: job.data.payload });
 
@@ -125,7 +138,13 @@ export const evalJobExecutorQueueProcessor = async (
     // do not log expected errors (api failures + missing api keys not provided by the user)
     traceException(e);
     if (
-      !(e instanceof BaseError && e.message.includes("API key for provider"))
+      !(e instanceof BaseError && e.message.includes("API key for provider")) &&
+      !(
+        e instanceof BaseError &&
+        e.message.includes(
+          "Please ensure the mapped data exists and consider extending the job delay."
+        )
+      )
     ) {
       traceException(e);
       logger.error(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves error handling and logging in `evalJobExecutorQueueProcessor` to prevent retries for missing API key errors and normalizes wait time metric.
> 
>   - **Error Handling**:
>     - In `evalJobExecutorQueueProcessor`, added condition to not retry jobs when `BaseError` indicates a missing API key.
>     - Moved `traceException(e)` to log all exceptions before checking error type.
>   - **Logging**:
>     - Adjusted logging to avoid logging expected errors related to missing API keys in `evalQueue.ts`.
>   - **Schema and Tests**:
>     - Added `delay` field to `EvalExecutionEvent` in `queues.ts`.
>     - Updated tests in `eval-service.test.ts` to include `delay` in payloads.
>   - **Metrics**:
>     - Normalized wait time metric in `evalJobExecutorQueueProcessor` by accounting for exponential backoff and job delay.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1b8f6a04d4eeec6b8594b70e62685e5fcf4de0c1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->