### PR TITLE
style: unify dataset buttons/badge with langfuse design system, add UI access check on archive dataset item 

### DIFF
--- a/web/src/features/datasets/components/DatasetActionButton.tsx
+++ b/web/src/features/datasets/components/DatasetActionButton.tsx
@@ -106,9 +106,10 @@ export const DatasetActionButton = (props: DatasetActionButtonProps) => {
             className={props.className}
             disabled={!hasAccess}
             onClick={() => capture("datasets:new_form_open")}
+            variant="secondary"
           >
             {hasAccess ? (
-              <PlusIcon className="-ml-0.5 mr-1.5" aria-hidden="true" />
+              <PlusIcon className="-ml-0.5 mr-1.5 h-4 w-4" aria-hidden="true" />
             ) : (
               <LockIcon className="-ml-0.5 mr-1.5 h-3 w-3" aria-hidden="true" />
             )}

--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -14,7 +14,6 @@ import { useQueryParams, withDefault, NumberParam } from "use-query-params";
 import { Archive, ListTree, MoreVertical } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import { type DatasetItem, DatasetStatus, type Prisma } from "@langfuse/shared";
-import { cn } from "@/src/utils/tailwind";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
 import { useEffect } from "react";

--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -24,6 +24,8 @@ import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-
 import { IOTableCell } from "@/src/components/ui/CodeJsonViewer";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
+import { StatusBadge } from "@/src/components/layouts/status-badge";
+import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 
 type RowData = {
   id: string;
@@ -59,6 +61,8 @@ export function DatasetItemsTable({
     "datasetItems",
     "s",
   );
+
+  const hasAccess = useHasProjectAccess({ projectId, scope: "datasets:CUD" });
 
   const items = api.datasets.itemsByDatasetId.useQuery({
     projectId,
@@ -133,17 +137,11 @@ export function DatasetItemsTable({
       cell: ({ row }) => {
         const status: DatasetStatus = row.getValue("status");
         return (
-          <div className="flex items-center gap-2">
-            <div
-              className={cn(
-                "h-2 w-2 rounded-full",
-                status === DatasetStatus.ACTIVE
-                  ? "bg-dark-green"
-                  : "bg-dark-yellow",
-              )}
-            />
-            <span>{status}</span>
-          </div>
+          <StatusBadge
+            className="capitalize"
+            type={status.toLowerCase()}
+            isLive={false}
+          />
         );
       },
     },
@@ -218,6 +216,7 @@ export function DatasetItemsTable({
             <DropdownMenuContent align="end">
               <DropdownMenuLabel>Actions</DropdownMenuLabel>
               <DropdownMenuItem
+                disabled={!hasAccess}
                 onClick={() => {
                   capture("dataset_item:archive_toggle", {
                     status:

--- a/web/src/features/datasets/components/NewDatasetItemButton.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemButton.tsx
@@ -4,6 +4,7 @@ import {
   Dialog,
   DialogContent,
   DialogHeader,
+  DialogTitle,
 } from "@/src/components/ui/dialog";
 import { useState } from "react";
 import { NewDatasetItemForm } from "@/src/features/datasets/components/NewDatasetItemForm";
@@ -40,7 +41,9 @@ export const NewDatasetItemButton = (props: {
         </Button>
       </DialogTrigger>
       <DialogContent className="h-[calc(100vh-5rem)] max-h-none w-[calc(100vw-5rem)] max-w-none items-start">
-        <DialogHeader>Create new dataset item</DialogHeader>
+        <DialogHeader>
+          <DialogTitle>Create new dataset item</DialogTitle>
+        </DialogHeader>
         <NewDatasetItemForm
           projectId={props.projectId}
           datasetId={props.datasetId}

--- a/web/src/features/datasets/components/NewDatasetItemButton.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemButton.tsx
@@ -32,7 +32,7 @@ export const NewDatasetItemButton = (props: {
           onClick={() => capture("dataset_item:new_form_open")}
         >
           {hasAccess ? (
-            <PlusIcon className="-ml-0.5 mr-1.5" aria-hidden="true" />
+            <PlusIcon className="-ml-0.5 mr-1.5 h-4 w-4" aria-hidden="true" />
           ) : (
             <LockIcon className="-ml-0.5 mr-1.5 h-3 w-3" aria-hidden="true" />
           )}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Unifies dataset UI with Langfuse design system and adds access checks for dataset actions in `DatasetActionButton`, `DatasetItemsTable`, and `NewDatasetItemButton`.
> 
>   - **UI Updates**:
>     - `DatasetActionButton`: Set button variant to `secondary`, adjusted `PlusIcon` and `LockIcon` sizes.
>     - `DatasetItemsTable`: Replaced status indicator with `StatusBadge`.
>     - `NewDatasetItemButton`: Adjusted icon sizes.
>   - **Access Control**:
>     - `DatasetActionButton`: Used `useHasProjectAccess` to disable button if no access.
>     - `DatasetItemsTable`: Used `useHasProjectAccess` to disable archive action if no access.
>     - `NewDatasetItemButton`: Used `useHasProjectAccess` to disable button if no access.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9d0c54eec4f8231d7aedf6fc1a2f567220283acf. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->