### PR TITLE
fix: treat api call failures for eval executions the same way as parsing errors.

### DIFF
--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -382,7 +382,7 @@ async function callLLM(
     logger.error(
       `Evaluating job ${jeId} failed to call LLM. Eval will fail. ${e}`
     );
-    throw new ApiError(`Failed to call LLM: ${e}`, e);
+    throw new ApiError(`Failed to call LLM: ${e}`);
   }
 }
 

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -356,39 +356,34 @@ async function callLLM(
   template: EvalTemplate,
   evalScoreSchema: z.ZodObject<{ score: z.ZodNumber; reasoning: z.ZodString }>
 ): Promise<z.infer<typeof evalScoreSchema>> {
-  const completion = await fetchLLMCompletion({
-    streaming: false,
-    apiKey: decrypt(llmApiKey.secretKey), // decrypt the secret key
-    baseURL: llmApiKey.baseURL || undefined,
-    messages: [
-      {
-        role: ChatMessageRole.System,
-        content: "You are an expert at evaluating LLM outputs.",
+  try {
+    const completion = await fetchLLMCompletion({
+      streaming: false,
+      apiKey: decrypt(llmApiKey.secretKey), // decrypt the secret key
+      baseURL: llmApiKey.baseURL || undefined,
+      messages: [
+        {
+          role: ChatMessageRole.System,
+          content: "You are an expert at evaluating LLM outputs.",
+        },
+        { role: ChatMessageRole.User, content: prompt },
+      ],
+      modelParams: {
+        provider: template.provider,
+        model: template.model,
+        adapter: llmApiKey.adapter,
+        ...modelParams,
       },
-      { role: ChatMessageRole.User, content: prompt },
-    ],
-    modelParams: {
-      provider: template.provider,
-      model: template.model,
-      adapter: llmApiKey.adapter,
-      ...modelParams,
-    },
-    structuredOutputSchema: evalScoreSchema,
-    config: llmApiKey.config,
-  });
-  const parsedLLMOutput = evalScoreSchema.safeParse(completion);
-
-  if (!parsedLLMOutput.success) {
+      structuredOutputSchema: evalScoreSchema,
+      config: llmApiKey.config,
+    });
+    return evalScoreSchema.parse(completion);
+  } catch (e) {
     logger.error(
-      `Evaluating job ${jeId} failed to parse LLM output ${completion}. Eval will fail. ${parsedLLMOutput.error}`
+      `Evaluating job ${jeId} failed to call LLM. Eval will fail. ${e}`
     );
-    // this is an API error as these are retried.
-    // Maybe a second call to the LLM will return a valid output.
-    throw new ApiError(
-      `Failed to parse LLM output: ${JSON.stringify(parsedLLMOutput.error)}`
-    );
+    throw new ApiError(`Failed to call LLM: ${e}`, e);
   }
-  return parsedLLMOutput.data;
 }
 
 export function compileHandlebarString(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Wraps `fetchLLMCompletion` in `callLLM` with try-catch to handle API call failures like parsing errors in `evalService.ts`.
> 
>   - **Error Handling**:
>     - Wraps `fetchLLMCompletion` call in `callLLM` function in `evalService.ts` with a try-catch block.
>     - Logs error and throws `ApiError` on API call failure, similar to parsing errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e7b89a2b4872911dc065c995236a0d3e4c34469f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->