### PR TITLE
fix(evals): put reasoning key before score

### DIFF
--- a/worker/src/features/evaluation/eval-service.ts
+++ b/worker/src/features/evaluation/eval-service.ts
@@ -262,8 +262,8 @@ export const evaluate = async ({
   }
 
   const evalScoreSchema = z.object({
-    score: z.number().describe(parsedOutputSchema.score),
     reasoning: z.string().describe(parsedOutputSchema.reasoning),
+    score: z.number().describe(parsedOutputSchema.score),
   });
 
   const modelParams = ZodModelConfig.parse(template.model_params);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reorder keys in `evalScoreSchema` in `evaluate()` in `eval-service.ts` to place `reasoning` before `score`.
> 
>   - **Behavior**:
>     - Reorder keys in `evalScoreSchema` in `evaluate()` in `eval-service.ts` to place `reasoning` before `score`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c1e5604830caab1b1182038e8081ccfb52823115. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->