### PR TITLE
Revert "chore(deps): bump react-hook-form from 7.51.5 to 7.53.0"

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,7 +323,7 @@ importers:
         version: 2.1.5(react@18.2.0)
       '@hookform/resolvers':
         specifier: ^3.3.4
-        version: 3.3.4(react-hook-form@7.53.0(react@18.2.0))
+        version: 3.3.4(react-hook-form@7.51.5(react@18.2.0))
       '@langchain/anthropic':
         specifier: ^0.3.1
         version: 0.3.1(@langchain/core@0.3.9(openai@4.62.1(zod@3.23.8)))
@@ -601,8 +601,8 @@ importers:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
       react-hook-form:
-        specifier: ^7.53.0
-        version: 7.53.0(react@18.2.0)
+        specifier: ^7.51.5
+        version: 7.51.5(react@18.2.0)
       react-icons:
         specifier: ^5.2.1
         version: 5.2.1(react@18.2.0)
@@ -9785,11 +9785,11 @@ packages:
     peerDependencies:
       react: ^18.2.0
 
-  react-hook-form@7.53.0:
-    resolution: {integrity: sha512-M1n3HhqCww6S2hxLxciEXy2oISPnAzxY7gvwVPrtlczTM/1dDadXgUxDpHMrMTblDOcm/AXtXxHwZ3jpg1mqKQ==}
-    engines: {node: '>=18.0.0'}
+  react-hook-form@7.51.5:
+    resolution: {integrity: sha512-J2ILT5gWx1XUIJRETiA7M19iXHlG74+6O3KApzvqB/w8S5NQR7AbU8HVZrMALdmDgWpRPYiZJl0zx8Z4L2mP6Q==}
+    engines: {node: '>=12.22.0'}
     peerDependencies:
-      react: ^16.8.0 || ^17 || ^18 || ^19
+      react: ^16.8.0 || ^17 || ^18
 
   react-icons@5.2.1:
     resolution: {integrity: sha512-zdbW5GstTzXaVKvGSyTaBalt7HSfuK5ovrzlpyiWHAFXndXTdd/1hdDHI4xBM1Mn7YriT6aqESucFl9kEXzrdw==}
@@ -12919,9 +12919,9 @@ snapshots:
     dependencies:
       react: 18.2.0
 
-  '@hookform/resolvers@3.3.4(react-hook-form@7.53.0(react@18.2.0))':
+  '@hookform/resolvers@3.3.4(react-hook-form@7.51.5(react@18.2.0))':
     dependencies:
-      react-hook-form: 7.53.0(react@18.2.0)
+      react-hook-form: 7.51.5(react@18.2.0)
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
@@ -22497,7 +22497,7 @@ snapshots:
       react: 18.2.0
       scheduler: 0.23.0
 
-  react-hook-form@7.53.0(react@18.2.0):
+  react-hook-form@7.51.5(react@18.2.0):
     dependencies:
       react: 18.2.0
 

--- a/web/package.json
+++ b/web/package.json
@@ -127,7 +127,7 @@
     "react": "18.2.0",
     "react-day-picker": "^8.10.1",
     "react-dom": "18.2.0",
-    "react-hook-form": "^7.53.0",
+    "react-hook-form": "^7.51.5",
     "react-icons": "^5.2.1",
     "react-markdown": "^9.0.1",
     "react-resizable-panels": "^2.1.1",

--- a/web/src/features/public-api/components/CreateLLMApiKeyDialog.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyDialog.tsx
@@ -26,7 +26,6 @@ export function CreateLLMApiKeyDialog({
     scope: "llmApiKeys:create",
   });
   const uiCustomization = useUiCustomization();
-  console.log("uiCustomization", uiCustomization);
 
   if (!hasAccess) return null;
 


### PR DESCRIPTION
Reverts langfuse/langfuse#3613
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Revert `react-hook-form` version in `package.json` and remove a console log in `CreateLLMApiKeyDialog.tsx`.
> 
>   - **Dependencies**:
>     - Revert `react-hook-form` version from `^7.53.0` to `^7.51.5` in `package.json`.
>   - **Code Cleanup**:
>     - Remove `console.log` statement in `CreateLLMApiKeyDialog` in `CreateLLMApiKeyDialog.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c9015ef8a255065aee12ac6e5222c73ebd79649e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->