### PR TITLE
feat: delete traces from clickhouse from the UI

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1,4 +1,5 @@
 import {
+  commandClickhouse,
   parseClickhouseUTCDateTimeFormat,
   queryClickhouse,
 } from "./clickhouse";
@@ -741,4 +742,22 @@ export const getCostForTraces = async (
     },
   });
   return res.length > 0 ? Number(res[0].total_cost) : undefined;
+};
+
+export const deleteObservationsByTraceIds = async (
+  projectId: string,
+  traceIds: string[],
+) => {
+  const query = `
+    DELETE FROM observations
+    WHERE project_id = {projectId: String}
+    AND trace_id IN ({traceIds: Array(String)});
+  `;
+  await commandClickhouse({
+    query: query,
+    params: {
+      projectId,
+      traceIds,
+    },
+  });
 };

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -473,3 +473,21 @@ export const deleteScore = async (projectId: string, scoreId: string) => {
     },
   });
 };
+
+export const deleteScoresByTraceIds = async (
+  projectId: string,
+  traceIds: string[],
+) => {
+  const query = `
+    DELETE FROM scores
+    WHERE project_id = {projectId: String}
+    AND trace_id IN ({traceIds: Array(String)});
+  `;
+  await commandClickhouse({
+    query: query,
+    params: {
+      projectId,
+      traceIds,
+    },
+  });
+};

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -1,4 +1,5 @@
 import {
+  commandClickhouse,
   parseClickhouseUTCDateTimeFormat,
   queryClickhouse,
 } from "./clickhouse";
@@ -629,4 +630,19 @@ export const getTracesForSession = async (
     name: row.name,
     timestamp: parseClickhouseUTCDateTimeFormat(row.timestamp),
   }));
+};
+
+export const deleteTraces = async (projectId: string, traceIds: string[]) => {
+  const query = `
+    DELETE FROM traces
+    WHERE project_id = {projectId: String}
+    AND id IN ({traceIds: Array(String)});
+  `;
+  await commandClickhouse({
+    query: query,
+    params: {
+      projectId,
+      traceIds,
+    },
+  });
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds functionality to delete traces, observations, and scores from Clickhouse via the UI, with conditional execution based on Clickhouse URL presence.
> 
>   - **Behavior**:
>     - Adds `deleteTraces`, `deleteObservationsByTraceIds`, and `deleteScoresByTraceIds` functions to delete data from Clickhouse tables `traces`, `observations`, and `scores` respectively.
>     - Updates `deleteMany` mutation in `traces.ts` to call these functions if `CLICKHOUSE_URL` is set.
>   - **Functions**:
>     - `deleteObservationsByTraceIds` in `observations.ts` deletes observations by `traceIds`.
>     - `deleteScoresByTraceIds` in `scores.ts` deletes scores by `traceIds`.
>     - `deleteTraces` in `traces.ts` deletes traces by `traceIds`.
>   - **Misc**:
>     - Imports `deleteTraces`, `deleteScoresByTraceIds`, and `deleteObservationsByTraceIds` in `traces.ts` router.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b551a14066629baff99692602fe9ed01de488760. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->