### PR TITLE
chore: add is_deleted column to clickhouse seeder

### DIFF
--- a/packages/shared/scripts/prepareClickhouse.ts
+++ b/packages/shared/scripts/prepareClickhouse.ts
@@ -23,15 +23,15 @@ export const prepareClickhouse = async (
   opts: {
     numberOfDays: number;
     totalObservations: number;
-  }
+  },
 ) => {
   logger.info(
-    `Preparing Clickhouse for ${projectIds.length} projects and ${opts.numberOfDays} days.`
+    `Preparing Clickhouse for ${projectIds.length} projects and ${opts.numberOfDays} days.`,
   );
 
   const projectData = projectIds.map((projectId) => {
     const observationsPerProject = Math.ceil(
-      randn_bm(0, opts.totalObservations, 2)
+      randn_bm(0, opts.totalObservations, 2),
     ); // Skew the number of observations
 
     const tracesPerProject = Math.floor(observationsPerProject / 6); // On average, one trace should have 6 observations
@@ -52,7 +52,7 @@ export const prepareClickhouse = async (
       scoresPerProject,
     } = data;
     logger.info(
-      `Preparing Clickhouse for ${projectId}: Traces: ${tracesPerProject}, Scores: ${scoresPerProject}, Observations: ${observationsPerProject}`
+      `Preparing Clickhouse for ${projectId}: Traces: ${tracesPerProject}, Scores: ${scoresPerProject}, Observations: ${observationsPerProject}`,
     );
 
     const tracesQuery = `
@@ -73,7 +73,8 @@ export const prepareClickhouse = async (
       concat('session_', toString(rand() % 100)) AS session_id,
       timestamp AS created_at,
       timestamp AS updated_at,
-      timestamp AS event_ts
+      timestamp AS event_ts,
+      0 AS is_deleted
     FROM numbers(${tracesPerProject});
   `;
 
@@ -113,7 +114,8 @@ export const prepareClickhouse = async (
       1000 AS prompt_version,
       start_time AS created_at,
       start_time AS updated_at,
-      start_time AS event_ts
+      start_time AS event_ts,
+      0 AS is_deleted
     FROM numbers(${observationsPerProject});
   `;
 
@@ -138,7 +140,8 @@ export const prepareClickhouse = async (
       toString(rand() % 100) as string_value,
       timestamp AS created_at,
       timestamp AS updated_at,
-      timestamp AS event_ts
+      timestamp AS event_ts,
+      0 AS is_deleted
     FROM numbers(${scoresPerProject});
   `;
 
@@ -177,7 +180,7 @@ export const prepareClickhouse = async (
 
     logger.info(
       `${table.charAt(0).toUpperCase() + table.slice(1)} per Project: \n` +
-        (await result.text())
+        (await result.text()),
     );
   }
 
@@ -208,7 +211,7 @@ export const prepareClickhouse = async (
 
     logger.info(
       `${table.charAt(0).toUpperCase() + table.slice(1)} per Date: \n` +
-        (await result.text())
+        (await result.text()),
     );
   }
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `is_deleted` column to Clickhouse seeder queries in `prepareClickhouse.ts` with default value `0`.
> 
>   - **Behavior**:
>     - Adds `is_deleted` column with default value `0` to `tracesQuery`, `observationsQuery`, and `scoresQuery` in `prepareClickhouse.ts`.
>   - **Misc**:
>     - Fixes trailing commas in `logger.info` calls in `prepareClickhouse.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c52db15ededb4c825dfa86333d7663fea80e530b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->