### PR TITLE
fix(tables): serialization issue in score column visibility

### DIFF
--- a/web/src/features/scores/lib/aggregateScores.ts
+++ b/web/src/features/scores/lib/aggregateScores.ts
@@ -18,7 +18,7 @@ export const composeAggregateScoreKey = ({
   dataType: ScoreDataType;
   keyPrefix?: string;
 }): string => {
-  const formattedName = name.replaceAll(/-/g, "_"); // "-" reserved for splitting in namespace
+  const formattedName = name.replaceAll(/[-\.]/g, "_"); // "-" and "." reserved for splitting in namespace
   return `${formattedName}-${source}-${dataType}`;
 };
 


### PR DESCRIPTION
* previously score columns including a "." in name could not be hidden
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes serialization issue in `composeAggregateScoreKey` to handle score columns with '.' in names.
> 
>   - **Behavior**:
>     - Fixes serialization issue in `composeAggregateScoreKey` in `aggregateScores.ts` by replacing '.' with '_' in score column names.
>     - Ensures score columns with '.' in names can be hidden.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9f80b16819963e16812bfd1c825488cd4c5a698d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->