### PR TITLE
chore: fix queue metric names

### DIFF
--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -44,9 +44,9 @@ export class WorkerManager {
     return async (job: Job) => {
       const startTime = Date.now();
       const waitTime = Date.now() - job.timestamp;
-      recordIncrement(convertQueueNameToMetricName(queueName + ".request"));
+      recordIncrement(convertQueueNameToMetricName(queueName) + ".request");
       recordHistogram(
-        convertQueueNameToMetricName(queueName + ".wait_time"),
+        convertQueueNameToMetricName(queueName) + ".wait_time",
         waitTime,
         {
           unit: "milliseconds",
@@ -57,7 +57,7 @@ export class WorkerManager {
         ?.count()
         .then((count) => {
           recordGauge(
-            convertQueueNameToMetricName(queueName + ".length"),
+            convertQueueNameToMetricName(queueName) + ".length",
             count,
             {
               unit: "records",
@@ -67,7 +67,7 @@ export class WorkerManager {
         })
         .catch();
       recordHistogram(
-        convertQueueNameToMetricName(queueName + ".processing_time"),
+        convertQueueNameToMetricName(queueName) + ".processing_time",
         Date.now() - startTime,
         { unit: "milliseconds" },
       );
@@ -128,11 +128,11 @@ export class WorkerManager {
         `Queue Job ${job?.name} with id ${job?.id} in ${queueName} failed`,
         err,
       );
-      recordIncrement(convertQueueNameToMetricName(queueName + ".failed"));
+      recordIncrement(convertQueueNameToMetricName(queueName) + ".failed");
     });
     worker.on("error", (failedReason: Error) => {
       logger.error(`Queue worker ${queueName} failed: ${failedReason}`);
-      recordIncrement(convertQueueNameToMetricName(queueName + ".error"));
+      recordIncrement(convertQueueNameToMetricName(queueName) + ".error");
     });
   }
 }


### PR DESCRIPTION
## What

Move the suffix append to outside the name generation.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix metric name generation in `workerManager.ts` by appending suffixes outside `convertQueueNameToMetricName` calls.
> 
>   - **Metric Name Generation**:
>     - In `workerManager.ts`, move suffix append outside `convertQueueNameToMetricName` calls for `.request`, `.wait_time`, `.length`, `.processing_time`, `.failed`, and `.error` metrics.
>     - Affects `recordIncrement`, `recordHistogram`, and `recordGauge` functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d02e535978b283253d35d8e75680d281edfc3952. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->