### PR TITLE
feat: move generations api to experimentation setup

### DIFF
--- a/web/src/server/api/routers/generations/filterOptionsQuery.ts
+++ b/web/src/server/api/routers/generations/filterOptionsQuery.ts
@@ -17,7 +17,10 @@ import {
   getTracesGroupedByName,
   getTracesGroupedByTags,
 } from "@langfuse/shared/src/server";
-import { isClickhouseEligible } from "@/src/server/utils/checkClickhouseAccess";
+import {
+  isClickhouseEligible,
+  measureAndReturnApi,
+} from "@/src/server/utils/checkClickhouseAccess";
 import { TRPCError } from "@trpc/server";
 
 export const filterOptionsQuery = protectedProjectProcedure
@@ -29,13 +32,6 @@ export const filterOptionsQuery = protectedProjectProcedure
     }),
   )
   .query(async ({ input, ctx }) => {
-    if (input.queryClickhouse && !isClickhouseEligible(ctx.session.user)) {
-      throw new TRPCError({
-        code: "UNAUTHORIZED",
-        message: "Not eligible to query clickhouse",
-      });
-    }
-
     const { startTimeFilter } = input;
     const prismaStartTimeFilter = startTimeFilter
       ? datetimeFilterToPrisma(startTimeFilter)
@@ -96,8 +92,12 @@ export const filterOptionsQuery = protectedProjectProcedure
 
     // Score names
     const [scores, model, name, promptNames, traceNames, tags] =
-      !input.queryClickhouse
-        ? await Promise.all([
+      await measureAndReturnApi({
+        input,
+        operation: "traces.all",
+        user: ctx.session.user,
+        pgExecution: async () => {
+          return await Promise.all([
             // scores
             ctx.prisma.score.groupBy({
               where: {
@@ -179,8 +179,10 @@ export const filterOptionsQuery = protectedProjectProcedure
             ${rawStartTimeFilter}
           LIMIT 1000;
       `),
-          ])
-        : await Promise.all([
+          ]);
+        },
+        clickhouseExecution: async () => {
+          return await Promise.all([
             //scores
             getScoresGroupedByName(
               input.projectId,
@@ -215,6 +217,8 @@ export const filterOptionsQuery = protectedProjectProcedure
             // trace tags
             getClickhouseTraceTags(),
           ]);
+        },
+      });
 
     // typecheck filter options, needs to include all columns with options
     const res: ObservationOptions = {

--- a/web/src/server/api/routers/generations/filterOptionsQuery.ts
+++ b/web/src/server/api/routers/generations/filterOptionsQuery.ts
@@ -17,11 +17,7 @@ import {
   getTracesGroupedByName,
   getTracesGroupedByTags,
 } from "@langfuse/shared/src/server";
-import {
-  isClickhouseEligible,
-  measureAndReturnApi,
-} from "@/src/server/utils/checkClickhouseAccess";
-import { TRPCError } from "@trpc/server";
+import { measureAndReturnApi } from "@/src/server/utils/checkClickhouseAccess";
 
 export const filterOptionsQuery = protectedProjectProcedure
   .input(

--- a/web/src/server/api/routers/generations/getAllQueries.ts
+++ b/web/src/server/api/routers/generations/getAllQueries.ts
@@ -9,7 +9,10 @@ import {
   parseGetAllGenerationsInput,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
-import { isClickhouseEligible } from "@/src/server/utils/checkClickhouseAccess";
+import {
+  isClickhouseEligible,
+  measureAndReturnApi,
+} from "@/src/server/utils/checkClickhouseAccess";
 
 const GetAllGenerationsInput = GenerationTableOptions.extend({
   ...paginationZod,
@@ -25,33 +28,32 @@ export const getAllQueries = {
       }),
     )
     .query(async ({ input, ctx }) => {
-      if (!input.queryClickhouse) {
-        const { generations } = await getAllGenerations({
-          input,
-          selectIOAndMetadata: false,
-        });
-
-        return {
-          generations: generations,
-        };
-      } else {
-        if (!isClickhouseEligible(ctx.session.user)) {
-          throw new TRPCError({
-            code: "UNAUTHORIZED",
-            message: "Not eligible to query clickhouse",
+      return await measureAndReturnApi({
+        input,
+        operation: "generations.all",
+        user: ctx.session.user,
+        pgExecution: async () => {
+          const { generations } = await getAllGenerations({
+            input,
+            selectIOAndMetadata: false,
           });
-        }
 
-        const { generations } = await getAllGenerations({
-          input,
-          selectIOAndMetadata: false,
-          queryClickhouse: true,
-        });
+          return {
+            generations: generations,
+          };
+        },
+        clickhouseExecution: async () => {
+          const { generations } = await getAllGenerations({
+            input,
+            selectIOAndMetadata: false,
+            queryClickhouse: true,
+          });
 
-        return {
-          generations: generations,
-        };
-      }
+          return {
+            generations: generations,
+          };
+        },
+      });
     }),
   countAll: protectedProjectProcedure
     .input(
@@ -60,14 +62,18 @@ export const getAllQueries = {
       }),
     )
     .query(async ({ input, ctx }) => {
-      if (!input.queryClickhouse) {
-        const { searchCondition, filterCondition, datetimeFilter } =
-          parseGetAllGenerationsInput(input);
+      return await measureAndReturnApi({
+        input,
+        operation: "generations.countAll",
+        user: ctx.session.user,
+        pgExecution: async () => {
+          const { searchCondition, filterCondition, datetimeFilter } =
+            parseGetAllGenerationsInput(input);
 
-        const totalGenerations = await ctx.prisma.$queryRaw<
-          Array<{ count: bigint }>
-        >(
-          Prisma.sql`
+          const totalGenerations = await ctx.prisma.$queryRaw<
+            Array<{ count: bigint }>
+          >(
+            Prisma.sql`
           SELECT
             count(*)
           FROM observations_view o
@@ -98,30 +104,32 @@ export const getAllQueries = {
             ${searchCondition}
             ${filterCondition}
     `,
-        );
+          );
 
-        const count = totalGenerations[0]?.count;
-        return {
-          totalCount: count ? Number(count) : undefined,
-        };
-      } else {
-        if (!isClickhouseEligible(ctx.session.user)) {
-          throw new TRPCError({
-            code: "UNAUTHORIZED",
-            message: "Not eligible to query clickhouse",
+          const count = totalGenerations[0]?.count;
+          return {
+            totalCount: count ? Number(count) : undefined,
+          };
+        },
+        clickhouseExecution: async () => {
+          if (!isClickhouseEligible(ctx.session.user)) {
+            throw new TRPCError({
+              code: "UNAUTHORIZED",
+              message: "Not eligible to query clickhouse",
+            });
+          }
+
+          const countQuery = await getObservationsTableCount({
+            projectId: ctx.session.projectId,
+            filter: input.filter ?? [],
+            limit: 1,
+            offset: 0,
           });
-        }
 
-        const countQuery = await getObservationsTableCount({
-          projectId: ctx.session.projectId,
-          filter: input.filter ?? [],
-          limit: 1,
-          offset: 0,
-        });
-
-        return {
-          totalCount: countQuery.shift()?.count,
-        };
-      }
+          return {
+            totalCount: countQuery.shift()?.count,
+          };
+        },
+      });
     }),
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor generations API to use `measureAndReturnApi` for handling PostgreSQL and Clickhouse queries, centralizing query logic and error handling.
> 
>   - **Behavior**:
>     - Refactor `filterOptionsQuery` and `getAllQueries` to use `measureAndReturnApi` for handling database queries.
>     - Centralizes logic for PostgreSQL and Clickhouse query execution based on `queryClickhouse` flag and user eligibility.
>   - **Functions**:
>     - Introduces `measureAndReturnApi` in `checkClickhouseAccess` to manage query execution paths.
>     - Removes direct Clickhouse eligibility checks from `filterOptionsQuery` and `getAllQueries`.
>   - **Error Handling**:
>     - Moves Clickhouse eligibility error handling into `measureAndReturnApi`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for df6d5a2ac231698ab8f20a9df1223a19bf46bf52. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->