### PR TITLE
feat: add note input field for API key management

### DIFF
--- a/web/src/features/public-api/components/ApiKeyList.tsx
+++ b/web/src/features/public-api/components/ApiKeyList.tsx
@@ -66,7 +66,7 @@ export function ApiKeyList(props: { projectId: string }) {
               <TableHead className="hidden text-primary md:table-cell">
                 Created
               </TableHead>
-              {/* <TableHead className="text-primary">Note</TableHead> */}
+              <TableHead className="text-primary">Note</TableHead>
               <TableHead className="text-primary">Public Key</TableHead>
               <TableHead className="text-primary">Secret Key</TableHead>
               {/* <TableHead className="text-primary">Last used</TableHead> */}
@@ -89,7 +89,7 @@ export function ApiKeyList(props: { projectId: string }) {
                   <TableCell className="hidden md:table-cell">
                     {apiKey.createdAt.toLocaleDateString()}
                   </TableCell>
-                  {/* <TableCell>{apiKey.note ?? ""}</TableCell> */}
+                  <TableCell>{apiKey.note ?? "No note"}</TableCell>
                   <TableCell className="font-mono">
                     <CodeView
                       className="inline-block text-xs"


### PR DESCRIPTION
## What does this PR do?

This PR adds the ability to attach notes to Langfuse API keys, improving management for users with multiple keys.

**Note:** The note field is currently not editable after creation due to backend limitations, which only allow read, create, or delete permissions. I have kept the changes as minimal as possible.

Fixes #3500


![Screen Recording 2024-10-14 at 22 50 50](https://github.com/user-attachments/assets/03faa693-e939-4cba-97f4-75a38b7ccb97)
## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Self-reviewed the code

Kindly let me know if any more changes are required.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds optional note input for API keys, displayed in `ApiKeyList.tsx` and created in `CreateApiKeyButton.tsx`, with non-editable notes post-creation.
> 
>   - **Feature**:
>     - Adds note input field for API keys in `CreateApiKeyButton.tsx`.
>     - Displays notes in `ApiKeyList.tsx`.
>   - **Behavior**:
>     - Notes are optional and cannot be edited post-creation.
>     - Focuses input field on dialog open in `CreateApiKeyButton.tsx`.
>   - **UI**:
>     - Updates `Dialog` in `CreateApiKeyButton.tsx` to include note input.
>     - Shows "No note" if note is absent in `ApiKeyList.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for edb2a4fd59197f80b2d63753ec58e4ea2446b4e4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->