### PR TITLE
chore: remove temporary column from PG to CH migrations

### DIFF
--- a/packages/shared/prisma/generated/types.ts
+++ b/packages/shared/prisma/generated/types.ts
@@ -148,6 +148,7 @@ export type BackgroundMigration = {
     name: string;
     script: string;
     args: unknown;
+    state: unknown;
     finished_at: Timestamp | null;
     failed_at: Timestamp | null;
     failed_reason: string | null;

--- a/packages/shared/prisma/migrations/20241104111600_background_migrations_add_state_column/migration.sql
+++ b/packages/shared/prisma/migrations/20241104111600_background_migrations_add_state_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "background_migrations" ADD COLUMN "state" jsonb NOT NULL DEFAULT '{}';

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -166,6 +166,7 @@ model BackgroundMigration {
   name         String    @unique
   script       String    @map("script")
   args         Json      @map("args")
+  state        Json      @map("state")
   finishedAt   DateTime? @map("finished_at")
   failedAt     DateTime? @map("failed_at")
   failedReason String?   @map("failed_reason")

--- a/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
@@ -8,27 +8,6 @@ import { parseArgs } from "node:util";
 import { prisma, Prisma } from "@langfuse/shared/src/db";
 import { env } from "../env";
 
-async function addTemporaryColumnIfNotExists() {
-  const columnExists = await prisma.$queryRaw<{ column_exists: boolean }[]>(
-    Prisma.sql`
-      SELECT EXISTS (
-        SELECT 1
-        FROM information_schema.columns
-        WHERE table_name = 'observations'
-        AND column_name = 'tmp_migrated_to_clickhouse'
-      ) AS column_exists;
-    `,
-  );
-  if (!columnExists[0]?.column_exists) {
-    await prisma.$executeRaw`ALTER TABLE observations ADD COLUMN tmp_migrated_to_clickhouse BOOLEAN DEFAULT FALSE;`;
-    logger.info("Added temporary column tmp_migrated_to_clickhouse");
-  } else {
-    logger.info(
-      "Temporary column tmp_migrated_to_clickhouse already exists. Continuing...",
-    );
-  }
-}
-
 export default class MigrateObservationsFromPostgresToClickhouse
   implements IBackgroundMigration
 {
@@ -54,9 +33,7 @@ export default class MigrateObservationsFromPostgresToClickhouse
 
     const maxRowsToProcess = Number(args.maxRowsToProcess ?? Infinity);
     const batchSize = Number(args.batchSize ?? 5000);
-    const maxDate = new Date((args.maxDate as string) ?? new Date());
-
-    await addTemporaryColumnIfNotExists();
+    let maxDate = new Date((args.maxDate as string) ?? new Date());
 
     let processedRows = 0;
     while (!this.isAborted && processedRows < maxRowsToProcess) {
@@ -68,7 +45,7 @@ export default class MigrateObservationsFromPostgresToClickhouse
         SELECT o.id, o.trace_id, o.project_id, o.type, o.parent_observation_id, o.start_time, o.end_time, o.name, o.metadata, o.level, o.status_message, o.version, o.input, o.output, o.unit, o.model, o.internal_model_id, o."modelParameters" as model_parameters, o.prompt_tokens, o.completion_tokens, o.total_tokens, o.completion_start_time, o.prompt_id, p.name as prompt_name, p.version as prompt_version, o.input_cost, o.output_cost, o.total_cost, o.calculated_input_cost, o.calculated_output_cost, o.calculated_total_cost, o.created_at, o.updated_at
         FROM observations o
         LEFT JOIN prompts p ON o.prompt_id = p.id
-        WHERE o.tmp_migrated_to_clickhouse = FALSE AND o.created_at <= ${maxDate}
+        WHERE o.created_at <= ${maxDate}
         ORDER BY o.created_at DESC
         LIMIT ${batchSize};
       `);
@@ -92,14 +69,12 @@ export default class MigrateObservationsFromPostgresToClickhouse
         `Inserted ${observations.length} observations into Clickhouse in ${Date.now() - insertStart}ms`,
       );
 
-      await prisma.$executeRaw`
-        UPDATE observations
-        SET tmp_migrated_to_clickhouse = TRUE
-        WHERE id IN (${Prisma.join(observations.map((observation) => observation.id))});
-      `;
+      maxDate = new Date(observations[observations.length - 1].created_at);
 
       processedRows += observations.length;
-      logger.info(`Processed batch in ${Date.now() - fetchStart}ms`);
+      logger.info(
+        `Processed batch in ${Date.now() - fetchStart}ms. Oldest record in batch: ${maxDate}`,
+      );
     }
 
     if (this.isAborted) {
@@ -109,7 +84,6 @@ export default class MigrateObservationsFromPostgresToClickhouse
       return;
     }
 
-    await prisma.$executeRaw`ALTER TABLE observations DROP COLUMN IF EXISTS tmp_migrated_to_clickhouse;`;
     logger.info(
       `Finished migration of observations from Postgres to Clickhouse in ${Date.now() - start}ms`,
     );

--- a/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
@@ -105,7 +105,7 @@ export default class MigrateObservationsFromPostgresToClickhouse
 
       processedRows += observations.length;
       logger.info(
-        `Processed batch in ${Date.now() - fetchStart}ms. Oldest record in batch: ${maxDate}`,
+        `Processed batch in ${Date.now() - fetchStart}ms. Oldest record in batch: ${new Date(observations[observations.length - 1].created_at).toISOString()}`,
       );
     }
 

--- a/worker/src/backgroundMigrations/migrateScoresFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateScoresFromPostgresToClickhouse.ts
@@ -8,10 +8,14 @@ import { parseArgs } from "node:util";
 import { prisma, Prisma } from "@langfuse/shared/src/db";
 import { env } from "../env";
 
+// This is hard-coded in our migrations and uniquely identifies the row in background_migrations table
+const backgroundMigrationId = "94e50334-50d3-4e49-ad2e-9f6d92c85ef7";
+
 export default class MigrateScoresFromPostgresToClickhouse
   implements IBackgroundMigration
 {
   private isAborted = false;
+  private isFinished = false;
 
   async validate(
     args: Record<string, unknown>,
@@ -33,18 +37,34 @@ export default class MigrateScoresFromPostgresToClickhouse
 
     const maxRowsToProcess = Number(args.maxRowsToProcess ?? Infinity);
     const batchSize = Number(args.batchSize ?? 5000);
-    let maxDate = new Date((args.maxDate as string) ?? new Date());
+    const maxDate = new Date((args.maxDate as string) ?? new Date());
+
+    await prisma.backgroundMigration.update({
+      where: { id: backgroundMigrationId },
+      data: { state: { maxDate } },
+    });
 
     let processedRows = 0;
-    while (!this.isAborted && processedRows < maxRowsToProcess) {
+    while (
+      !this.isAborted &&
+      !this.isFinished &&
+      processedRows < maxRowsToProcess
+    ) {
       const fetchStart = Date.now();
+
+      // @ts-ignore
+      const migrationState: { state: { maxDate: string } } =
+        await prisma.backgroundMigration.findUniqueOrThrow({
+          where: { id: backgroundMigrationId },
+          select: { state: true },
+        });
 
       const scores = await prisma.$queryRaw<
         Array<Record<string, any>>
       >(Prisma.sql`
         SELECT id, timestamp, project_id, trace_id, observation_id, name, value, source, comment, author_user_id, config_id, data_type, string_value, queue_id, created_at, updated_at
         FROM scores
-        WHERE created_at <= ${maxDate}
+        WHERE created_at <= ${new Date(migrationState.state.maxDate)}
         ORDER BY created_at DESC
         LIMIT ${batchSize};
       `);
@@ -68,7 +88,19 @@ export default class MigrateScoresFromPostgresToClickhouse
         `Inserted ${scores.length} scores into Clickhouse in ${Date.now() - insertStart}ms`,
       );
 
-      maxDate = new Date(scores[scores.length - 1].created_at);
+      await prisma.backgroundMigration.update({
+        where: { id: backgroundMigrationId },
+        data: {
+          state: {
+            maxDate: new Date(scores[scores.length - 1].created_at),
+          },
+        },
+      });
+
+      if (scores.length < batchSize) {
+        logger.info("No more scores to migrate. Exiting...");
+        this.isFinished = true;
+      }
 
       processedRows += scores.length;
       logger.info(

--- a/worker/src/backgroundMigrations/migrateScoresFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateScoresFromPostgresToClickhouse.ts
@@ -8,27 +8,6 @@ import { parseArgs } from "node:util";
 import { prisma, Prisma } from "@langfuse/shared/src/db";
 import { env } from "../env";
 
-async function addTemporaryColumnIfNotExists() {
-  const columnExists = await prisma.$queryRaw<{ column_exists: boolean }[]>(
-    Prisma.sql`
-      SELECT EXISTS (
-        SELECT 1
-        FROM information_schema.columns
-        WHERE table_name = 'scores'
-        AND column_name = 'tmp_migrated_to_clickhouse'
-      ) AS column_exists;
-    `,
-  );
-  if (!columnExists[0]?.column_exists) {
-    await prisma.$executeRaw`ALTER TABLE scores ADD COLUMN tmp_migrated_to_clickhouse BOOLEAN DEFAULT FALSE;`;
-    logger.info("Added temporary column tmp_migrated_to_clickhouse");
-  } else {
-    logger.info(
-      "Temporary column tmp_migrated_to_clickhouse already exists. Continuing...",
-    );
-  }
-}
-
 export default class MigrateScoresFromPostgresToClickhouse
   implements IBackgroundMigration
 {
@@ -54,9 +33,7 @@ export default class MigrateScoresFromPostgresToClickhouse
 
     const maxRowsToProcess = Number(args.maxRowsToProcess ?? Infinity);
     const batchSize = Number(args.batchSize ?? 5000);
-    const maxDate = new Date((args.maxDate as string) ?? new Date());
-
-    await addTemporaryColumnIfNotExists();
+    let maxDate = new Date((args.maxDate as string) ?? new Date());
 
     let processedRows = 0;
     while (!this.isAborted && processedRows < maxRowsToProcess) {
@@ -67,7 +44,7 @@ export default class MigrateScoresFromPostgresToClickhouse
       >(Prisma.sql`
         SELECT id, timestamp, project_id, trace_id, observation_id, name, value, source, comment, author_user_id, config_id, data_type, string_value, queue_id, created_at, updated_at
         FROM scores
-        WHERE tmp_migrated_to_clickhouse = FALSE AND created_at <= ${maxDate}
+        WHERE created_at <= ${maxDate}
         ORDER BY created_at DESC
         LIMIT ${batchSize};
       `);
@@ -91,14 +68,12 @@ export default class MigrateScoresFromPostgresToClickhouse
         `Inserted ${scores.length} scores into Clickhouse in ${Date.now() - insertStart}ms`,
       );
 
-      await prisma.$executeRaw`
-        UPDATE scores
-        SET tmp_migrated_to_clickhouse = TRUE
-        WHERE id IN (${Prisma.join(scores.map((score) => score.id))});
-      `;
+      maxDate = new Date(scores[scores.length - 1].created_at);
 
       processedRows += scores.length;
-      logger.info(`Processed batch in ${Date.now() - fetchStart}ms`);
+      logger.info(
+        `Processed batch in ${Date.now() - fetchStart}ms. Oldest record in batch: ${maxDate}`,
+      );
     }
 
     if (this.isAborted) {
@@ -108,7 +83,6 @@ export default class MigrateScoresFromPostgresToClickhouse
       return;
     }
 
-    await prisma.$executeRaw`ALTER TABLE scores DROP COLUMN IF EXISTS tmp_migrated_to_clickhouse;`;
     logger.info(
       `Finished migration of scores from Postgres to Clickhouse in ${Date.now() - start}ms`,
     );

--- a/worker/src/backgroundMigrations/migrateScoresFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateScoresFromPostgresToClickhouse.ts
@@ -104,7 +104,7 @@ export default class MigrateScoresFromPostgresToClickhouse
 
       processedRows += scores.length;
       logger.info(
-        `Processed batch in ${Date.now() - fetchStart}ms. Oldest record in batch: ${maxDate}`,
+        `Processed batch in ${Date.now() - fetchStart}ms. Oldest record in batch: ${new Date(scores[scores.length - 1].created_at).toISOString()}`,
       );
     }
 

--- a/worker/src/backgroundMigrations/migrateTracesFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateTracesFromPostgresToClickhouse.ts
@@ -104,7 +104,7 @@ export default class MigrateTracesFromPostgresToClickhouse
 
       processedRows += traces.length;
       logger.info(
-        `Processed batch in ${Date.now() - fetchStart}ms. Oldest record in batch: ${maxDate}`,
+        `Processed batch in ${Date.now() - fetchStart}ms. Oldest record in batch: ${new Date(traces[traces.length - 1].created_at).toISOString()}`,
       );
     }
 


### PR DESCRIPTION
## What does this PR do?

 Removes the temporary column as it's too heavy on the postgres IO to read and write all records back to disk. 

Once verified that this reduces IOPS issues during the migration, we plan to store the maxDate per batch in a `state` column on the background_migrations job. 

With the current logic, we will loop over the last record perpetually, i.e. we need a better exit condition as well.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes temporary column from migrations and adds `state` column to `background_migrations` for improved migration logic.
> 
>   - **Behavior**:
>     - Removes temporary column `tmp_migrated_to_clickhouse` from migration scripts in `migrateObservationsFromPostgresToClickhouse.ts`, `migrateScoresFromPostgresToClickhouse.ts`, and `migrateTracesFromPostgresToClickhouse.ts`.
>     - Introduces `state` column in `background_migrations` table to store `maxDate` for each batch.
>     - Updates migration logic to use `state.maxDate` for fetching records and determining exit condition.
>   - **Database**:
>     - Adds `state` column to `BackgroundMigration` model in `schema.prisma` and `types.ts`.
>     - SQL migration script `20241104111600_background_migrations_add_state_column/migration.sql` adds `state` column to `background_migrations` table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4dffb0f71136fec0754fbceddd27d99e6506296d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->