### PR TITLE
feat: query second row of dashboards using clickhouse

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-filter/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-filter/clickhouse-filter.ts
@@ -291,6 +291,10 @@ export class FilterList {
     this.filters.push(...filter);
   }
 
+  find(predicate: (filter: Filter) => boolean) {
+    return this.filters.find(predicate);
+  }
+
   public apply(): ClickhouseFilter {
     if (this.filters.length === 0) {
       return {

--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -42,7 +42,7 @@ export const getObservationsCostGroupedByName = async (
     createFilterFromFilterState(filter, dashboardColumnDefinitions),
   );
 
-  const appliedFiler = chFilter.apply();
+  const appliedFilter = chFilter.apply();
 
   const hasTraceFilter = chFilter.find((f) => f.clickhouseTable === "traces");
 
@@ -53,7 +53,7 @@ export const getObservationsCostGroupedByName = async (
       sumMap(usage_details)['total'] as sum_usage_details
     FROM observations o FINAL ${hasTraceFilter ? "LEFT JOIN traces t ON o.trace_id = t.id AND o.project_id = t.project_id" : ""}
     WHERE project_id = {projectId: String}
-    AND ${appliedFiler.query}
+    AND ${appliedFilter.query}
     GROUP BY provided_model_name
     ORDER BY sumMap(cost_details)['total'] DESC
     `;
@@ -66,7 +66,7 @@ export const getObservationsCostGroupedByName = async (
     query,
     params: {
       projectId,
-      ...appliedFiler.params,
+      ...appliedFilter.params,
     },
   });
 

--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -1,9 +1,7 @@
 import { queryClickhouse } from "./clickhouse";
 import { createFilterFromFilterState } from "../queries/clickhouse-filter/factory";
 import { FilterState } from "../../types";
-import { logger } from "../logger";
 import { FilterList } from "../queries/clickhouse-filter/clickhouse-filter";
-import { observationsTableUiColumnDefinitions } from "../../tableDefinitions";
 import { dashboardColumnDefinitions } from "../../tableDefinitions/mapDashboards";
 
 export const getTotalTraces = async (
@@ -42,16 +40,20 @@ export const getObservationsCostGroupedByName = async (
 ) => {
   const chFilter = new FilterList(
     createFilterFromFilterState(filter, dashboardColumnDefinitions),
-  ).apply();
+  );
+
+  const appliedFiler = chFilter.apply();
+
+  const hasTraceFilter = chFilter.find((f) => f.clickhouseTable === "traces");
 
   const query = `
     SELECT 
       provided_model_name as name,
       sumMap(cost_details)['total'] as sum_cost_details,
       sumMap(usage_details)['total'] as sum_usage_details
-    FROM observations o FINAL LEFT JOIN traces t ON o.trace_id = t.id AND o.project_id = t.project_id
+    FROM observations o FINAL ${hasTraceFilter ? "LEFT JOIN traces t ON o.trace_id = t.id AND o.project_id = t.project_id" : ""}
     WHERE project_id = {projectId: String}
-    AND ${chFilter.query}
+    AND ${appliedFiler.query}
     GROUP BY provided_model_name
     ORDER BY sumMap(cost_details)['total'] DESC
     `;
@@ -64,7 +66,7 @@ export const getObservationsCostGroupedByName = async (
     query,
     params: {
       projectId,
-      ...chFilter.params,
+      ...appliedFiler.params,
     },
   });
 

--- a/web/src/features/dashboard/components/ModelUsageChart.tsx
+++ b/web/src/features/dashboard/components/ModelUsageChart.tsx
@@ -18,7 +18,7 @@ import {
   dashboardDateRangeAggregationSettings,
   type DashboardDateRangeAggregationOption,
 } from "@/src/utils/date-range-utils";
-
+import { useClickhouse } from "@/src/components/layouts/ClickhouseAdminToggle";
 import { env } from "@/src/env.mjs";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 
@@ -62,6 +62,8 @@ export const ModelUsageChart = ({
       orderBy: [
         { column: "calculatedTotalCost", direction: "DESC", agg: "SUM" },
       ],
+      queryClickhouse: useClickhouse(),
+      queryName: "observations-usage-timeseries",
     },
     {
       trpc: {

--- a/web/src/features/dashboard/components/TracesTimeSeriesChart.tsx
+++ b/web/src/features/dashboard/components/TracesTimeSeriesChart.tsx
@@ -10,6 +10,7 @@ import {
   type DashboardDateRangeAggregationOption,
 } from "@/src/utils/date-range-utils";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
+import { useClickhouse } from "@/src/components/layouts/ClickhouseAdminToggle";
 
 export const TracesTimeSeriesChart = ({
   className,
@@ -37,6 +38,8 @@ export const TracesTimeSeriesChart = ({
           temporalUnit: dashboardDateRangeAggregationSettings[agg].date_trunc,
         },
       ],
+      queryClickhouse: useClickhouse(),
+      queryName: "traces-timeseries",
     },
     {
       trpc: {

--- a/web/src/utils/date-range-utils.ts
+++ b/web/src/utils/date-range-utils.ts
@@ -1,6 +1,7 @@
 import { type DateRange } from "react-day-picker";
 import { z } from "zod";
 import { addMinutes } from "date-fns";
+import { type DateTrunc } from "@langfuse/shared/src/server";
 
 export const DEFAULT_DASHBOARD_AGGREGATION_SELECTION = "24 hours" as const;
 export const DASHBOARD_AGGREGATION_PLACEHOLDER = "Custom" as const;
@@ -57,7 +58,7 @@ export type TableDateRangeOptions = TableDateRangeAggregationOption;
 export type DashboardDateRangeAggregationSettings = Record<
   DashboardDateRangeAggregationOption,
   {
-    date_trunc: "year" | "month" | "week" | "day" | "hour" | "minute";
+    date_trunc: DateTrunc;
     minutes: number;
   }
 >;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add Clickhouse-based time series querying and display for dashboards, with new functions, components, and router updates.
> 
>   - **Features**:
>     - Add `groupTracesByTime` and `getObservationUsageByTime` functions in `dashboards.ts` to query time series data from Clickhouse.
>     - Add `find` method to `FilterList` in `clickhouse-filter.ts` to locate specific filters.
>   - **Components**:
>     - Update `ModelUsageChart.tsx` and `TracesTimeSeriesChart.tsx` to use Clickhouse queries for data retrieval.
>     - Add `useClickhouse` hook to toggle Clickhouse usage in charts.
>   - **Router**:
>     - Extend `dashboard-router.ts` to handle new query types `traces-timeseries` and `observations-usage-timeseries`.
>   - **Utilities**:
>     - Add `DateTrunc` type and update `date-range-utils.ts` to support new date truncation options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a7f2de0174351471402a223a2ce5576fd73396b1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->