### PR TITLE
chore(ui): slightly lighter bg of darkmode sidebar

### DIFF
--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -127,7 +127,7 @@
 
     --radius: 0.5rem;
 
-    --sidebar-background: 222.2 84% 3.9%;
+    --sidebar-background: 222.2 84% 4.4%;
     --sidebar-foreground: 210 40% 86%;
     --sidebar-primary: 210 40% 81%;
     --sidebar-primary-foreground: 222.2 47.4% 10.2%;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjusts dark mode sidebar background color in `globals.css` to be slightly lighter.
> 
>   - **Styles**:
>     - Adjust `--sidebar-background` in `globals.css` from `222.2 84% 3.9%` to `222.2 84% 4.4%` for a lighter dark mode sidebar.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b960a4da117380e34343a8ed299ef021a45864fe. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->