### PR TITLE
chore: restrict domain timestamp updates to one day in clickhouse ingestion

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -141,7 +141,7 @@ export class IngestionService {
           table: TableName.Scores,
           additionalFilters: {
             whereCondition: timestamp
-              ? " AND timestamp = {timestamp: DateTime} - INTERVAL 1 DAY "
+              ? " AND timestamp >= {timestamp: DateTime} - INTERVAL 1 DAY "
               : "",
             params: { timestamp },
           },
@@ -220,7 +220,7 @@ export class IngestionService {
         table: TableName.Traces,
         additionalFilters: {
           whereCondition: timestamp
-            ? " AND timestamp = {timestamp: DateTime} - INTERVAL 1 DAY "
+            ? " AND timestamp >= {timestamp: DateTime} - INTERVAL 1 DAY "
             : "",
           params: { timestamp },
         },
@@ -266,7 +266,7 @@ export class IngestionService {
           entityId,
           table: TableName.Observations,
           additionalFilters: {
-            whereCondition: `AND type = {type: String} ${startTime ? "AND start_time = {startTime: DateTime} - INTERVAL 1 DAY" : ""}`,
+            whereCondition: `AND type = {type: String} ${startTime ? "AND start_time >= {startTime: DateTime} - INTERVAL 1 DAY" : ""}`,
             params: { type, startTime },
           },
         }),

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -1259,9 +1259,6 @@ describe("Ingestion end-to-end tests", () => {
     const observationId = randomUUID();
 
     const latestEvent = new Date();
-    const oldEvent = new Date(latestEvent).setSeconds(
-      latestEvent.getSeconds() - 1,
-    );
 
     const observationEventList1: ObservationEvent[] = [
       {
@@ -1271,6 +1268,7 @@ describe("Ingestion end-to-end tests", () => {
         body: {
           id: observationId,
           traceId: traceId,
+          startTime: new Date().toISOString(),
           output: "to overwrite",
           usage: undefined,
         },


### PR DESCRIPTION
## What

Only search for existing clickhouse events within the last day of the provided domain timestamp. This ensures optimal index usage and should reduce total database load within our ingestion pipeline.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Restrict Clickhouse event searches to the last day of the provided domain timestamp in `IngestionService` methods and update integration tests accordingly.
> 
>   - **Behavior**:
>     - Restrict Clickhouse event search to the last day of the provided domain timestamp in `processScoreEventList`, `processTraceEventList`, and `processObservationEventList` in `index.ts`.
>   - **Tests**:
>     - Update integration tests in `IngestionService.integration.test.ts` to align with the new timestamp restriction logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8a5937903afd58cd183eaf9ec4eb60fd309b6923. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->