### PR TITLE
fix(llm-api-keys): add exact bedrock permission needed

### DIFF
--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -329,7 +329,7 @@ export function CreateLLMApiKeyForm({
                   <FormLabel>AWS Access Key ID</FormLabel>
                   <FormDescription>
                     These should be long-lived credentials for an AWS user with
-                    the appropriate Bedrock permissions.
+                    `bedrock:InvokeModel` permission.
                   </FormDescription>
                   <FormControl>
                     <Input {...field} />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `CreateLLMApiKeyForm` to specify `bedrock:InvokeModel` permission for AWS credentials.
> 
>   - **Form Description Update**:
>     - In `CreateLLMApiKeyForm`, updated `FormDescription` for `awsAccessKeyId` to specify `bedrock:InvokeModel` permission is needed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b89e5fe0c6e0df20254d6ad65df872142274cb8b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->