### PR TITLE
fix: populate default `metadata` when adding observation as dataset item

### DIFF
--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -259,7 +259,7 @@ export const ObservationPreview = ({
                   projectId={projectId}
                   input={observationWithInputAndOutput.data.input}
                   output={observationWithInputAndOutput.data.output}
-                  metadata={preloadedObservation.metadata}
+                  metadata={observationWithInputAndOutput.data.metadata}
                   key={preloadedObservation.id}
                 />
               ) : null}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes metadata assignment in `ObservationPreview` component to use correct source for dataset item creation.
> 
>   - **Behavior**:
>     - Fixes metadata assignment in `ObservationPreview` component by using `observationWithInputAndOutput.data.metadata` instead of `preloadedObservation.metadata`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d455c5d68250242a35ec725f0bf61ece98422019. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->