### PR TITLE
feat: query scores over time

### DIFF
--- a/packages/shared/scripts/prepareClickhouse.ts
+++ b/packages/shared/scripts/prepareClickhouse.ts
@@ -131,7 +131,7 @@ export const prepareClickhouse = async (
         toString(floor(randUniform(0, ${observationsPerProject}))),
         NULL
       ) AS observation_id,
-      concat('name_', toString(rand() % 100)) AS name,
+      concat('name_', toString(rand() % 10)) AS name,
       randUniform(0, 100) as value,
       'API' as source,
       'comment' as comment,

--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -263,7 +263,7 @@ export const getScoresAggregateOverTime = async (
     data_type,
     source,
     AVG(value) as avg_value
-  FROM scores FINAl
+  FROM scores FINAL
   WHERE project_id = {projectId: String}
   AND ${appliedFilter.query}
   AND data_type IN ('NUMERIC', 'BOOLEAN')

--- a/packages/shared/src/tableDefinitions/mapDashboards.ts
+++ b/packages/shared/src/tableDefinitions/mapDashboards.ts
@@ -27,6 +27,12 @@ export const dashboardColumnDefinitions: UiColumnMapping[] = [
   },
   {
     clickhouseTableName: "scores",
+    clickhouseSelect: "data_type",
+    uiTableId: "scoreDataType",
+    uiTableName: "Scores Data Type",
+  },
+  {
+    clickhouseTableName: "scores",
     clickhouseSelect: "value",
     uiTableId: "value",
     uiTableName: "value",

--- a/web/src/features/dashboard/components/ChartScores.tsx
+++ b/web/src/features/dashboard/components/ChartScores.tsx
@@ -8,7 +8,7 @@ import {
   fillMissingValuesAndTransform,
   isEmptyTimeSeries,
 } from "@/src/features/dashboard/components/hooks";
-
+import { useClickhouse } from "@/src/components/layouts/ClickhouseAdminToggle";
 import { createTracesTimeFilter } from "@/src/features/dashboard/lib/dashboard-utils";
 import {
   dashboardDateRangeAggregationSettings,
@@ -56,6 +56,8 @@ export function ChartScores(props: {
         { type: "string", column: "scoreDataType" },
         { type: "string", column: "scoreSource" },
       ],
+      queryClickhouse: useClickhouse(),
+      queryName: "scores-aggregate-timeseries",
     },
     {
       trpc: {

--- a/web/src/features/dashboard/server/dashboard-router.ts
+++ b/web/src/features/dashboard/server/dashboard-router.ts
@@ -20,6 +20,7 @@ import {
   getObservationUsageByTime,
   groupTracesByTime,
   getDistinctModels,
+  getScoresAggregateOverTime,
 } from "@langfuse/shared/src/server";
 import { type DatabaseRow } from "@/src/server/api/services/queryBuilder";
 import { dashboardColumnDefinitions } from "@langfuse/shared";
@@ -40,6 +41,7 @@ export const dashboardRouter = createTRPCRouter({
             "traces-timeseries",
             "observations-usage-timeseries",
             "distinct-models",
+            "scores-aggregate-timeseries",
           ])
           .nullish(),
       }),
@@ -138,6 +140,19 @@ export const dashboardRouter = createTRPCRouter({
             input.filter ?? [],
           );
           return models as DatabaseRow[];
+
+        case "scores-aggregate-timeseries":
+          const dateTruncScores = extractTimeSeries(input.groupBy);
+          if (!dateTruncScores) {
+            return [];
+          }
+          const aggregatedScores = await getScoresAggregateOverTime(
+            input.projectId,
+            input.filter ?? [],
+            dateTruncScores,
+          );
+
+          return aggregatedScores as DatabaseRow[];
 
         default:
           throw new TRPCError({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds functionality to query and display average scores over time in the dashboard, including backend and UI updates.
> 
>   - **Behavior**:
>     - Adds `getScoresAggregateOverTime` function in `dashboards.ts` to query average scores over time, grouped by `timestamp`, `name`, `data_type`, and `source`.
>     - Updates `dashboard-router.ts` to handle `scores-aggregate-timeseries` query, returning aggregated score data.
>     - Modifies `ChartScores.tsx` to use new query for displaying score data over time.
>   - **Models**:
>     - Adds `scoreDataType` to `dashboardColumnDefinitions` in `mapDashboards.ts`.
>   - **Misc**:
>     - Changes `prepareClickhouse.ts` to reduce `name` randomization range from 100 to 10.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1efd0fe9e7b2864a2d6b885947e2a3046cd89fa4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->