### PR TITLE
feat: add order by to clickhouse tables

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-filter/orderby-factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-filter/orderby-factory.ts
@@ -1,0 +1,33 @@
+import z from "zod";
+import { OrderByState } from "../../../interfaces/orderBy";
+import { UiColumnMapping } from "../../../tableDefinitions";
+import { logger } from "../../logger";
+
+export function orderByToClickhouseSql(
+  orderBy: OrderByState,
+  tableColumns: UiColumnMapping[],
+): string {
+  if (!orderBy) {
+    return "";
+  }
+  // Get column definition to map column to internal name, e.g. "t.id"
+  const col = tableColumns.find(
+    (c) => c.uiTableName === orderBy.column || c.uiTableId === orderBy.column,
+  );
+
+  if (!col) {
+    logger.warn("Invalid order by column", orderBy.column);
+    throw new Error("Invalid order by column: " + orderBy.column);
+  }
+
+  // Assert that orderBy.order is either "asc" or "desc"
+  const orderByOrder = z.enum(["ASC", "DESC"]);
+  const order = orderByOrder.safeParse(orderBy.order);
+  if (!order.success) {
+    logger.warn("Invalid order", orderBy.order);
+    throw new Error("Invalid order: " + orderBy.order);
+  }
+
+  // Both column and order are safe, can use raw SQL
+  return `ORDER BY ${col.queryPrefix ? col.queryPrefix + "." : ""}${col.clickhouseSelect} ${order.data}`;
+}

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -142,6 +142,7 @@ export const getScoresGroupedByName = async (
     ? createFilterFromFilterState(timestampFilter, [
         {
           uiTableName: "Timestamp",
+          uiTableId: "timestamp",
           clickhouseTableName: "scores",
           clickhouseSelect: "timestamp",
         },
@@ -158,7 +159,7 @@ export const getScoresGroupedByName = async (
       from scores s final
       WHERE s.project_id = {projectId: String}
       AND has(['NUMERIC', 'BOOLEAN'], s.data_type)
-      ${timestampFilterRes ? `AND ${timestampFilterRes.query}` : ""}
+      ${timestampFilterRes?.query ? `AND ${timestampFilterRes.query}` : ""}
       GROUP BY name
       ORDER BY count() desc
       LIMIT 1000;

--- a/packages/shared/src/tableDefinitions/mapObservationsTable.ts
+++ b/packages/shared/src/tableDefinitions/mapObservationsTable.ts
@@ -6,141 +6,167 @@ import { UiColumnMapping } from "./types";
 export const observationsTableUiColumnDefinitions: UiColumnMapping[] = [
   {
     uiTableName: "ID",
+    uiTableId: "id",
     clickhouseTableName: "observations",
     clickhouseSelect: 'o."id"',
   },
   {
     uiTableName: "Name",
+    uiTableId: "name",
     clickhouseTableName: "observations",
     clickhouseSelect: 'o."name"',
   },
   {
     uiTableName: "Trace ID",
+    uiTableId: "traceId",
     clickhouseTableName: "observations",
     clickhouseSelect: 'o."trace_id"',
   },
   {
     uiTableName: "Trace Name",
+    uiTableId: "traceName",
     clickhouseTableName: "observations",
-    clickhouseSelect: 'o."trace_name"',
+    clickhouseSelect: 't."name"',
   },
   {
     uiTableName: "User ID",
+    uiTableId: "userId",
     clickhouseTableName: "traces",
-    clickhouseSelect: 't."trace_user_id"',
+    clickhouseSelect: 't."user_id"',
   },
   {
     uiTableName: "Start Time",
+    uiTableId: "startTime",
     clickhouseTableName: "observations",
     clickhouseSelect: 'o."start_time"',
   },
   {
     uiTableName: "End Time",
+    uiTableId: "endTime",
     clickhouseTableName: "observations",
     clickhouseSelect: 'o."end_time"',
   },
   {
     uiTableName: "Time To First Token (s)",
+    uiTableId: "timeToFirstToken",
     clickhouseTableName: "observations",
     clickhouseSelect:
       "if(isNull(completion_start_time), NULL,  date_diff('seconds', start_time, completion_start_time))}",
   },
   {
     uiTableName: "Latency (s)",
+    uiTableId: "latency",
     clickhouseTableName: "observations",
     clickhouseSelect:
       "if(isNull(end_time), NULL, date_diff('seconds', start_time, end_time))",
   },
   {
     uiTableName: "Tokens per second",
+    uiTableId: "tokensPerSecond",
     clickhouseTableName: "observations",
     clickhouseSelect:
       " if(isNull(end_time) && mapExists((k, v) -> (k = 'input'), usage_details) != 1, NULL, usage_details['input'] / date_diff('seconds', start_time, end_time)",
   },
   {
     uiTableName: "Input Cost ($)",
+    uiTableId: "inputCost",
     clickhouseTableName: "observations",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'input'), cost_details), cost_details['input'], NULL)",
   },
   {
     uiTableName: "Output Cost ($)",
+    uiTableId: "outputCost",
     clickhouseTableName: "observations",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'output'), cost_details), cost_details['output'], NULL)",
   },
   {
     uiTableName: "Total Cost ($)",
+    uiTableId: "totalCost",
     clickhouseTableName: "observations",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'total'), cost_details), cost_details['total'], NULL)",
   },
   {
     uiTableName: "Level",
+    uiTableId: "level",
     clickhouseTableName: "observations",
     clickhouseSelect: 'o."level"',
   },
   {
     uiTableName: "Status Message",
+    uiTableId: "statusMessage",
     clickhouseTableName: "observations",
     clickhouseSelect: 'o."status_message"',
   },
   {
     uiTableName: "Model",
+    uiTableId: "model",
     clickhouseTableName: "observations",
     clickhouseSelect: 'o."model"',
   },
   {
     uiTableName: "Input Tokens",
+    uiTableId: "inputTokens",
     clickhouseTableName: "observations",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'input'), usage_details), usage_details['input'], NULL)",
   },
   {
     uiTableName: "Output Tokens",
+    uiTableId: "outputTokens",
     clickhouseTableName: "observations",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'output'), usage_details), usage_details['output'], NULL)",
   },
   {
     uiTableName: "Total Tokens",
+    uiTableId: "totalTokens",
     clickhouseTableName: "observations",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'total'), usage_details), usage_details['total'], NULL)",
   },
   {
     uiTableName: "Usage",
+    uiTableId: "usage",
     clickhouseTableName: "observations",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'total'), usage_details), usage_details['total'], NULL)",
   },
   {
     uiTableName: "Metadata",
+    uiTableId: "metadata",
     clickhouseTableName: "observations",
     clickhouseSelect: 'o."metadata"',
   },
   {
     uiTableName: "Scores",
+    uiTableId: "scores",
     clickhouseTableName: "observations",
     clickhouseSelect: "s_avg.scores_avg",
   },
   {
     uiTableName: "Version",
+    uiTableId: "version",
     clickhouseTableName: "observations",
     clickhouseSelect: 'o."version"',
   },
   {
     uiTableName: "Prompt Name",
+    uiTableId: "promptName",
     clickhouseTableName: "prompts",
     clickhouseSelect: "p.name",
   },
   {
     uiTableName: "Prompt Version",
+    uiTableId: "promptVersion",
     clickhouseTableName: "prompts",
     clickhouseSelect: "p.version",
   },
   {
     uiTableName: "Trace Tags",
+    uiTableId: "traceTags",
     clickhouseTableName: "traces",
     clickhouseSelect: "t.tags",
   },

--- a/packages/shared/src/tableDefinitions/mapTracesTable.ts
+++ b/packages/shared/src/tableDefinitions/mapTracesTable.ts
@@ -1,102 +1,117 @@
-// This structure is maintained to relate the frontend table definitions with the clickhouse table definitions.
-// The frontend only sends the column names to the backend. This needs to be changed in the future to send column IDs.
-
 import { UiColumnMapping } from "./types";
 
 export const tracesTableUiColumnDefinitions: UiColumnMapping[] = [
   {
     uiTableName: "bookmarked",
+    uiTableId: "bookmarked",
     clickhouseTableName: "traces",
     clickhouseSelect: "bookmarked",
     queryPrefix: "t",
   },
   {
     uiTableName: "Level",
+    uiTableId: "level",
     clickhouseTableName: "observations",
     clickhouseSelect: "level",
   },
   {
     uiTableName: "ID",
+    uiTableId: "id",
     clickhouseTableName: "traces",
     clickhouseSelect: "id",
   },
   {
     uiTableName: "Name",
+    uiTableId: "name",
     clickhouseTableName: "traces",
     clickhouseSelect: "name",
   },
   {
     uiTableName: "Timestamp",
+    uiTableId: "timestamp",
     clickhouseTableName: "traces",
     clickhouseSelect: "timestamp",
   },
   {
     uiTableName: "User ID",
+    uiTableId: "userId",
     clickhouseTableName: "traces",
     clickhouseSelect: "user_id",
   },
   {
     uiTableName: "Session ID",
+    uiTableId: "sessionId",
     clickhouseTableName: "traces",
     clickhouseSelect: "session_id",
   },
   {
     uiTableName: "Metadata",
+    uiTableId: "metadata",
     clickhouseTableName: "traces",
     clickhouseSelect: "metadata",
   },
   {
     uiTableName: "Version",
+    uiTableId: "version",
     clickhouseTableName: "traces",
     clickhouseSelect: "version",
   },
   {
     uiTableName: "Release",
+    uiTableId: "release",
     clickhouseTableName: "traces",
     clickhouseSelect: "release",
   },
   {
     uiTableName: "Tags",
+    uiTableId: "tags",
     clickhouseTableName: "traces",
     clickhouseSelect: "tags",
   },
   {
     uiTableName: "Input Tokens",
+    uiTableId: "inputTokens",
     clickhouseTableName: "traces",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'input'), usage_details), usage_details['input'], NULL)",
   },
   {
     uiTableName: "Output Tokens",
+    uiTableId: "outputTokens",
     clickhouseTableName: "traces",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'output'), usage_details), usage_details['output'], NULL)",
   },
   {
     uiTableName: "Total Tokens",
+    uiTableId: "totalTokens",
     clickhouseTableName: "traces",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'total'), usage_details), usage_details['total'], NULL)",
   },
   {
     uiTableName: "Latency (s)",
+    uiTableId: "latency",
     clickhouseTableName: "traces",
     clickhouseSelect: "latency",
   },
   {
     uiTableName: "Input Cost ($)",
+    uiTableId: "inputCost",
     clickhouseTableName: "traces",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'input'), cost_details), usage_details['input'], NULL)",
   },
   {
     uiTableName: "Output Cost ($)",
+    uiTableId: "outputCost",
     clickhouseTableName: "traces",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'output'), cost_details), usage_details['output'], NULL)",
   },
   {
     uiTableName: "Total Cost ($)",
+    uiTableId: "totalCost",
     clickhouseTableName: "traces",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'total'), cost_details), usage_details['total'], NULL)",

--- a/packages/shared/src/tableDefinitions/types.ts
+++ b/packages/shared/src/tableDefinitions/types.ts
@@ -1,5 +1,6 @@
 export type UiColumnMapping = {
   uiTableName: string;
+  uiTableId: string;
   clickhouseTableName: string;
   clickhouseSelect: string;
   queryPrefix?: string;

--- a/web/src/server/api/routers/generations/db/getAllGenerationsSqlQuery.ts
+++ b/web/src/server/api/routers/generations/db/getAllGenerationsSqlQuery.ts
@@ -30,6 +30,7 @@ export async function getAllGenerations({
     generations = await getObservationsTable({
       projectId: input.projectId,
       filter: input.filter,
+      orderBy: input.orderBy,
       selectIOAndMetadata: selectIOAndMetadata,
       offset: input.page * input.limit,
       limit: input.limit,

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -200,6 +200,7 @@ export const traceRouter = createTRPCRouter({
         const res = await getTracesTable(
           ctx.session.projectId,
           input.filter ?? [],
+          input.orderBy,
           input.limit,
           input.page,
         );
@@ -247,6 +248,7 @@ export const traceRouter = createTRPCRouter({
         const countQuery = await getTracesTableCount(
           ctx.session.projectId,
           input.filter ?? [],
+          null,
           input.limit,
           input.page,
         );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add ordering support to Clickhouse table queries by introducing `orderByToClickhouseSql` and updating related functions and table definitions.
> 
>   - **Behavior**:
>     - Add `orderByToClickhouseSql` function in `orderby-factory.ts` to convert order by conditions to Clickhouse SQL.
>     - Update `getObservationsTable`, `getTracesTable`, and `getScoresGroupedByName` to accept `orderBy` parameter.
>     - Modify `getAllGenerations` and `traceRouter` to handle `orderBy` in queries.
>   - **Table Definitions**:
>     - Add `uiTableId` to `UiColumnMapping` in `types.ts`.
>     - Update `observationsTableUiColumnDefinitions` and `tracesTableUiColumnDefinitions` to include `uiTableId`.
>   - **Misc**:
>     - Minor query adjustments in `scores.ts` and `traces.ts` for consistency with new ordering feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8dd387b954c06f0234a765bfc57df86f17a2485e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->