### PR TITLE
fix: use trace/observation createdAt for health endpoint

### DIFF
--- a/web/src/pages/api/public/health.ts
+++ b/web/src/pages/api/public/health.ts
@@ -19,7 +19,7 @@ export default async function handler(
         const now = Date.now();
         const trace = await prisma.trace.findFirst({
           where: {
-            timestamp: {
+            createdAt: {
               gte: new Date(now - 180000), // 3 minutes ago
               lte: new Date(now),
             },
@@ -30,7 +30,7 @@ export default async function handler(
         });
         const observation = await prisma.observation.findFirst({
           where: {
-            startTime: {
+            createdAt: {
               gte: new Date(now - 180000), // 3 minutes ago
               lte: new Date(now),
             },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update health endpoint in `health.ts` to use `createdAt` for recent event checks.
> 
>   - **Behavior**:
>     - Update `prisma.trace.findFirst` and `prisma.observation.findFirst` in `health.ts` to use `createdAt` instead of `timestamp` and `startTime` for recent event checks.
>     - Ensures health endpoint checks for events created within the last 3 minutes using `createdAt`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6191c72059f46f6994111d2a2924507744c46a1f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->