### PR TITLE
feat: add table search for clickhouse

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/search.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/search.ts
@@ -1,0 +1,20 @@
+const regexIndefiniteCharacters = "%";
+
+export const clickhouseSearchCondition = (query?: string) => {
+  return {
+    query: query
+      ? `
+    AND (
+      id ILIKE {searchString: String} OR 
+      user_id ILIKE {searchString: String} OR 
+      name ILIKE {searchString: String}
+    )
+  `
+      : "",
+    params: query
+      ? {
+          searchString: `${regexIndefiniteCharacters}${query}${regexIndefiniteCharacters}`,
+        }
+      : {},
+  };
+};

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -25,7 +25,6 @@ import {
   convertObservationToView,
   convertObservation,
 } from "./observations_converters";
-import { cli } from "winston/lib/winston/config";
 import { clickhouseSearchCondition } from "../queries/clickhouse-sql/search";
 
 export const getObservationsViewForTrace = async (

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -25,6 +25,8 @@ import {
   convertObservationToView,
   convertObservation,
 } from "./observations_converters";
+import { cli } from "winston/lib/winston/config";
+import { clickhouseSearchCondition } from "../queries/clickhouse-sql/search";
 
 export const getObservationsViewForTrace = async (
   traceId: string,
@@ -136,6 +138,7 @@ export type ObservationTableQuery = {
   projectId: string;
   filter: FilterState;
   orderBy?: OrderByState;
+  searchQuery?: string;
   limit?: number;
   offset?: number;
   selectIOAndMetadata?: boolean;
@@ -326,6 +329,8 @@ const getObservationsTableInternal = async <T>(
   const appliedScoresFilter = scoresFilter.apply();
   const appliedObservationsFilter = observationsFilter.apply();
 
+  const search = clickhouseSearchCondition(opts.searchQuery);
+
   const scoresCte = `WITH scores_avg AS (
     SELECT
       trace_id,
@@ -367,6 +372,7 @@ const getObservationsTableInternal = async <T>(
         LEFT JOIN scores_avg AS s_avg ON s_avg.trace_id = o.trace_id and s_avg.observation_id = o.id
       WHERE ${appliedObservationsFilter.query}
         ${timeFilter ? `AND t.timestamp > {tracesTimestampFilter: DateTime64} - INTERVAL 2 DAY` : ""}
+        ${search.query}
       ${orderByToClickhouseSql(orderBy ?? null, observationsTableUiColumnDefinitions)}
       ${limit !== undefined && offset !== undefined ? `LIMIT ${limit} OFFSET ${offset}` : ""};`;
 
@@ -382,6 +388,7 @@ const getObservationsTableInternal = async <T>(
               ),
             }
           : {}),
+        ...search.params,
       },
     });
 

--- a/web/src/server/api/routers/generations/db/getAllGenerationsSqlQuery.ts
+++ b/web/src/server/api/routers/generations/db/getAllGenerationsSqlQuery.ts
@@ -31,6 +31,7 @@ export async function getAllGenerations({
       projectId: input.projectId,
       filter: input.filter,
       orderBy: input.orderBy,
+      searchQuery: input.searchQuery ?? undefined,
       selectIOAndMetadata: selectIOAndMetadata,
       offset: input.page * input.limit,
       limit: input.limit,

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -135,6 +135,7 @@ export const traceRouter = createTRPCRouter({
         const res = await getTracesTable(
           ctx.session.projectId,
           input.filter ?? [],
+          input.searchQuery ?? undefined,
           input.orderBy,
           input.limit,
           input.page,
@@ -180,13 +181,13 @@ export const traceRouter = createTRPCRouter({
           });
         }
 
-        const countQuery = await getTracesTableCount(
-          ctx.session.projectId,
-          input.filter ?? [],
-          null,
-          1,
-          0,
-        );
+        const countQuery = await getTracesTableCount({
+          projectId: ctx.session.projectId,
+          filter: input.filter ?? [],
+          searchQuery: input.searchQuery ?? undefined,
+          limit: 1,
+          offset: 0,
+        });
 
         return {
           totalCount: countQuery,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds search functionality for Clickhouse tables, enabling search by `id`, `user_id`, and `name`, and integrates it into existing query functions.
> 
>   - **Search Functionality**:
>     - Adds `clickhouseSearchCondition` in `search.ts` for searching by `id`, `user_id`, and `name` using ILIKE.
>     - Integrates search condition into `getObservationsTableInternal` in `observations.ts` and `getTracesTableGeneric` in `traces.ts`.
>   - **API Enhancements**:
>     - Updates `getAllGenerations` in `getAllGenerationsSqlQuery.ts` to include `searchQuery`.
>     - Modifies `traceRouter` in `traces.ts` to handle `searchQuery` for fetching and counting traces.
>   - **Miscellaneous**:
>     - Refactors `getTracesTableCount` and `getTracesTable` in `traces.ts` to accept a `searchQuery` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f1b8d2057a92e9d76a1caf15c06ab827908b9209. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->