### PR TITLE
feat(models): add claude haiku 3.5 support

### DIFF
--- a/packages/shared/prisma/migrations/20241105110900_add_claude_haiku_35/migration.sql
+++ b/packages/shared/prisma/migrations/20241105110900_add_claude_haiku_35/migration.sql
@@ -1,0 +1,29 @@
+INSERT INTO models (
+  id,
+  project_id,
+  model_name,
+  match_pattern,
+  start_date,
+  input_price,
+  output_price,
+  total_price,
+  unit,
+  tokenizer_id,
+  tokenizer_config
+)
+VALUES
+  -- https://docs.anthropic.com/en/docs/about-claude/models#model-comparison-table
+  ('cm34aq60d000207ml0j1h31ar', NULL, 'claude-3-5-haiku-20241022', '(?i)^(claude-3-5-haiku-20241022|anthropic\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$', NULL, 0.000001, 0.000005, NULL, 'TOKENS', 'claude', NULL),
+  ('cm34aqb9h000307ml6nypd618', NULL, 'claude-3.5-haiku-latest', '(?i)^(claude-3-5-haiku-latest)$', NULL, 0.000001, 0.000005, NULL, 'TOKENS', 'claude', NULL);
+
+INSERT INTO prices (
+  id, 
+  model_id, 
+  usage_type,
+  price
+)
+VALUES
+  ('cm34ax6mc000008jkfqed92mb', 'cm34aq60d000207ml0j1h31ar', 'input', 0.000001),
+  ('cm34axb2o000108jk09wn9b47', 'cm34aqb9h000307ml6nypd618', 'input', 0.000001),
+  ('cm34axeie000208jk8b2ke2t8', 'cm34aq60d000207ml0j1h31ar', 'output', 0.000005),
+  ('cm34axi67000308jk7x1a7qko', 'cm34aqb9h000307ml6nypd618', 'output', 0.000005);

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -49,7 +49,7 @@ export const ZodModelConfig = z.object({
   top_p: z.coerce.number().optional(),
 });
 
-// NOTE: Update docs page when changing this!
+// NOTE: Update docs page when changing this! https://langfuse.com/docs/playground#openai-playground--anthropic-playground
 export const openAIModels = [
   "gpt-4o",
   "gpt-4o-2024-08-06",
@@ -76,7 +76,7 @@ export const openAIModels = [
 
 export type OpenAIModel = (typeof openAIModels)[number];
 
-// NOTE: Update docs page when changing this!
+// NOTE: Update docs page when changing this! https://langfuse.com/docs/playground#openai-playground--anthropic-playground
 export const anthropicModels = [
   "claude-3-5-sonnet-20241022",
   "claude-3-5-sonnet-20240620",

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -78,9 +78,11 @@ export type OpenAIModel = (typeof openAIModels)[number];
 
 // NOTE: Update docs page when changing this!
 export const anthropicModels = [
+  "claude-3-5-sonnet-20241022",
   "claude-3-5-sonnet-20240620",
   "claude-3-opus-20240229",
   "claude-3-sonnet-20240229",
+  "claude-3-5-haiku-20241022",
   "claude-3-haiku-20240307",
   "claude-2.1",
   "claude-2.0",

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1134,5 +1134,31 @@
     },
     "tokenizer_config": null,
     "tokenizer_id": "claude"
+  },
+  {
+    "id": "cm34aq60d000207ml0j1h31ar",
+    "model_name": "claude-3-5-haiku-20241022",
+    "match_pattern": "(?i)^(claude-3-5-haiku-20241022|anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
+    "created_at": "2024-11-05T10:30:50.566Z",
+    "updated_at": "2024-11-05T10:30:50.566Z",
+    "prices": {
+      "input": 0.000001,
+      "output": 0.000005
+    },
+    "tokenizer_config": null,
+    "tokenizer_id": "claude"
+  },
+  {
+    "id": "cm34aqb9h000307ml6nypd618",
+    "model_name": "claude-3.5-haiku-latest",
+    "match_pattern": "(?i)^(claude-3-5-haiku-latest)$",
+    "created_at": "2024-11-05T10:30:50.566Z",
+    "updated_at": "2024-11-05T10:30:50.566Z",
+    "prices": {
+      "input": 0.000001,
+      "output": 0.000005
+    },
+    "tokenizer_config": null,
+    "tokenizer_id": "claude"
   }
 ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for Claude Haiku 3.5 model by updating database schema, model list, and pricing details.
> 
>   - **Database**:
>     - Adds migration `20241105110900_add_claude_haiku_35/migration.sql` to insert `claude-3-5-haiku-20241022` and `claude-3.5-haiku-latest` into `models` and `prices` tables.
>   - **Model List**:
>     - Adds `claude-3-5-haiku-20241022` to `anthropicModels` in `types.ts`.
>   - **Pricing**:
>     - Updates `default-model-prices.json` with `claude-3-5-haiku-20241022` and `claude-3.5-haiku-latest` pricing details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 731cc0b1450c2b016a32ecb628b55d38bb0fcb64. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->