### PR TITLE
fix(ui): table pagination distinguish between no data and loading states

### DIFF
--- a/web/src/components/table/data-table-pagination.tsx
+++ b/web/src/components/table/data-table-pagination.tsx
@@ -21,11 +21,13 @@ import { useEffect, useState } from "react";
 
 interface DataTablePaginationProps<TData> {
   table: Table<TData>;
+  isLoading: boolean;
   paginationOptions?: number[];
 }
 
 export function DataTablePagination<TData>({
   table,
+  isLoading,
   paginationOptions = [10, 20, 30, 40, 50],
 }: DataTablePaginationProps<TData>) {
   const capture = usePostHogClientCapture();
@@ -129,7 +131,11 @@ export function DataTablePagination<TData>({
           ) : (
             <span>
               of{" "}
-              <LoaderCircle className="ml-1 inline-block h-3 w-3 animate-spin text-muted-foreground" />
+              {isLoading ? (
+                <LoaderCircle className="ml-1 inline-block h-3 w-3 animate-spin text-muted-foreground" />
+              ) : (
+                1
+              )}
             </span>
           )}
         </div>
@@ -172,7 +178,7 @@ export function DataTablePagination<TData>({
                 type: "nextPage",
               });
             }}
-            disabled={!table.getCanNextPage()}
+            disabled={!table.getCanNextPage() || pageCount === -1}
           >
             <span className="sr-only">Go to next page</span>
             <ChevronRightIcon className="h-4 w-4" />

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -342,6 +342,7 @@ export function DataTable<TData extends object, TValue>({
         >
           <DataTablePagination
             table={table}
+            isLoading={data.isLoading}
             paginationOptions={pagination.options}
           />
         </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `isLoading` prop to `DataTablePagination` to handle loading states in table pagination.
> 
>   - **Behavior**:
>     - Add `isLoading` prop to `DataTablePagination` in `data-table-pagination.tsx` to distinguish between loading and no data states.
>     - Update pagination display to show a loading spinner when `isLoading` is true and page count is unknown.
>     - Disable "next page" button when `pageCount` is -1 in `data-table-pagination.tsx`.
>   - **Integration**:
>     - Pass `data.isLoading` to `DataTablePagination` in `data-table.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 962de4dc2288aa307551df8de5c24fc3f824582a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->