### PR TITLE
fix: add default minimum width for dynamic score columns, allow column reordering for prompts metrics table

### DIFF
--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -77,6 +77,11 @@ function insertArrayAfterKey(array: string[], toInsert: Map<string, string[]>) {
   }, []);
 }
 
+function isValidCssVariableName(name: string) {
+  const regex = /^(?![0-9])([a-zA-Z][a-zA-Z0-9-_]*)$/;
+  return regex.test(name);
+}
+
 export function DataTable<TData extends object, TValue>({
   columns,
   data,
@@ -204,6 +209,11 @@ export function DataTable<TData extends object, TValue>({
                     const columnDef = header.column
                       .columnDef as LangfuseColumnDef<ModelTableRow>;
                     const sortingEnabled = columnDef.enableSorting;
+                    // if the header id does not translate to a valid css variable name, default to 150px as width
+                    // may only happen for dynamic columns, as column names are user defined
+                    const width = isValidCssVariableName(header.id)
+                      ? `calc(var(--header-${header.id}-size) * 1px)`
+                      : 150;
 
                     return header.column.getIsVisible() ? (
                       <TableHead
@@ -212,9 +222,7 @@ export function DataTable<TData extends object, TValue>({
                           "group p-1 first:pl-2",
                           sortingEnabled && "cursor-pointer",
                         )}
-                        style={{
-                          width: `calc(var(--header-${header.id}-size) * 1px)`,
-                        }}
+                        style={{ width }}
                         onClick={(event) => {
                           event.preventDefault();
 

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -77,8 +77,16 @@ function insertArrayAfterKey(array: string[], toInsert: Map<string, string[]>) {
   }, []);
 }
 
-function isValidCssVariableName(name: string) {
-  const regex = /^(?![0-9])([a-zA-Z][a-zA-Z0-9-_]*)$/;
+function isValidCssVariableName({
+  name,
+  includesHyphens = true,
+}: {
+  name: string;
+  includesHyphens?: boolean;
+}) {
+  const regex = includesHyphens
+    ? /^--(?![0-9])([a-zA-Z][a-zA-Z0-9-_]*)$/
+    : /^(?![0-9])([a-zA-Z][a-zA-Z0-9-_]*)$/;
   return regex.test(name);
 }
 
@@ -211,7 +219,10 @@ export function DataTable<TData extends object, TValue>({
                     const sortingEnabled = columnDef.enableSorting;
                     // if the header id does not translate to a valid css variable name, default to 150px as width
                     // may only happen for dynamic columns, as column names are user defined
-                    const width = isValidCssVariableName(header.id)
+                    const width = isValidCssVariableName({
+                      name: header.id,
+                      includesHyphens: false,
+                    })
                       ? `calc(var(--header-${header.id}-size) * 1px)`
                       : 150;
 

--- a/web/src/pages/project/[projectId]/prompts/[promptName]/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/[promptName]/metrics.tsx
@@ -20,6 +20,7 @@ import { type FilterState } from "@langfuse/shared";
 import { useTableDateRange } from "@/src/hooks/useTableDateRange";
 import { type ScoreAggregate } from "@/src/features/scores/lib/types";
 import { useIndividualScoreColumns } from "@/src/features/scores/hooks/useIndividualScoreColumns";
+import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 
 export type PromptVersionTableRow = {
   version: number;
@@ -345,6 +346,11 @@ export default function PromptVersionTable() {
       columns,
     );
 
+  const [columnOrder, setColumnOrder] = useColumnOrder<PromptVersionTableRow>(
+    "promptVersionsColumnOrder",
+    columns,
+  );
+
   const totalCount = promptVersions?.data?.totalCount ?? null;
 
   const { combinedData } = joinPromptCoreAndMetricData(
@@ -426,6 +432,8 @@ export default function PromptVersionTable() {
           setColumnVisibility={setColumnVisibilityState}
           selectedOption={selectedOption}
           setDateRangeAndOption={setDateRangeAndOption}
+          columnOrder={columnOrder}
+          setColumnOrder={setColumnOrder}
         />
       </div>
       <DataTable
@@ -454,6 +462,8 @@ export default function PromptVersionTable() {
         orderBy={orderByState}
         columnVisibility={columnVisibility}
         onColumnVisibilityChange={setColumnVisibilityState}
+        columnOrder={columnOrder}
+        onColumnOrderChange={setColumnOrder}
         rowHeight={rowHeight}
       />
     </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds default width for invalid CSS variable names in `DataTable` and column reordering in `PromptVersionTable`.
> 
>   - **Behavior**:
>     - Adds `isValidCssVariableName()` in `data-table.tsx` to validate CSS variable names.
>     - Sets default width to 150px for invalid CSS variable names in `DataTable`.
>   - **Features**:
>     - Adds column order management in `PromptVersionTable` using `useColumnOrder` hook.
>   - **Misc**:
>     - Updates `PromptVersionTable` to pass `columnOrder` and `setColumnOrder` to `DataTable` and `DataTableToolbar`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5b2dba918edd8c3570bb98f8490a39f197691819. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->