### PR TITLE
chore(api): Improve error message for ingestion api endpoint prompt f…

### DIFF
--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -122,12 +122,10 @@ export const CreateGenerationBody = CreateSpanBody.extend({
   promptName: z.string().nullish(),
   promptVersion: z.number().int().nullish(),
 }).refine((value) => {
-  // ensure that either promptName and promptVersion are set, or none
-
   if (!value.promptName && !value.promptVersion) return true;
   if (value.promptName && value.promptVersion) return true;
   return false;
-});
+}, "Either both 'promptName' and 'promptVersion' must be provided, or neither.");
 
 export const UpdateGenerationBody = UpdateSpanBody.extend({
   completionStartTime: stringDateTime,
@@ -150,12 +148,10 @@ export const UpdateGenerationBody = UpdateSpanBody.extend({
   promptName: z.string().nullish(),
   promptVersion: z.number().int().nullish(),
 }).refine((value) => {
-  // ensure that either promptName and promptVersion are set, or none
-
   if (!value.promptName && !value.promptVersion) return true;
   if (value.promptName && value.promptVersion) return true;
   return false;
-});
+}, "Either both 'promptName' and 'promptVersion' must be provided, or neither.");
 
 const BaseScoreBody = z.object({
   id: z.string().nullish(),


### PR DESCRIPTION
## What does this PR do?

Provides a more meaningful error message instead of a generic "Invalid input" when the promptName and promptVersion validation fails.

Previous behavior hides the reason for the failure with only a comment in the source code, making it difficult for users to understand why their request was rejected.

### Motivations

LangFuse offers an open public API, allowing users who cannot directly consume the existing SDKs to build language-specific "wrapper" over the API.

By making the validation error messages more explicit, users can more easily understand the API's requirements and constraints, which simplifies the process of building their custom facades or remote proxies over the HTTP API.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## How To Replicate

1. Go to Postman
2. Prepare request against POST `{{baseUrl}}/api/public/ingestion`
3. Use below provided POST request body payload
4. Send message

```json
{
  "batch": [
    {
      "$type": "generation-update",
      "type": "generation-update",
      "body": {
        "completionStartTime": "2024-10-15T21:57:13.493Z",
        "model": "gpt-4o",
        "promptVersion": 1,
        "id": "ab88ddc9-77f5-40b2-87df-2821c3786be4",
        "traceId": "70caec8f-95bc-46e3-bf9e-a7b42b1f3797",
        "name": null,
        "startTime": null,
        "metadata": null,
        "input": [
          {
            "content": "testing"
          }
        ],
        "output": "123"
      },
      "id": "ab88ddc9-77f5-40b2-87df-2821c3786be4",
      "timestamp": "2024-10-15T21:57:13.494Z"
    }
  ]
}
```

### Actual Response
```json
{
    "errors": [
        {
            "id": "ab88ddc9-77f5-40b2-87df-2821c3786be4",
            "status": 400,
            "message": "Invalid request data",
            "error": "[\n  {\n    \"code\": \"custom\",\n    \"message\": \"Invalid input\",\n    \"path\": [\n      \"body\"\n    ]\n  }\n]"
        }
    ],
    "successes": []
}
```

### Response After Improvement
```json
{
    "errors": [
        {
            "id": "ab88ddc9-77f5-40b2-87df-2821c3786be4",
            "status": 400,
            "message": "Invalid request data",
            "error": "[\n  {\n    \"code\": \"custom\",\n    \"message\": \"Either both 'promptName' and 'promptVersion' must be provided, or neither.\",\n    \"path\": [\n      \"body\"\n    ]\n  }\n]"
        }
    ],
    "successes": []
}
```

## Screenshots
### Before Changes
![image](https://github.com/user-attachments/assets/48c78346-1009-4107-8608-d48c86053651)

### After Changes
![image](https://github.com/user-attachments/assets/17f6a718-0aba-4a7c-befe-614bc0a5838f)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves error messages for `promptName` and `promptVersion` validation in `CreateGenerationBody` and `UpdateGenerationBody` in `types.ts`.
> 
>   - **Behavior**:
>     - Improved error message for `CreateGenerationBody` and `UpdateGenerationBody` in `types.ts` when `promptName` and `promptVersion` validation fails.
>     - New error message: "Either both 'promptName' and 'promptVersion' must be provided, or neither."
>   - **Validation**:
>     - Refines validation logic in `CreateGenerationBody` and `UpdateGenerationBody` to provide explicit error messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2df7c43c98c132ad0a86cdef58d234fd43eaa2c4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->