### PR TITLE
fix: don't throw unauthorized errors when viewing a public trace

### DIFF
--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -32,6 +32,7 @@ import { CreateNewAnnotationQueueItem } from "@/src/ee/features/annotation-queue
 import { useHasOrgEntitlement } from "@/src/features/entitlements/hooks";
 import { calculateDisplayTotalCost } from "@/src/components/trace/lib/helpers";
 import { useMemo } from "react";
+import { useIsAuthenticatedAndProjectMember } from "@/src/features/auth/hooks";
 
 export const ObservationPreview = ({
   observations,
@@ -60,6 +61,8 @@ export const ObservationPreview = ({
     string[]
   >("emptySelectedConfigIds", []);
   const hasEntitlement = useHasOrgEntitlement("annotation-queues");
+  const isAuthenticatedAndProjectMember =
+    useIsAuthenticatedAndProjectMember(projectId);
 
   const observationWithInputAndOutput = api.observations.byId.useQuery({
     observationId: currentObservationId,
@@ -120,12 +123,14 @@ export const ObservationPreview = ({
               >
                 Preview
               </TabsTrigger>
-              <TabsTrigger
-                value="scores"
-                className="h-full rounded-none border-b-4 border-transparent data-[state=active]:border-primary-accent data-[state=active]:shadow-none"
-              >
-                Scores
-              </TabsTrigger>
+              {isAuthenticatedAndProjectMember && (
+                <TabsTrigger
+                  value="scores"
+                  className="h-full rounded-none border-b-4 border-transparent data-[state=active]:border-primary-accent data-[state=active]:shadow-none"
+                >
+                  Scores
+                </TabsTrigger>
+              )}
             </TabsList>
           </Tabs>
         </div>

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -32,6 +32,7 @@ import { useHasOrgEntitlement } from "@/src/features/entitlements/hooks";
 import { useMemo } from "react";
 import { usdFormatter } from "@/src/utils/numbers";
 import { calculateDisplayTotalCost } from "@/src/components/trace/lib/helpers";
+import { useIsAuthenticatedAndProjectMember } from "@/src/features/auth/hooks";
 
 export const TracePreview = ({
   trace,
@@ -56,6 +57,9 @@ export const TracePreview = ({
     string[]
   >("emptySelectedConfigIds", []);
   const hasEntitlement = useHasOrgEntitlement("annotation-queues");
+  const isAuthenticatedAndProjectMember = useIsAuthenticatedAndProjectMember(
+    trace.projectId,
+  );
 
   const traceScores = scores.filter((s) => s.observationId === null);
   const traceScoresBySource = traceScores.reduce((acc, score) => {
@@ -95,12 +99,14 @@ export const TracePreview = ({
               >
                 Preview
               </TabsTrigger>
-              <TabsTrigger
-                value="scores"
-                className="h-full rounded-none border-b-4 border-transparent data-[state=active]:border-primary-accent data-[state=active]:shadow-none"
-              >
-                Scores
-              </TabsTrigger>
+              {isAuthenticatedAndProjectMember && (
+                <TabsTrigger
+                  value="scores"
+                  className="h-full rounded-none border-b-4 border-transparent data-[state=active]:border-primary-accent data-[state=active]:shadow-none"
+                >
+                  Scores
+                </TabsTrigger>
+              )}
             </TabsList>
           </Tabs>
         </div>

--- a/web/src/components/trace/TraceTimelineView.tsx
+++ b/web/src/components/trace/TraceTimelineView.tsx
@@ -30,7 +30,7 @@ import { TracePreview } from "@/src/components/trace/TracePreview";
 import { ObservationPreview } from "@/src/components/trace/ObservationPreview";
 import useSessionStorage from "@/src/components/useSessionStorage";
 import { api } from "@/src/utils/api";
-import { useSession } from "next-auth/react";
+import { useIsAuthenticatedAndProjectMember } from "@/src/features/auth/hooks";
 
 // Fixed widths for styling for v1
 const SCALE_WIDTH = 800;
@@ -313,7 +313,8 @@ export function TraceTimelineView({
     [nestedObservations],
   );
 
-  const session = useSession();
+  const isAuthenticatedAndProjectMember =
+    useIsAuthenticatedAndProjectMember(projectId);
 
   const observationCommentCounts = api.comments.getCountByObjectType.useQuery(
     {
@@ -327,7 +328,7 @@ export function TraceTimelineView({
         },
       },
       refetchOnMount: false, // prevents refetching loops
-      enabled: session.status === "authenticated",
+      enabled: isAuthenticatedAndProjectMember,
     },
   );
 
@@ -344,7 +345,7 @@ export function TraceTimelineView({
         },
       },
       refetchOnMount: false, // prevents refetching loops
-      enabled: session.status === "authenticated",
+      enabled: isAuthenticatedAndProjectMember,
     },
   );
 

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -33,9 +33,9 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
 import { TraceTimelineView } from "@/src/components/trace/TraceTimelineView";
 import { type APIScore } from "@langfuse/shared";
-import { useSession } from "next-auth/react";
 import { FullScreenPage } from "@/src/components/layouts/full-screen-page";
 import { calculateDisplayTotalCost } from "@/src/components/trace/lib/helpers";
+import { useIsAuthenticatedAndProjectMember } from "@/src/features/auth/hooks";
 
 export function Trace(props: {
   observations: Array<ObservationReturnType>;
@@ -67,7 +67,9 @@ export function Trace(props: {
     [],
   );
 
-  const session = useSession();
+  const isAuthenticatedAndProjectMember = useIsAuthenticatedAndProjectMember(
+    props.projectId,
+  );
 
   const observationCommentCounts = api.comments.getCountByObjectType.useQuery(
     {
@@ -81,7 +83,7 @@ export function Trace(props: {
         },
       },
       refetchOnMount: false, // prevents refetching loops
-      enabled: session.status === "authenticated",
+      enabled: isAuthenticatedAndProjectMember,
     },
   );
 
@@ -98,7 +100,7 @@ export function Trace(props: {
         },
       },
       refetchOnMount: false, // prevents refetching loops
-      enabled: session.status === "authenticated",
+      enabled: isAuthenticatedAndProjectMember,
     },
   );
 
@@ -242,7 +244,9 @@ export function TracePage({ traceId }: { traceId: string }) {
   const capture = usePostHogClientCapture();
   const router = useRouter();
   const utils = api.useUtils();
-  const session = useSession();
+  const isAuthenticatedAndProjectMember = useIsAuthenticatedAndProjectMember(
+    router.query.projectId as string,
+  );
   const trace = api.traces.byIdWithObservationsAndScores.useQuery(
     { traceId, projectId: router.query.projectId as string },
     {
@@ -266,7 +270,7 @@ export function TracePage({ traceId }: { traceId: string }) {
       enabled:
         !!trace.data?.projectId &&
         trace.isSuccess &&
-        session.status === "authenticated",
+        isAuthenticatedAndProjectMember,
     },
   );
 

--- a/web/src/features/auth/hooks.ts
+++ b/web/src/features/auth/hooks.ts
@@ -1,0 +1,15 @@
+import { useSession } from "next-auth/react";
+
+/**
+ * Hook to check if the user is authenticated and a member of the project.
+ */
+export const useIsAuthenticatedAndProjectMember = (projectId: string) => {
+  const session = useSession();
+
+  return (
+    session.status === "authenticated" &&
+    !!session.data?.user?.organizations
+      .flatMap((org) => org.projects)
+      .find(({ id }) => id === projectId)
+  );
+};

--- a/web/src/features/auth/hooks.ts
+++ b/web/src/features/auth/hooks.ts
@@ -3,7 +3,9 @@ import { useSession } from "next-auth/react";
 /**
  * Hook to check if the user is authenticated and a member of the project.
  */
-export const useIsAuthenticatedAndProjectMember = (projectId: string) => {
+export const useIsAuthenticatedAndProjectMember = (
+  projectId: string,
+): boolean => {
   const session = useSession();
 
   return (

--- a/web/src/features/datasets/components/NewDatasetItemFromObservationButton.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemFromObservationButton.tsx
@@ -18,10 +18,10 @@ import {
 import Link from "next/link";
 import { NewDatasetItemForm } from "@/src/features/datasets/components/NewDatasetItemForm";
 import { type Prisma } from "@langfuse/shared/src/db";
-import { useSession } from "next-auth/react";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { Button } from "@/src/components/ui/button";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { useIsAuthenticatedAndProjectMember } from "@/src/features/auth/hooks";
 
 export const NewDatasetItemFromTrace = (props: {
   projectId: string;
@@ -32,7 +32,9 @@ export const NewDatasetItemFromTrace = (props: {
   metadata: Prisma.JsonValue;
 }) => {
   const [isFormOpen, setIsFormOpen] = useState(false);
-  const session = useSession();
+  const isAuthenticatedAndProjectMember = useIsAuthenticatedAndProjectMember(
+    props.projectId,
+  );
   const observationInDatasets =
     api.datasets.datasetItemsBasedOnTraceOrObservation.useQuery(
       {
@@ -41,7 +43,7 @@ export const NewDatasetItemFromTrace = (props: {
         observationId: props.observationId,
       },
       {
-        enabled: session.status === "authenticated",
+        enabled: isAuthenticatedAndProjectMember,
       },
     );
   const hasAccess = useHasProjectAccess({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces `useIsAuthenticatedAndProjectMember` hook to manage API queries and UI rendering based on user authentication and project membership, preventing unauthorized errors.
> 
>   - **Authentication**:
>     - Introduced `useIsAuthenticatedAndProjectMember` hook in `hooks.ts` to check user authentication and project membership.
>   - **Components**:
>     - Replaced `useSession` with `useIsAuthenticatedAndProjectMember` in `TraceTimelineView`, `Trace`, and `NewDatasetItemFromObservationButton` to control API query execution.
>     - Updated `TraceTimelineView` and `Trace` to enable comment count queries only if the user is authenticated and a project member.
>     - Updated `TracePage` to conditionally enable `traceFilterOptions` query based on authentication and project membership.
>     - Modified `ObservationPreview` and `TracePreview` to conditionally render "Scores" tab based on authentication and project membership.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e839bbc87b3f9c89ebcded30c13ddc9980768661. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->