### PR TITLE
chore: convert starttime filter to DateTime in Ingestion pipeline

### DIFF
--- a/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.unit.test.ts
@@ -16,4 +16,14 @@ describe("IngestionService unit tests", () => {
     expect(sortedEventList).toEqual([firstTrace, secondTrace, thirdTrace]);
     expect(sortedEventList).not.toBe(records); // Ensure that the original array is not mutated
   });
+
+  it("correctly convert Date to Clickhouse DateTime", async () => {
+    const date = new Date("2024-10-12T12:13:14.000Z");
+
+    const clickhouseDateTime = (
+      IngestionService as any
+    ).convertDateToClickhouseDateTime(date);
+
+    expect(clickhouseDateTime).toEqual("2024-10-12 12:13:14");
+  });
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Convert timestamps to Clickhouse DateTime format in `IngestionService` and update related SQL queries.
> 
>   - **Behavior**:
>     - Convert `minTimestamp` and `minStartTime` to Clickhouse DateTime format using `convertDateToClickhouseDateTime()` in `IngestionService`.
>     - Remove `- INTERVAL 1 DAY` from SQL `whereCondition` for `timestamp` and `start_time` filters in `IngestionService`.
>   - **Functions**:
>     - Add `convertDateToClickhouseDateTime()` to `IngestionService` to format JavaScript dates to Clickhouse DateTime.
>   - **Tests**:
>     - Add unit test for `convertDateToClickhouseDateTime()` in `IngestionService.unit.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3272701e30ce06e201209aae80299a8566c3a3eb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->