### PR TITLE
perf: only join in dashboard if required

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-filter/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-filter/clickhouse-filter.ts
@@ -291,6 +291,10 @@ export class FilterList {
     this.filters.push(...filter);
   }
 
+  find(predicate: (filter: Filter) => boolean) {
+    return this.filters.find(predicate);
+  }
+
   public apply(): ClickhouseFilter {
     if (this.filters.length === 0) {
       return {

--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -42,7 +42,7 @@ export const getObservationsCostGroupedByName = async (
     createFilterFromFilterState(filter, dashboardColumnDefinitions),
   );
 
-  const appliedFiler = chFilter.apply();
+  const appliedFilter = chFilter.apply();
 
   const hasTraceFilter = chFilter.find((f) => f.clickhouseTable === "traces");
 
@@ -53,7 +53,7 @@ export const getObservationsCostGroupedByName = async (
       sumMap(usage_details)['total'] as sum_usage_details
     FROM observations o FINAL ${hasTraceFilter ? "LEFT JOIN traces t ON o.trace_id = t.id AND o.project_id = t.project_id" : ""}
     WHERE project_id = {projectId: String}
-    AND ${appliedFiler.query}
+    AND ${appliedFilter.query}
     GROUP BY provided_model_name
     ORDER BY sumMap(cost_details)['total'] DESC
     `;
@@ -66,7 +66,7 @@ export const getObservationsCostGroupedByName = async (
     query,
     params: {
       projectId,
-      ...appliedFiler.params,
+      ...appliedFilter.params,
     },
   });
 

--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -1,9 +1,7 @@
 import { queryClickhouse } from "./clickhouse";
 import { createFilterFromFilterState } from "../queries/clickhouse-filter/factory";
 import { FilterState } from "../../types";
-import { logger } from "../logger";
 import { FilterList } from "../queries/clickhouse-filter/clickhouse-filter";
-import { observationsTableUiColumnDefinitions } from "../../tableDefinitions";
 import { dashboardColumnDefinitions } from "../../tableDefinitions/mapDashboards";
 
 export const getTotalTraces = async (
@@ -42,16 +40,20 @@ export const getObservationsCostGroupedByName = async (
 ) => {
   const chFilter = new FilterList(
     createFilterFromFilterState(filter, dashboardColumnDefinitions),
-  ).apply();
+  );
+
+  const appliedFiler = chFilter.apply();
+
+  const hasTraceFilter = chFilter.find((f) => f.clickhouseTable === "traces");
 
   const query = `
     SELECT 
       provided_model_name as name,
       sumMap(cost_details)['total'] as sum_cost_details,
       sumMap(usage_details)['total'] as sum_usage_details
-    FROM observations o FINAL LEFT JOIN traces t ON o.trace_id = t.id AND o.project_id = t.project_id
+    FROM observations o FINAL ${hasTraceFilter ? "LEFT JOIN traces t ON o.trace_id = t.id AND o.project_id = t.project_id" : ""}
     WHERE project_id = {projectId: String}
-    AND ${chFilter.query}
+    AND ${appliedFiler.query}
     GROUP BY provided_model_name
     ORDER BY sumMap(cost_details)['total'] DESC
     `;
@@ -64,7 +66,7 @@ export const getObservationsCostGroupedByName = async (
     query,
     params: {
       projectId,
-      ...chFilter.params,
+      ...appliedFiler.params,
     },
   });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimize `getObservationsCostGroupedByName` in `dashboards.ts` by conditionally joining `traces` table based on filter presence, enhancing performance.
> 
>   - **Performance Optimization**:
>     - `getObservationsCostGroupedByName` in `dashboards.ts` now conditionally joins `traces` table only if a `traces` filter exists, improving query performance.
>   - **FilterList Enhancements**:
>     - Added `find(predicate)` method to `FilterList` in `clickhouse-filter.ts` to support conditional logic for joins.
>   - **Query Adjustments**:
>     - Updated query parameters and logic in `getObservationsCostGroupedByName` to use `appliedFilter` and conditional join.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for edd0d7a0c9c5ae37c6c2a8141123e30442d645f0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->