### PR TITLE
feat: add is_deleted to clickhouse

### DIFF
--- a/packages/shared/clickhouse/migrations/0001_traces.up.sql
+++ b/packages/shared/clickhouse/migrations/0001_traces.up.sql
@@ -14,12 +14,13 @@ CREATE TABLE traces (
     `output` Nullable(String) CODEC(ZSTD(1)),
     `session_id` Nullable(String),
     `created_at` DateTime64(3) DEFAULT now(),
-    `updated_at` DateTime64(3) DEFAULT now(),
-    event_ts DateTime64(3),
+    updated_at DateTime64(3) DEFAULT now(),
+    `event_ts` DateTime64(3),
+    `is_deleted` UInt8,
     INDEX idx_id id TYPE bloom_filter(0.001) GRANULARITY 1,
     INDEX idx_res_metadata_key mapKeys(metadata) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_res_metadata_value mapValues(metadata) TYPE bloom_filter(0.01) GRANULARITY 1
-) ENGINE = ReplacingMergeTree Partition by toYYYYMM(timestamp)
+) ENGINE = ReplacingMergeTree(event_ts, is_deleted) Partition by toYYYYMM(timestamp)
 PRIMARY KEY (
         project_id,
         toDate(timestamp)

--- a/packages/shared/clickhouse/migrations/0002_observations.up.sql
+++ b/packages/shared/clickhouse/migrations/0002_observations.up.sql
@@ -36,12 +36,13 @@ CREATE TABLE observations (
     `created_at` DateTime64(3) DEFAULT now(),
     `updated_at` DateTime64(3) DEFAULT now(),
     event_ts DateTime64(3),
+    is_deleted UInt8,
     INDEX idx_id id TYPE bloom_filter() GRANULARITY 1,
     INDEX idx_trace_id trace_id TYPE bloom_filter() GRANULARITY 1,
     INDEX idx_project_id project_id TYPE bloom_filter() GRANULARITY 1,
     INDEX idx_res_metadata_key mapKeys(metadata) TYPE bloom_filter() GRANULARITY 1,
     INDEX idx_res_metadata_value mapValues(metadata) TYPE bloom_filter() GRANULARITY 1
-) ENGINE = ReplacingMergeTree Partition by toYYYYMM(start_time)
+) ENGINE = ReplacingMergeTree(event_ts, is_deleted) Partition by toYYYYMM(start_time)
 PRIMARY KEY (
         project_id,
         `type`,

--- a/packages/shared/clickhouse/migrations/0003_scores.up.sql
+++ b/packages/shared/clickhouse/migrations/0003_scores.up.sql
@@ -15,9 +15,10 @@ CREATE TABLE scores (
     `created_at` DateTime64(3) DEFAULT now(),
     `updated_at` DateTime64(3) DEFAULT now(),
     event_ts DateTime64(3),
+    `is_deleted` UInt8,
     INDEX idx_id id TYPE bloom_filter(0.001) GRANULARITY 1,
     INDEX idx_project_trace_observation (project_id, trace_id, observation_id) TYPE bloom_filter(0.001) GRANULARITY 1
-) ENGINE = ReplacingMergeTree Partition by toYYYYMM(timestamp)
+) ENGINE = ReplacingMergeTree(event_ts, is_deleted) Partition by toYYYYMM(timestamp)
 PRIMARY KEY (
         project_id,
         toDate(timestamp),

--- a/packages/shared/clickhouse/migrations/0004_observations_wide.up.sql
+++ b/packages/shared/clickhouse/migrations/0004_observations_wide.up.sql
@@ -51,8 +51,9 @@ CREATE TABLE observations_wide
     trace_bookmarked Bool,
     trace_tags Array(String),
     trace_session_id Nullable(String),
-    trace_event_ts DateTime64(3)
-) ENGINE = ReplacingMergeTree Partition by toYYYYMM(start_time)
+    trace_event_ts DateTime64(3),
+    is_deleted UInt8,
+) ENGINE = ReplacingMergeTree(event_ts, is_deleted) Partition by toYYYYMM(start_time)
 PRIMARY KEY (
         project_id,
         `type`,

--- a/packages/shared/clickhouse/migrations/0005_traces_wide.up.sql
+++ b/packages/shared/clickhouse/migrations/0005_traces_wide.up.sql
@@ -51,8 +51,9 @@ CREATE TABLE traces_wide
     trace_bookmarked Bool,
     trace_tags Array(String),
     trace_session_id Nullable(String),
-    trace_event_ts DateTime64(3)
-) ENGINE = ReplacingMergeTree Partition by toYYYYMM(start_time)
+    trace_event_ts DateTime64(3),
+    is_deleted UInt8
+) ENGINE = ReplacingMergeTree(event_ts, is_deleted) Partition by toYYYYMM(start_time)
 PRIMARY KEY (
         project_id,
         `type`,

--- a/packages/shared/src/server/definitions.ts
+++ b/packages/shared/src/server/definitions.ts
@@ -39,6 +39,7 @@ export const observationRecordBaseSchema = z.object({
   prompt_id: z.string().nullish(),
   prompt_name: z.string().nullish(),
   prompt_version: z.number().nullish(),
+  is_deleted: z.number(),
 });
 export type ObservationRecordBaseType = z.infer<
   typeof observationRecordBaseSchema
@@ -84,6 +85,7 @@ export const traceRecordBaseSchema = z.object({
   input: z.string().nullish(),
   output: z.string().nullish(),
   session_id: z.string().nullish(),
+  is_deleted: z.number(),
 });
 export type TraceRecordBaseType = z.infer<typeof traceRecordBaseSchema>;
 
@@ -116,6 +118,7 @@ export const scoreRecordBaseSchema = z.object({
   config_id: z.string().nullish(),
   data_type: z.enum(["NUMERIC", "CATEGORICAL", "BOOLEAN"]).nullish(),
   string_value: z.string().nullish(),
+  is_deleted: z.number(),
 });
 export type ScoreRecordBaseType = z.infer<typeof scoreRecordBaseSchema>;
 

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -258,6 +258,7 @@ export class IngestionService {
         bookmarked: false,
         public: false,
         event_ts: Date.now(),
+        is_deleted: 0
       };
 
       this.clickHouseWriter.addToQueue(TableName.Traces, wrapperTraceRecord);

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -140,6 +140,7 @@ export class IngestionService {
           created_at: Date.now(),
           updated_at: Date.now(),
           event_ts: new Date(scoreEvent.timestamp).getTime(),
+          is_deleted: 0,
         };
       });
 
@@ -631,6 +632,7 @@ export class IngestionService {
         created_at: Date.now(),
         updated_at: Date.now(),
         event_ts: new Date(trace.timestamp).getTime(),
+        is_deleted: 0,
       };
 
       return traceRecord;
@@ -739,6 +741,7 @@ export class IngestionService {
         created_at: Date.now(),
         updated_at: Date.now(),
         event_ts: new Date(obs.timestamp).getTime(),
+        is_deleted: 0,
       };
 
       return observationRecord;

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -243,9 +243,6 @@ export class IngestionService {
       observationRecords,
       clickhouseObservationRecord,
     });
-
-    logger.info(`Final observation: ${JSON.stringify(finalObservationRecord)}`);
-
     // Backward compat: create wrapper trace for SDK < 2.0.0 events that do not have a traceId
     if (!finalObservationRecord.trace_id) {
       const traceId = randomUUID();

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -990,6 +990,8 @@ describe("Ingestion end-to-end tests", () => {
       generationId
     );
 
+    console.log(generationId);
+
     expect(generation.id).toBe(generationId);
     expect(generation.trace_id).toBe(traceId);
     expect(generation.output).toEqual(

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -990,8 +990,6 @@ describe("Ingestion end-to-end tests", () => {
       generationId
     );
 
-    console.log(generationId);
-
     expect(generation.id).toBe(generationId);
     expect(generation.trace_id).toBe(traceId);
     expect(generation.output).toEqual(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `is_deleted` column to Clickhouse tables and update schemas and services for soft deletion support.
> 
>   - **Database Migrations**:
>     - Add `is_deleted` column to `traces`, `observations`, `scores`, `observations_wide`, and `traces_wide` tables.
>     - Update `ReplacingMergeTree` engine to include `is_deleted` in `traces`, `observations`, `scores`, `observations_wide`, and `traces_wide`.
>   - **Schemas**:
>     - Add `is_deleted` field to `observationRecordBaseSchema`, `traceRecordBaseSchema`, and `scoreRecordBaseSchema` in `definitions.ts`.
>   - **Ingestion Service**:
>     - Set `is_deleted` to `0` in `processScoreEventList`, `processTraceEventList`, and `processObservationEventList` in `IngestionService/index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9d19e63a79081a45b071309dab52d9a745f9840d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->