### PR TITLE
chore: ensure model parameters are cast correctly in clickhouse ingestion

### DIFF
--- a/packages/shared/src/server/definitions.ts
+++ b/packages/shared/src/server/definitions.ts
@@ -244,7 +244,9 @@ export const convertPostgresObservationToInsert = (
     output: observation.output ? JSON.stringify(observation.output) : null,
     provided_model_name: observation.model,
     internal_model_id: observation.internal_model_id,
-    model_parameters: observation.model_parameters,
+    model_parameters: observation.model_parameters
+      ? JSON.stringify(observation.model_parameters)
+      : null,
     provided_usage_details: {},
     usage_details: {
       input: observation.prompt_tokens,

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -1071,6 +1071,7 @@ describe("Ingestion end-to-end tests", () => {
         startTime: new Date(oldEvent),
         // Validates that numbers are parsed correctly. Since there is no usage, no effect on result
         calculatedTotalCost: "0.273330000000000000000000000000",
+        modelParameters: { hello: "world" },
       },
     });
 
@@ -1082,7 +1083,6 @@ describe("Ingestion end-to-end tests", () => {
         body: {
           id: observationId,
           traceId: traceId,
-          modelParameters: { someKey: ["user-1", "user-2"] },
           output: "overwritten",
           usage: null,
         },
@@ -1105,6 +1105,7 @@ describe("Ingestion end-to-end tests", () => {
     expect(observation.name).toBe("generation-name");
     expect(observation.input).toBe(JSON.stringify({ key: "value" }));
     expect(observation.output).toBe("overwritten");
+    expect(observation.model_parameters).toBe('{"hello":"world"}');
     expect(observation.project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
   });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure `model_parameters` are JSON stringified during Clickhouse ingestion in `convertPostgresObservationToInsert`.
> 
>   - **Behavior**:
>     - In `convertPostgresObservationToInsert` in `definitions.ts`, `model_parameters` are now JSON stringified if present, otherwise set to null.
>   - **Tests**:
>     - Updated `IngestionService.integration.test.ts` to include tests for `model_parameters` JSON stringification, ensuring correct ingestion behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4c313ea638cc0a05dd16daca970841e63503d5d7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->