### PR TITLE
fix: show add to annotation queue only when flag is set

### DIFF
--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -32,6 +32,11 @@ import { CreateNewAnnotationQueueItem } from "@/src/features/scores/components/C
 import { useHasOrgEntitlement } from "@/src/features/entitlements/hooks";
 import { calculateDisplayTotalCost } from "@/src/components/trace/lib/helpers";
 import { useMemo } from "react";
+import {
+  FeatureFlagToggle,
+  isFeatureFlagEnabled,
+} from "@/src/features/feature-flags/components/FeatureFlagToggle";
+import { useSession } from "next-auth/react";
 
 export const ObservationPreview = ({
   observations,
@@ -52,6 +57,7 @@ export const ObservationPreview = ({
   viewType?: "focused" | "detailed";
   className?: string;
 }) => {
+  const session = useSession();
   const [selectedTab, setSelectedTab] = useQueryParam(
     "view",
     withDefault(StringParam, "preview"),
@@ -221,6 +227,7 @@ export const ObservationPreview = ({
               />
               <div className="flex items-start">
                 <AnnotateDrawer
+                  key={"annotation-drawer" + preloadedObservation.id}
                   projectId={projectId}
                   traceId={traceId}
                   observationId={preloadedObservation.id}
@@ -228,13 +235,21 @@ export const ObservationPreview = ({
                   emptySelectedConfigIds={emptySelectedConfigIds}
                   setEmptySelectedConfigIds={setEmptySelectedConfigIds}
                   type="observation"
-                  key={"annotation-drawer" + preloadedObservation.id}
+                  hasGroupedButton={
+                    hasEntitlement &&
+                    isFeatureFlagEnabled(session, "annotationQueues")
+                  }
                 />
                 {hasEntitlement && (
-                  <CreateNewAnnotationQueueItem
-                    projectId={projectId}
-                    objectId={preloadedObservation.id}
-                    objectType={AnnotationQueueObjectType.OBSERVATION}
+                  <FeatureFlagToggle
+                    featureFlag="annotationQueues"
+                    whenEnabled={
+                      <CreateNewAnnotationQueueItem
+                        projectId={projectId}
+                        objectId={preloadedObservation.id}
+                        objectType={AnnotationQueueObjectType.OBSERVATION}
+                      />
+                    }
                   />
                 )}
               </div>

--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -32,11 +32,8 @@ import { CreateNewAnnotationQueueItem } from "@/src/features/scores/components/C
 import { useHasOrgEntitlement } from "@/src/features/entitlements/hooks";
 import { calculateDisplayTotalCost } from "@/src/components/trace/lib/helpers";
 import { useMemo } from "react";
-import {
-  FeatureFlagToggle,
-  isFeatureFlagEnabled,
-} from "@/src/features/feature-flags/components/FeatureFlagToggle";
-import { useSession } from "next-auth/react";
+import { FeatureFlagToggle } from "@/src/features/feature-flags/components/FeatureFlagToggle";
+import useIsFeatureEnabled from "@/src/features/feature-flags/hooks/useIsFeatureEnabled";
 
 export const ObservationPreview = ({
   observations,
@@ -57,7 +54,7 @@ export const ObservationPreview = ({
   viewType?: "focused" | "detailed";
   className?: string;
 }) => {
-  const session = useSession();
+  const isFeatureFlagEnabled = useIsFeatureEnabled("annotationQueues");
   const [selectedTab, setSelectedTab] = useQueryParam(
     "view",
     withDefault(StringParam, "preview"),
@@ -235,10 +232,7 @@ export const ObservationPreview = ({
                   emptySelectedConfigIds={emptySelectedConfigIds}
                   setEmptySelectedConfigIds={setEmptySelectedConfigIds}
                   type="observation"
-                  hasGroupedButton={
-                    hasEntitlement &&
-                    isFeatureFlagEnabled(session, "annotationQueues")
-                  }
+                  hasGroupedButton={hasEntitlement && isFeatureFlagEnabled}
                 />
                 {hasEntitlement && (
                   <FeatureFlagToggle

--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -32,7 +32,6 @@ import { CreateNewAnnotationQueueItem } from "@/src/features/scores/components/C
 import { useHasOrgEntitlement } from "@/src/features/entitlements/hooks";
 import { calculateDisplayTotalCost } from "@/src/components/trace/lib/helpers";
 import { useMemo } from "react";
-import { FeatureFlagToggle } from "@/src/features/feature-flags/components/FeatureFlagToggle";
 import useIsFeatureEnabled from "@/src/features/feature-flags/hooks/useIsFeatureEnabled";
 
 export const ObservationPreview = ({
@@ -234,16 +233,11 @@ export const ObservationPreview = ({
                   type="observation"
                   hasGroupedButton={hasEntitlement && isFeatureFlagEnabled}
                 />
-                {hasEntitlement && (
-                  <FeatureFlagToggle
-                    featureFlag="annotationQueues"
-                    whenEnabled={
-                      <CreateNewAnnotationQueueItem
-                        projectId={projectId}
-                        objectId={preloadedObservation.id}
-                        objectType={AnnotationQueueObjectType.OBSERVATION}
-                      />
-                    }
+                {hasEntitlement && isFeatureFlagEnabled && (
+                  <CreateNewAnnotationQueueItem
+                    projectId={projectId}
+                    objectId={preloadedObservation.id}
+                    objectType={AnnotationQueueObjectType.OBSERVATION}
                   />
                 )}
               </div>

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -32,6 +32,11 @@ import { useHasOrgEntitlement } from "@/src/features/entitlements/hooks";
 import { useMemo } from "react";
 import { usdFormatter } from "@/src/utils/numbers";
 import { calculateDisplayTotalCost } from "@/src/components/trace/lib/helpers";
+import {
+  FeatureFlagToggle,
+  isFeatureFlagEnabled,
+} from "@/src/features/feature-flags/components/FeatureFlagToggle";
+import { useSession } from "next-auth/react";
 
 export const TracePreview = ({
   trace,
@@ -48,6 +53,7 @@ export const TracePreview = ({
   viewType?: "detailed" | "focused";
   className?: string;
 }) => {
+  const session = useSession();
   const [selectedTab, setSelectedTab] = useQueryParam(
     "view",
     withDefault(StringParam, "preview"),
@@ -149,19 +155,27 @@ export const TracePreview = ({
               />
               <div className="flex items-start">
                 <AnnotateDrawer
+                  key={"annotation-drawer" + trace.id}
                   projectId={trace.projectId}
                   traceId={trace.id}
                   scores={scores}
                   emptySelectedConfigIds={emptySelectedConfigIds}
                   setEmptySelectedConfigIds={setEmptySelectedConfigIds}
-                  key={"annotation-drawer" + trace.id}
-                  hasGroupedButton={hasEntitlement}
+                  hasGroupedButton={
+                    hasEntitlement &&
+                    isFeatureFlagEnabled(session, "annotationQueues")
+                  }
                 />
                 {hasEntitlement && (
-                  <CreateNewAnnotationQueueItem
-                    projectId={trace.projectId}
-                    objectId={trace.id}
-                    objectType={AnnotationQueueObjectType.TRACE}
+                  <FeatureFlagToggle
+                    featureFlag="annotationQueues"
+                    whenEnabled={
+                      <CreateNewAnnotationQueueItem
+                        projectId={trace.projectId}
+                        objectId={trace.id}
+                        objectType={AnnotationQueueObjectType.TRACE}
+                      />
+                    }
                   />
                 )}
               </div>

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -32,7 +32,6 @@ import { useHasOrgEntitlement } from "@/src/features/entitlements/hooks";
 import { useMemo } from "react";
 import { usdFormatter } from "@/src/utils/numbers";
 import { calculateDisplayTotalCost } from "@/src/components/trace/lib/helpers";
-import { FeatureFlagToggle } from "@/src/features/feature-flags/components/FeatureFlagToggle";
 import useIsFeatureEnabled from "@/src/features/feature-flags/hooks/useIsFeatureEnabled";
 
 export const TracePreview = ({
@@ -160,16 +159,11 @@ export const TracePreview = ({
                   setEmptySelectedConfigIds={setEmptySelectedConfigIds}
                   hasGroupedButton={hasEntitlement && isFeatureFlagEnabled}
                 />
-                {hasEntitlement && (
-                  <FeatureFlagToggle
-                    featureFlag="annotationQueues"
-                    whenEnabled={
-                      <CreateNewAnnotationQueueItem
-                        projectId={trace.projectId}
-                        objectId={trace.id}
-                        objectType={AnnotationQueueObjectType.TRACE}
-                      />
-                    }
+                {hasEntitlement && isFeatureFlagEnabled && (
+                  <CreateNewAnnotationQueueItem
+                    projectId={trace.projectId}
+                    objectId={trace.id}
+                    objectType={AnnotationQueueObjectType.TRACE}
                   />
                 )}
               </div>

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -32,11 +32,8 @@ import { useHasOrgEntitlement } from "@/src/features/entitlements/hooks";
 import { useMemo } from "react";
 import { usdFormatter } from "@/src/utils/numbers";
 import { calculateDisplayTotalCost } from "@/src/components/trace/lib/helpers";
-import {
-  FeatureFlagToggle,
-  isFeatureFlagEnabled,
-} from "@/src/features/feature-flags/components/FeatureFlagToggle";
-import { useSession } from "next-auth/react";
+import { FeatureFlagToggle } from "@/src/features/feature-flags/components/FeatureFlagToggle";
+import useIsFeatureEnabled from "@/src/features/feature-flags/hooks/useIsFeatureEnabled";
 
 export const TracePreview = ({
   trace,
@@ -53,7 +50,7 @@ export const TracePreview = ({
   viewType?: "detailed" | "focused";
   className?: string;
 }) => {
-  const session = useSession();
+  const isFeatureFlagEnabled = useIsFeatureEnabled("annotationQueues");
   const [selectedTab, setSelectedTab] = useQueryParam(
     "view",
     withDefault(StringParam, "preview"),
@@ -161,10 +158,7 @@ export const TracePreview = ({
                   scores={scores}
                   emptySelectedConfigIds={emptySelectedConfigIds}
                   setEmptySelectedConfigIds={setEmptySelectedConfigIds}
-                  hasGroupedButton={
-                    hasEntitlement &&
-                    isFeatureFlagEnabled(session, "annotationQueues")
-                  }
+                  hasGroupedButton={hasEntitlement && isFeatureFlagEnabled}
                 />
                 {hasEntitlement && (
                   <FeatureFlagToggle

--- a/web/src/features/feature-flags/components/FeatureFlagToggle.tsx
+++ b/web/src/features/feature-flags/components/FeatureFlagToggle.tsx
@@ -19,16 +19,6 @@ const isWhitelistedForFeature = (
   return flags !== undefined && flags[featureFlag];
 };
 
-export const isFeatureFlagEnabled = (
-  session: SessionContextValue,
-  featureFlag: Flag,
-): boolean => {
-  return (
-    isAdminOrExperimentalFeatures(session) ||
-    isWhitelistedForFeature(session, featureFlag)
-  );
-};
-
 export const FeatureFlagToggle = (props: {
   featureFlag: Flag;
   whenEnabled?: React.ReactNode;

--- a/web/src/features/feature-flags/components/FeatureFlagToggle.tsx
+++ b/web/src/features/feature-flags/components/FeatureFlagToggle.tsx
@@ -24,8 +24,8 @@ export const isFeatureFlagEnabled = (
   featureFlag: Flag,
 ): boolean => {
   return (
-    isWhitelistedForFeature(session, featureFlag) ||
-    isAdminOrExperimentalFeatures(session)
+    isAdminOrExperimentalFeatures(session) ||
+    isWhitelistedForFeature(session, featureFlag)
   );
 };
 

--- a/web/src/features/feature-flags/components/FeatureFlagToggle.tsx
+++ b/web/src/features/feature-flags/components/FeatureFlagToggle.tsx
@@ -1,5 +1,33 @@
 import { type Flag } from "@/src/features/feature-flags/types";
-import { useSession } from "next-auth/react";
+import { type SessionContextValue, useSession } from "next-auth/react";
+
+const isAdminOrExperimentalFeatures = (
+  session: SessionContextValue,
+): boolean => {
+  const enableExperimentalFeatures =
+    session.data?.environment?.enableExperimentalFeatures ?? false;
+  const isAdmin = session.data?.user?.admin ?? false;
+
+  return enableExperimentalFeatures || isAdmin;
+};
+
+const isWhitelistedForFeature = (
+  session: SessionContextValue,
+  featureFlag: Flag,
+): boolean => {
+  const flags = session.data?.user?.featureFlags;
+  return flags !== undefined && flags[featureFlag];
+};
+
+export const isFeatureFlagEnabled = (
+  session: SessionContextValue,
+  featureFlag: Flag,
+): boolean => {
+  return (
+    isWhitelistedForFeature(session, featureFlag) ||
+    isAdminOrExperimentalFeatures(session)
+  );
+};
 
 export const FeatureFlagToggle = (props: {
   featureFlag: Flag;
@@ -9,18 +37,15 @@ export const FeatureFlagToggle = (props: {
 }) => {
   const session = useSession();
 
-  const enableExperimentalFeatures =
-    session.data?.environment.enableExperimentalFeatures ?? false;
-  const isAdmin = session.data?.user?.admin ?? false;
+  if (isAdminOrExperimentalFeatures(session)) return props.whenEnabled ?? <></>;
 
-  if (enableExperimentalFeatures || isAdmin) return props.whenEnabled ?? <></>;
-
-  const flags = session.data?.user?.featureFlags;
-  const isEnabled = flags !== undefined && flags[props.featureFlag];
+  const isEnabled = isWhitelistedForFeature(session, props.featureFlag);
 
   if (session.status === "loading") {
     return props.whenLoading ?? <div>Loading ...</div>;
   }
 
-  return isEnabled ? props.whenEnabled ?? <></> : props.whenDisabled ?? <></>;
+  return isEnabled
+    ? (props.whenEnabled ?? <></>)
+    : (props.whenDisabled ?? <></>);
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add feature flag handling for 'Add to Annotation Queue' button in `ObservationPreview.tsx` and `TracePreview.tsx` using `FeatureFlagToggle`.
> 
>   - **Feature Flag Handling**:
>     - Add `isFeatureFlagEnabled` in `ObservationPreview.tsx` and `TracePreview.tsx` to conditionally render `CreateNewAnnotationQueueItem` based on `annotationQueues` feature flag.
>     - Use `isFeatureFlagEnabled` to check feature flag status in `AnnotateDrawer` components.
>   - **Functions**:
>     - Add `isFeatureFlagEnabled` function in `FeatureFlagToggle.tsx` to determine if a feature flag is enabled based on session data.
>     - Refactor `FeatureFlagToggle` to use `isAdminOrExperimentalFeatures` and `isWhitelistedForFeature` for cleaner logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8067da6f86a4f8dd5e8d57081b4c7ab1e6a57035. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->