### PR TITLE
chore: include usagedetails from postgres in ingestion pipeline

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -364,6 +364,14 @@ export class IngestionService {
       observationRecord: parsedObservationRecord,
     });
 
+    if (
+      "usage_details" in generationUsage &&
+      Object.keys(generationUsage.usage_details).length === 0
+    ) {
+      generationUsage.usage_details =
+        postgresObservationRecord?.usage_details ?? {};
+    }
+
     return {
       ...parsedObservationRecord,
       ...generationUsage,

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -1069,6 +1069,7 @@ describe("Ingestion end-to-end tests", () => {
         model: "gpt-3.5",
         projectId,
         startTime: new Date(oldEvent),
+        completionTokens: 5,
         // Validates that numbers are parsed correctly. Since there is no usage, no effect on result
         calculatedTotalCost: "0.273330000000000000000000000000",
         modelParameters: { hello: "world" },
@@ -1106,6 +1107,7 @@ describe("Ingestion end-to-end tests", () => {
     expect(observation.input).toBe(JSON.stringify({ key: "value" }));
     expect(observation.output).toBe("overwritten");
     expect(observation.model_parameters).toBe('{"hello":"world"}');
+    expect(observation.usage_details.output).toBe("5");
     expect(observation.project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
   });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Populate `usage_details` from Postgres in `IngestionService` when missing in event data.
> 
>   - **Behavior**:
>     - In `IngestionService`, if `usage_details` in `generationUsage` is empty, populate it from `postgresObservationRecord`.
>   - **Tests**:
>     - Add test in `IngestionService.integration.test.ts` to verify `usage_details` is populated from Postgres when missing in event data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 441f78608963f99d7bb9ef4b6bf77c38dbe8c5a5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->