### PR TITLE
chore: add type filter to observation lookup in ingestion queue

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -33,7 +33,6 @@ import {
   traceRecordReadSchema,
   validateAndInflateScore,
   UsageCostType,
-  getClickhouseEntityType,
 } from "@langfuse/shared/src/server";
 
 import { tokenCount } from "../../features/tokenisation/usage";

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -33,6 +33,7 @@ import {
   traceRecordReadSchema,
   validateAndInflateScore,
   UsageCostType,
+  getClickhouseEntityType,
 } from "@langfuse/shared/src/server";
 
 import { tokenCount } from "../../features/tokenisation/usage";
@@ -133,6 +134,7 @@ export class IngestionService {
           projectId,
           entityId,
           table: TableName.Scores,
+          additionalFilters: { whereCondition: "", params: {} },
         }),
         Promise.all(
           timeSortedEvents.map(async (scoreEvent) => {
@@ -200,6 +202,7 @@ export class IngestionService {
         projectId,
         entityId,
         table: TableName.Traces,
+        additionalFilters: { whereCondition: "", params: {} },
       }),
     ]);
 
@@ -223,6 +226,7 @@ export class IngestionService {
     const timeSortedEvents =
       IngestionService.toTimeSortedEventList(observationEventList);
 
+    const type = this.getObservationType(observationEventList[0]);
     const [postgresObservationRecord, clickhouseObservationRecord, prompt] =
       await Promise.all([
         this.getPostgresRecord({
@@ -234,6 +238,10 @@ export class IngestionService {
           projectId,
           entityId,
           table: TableName.Observations,
+          additionalFilters: {
+            whereCondition: "AND type = {type: String}",
+            params: { type },
+          },
         }),
         this.getPrompt(projectId, observationEventList),
       ]);
@@ -608,28 +616,44 @@ export class IngestionService {
     projectId: string;
     entityId: string;
     table: TableName.Traces;
+    additionalFilters: {
+      whereCondition: string;
+      params: Record<string, unknown>;
+    };
   }): Promise<TraceRecordInsertType | null>;
   private async getClickhouseRecord(params: {
     projectId: string;
     entityId: string;
     table: TableName.Scores;
+    additionalFilters: {
+      whereCondition: string;
+      params: Record<string, unknown>;
+    };
   }): Promise<ScoreRecordInsertType | null>;
   private async getClickhouseRecord(params: {
     projectId: string;
     entityId: string;
     table: TableName.Observations;
+    additionalFilters: {
+      whereCondition: string;
+      params: Record<string, unknown>;
+    };
   }): Promise<ObservationRecordInsertType | null>;
   private async getClickhouseRecord(params: {
     projectId: string;
     entityId: string;
     table: TableName;
+    additionalFilters: {
+      whereCondition: string;
+      params: Record<string, unknown>;
+    };
   }) {
     const recordParser = {
       traces: traceRecordReadSchema,
       scores: scoreRecordReadSchema,
       observations: observationRecordReadSchema,
     };
-    const { projectId, entityId, table } = params;
+    const { projectId, entityId, table, additionalFilters } = params;
 
     return await instrumentAsync(
       { name: `get-clickhouse-${table}` },
@@ -640,11 +664,12 @@ export class IngestionService {
             FROM ${table}
             WHERE project_id = {projectId: String}
             AND id = {entityId: String}
+            ${additionalFilters.whereCondition}
             ORDER BY event_ts DESC
             LIMIT 1 BY id, project_id SETTINGS use_query_cache = false;
           `,
           format: "JSONEachRow",
-          query_params: { projectId, entityId },
+          query_params: { projectId, entityId, ...additionalFilters.params },
         });
 
         const result = await queryResult.json();
@@ -760,6 +785,24 @@ export class IngestionService {
     });
   }
 
+  private getObservationType(
+    observation: ObservationEvent,
+  ): "EVENT" | "SPAN" | "GENERATION" {
+    switch (observation.type) {
+      case eventTypes.OBSERVATION_CREATE:
+      case eventTypes.OBSERVATION_UPDATE:
+        return observation.body.type;
+      case eventTypes.EVENT_CREATE:
+        return "EVENT" as const;
+      case eventTypes.SPAN_CREATE:
+      case eventTypes.SPAN_UPDATE:
+        return "SPAN" as const;
+      case eventTypes.GENERATION_CREATE:
+      case eventTypes.GENERATION_UPDATE:
+        return "GENERATION" as const;
+    }
+  }
+
   private mapObservationEventsToRecords(params: {
     projectId: string;
     entityId: string;
@@ -769,24 +812,7 @@ export class IngestionService {
     const { projectId, entityId, observationEventList, prompt } = params;
 
     return observationEventList.map((obs) => {
-      let observationType: "EVENT" | "SPAN" | "GENERATION";
-      switch (obs.type) {
-        case eventTypes.OBSERVATION_CREATE:
-        case eventTypes.OBSERVATION_UPDATE:
-          observationType = obs.body.type;
-          break;
-        case eventTypes.EVENT_CREATE:
-          observationType = "EVENT" as const;
-          break;
-        case eventTypes.SPAN_CREATE:
-        case eventTypes.SPAN_UPDATE:
-          observationType = "SPAN" as const;
-          break;
-        case eventTypes.GENERATION_CREATE:
-        case eventTypes.GENERATION_UPDATE:
-          observationType = "GENERATION" as const;
-          break;
-      }
+      const observationType = this.getObservationType(obs);
 
       const newInputCount =
         "usage" in obs.body ? obs.body.usage?.input : undefined;

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -1254,6 +1254,65 @@ describe("Ingestion end-to-end tests", () => {
     expect(observation.total_cost).toBe(0.00020505);
   });
 
+  it("should merge observations from clickhouse and event list", async () => {
+    const traceId = randomUUID();
+    const observationId = randomUUID();
+
+    const latestEvent = new Date();
+    const oldEvent = new Date(latestEvent).setSeconds(
+      latestEvent.getSeconds() - 1,
+    );
+
+    const observationEventList1: ObservationEvent[] = [
+      {
+        id: randomUUID(),
+        type: "generation-create",
+        timestamp: new Date().toISOString(),
+        body: {
+          id: observationId,
+          traceId: traceId,
+          output: "to overwrite",
+          usage: undefined,
+        },
+      },
+    ];
+    await ingestionService.processObservationEventList({
+      projectId,
+      entityId: observationId,
+      observationEventList: observationEventList1,
+    });
+    await clickhouseWriter.flushAll(true);
+
+    const observationEventList2: ObservationEvent[] = [
+      {
+        id: randomUUID(),
+        type: "generation-update",
+        timestamp: new Date().toISOString(),
+        body: {
+          id: observationId,
+          name: "generation-name",
+          traceId: traceId,
+          output: "overwritten",
+          usage: undefined,
+        },
+      },
+    ];
+    await ingestionService.processObservationEventList({
+      projectId,
+      entityId: observationId,
+      observationEventList: observationEventList2,
+    });
+    await clickhouseWriter.flushAll(true);
+
+    const observation = await getClickhouseRecord(
+      TableName.Observations,
+      observationId,
+    );
+
+    expect(observation.name).toBe("generation-name");
+    expect(observation.output).toBe("overwritten");
+  });
+
   it("should put observation updates after creates if timestamp is same", async () => {
     const generationId = randomUUID();
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add type filter to observation lookups in `IngestionService` and update integration tests to verify behavior.
> 
>   - **Behavior**:
>     - Add `additionalFilters` with type filter to `getClickhouseRecord` calls for observations in `IngestionService`.
>     - Introduce `getObservationType()` to determine observation type.
>   - **Tests**:
>     - Add integration test `should merge observations from clickhouse and event list` in `IngestionService.integration.test.ts` to verify observation merging with type filter.
>     - Update existing tests to ensure correct behavior with new type filter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 898b6c20486e4a411cf9e616d8262dca42200cc4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->