### PR TITLE
feat(cloud): add event usage metering

### DIFF
--- a/worker/src/queues/cloudUsageMeteringQueue.ts
+++ b/worker/src/queues/cloudUsageMeteringQueue.ts
@@ -51,13 +51,13 @@ export class CloudUsageMeteringQueue {
         {},
         {
           repeat: { pattern: "5 * * * *" },
-        },
+        }
       );
 
       CloudUsageMeteringQueue.instance.add(
         QueueJobs.CloudUsageMeteringJob,
         {},
-        {},
+        {}
       );
     }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds event usage metering to cloud usage metering job, updating logic to count and log events, and push metrics to Stripe.
> 
>   - **Behavior**:
>     - Adds event usage metering in `handleCloudUsageMeteringJob.ts` by counting `score` and `trace` events and logging them.
>     - Pushes event metrics to Stripe with `event_name: "tracing_events"`.
>     - Updates `cloudUsageMeteringQueue.ts` to handle new job logic.
>   - **Metrics**:
>     - Records `cloud_usage_metering_processed_events` gauge in `handleCloudUsageMeteringJob.ts`.
>   - **Misc**:
>     - Minor logging message format changes in `handleCloudUsageMeteringJob.ts` and `cloudUsageMeteringQueue.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5a26edc11d1c83a888be477fb44b9d08509d25b3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->