### PR TITLE
fix(self-host): LANGFUSE_INIT_USER_EMAIL lowercased for headless initialization

### DIFF
--- a/web/src/initialize.ts
+++ b/web/src/initialize.ts
@@ -65,8 +65,9 @@ if (env.LANGFUSE_INIT_ORG_ID) {
 
   // Create User: Org -> User
   if (env.LANGFUSE_INIT_USER_EMAIL && env.LANGFUSE_INIT_USER_PASSWORD) {
+    const email = env.LANGFUSE_INIT_USER_EMAIL.toLowerCase();
     const existingUser = await prisma.user.findUnique({
-      where: { email: env.LANGFUSE_INIT_USER_EMAIL },
+      where: { email },
     });
 
     let userId = existingUser?.id;
@@ -74,7 +75,7 @@ if (env.LANGFUSE_INIT_ORG_ID) {
     // Create user if it doesn't exist yet
     if (!userId) {
       userId = await createUserEmailPassword(
-        env.LANGFUSE_INIT_USER_EMAIL,
+        email,
         env.LANGFUSE_INIT_USER_PASSWORD,
         env.LANGFUSE_INIT_USER_NAME ?? "Provisioned User",
       );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Lowercase `LANGFUSE_INIT_USER_EMAIL` in `initialize.ts` for consistent user creation and lookup.
> 
>   - **Behavior**:
>     - Convert `LANGFUSE_INIT_USER_EMAIL` to lowercase in `initialize.ts` for user creation and lookup.
>     - Ensures consistent email handling during headless initialization.
>   - **Functions**:
>     - Modify `prisma.user.findUnique` and `createUserEmailPassword` calls to use the lowercased email.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e63d5c7043dc997b2462a845a2fa1a7032dac51d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->