### PR TITLE
chore: authenticate with docker hub for CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_READ }}
       - name: Set NEXT_PUBLIC_BUILD_ID
         run: echo "NEXT_PUBLIC_BUILD_ID=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Build and run both images from compose
@@ -86,8 +86,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_READ }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -148,8 +148,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_READ }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -207,8 +207,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_READ }}
       - name: install dependencies
         run: |
           pnpm install
@@ -239,8 +239,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_READ }}
       - uses: pnpm/action-setup@v3
         with:
           version: 9.5.0

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -40,15 +40,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set NEXT_PUBLIC_BUILD_ID
         run: echo "NEXT_PUBLIC_BUILD_ID=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-
       - name: Build and run both images from compose
         run: |
           docker compose -f docker-compose.build.yml up -d
           sleep 5 # Wait for PostgreSQL to accept connections
-
       - name: Ensure no unhealthy status
         run: |
           if docker-compose ps | grep "(unhealthy)"; then
@@ -57,11 +59,9 @@ jobs:
           else
             echo "All services are healthy"
           fi
-
       - name: Check worker health
         run: |
           timeout 10 bash -c 'until curl -f http://localhost:3030/api/health; do sleep 2; done'
-
       - name: Check server health
         run: |
           timeout 10 bash -c 'until curl -f http://localhost:3000/api/public/health; do sleep 2; done'
@@ -79,27 +79,28 @@ jobs:
         uses: pierotofy/set-swap-space@master
         with:
           swap-size-gb: 10
-
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
           version: 9.5.0
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
-
       - name: install dependencies
         run: |
           pnpm install
-
       - name: Load default env
         run: |
           cp .env.dev.example .env
           grep -v -e '^S3_BUCKET_NAME=' -e '^REDIS_HOST=' -e '^NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT=' .env.dev.example > .env
-
       - name: Run + migrate
         run: |
           docker compose -f docker-compose.dev.yml up -d
@@ -107,14 +108,11 @@ jobs:
           docker compose ps
         env:
           POSTGRES_VERSION: ${{ matrix.postgres-version }}
-
       - name: Seed DB
         run: |
           pnpm run db:migrate
-
       - name: Build
         run: pnpm run build
-
       - name: Start Langfuse
         run: (pnpm run start&)
         env:
@@ -127,7 +125,6 @@ jobs:
           LANGFUSE_INIT_USER_EMAIL: "demo@langfuse.com"
           LANGFUSE_INIT_USER_NAME: "Demo User"
           LANGFUSE_INIT_USER_PASSWORD: "password"
-
       - name: run tests
         run: pnpm --filter=web run test
 
@@ -144,41 +141,39 @@ jobs:
         uses: pierotofy/set-swap-space@master
         with:
           swap-size-gb: 10
-
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
           version: 9.5.0
-
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
-
       - name: install dependencies
         run: |
           pnpm install
-
       - name: Install golang-migrate for Clickhouse migrations
         run: |
           curl -L https://github.com/golang-migrate/migrate/releases/download/v4.16.2/migrate.linux-amd64.tar.gz | tar xvz
           sudo mv migrate /usr/bin/migrate
           which migrate
-
       - name: Load default env
         run: |
           cp .env.dev.example .env
           cp .env.dev.example web/.env
           cp .env.dev.example worker/.env
-
       - name: Run + migrate
         run: |
           docker compose -f docker-compose.dev.yml up -d
           sleep 5 # Wait for PostgreSQL to accept connections
           docker compose ps
-
       - name: Ensure no unhealthy status
         run: |
           if docker compose ps | grep "(unhealthy)"; then
@@ -187,18 +182,16 @@ jobs:
           else
             echo "All services are healthy"
           fi
-
       - name: Seed DB
         run: |
           pnpm run db:migrate
           pnpm run db:seed
           pnpm run --filter=shared ch:up
-
       - name: Build
         run: pnpm --filter=worker... run build
-
       - name: run tests
         run: pnpm --filter=worker run test
+
   e2e-tests:
     runs-on: ubuntu-latest
     steps:
@@ -211,33 +204,31 @@ jobs:
           node-version: 20
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
-
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: install dependencies
         run: |
           pnpm install
-
       - name: Load default env
         run: |
           cp .env.dev.example .env
           cp .env.dev.example web/.env
-
       - name: Run + migrate
         run: |
           docker compose -f docker-compose.dev.yml up -d
           docker compose ps
           sleep 5 # Wait for PostgreSQL to accept connections
-
       - name: Seed DB
         run: |
           pnpm run db:migrate
           pnpm run db:seed
-
       - name: Build
         run: pnpm run build
-
       - name: Install playwright
         run: pnpm --filter=web exec playwright install --with-deps
-
       - name: Run e2e tests
         run: pnpm --filter=web run test:e2e
 
@@ -245,6 +236,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: pnpm/action-setup@v3
         with:
           version: 9.5.0
@@ -253,35 +249,28 @@ jobs:
           node-version: 20
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
-
       - name: install dependencies
         run: |
           pnpm install
-
       - name: Load default env
         run: |
           cp .env.dev.example .env
           echo "LANGFUSE_ASYNC_INGESTION_PROCESSING=true" >> .env
           echo "LANGFUSE_CACHE_API_KEY_ENABLED=true" >> .env
           echo "LANGFUSE_CACHE_PROMPT_ENABLED=true" >> .env
-
       - name: Run + migrate
         run: |
           docker compose -f docker-compose.dev.yml up -d
           docker compose ps
           sleep 5 # Wait for PostgreSQL to accept connections
-
       - name: Seed DB
         run: |
           pnpm run db:migrate
           pnpm run db:seed:examples
-
       - name: Build
         run: pnpm run build
-
       - name: Run server
         run: (pnpm run start&)
-
       - name: Run e2e tests
         run: pnpm --filter=web run test:e2e:server
 
@@ -326,34 +315,27 @@ jobs:
         with:
           node-version: 20
           cache-dependency-path: "pnpm-lock.yaml"
-
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Set NEXT_PUBLIC_BUILD_ID
         run: echo "NEXT_PUBLIC_BUILD_ID=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-
       - name: Log in to the GitHub Container registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta-web
         uses: docker/metadata-action@v4
@@ -368,7 +350,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-
       - name: Build and push Docker image (web)
         uses: docker/build-push-action@v4
         with:
@@ -380,7 +361,6 @@ jobs:
           platforms: |
             linux/amd64
             ${{ startsWith(github.ref, 'refs/tags/') && 'linux/arm64' || '' }}
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta-worker
         uses: docker/metadata-action@v4
@@ -395,7 +375,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-
       - name: Build and push Docker image (worker)
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
## What does this PR do?

Authenticate with docker hub during CI runs to expand our rate limits.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds Docker Hub authentication to CI jobs in `pipeline.yml` to expand rate limits.
> 
>   - **CI/CD Workflow**:
>     - Adds Docker Hub authentication using `docker/login-action@v3` in `pipeline.yml`.
>     - Uses `secrets.DOCKERHUB_USERNAME_READ` and `secrets.DOCKERHUB_TOKEN_READ` for authentication.
>   - **Jobs Updated**:
>     - `test-docker-build`, `tests-web`, `tests-worker`, `e2e-tests`, `e2e-server-tests`, and `push-docker-image` now include Docker Hub login steps.
>   - **Purpose**:
>     - Expands Docker Hub rate limits during CI runs by authenticating requests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7ce50991d1770fbfa14437e818b88ef33f848d29. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->