### PR TITLE
feat: log all project_ids with missing domain id

### DIFF
--- a/packages/shared/src/server/ingestion/legacy/EventProcessor.ts
+++ b/packages/shared/src/server/ingestion/legacy/EventProcessor.ts
@@ -220,7 +220,15 @@ export class ObservationProcessor implements EventProcessor {
       logger.warn("Prompt not found for observation", this.event.body);
     }
 
-    const observationId = this.event.body.id ?? v4();
+    const observationId =
+      this.event.body.id ??
+      (() => {
+        const newId = v4();
+        logger.info(
+          `observation.id is null. Generating for projectId: ${apiScope.projectId}, id: ${newId}`,
+        );
+        return newId;
+      })();
 
     return {
       id: observationId,
@@ -551,7 +559,15 @@ export class TraceProcessor implements EventProcessor {
 
     this.auth(apiScope);
 
-    const internalId = body.id ?? v4();
+    const internalId =
+      body.id ??
+      (() => {
+        const newId = v4();
+        logger.info(
+          `trace.id is null. Generating for projectId: ${apiScope.projectId}, id: ${newId}`,
+        );
+        return newId;
+      })();
 
     logger.debug(
       `Trying to create trace, project ${apiScope.projectId}, id: ${internalId}`,
@@ -663,7 +679,15 @@ export class ScoreProcessor implements EventProcessor {
 
     this.auth(apiScope);
 
-    const id = body.id ?? v4();
+    const id =
+      body.id ??
+      (() => {
+        const newId = v4();
+        logger.info(
+          `score.id is null. Generating for projectId: ${apiScope.projectId}, id: ${newId}`,
+        );
+        return newId;
+      })();
 
     const existingScore = await prisma.score.findFirst({
       where: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add logging for missing IDs in `ObservationProcessor`, `TraceProcessor`, and `ScoreProcessor` to log project ID and generated ID.
> 
>   - **Behavior**:
>     - Log message added when `observation.id` is null in `ObservationProcessor`, generating a new ID and logging the project ID and new ID.
>     - Log message added when `trace.id` is null in `TraceProcessor`, generating a new ID and logging the project ID and new ID.
>     - Log message added when `score.id` is null in `ScoreProcessor`, generating a new ID and logging the project ID and new ID.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 46fd4c980aae9288ecc22baa3d414ed34158a082. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->