### PR TITLE
perf: add sessions index in clickhouse

### DIFF
--- a/packages/shared/clickhouse/migrations/0005_add_session_id_index.down.sql
+++ b/packages/shared/clickhouse/migrations/0005_add_session_id_index.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE traces DROP INDEX IF EXISTS idx_session_id;

--- a/packages/shared/clickhouse/migrations/0005_add_session_id_index.up.sql
+++ b/packages/shared/clickhouse/migrations/0005_add_session_id_index.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE traces ADD INDEX IF NOT EXISTS idx_session_id session_id TYPE bloom_filter() GRANULARITY 1;
+ALTER TABLE traces MATERIALIZE INDEX IF EXISTS idx_session_id;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add and remove `idx_session_id` index in ClickHouse `traces` table for performance improvement.
> 
>   - **Migrations**:
>     - Add `idx_session_id` index to `traces` table in ClickHouse using a bloom filter with granularity 1 in `0005_add_session_id_index.up.sql`.
>     - Materialize the `idx_session_id` index in `0005_add_session_id_index.up.sql`.
>     - Drop `idx_session_id` index if it exists in `0005_add_session_id_index.down.sql`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0abbd81234b906e064bebd4d8b9764e6f083a6dc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->