### PR TITLE
perf: add time filter for sessions

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -590,6 +590,17 @@ const getSessionsTableGeneric = async <T>(props: FetchTracesTableProps) => {
       (f.operator === ">=" || f.operator === ">"),
   ) as DateTimeFilter | undefined;
 
+  const singleTraceFilter = traceTimestampFilter
+    ? new FilterList([
+        new DateTimeFilter({
+          clickhouseTable: "traces",
+          field: "timestamp",
+          operator: traceTimestampFilter.operator,
+          value: traceTimestampFilter.value,
+        }),
+      ]).apply()
+    : undefined;
+
   const query = `
       WITH observations_agg AS (
         SELECT o.trace_id,
@@ -629,6 +640,7 @@ const getSessionsTableGeneric = async <T>(props: FetchTracesTableProps) => {
         LEFT JOIN observations_agg o ON t.id = o.trace_id AND t.project_id = o.project_id
         WHERE t.session_id IS NOT NULL
             AND t.project_id = {projectId: String}
+            AND ${singleTraceFilter?.query ? singleTraceFilter.query : ""}
         GROUP BY t.session_id
     )
     SELECT ${select}
@@ -651,6 +663,7 @@ const getSessionsTableGeneric = async <T>(props: FetchTracesTableProps) => {
       ...tracesFilterRes.params,
       ...observationsStatsRes.params,
       ...scoresAvgFilterRes.params,
+      ...singleTraceFilter?.params,
       ...(obsStartTimeValue
         ? { observationsStartTime: obsStartTimeValue }
         : {}),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a time filter to session queries in `traces.ts` to optimize session data retrieval by filtering based on trace timestamps.
> 
>   - **Behavior**:
>     - Adds a time filter for sessions in `getSessionsTableGeneric()` in `traces.ts` by applying a `DateTimeFilter` on `traces.timestamp`.
>     - Filters sessions based on `min_timestamp` using `traceTimestampFilter`.
>   - **Query Changes**:
>     - Modifies the SQL query in `getSessionsTableGeneric()` to include the new time filter condition.
>     - Updates query parameters to include `singleTraceFilter` parameters if applicable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 087cd6ba46a4495bfea10df8b9369aaab2259004. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->