### PR TITLE
chore: faster healthcheck of minio in dev docker compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,10 +31,10 @@ services:
       - langfuse_minio_data:/data
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
-      interval: 10s
+      interval: 1s
       timeout: 5s
       retries: 5
-      start_period: 5s
+      start_period: 1s
 
   miniocreatebucket:
     image: minio/mc


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update MinIO health check interval and start period in `docker-compose.dev.yml` for faster checks.
> 
>   - **Docker Compose**:
>     - In `docker-compose.dev.yml`, update MinIO service health check:
>       - Change `interval` from `10s` to `1s`.
>       - Change `start_period` from `5s` to `1s`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8c68d84ff6816d358acd911b7e46eb629378c969. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->