### PR TITLE
style(ui): standardize table header line height across selection states

### DIFF
--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -231,30 +231,32 @@ export default function TracesTable({
       size: 30,
       isPinned: true,
       header: ({ table }) => (
-        <Checkbox
-          checked={
-            table.getIsAllPageRowsSelected()
-              ? true
-              : table.getIsSomePageRowsSelected()
-                ? "indeterminate"
-                : false
-          }
-          onCheckedChange={(value) => {
-            table.toggleAllPageRowsSelected(!!value);
-            if (!value) {
-              setSelectedRows({});
+        <div className="mt-1 h-5">
+          <Checkbox
+            checked={
+              table.getIsAllPageRowsSelected()
+                ? true
+                : table.getIsSomePageRowsSelected()
+                  ? "indeterminate"
+                  : false
             }
-          }}
-          aria-label="Select all"
-          className="mt-1 opacity-60 data-[state=checked]:mt-[6px] data-[state=indeterminate]:mt-[6px]"
-        />
+            onCheckedChange={(value) => {
+              table.toggleAllPageRowsSelected(!!value);
+              if (!value) {
+                setSelectedRows({});
+              }
+            }}
+            aria-label="Select all"
+            className="opacity-60"
+          />
+        </div>
       ),
       cell: ({ row }) => (
         <Checkbox
           checked={row.getIsSelected()}
           onCheckedChange={(value) => row.toggleSelected(!!value)}
           aria-label="Select row"
-          className="mt-1 opacity-60 data-[state=checked]:mt-[5px]"
+          className="opacity-60"
         />
       ),
     },

--- a/web/src/ee/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
+++ b/web/src/ee/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
@@ -167,23 +167,25 @@ export function AnnotationQueueItemsTable({
       isPinned: true,
       header: ({ table }) => {
         return (
-          <Checkbox
-            checked={
-              table.getIsAllPageRowsSelected()
-                ? true
-                : table.getIsSomePageRowsSelected()
-                  ? "indeterminate"
-                  : false
-            }
-            onCheckedChange={(value) => {
-              table.toggleAllPageRowsSelected(!!value);
-              if (!value) {
-                setSelectedRows({});
+          <div className="mt-1 h-5">
+            <Checkbox
+              checked={
+                table.getIsAllPageRowsSelected()
+                  ? true
+                  : table.getIsSomePageRowsSelected()
+                    ? "indeterminate"
+                    : false
               }
-            }}
-            aria-label="Select all"
-            className="mt-1 opacity-60 data-[state=checked]:mt-[6px] data-[state=indeterminate]:mt-[6px]"
-          />
+              onCheckedChange={(value) => {
+                table.toggleAllPageRowsSelected(!!value);
+                if (!value) {
+                  setSelectedRows({});
+                }
+              }}
+              aria-label="Select all"
+              className="opacity-60"
+            />
+          </div>
         );
       },
       cell: ({ row }) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Standardize table header line height across selection states in `traces.tsx` and `AnnotationQueueItemsTable.tsx`.
> 
>   - **UI Changes**:
>     - Standardize table header line height in `traces.tsx` and `AnnotationQueueItemsTable.tsx` by wrapping `Checkbox` in a `div` with `className="mt-1 h-5"`.
>     - Remove `mt-1` and state-specific margin classes from `Checkbox` components in both files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a2e130c9fa6807c50cc8d6aeaeab976bd203bea2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->