### PR TITLE
fix: opening public langfuse urls

### DIFF
--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -275,7 +275,7 @@ export default function Layout(props: PropsWithChildren) {
   if (hideNavigation)
     return (
       <SidebarProvider>
-        <main className="h-dvh w-full bg-primary-foreground p-3 px-4 py-4">
+        <main className="h-dvh w-full bg-primary-foreground p-3 px-4 py-4 sm:px-6 lg:px-8">
           {props.children}
         </main>
       </SidebarProvider>

--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -274,9 +274,11 @@ export default function Layout(props: PropsWithChildren) {
     router.pathname.startsWith("/public/");
   if (hideNavigation)
     return (
-      <main className="min-h-screen bg-primary-foreground px-4 py-4 sm:px-6 lg:px-8">
-        {props.children}
-      </main>
+      <SidebarProvider>
+        <main className="h-dvh w-full bg-primary-foreground p-3 px-4 py-4">
+          {props.children}
+        </main>
+      </SidebarProvider>
     );
   return (
     <>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Wraps main content with `SidebarProvider` in `layout.tsx` for public URLs, ensuring consistent layout and adjusts CSS classes for height and width.
> 
>   - **Behavior**:
>     - Wraps main content with `SidebarProvider` in `layout.tsx` when `hideNavigation` is true, ensuring consistent layout for public URLs.
>   - **Misc**:
>     - Adjusts CSS classes for the main content area in `layout.tsx` to use `h-dvh` and `w-full` for height and width.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 450dea273ab6edeb9fecaed3689551799330138d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->