### PR TITLE
fix: show number of observations in trace table

### DIFF
--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -57,7 +57,7 @@ export type TracesTableRow = {
   name: string;
   userId: string;
   level?: ObservationLevel;
-  observationCount?: number;
+  observationCount?: bigint;
   // scores holds grouped column with individual scores
   scores?: ScoreAggregate;
   latency?: number;
@@ -602,7 +602,7 @@ export default function TracesTable({
         const value: TracesTableRow["observationCount"] =
           row.getValue("observationCount");
         if (!traceMetrics.data) return <Skeleton className="h-3 w-1/2" />;
-        return <span>{value}</span>;
+        return <span>{numberFormatter(value, 0)}</span>;
       },
     },
     {

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -157,10 +157,9 @@ export const traceRouter = createTRPCRouter({
             promptTokens: bigint;
             completionTokens: bigint;
             totalTokens: bigint;
-            totalCount: number;
             latency: number | null;
             level: ObservationLevel;
-            observationCount: number;
+            observationCount: bigint;
             calculatedTotalCost: Decimal | null;
             calculatedInputCost: Decimal | null;
             calculatedOutputCost: Decimal | null;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `observationCount` to `bigint` and format it in `traces.tsx` and `traces.ts`.
> 
>   - **Data Type Change**:
>     - Change `observationCount` from `number` to `bigint` in `TracesTableRow` in `traces.tsx`.
>     - Change `observationCount` from `number` to `bigint` in `metrics` query in `traces.ts`.
>   - **Frontend Display**:
>     - Format `observationCount` using `numberFormatter` in `traces.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9404d51fe8be6ab07a04c0220a6c9a32d9cf22f8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->