### PR TITLE
fix: respect limit and offset for traces table query

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -176,7 +176,7 @@ const getTracesTableGeneric = async <T>(
 
       WHERE ${tracesFilterRes.query}
       ${orderBy ? orderBy : ""}
-      ${limit && offset ? `limit {limit: Int32} offset {offset: Int32}` : ""}
+      ${limit !== undefined && offset !== undefined ? `limit {limit: Int32} offset {offset: Int32}` : ""}
     `;
 
   return await queryClickhouse<T>({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes condition to apply `limit` and `offset` in `getTracesTableGeneric()` in `traces.ts` for correct pagination.
> 
>   - **Behavior**:
>     - Fixes the condition for applying `limit` and `offset` in the SQL query in `getTracesTableGeneric()` in `traces.ts`.
>     - Ensures `limit` and `offset` are applied only when both are defined, preventing potential query errors or unexpected behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 059cc921837f433b6e26707c9afd90b98e7d19d1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->