### PR TITLE
feat: build scores table for clickhouse

### DIFF
--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -194,13 +194,16 @@ export const getScoresUiCount = async (props: {
   orderBy: OrderByState;
   limit?: number;
   offset?: number;
-}) =>
-  await getScoresUiGeneric<{ count: string }>({
+}) => {
+  const rows = await getScoresUiGeneric<{ count: string }>({
     select: `
     count(*) as count
     `,
     ...props,
   });
+
+  return Number(rows[0].count);
+};
 
 export type ScoreUiTableRow = Score & {
   traceName: string | null;
@@ -330,6 +333,7 @@ export const getScoresUiGeneric = async <T>(props: {
       offset: offset,
     },
   });
+  console.log(rows);
 
   return rows;
 };

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -333,7 +333,6 @@ export const getScoresUiGeneric = async <T>(props: {
       offset: offset,
     },
   });
-  console.log(rows);
 
   return rows;
 };

--- a/packages/shared/src/tableDefinitions/index.ts
+++ b/packages/shared/src/tableDefinitions/index.ts
@@ -3,3 +3,4 @@ export * from "./types";
 export * from "./mapObservationsTable";
 export * from "./mapTracesTable";
 export * from "./mapDashboards";
+export * from "./mapScoresTable";

--- a/packages/shared/src/tableDefinitions/mapScoresTable.ts
+++ b/packages/shared/src/tableDefinitions/mapScoresTable.ts
@@ -1,0 +1,88 @@
+import { UiColumnMapping } from "./types";
+
+export const scoresTableUiColumnDefinitions: UiColumnMapping[] = [
+  {
+    uiTableName: "ID",
+    uiTableId: "id",
+    clickhouseTableName: "scores",
+    clickhouseSelect: "id",
+  },
+  {
+    uiTableName: "Timestamp",
+    uiTableId: "timestamp",
+    clickhouseTableName: "scores",
+    clickhouseSelect: "timestamp",
+  },
+  {
+    uiTableName: "Trace ID",
+    uiTableId: "traceId",
+    clickhouseTableName: "scores",
+    clickhouseSelect: "trace_id",
+  },
+  {
+    uiTableName: "Observation ID",
+    uiTableId: "observationId",
+    clickhouseTableName: "scores",
+    clickhouseSelect: "observation_id",
+  },
+  {
+    uiTableName: "Name",
+    uiTableId: "name",
+    clickhouseTableName: "scores",
+    clickhouseSelect: "name",
+  },
+  {
+    uiTableName: "Value",
+    uiTableId: "value",
+    clickhouseTableName: "scores",
+    clickhouseSelect: "value",
+  },
+  {
+    uiTableName: "Source",
+    uiTableId: "source",
+    clickhouseTableName: "scores",
+    clickhouseSelect: "source",
+  },
+  {
+    uiTableName: "Comment",
+    uiTableId: "comment",
+    clickhouseTableName: "scores",
+    clickhouseSelect: "comment",
+  },
+  {
+    uiTableName: "Author User ID",
+    uiTableId: "authorUserId",
+    clickhouseTableName: "scores",
+    clickhouseSelect: "author_user_id",
+  },
+  {
+    uiTableName: "Data Type",
+    uiTableId: "dataType",
+    clickhouseTableName: "scores",
+    clickhouseSelect: "data_type",
+  },
+  {
+    uiTableName: "String Value",
+    uiTableId: "stringValue",
+    clickhouseTableName: "scores",
+    clickhouseSelect: "string_value",
+  },
+  {
+    uiTableName: "Trace Name",
+    uiTableId: "trace_name",
+    clickhouseTableName: "traces",
+    clickhouseSelect: "t.name",
+  },
+  {
+    uiTableName: "User ID",
+    uiTableId: "user_id",
+    clickhouseTableName: "traces",
+    clickhouseSelect: "t.user_id",
+  },
+  {
+    uiTableName: "Trace Tags",
+    uiTableId: "trace_tags",
+    clickhouseTableName: "traces",
+    clickhouseSelect: "t.tags",
+  },
+];

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -27,6 +27,7 @@ import { useQueryParams, withDefault, NumberParam } from "use-query-params";
 import TagList from "@/src/features/tag/components/TagList";
 import { cn } from "@/src/utils/tailwind";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
+import { useClickhouse } from "@/src/components/layouts/ClickhouseAdminToggle";
 
 export type ScoresTableRow = {
   id: string;
@@ -131,6 +132,7 @@ export default function ScoresTable({
     page: 0,
     limit: 1,
     orderBy: null,
+    queryClickhouse: useClickhouse(),
   };
 
   const getAllPayload = {
@@ -138,6 +140,7 @@ export default function ScoresTable({
     page: paginationState.pageIndex,
     limit: paginationState.pageSize,
     orderBy: orderByState,
+    queryClickhouse: useClickhouse(),
   };
 
   const scores = api.scores.all.useQuery(getAllPayload);
@@ -151,6 +154,7 @@ export default function ScoresTable({
         dateRangeFilter[0]?.type === "datetime"
           ? dateRangeFilter[0]
           : undefined,
+      queryClickhouse: useClickhouse(),
     },
     {
       trpc: {

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -181,12 +181,12 @@ export const scoresRouter = createTRPCRouter({
           projectId: input.projectId,
           filter: input.filter ?? [],
           orderBy: input.orderBy,
-          limit: input.limit,
-          offset: input.page * input.limit,
+          limit: 1,
+          offset: 0,
         });
 
         return {
-          totalCount: clickhouseScoreData.length,
+          totalCount: clickhouseScoreData,
         };
       }
 

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -29,6 +29,8 @@ import {
   datetimeFilterToPrisma,
   datetimeFilterToPrismaSql,
   getScoresGroupedByNameSourceType,
+  getScoresUiCount,
+  getScoresUiTable,
   orderByToPrismaSql,
   tableColumnsToSqlFilterAndPrefix,
 } from "@langfuse/shared/src/server";
@@ -44,26 +46,89 @@ const ScoreFilterOptions = z.object({
 const ScoreAllOptions = ScoreFilterOptions.extend({
   ...paginationZod,
 });
+type AllScoresReturnType = Score & {
+  traceName: string | null;
+  traceUserId: string | null;
+  traceTags: Array<string> | null;
+  jobConfigurationId: string | null;
+  authorUserImage: string | null;
+  authorUserName: string | null;
+};
 
 export const scoresRouter = createTRPCRouter({
   all: protectedProjectProcedure
-    .input(ScoreAllOptions)
+    .input(
+      ScoreAllOptions.extend({ queryClickhouse: z.boolean().default(false) }),
+    )
     .query(async ({ input, ctx }) => {
+      if (input.queryClickhouse && !isClickhouseEligible(ctx.session.user)) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Clickhouse access is not enabled",
+        });
+      }
+
+      if (input.queryClickhouse) {
+        const clickhouseScoreData = await getScoresUiTable({
+          projectId: input.projectId,
+          filter: input.filter ?? [],
+          orderBy: input.orderBy,
+          limit: input.limit,
+          offset: input.page * input.limit,
+        });
+
+        const [jobExecutions, users] = await Promise.all([
+          ctx.prisma.jobExecution.findMany({
+            where: {
+              projectId: input.projectId,
+              jobOutputScoreId: {
+                in: clickhouseScoreData.map((score) => score.id),
+              },
+            },
+            select: {
+              id: true,
+              jobConfigurationId: true,
+              jobOutputScoreId: true,
+            },
+          }),
+          ctx.prisma.user.findMany({
+            where: {
+              id: {
+                in: clickhouseScoreData
+                  .map((score) => score.authorUserId)
+                  .filter((s): s is string => Boolean(s)),
+              },
+            },
+            select: {
+              id: true,
+              name: true,
+              image: true,
+            },
+          }),
+        ]);
+
+        return {
+          scores: clickhouseScoreData.map<AllScoresReturnType>((score) => {
+            const jobExecution = jobExecutions.find(
+              (je) => je.jobOutputScoreId === score.id,
+            );
+
+            const user = users.find((u) => u.id === score.authorUserId);
+
+            return {
+              ...score,
+              jobConfigurationId: jobExecution?.jobConfigurationId ?? null,
+              authorUserImage: user?.image ?? null,
+              authorUserName: user?.name ?? null,
+            };
+          }),
+        };
+      }
+
       const { filterCondition, orderByCondition } =
         parseScoresGetAllOptions(input);
 
-      const scores = await ctx.prisma.$queryRaw<
-        Array<
-          Score & {
-            traceName: string | null;
-            traceUserId: string | null;
-            traceTags: Array<string> | null;
-            jobConfigurationId: string | null;
-            authorUserImage: string | null;
-            authorUserName: string | null;
-          }
-        >
-      >(
+      const scores = await ctx.prisma.$queryRaw<Array<AllScoresReturnType>>(
         generateScoresQuery(
           Prisma.sql` 
           s.id,
@@ -98,8 +163,31 @@ export const scoresRouter = createTRPCRouter({
       };
     }),
   countAll: protectedProjectProcedure
-    .input(ScoreAllOptions)
+    .input(
+      ScoreAllOptions.extend({ queryClickhouse: z.boolean().default(false) }),
+    )
     .query(async ({ input, ctx }) => {
+      if (input.queryClickhouse && !isClickhouseEligible(ctx.session.user)) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Clickhouse access is not enabled",
+        });
+      }
+
+      if (input.queryClickhouse) {
+        const clickhouseScoreData = await getScoresUiCount({
+          projectId: input.projectId,
+          filter: input.filter ?? [],
+          orderBy: input.orderBy,
+          limit: input.limit,
+          offset: input.page * input.limit,
+        });
+
+        return {
+          totalCount: clickhouseScoreData.length,
+        };
+      }
+
       const { filterCondition } = parseScoresGetAllOptions(input);
 
       const scoresCount = await ctx.prisma.$queryRaw<
@@ -126,6 +214,7 @@ export const scoresRouter = createTRPCRouter({
       z.object({
         projectId: z.string(),
         timestampFilter: timeFilter.optional(),
+        queryClickhouse: z.boolean().default(false),
       }),
     )
     .query(async ({ input, ctx }) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for building and querying a scores table in Clickhouse with backend and frontend updates.
> 
>   - **Backend**:
>     - Add `getScoresUiTable`, `getScoresUiCount`, and `getScoresUiGeneric` in `scores.ts` for Clickhouse queries.
>     - Update `scoresRouter` in `routers/scores.ts` to handle `queryClickhouse` flag.
>     - Add `mapScoresTable.ts` with `scoresTableUiColumnDefinitions` for Clickhouse mapping.
>   - **Frontend**:
>     - Update `ScoresTable` in `scores.tsx` to use Clickhouse data with `useClickhouse` hook.
>     - Modify API calls in `scores.tsx` to include `queryClickhouse` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a9b9873c315fe93c880fe9cfbed970b49fc28810. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->