### PR TITLE
feat: add traces experimentation

### DIFF
--- a/web/src/server/utils/checkClickhouseAccess.ts
+++ b/web/src/server/utils/checkClickhouseAccess.ts
@@ -47,13 +47,15 @@ export const measureAndReturnApi = async <T, Y>(args: {
         });
       }
 
-      if (!input.queryClickhouse) {
-        return await pgExecution(input);
-      }
-
+      // if query clickhouse, return clickhouse only. Only possible for admin users
       if (input.queryClickhouse) {
         return await clickhouseExecution(input);
       }
+
+      // logic for regular users:
+      // if env.LANGFUSE_READ_FROM_POSTGRES_ONLY is true, return postgres only
+      // otherwise fetch both and compare timing
+      // if env.LANGFUSE_RETURN_FROM_CLICKHOUSE is true, return clickhouse data
 
       if (env.LANGFUSE_READ_FROM_POSTGRES_ONLY === "true") {
         logger.info("Read from postgres only");

--- a/web/src/server/utils/checkClickhouseAccess.ts
+++ b/web/src/server/utils/checkClickhouseAccess.ts
@@ -51,6 +51,10 @@ export const measureAndReturnApi = async <T, Y>(args: {
         return await pgExecution(input);
       }
 
+      if (input.queryClickhouse) {
+        return await clickhouseExecution(input);
+      }
+
       if (env.LANGFUSE_READ_FROM_POSTGRES_ONLY === "true") {
         logger.info("Read from postgres only");
         return await pgExecution(input);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces dual execution paths for PostgreSQL and Clickhouse in `traces.ts` with eligibility checks and error handling for Clickhouse access.
> 
>   - **Behavior**:
>     - Introduces `measureAndReturnApi` in `checkClickhouseAccess.ts` for dual execution paths (PostgreSQL and Clickhouse) in `traces.ts`.
>     - Adds Clickhouse eligibility checks using `isClickhouseEligible()` in `traces.ts`.
>     - Handles unauthorized Clickhouse access by throwing `TRPCError` with code `UNAUTHORIZED`.
>   - **Functions**:
>     - Updates `countAll`, `metrics`, `filterOptions`, `byId`, `byIdWithObservationsAndScores` in `traces.ts` to use `measureAndReturnApi` for dual execution.
>     - Adds `clickhouseExecution` logic to handle Clickhouse-specific queries in the above functions.
>   - **Misc**:
>     - Refactors existing logic in `traces.ts` to separate PostgreSQL and Clickhouse execution paths.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for da96ee7455a6449302396aa6f5206391b4f6d5ed. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->