### PR TITLE
perf(ui): do not refetch filter options on page mount

### DIFF
--- a/web/src/components/table/use-cases/generations.tsx
+++ b/web/src/components/table/use-cases/generations.tsx
@@ -209,6 +209,10 @@ export default function GenerationsTable({
           skipBatch: true,
         },
       },
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: Infinity,
     },
   );
 

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -158,6 +158,10 @@ export default function ScoresTable({
           skipBatch: true,
         },
       },
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: Infinity,
     },
   );
 

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -153,6 +153,10 @@ export default function SessionsTable({
           skipBatch: true,
         },
       },
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: Infinity,
     },
   );
 

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -209,6 +209,10 @@ export default function TracesTable({
           skipBatch: true,
         },
       },
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: Infinity,
     },
   );
 

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -276,6 +276,10 @@ export function TracePage({ traceId }: { traceId: string }) {
         !!trace.data?.projectId &&
         trace.isSuccess &&
         isAuthenticatedAndProjectMember,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: Infinity,
     },
   );
 

--- a/web/src/ee/features/evals/components/evaluator-form.tsx
+++ b/web/src/ee/features/evals/components/evaluator-form.tsx
@@ -315,9 +315,22 @@ export const InnerEvalConfigForm = (props: {
     },
   });
 
-  const traceFilterOptions = api.traces.filterOptions.useQuery({
-    projectId: props.projectId,
-  });
+  const traceFilterOptions = api.traces.filterOptions.useQuery(
+    {
+      projectId: props.projectId,
+    },
+    {
+      trpc: {
+        context: {
+          skipBatch: true,
+        },
+      },
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: Infinity,
+    },
+  );
 
   useEffect(() => {
     if (props.evalTemplate && form.getValues("mapping").length === 0) {

--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -110,7 +110,13 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
     {
       projectId: projectId as string, // Typecast as query is enabled only when projectId is present
     },
-    { enabled: Boolean(projectId) },
+    {
+      enabled: Boolean(projectId),
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: Infinity,
+    },
   ).data?.name;
 
   function onSubmit(values: NewPromptFormSchemaType) {

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -83,6 +83,15 @@ export const PromptDetail = () => {
       },
       {
         enabled: Boolean(projectId),
+        trpc: {
+          context: {
+            skipBatch: true,
+          },
+        },
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+        staleTime: Infinity,
       },
     ).data?.tags ?? []
   ).map((t) => t.value);

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -117,6 +117,10 @@ export function PromptTable() {
           skipBatch: true,
         },
       },
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: Infinity,
     },
   );
   const filterOptionTags = promptFilterOptions.data?.tags ?? [];

--- a/web/src/pages/project/[projectId]/index.tsx
+++ b/web/src/pages/project/[projectId]/index.tsx
@@ -50,6 +50,10 @@ export default function Dashboard() {
           skipBatch: true,
         },
       },
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: Infinity,
     },
   );
   const nameOptions = traceFilterOptions.data?.name || [];


### PR DESCRIPTION
Filter options is expensive if it is not time-constrained (#3966). Right now this query is executed for every trace that's viewed. This change applies the following react query configuration to all calls to this api which should dramatically reduce the number of times the api is invoked:

```
refetchOnMount: false,
refetchOnWindowFocus: false,
refetchOnReconnect: false,
staleTime: Infinity,
``` 


<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize UI performance by preventing unnecessary refetching of filter options on page mount and other events across multiple components.
> 
>   - **Behavior**:
>     - Prevents refetching of filter options on page mount, window focus, and reconnect by setting `refetchOnMount`, `refetchOnWindowFocus`, and `refetchOnReconnect` to `false` in `generations.tsx`, `scores.tsx`, `sessions.tsx`, `traces.tsx`, `index.tsx`, `evaluator-form.tsx`, `NewPromptForm/index.tsx`, `prompt-detail.tsx`, `prompts-table.tsx`, and `index.tsx`.
>     - Sets `staleTime` to `Infinity` in the same files to avoid unnecessary data refetching.
>   - **Files Affected**:
>     - `generations.tsx`, `scores.tsx`, `sessions.tsx`, `traces.tsx`, `index.tsx`, `evaluator-form.tsx`, `NewPromptForm/index.tsx`, `prompt-detail.tsx`, `prompts-table.tsx`, `index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 992b107c0fca74b2cb2c4fc22d0f21c47f772d31. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->