### PR TITLE
feat(api): add `traceTags` query param to GET /scores

### DIFF
--- a/fern/apis/server/definition/score.yml
+++ b/fern/apis/server/definition/score.yml
@@ -58,7 +58,11 @@ service:
           dataType:
             type: optional<commons.ScoreDataType>
             docs: Retrieve only scores with a specific dataType.
-      response: Scores
+          traceTags:
+            type: optional<list<string>>
+            allow-multiple: true
+            docs: Only scores linked to traces that include all of these tags will be returned.
+      response: GetScoresResponse
     get-by-id:
       docs: Get a score
       method: GET
@@ -135,7 +139,19 @@ types:
       id:
         type: string
         docs: The id of the created object in Langfuse
-  Scores:
+  GetScoresResponseTraceData:
     properties:
-      data: list<commons.Score>
+      userId:
+        type: optional<string>
+        docs: The user ID associated with the trace referenced by score
+      tags:
+        type: optional<list<string>>
+        docs: A list of tags associated with the trace referenced by score
+  GetScoresResponseData:
+    properties:
+      <<: commons.Score
+      trace: GetScoresResponseTraceData
+  GetScoresResponse:
+    properties:
+      data: list<GetScoresResponseData>
       meta: pagination.MetaResponse

--- a/packages/shared/src/features/scores/scoreTypes.ts
+++ b/packages/shared/src/features/scores/scoreTypes.ts
@@ -236,6 +236,7 @@ export const GetScoresQuery = z.object({
   dataType: z.enum(ScoreDataType).nullish(),
   configId: z.string().nullish(),
   queueId: z.string().nullish(),
+  traceTags: z.union([z.array(z.string()), z.string()]).nullish(),
   name: z.string().nullish(),
   fromTimestamp: stringDateTime,
   toTimestamp: stringDateTime,
@@ -257,6 +258,7 @@ const LegacyGetScoreResponseDataV1 = z.intersection(
   z.object({
     trace: z.object({
       userId: z.string().nullish(),
+      tags: z.array(z.string()).nullish(),
     }),
   })
 );

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -1788,13 +1788,24 @@ paths:
           schema:
             $ref: '#/components/schemas/ScoreDataType'
             nullable: true
+        - name: traceTags
+          in: query
+          description: >-
+            Only scores linked to traces that include all of these tags will be
+            returned.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              nullable: true
       responses:
         '200':
           description: ''
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Scores'
+                $ref: '#/components/schemas/GetScoresResponse'
         '400':
           description: ''
           content:
@@ -4305,14 +4316,39 @@ components:
           description: The id of the created object in Langfuse
       required:
         - id
-    Scores:
-      title: Scores
+    GetScoresResponseTraceData:
+      title: GetScoresResponseTraceData
+      type: object
+      properties:
+        userId:
+          type: string
+          nullable: true
+          description: The user ID associated with the trace referenced by score
+        tags:
+          type: array
+          items:
+            type: string
+          nullable: true
+          description: A list of tags associated with the trace referenced by score
+    GetScoresResponseData:
+      title: GetScoresResponseData
+      type: object
+      properties:
+        '<<':
+          $ref: '#/components/schemas/Score'
+        trace:
+          $ref: '#/components/schemas/GetScoresResponseTraceData'
+      required:
+        - '<<'
+        - trace
+    GetScoresResponse:
+      title: GetScoresResponse
       type: object
       properties:
         data:
           type: array
           items:
-            $ref: '#/components/schemas/Score'
+            $ref: '#/components/schemas/GetScoresResponseData'
         meta:
           $ref: '#/components/schemas/utilsMetaResponse'
       required:

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -1244,7 +1244,7 @@
           "request": {
             "description": "Get a list of scores",
             "url": {
-              "raw": "{{baseUrl}}/api/public/scores?page=&limit=&userId=&name=&fromTimestamp=&toTimestamp=&source=&operator=&value=&scoreIds=&configId=&queueId=&dataType=",
+              "raw": "{{baseUrl}}/api/public/scores?page=&limit=&userId=&name=&fromTimestamp=&toTimestamp=&source=&operator=&value=&scoreIds=&configId=&queueId=&dataType=&traceTags=",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1318,6 +1318,11 @@
                   "key": "dataType",
                   "value": "",
                   "description": "Retrieve only scores with a specific dataType."
+                },
+                {
+                  "key": "traceTags",
+                  "value": "",
+                  "description": "Only scores linked to traces that include all of these tags will be returned."
                 }
               ],
               "variable": []


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `traceTags` query parameter to GET /scores for filtering by trace tags, with updated schema, SQL query, and tests.
> 
>   - **Behavior**:
>     - Add `traceTags` query parameter to GET `/api/public/scores` in `index.ts` for filtering scores by trace tags.
>     - Update `GetScoresQuery` in `scoreTypes.ts` to include `traceTags` as a nullable union of array or string.
>     - Modify SQL query in `index.ts` to include `traceTagsCondition` for filtering.
>   - **Tests**:
>     - Add test cases in `scores.servertest.ts` to verify filtering by single and multiple `traceTags`.
>     - Update existing test cases to account for new `traceTags` functionality.
>   - **Models**:
>     - Update `LegacyGetScoreResponseDataV1` in `scoreTypes.ts` to include `tags` in the `trace` object.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 24c6d577c120b372b916a0c0140da3be1a486c15. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->