### PR TITLE
fix(ui): md-view, ordered lists with many items

### DIFF
--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -115,7 +115,9 @@ function MarkdownRenderer({
         },
         li({ children }) {
           return (
-            <li className="mb-1">{transformListItemChildren(children)}</li>
+            <li className="mt-1 [&>ol]:pl-4 [&>ul]:pl-4">
+              {transformListItemChildren(children)}
+            </li>
           );
         },
         pre({ children }) {

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -108,16 +108,14 @@ function MarkdownRenderer({
           if (isChecklist(children))
             return <ul className="list-none">{children}</ul>;
 
-          return <ul className="list-outside list-disc pl-4">{children}</ul>;
+          return <ul className="list-inside list-disc">{children}</ul>;
         },
         ol({ children }) {
-          return <ol className="list-outside list-decimal pl-4">{children}</ol>;
+          return <ol className="list-inside list-decimal">{children}</ol>;
         },
         li({ children }) {
           return (
-            <li className="mb-1 list-item">
-              {transformListItemChildren(children)}
-            </li>
+            <li className="mb-1">{transformListItemChildren(children)}</li>
           );
         },
         pre({ children }) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjust list styling in `MarkdownViewer.tsx` to use `list-inside` and update `li` padding for nested lists.
> 
>   - **Styling Changes**:
>     - Change `ul` and `ol` elements from `list-outside` to `list-inside` in `MarkdownViewer.tsx`.
>     - Adjust `li` elements to have `mt-1` and specific padding for nested lists (`[&>ol]:pl-4 [&>ul]:pl-4`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c20bc6f85424cf4b792d3628faf2fbbbd952f19e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->