### PR TITLE
fix(models): allow for time tolerance in updateat diff

### DIFF
--- a/worker/src/scripts/upsertDefaultModelPrices.ts
+++ b/worker/src/scripts/upsertDefaultModelPrices.ts
@@ -80,10 +80,13 @@ export const upsertDefaultModelPrices = async (force = false) => {
           defaultModelPrice.id
         );
 
+        const toleranceInMs = 1000 * 60 * 60; // 1 hour. US and EU databases have different update times for when the migration was applied.
+
         if (
           !force &&
           existingModelUpdateDate &&
-          existingModelUpdateDate > defaultModelPrice.updated_at
+          existingModelUpdateDate.getTime() >
+            defaultModelPrice.updated_at.getTime() + toleranceInMs
         ) {
           logger.error(
             `Model drift detected for default model ${defaultModelPrice.model_name} (${defaultModelPrice.id}). updatedAt ${existingModelUpdateDate} after ${defaultModelPrice.updated_at}.`
@@ -94,8 +97,10 @@ export const upsertDefaultModelPrices = async (force = false) => {
         if (
           !force &&
           existingModelUpdateDate &&
-          existingModelUpdateDate.getTime() ==
-            defaultModelPrice.updated_at.getTime()
+          Math.abs(
+            existingModelUpdateDate.getTime() -
+              defaultModelPrice.updated_at.getTime()
+          ) <= toleranceInMs
         ) {
           logger.debug(
             `Default model ${defaultModelPrice.model_name} (${defaultModelPrice.id}) already up to date. Skipping.`


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a 1-hour time tolerance in `upsertDefaultModelPrices` to handle update time discrepancies between US and EU databases.
> 
>   - **Behavior**:
>     - Introduces a 1-hour time tolerance in `upsertDefaultModelPrices` to handle update time discrepancies between US and EU databases.
>     - Adjusts condition to skip updates if `existingModelUpdateDate` is within 1-hour tolerance of `defaultModelPrice.updated_at`.
>   - **Logging**:
>     - Logs an error if model drift is detected beyond the 1-hour tolerance.
>     - Logs a debug message if a model is already up to date within the tolerance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 25ceaba63bf2220637187c2c3958d5faade85096. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->