### PR TITLE
fix(evals): show eval filters in eval-configs table

### DIFF
--- a/web/src/ee/features/evals/components/eval-config-table.tsx
+++ b/web/src/ee/features/evals/components/eval-config-table.tsx
@@ -78,7 +78,11 @@ export default function EvalConfigTable({ projectId }: { projectId: string }) {
       size: 200,
       cell: (row) => {
         const node = row.getValue();
-        return <InlineFilterState filterState={node} />;
+        return (
+          <div className="flex h-full overflow-x-auto">
+            <InlineFilterState filterState={node} />
+          </div>
+        );
       },
     }),
   ] as LangfuseColumnDef<EvalConfigRow>[];

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -108,7 +108,10 @@ export function PopoverFilterBuilder({
             <Filter className="h-4 w-4" />
             <span className="hidden @6xl:ml-2 @6xl:inline">Filter</span>
             {filterState.length > 0 && filterState.length < 3 ? (
-              <InlineFilterState filterState={filterState} className="hidden" />
+              <InlineFilterState
+                filterState={filterState}
+                className="hidden @6xl:block"
+              />
             ) : null}
             {filterState.length > 0 && (
               <span
@@ -160,7 +163,7 @@ export function InlineFilterState({
       <span
         key={i}
         className={cn(
-          "ml-2 whitespace-nowrap rounded-md bg-input px-2 py-1 text-xs @6xl:block",
+          "ml-2 whitespace-nowrap rounded-md bg-input px-2 py-1 text-xs",
           className,
         )}
       >

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -108,7 +108,7 @@ export function PopoverFilterBuilder({
             <Filter className="h-4 w-4" />
             <span className="hidden @6xl:ml-2 @6xl:inline">Filter</span>
             {filterState.length > 0 && filterState.length < 3 ? (
-              <InlineFilterState filterState={filterState} />
+              <InlineFilterState filterState={filterState} className="hidden" />
             ) : null}
             {filterState.length > 0 && (
               <span
@@ -150,14 +150,19 @@ export function PopoverFilterBuilder({
 
 export function InlineFilterState({
   filterState,
+  className,
 }: {
   filterState: FilterState;
+  className?: string;
 }) {
   return filterState.map((filter, i) => {
     return (
       <span
         key={i}
-        className="ml-2 hidden whitespace-nowrap rounded-md bg-input px-2 py-1 text-xs @6xl:block"
+        className={cn(
+          "ml-2 whitespace-nowrap rounded-md bg-input px-2 py-1 text-xs @6xl:block",
+          className,
+        )}
       >
         {filter.column}
         {filter.type === "stringObject" || filter.type === "numberObject"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modify `PopoverFilterBuilder` to conditionally hide `InlineFilterState` and add styling support, updating `eval-config-table.tsx` and `filter-builder.tsx`.
> 
>   - **Behavior**:
>     - Modify `PopoverFilterBuilder` to hide `InlineFilterState` when filter count is between 1 and 2.
>   - **Components**:
>     - Add `className` prop to `InlineFilterState` for conditional styling.
>   - **Files**:
>     - Update `eval-config-table.tsx` to wrap `InlineFilterState` in a `div` with flex and overflow styling.
>     - Update `filter-builder.tsx` to apply `className` to `InlineFilterState` when filter count is between 1 and 2.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for aba682288a20f04406cacbda06738bb3f1395638. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->