### PR TITLE
perf: remove ch read

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -577,26 +577,28 @@ export class IngestionService {
       scores: scoreRecordReadSchema,
       observations: observationRecordReadSchema,
     };
-    const { projectId, entityId, table } = params;
+    // const { projectId, entityId, table } = params;
 
-    return await instrumentAsync({ name: `get-${table}` }, async () => {
-      const queryResult = await this.clickhouseClient.query({
-        query: `SELECT * FROM ${table} WHERE project_id = '${projectId}' AND id = '${entityId}' ORDER BY updated_at DESC LIMIT 1`,
-        format: "JSONEachRow",
-      });
+    // return await instrumentAsync({ name: `get-${table}` }, async () => {
+    //   const queryResult = await this.clickhouseClient.query({
+    //     query: `SELECT * FROM ${table} WHERE project_id = '${projectId}' AND id = '${entityId}' ORDER BY updated_at DESC LIMIT 1`,
+    //     format: "JSONEachRow",
+    //   });
 
-      const result = await queryResult.json();
+    //   const result = await queryResult.json();
 
-      if (result.length === 0) return null;
+    //   if (result.length === 0) return null;
 
-      return table === TableName.Traces
-        ? convertTraceReadToInsert(recordParser[table].parse(result[0]))
-        : table === TableName.Scores
-          ? convertScoreReadToInsert(recordParser[table].parse(result[0]))
-          : convertObservationReadToInsert(
-              recordParser[table].parse(result[0])
-            );
-    });
+    //   return table === TableName.Traces
+    //     ? convertTraceReadToInsert(recordParser[table].parse(result[0]))
+    //     : table === TableName.Scores
+    //       ? convertScoreReadToInsert(recordParser[table].parse(result[0]))
+    //       : convertObservationReadToInsert(
+    //           recordParser[table].parse(result[0])
+    //         );
+    // });
+
+    return null;
   }
 
   private mapTraceEventsToRecords(params: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes Clickhouse read operation in `getClickhouseRecord` of `IngestionService`, returning `null` directly for performance improvement.
> 
>   - **Behavior**:
>     - Removes Clickhouse read operation in `getClickhouseRecord` in `index.ts` of `IngestionService`. The function now returns `null` directly.
>     - Commented out code for querying Clickhouse and parsing results.
>   - **Misc**:
>     - No changes to other functions or classes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 58e28d9ba3d33feff513078f47b5a4f26f756209. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->