### PR TITLE
chore: support more decimal digits for cost in session view

### DIFF
--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -121,7 +121,7 @@ export const SessionPage: React.FC<{
         <Badge variant="outline">Traces: {session.data?.traces.length}</Badge>
         {session.data && (
           <Badge variant="outline">
-            Total cost: {usdFormatter(session.data.totalCost, 2, 2)}
+            Total cost: {usdFormatter(session.data.totalCost, 2)}
           </Badge>
         )}
       </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjust `usdFormatter` call in `SessionPage` to allow more decimal digits for cost display.
> 
>   - **Behavior**:
>     - Adjust `usdFormatter` call in `SessionPage` component to allow more decimal digits for cost display by removing the second parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 24cb38620260aad29f8a257b36834596092b74a1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->