### PR TITLE
chore: do not send auth errors to DLQ in bull

### DIFF
--- a/packages/shared/src/server/ingestion/legacy/index.ts
+++ b/packages/shared/src/server/ingestion/legacy/index.ts
@@ -77,7 +77,7 @@ export const handleBatch = async (
       // Decide how to handle the error: rethrow, continue, or push an error object to results
       // For example, push an error object:
       errors.push({
-        error: error,
+        error,
         id: singleEvent.id,
         type: singleEvent.type,
       });

--- a/worker/src/queues/legacyIngestionQueue.ts
+++ b/worker/src/queues/legacyIngestionQueue.ts
@@ -95,15 +95,11 @@ export const legacyIngestionQueueProcessor: Processor = async (
     );
 
     // Do not retry events via bullmq for auth errors
-    const processingErrors = result.errors.flatMap((error) => {
-      if (
-        error.error instanceof UnauthorizedError ||
-        error.error instanceof ForbiddenError
-      ) {
-        return [];
-      }
-      return [error.error];
-    });
+    const processingErrors = result.errors.filter(
+      (e) =>
+        !(e.error instanceof UnauthorizedError) &&
+        !(e.error instanceof ForbiddenError),
+    );
     if (processingErrors.length > 0) {
       // Raise errors if any are returned to retry the batch via bullmq
       logger.error(`Failed to process ${processingErrors.length} events`, {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Prevent authentication errors from triggering retries in BullMQ by filtering them out in `legacyIngestionQueueProcessor`.
> 
>   - **Behavior**:
>     - In `legacyIngestionQueueProcessor` in `legacyIngestionQueue.ts`, authentication errors (`UnauthorizedError`, `ForbiddenError`) are filtered out from retry logic in BullMQ.
>     - Logs errors and throws an error if non-authentication errors are present.
>   - **Code Style**:
>     - Simplified object property assignment in `handleBatch` in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4ba2ee861fa554859d92dffc7c40a6d4ee735133. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->