### PR TITLE
chore: retry legacy ingestion batches on errors

### DIFF
--- a/worker/src/queues/legacyIngestionQueue.ts
+++ b/worker/src/queues/legacyIngestionQueue.ts
@@ -93,6 +93,11 @@ export const legacyIngestionQueueProcessor: Processor = async (
       tokenCount,
     );
 
+    if (result.errors.length > 0) {
+      // Raise errors if any are returned to retry the batch via bullmq
+      throw new Error(`Failed to process ${result.errors.length} events`);
+    }
+
     // send out REDIS requests to worker for all trace types
     await addTracesToTraceUpsertQueue(
       result.results,


### PR DESCRIPTION
## What does this PR do?

 Reject batches in the legacy ingestion pipeline if they fail to ensure they're retried via bullmq and trigger our alerts.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Throw error in `legacyIngestionQueueProcessor` if `handleBatch` returns errors to ensure batch retry via bullmq.
> 
>   - **Behavior**:
>     - In `legacyIngestionQueueProcessor` in `legacyIngestionQueue.ts`, throw an error if `handleBatch` returns any errors to ensure batch retry via bullmq.
>   - **Error Handling**:
>     - Logs error and traces exception if batch processing fails, ensuring proper alerting and retry mechanism.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f25e0c0e57e657cebde49d4fd1b126cdd6b40d34. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->