### PR TITLE
chore: init migration scripts with state on restarts

### DIFF
--- a/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
@@ -35,9 +35,18 @@ export default class MigrateObservationsFromPostgresToClickhouse
       `Migrating observations from postgres to clickhouse with ${JSON.stringify(args)}`,
     );
 
+    // @ts-ignore
+    const initialMigrationState: { state: { maxDate: string | undefined } } =
+      await prisma.backgroundMigration.findUniqueOrThrow({
+        where: { id: backgroundMigrationId },
+        select: { state: true },
+      });
+
     const maxRowsToProcess = Number(args.maxRowsToProcess ?? Infinity);
     const batchSize = Number(args.batchSize ?? 5000);
-    const maxDate = new Date((args.maxDate as string) ?? new Date());
+    const maxDate = initialMigrationState.state?.maxDate
+      ? new Date(initialMigrationState.state.maxDate)
+      : new Date((args.maxDate as string) ?? new Date());
 
     await prisma.backgroundMigration.update({
       where: { id: backgroundMigrationId },

--- a/worker/src/backgroundMigrations/migrateScoresFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateScoresFromPostgresToClickhouse.ts
@@ -35,9 +35,18 @@ export default class MigrateScoresFromPostgresToClickhouse
       `Migrating scores from postgres to clickhouse with ${JSON.stringify(args)}`,
     );
 
+    // @ts-ignore
+    const initialMigrationState: { state: { maxDate: string | undefined } } =
+      await prisma.backgroundMigration.findUniqueOrThrow({
+        where: { id: backgroundMigrationId },
+        select: { state: true },
+      });
+
     const maxRowsToProcess = Number(args.maxRowsToProcess ?? Infinity);
     const batchSize = Number(args.batchSize ?? 5000);
-    const maxDate = new Date((args.maxDate as string) ?? new Date());
+    const maxDate = initialMigrationState.state?.maxDate
+      ? new Date(initialMigrationState.state.maxDate)
+      : new Date((args.maxDate as string) ?? new Date());
 
     await prisma.backgroundMigration.update({
       where: { id: backgroundMigrationId },

--- a/worker/src/backgroundMigrations/migrateTracesFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateTracesFromPostgresToClickhouse.ts
@@ -35,9 +35,18 @@ export default class MigrateTracesFromPostgresToClickhouse
       `Migrating traces from postgres to clickhouse with ${JSON.stringify(args)}`,
     );
 
+    // @ts-ignore
+    const initialMigrationState: { state: { maxDate: string | undefined } } =
+      await prisma.backgroundMigration.findUniqueOrThrow({
+        where: { id: backgroundMigrationId },
+        select: { state: true },
+      });
+
     const maxRowsToProcess = Number(args.maxRowsToProcess ?? Infinity);
     const batchSize = Number(args.batchSize ?? 5000);
-    const maxDate = new Date((args.maxDate as string) ?? new Date());
+    const maxDate = initialMigrationState.state?.maxDate
+      ? new Date(initialMigrationState.state.maxDate)
+      : new Date((args.maxDate as string) ?? new Date());
 
     await prisma.backgroundMigration.update({
       where: { id: backgroundMigrationId },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Initialize migration scripts with state on restarts by fetching and updating `maxDate` in migration state for observations, scores, and traces.
> 
>   - **Behavior**:
>     - Initialize migration scripts with state on restarts in `migrateObservationsFromPostgresToClickhouse.ts`, `migrateScoresFromPostgresToClickhouse.ts`, and `migrateTracesFromPostgresToClickhouse.ts`.
>     - Fetch `maxDate` from `prisma.backgroundMigration` to resume migration from last state.
>     - Update `maxDate` in migration state after each batch is processed.
>   - **Misc**:
>     - Add `@ts-ignore` comments to ignore TypeScript errors when accessing migration state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a98c34c676c98dfe7ec076f6bf1fdcca46e24497. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->