### PR TITLE
fix: loading state of annotation queue dropdown

### DIFF
--- a/web/src/ee/features/annotation-queues/components/CreateNewAnnotationQueueItem.tsx
+++ b/web/src/ee/features/annotation-queues/components/CreateNewAnnotationQueueItem.tsx
@@ -94,10 +94,12 @@ export const CreateNewAnnotationQueueItem = ({
     return (
       <Button
         variant="secondary"
-        disabled
+        disabled={session.status !== "authenticated"}
         className="rounded-l-none rounded-r-md border-l-2"
       >
-        <ChevronDown className="h-3 w-3" />
+        <span className="relative mr-1 text-xs">
+          <ChevronDown className="h-3 w-3" />
+        </span>
       </Button>
     );
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `Button` disabled state and styling in `CreateNewAnnotationQueueItem` based on session status.
> 
>   - **Behavior**:
>     - In `CreateNewAnnotationQueueItem`, the `Button`'s `disabled` prop is now conditionally set based on `session.status` being "authenticated".
>     - Wraps `ChevronDown` icon in a `span` with class `relative mr-1 text-xs` for consistent styling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bccd8c37bd5101f330bd915deb9f4d6108a9cd50. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->