### PR TITLE
perf: remove query cache in ingestion pipeline

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -581,7 +581,7 @@ export class IngestionService {
 
     return await instrumentAsync({ name: `get-${table}` }, async () => {
       const queryResult = await this.clickhouseClient.query({
-        query: `SELECT * FROM ${table} WHERE project_id = '${projectId}' AND id = '${entityId}' ORDER BY updated_at DESC LIMIT 1`,
+        query: `SELECT * FROM ${table} WHERE project_id = '${projectId}' AND id = '${entityId}' ORDER BY updated_at DESC LIMIT 1 SETTINGS use_query_cache = false;`,
         format: "JSONEachRow",
       });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Disable query cache in `getClickhouseRecord()` in `index.ts` for up-to-date data retrieval.
> 
>   - **Performance**:
>     - Disable query cache in `getClickhouseRecord()` in `index.ts` by adding `SETTINGS use_query_cache = false` to the query string.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 82cff8d7851b271dd00abed2b19916e843bb691d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->