### PR TITLE
chore: drop redundant observation project_id index on Clickhouse

### DIFF
--- a/packages/shared/clickhouse/migrations/0004_drop_observations_index.down.sql
+++ b/packages/shared/clickhouse/migrations/0004_drop_observations_index.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE observations ADD INDEX IF NOT EXISTS idx_project_id project_id TYPE bloom_filter() GRANULARITY 1;

--- a/packages/shared/clickhouse/migrations/0004_drop_observations_index.up.sql
+++ b/packages/shared/clickhouse/migrations/0004_drop_observations_index.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE observations DROP INDEX IF EXISTS idx_project_id;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Drop redundant `idx_project_id` index from `observations` table in Clickhouse with reversible migration.
> 
>   - **Database Migrations**:
>     - In `0004_drop_observations_index.up.sql`, drop redundant `idx_project_id` index from `observations` table.
>     - In `0004_drop_observations_index.down.sql`, add `idx_project_id` index back to `observations` table if it doesn't exist, using a bloom filter with granularity 1.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c0f9129d154549cbd92a73354dd98de05b21a475. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->