### PR TITLE
bug: UI prompt edit changes go away when tab switching

### DIFF
--- a/web/src/features/prompts/components/prompt-new.tsx
+++ b/web/src/features/prompts/components/prompt-new.tsx
@@ -14,7 +14,11 @@ export const NewPrompt = () => {
       projectId: projectId as string, // Typecast as query is enabled only when projectId is present
       id: initialPromptId ?? "",
     },
-    { enabled: Boolean(initialPromptId && projectId) },
+    {
+      enabled: Boolean(initialPromptId && projectId),
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    },
   );
 
   if (isInitialLoading) {


### PR DESCRIPTION
Fixes #3807


<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add options to `useQuery` in `prompt-new.tsx` to prevent refetching on window focus and reconnect.
> 
>   - **Behavior**:
>     - In `prompt-new.tsx`, `useQuery` now includes `refetchOnWindowFocus: false` and `refetchOnReconnect: false` to prevent unnecessary data refetching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2084bbf1f18cd800bf57117388dca7a7a31c3f81. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->