### PR TITLE
chore: add stateSuffix to observation migration for potential parallelization

### DIFF
--- a/packages/shared/prisma/generated/types.ts
+++ b/packages/shared/prisma/generated/types.ts
@@ -148,7 +148,7 @@ export type BackgroundMigration = {
     name: string;
     script: string;
     args: unknown;
-    state: unknown;
+    state: Generated<unknown>;
     finished_at: Timestamp | null;
     failed_at: Timestamp | null;
     failed_reason: string | null;

--- a/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
@@ -46,7 +46,7 @@ export default class MigrateObservationsFromPostgresToClickhouse
     const maxRowsToProcess = Number(args.maxRowsToProcess ?? Infinity);
     const batchSize = Number(args.batchSize ?? 5000);
     const maxDate = initialMigrationState.state?.[`maxDate${stateSuffix}`]
-      ? new Date(initialMigrationState.state[`maxDate${stateSuffix}`])
+      ? new Date(initialMigrationState.state[`maxDate${stateSuffix}`] as string)
       : new Date((args.maxDate as string) ?? new Date());
 
     await prisma.backgroundMigration.update({

--- a/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
@@ -46,7 +46,7 @@ export default class MigrateObservationsFromPostgresToClickhouse
     const maxRowsToProcess = Number(args.maxRowsToProcess ?? Infinity);
     const batchSize = Number(args.batchSize ?? 5000);
     const maxDate = initialMigrationState.state?.[`maxDate${stateSuffix}`]
-      ? new Date(initialMigrationState.state[`maxDate${stateSuffix}`] as string)
+      ? new Date(initialMigrationState.state[`maxDate${stateSuffix}`])
       : new Date((args.maxDate as string) ?? new Date());
 
     await prisma.backgroundMigration.update({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `stateSuffix` to migration script for parallel runs and update `BackgroundMigration` state type.
> 
>   - **Behavior**:
>     - Add `stateSuffix` to `migrateObservationsFromPostgresToClickhouse.ts` for parallel migrations by appending to `maxDate` state key.
>     - Update `state` field in `BackgroundMigration` type in `types.ts` to `Generated<unknown>`.
>   - **Migration Logic**:
>     - Modify `run()` in `MigrateObservationsFromPostgresToClickhouse` to use `stateSuffix` for `maxDate` key.
>     - Add `stateSuffix` argument in `main()` function for unique migration runs.
>   - **Misc**:
>     - Update comments in `migrateObservationsFromPostgresToClickhouse.ts` to explain `stateSuffix` usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4ece3caa63e67f3ac12fc819926401b207b62c69. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->