### PR TITLE
chore: include backgroundmigration state default in schema.prisma

### DIFF
--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -166,7 +166,7 @@ model BackgroundMigration {
   name         String    @unique
   script       String    @map("script")
   args         Json      @map("args")
-  state        Json      @map("state")
+  state        Json      @default("{}") @map("state")
   finishedAt   DateTime? @map("finished_at")
   failedAt     DateTime? @map("failed_at")
   failedReason String?   @map("failed_reason")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set default value for `state` field in `BackgroundMigration` model to an empty JSON object in `schema.prisma`.
> 
>   - **Schema Changes**:
>     - In `schema.prisma`, set default value for `state` field in `BackgroundMigration` model to an empty JSON object (`{}`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for dd51886bb1b0da4f9f18106735435762b8f955dd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->