### PR TITLE
fix: scores tab in observation preview to only show scores liked to observation and trace id

### DIFF
--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -289,6 +289,7 @@ export const ObservationPreview = ({
           {selectedTab === "scores" && (
             <ScoresTable
               projectId={projectId}
+              traceId={traceId}
               omittedFilter={["Observation ID"]}
               observationId={preloadedObservation.id}
               hiddenColumns={[


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `traceId` to `ScoresTable` in `ObservationPreview.tsx` to filter scores by `traceId` and `observationId`.
> 
>   - **Behavior**:
>     - Add `traceId` to `ScoresTable` in `ObservationPreview.tsx` to filter scores by `traceId` and `observationId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 81eaf82475b78756cb911ba3a871371eef63fbf8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->