### PR TITLE
perf: fix timeseries clickouse

### DIFF
--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -217,7 +217,7 @@ const orderByTimeSeries = (dateTrunc: DateTrunc, col: string) => {
       interval = "toIntervalHour(1)";
       break;
     case "minute":
-      interval = "toMinute";
+      interval = "toIntervalMinute(1)";
       break;
     default:
       return undefined;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves performance in `orderByTimeSeries` by using `toIntervalMinute(1)` for 'minute' case in `dashboards.ts`.
> 
>   - **Performance Improvement**:
>     - In `dashboards.ts`, `orderByTimeSeries` function now uses `toIntervalMinute(1)` instead of `toMinute` for 'minute' case.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 06027a0b527ff74bc420865b7f9964c9b789c895. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->