### PR TITLE
fix(ui): transition from uncontrolled to controlled component, add expected drawer title

### DIFF
--- a/web/src/components/layouts/doc-popup.tsx
+++ b/web/src/components/layouts/doc-popup.tsx
@@ -10,9 +10,14 @@ import { Info } from "lucide-react";
 export type DocPopupProps = {
   description: React.ReactNode;
   href?: string;
+  className?: string;
 };
 
-export default function DocPopup({ description, href }: DocPopupProps) {
+export default function DocPopup({
+  description,
+  href,
+  className,
+}: DocPopupProps) {
   const capture = usePostHogClientCapture();
 
   return (
@@ -49,7 +54,12 @@ export default function DocPopup({ description, href }: DocPopupProps) {
       </HoverCardTrigger>
       <HoverCardContent>
         {typeof description === "string" ? (
-          <div className="whitespace-break-spaces text-xs font-normal text-primary sm:pl-0">
+          <div
+            className={cn(
+              "whitespace-break-spaces text-xs font-normal text-primary sm:pl-0",
+              className,
+            )}
+          >
             {description}
           </div>
         ) : (

--- a/web/src/components/layouts/header.tsx
+++ b/web/src/components/layouts/header.tsx
@@ -48,7 +48,7 @@ export default function Header({
     text: string;
     href: string;
   };
-  help?: { description: string; href?: string };
+  help?: { description: string; href?: string; className?: string };
   featureBetaURL?: string;
   actionButtons?: React.ReactNode;
   level?: "h2" | "h3";
@@ -77,6 +77,7 @@ export default function Header({
               <DocPopup
                 description={props.help.description}
                 href={props.help.href}
+                className={props.help.className}
               />
             ) : null}
             {props.featureBetaURL ? (

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -41,6 +41,7 @@ const DialogContent = React.forwardRef<
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
+      aria-describedby={undefined}
       {...props}
     >
       {children}

--- a/web/src/components/ui/drawer.tsx
+++ b/web/src/components/ui/drawer.tsx
@@ -66,6 +66,9 @@ const DrawerContent = React.forwardRef<
       )}
       {...props}
     >
+      <DrawerDescription className="sr-only">
+        {props.title ?? ""}
+      </DrawerDescription>
       {children}
     </DrawerPrimitive.Content>
   </DrawerPortal>

--- a/web/src/features/comments/CommentDrawerButton.tsx
+++ b/web/src/features/comments/CommentDrawerButton.tsx
@@ -4,6 +4,7 @@ import {
   Drawer,
   DrawerContent,
   DrawerHeader,
+  DrawerTitle,
   DrawerTrigger,
 } from "@/src/components/ui/drawer";
 import { CommentCountIcon } from "@/src/features/comments/CommentCountIcon";
@@ -57,6 +58,7 @@ export function CommentDrawerButton({
         <div className="mx-auto w-full overflow-y-auto md:max-h-full">
           <DrawerHeader className="sticky top-0 z-10 rounded-sm bg-background">
             <Header title="Comments" level="h3"></Header>
+            <DrawerTitle className="sr-only">Comments</DrawerTitle>
           </DrawerHeader>
           <div data-vaul-no-drag className="px-2">
             <CommentList

--- a/web/src/features/comments/CommentDrawerButton.tsx
+++ b/web/src/features/comments/CommentDrawerButton.tsx
@@ -57,8 +57,9 @@ export function CommentDrawerButton({
       <DrawerContent className="h-1/3" overlayClassName="bg-primary/10">
         <div className="mx-auto w-full overflow-y-auto md:max-h-full">
           <DrawerHeader className="sticky top-0 z-10 rounded-sm bg-background">
-            <Header title="Comments" level="h3"></Header>
-            <DrawerTitle className="sr-only">Comments</DrawerTitle>
+            <DrawerTitle>
+              <Header title="Comments" level="h3"></Header>
+            </DrawerTitle>
           </DrawerHeader>
           <div data-vaul-no-drag className="px-2">
             <CommentList

--- a/web/src/features/scores/components/AnnotateDrawer.tsx
+++ b/web/src/features/scores/components/AnnotateDrawer.tsx
@@ -5,6 +5,7 @@ import {
   Drawer,
   DrawerContent,
   DrawerHeader,
+  DrawerTitle,
   DrawerTrigger,
 } from "@/src/components/ui/drawer";
 import { type APIScore } from "@langfuse/shared";
@@ -117,6 +118,7 @@ export function AnnotateDrawer({
                 href: "https://langfuse.com/docs/scores/manually",
               }}
             ></Header>
+            <DrawerTitle className="sr-only">Annotate</DrawerTitle>
             <div className="flex min-h-[9rem] items-center justify-center rounded border border-dashed p-2">
               <LoaderCircle className="mr-1.5 h-4 w-4 animate-spin text-muted-foreground" />
               <span className="text-xs text-muted-foreground opacity-60">

--- a/web/src/features/scores/components/AnnotateDrawer.tsx
+++ b/web/src/features/scores/components/AnnotateDrawer.tsx
@@ -110,15 +110,16 @@ export function AnnotateDrawer({
       <DrawerContent className="h-1/3">
         {configsData.isLoading ? (
           <DrawerHeader className="sticky top-0 z-10 rounded-sm bg-background">
-            <Header
-              title="Annotate"
-              level="h3"
-              help={{
-                description: `Annotate ${observationId ? "observation" : "trace"} with scores to capture human evaluation across different dimensions.`,
-                href: "https://langfuse.com/docs/scores/manually",
-              }}
-            ></Header>
-            <DrawerTitle className="sr-only">Annotate</DrawerTitle>
+            <DrawerTitle>
+              <Header
+                title="Annotate"
+                level="h3"
+                help={{
+                  description: `Annotate ${observationId ? "observation" : "trace"} with scores to capture human evaluation across different dimensions.`,
+                  href: "https://langfuse.com/docs/scores/manually",
+                }}
+              ></Header>
+            </DrawerTitle>
             <div className="flex min-h-[9rem] items-center justify-center rounded border border-dashed p-2">
               <LoaderCircle className="mr-1.5 h-4 w-4 animate-spin text-muted-foreground" />
               <span className="text-xs text-muted-foreground opacity-60">

--- a/web/src/features/scores/components/AnnotateDrawerContent.tsx
+++ b/web/src/features/scores/components/AnnotateDrawerContent.tsx
@@ -797,6 +797,15 @@ export function AnnotateDrawerContent({
                                     <Input
                                       {...field}
                                       value={field.value ?? ""}
+                                      // manually manage controlled input state
+                                      onChange={(e) => {
+                                        const value = e.target.value;
+                                        field.onChange(
+                                          value === ""
+                                            ? undefined
+                                            : Number(value),
+                                        );
+                                      }}
                                       type="number"
                                       className="text-xs"
                                       disabled={config.isArchived}

--- a/web/src/features/scores/components/AnnotateDrawerContent.tsx
+++ b/web/src/features/scores/components/AnnotateDrawerContent.tsx
@@ -536,30 +536,35 @@ export function AnnotateDrawerContent({
   return (
     <div className="mx-auto w-full overflow-y-auto md:max-h-full">
       <DrawerHeader className="sticky top-0 z-10 rounded-sm bg-background">
-        <Header
-          title="Annotate"
-          level="h3"
-          help={{
-            description: `Annotate ${observationId ? "observation" : "trace"} with scores to capture human evaluation across different dimensions.`,
-            href: "https://langfuse.com/docs/scores/manually",
-          }}
-          actionButtons={[
-            <div className="flex items-center justify-end" key="saving-spinner">
-              <div className="mr-1 items-center justify-center">
-                {showSaving ? (
-                  <Loader2 className="h-3 w-3 animate-spin" />
-                ) : (
-                  <Check className="h-3 w-3" />
-                )}
-              </div>
-              <span className="text-xs text-muted-foreground">
-                {showSaving ? "Saving score data" : "Score data saved"}
-              </span>
-            </div>,
-            actionButtons,
-          ]}
-        ></Header>
-        <DrawerTitle className="sr-only">Annotate</DrawerTitle>
+        <DrawerTitle>
+          <Header
+            title="Annotate"
+            level="h3"
+            help={{
+              description: `Annotate ${observationId ? "observation" : "trace"} with scores to capture human evaluation across different dimensions.`,
+              href: "https://langfuse.com/docs/scores/manually",
+              className: "leading-relaxed",
+            }}
+            actionButtons={[
+              <div
+                className="flex items-center justify-end"
+                key="saving-spinner"
+              >
+                <div className="mr-1 items-center justify-center">
+                  {showSaving ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    <Check className="h-3 w-3" />
+                  )}
+                </div>
+                <span className="text-xs text-muted-foreground">
+                  {showSaving ? "Saving score data" : "Score data saved"}
+                </span>
+              </div>,
+              actionButtons,
+            ]}
+          ></Header>
+        </DrawerTitle>
 
         {!isSelectHidden && (
           <div className="grid grid-flow-col items-center">

--- a/web/src/features/scores/components/AnnotateDrawerContent.tsx
+++ b/web/src/features/scores/components/AnnotateDrawerContent.tsx
@@ -795,7 +795,7 @@ export function AnnotateDrawerContent({
                                   {isNumericDataType(score.dataType) ? (
                                     <Input
                                       {...field}
-                                      value={field.value ?? undefined}
+                                      value={field.value ?? ""}
                                       type="number"
                                       className="text-xs"
                                       disabled={config.isArchived}

--- a/web/src/features/scores/components/AnnotateDrawerContent.tsx
+++ b/web/src/features/scores/components/AnnotateDrawerContent.tsx
@@ -23,7 +23,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/src/components/ui/form";
-import { DrawerHeader } from "@/src/components/ui/drawer";
+import { DrawerHeader, DrawerTitle } from "@/src/components/ui/drawer";
 import {
   type APIScore,
   isPresent,
@@ -559,6 +559,7 @@ export function AnnotateDrawerContent({
             actionButtons,
           ]}
         ></Header>
+        <DrawerTitle className="sr-only">Annotate</DrawerTitle>
 
         {!isSelectHidden && (
           <div className="grid grid-flow-col items-center">

--- a/web/src/features/scores/components/CreateScoreConfigButton.tsx
+++ b/web/src/features/scores/components/CreateScoreConfigButton.tsx
@@ -263,9 +263,13 @@ export function CreateScoreConfigButton({ projectId }: { projectId: string }) {
                     name="minValue"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>Minimum (optional)</FormLabel>
+                        <FormLabel>Minimum (optional) </FormLabel>
                         <FormControl>
-                          <Input {...field} type="number" />
+                          <Input
+                            {...field}
+                            value={field.value ?? ""}
+                            type="number"
+                          />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -278,7 +282,11 @@ export function CreateScoreConfigButton({ projectId }: { projectId: string }) {
                       <FormItem>
                         <FormLabel>Maximum (optional)</FormLabel>
                         <FormControl>
-                          <Input {...field} type="number" />
+                          <Input
+                            {...field}
+                            value={field.value ?? ""}
+                            type="number"
+                          />
                         </FormControl>
                         <FormMessage />
                       </FormItem>

--- a/web/src/features/scores/components/CreateScoreConfigButton.tsx
+++ b/web/src/features/scores/components/CreateScoreConfigButton.tsx
@@ -268,6 +268,13 @@ export function CreateScoreConfigButton({ projectId }: { projectId: string }) {
                           <Input
                             {...field}
                             value={field.value ?? ""}
+                            // manually manage controlled input state
+                            onChange={(e) => {
+                              const value = e.target.value;
+                              field.onChange(
+                                value === "" ? undefined : Number(value),
+                              );
+                            }}
                             type="number"
                           />
                         </FormControl>
@@ -285,6 +292,13 @@ export function CreateScoreConfigButton({ projectId }: { projectId: string }) {
                           <Input
                             {...field}
                             value={field.value ?? ""}
+                            // manually manage controlled input state
+                            onChange={(e) => {
+                              const value = e.target.value;
+                              field.onChange(
+                                value === "" ? undefined : Number(value),
+                              );
+                            }}
                             type="number"
                           />
                         </FormControl>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improve accessibility with screen reader titles and fix uncontrolled to controlled component transitions in input fields.
> 
>   - **Accessibility**:
>     - Add `DrawerDescription` with `sr-only` class for screen reader titles in `drawer.tsx`.
>     - Add `DrawerTitle` with `sr-only` class in `CommentDrawerButton.tsx`, `AnnotateDrawer.tsx`, and `AnnotateDrawerContent.tsx`.
>   - **Controlled Components**:
>     - Change `value` to `field.value ?? ""` for `Input` components in `AnnotateDrawerContent.tsx` and `CreateScoreConfigButton.tsx` to handle transition from uncontrolled to controlled components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b848c77f09ff7d6a50df72a3f9b1af0c740ddcdf. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->