### PR TITLE
chore: set source: API if no source provided

### DIFF
--- a/packages/shared/src/server/ingestion/validateAndInflateScore.ts
+++ b/packages/shared/src/server/ingestion/validateAndInflateScore.ts
@@ -76,7 +76,7 @@ function inflateScoreBody(
   const { body, projectId, scoreId, config } = params;
 
   const relevantDataType = config?.dataType ?? body.dataType;
-  const scoreProps = { ...body, id: scoreId, projectId };
+  const scoreProps = { source: "API", ...body, id: scoreId, projectId };
 
   if (typeof body.value === "number") {
     if (relevantDataType && relevantDataType === ScoreDataType.BOOLEAN) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Sets default `source: "API"` in `inflateScoreBody()` in `validateAndInflateScore.ts` if no source is provided.
> 
>   - **Behavior**:
>     - Sets default `source: "API"` in `scoreProps` within `inflateScoreBody()` in `validateAndInflateScore.ts` if no source is provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3e4ac42fc6c543c06e1e510fc0e46f40bbebda30. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->