### PR TITLE
fix: pagination for clickhouse tables

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -68,8 +68,8 @@ export const getTracesTableCount = async (
   orderBy?: OrderByState,
   limit?: number,
   offset?: number,
-) =>
-  getTracesTableGeneric<TableCount>({
+) => {
+  const countRows = await getTracesTableGeneric<{ count: string }>({
     select: "count(*) as count",
     projectId,
     filter,
@@ -77,6 +77,13 @@ export const getTracesTableCount = async (
     limit,
     offset,
   });
+
+  const converted = countRows.map((row) => ({
+    count: Number(row.count),
+  }));
+
+  return converted.length > 0 ? converted[0].count : 0;
+};
 
 export const getTracesTable = async (
   projectId: string,

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -254,8 +254,6 @@ export const traceRouter = createTRPCRouter({
           0,
         );
 
-        console.log("countQuery", countQuery);
-
         return {
           totalCount: countQuery,
         };

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -250,12 +250,14 @@ export const traceRouter = createTRPCRouter({
           ctx.session.projectId,
           input.filter ?? [],
           null,
-          input.limit,
-          input.page,
+          1,
+          0,
         );
 
+        console.log("countQuery", countQuery);
+
         return {
-          totalCount: countQuery.shift()?.count,
+          totalCount: countQuery,
         };
       }
     }),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes pagination issue in Clickhouse tables by converting count to number and updating `traceRouter` usage.
> 
>   - **Behavior**:
>     - Fixes pagination issue in `getTracesTableCount` in `traces.ts` by converting count from string to number.
>     - Updates `traceRouter` in `traces.ts` to use `getTracesTableCount` with fixed pagination parameters.
>   - **Logging**:
>     - Adds console log for `countQuery` in `traceRouter` in `traces.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8d9a5bb9ab35718074f8faade0391ce261331b35. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->