### PR TITLE
perf: add timestamp to filteroptions api

### DIFF
--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -163,6 +163,7 @@ export default function TracesTable({
   const traceMetrics = api.traces.metrics.useQuery(
     {
       projectId,
+      filter: filterState,
       traceIds: traces.data?.traces.map((t) => t.id) ?? [],
       queryClickhouse: useClickhouse(),
     },

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-
 import { env } from "@/src/env.mjs";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
@@ -222,6 +221,7 @@ export const traceRouter = createTRPCRouter({
       z.object({
         projectId: z.string(),
         traceIds: z.array(z.string()),
+        filter: z.array(singleFilter).nullable(),
         queryClickhouse: z.boolean().default(false),
       }),
     )
@@ -284,6 +284,7 @@ export const traceRouter = createTRPCRouter({
           }
 
           const res = await getTracesTable(ctx.session.projectId, [
+            ...(input.filter ?? []),
             {
               type: "stringOptions",
               operator: "any of",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds filter parameter to traceMetrics query and updates traceRouter to handle it, enhancing trace metrics filtering.
> 
>   - **Behavior**:
>     - Adds `filter` parameter to `traceMetrics` query in `traces.tsx` to allow filtering of trace metrics.
>     - Updates `traceRouter` in `traces.ts` to handle `filter` parameter in `metrics` endpoint.
>   - **API**:
>     - Modifies `metrics` endpoint in `traceRouter` to include `filter` in both Postgres and Clickhouse executions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d730aafd72940335e651499e8e0057c26fb49471. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->