### PR TITLE
revert: revert clickhouse trace check

### DIFF
--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -336,19 +336,15 @@ const enforceTraceAccess = t.middleware(async ({ ctx, rawInput, next }) => {
   const projectId = result.data.projectId;
 
   // if the user is eligible for clickhouse, and wants to use clickhouse, do so.
-  const trace =
-    result.data.queryClickhouse === true &&
-    isClickhouseEligible(ctx.session?.user)
-      ? await getTraceById(traceId, projectId)
-      : await prisma.trace.findFirst({
-          where: {
-            id: traceId,
-            projectId: projectId,
-          },
-          select: {
-            public: true,
-          },
-        });
+  const trace = await prisma.trace.findFirst({
+    where: {
+      id: traceId,
+      projectId: projectId,
+    },
+    select: {
+      public: true,
+    },
+  });
 
   if (!trace)
     throw new TRPCError({

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -78,12 +78,7 @@ import superjson from "superjson";
 import { ZodError } from "zod";
 import { setUpSuperjson } from "@/src/utils/superjson";
 import { DB } from "@/src/server/db";
-import {
-  addUserToSpan,
-  getTraceById,
-  logger,
-} from "@langfuse/shared/src/server";
-import { isClickhouseEligible } from "@/src/server/utils/checkClickhouseAccess";
+import { addUserToSpan, logger } from "@langfuse/shared/src/server";
 
 setUpSuperjson();
 
@@ -335,7 +330,6 @@ const enforceTraceAccess = t.middleware(async ({ ctx, rawInput, next }) => {
   const traceId = result.data.traceId;
   const projectId = result.data.projectId;
 
-  // if the user is eligible for clickhouse, and wants to use clickhouse, do so.
   const trace = await prisma.trace.findFirst({
     where: {
       id: traceId,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reverts Clickhouse trace check in `trpc.ts`, always using `prisma.trace.findFirst` for trace retrieval, with specific error handling for not found and unauthorized cases.
> 
>   - **Behavior**:
>     - Reverts Clickhouse trace check in `enforceTraceAccess` middleware in `trpc.ts`.
>     - Traces are now always retrieved using `prisma.trace.findFirst` regardless of Clickhouse eligibility.
>   - **Error Handling**:
>     - If trace is not found, throws `NOT_FOUND` error.
>     - If user is unauthorized, throws `UNAUTHORIZED` error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 623ee15ccc91c394cc3fbac066b67598d5646785. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->