### PR TITLE
feat: support traces.countAll api with clickhouse

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-filter/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-filter/clickhouse-filter.ts
@@ -240,7 +240,10 @@ export class FilterList {
     this.filters.push(...filter);
   }
 
-  public apply(): ClickhouseFilter {
+  public apply(): ClickhouseFilter | undefined {
+    if (this.filters.length === 0) {
+      return undefined;
+    }
     const queries = this.filters.map((filter) => filter.apply().query);
     const params = this.filters.reduce((acc, filter) => {
       return { ...acc, ...filter.apply().params };

--- a/packages/shared/src/server/queries/clickhouse-filter/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-filter/clickhouse-filter.ts
@@ -17,7 +17,7 @@ export interface Filter {
 }
 type ClickhouseFilter = {
   query: string;
-  params: { [x: string]: any };
+  params: { [x: string]: any } | {};
 };
 
 export class StringFilter implements Filter {
@@ -256,9 +256,12 @@ export class FilterList {
     this.filters.push(...filter);
   }
 
-  public apply(): ClickhouseFilter | undefined {
+  public apply(): ClickhouseFilter {
     if (this.filters.length === 0) {
-      return undefined;
+      return {
+        query: "",
+        params: {},
+      };
     }
     const compiledQueries = this.filters.map((filter) => filter.apply());
     const { params, queries } = compiledQueries.reduce(

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -238,7 +238,6 @@ export const getTracesGroupedByTags = async (
   projectId: string,
   timestampFilter?: FilterState,
 ) => {
-  logger.error(`timestampFilterRes input ${JSON.stringify(timestampFilter)}`);
   const chFilter = timestampFilter
     ? createFilterFromFilterState(timestampFilter, {
         tracesPrefix: "t",
@@ -249,7 +248,6 @@ export const getTracesGroupedByTags = async (
     ? new FilterList(chFilter).apply()
     : undefined;
 
-  logger.error(`timestampFilterRes ${JSON.stringify(timestampFilterRes)}`);
   const query = `
       select 
         distinct(arrayJoin(tags)) as value

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -32,9 +32,63 @@ export type TracesTableReturnType = Pick<
   scores_avg: Array<{ name: string; avg_value: number }>;
 };
 
+export type TableCount = {
+  count: number;
+};
+
+export const getTracesTableCount = async (
+  projectId: string,
+  filter: FilterState,
+  limit?: number,
+  offset?: number,
+) =>
+  getTracesTableGeneric<TableCount>(
+    "count(*) as count",
+    projectId,
+    filter,
+    undefined,
+    limit,
+    offset,
+  );
+
 export const getTracesTable = async (
   projectId: string,
   filter: FilterState,
+  limit?: number,
+  offset?: number,
+) =>
+  getTracesTableGeneric<TracesTableReturnType>(
+    `
+    t.id, 
+    t.project_id, 
+    t.timestamp, 
+    t.tags, 
+    t.bookmarked, 
+    t.name, 
+    t.release, 
+    t.version, 
+    t.user_id, 
+    t.session_id,
+    os.latencyMs as latency,
+    os.cost_details as cost_details,
+    os.usage_details as usage_details,
+    os.level as level,
+    os.observation_count as observation_count,
+    s.scores_avg as scores_avg,
+    t.metadata,
+    t.public`,
+    projectId,
+    filter,
+    "ORDER BY t.timestamp desc",
+    limit,
+    offset,
+  );
+
+const getTracesTableGeneric = async <T>(
+  select: string,
+  projectId: string,
+  filter: FilterState,
+  orderBy?: string,
   limit?: number,
   offset?: number,
 ) => {
@@ -89,34 +143,17 @@ export const getTracesTable = async (
                           GROUP BY project_id,
                                   trace_id)
       select 
-        t.id, 
-        t.project_id, 
-        t.timestamp, 
-        t.tags, 
-        t.bookmarked, 
-        t.name, 
-        t.release, 
-        t.version, 
-        t.user_id, 
-        t.session_id,
-        os.latencyMs as latency,
-        os.cost_details as cost_details,
-        os.usage_details as usage_details,
-        os.level as level,
-        os.observation_count as observation_count,
-        s.scores_avg as scores_avg,
-        t.metadata,
-        t.public
+       ${select}
       from traces t final
               left join observations_stats os on os.project_id = t.project_id and os.trace_id = t.id
               left join scores_avg s on s.project_id = t.project_id and s.trace_id = t.id
 
       WHERE ${tracesFilterRes.query}
-      order by t.timestamp desc
+      ${orderBy ? orderBy : ""}
       ${limit && offset ? `limit {limit: Int32} offset {offset: Int32}` : ""}
     `;
 
-  const rows = await queryClickhouse<TracesTableReturnType>({
+  const rows = await queryClickhouse<T>({
     query: query,
     params: {
       limit: limit,
@@ -201,6 +238,7 @@ export const getTracesGroupedByTags = async (
   projectId: string,
   timestampFilter?: FilterState,
 ) => {
+  logger.error(`timestampFilterRes input ${JSON.stringify(timestampFilter)}`);
   const chFilter = timestampFilter
     ? createFilterFromFilterState(timestampFilter, {
         tracesPrefix: "t",
@@ -211,6 +249,7 @@ export const getTracesGroupedByTags = async (
     ? new FilterList(chFilter).apply()
     : undefined;
 
+  logger.error(`timestampFilterRes ${JSON.stringify(timestampFilterRes)}`);
   const query = `
       select 
         distinct(arrayJoin(tags)) as value

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -148,6 +148,7 @@ export default function TracesTable({
     page: 0,
     limit: 0,
     orderBy: null,
+    queryClickhouse: useClickhouse(),
   };
 
   const tracesAllQueryFilter = {

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -16,7 +16,6 @@ import {
   timeFilter,
   type TraceOptions,
 } from "@langfuse/shared";
-
 import {
   type ObservationLevel,
   type ObservationView,
@@ -30,6 +29,7 @@ import {
   createTracesQuery,
   parseTraceAllFilters,
   getTracesTable,
+  getTracesTableCount,
   getScoresForTraces,
   getTraceById,
   type TracesTableReturnType,
@@ -209,28 +209,51 @@ export const traceRouter = createTRPCRouter({
       }
     }),
   countAll: protectedProjectProcedure
-    .input(TraceFilterOptions)
+    .input(
+      TraceFilterOptions.extend({
+        queryClickhouse: z.boolean().default(false),
+      }),
+    )
     .query(async ({ input, ctx }) => {
       const { filterCondition, observationTimeseriesFilter, searchCondition } =
         parseTraceAllFilters(input);
+      if (!input.queryClickhouse) {
+        const countQuery = createTracesQuery({
+          select: Prisma.sql`count(*)`,
+          projectId: input.projectId,
+          observationTimeseriesFilter,
+          page: 0,
+          limit: 1,
+          searchCondition,
+          filterCondition,
+        });
 
-      const countQuery = createTracesQuery({
-        select: Prisma.sql`count(*)`,
-        projectId: input.projectId,
-        observationTimeseriesFilter,
-        page: 0,
-        limit: 1,
-        searchCondition,
-        filterCondition,
-      });
+        const totalTraces =
+          await ctx.prisma.$queryRaw<Array<{ count: bigint }>>(countQuery);
 
-      const totalTraces =
-        await ctx.prisma.$queryRaw<Array<{ count: bigint }>>(countQuery);
+        const totalTraceCount = totalTraces[0]?.count;
+        return {
+          totalCount: totalTraceCount ? Number(totalTraceCount) : undefined,
+        };
+      } else {
+        if (!isClickhouseEligible(ctx.session.user)) {
+          throw new TRPCError({
+            code: "UNAUTHORIZED",
+            message: "Not eligible to query clickhouse",
+          });
+        }
 
-      const totalTraceCount = totalTraces[0]?.count;
-      return {
-        totalCount: totalTraceCount ? Number(totalTraceCount) : undefined,
-      };
+        const countQuery = await getTracesTableCount(
+          ctx.session.projectId,
+          input.filter ?? [],
+          input.limit,
+          input.page,
+        );
+
+        return {
+          totalCount: countQuery.shift()?.count,
+        };
+      }
     }),
   metrics: protectedProjectProcedure
     .input(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for `traces.countAll` API with Clickhouse, including new functions and conditional query handling in the API and UI.
> 
>   - **Behavior**:
>     - Add support for `traces.countAll` API with Clickhouse in `traces.ts`.
>     - Introduce `getTracesTableCount` function in `traces.ts` to count traces using Clickhouse.
>     - Modify `apply()` in `clickhouse-filter.ts` to return `undefined` if no filters are applied.
>   - **API**:
>     - Update `traceRouter` in `traces.ts` to handle Clickhouse queries conditionally.
>     - Add `queryClickhouse` flag to API inputs to toggle Clickhouse usage.
>   - **UI**:
>     - Add `queryClickhouse` to `tracesAllQueryFilter` in `traces.tsx` to support Clickhouse queries in the UI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e87f1de1ef685c052012a5bafcec32b1797e0b34. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->