### PR TITLE
fix: handle internal error of traces.byId

### DIFF
--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -261,13 +261,20 @@ export const traceRouter = createTRPCRouter({
       }),
     )
     .query(async ({ input, ctx }) => {
-      const trace = await ctx.prisma.trace.findFirstOrThrow({
-        where: {
-          id: input.traceId,
-          projectId: input.projectId,
-        },
-      });
-      return trace;
+      try {
+        const trace = await ctx.prisma.trace.findFirstOrThrow({
+          where: {
+            id: input.traceId,
+            projectId: input.projectId,
+          },
+        });
+        return trace;
+      } catch (e) {
+        console.error(e);
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+        });
+      }
     }),
   byIdWithObservationsAndScores: protectedGetTraceProcedure
     .input(

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -29,6 +29,7 @@ import {
   traceException,
   createTracesQuery,
   parseTraceAllFilters,
+  logger,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 import type Decimal from "decimal.js";
@@ -270,7 +271,7 @@ export const traceRouter = createTRPCRouter({
         });
         return trace;
       } catch (e) {
-        console.error(e);
+        logger.error(e);
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
         });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds error handling to `byId` query in `traces.ts` to log errors and throw `INTERNAL_SERVER_ERROR`.
> 
>   - **Error Handling**:
>     - Wraps `ctx.prisma.trace.findFirstOrThrow` in `byId` query in `traces.ts` with a `try-catch` block.
>     - Logs error to console and throws `TRPCError` with `INTERNAL_SERVER_ERROR` code on failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0e54decd2cf60c54c67ac58471fe946343ee6c90. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->