### PR TITLE
fix(models): start_date type to datetime in fern

### DIFF
--- a/fern/apis/server/definition/models.yml
+++ b/fern/apis/server/definition/models.yml
@@ -55,7 +55,7 @@ types:
         type: string
       startDate:
         docs: Apply only to generations which are newer than this ISO date.
-        type: optional<date>
+        type: optional<datetime>
       unit:
         docs: Unit used by this model.
         type: commons.ModelUsageUnit

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3625,7 +3625,7 @@ components:
             to exact match, use `(?i)^modelname$`
         startDate:
           type: string
-          format: date
+          format: date-time
           nullable: true
           description: Apply only to generations which are newer than this ISO date.
         unit:

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -563,7 +563,7 @@
             "auth": null,
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"modelName\": \"example\",\n    \"matchPattern\": \"example\",\n    \"startDate\": \"1994-11-05\",\n    \"unit\": \"CHARACTERS\",\n    \"inputPrice\": 0,\n    \"outputPrice\": 0,\n    \"totalPrice\": 0,\n    \"tokenizerId\": \"example\",\n    \"tokenizerConfig\": \"UNKNOWN\"\n}",
+              "raw": "{\n    \"modelName\": \"example\",\n    \"matchPattern\": \"example\",\n    \"startDate\": \"1994-11-05T13:15:30Z\",\n    \"unit\": \"CHARACTERS\",\n    \"inputPrice\": 0,\n    \"outputPrice\": 0,\n    \"totalPrice\": 0,\n    \"tokenizerId\": \"example\",\n    \"tokenizerConfig\": \"UNKNOWN\"\n}",
               "options": {
                 "raw": {
                   "language": "json"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `startDate` type from `date` to `datetime` in `models.yml`, `openapi.yml`, and `collection.json` for more precise time representation.
> 
>   - **Behavior**:
>     - Change `startDate` type from `optional<date>` to `optional<datetime>` in `models.yml`.
>     - Update `startDate` format from `date` to `date-time` in `openapi.yml`.
>     - Modify `startDate` example value to include time in `collection.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0cdff357b3d621d38678bc3307f6ca3e3cc65a41. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->