### PR TITLE
fix(ui): render dataset run description and metadata on screen given table

### DIFF
--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/runs/[runId].tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/runs/[runId].tsx
@@ -1,5 +1,6 @@
 import { FullScreenPage } from "@/src/components/layouts/full-screen-page";
 import Header from "@/src/components/layouts/header";
+import { TableWithMetadataWrapper } from "@/src/components/table/TableWithMetadataWrapper";
 import { JSONView } from "@/src/components/ui/CodeJsonViewer";
 import { DatasetRunItemsTable } from "@/src/features/datasets/components/DatasetRunItemsTable";
 import { DeleteDatasetRunButton } from "@/src/features/datasets/components/DeleteDatasetRunButton";
@@ -53,19 +54,44 @@ export default function Dataset() {
           </>
         }
       />
-      <div className="flex flex-col gap-2">
-        {!!run.data?.description && (
-          <JSONView json={run.data.description} title="Description" />
-        )}
-        {!!run.data?.metadata && (
-          <JSONView json={run.data.metadata} title="Metadata" />
-        )}
-      </div>
-      <DatasetRunItemsTable
-        projectId={projectId}
-        datasetId={datasetId}
-        datasetRunId={runId}
-      />
+      {run.data?.description || run.data?.metadata ? (
+        <TableWithMetadataWrapper
+          tableComponent={
+            <DatasetRunItemsTable
+              projectId={projectId}
+              datasetId={datasetId}
+              datasetRunId={runId}
+            />
+          }
+          cardTitleChildren={
+            <span className="text-lg font-medium">Run details</span>
+          }
+          cardContentChildren={
+            <div className="grid h-full grid-cols-1 gap-2 overflow-hidden">
+              {!!run.data?.description && (
+                <JSONView
+                  json={run.data.description}
+                  title="Description"
+                  className="overflow-y-auto"
+                />
+              )}
+              {!!run.data?.metadata && (
+                <JSONView
+                  json={run.data.metadata}
+                  title="Metadata"
+                  className="overflow-y-auto"
+                />
+              )}
+            </div>
+          }
+        />
+      ) : (
+        <DatasetRunItemsTable
+          projectId={projectId}
+          datasetId={datasetId}
+          datasetRunId={runId}
+        />
+      )}
     </FullScreenPage>
   );
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Wraps `DatasetRunItemsTable` with `TableWithMetadataWrapper` to display dataset run description and metadata if available.
> 
>   - **Behavior**:
>     - Wraps `DatasetRunItemsTable` with `TableWithMetadataWrapper` in `run/[runId].tsx` to display run description and metadata if available.
>     - Displays `JSONView` for `description` and `metadata` within `TableWithMetadataWrapper`.
>   - **Components**:
>     - Adds `TableWithMetadataWrapper` import to `run/[runId].tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5e7b0e49f54d2e64fd8d03a5851a541d1e56a9e5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->