### PR TITLE
chore: swap negative provided usage for null

### DIFF
--- a/packages/shared/src/server/repositories/definitions.ts
+++ b/packages/shared/src/server/repositories/definitions.ts
@@ -279,9 +279,12 @@ export const convertPostgresObservationToInsert = (
       : null,
     provided_usage_details: {},
     usage_details: {
-      input: observation.prompt_tokens,
-      output: observation.completion_tokens,
-      total: observation.total_tokens,
+      input: observation.prompt_tokens >= 0 ? observation.prompt_tokens : null,
+      output:
+        observation.completion_tokens >= 0
+          ? observation.completion_tokens
+          : null,
+      total: observation.total_tokens >= 0 ? observation.total_tokens : null,
     },
     provided_cost_details: {
       input: observation.input_cost?.toNumber() ?? null,

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -27,8 +27,6 @@ describe("Ingestion end-to-end tests", () => {
   let ingestionService: IngestionService;
   let clickhouseWriter: ClickhouseWriter;
 
-  const mockIngestionFlushQueue = vi.fn() as any;
-
   beforeEach(async () => {
     if (!redis) throw new Error("Redis not initialized");
     await pruneDatabase();
@@ -1109,6 +1107,141 @@ describe("Ingestion end-to-end tests", () => {
     expect(observation.model_parameters).toBe('{"hello":"world"}');
     expect(observation.usage_details.output).toBe(5);
     expect(observation.project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+  });
+
+  it("should merge observations and set negative tokens and cost to null", async () => {
+    await prisma.model.create({
+      data: {
+        id: "clyrjpbe20000t0mzcbwc42rg",
+        modelName: "gpt-4o-mini-2024-07-18",
+        matchPattern: "(?i)^(gpt-4o-mini-2024-07-18)$",
+        startDate: new Date("2021-01-01T00:00:00.000Z"),
+        unit: ModelUsageUnit.Tokens,
+        tokenizerId: "openai",
+        inputPrice: 0.00000015,
+        outputPrice: 0.0000006,
+        tokenizerConfig: {
+          tokensPerName: 1,
+          tokenizerModel: "gpt-4o",
+          tokensPerMessage: 3,
+        },
+      },
+    });
+
+    await prisma.price.create({
+      data: {
+        id: "cm2uio8ef006mh6qlzc2mqa0e",
+        modelId: "clyrjpbe20000t0mzcbwc42rg",
+        price: 0.00000015,
+        usageType: "input",
+      },
+    });
+
+    await prisma.price.create({
+      data: {
+        id: "cm2uio8ef006oh6qlldn36376",
+        modelId: "clyrjpbe20000t0mzcbwc42rg",
+        price: 0.0000006,
+        usageType: "output",
+      },
+    });
+
+    await prisma.observation.create({
+      data: {
+        id: "c8d30f61-4097-407f-a337-5fb1e0c100f2",
+        name: "extract_location",
+        startTime: "2024-11-04T16:13:51.495868Z",
+        endTime: "2024-11-04T16:13:52.156248Z",
+        type: "GENERATION",
+        traceId: "82c480bc-1c4e-4ba8-a153-0bd9f9e1a28e",
+        internalModel: "gpt-4o-mini-2024-07-18",
+        internalModelId: "clyrjpbe20000t0mzcbwc42rg",
+        modelParameters: {
+          temperature: "0.4",
+          max_tokens: 1000,
+        },
+        input: "Sample input",
+        output: "Sample output",
+        projectId,
+        completionTokens: -7,
+        promptTokens: 4,
+        totalTokens: -3,
+      },
+    });
+
+    const observationId = "c8d30f61-4097-407f-a337-5fb1e0c100f2";
+    const observationEventList: ObservationEvent[] = [
+      {
+        id: "084274e5-f15e-4f66-8419-a171808d8180",
+        timestamp: "2024-11-04T16:13:51.496457Z",
+        type: "generation-create",
+        body: {
+          traceId: "82c480bc-1c4e-4ba8-a153-0bd9f9e1a28e",
+          name: "extract_location",
+          startTime: "2024-11-04T16:13:51.495868Z",
+          metadata: {
+            ls_provider: "openai",
+            ls_model_name: "gpt-4o-mini-2024-07-18",
+            ls_model_type: "chat",
+            ls_temperature: 0.4,
+            ls_max_tokens: 1000,
+          },
+          input: "Sample input",
+          id: "c8d30f61-4097-407f-a337-5fb1e0c100f2",
+          model: "gpt-4o-mini-2024-07-18",
+          modelParameters: {
+            temperature: "0.4",
+            max_tokens: 1000,
+          },
+          usage: null,
+        },
+      },
+      {
+        id: "ef654262-b1d0-4b0b-9e4a-2a410e0577a6",
+        timestamp: "2024-11-04T16:13:52.156691Z",
+        type: "generation-update",
+        body: {
+          traceId: "82c480bc-1c4e-4ba8-a153-0bd9f9e1a28e",
+          output: "Sample output",
+          id: "c8d30f61-4097-407f-a337-5fb1e0c100f2",
+          endTime: "2024-11-04T16:13:52.156248Z",
+          model: "gpt-4o-mini-2024-07-18",
+          usage: {
+            input: 4,
+            output: -7,
+            total: -3,
+            unit: "TOKENS",
+          },
+        },
+      },
+    ];
+
+    await ingestionService.processObservationEventList({
+      projectId,
+      entityId: observationId,
+      observationEventList,
+    });
+
+    await clickhouseWriter.flushAll(true);
+
+    const observation = await getClickhouseRecord(
+      TableName.Observations,
+      observationId,
+    );
+
+    expect(observation.name).toBe("extract_location");
+    expect(observation.provided_usage_details).toStrictEqual({
+      input: 4,
+    });
+    expect(observation.usage_details).toStrictEqual({
+      input: 4,
+    });
+    expect(observation.provided_cost_details).toStrictEqual({});
+    expect(observation.cost_details).toStrictEqual({
+      input: 0.0000006,
+      total: 0.0000006,
+    });
+    expect(observation.total_cost).toBe(0.0000006);
   });
 
   it("should merge observations and calculate cost", async () => {


### PR DESCRIPTION
## What

If users provide negative usage, it fails to be upserted into Clickhouse. As those values don't make sense, we swap them for `null` values and ignore them going forward.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace negative usage values with nulls to prevent Clickhouse upsert failures, updating conversion and ingestion logic with tests verifying the change.
> 
>   - **Behavior**:
>     - Replace negative usage values with `null` in `convertPostgresObservationToInsert()` in `definitions.ts`.
>     - Update `getUsageUnits()` in `IngestionService` to filter out negative values from `provided_usage_details`.
>   - **Tests**:
>     - Add test `should merge observations and set negative tokens and cost to null` in `IngestionService.integration.test.ts` to verify behavior.
>     - Ensure tests cover scenarios with negative values in usage and cost details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 382185dbdbb356de5153433e00e09ac1d4d09985. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->