### PR TITLE
chore: group events on S3 by clickhouse entity

### DIFF
--- a/packages/shared/src/server/clickhouse.ts
+++ b/packages/shared/src/server/clickhouse.ts
@@ -1,7 +1,8 @@
 import { createClient } from "@clickhouse/client";
 
 import { env } from "../env";
-import { eventTypes, IngestionEventType } from "./ingestion/types";
+import { eventTypes } from "./ingestion/types";
+import { LangfuseNotFoundError } from "../errors";
 
 export enum ClickhouseEntityType {
   Trace = "trace",
@@ -11,9 +12,9 @@ export enum ClickhouseEntityType {
 }
 
 export function getClickhouseEntityType(
-  event: IngestionEventType,
+  eventType: string,
 ): ClickhouseEntityType {
-  switch (event.type) {
+  switch (eventType) {
     case eventTypes.TRACE_CREATE:
       return ClickhouseEntityType.Trace;
     case eventTypes.OBSERVATION_CREATE:
@@ -28,6 +29,8 @@ export function getClickhouseEntityType(
       return ClickhouseEntityType.Score;
     case eventTypes.SDK_LOG:
       return ClickhouseEntityType.SdkLog;
+    default:
+      throw new LangfuseNotFoundError(`Unknown event type: ${eventType}`);
   }
 }
 

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -56,10 +56,6 @@ export const ingestionQueueProcessor: Processor = async (
     const s3Client = getS3StorageServiceClient(
       env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
     );
-    const eventName = job.data.payload.data.type.split("-").shift();
-    if (!eventName) {
-      throw new Error("Event name not found");
-    }
 
     logger.info("Processing ingestion event", {
       projectId: job.data.payload.authCheck.scope.projectId,
@@ -68,7 +64,7 @@ export const ingestionQueueProcessor: Processor = async (
 
     // Download all events from folder into a local array
     const eventFiles = await s3Client.listFiles(
-      `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${eventName}/${job.data.payload.data.eventBodyId}/`,
+      `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${getClickhouseEntityType(job.data.payload.data.type)}/${job.data.payload.data.eventBodyId}/`,
     );
 
     const events: IngestionEventType[] = (
@@ -110,7 +106,7 @@ export const ingestionQueueProcessor: Processor = async (
       ClickhouseWriter.getInstance(),
       clickhouseClient,
     ).mergeAndWrite(
-      getClickhouseEntityType(events[0]),
+      getClickhouseEntityType(events[0].type),
       job.data.payload.authCheck.scope.projectId,
       job.data.payload.data.eventBodyId,
       events,

--- a/worker/src/queues/legacyIngestionQueue.ts
+++ b/worker/src/queues/legacyIngestionQueue.ts
@@ -12,6 +12,7 @@ import {
   S3StorageService,
   ingestionBatchEvent,
   ingestionEvent,
+  getClickhouseEntityType,
 } from "@langfuse/shared/src/server";
 
 import {
@@ -60,9 +61,8 @@ export const legacyIngestionQueueProcessor: Processor = async (
       ingestionEvents = (
         await Promise.all(
           job.data.payload.data.map(async (record) => {
-            const eventName = record.type.split("-").shift();
             const file = await s3Client.download(
-              `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${eventName}/${record.eventBodyId}/${record.eventId}.json`,
+              `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${getClickhouseEntityType(record.type)}/${record.eventBodyId}/${record.eventId}.json`,
             );
             const parsedFile = JSON.parse(file);
             const parsed = ingestionBatchEvent.safeParse(parsedFile);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Group events on S3 by Clickhouse entity type using `getClickhouseEntityType()` and improve error handling for unknown event types.
> 
>   - **Behavior**:
>     - Events are now grouped on S3 by Clickhouse entity type using `getClickhouseEntityType()`.
>     - Throws `LangfuseNotFoundError` for unknown event types in `clickhouse.ts`.
>   - **Functions**:
>     - `getClickhouseEntityType()` updated to accept `eventType` string instead of `IngestionEventType`.
>   - **Ingestion**:
>     - Updated S3 path in `ingestion.ts` to use `getClickhouseEntityType()` for event type.
>     - Removed `eventName` extraction logic in `ingestionQueue.ts` and `legacyIngestionQueue.ts`.
>   - **Error Handling**:
>     - Added error handling for unknown event types in `clickhouse.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a3fa192f40b59ae47a59c00607b66cd4b9968a70. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->