### PR TITLE
feat: add posthog event for tracing_check_active

### DIFF
--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -103,7 +103,7 @@ const events = {
     "modal_open",
     "create_new_button_click",
   ],
-  onboarding: ["code_example_tab_switch"],
+  onboarding: ["code_example_tab_switch", "tracing_check_active"],
   user_settings: ["theme_changed"],
   project_settings: [
     "project_delete",

--- a/web/src/features/setup/components/SetupTracingButton.tsx
+++ b/web/src/features/setup/components/SetupTracingButton.tsx
@@ -6,6 +6,8 @@ import { setupTracingRoute } from "@/src/features/setup/setupRoutes";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { LockIcon } from "lucide-react";
 import { useRouter } from "next/router";
+import { useEffect } from "react";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 const SetupTracingButton = () => {
   const { project } = useQueryProjectOrOrganization();
@@ -24,6 +26,13 @@ const SetupTracingButton = () => {
       },
     },
   );
+
+  const capture = usePostHogClientCapture();
+  useEffect(() => {
+    if (hasAnyTrace !== undefined) {
+      capture("onboarding:tracing_check_active", { active: hasAnyTrace });
+    }
+  }, [hasAnyTrace, capture]);
 
   const hasAccess = useHasProjectAccess({
     projectId: project?.id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `tracing_check_active` PostHog event to track tracing status during onboarding in `SetupPage` and `SetupTracingButton`.
> 
>   - **Behavior**:
>     - Add `tracing_check_active` event to `onboarding` in `usePostHogClientCapture.ts`.
>     - Capture `tracing_check_active` event in `SetupPage.tsx` and `SetupTracingButton.tsx` when tracing status is checked.
>   - **Functions**:
>     - Use `usePostHogClientCapture` to capture events in `SetupPage` and `SetupTracingButton`.
>   - **Misc**:
>     - Ensure `hasAnyTrace` is checked before capturing the event in both `SetupPage.tsx` and `SetupTracingButton.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 427ca5cb078505358d3b32322e1730dccd5c8c35. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->