### PR TITLE
fix: fix clickhouse untis and conversions

### DIFF
--- a/packages/shared/src/server/repositories/definitions.ts
+++ b/packages/shared/src/server/repositories/definitions.ts
@@ -7,8 +7,12 @@ export const clickhouseStringDateSchema = z
   .transform((str) => str.replace(" ", "T") + "Z")
   .pipe(z.string().datetime());
 
-export const UsageCostSchema = z.record(z.string(), z.coerce.number());
-export type UsageCostType = z.infer<typeof UsageCostSchema>;
+//https://clickhouse.com/docs/en/integrations/javascript#integral-types-int64-int128-int256-uint64-uint128-uint256
+// clickhouse returns int64 as string
+export const UsageCostReadSchema = z.record(z.string(), z.string());
+export const UsageCostWriteSchema = z.record(z.string(), z.number());
+export type UsageCostReadType = z.infer<typeof UsageCostReadSchema>;
+export type UsageCostWriteType = z.infer<typeof UsageCostWriteSchema>;
 
 export const observationRecordBaseSchema = z.object({
   id: z.string(),
@@ -26,10 +30,6 @@ export const observationRecordBaseSchema = z.object({
   provided_model_name: z.string().nullish(),
   internal_model_id: z.string().nullish(),
   model_parameters: z.string().nullish(),
-  provided_usage_details: UsageCostSchema,
-  provided_cost_details: UsageCostSchema,
-  usage_details: UsageCostSchema,
-  cost_details: UsageCostSchema,
   total_cost: z.number().nullish(),
   prompt_id: z.string().nullish(),
   prompt_name: z.string().nullish(),
@@ -47,6 +47,10 @@ export const observationRecordReadSchema = observationRecordBaseSchema.extend({
   end_time: clickhouseStringDateSchema.nullish(),
   completion_start_time: clickhouseStringDateSchema.nullish(),
   event_ts: clickhouseStringDateSchema,
+  provided_usage_details: UsageCostReadSchema,
+  provided_cost_details: UsageCostReadSchema,
+  usage_details: UsageCostReadSchema,
+  cost_details: UsageCostReadSchema,
 });
 export type ObservationRecordReadType = z.infer<
   typeof observationRecordReadSchema
@@ -60,6 +64,10 @@ export const observationRecordInsertSchema = observationRecordBaseSchema.extend(
     end_time: z.number().nullish(),
     completion_start_time: z.number().nullish(),
     event_ts: z.number(),
+    provided_usage_details: UsageCostWriteSchema,
+    provided_cost_details: UsageCostWriteSchema,
+    usage_details: UsageCostWriteSchema,
+    cost_details: UsageCostWriteSchema,
   },
 );
 export type ObservationRecordInsertType = z.infer<
@@ -149,16 +157,27 @@ export const convertTraceReadToInsert = (
 export const convertObservationReadToInsert = (
   record: ObservationRecordReadType,
 ): ObservationRecordInsertType => {
+  const convertDate = (date: string) => new Date(date).getTime();
+
+  const convertDetails = (details: Record<string, string>) =>
+    Object.fromEntries(
+      Object.entries(details).map(([key, value]) => [key, Number(value)]),
+    );
+
   return {
     ...record,
-    created_at: new Date(record.created_at).getTime(),
-    updated_at: new Date(record.updated_at).getTime(),
-    start_time: new Date(record.start_time).getTime(),
-    end_time: record.end_time ? new Date(record.end_time).getTime() : undefined,
+    created_at: convertDate(record.created_at),
+    updated_at: convertDate(record.updated_at),
+    start_time: convertDate(record.start_time),
+    end_time: record.end_time ? convertDate(record.end_time) : undefined,
     completion_start_time: record.completion_start_time
-      ? new Date(record.completion_start_time).getTime()
+      ? convertDate(record.completion_start_time)
       : undefined,
-    event_ts: new Date(record.event_ts).getTime(),
+    event_ts: convertDate(record.event_ts),
+    provided_usage_details: convertDetails(record.provided_usage_details),
+    provided_cost_details: convertDetails(record.provided_cost_details),
+    usage_details: convertDetails(record.usage_details),
+    cost_details: convertDetails(record.cost_details),
   };
 };
 

--- a/packages/shared/src/server/repositories/definitions.ts
+++ b/packages/shared/src/server/repositories/definitions.ts
@@ -9,10 +9,10 @@ export const clickhouseStringDateSchema = z
 
 //https://clickhouse.com/docs/en/integrations/javascript#integral-types-int64-int128-int256-uint64-uint128-uint256
 // clickhouse returns int64 as string
-export const UsageCostReadSchema = z.record(z.string(), z.string());
-export const UsageCostWriteSchema = z.record(z.string(), z.number());
-export type UsageCostReadType = z.infer<typeof UsageCostReadSchema>;
-export type UsageCostWriteType = z.infer<typeof UsageCostWriteSchema>;
+export const UsageCostStringSchema = z.record(z.string(), z.string());
+export const UsageCostNumberSchema = z.record(z.string(), z.coerce.number());
+export type UsageCostStringType = z.infer<typeof UsageCostStringSchema>;
+export type UsageCostNumberType = z.infer<typeof UsageCostNumberSchema>;
 
 export const observationRecordBaseSchema = z.object({
   id: z.string(),
@@ -47,10 +47,10 @@ export const observationRecordReadSchema = observationRecordBaseSchema.extend({
   end_time: clickhouseStringDateSchema.nullish(),
   completion_start_time: clickhouseStringDateSchema.nullish(),
   event_ts: clickhouseStringDateSchema,
-  provided_usage_details: UsageCostReadSchema,
-  provided_cost_details: UsageCostReadSchema,
-  usage_details: UsageCostReadSchema,
-  cost_details: UsageCostReadSchema,
+  provided_usage_details: UsageCostStringSchema,
+  provided_cost_details: UsageCostNumberSchema,
+  usage_details: UsageCostStringSchema,
+  cost_details: UsageCostNumberSchema,
 });
 export type ObservationRecordReadType = z.infer<
   typeof observationRecordReadSchema
@@ -64,10 +64,10 @@ export const observationRecordInsertSchema = observationRecordBaseSchema.extend(
     end_time: z.number().nullish(),
     completion_start_time: z.number().nullish(),
     event_ts: z.number(),
-    provided_usage_details: UsageCostWriteSchema,
-    provided_cost_details: UsageCostWriteSchema,
-    usage_details: UsageCostWriteSchema,
-    cost_details: UsageCostWriteSchema,
+    provided_usage_details: UsageCostNumberSchema,
+    provided_cost_details: UsageCostNumberSchema,
+    usage_details: UsageCostNumberSchema,
+    cost_details: UsageCostNumberSchema,
   },
 );
 export type ObservationRecordInsertType = z.infer<
@@ -175,9 +175,9 @@ export const convertObservationReadToInsert = (
       : undefined,
     event_ts: convertDate(record.event_ts),
     provided_usage_details: convertDetails(record.provided_usage_details),
-    provided_cost_details: convertDetails(record.provided_cost_details),
+    provided_cost_details: record.provided_cost_details,
     usage_details: convertDetails(record.usage_details),
-    cost_details: convertDetails(record.cost_details),
+    cost_details: record.cost_details,
   };
 };
 

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -19,19 +19,7 @@ import { ObservationRecordReadType } from "./definitions";
 
 export const convertObservation = async (
   record: ObservationRecordReadType,
-): Promise<Observation> => {
-  const model = record.internal_model_id
-    ? await prisma.model.findFirst({
-        where: {
-          id: record.internal_model_id,
-        },
-        include: {
-          Price: true,
-        },
-      })
-    : undefined;
-  return await convertObservationAndModel(record, model);
-};
+): Promise<Observation> => convertObservationAndModel(record);
 
 export const convertObservationToView = async (
   record: ObservationRecordReadType,
@@ -47,7 +35,7 @@ export const convertObservationToView = async (
       })
     : undefined;
   return {
-    ...(await convertObservationAndModel(record, model)),
+    ...convertObservationAndModel(record),
     latency: record.end_time
       ? parseClickhouseUTCDateTimeFormat(record.end_time).getTime() -
         parseClickhouseUTCDateTimeFormat(record.start_time).getTime()
@@ -68,10 +56,9 @@ export const convertObservationToView = async (
   };
 };
 
-const convertObservationAndModel = async (
+const convertObservationAndModel = (
   record: ObservationRecordReadType,
-  model?: (Model & { Price: Price[] }) | null,
-): Promise<Observation> => {
+): Observation => {
   return {
     id: record.id,
     traceId: record.trace_id ?? null,
@@ -121,7 +108,7 @@ const convertObservationAndModel = async (
     model: record.provided_model_name ?? null,
     internalModelId: record.internal_model_id ?? null,
     internalModel: model?.modelName ?? null, // to be removed
-    unit: model?.Price?.shift()?.usageType ?? null,
+    unit: "TOKENS", // to be removed.
   };
 };
 

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -72,7 +72,6 @@ const convertObservationAndModel = async (
   record: ObservationRecordReadType,
   model?: Model & { Price: Price[] },
 ): Promise<Observation> => {
-  logger.debug(`Converting observation ${JSON.stringify(record)}`);
   return {
     id: record.id,
     traceId: record.trace_id ?? null,

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -30,7 +30,7 @@ export const convertObservation = async (
         },
       })
     : undefined;
-  return await convertObservationAndModel(record, model);
+  return await convertObservationAndModel(record, model ?? undefined);
 };
 
 export const convertObservationToView = async (
@@ -47,7 +47,7 @@ export const convertObservationToView = async (
       })
     : undefined;
   return {
-    ...(await convertObservationAndModel(record, model)),
+    ...(await convertObservationAndModel(record, model ?? undefined)),
     latency: record.end_time
       ? parseClickhouseUTCDateTimeFormat(record.end_time).getTime() -
         parseClickhouseUTCDateTimeFormat(record.start_time).getTime()
@@ -70,8 +70,9 @@ export const convertObservationToView = async (
 
 const convertObservationAndModel = async (
   record: ObservationRecordReadType,
-  model?: (Model & { Price: Price[] }) | null,
+  model?: Model & { Price: Price[] },
 ): Promise<Observation> => {
+  logger.debug(`Converting observation ${JSON.stringify(record)}`);
   return {
     id: record.id,
     traceId: record.trace_id ?? null,
@@ -96,9 +97,15 @@ const convertObservationAndModel = async (
     promptId: record.prompt_id ?? null,
     createdAt: parseClickhouseUTCDateTimeFormat(record.created_at),
     updatedAt: parseClickhouseUTCDateTimeFormat(record.updated_at),
-    promptTokens: record.usage_details?.input ?? 0,
-    completionTokens: record.usage_details?.output ?? 0,
-    totalTokens: record.usage_details?.total ?? 0,
+    promptTokens: record.usage_details?.input
+      ? Number(record.usage_details?.input)
+      : 0,
+    completionTokens: record.usage_details?.output
+      ? Number(record.usage_details?.output)
+      : 0,
+    totalTokens: record.usage_details?.total
+      ? Number(record.usage_details?.total)
+      : 0,
     calculatedInputCost: record.cost_details?.input
       ? new Decimal(record.cost_details.input)
       : null,
@@ -114,10 +121,7 @@ const convertObservationAndModel = async (
     outputCost: record.cost_details?.output
       ? new Decimal(record.cost_details?.output)
       : null,
-    totalCost: record.cost_details?.total
-      ? new Decimal(record.cost_details?.total)
-      : null,
-
+    totalCost: record.total_cost ? new Decimal(record.total_cost) : null,
     model: record.provided_model_name ?? null,
     internalModelId: record.internal_model_id ?? null,
     internalModel: model?.modelName ?? null, // to be removed

--- a/web/src/__tests__/server/repositories/observation-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/observation-repository.servertest.ts
@@ -15,7 +15,7 @@ describe("Clickhouse Observations Repository Test", () => {
     await expect(getObservationById(v4(), v4())).rejects.toThrow();
   });
 
-  it.only("should return an observation if exists", async () => {
+  it("should return an observation if exists", async () => {
     const observationId = v4();
     const traceId = v4();
 

--- a/web/src/__tests__/server/repositories/observation-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/observation-repository.servertest.ts
@@ -1,6 +1,7 @@
 import { createObservation } from "@/src/__tests__/server/repositories/clickhouse-helpers";
 import { pruneDatabase } from "@/src/__tests__/test-utils";
 import { getObservationById } from "@langfuse/shared/src/server";
+import Decimal from "decimal.js";
 import { v4 } from "uuid";
 
 const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
@@ -14,7 +15,7 @@ describe("Clickhouse Observations Repository Test", () => {
     await expect(getObservationById(v4(), v4())).rejects.toThrow();
   });
 
-  it("should return an observation if exists", async () => {
+  it.only("should return an observation if exists", async () => {
     const observationId = v4();
     const traceId = v4();
 
@@ -24,10 +25,10 @@ describe("Clickhouse Observations Repository Test", () => {
       project_id: projectId,
       type: "sample_type",
       metadata: {},
-      provided_usage_details: {},
-      provided_cost_details: {},
-      usage_details: {},
-      cost_details: {},
+      provided_usage_details: { input: 1234, output: 5678, total: 6912 },
+      provided_cost_details: { input: 100, output: 200, total: 300 },
+      usage_details: { input: 1234, output: 5678, total: 6912 },
+      cost_details: { input: 100, output: 200, total: 300 },
       is_deleted: 0,
       created_at: Date.now(),
       updated_at: Date.now(),
@@ -42,7 +43,7 @@ describe("Clickhouse Observations Repository Test", () => {
       provided_model_name: "sample_model",
       internal_model_id: "sample_internal_model_id",
       model_parameters: "sample_parameters",
-      total_cost: 0,
+      total_cost: 300,
       prompt_id: "sample_prompt_id",
       prompt_name: "sample_prompt_name",
       prompt_version: 1,
@@ -74,5 +75,9 @@ describe("Clickhouse Observations Repository Test", () => {
     expect(result.completionStartTime).toEqual(
       new Date(observation.completion_start_time),
     );
+    expect(result.totalCost).toEqual(new Decimal(observation.total_cost));
+    expect(result.promptTokens).toEqual(1234);
+    expect(result.completionTokens).toEqual(5678);
+    expect(result.totalTokens).toEqual(6912);
   });
 });

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -31,8 +31,8 @@ import {
   traceRecordInsertSchema,
   TraceRecordInsertType,
   traceRecordReadSchema,
-  UsageCostType,
   validateAndInflateScore,
+  UsageCostWriteType,
 } from "@langfuse/shared/src/server";
 
 import { tokenCount } from "../../features/tokenisation/usage";
@@ -529,7 +529,7 @@ export class IngestionService {
   static calculateUsageCosts(
     modelPrices: Price[] | null | undefined,
     observationRecord: ObservationRecordInsertType,
-    usageUnits: UsageCostType,
+    usageUnits: UsageCostWriteType,
   ): Pick<ObservationRecordInsertType, "cost_details" | "total_cost"> {
     const { provided_cost_details } = observationRecord;
 

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -32,7 +32,7 @@ import {
   TraceRecordInsertType,
   traceRecordReadSchema,
   validateAndInflateScore,
-  UsageCostWriteType,
+  UsageCostNumberType,
 } from "@langfuse/shared/src/server";
 
 import { tokenCount } from "../../features/tokenisation/usage";
@@ -346,6 +346,10 @@ export class IngestionService {
       recordsToMerge,
       immutableEntityKeys[TableName.Observations],
     );
+
+    logger.info(
+      `Merging observation records ${JSON.stringify(observationRecords)}, postgresObservationRecord ${JSON.stringify(postgresObservationRecord)}, clickhouseObservationRecord ${clickhouseObservationRecord}, mergedRecord ${JSON.stringify(mergedRecord)}`,
+    );
     const parsedObservationRecord =
       observationRecordInsertSchema.parse(mergedRecord);
 
@@ -529,7 +533,7 @@ export class IngestionService {
   static calculateUsageCosts(
     modelPrices: Price[] | null | undefined,
     observationRecord: ObservationRecordInsertType,
-    usageUnits: UsageCostWriteType,
+    usageUnits: UsageCostNumberType,
   ): Pick<ObservationRecordInsertType, "cost_details" | "total_cost"> {
     const { provided_cost_details } = observationRecord;
 

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -238,9 +238,6 @@ export class IngestionService {
         this.getPrompt(projectId, observationEventList),
       ]);
 
-    logger.info(
-      `Processing observation event list ${JSON.stringify(observationEventList)},  postgresObservationRecord ${JSON.stringify(postgresObservationRecord)}, clickhouseObservationRecord ${JSON.stringify(clickhouseObservationRecord)}}`,
-    );
     const observationRecords = this.mapObservationEventsToRecords({
       observationEventList: timeSortedEvents,
       projectId,

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -252,7 +252,6 @@ export class IngestionService {
       clickhouseObservationRecord,
     });
 
-    logger.info(`finaaal ${JSON.stringify(finalObservationRecord)} `);
     // Backward compat: create wrapper trace for SDK < 2.0.0 events that do not have a traceId
     if (!finalObservationRecord.trace_id) {
       const traceId = randomUUID();
@@ -349,9 +348,6 @@ export class IngestionService {
       immutableEntityKeys[TableName.Observations],
     );
 
-    logger.info(
-      `Merging observation records ${JSON.stringify(observationRecords)}, postgresObservationRecord ${JSON.stringify(postgresObservationRecord)}, clickhouseObservationRecord ${clickhouseObservationRecord}, mergedRecord ${JSON.stringify(mergedRecord)}`,
-    );
     const parsedObservationRecord =
       observationRecordInsertSchema.parse(mergedRecord);
 

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -238,6 +238,9 @@ export class IngestionService {
         this.getPrompt(projectId, observationEventList),
       ]);
 
+    logger.info(
+      `Processing observation event list ${JSON.stringify(observationEventList)},  postgresObservationRecord ${JSON.stringify(postgresObservationRecord)}, clickhouseObservationRecord ${JSON.stringify(clickhouseObservationRecord)}}`,
+    );
     const observationRecords = this.mapObservationEventsToRecords({
       observationEventList: timeSortedEvents,
       projectId,
@@ -251,6 +254,8 @@ export class IngestionService {
       postgresObservationRecord,
       clickhouseObservationRecord,
     });
+
+    logger.info(`finaaal ${JSON.stringify(finalObservationRecord)} `);
     // Backward compat: create wrapper trace for SDK < 2.0.0 events that do not have a traceId
     if (!finalObservationRecord.trace_id) {
       const traceId = randomUUID();

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -342,13 +342,13 @@ describe("Ingestion end-to-end tests", () => {
       expect(generation.version).toBe("2.0.0");
       expect(generation.internal_model_id).toBeNull();
       expect(generation.usage_details.input).toEqual(
-        testConfig.expectedInputUnits,
+        testConfig.expectedInputUnits?.toString(),
       );
       expect(generation.usage_details.output).toEqual(
-        testConfig.expectedOutputUnits,
+        testConfig.expectedOutputUnits?.toString(),
       );
       expect(generation.usage_details.total).toEqual(
-        testConfig.expectedTotalUnits,
+        testConfig.expectedTotalUnits?.toString(),
       );
       expect(generation.output).toEqual(
         JSON.stringify({
@@ -652,10 +652,10 @@ describe("Ingestion end-to-end tests", () => {
         testConfig.observationExternalModel,
       );
       expect(generation.usage_details.input).toBe(
-        testConfig.expectedInputUnits,
+        testConfig.expectedInputUnits?.toString(),
       );
       expect(generation.usage_details.output).toBe(
-        testConfig.expectedOutputUnits,
+        testConfig.expectedOutputUnits?.toString(),
       );
       expect(generation.internal_model_id).toBe(
         testConfig.expectedInternalModelId,
@@ -1049,7 +1049,7 @@ describe("Ingestion end-to-end tests", () => {
     expect(score.project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
   });
 
-  it("should merge observations from postgres and event list", async () => {
+  it.only("should merge observations from postgres and event list", async () => {
     const traceId = randomUUID();
     const observationId = randomUUID();
 
@@ -1261,13 +1261,13 @@ describe("Ingestion end-to-end tests", () => {
       generationId,
     );
 
-    expect(generation.usage_details.input).toEqual(1285);
-    expect(generation.usage_details.output).toEqual(513);
-    expect(generation.usage_details.total).toEqual(1798);
+    expect(generation.usage_details.input).toEqual("1285");
+    expect(generation.usage_details.output).toEqual("513");
+    expect(generation.usage_details.total).toEqual("1798");
 
-    expect(generation.usage_details.input).toEqual(1285);
-    expect(generation.usage_details.output).toEqual(513);
-    expect(generation.usage_details.total).toEqual(1798);
+    expect(generation.provided_usage_details.input).toEqual("1285");
+    expect(generation.provided_usage_details.output).toEqual("513");
+    expect(generation.provided_usage_details.total).toEqual("1798");
 
     expect(generation.cost_details.input).toEqual(0.0006425);
     expect(generation.cost_details.output).toEqual(0.0007695);
@@ -1374,8 +1374,8 @@ describe("Ingestion end-to-end tests", () => {
     expect(generation?.output).toEqual(
       JSON.stringify({ key: "this is a great gpt output" }),
     );
-    expect(generation?.usage_details.input).toEqual(5);
-    expect(generation?.usage_details.output).toEqual(11);
+    expect(generation?.usage_details.input).toEqual("5");
+    expect(generation?.usage_details.output).toEqual("11");
   });
 
   it("should update all token counts if update does not contain model name and events come in wrong order", async () => {
@@ -1469,8 +1469,8 @@ describe("Ingestion end-to-end tests", () => {
     expect(observation?.output).toEqual(
       JSON.stringify({ key: "this is a great gpt output" }),
     );
-    expect(observation?.usage_details.input).toEqual(5);
-    expect(observation?.usage_details.output).toEqual(11);
+    expect(observation?.usage_details.input).toEqual("5");
+    expect(observation?.usage_details.output).toEqual("11");
   });
 
   it("null does not override set values", async () => {

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { prisma } from "@langfuse/shared/src/db";
 import {
   clickhouseClient,
-  logger,
   ObservationEvent,
   observationRecordReadSchema,
   ObservationRecordReadType,
@@ -21,7 +20,6 @@ import { pruneDatabase } from "../../../__tests__/utils";
 import { ClickhouseWriter, TableName } from "../../ClickhouseWriter";
 import { IngestionService } from "../../IngestionService";
 import { ModelUsageUnit, ScoreSource } from "@langfuse/shared";
-import { log } from "node:console";
 
 const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
 
@@ -1051,11 +1049,9 @@ describe("Ingestion end-to-end tests", () => {
     expect(score.project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
   });
 
-  it.only("should merge observations from postgres and event list", async () => {
+  it("should merge observations from postgres and event list", async () => {
     const traceId = randomUUID();
     const observationId = randomUUID();
-
-    logger.info(`Creating observation in postgres ${observationId}`);
 
     const latestEvent = new Date();
     const oldEvent = new Date(latestEvent).setSeconds(
@@ -1105,8 +1101,6 @@ describe("Ingestion end-to-end tests", () => {
       TableName.Observations,
       observationId,
     );
-
-    logger.info(`Observation in clickhouse ${JSON.stringify(observation)}`);
 
     expect(observation.name).toBe("generation-name");
     expect(observation.input).toBe(JSON.stringify({ key: "value" }));

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -1076,7 +1076,6 @@ describe("Ingestion end-to-end tests", () => {
         // Validates that numbers are parsed correctly. Since there is no usage, no effect on result
         calculatedTotalCost: "0.273330000000000000000000000000",
         modelParameters: { hello: "world" },
-        promptTokens: 10,
       },
     });
 
@@ -1114,7 +1113,6 @@ describe("Ingestion end-to-end tests", () => {
     expect(observation.output).toBe("overwritten");
     expect(observation.model_parameters).toBe('{"hello":"world"}');
     expect(observation.project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-    expect(observation.usage_details).toBe({ input: 10 });
   });
 
   it("should put observation updates after creates if timestamp is same", async () => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduce schemas for Clickhouse integer conversion, update related functions, and modify tests to validate changes.
> 
>   - **Schemas**:
>     - Add `UsageCostStringSchema` and `UsageCostNumberSchema` in `definitions.ts` for handling Clickhouse integer data as strings and numbers.
>     - Update `observationRecordReadSchema` and `observationRecordInsertSchema` to use new schemas for `usage_details` and `cost_details`.
>   - **Functions**:
>     - Add `convertDate` and `convertDetails` in `convertObservationReadToInsert` in `definitions.ts` for date and integer conversion.
>     - Update `convertObservationAndModel` in `observations.ts` to convert string integers to numbers for token and cost fields.
>   - **Tests**:
>     - Modify tests in `observation-repository.servertest.ts` to include non-empty `usage_details` and `cost_details` and validate conversion results.
>     - Add logging in `IngestionService/index.ts` to track processing of observation events and merging of records.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0563608d1203dcd1122cde3ef4b7857123ad2442. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->