### PR TITLE
fix: fail open on rate limit errors

### DIFF
--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -118,13 +118,19 @@ export default async function handler(
       throw new UnauthorizedError(authCheck.error);
     }
 
-    const rateLimitCheck = await new RateLimitService(redis).rateLimitRequest(
-      authCheck.scope,
-      "ingestion",
-    );
+    try {
+      const rateLimitCheck = await new RateLimitService(redis).rateLimitRequest(
+        authCheck.scope,
+        "ingestion",
+      );
 
-    if (rateLimitCheck?.isRateLimited()) {
-      return rateLimitCheck.sendRestResponseIfLimited(res);
+      if (rateLimitCheck?.isRateLimited()) {
+        return rateLimitCheck.sendRestResponseIfLimited(res);
+      }
+    } catch (e) {
+      // If rate-limiter returns an error, we log it and continue processing.
+      // This allows us to fail open instead of reject requests.
+      logger.error("Error while rate limiting", e);
     }
 
     const batchType = z.object({


### PR DESCRIPTION
## What

If the rate limited throws an error, e.g. because redis is unavailable, we fail open and allow the request.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `ingestion.ts` to fail open on rate limit errors, logging them and allowing requests to proceed.
> 
>   - **Behavior**:
>     - In `ingestion.ts`, modify rate limiting logic to fail open on errors.
>     - Log errors from `RateLimitService` and continue processing requests.
>   - **Logging**:
>     - Add error logging for rate limit errors in `ingestion.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bc2b5bf6965eb7a2293ec0a3cdf3f00bfad61a4f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->