### PR TITLE
fix(user_table): reset `orderBy` state on tab navigation

### DIFF
--- a/web/src/pages/project/[projectId]/users/[userId].tsx
+++ b/web/src/pages/project/[projectId]/users/[userId].tsx
@@ -42,9 +42,10 @@ export default function UserPage() {
   };
 
   const handleTabChange = async (tab: string) => {
-    if (router.query.filter) {
+    if (router.query.filter || router.query.orderBy) {
       const newQuery = { ...router.query };
       delete newQuery.filter;
+      delete newQuery.orderBy;
       await router.replace({ query: newQuery });
     }
     setCurrentTab(tab);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reset `orderBy` state on tab navigation in `users/[userId].tsx` to ensure consistent state.
> 
>   - **Behavior**:
>     - In `users/[userId].tsx`, `handleTabChange()` now resets `orderBy` state on tab change by deleting `orderBy` from `router.query`.
>     - Ensures consistent state by clearing both `filter` and `orderBy` when navigating tabs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f69d31cf5b42356193d42574f348a7cc8827f308. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->