### PR TITLE
feat(ui): add toggle for color coding of metrics on trace tree

### DIFF
--- a/web/src/components/trace/ObservationTree.tsx
+++ b/web/src/components/trace/ObservationTree.tsx
@@ -31,6 +31,7 @@ export const ObservationTree = (props: {
   setCurrentObservationId: (id: string | undefined) => void;
   showMetrics: boolean;
   showScores: boolean;
+  colorCodeMetrics: boolean;
   observationCommentCounts?: Map<string, number>;
   traceCommentCounts?: Map<string, number>;
   className?: string;
@@ -70,7 +71,7 @@ export const ObservationTree = (props: {
         setCurrentObservationId={props.setCurrentObservationId}
         showMetrics={props.showMetrics}
         showScores={props.showScores}
-        colorCodeMetrics={props.observations.length >= 3}
+        colorCodeMetrics={props.colorCodeMetrics}
         parentTotalCost={totalCost}
         parentTotalDuration={
           props.trace.latency ? props.trace.latency * 1000 : undefined

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -24,6 +24,7 @@ import {
   ChevronsUpDown,
   ListTree,
   Network,
+  Percent,
 } from "lucide-react";
 import { usdFormatter } from "@/src/utils/numbers";
 import { useCallback, useState } from "react";
@@ -57,6 +58,10 @@ export function Trace(props: {
     "scoresOnObservationTree",
     true,
   );
+  const [
+    colorCodeMetricsOnObservationTree,
+    setColorCodeMetricsOnObservationTree,
+  ] = useLocalStorage("colorCodeMetricsOnObservationTree", true);
 
   const [collapsedObservations, setCollapsedObservations] = useState<string[]>(
     [],
@@ -201,6 +206,14 @@ export function Trace(props: {
               <ChevronsUpDown className="h-4 w-4" />
             )}
           </Toggle>
+          <Toggle
+            pressed={colorCodeMetricsOnObservationTree}
+            onPressedChange={(e) => setColorCodeMetricsOnObservationTree(e)}
+            size="xs"
+            title="Color code metrics (>50% yellow, >75% red)"
+          >
+            <Percent className="h-4 w-4" />
+          </Toggle>
         </div>
 
         <ObservationTree
@@ -215,6 +228,7 @@ export function Trace(props: {
           setCurrentObservationId={setCurrentObservationId}
           showMetrics={metricsOnObservationTree}
           showScores={scoresOnObservationTree}
+          colorCodeMetrics={colorCodeMetricsOnObservationTree}
           observationCommentCounts={observationCommentCounts.data}
           traceCommentCounts={traceCommentCounts.data}
           className="flex w-full flex-col overflow-y-auto"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a toggle in the UI to enable color coding of metrics in the trace tree, with logic applied in `ObservationTreeNode`.
> 
>   - **UI Feature**:
>     - Adds `colorCodeMetrics` toggle in `Trace` component to enable/disable color coding of metrics.
>     - Updates `ObservationTree` to accept `colorCodeMetrics` prop.
>   - **Logic**:
>     - Implements color coding logic in `ObservationTreeNode` using `heatMapTextColor()` to apply text color based on metric thresholds (>50% yellow, >75% red).
>   - **State Management**:
>     - Uses `useLocalStorage` to persist `colorCodeMetricsOnObservationTree` state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4e3b0497b078e76ff4d159fa39f39ec7afd46e13. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->