### PR TITLE
fix: multi-select header partially cut off on Firefox

### DIFF
--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -240,7 +240,7 @@ export default function TracesTable({
       size: 30,
       isPinned: true,
       header: ({ table }) => (
-        <div className="mt-1 h-5">
+        <div className="flex h-full items-center">
           <Checkbox
             checked={
               table.getIsAllPageRowsSelected()

--- a/web/src/ee/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
+++ b/web/src/ee/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
@@ -167,7 +167,7 @@ export function AnnotationQueueItemsTable({
       isPinned: true,
       header: ({ table }) => {
         return (
-          <div className="mt-1 h-5">
+          <div className="flex h-full items-center">
             <Checkbox
               checked={
                 table.getIsAllPageRowsSelected()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes multi-select header cut-off issue in Firefox by adjusting CSS in `traces.tsx` and `AnnotationQueueItemsTable.tsx`.
> 
>   - **UI Fix**:
>     - Adjusted CSS for checkbox header in `traces.tsx` and `AnnotationQueueItemsTable.tsx` to fix multi-select header cut-off issue in Firefox.
>     - Replaced `mt-1 h-5` with `flex h-full items-center` for consistent alignment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 773c26cab6b0e307d6306db726aabe1ef9eed4e8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->