### PR TITLE
chore: remove remaining zod parses in worker pipeline

### DIFF
--- a/packages/shared/src/server/ingestion/legacy/index.ts
+++ b/packages/shared/src/server/ingestion/legacy/index.ts
@@ -1,7 +1,7 @@
 import { env } from "node:process";
 import z from "zod";
 import { ForbiddenError, UnauthorizedError } from "../../../errors";
-import { eventTypes, ingestionApiSchema, ingestionEvent } from "../types";
+import { eventTypes, ingestionApiSchema, IngestionEventType } from "../types";
 import { getProcessorForEvent } from "./EventProcessor";
 import { TraceUpsertEventType } from "../../queues";
 import {
@@ -102,7 +102,7 @@ async function retry<T>(request: () => Promise<T>): Promise<T> {
 }
 
 const handleSingleEvent = async (
-  event: z.infer<typeof ingestionEvent>,
+  event: IngestionEventType,
   apiScope: LegacyIngestionAccessScope,
   calculateTokenDelegate: (p: {
     model: Model;
@@ -126,7 +126,7 @@ const handleSingleEvent = async (
     `handling single event ${event.id} of type ${event.type}:  ${JSON.stringify({ body: restEvent })}`,
   );
 
-  const cleanedEvent = ingestionEvent.parse(cleanEvent(event));
+  const cleanedEvent = cleanEvent(event) as IngestionEventType;
 
   // Deny access to non-score events if the access level is not "all"
   // This is an additional safeguard to auth checks in EventProcessor


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces `zod` parsing with direct type assertion in `handleSingleEvent` function in `index.ts`.
> 
>   - **Behavior**:
>     - Replaces `zod` parsing with direct type assertion in `handleSingleEvent` function in `index.ts`.
>     - Changes `event` parameter type from `z.infer<typeof ingestionEvent>` to `IngestionEventType`.
>     - Removes `ingestionEvent.parse` call, using `cleanEvent(event) as IngestionEventType` instead.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 685dc71487135a0f7bfeb2429cbe2ba0d32a9ca8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->