### PR TITLE
chore: remove zod parsing from worker

### DIFF
--- a/worker/src/queues/legacyIngestionQueue.ts
+++ b/worker/src/queues/legacyIngestionQueue.ts
@@ -6,8 +6,6 @@ import {
   logger,
   IngestionEventType,
   S3StorageService,
-  ingestionBatchEvent,
-  ingestionEvent,
   getClickhouseEntityType,
 } from "@langfuse/shared/src/server";
 
@@ -59,20 +57,7 @@ export const legacyIngestionQueueProcessor: Processor = async (
               `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${getClickhouseEntityType(record.type)}/${record.eventBodyId}/${record.eventId}.json`,
             );
             const parsedFile = JSON.parse(file);
-            const parsed = ingestionBatchEvent.safeParse(parsedFile);
-            if (parsed.success) {
-              return parsed.data;
-            } else {
-              // Fallback to non-array format for backwards compatibility
-              const parsed = ingestionEvent.safeParse(parsedFile);
-              if (parsed.success) {
-                return [parsed.data];
-              } else {
-                throw new Error(
-                  `Failed to parse event from S3: ${parsed.error.message}`,
-                );
-              }
-            }
+            return Array.isArray(parsedFile) ? parsedFile : [parsedFile];
           }),
         )
       ).flat();


### PR DESCRIPTION
## What does this PR do?

Removes the zod parsing on the worker to free up CPU cycles there. As we validate all incoming events in the web container there shouldn't be any invalid ones in S3 or redis which makes this parsing obsolete.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes redundant Zod parsing from worker processors in `ingestionQueue.ts` and `legacyIngestionQueue.ts`, simplifying event handling.
> 
>   - **Behavior**:
>     - Removes Zod parsing from `ingestionQueueProcessor` in `ingestionQueue.ts` and `legacyIngestionQueueProcessor` in `legacyIngestionQueue.ts`.
>     - Replaces parsing logic with a check to return an array if `parsedFile` is an array, or wrap it in an array if not.
>   - **Rationale**:
>     - Parsing is redundant as events are validated in the web container, ensuring no invalid events in S3 or Redis.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1b64d2cfd62139c6585bd476c0fd676b1fdb86a9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->