### PR TITLE
feat: add user charts

### DIFF
--- a/packages/shared/scripts/load-seed.ts
+++ b/packages/shared/scripts/load-seed.ts
@@ -13,7 +13,7 @@ const createRandomProjectId = () => randomUUID().toString();
 
 const prepareProjectsAndApiKeys = async (
   numOfProjects: number,
-  opts: { requiredProjectIds: string[] }
+  opts: { requiredProjectIds: string[] },
 ) => {
   const { requiredProjectIds } = opts;
   const projectsToCreate = numOfProjects - requiredProjectIds.length;
@@ -51,7 +51,7 @@ const prepareProjectsAndApiKeys = async (
     });
     if (!apiKeyExists) {
       const sk = await hashSecretKey(
-        `sk-${Math.random().toString(36).substr(2, 9)}`
+        `sk-${Math.random().toString(36).substr(2, 9)}`,
       );
       await prisma.apiKey.create({
         data: {
@@ -75,33 +75,38 @@ const prepareProjectsAndApiKeys = async (
 };
 
 async function main() {
-  let numOfProjects = parseInt(process.argv[2], 10);
-  let numberOfDays = parseInt(process.argv[3], 10);
-  let totalObservations = parseInt(process.argv[4], 10);
+  let numOfProjects = parseInt(process.argv[3], 10);
+  let numberOfDays = parseInt(process.argv[4], 10);
+  let totalObservations = parseInt(process.argv[5], 10);
+
+  logger.info(process.argv);
+  logger.info(
+    `Preparing Clickhouse for ${numOfProjects} projects and ${numberOfDays} days with max Observations ${totalObservations}.`,
+  );
 
   if (isNaN(totalObservations)) {
     logger.warn(
-      "Total observations not provided or invalid. Defaulting to 1000 observations."
+      "Total observations not provided or invalid. Defaulting to 1000 observations.",
     );
     totalObservations = 1000;
   }
 
   if (isNaN(numOfProjects)) {
     logger.warn(
-      "Number of projects not provided or invalid. Defaulting to 10 projects."
+      "Number of projects not provided or invalid. Defaulting to 10 projects.",
     );
     numOfProjects = 10;
   }
 
   if (isNaN(numberOfDays)) {
     logger.warn(
-      "Number of days not provided or invalid. Defaulting to 3 days."
+      "Number of days not provided or invalid. Defaulting to 3 days.",
     );
     numberOfDays = 3;
   }
 
   logger.info(
-    `Preparing Clickhouse for ${numOfProjects} projects and ${numberOfDays} days with max Observations ${totalObservations}.`
+    `Preparing Clickhouse for ${numOfProjects} projects and ${numberOfDays} days with max Observations ${totalObservations}.`,
   );
 
   try {

--- a/packages/shared/scripts/prepareClickhouse.ts
+++ b/packages/shared/scripts/prepareClickhouse.ts
@@ -61,7 +61,7 @@ export const prepareClickhouse = async (
     SELECT toString(number) AS id,
       toDateTime(now() - randUniform(0, ${opts.numberOfDays} * 24 * 60 * 60)) AS timestamp,
       concat('name_', toString(rand() % 100)) AS name,
-      concat('user_id_', toString(randUniform(0, 100))) AS user_id,
+      concat('user_id_', toInt64(randExponential(1 / 100))) AS user_id,
       map('key', 'value') AS metadata,
       concat('release_', toString(randUniform(0, 100))) AS release,
       concat('version_', toString(randUniform(0, 100))) AS version,

--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -1,7 +1,10 @@
 import { queryClickhouse } from "./clickhouse";
 import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
 import { FilterState } from "../../types";
-import { FilterList } from "../queries/clickhouse-sql/clickhouse-filter";
+import {
+  DateTimeFilter,
+  FilterList,
+} from "../queries/clickhouse-sql/clickhouse-filter";
 import { dashboardColumnDefinitions } from "../../tableDefinitions/mapDashboards";
 
 export type DateTrunc = "year" | "month" | "week" | "day" | "hour" | "minute";
@@ -225,6 +228,57 @@ export const getDistinctModels = async (
   });
 
   return result;
+};
+
+export const getModelUsageByUser = async (
+  projectId: string,
+  filter: FilterState,
+) => {
+  const chFilter = new FilterList(
+    createFilterFromFilterState(filter, dashboardColumnDefinitions),
+  );
+
+  const appliedFilter = chFilter.apply();
+
+  const timeFilter = chFilter.find(
+    (f) =>
+      f.clickhouseTable === "observations" &&
+      f.field === "start_time" &&
+      (f.operator === ">=" || f.operator === ">"),
+  ) as DateTimeFilter | undefined;
+
+  const query = `
+    SELECT 
+      sumMap(usage_details)['total'] as sum_usage_details,
+      sumMap(cost_details)['total'] as sum_cost_details,
+      user_id
+    FROM observations o FINAL
+      JOIN traces t ON o.trace_id = t.id AND o.project_id = t.project_id
+    WHERE project_id = {projectId: String}
+    AND t.user_id IS NOT NULL
+    AND ${appliedFilter.query}
+    ${timeFilter ? `AND t.timestamp >= {tractTimestamp: DateTime} - INTERVAL 1 HOUR` : ""}
+    GROUP BY user_id
+    `;
+
+  const result = await queryClickhouse<{
+    sum_usage_details: string;
+    sum_cost_details: number;
+    user_id: string;
+  }>({
+    query,
+    params: {
+      projectId,
+      ...appliedFilter.params,
+      ...(timeFilter ? { tractTimestamp: timeFilter.value } : {}),
+    },
+  });
+
+  return result.map((row) => ({
+    sumUsageDetails: Number(row.sum_usage_details),
+    sumCostDetails: Number(row.sum_cost_details),
+    userId: row.user_id,
+  }));
 };
 
 const orderByTimeSeries = (dateTrunc: DateTrunc, col: string) => {

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -334,6 +334,45 @@ export const getTracesGroupedByName = async (
   return rows;
 };
 
+export const getTracesGroupedByUsers = async (
+  projectId: string,
+  filter: FilterState,
+  columns?: UiColumnMapping[],
+) => {
+  const chFilter = createFilterFromFilterState(
+    filter,
+    columns ?? tracesTableUiColumnDefinitions,
+  );
+
+  const filterRes = new FilterList(chFilter).apply();
+
+  const query = `
+      select 
+        user_id as user,
+        count(*) as count
+      from traces t final
+      WHERE t.project_id = {projectId: String}
+      AND t.user_id IS NOT NULL
+      ${filterRes?.query ? `AND ${filterRes.query}` : ""}
+      GROUP BY user
+      ORDER BY count desc
+      LIMIT 1000;
+    `;
+
+  const rows = await queryClickhouse<{
+    user: string;
+    count: string;
+  }>({
+    query: query,
+    params: {
+      projectId: projectId,
+      ...(filterRes ? filterRes.params : {}),
+    },
+  });
+
+  return rows;
+};
+
 export type GroupedTracesQueryProp = {
   projectId: string;
   filter: FilterState;

--- a/web/src/features/dashboard/components/UserChart.tsx
+++ b/web/src/features/dashboard/components/UserChart.tsx
@@ -14,6 +14,7 @@ import {
 import { env } from "@/src/env.mjs";
 import { type DashboardDateRangeAggregationOption } from "@/src/utils/date-range-utils";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
+import { useClickhouse } from "@/src/components/layouts/ClickhouseAdminToggle";
 
 type BarChartDataPoint = {
   name: string;
@@ -60,6 +61,8 @@ export const UserChart = ({
       orderBy: [
         { column: "calculatedTotalCost", direction: "DESC", agg: "SUM" },
       ],
+      queryClickhouse: useClickhouse(),
+      queryName: "observations-usage-by-users",
     },
     {
       trpc: {
@@ -83,6 +86,8 @@ export const UserChart = ({
         },
       ],
       orderBy: [{ column: "traceId", agg: "COUNT", direction: "DESC" }],
+      queryClickhouse: useClickhouse(),
+      queryName: "traces-grouped-by-user",
     },
     {
       trpc: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add user charts by implementing new queries and functions to fetch and display user-related data from Clickhouse.
> 
>   - **Behavior**:
>     - Add `getModelUsageByUser` and `getTracesGroupedByUsers` functions in `dashboards.ts` and `traces.ts` to fetch user-related data.
>     - Update `UserChart.tsx` to use new queries `observations-usage-by-users` and `traces-grouped-by-user`.
>   - **Queries**:
>     - Add `observations-usage-by-users` and `traces-grouped-by-user` query cases in `dashboard-router.ts`.
>     - Modify `prepareClickhouse.ts` to use `randExponential` for `user_id` generation.
>   - **Misc**:
>     - Import `DateTimeFilter` in `dashboards.ts` for time-based filtering.
>     - Use `useClickhouse` in `UserChart.tsx` for querying Clickhouse.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2488e38e1691a4f37a95411dcb16874204c900a4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->