### PR TITLE
chore: reduce startTime missing logs to create events

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -820,7 +820,7 @@ export class IngestionService {
         if (totalCost != null) provided_cost_details.total = totalCost;
       }
 
-      if (!obs.body?.startTime) {
+      if (obs.type?.endsWith("-create") && !obs.body?.startTime) {
         logger.warn(
           `Observation ${entityId} in project ${projectId} does not have a startTime, using event time`,
         );


### PR DESCRIPTION
## What

Only log the missing startTime warning for create types to reduce noisyness and understand true impact.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `IngestionService` to log missing `startTime` warnings only for '-create' event types.
> 
>   - **Behavior**:
>     - Modify `mapObservationEventsToRecords` in `IngestionService` to log missing `startTime` warnings only for event types ending with '-create'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 53e3077b9148485af7a37af58e8bb58e99bbfdb5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->