### PR TITLE
chore: ignore all .env files aside from examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,10 @@ yarn-error.log*
 
 # local env files
 # do not commit any .env files to git, except for the .env.example file. https://create.t3.gg/en/usage/env-variables#using-environment-variables
-.env
-.env.local
-.env*.local
+.env*
+!.env.dev.example
+!.env.local.example
+!.env.prod.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## What

Ignore all .env files aside from the three examples.