### PR TITLE
chore: add error listeners on queues

### DIFF
--- a/packages/shared/src/server/redis/batchExport.ts
+++ b/packages/shared/src/server/redis/batchExport.ts
@@ -1,6 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, TQueueJobTypes } from "../queues";
 import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import { logger } from "../logger";
 
 export class BatchExportQueue {
   private static instance: Queue<TQueueJobTypes[QueueName.BatchExport]> | null =
@@ -33,6 +34,10 @@ export class BatchExportQueue {
           },
         )
       : null;
+
+    BatchExportQueue.instance?.on("error", (err) => {
+      logger.error("BatchExportQueue error", err);
+    });
 
     return BatchExportQueue.instance;
   }

--- a/packages/shared/src/server/redis/ingestionQueue.ts
+++ b/packages/shared/src/server/redis/ingestionQueue.ts
@@ -1,6 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, TQueueJobTypes } from "../queues";
 import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import { logger } from "../logger";
 
 export class IngestionQueue {
   private static instance: Queue<
@@ -34,6 +35,10 @@ export class IngestionQueue {
           },
         )
       : null;
+
+    IngestionQueue.instance?.on("error", (err) => {
+      logger.error("IngestionQueue error", err);
+    });
 
     return IngestionQueue.instance;
   }

--- a/packages/shared/src/server/redis/legacyIngestion.ts
+++ b/packages/shared/src/server/redis/legacyIngestion.ts
@@ -1,6 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, TQueueJobTypes } from "../queues";
 import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import { logger } from "../logger";
 
 export class LegacyIngestionQueue {
   private static instance: Queue<
@@ -34,6 +35,10 @@ export class LegacyIngestionQueue {
           },
         )
       : null;
+
+    LegacyIngestionQueue.instance?.on("error", (err) => {
+      logger.error("LegacyIngestionQueue error", err);
+    });
 
     return LegacyIngestionQueue.instance;
   }

--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -23,7 +23,7 @@ export const redisQueueRetryOptions: Partial<RedisOptions> = {
 export const createNewRedisInstance = (
   additionalOptions: Partial<RedisOptions> = {},
 ) => {
-  return env.REDIS_CONNECTION_STRING
+  const instance = env.REDIS_CONNECTION_STRING
     ? new Redis(env.REDIS_CONNECTION_STRING, {
         ...defaultRedisOptions,
         ...additionalOptions,
@@ -37,6 +37,12 @@ export const createNewRedisInstance = (
           ...additionalOptions,
         })
       : null;
+
+  instance?.on("error", (error) => {
+    logger.error("Redis error", error);
+  });
+
+  return instance;
 };
 
 const createRedisClient = () => {

--- a/packages/shared/src/server/redis/traceUpsert.ts
+++ b/packages/shared/src/server/redis/traceUpsert.ts
@@ -7,6 +7,7 @@ import {
 } from "../queues";
 import { Queue } from "bullmq";
 import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import { logger } from "../logger";
 
 export class TraceUpsertQueue {
   private static instance: Queue<TQueueJobTypes[QueueName.TraceUpsert]> | null =
@@ -39,6 +40,10 @@ export class TraceUpsertQueue {
           },
         )
       : null;
+
+    TraceUpsertQueue.instance?.on("error", (err) => {
+      logger.error("TraceUpsertQueue error", err);
+    });
 
     return TraceUpsertQueue.instance;
   }

--- a/worker/src/queues/cloudUsageMeteringQueue.ts
+++ b/worker/src/queues/cloudUsageMeteringQueue.ts
@@ -41,6 +41,10 @@ export class CloudUsageMeteringQueue {
         })
       : null;
 
+    CloudUsageMeteringQueue.instance?.on("error", (err) => {
+      logger.error("CloudUsageMeteringQueue error", err);
+    });
+
     if (CloudUsageMeteringQueue.instance) {
       CloudUsageMeteringQueue.instance.add(
         QueueJobs.CloudUsageMeteringJob,

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -45,6 +45,10 @@ export class EvalExecutionQueue {
         )
       : null;
 
+    EvalExecutionQueue.instance?.on("error", (err) => {
+      logger.error("EvalExecutionQueue error", err);
+    });
+
     return EvalExecutionQueue.instance;
   }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add error listeners to various queue instances and Redis connections to log errors using a logger.
> 
>   - **Error Handling**:
>     - Add error listeners to `BatchExportQueue`, `IngestionQueue`, `LegacyIngestionQueue`, `TraceUpsertQueue`, `CloudUsageMeteringQueue`, and `EvalExecutionQueue` to log errors using `logger.error()`.
>     - Modify `createNewRedisInstance` in `redis.ts` to log Redis connection errors.
>   - **Misc**:
>     - Import `logger` in all modified files to support error logging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2fa2a3c6bed01f39de5ac0ad3c7bfa09fa649121. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->