### PR TITLE
fix: fix latency calculations when reading from clickhouse

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -324,8 +324,8 @@ export const getObservationsTable = async (
         o.total_cost as "total_cost",
         internal_model_id as "internal_model_id",
         provided_model_name as "provided_model_name",
-        if(isNull(end_time), NULL, date_diff('seconds', start_time, end_time)) as latency,
-        if(isNull(completion_start_time), NULL,  date_diff('seconds', start_time, completion_start_time)) as "time_to_first_token"`,
+        if(isNull(end_time), NULL, date_diff('milliseconds', start_time, end_time)) as latency,
+        if(isNull(completion_start_time), NULL,  date_diff('milliseconds', start_time, completion_start_time)) as "time_to_first_token"`,
   });
 
   const uniqueModels: string[] = Array.from(
@@ -396,9 +396,9 @@ export const getObservationsTable = async (
       completionStartTime: o.completion_start_time
         ? parseClickhouseUTCDateTimeFormat(o.completion_start_time)
         : null,
-      latency: o.latency ? Number(o.latency) : null,
+      latency: o.latency ? Number(o.latency) / 1000 : null,
       timeToFirstToken: o.time_to_first_token
-        ? Number(o.time_to_first_token)
+        ? Number(o.time_to_first_token) / 1000
         : null,
       promptId: o.prompt_id ?? null,
       promptName: o.prompt_name ?? null,

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -60,7 +60,7 @@ export type TracesTableReturnType = Pick<
 > & {
   level: ObservationLevel;
   observation_count: number | null;
-  latency: string | null;
+  latency_milliseconds: string | null;
   usage_details: Record<string, number>;
   cost_details: Record<string, number>;
   scores_avg: Array<{ name: string; avg_value: number }>;
@@ -108,7 +108,7 @@ export const getTracesTable = async (
     t.version, 
     t.user_id, 
     t.session_id,
-    os.latencyMs as latency,
+    os.latency_milliseconds,
     os.cost_details as cost_details,
     os.usage_details as usage_details,
     os.level as level,
@@ -184,7 +184,7 @@ const getTracesTableGeneric = async <T>(props: FetchTracesTableProps) => {
     COUNT(*) AS observation_count,
       sumMap(usage_details) as usage_details,
       SUM(total_cost) AS total_cost,
-      date_diff('seconds', least(min(start_time), min(end_time)), greatest(max(start_time), max(end_time))) as latencyMs,
+      date_diff('milliseconds', least(min(start_time), min(end_time)), greatest(max(start_time), max(end_time))) as latency_milliseconds,
       multiIf(
         arrayExists(x -> x = 'ERROR', groupArray(level)), 'ERROR',
         arrayExists(x -> x = 'WARNING', groupArray(level)), 'WARNING',
@@ -547,7 +547,7 @@ const getSessionsTableGeneric = async <T>(props: FetchTracesTableProps) => {
             groupUniqArrayArray(t.tags) as trace_tags,
             -- Aggregate observations data at session level
             sum(o.obs_count) as total_observations,
-            date_diff('seconds', min(min_start_time), max(max_end_time)) as duration,
+            date_diff('milliseconds', min(min_start_time), max(max_end_time)) as duration,
             sumMap(o.sum_usage_details) as session_usage_details,
             sumMap(o.sum_cost_details) as session_cost_details,
             sumMap(o.sum_cost_details)['input'] as session_input_cost,

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -83,7 +83,7 @@ export const sessionRouter = createTRPCRouter({
               id: s.session_id,
               userIds: s.user_ids,
               countTraces: s.trace_ids.length,
-              sessionDuration: Number(s.duration),
+              sessionDuration: Number(s.duration) / 1000,
               inputCost: new Decimal(s.session_input_cost),
               outputCost: new Decimal(s.session_output_cost),
               totalCost: new Decimal(s.session_total_cost),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix latency calculations by switching from seconds to milliseconds across multiple files, ensuring precise measurements.
> 
>   - **Behavior**:
>     - Change latency calculation from seconds to milliseconds in `getObservationsTable` and `getTracesTable` functions.
>     - Update `latency` and `time_to_first_token` fields to use milliseconds in `observations.ts`.
>     - Adjust `sessionDuration` and `latency` calculations to divide by 1000 for conversion to seconds in `sessions.ts` and `traces.ts`.
>   - **Refactoring**:
>     - Rename `latency` to `latency_milliseconds` in `TracesTableReturnType` in `traces.ts`.
>     - Update SQL queries to use `date_diff('milliseconds', ...)` for latency calculations in `observations.ts` and `traces.ts`.
>   - **Misc**:
>     - Add Clickhouse deletion logic for traces, observations, and scores in `traces.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5d122778440b9e5d1103fea41ce3eb509ebbe8ef. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->