### PR TITLE
chore: remove interval from filter range

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -141,7 +141,7 @@ export class IngestionService {
           table: TableName.Scores,
           additionalFilters: {
             whereCondition: timestamp
-              ? " AND timestamp >= {timestamp: DateTime} - INTERVAL 1 DAY "
+              ? " AND timestamp >= {timestamp: DateTime} "
               : "",
             params: { timestamp },
           },
@@ -220,7 +220,7 @@ export class IngestionService {
         table: TableName.Traces,
         additionalFilters: {
           whereCondition: timestamp
-            ? " AND timestamp >= {timestamp: DateTime} - INTERVAL 1 DAY "
+            ? " AND timestamp >= {timestamp: DateTime} "
             : "",
           params: { timestamp },
         },
@@ -266,7 +266,7 @@ export class IngestionService {
           entityId,
           table: TableName.Observations,
           additionalFilters: {
-            whereCondition: `AND type = {type: String} ${startTime ? "AND start_time >= {startTime: DateTime} - INTERVAL 1 DAY" : ""}`,
+            whereCondition: `AND type = {type: String} ${startTime ? "AND start_time >= {startTime: DateTime} " : ""}`,
             params: { type, startTime },
           },
         }),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `- INTERVAL 1 DAY` from timestamp filter in `IngestionService` SQL queries.
> 
>   - **Behavior**:
>     - Removed `- INTERVAL 1 DAY` from `timestamp` filter in SQL `whereCondition` for `Scores`, `Traces`, and `Observations` in `IngestionService`.
>     - Affects `getClickhouseRecord` calls in `processScoreEventList`, `processTraceEventList`, and `processObservationEventList` methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 67b1feff56bec8ce002caf08741dafe2e657775e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->