### PR TITLE
feat: support DnD reordering of playground messages

### DIFF
--- a/web/src/components/ChatMessages/ChatMessageComponent.tsx
+++ b/web/src/components/ChatMessages/ChatMessageComponent.tsx
@@ -1,11 +1,14 @@
 import { capitalize } from "lodash";
-import { MinusCircleIcon } from "lucide-react";
+import { GripVertical, MinusCircleIcon } from "lucide-react";
 import { type ChangeEvent, useEffect, useState, useRef } from "react";
 import { ChatMessageRole, type ChatMessageWithId } from "@langfuse/shared";
 import { Button } from "@/src/components/ui/button";
 import { Card, CardContent } from "@/src/components/ui/card";
 import { Textarea } from "@/src/components/ui/textarea";
 import type { MessagesContext } from "./types";
+import { useSortable } from "@dnd-kit/sortable";
+import { cn } from "@/src/utils/tailwind";
+import { CSS } from "@dnd-kit/utilities";
 
 type ChatMessageProps = Pick<
   MessagesContext,
@@ -21,6 +24,15 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
   const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
   const [textAreaRows, setTextAreaRows] = useState(1);
   const [roleIndex, setRoleIndex] = useState(1);
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: message.id });
 
   const toggleRole = () => {
     if (message.role === ChatMessageRole.System) return;
@@ -61,8 +73,27 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
   }, [message.content]);
 
   return (
-    <Card className="p-3">
-      <CardContent className="flex flex-row space-x-1 p-0">
+    <Card
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
+      className={cn(
+        isDragging ? "opacity-80" : "opacity-100",
+        "group relative whitespace-nowrap p-3",
+      )}
+    >
+      {message.role !== ChatMessageRole.System && (
+        <div
+          {...attributes}
+          {...listeners}
+          className="absolute bottom-0 left-0 top-4 flex w-6 cursor-move justify-center"
+        >
+          <GripVertical className="h-4 w-4" />
+        </div>
+      )}
+      <CardContent className="ml-4 flex flex-row space-x-1 p-0">
         <div className="min-w-[6rem]">
           <Button
             onClick={toggleRole}

--- a/web/src/components/ChatMessages/index.tsx
+++ b/web/src/components/ChatMessages/index.tsx
@@ -52,11 +52,14 @@ export const ChatMessages: React.FC<ChatMessagesProps> = (props) => {
     if (active && over && active.id !== over.id) {
       if (isString(active.id) && isString(over.id)) {
         const newIndex = messages.findIndex((m) => m.id === over.id);
+        const oldIndex = messages.findIndex((m) => m.id === active.id);
+        if (newIndex < 0 || oldIndex < 0) {
+          return;
+        }
         // prevent reordering system messages
         if (messages[newIndex].role === ChatMessageRole.System) {
           return;
         }
-        const oldIndex = messages.findIndex((m) => m.id === active.id);
         const newMessages = arrayMove(messages, oldIndex, newIndex);
         props.setMessages(newMessages);
       }

--- a/web/src/components/ChatMessages/index.tsx
+++ b/web/src/components/ChatMessages/index.tsx
@@ -7,6 +7,23 @@ import { ChatMessageRole } from "@langfuse/shared";
 import { ChatMessageComponent } from "./ChatMessageComponent";
 
 import type { MessagesContext } from "./types";
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import {
+  arrayMove,
+  SortableContext,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { isString } from "@/src/utils/types";
 
 type ChatMessagesProps = MessagesContext;
 export const ChatMessages: React.FC<ChatMessagesProps> = (props) => {
@@ -23,25 +40,60 @@ export const ChatMessages: React.FC<ChatMessagesProps> = (props) => {
     prevMessageCount.current = messages.length;
   }, [scrollAreaRef, messages.length]);
 
+  const sensors = useSensors(
+    useSensor(MouseSensor, {}),
+    useSensor(TouchSensor, {}),
+    useSensor(KeyboardSensor, {}),
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+
+    if (active && over && active.id !== over.id) {
+      if (isString(active.id) && isString(over.id)) {
+        const newIndex = messages.findIndex((m) => m.id === over.id);
+        // prevent reordering system messages
+        if (messages[newIndex].role === ChatMessageRole.System) {
+          return;
+        }
+        const oldIndex = messages.findIndex((m) => m.id === active.id);
+        const newMessages = arrayMove(messages, oldIndex, newIndex);
+        props.setMessages(newMessages);
+      }
+    }
+  }
+
   return (
-    <div className="flex h-full flex-col">
-      <div className="mb-2 font-semibold">Messages</div>
-      <div className="flex-1 overflow-auto scroll-smooth" ref={scrollAreaRef}>
-        <div className="mb-4 flex-1 space-y-3">
-          {props.messages.map((message) => {
-            return (
-              <ChatMessageComponent
-                {...{ message, ...props }}
-                key={message.id}
-              />
-            );
-          })}
+    <DndContext
+      collisionDetection={closestCenter}
+      modifiers={[restrictToVerticalAxis]}
+      onDragEnd={handleDragEnd}
+      sensors={sensors}
+    >
+      <div className="flex h-full flex-col">
+        <div className="mb-2 font-semibold">Messages</div>
+        <div className="flex-1 overflow-auto scroll-smooth" ref={scrollAreaRef}>
+          <div className="mb-4 flex-1 space-y-3">
+            <SortableContext
+              items={props.messages.map((message) => message.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              {props.messages.map((message) => {
+                return (
+                  <ChatMessageComponent
+                    {...{ message, ...props }}
+                    key={message.id}
+                  />
+                );
+              })}
+            </SortableContext>
+          </div>
+        </div>
+        <div className="py-3">
+          <AddMessageButton {...props} />
         </div>
       </div>
-      <div className="py-3">
-        <AddMessageButton {...props} />
-      </div>
-    </div>
+    </DndContext>
   );
 };
 

--- a/web/src/components/ChatMessages/types.ts
+++ b/web/src/components/ChatMessages/types.ts
@@ -3,6 +3,7 @@ import type { ChatMessageRole, ChatMessageWithId } from "@langfuse/shared";
 export type MessagesContext = {
   messages: ChatMessageWithId[];
   addMessage: (role: ChatMessageRole, content?: string) => ChatMessageWithId;
+  setMessages: (messages: ChatMessageWithId[]) => void;
   deleteMessage: (id: string) => void;
   updateMessage: <Key extends keyof ChatMessageWithId>(
     id: string,

--- a/web/src/ee/features/playground/page/context/index.tsx
+++ b/web/src/ee/features/playground/page/context/index.tsx
@@ -235,6 +235,7 @@ export const PlaygroundProvider: React.FC<PropsWithChildren> = ({
 
         messages,
         addMessage,
+        setMessages,
         updateMessage,
         deleteMessage,
 

--- a/web/src/features/prompts/components/NewPromptForm/PromptChatMessages.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/PromptChatMessages.tsx
@@ -89,6 +89,7 @@ export const PromptChatMessages: React.FC<PromptChatMessagesProps> = ({
       {...{
         messages,
         addMessage,
+        setMessages,
         deleteMessage,
         updateMessage,
         availableRoles,

--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -363,7 +363,7 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
             !initialPrompt && form.formState.errors.name?.message,
           )} // Disable button if prompt name already exists. Check is dynamic and not part of zod schema
         >
-          {!initialPrompt ? "Create prompt" : "Update prompt"}
+          {!initialPrompt ? "Create prompt" : "Save prompt version"}
         </Button>
       </form>
       {formError && (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add drag-and-drop reordering for chat messages in the playground, excluding system messages, using `@dnd-kit`.
> 
>   - **Behavior**:
>     - Add drag-and-drop reordering for chat messages using `@dnd-kit` in `ChatMessages/index.tsx`.
>     - Prevent reordering of system messages in `handleDragEnd()`.
>   - **Components**:
>     - Update `ChatMessageComponent.tsx` to include drag handles for non-system messages.
>     - Use `useSortable` from `@dnd-kit/sortable` for drag-and-drop functionality.
>   - **Context and Types**:
>     - Add `setMessages` to `MessagesContext` in `types.ts`.
>     - Update `PlaygroundProvider` in `context/index.tsx` to include `setMessages`.
>   - **Misc**:
>     - Update `PromptChatMessages.tsx` to support drag-and-drop reordering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b41fca7e9ca23b67a5999c1c14a729e551a3d4c8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->