### PR TITLE
feat: move sessions api to experimentation setup

### DIFF
--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -207,7 +207,7 @@ export const sessionRouter = createTRPCRouter({
         if (input.sessionIds.length === 0) return [];
         return await measureAndReturnApi({
           input,
-          operation: "traces.countAll",
+          operation: "traces.metrics",
           user: ctx.session.user,
           pgExecution: async () => {
             const inputForMetrics: z.infer<typeof SessionFilterOptions> = {

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -18,7 +18,10 @@ import {
 } from "@langfuse/shared";
 import { Prisma } from "@langfuse/shared/src/db";
 import { TRPCError } from "@trpc/server";
-import { isClickhouseEligible } from "@/src/server/utils/checkClickhouseAccess";
+import {
+  isClickhouseEligible,
+  measureAndReturnApi,
+} from "@/src/server/utils/checkClickhouseAccess";
 import Decimal from "decimal.js";
 import {
   createSessionsAllQuery,
@@ -49,80 +52,79 @@ export const sessionRouter = createTRPCRouter({
     )
     .query(async ({ input, ctx }) => {
       try {
-        if (input.queryClickhouse && !isClickhouseEligible(ctx.session.user)) {
-          throw new TRPCError({
-            code: "UNAUTHORIZED",
-            message: "Not eligible to query clickhouse",
-          });
-        }
-
-        if (input.queryClickhouse) {
-          const sessions = await getSessionsTable({
-            projectId: input.projectId,
-            filter: input.filter ?? [],
-            orderBy: input.orderBy,
-            offset: input.page * input.limit,
-            limit: input.limit,
-          });
-
-          const prismaSessionInfo = await ctx.prisma.traceSession.findMany({
-            where: {
-              id: {
-                in: sessions.map((s) => s.session_id),
-              },
-              projectId: input.projectId,
-            },
-            select: {
-              id: true,
-              bookmarked: true,
-              public: true,
-            },
-          });
-          return {
-            sessions: sessions.map((s) => ({
-              id: s.session_id,
-              userIds: s.user_ids,
-              countTraces: s.trace_ids.length,
-              sessionDuration: Number(s.duration) / 1000,
-              inputCost: new Decimal(s.session_input_cost),
-              outputCost: new Decimal(s.session_output_cost),
-              totalCost: new Decimal(s.session_total_cost),
-              promptTokens: Number(s.session_input_usage),
-              completionTokens: Number(s.session_output_usage),
-              totalTokens: Number(s.session_total_usage),
-              traceTags: s.trace_tags,
-              createdAt: s.min_timestamp,
-              bookmarked:
-                prismaSessionInfo.find((p) => p.id === s.session_id)
-                  ?.bookmarked ?? false,
-              public: prismaSessionInfo.find((p) => p.id === s.session_id)
-                ?.public,
-            })),
-          };
-        }
-
-        const sessions = await ctx.prisma.$queryRaw<
-          Array<{
-            id: string;
-            createdAt: Date;
-            bookmarked: boolean;
-            public: boolean;
-          }>
-        >(
-          createSessionsAllQuery(
-            Prisma.sql`
+        return await measureAndReturnApi({
+          input,
+          operation: "sessions.all",
+          user: ctx.session.user,
+          pgExecution: async () => {
+            const sessions = await ctx.prisma.$queryRaw<
+              Array<{
+                id: string;
+                createdAt: Date;
+                bookmarked: boolean;
+                public: boolean;
+              }>
+            >(
+              createSessionsAllQuery(
+                Prisma.sql`
               s.id,
               s."created_at" AS "createdAt",
               s.bookmarked,
               s.public
             `,
-            input,
-          ),
-        );
+                input,
+              ),
+            );
 
-        return {
-          sessions,
-        };
+            return {
+              sessions,
+            };
+          },
+          clickhouseExecution: async () => {
+            const sessions = await getSessionsTable({
+              projectId: input.projectId,
+              filter: input.filter ?? [],
+              orderBy: input.orderBy,
+              offset: input.page * input.limit,
+              limit: input.limit,
+            });
+
+            const prismaSessionInfo = await ctx.prisma.traceSession.findMany({
+              where: {
+                id: {
+                  in: sessions.map((s) => s.session_id),
+                },
+                projectId: input.projectId,
+              },
+              select: {
+                id: true,
+                bookmarked: true,
+                public: true,
+              },
+            });
+            return {
+              sessions: sessions.map((s) => ({
+                id: s.session_id,
+                userIds: s.user_ids,
+                countTraces: s.trace_ids.length,
+                sessionDuration: Number(s.duration) / 1000,
+                inputCost: new Decimal(s.session_input_cost),
+                outputCost: new Decimal(s.session_output_cost),
+                totalCost: new Decimal(s.session_total_cost),
+                promptTokens: Number(s.session_input_usage),
+                completionTokens: Number(s.session_output_usage),
+                totalTokens: Number(s.session_total_usage),
+                traceTags: s.trace_tags,
+                createdAt: s.min_timestamp,
+                bookmarked:
+                  prismaSessionInfo.find((p) => p.id === s.session_id)
+                    ?.bookmarked ?? false,
+                public: prismaSessionInfo.find((p) => p.id === s.session_id)
+                  ?.public,
+              })),
+            };
+          },
+        });
       } catch (e) {
         console.error(e);
         throw new TRPCError({
@@ -139,54 +141,53 @@ export const sessionRouter = createTRPCRouter({
     )
     .query(async ({ input, ctx }) => {
       try {
-        if (input.queryClickhouse && !isClickhouseEligible(ctx.session.user)) {
-          throw new TRPCError({
-            code: "UNAUTHORIZED",
-            message: "Not eligible to query clickhouse",
-          });
-        }
+        return await measureAndReturnApi({
+          input,
+          operation: "traces.countAll",
+          user: ctx.session.user,
+          pgExecution: async () => {
+            const inputForTotal: z.infer<typeof SessionFilterOptions> = {
+              filter: input.filter,
+              projectId: input.projectId,
+              orderBy: null,
+              limit: 1,
+              page: 0,
+            };
 
-        if (input.queryClickhouse) {
-          const count = await getSessionsTableCount({
-            projectId: input.projectId,
-            filter: input.filter ?? [],
-            orderBy: input.orderBy,
-            offset: input.page * input.limit,
-            limit: input.limit,
-          });
+            const totalCount = await ctx.prisma.$queryRaw<
+              Array<{
+                totalCount: number;
+              }>
+            >(
+              createSessionsAllQuery(
+                Prisma.sql`
+                    count(*)::int as "totalCount"
+                  `,
+                inputForTotal,
+                {
+                  ignoreOrderBy: true,
+                },
+              ),
+            );
 
-          return {
-            totalCount: count,
-          };
-        }
+            return {
+              totalCount: totalCount[0].totalCount,
+            };
+          },
+          clickhouseExecution: async () => {
+            const count = await getSessionsTableCount({
+              projectId: input.projectId,
+              filter: input.filter ?? [],
+              orderBy: input.orderBy,
+              offset: input.page * input.limit,
+              limit: input.limit,
+            });
 
-        const inputForTotal: z.infer<typeof SessionFilterOptions> = {
-          filter: input.filter,
-          projectId: input.projectId,
-          orderBy: null,
-          limit: 1,
-          page: 0,
-        };
-
-        const totalCount = await ctx.prisma.$queryRaw<
-          Array<{
-            totalCount: number;
-          }>
-        >(
-          createSessionsAllQuery(
-            Prisma.sql`
-                count(*)::int as "totalCount"
-              `,
-            inputForTotal,
-            {
-              ignoreOrderBy: true,
-            },
-          ),
-        );
-
-        return {
-          totalCount: totalCount[0].totalCount,
-        };
+            return {
+              totalCount: count,
+            };
+          },
+        });
       } catch (e) {
         console.error(e);
         throw new TRPCError({
@@ -205,70 +206,69 @@ export const sessionRouter = createTRPCRouter({
     )
     .query(async ({ input, ctx }) => {
       try {
-        if (input.queryClickhouse && !isClickhouseEligible(ctx.session.user)) {
-          throw new TRPCError({
-            code: "UNAUTHORIZED",
-            message: "Not eligible to query clickhouse",
-          });
-        }
-
         if (input.sessionIds.length === 0) return [];
+        return await measureAndReturnApi({
+          input,
+          operation: "traces.countAll",
+          user: ctx.session.user,
+          pgExecution: async () => {
+            const inputForMetrics: z.infer<typeof SessionFilterOptions> = {
+              filter: [],
+              projectId: input.projectId,
+              orderBy: null,
+              limit: 10000, // no limit
+              page: 0,
+            };
 
-        if (input.queryClickhouse) {
-          return []; // initial endpoint returns all data from CH.
-        }
+            const metrics = await ctx.prisma.$queryRaw<
+              Array<{
+                id: string;
+                countTraces: number;
+                userIds: (string | null)[] | null;
+                sessionDuration: number | null;
+                inputCost: Decimal;
+                outputCost: Decimal;
+                totalCost: Decimal;
+                promptTokens: number;
+                completionTokens: number;
+                totalTokens: number;
+                traceTags: string[];
+              }>
+            >(
+              createSessionsAllQuery(
+                Prisma.sql`
+                s.id,
+                t."userIds",
+                t."countTraces",
+                o."sessionDuration",
+                o."totalCost" AS "totalCost",
+                o."inputCost" AS "inputCost",
+                o."outputCost" AS "outputCost",
+                o."promptTokens" AS "promptTokens",
+                o."completionTokens" AS "completionTokens",
+                o."totalTokens" AS "totalTokens",
+                t."tags" AS "traceTags"
+              `,
+                inputForMetrics,
+                {
+                  ignoreOrderBy: true,
+                  sessionIdList: input.sessionIds,
+                },
+              ),
+            );
 
-        const inputForMetrics: z.infer<typeof SessionFilterOptions> = {
-          filter: [],
-          projectId: input.projectId,
-          orderBy: null,
-          limit: 10000, // no limit
-          page: 0,
-        };
-
-        const metrics = await ctx.prisma.$queryRaw<
-          Array<{
-            id: string;
-            countTraces: number;
-            userIds: (string | null)[] | null;
-            sessionDuration: number | null;
-            inputCost: Decimal;
-            outputCost: Decimal;
-            totalCost: Decimal;
-            promptTokens: number;
-            completionTokens: number;
-            totalTokens: number;
-            traceTags: string[];
-          }>
-        >(
-          createSessionsAllQuery(
-            Prisma.sql`
-              s.id,
-              t."userIds",
-              t."countTraces",
-              o."sessionDuration",
-              o."totalCost" AS "totalCost",
-              o."inputCost" AS "inputCost",
-              o."outputCost" AS "outputCost",
-              o."promptTokens" AS "promptTokens",
-              o."completionTokens" AS "completionTokens",
-              o."totalTokens" AS "totalTokens",
-              t."tags" AS "traceTags"
-            `,
-            inputForMetrics,
-            {
-              ignoreOrderBy: true,
-              sessionIdList: input.sessionIds,
-            },
-          ),
-        );
-
-        return metrics.map((row) => ({
-          ...row,
-          userIds: (row.userIds?.filter((t) => t !== null) ?? []) as string[],
-          traceTags: (row.traceTags?.filter((t) => t !== null) ??
-            []) as string[],
-        }));
+            return metrics.map((row) => ({
+              ...row,
+              userIds: (row.userIds?.filter((t) => t !== null) ??
+                []) as string[],
+              traceTags: (row.traceTags?.filter((t) => t !== null) ??
+                []) as string[],
+            }));
+          },
+          clickhouseExecution: async () => {
+            return []; // initial endpoint returns all data from CH.
+          },
+        });
       } catch (e) {
         console.error(e);
         throw new TRPCError({
@@ -288,91 +288,89 @@ export const sessionRouter = createTRPCRouter({
     .query(async ({ input, ctx }) => {
       try {
         const { timestampFilter } = input;
+        return await measureAndReturnApi({
+          input,
+          operation: "sessions.filterOptions",
+          user: ctx.session.user,
+          pgExecution: async () => {
+            const rawTimestampFilter =
+              timestampFilter && timestampFilter.type === "datetime"
+                ? datetimeFilterToPrismaSql(
+                    "timestamp",
+                    timestampFilter.operator,
+                    timestampFilter.value,
+                  )
+                : Prisma.empty;
+            const [userIds, tags] = await Promise.all([
+              ctx.prisma.$queryRaw<Array<{ value: string }>>(Prisma.sql`
+              SELECT 
+                traces.user_id AS value
+              FROM traces
+              WHERE 
+                traces.session_id IS NOT NULL
+                AND traces.user_id IS NOT NULL
+                AND traces.project_id = ${input.projectId} ${rawTimestampFilter}
+              GROUP BY traces.user_id 
+              ORDER BY traces.user_id ASC
+              LIMIT 1000;
+            `),
+              ctx.prisma.$queryRaw<
+                Array<{
+                  value: string;
+                }>
+              >(Prisma.sql`
+              SELECT DISTINCT tag AS value
+              FROM traces t
+              JOIN observations o ON o.trace_id = t.id,
+              UNNEST(t.tags) AS tag
+              WHERE o.type = 'GENERATION'
+                AND o.project_id = ${input.projectId}
+                AND t.project_id = ${input.projectId} ${rawTimestampFilter}
+              LIMIT 1000;
+            `),
+            ]);
 
-        if (input.queryClickhouse && !isClickhouseEligible(ctx.session.user)) {
-          throw new TRPCError({
-            code: "UNAUTHORIZED",
-            message: "Not eligible to query clickhouse",
-          });
-        }
+            const res: SessionOptions = {
+              userIds: userIds,
+              tags: tags,
+            };
+            return res;
+          },
+          clickhouseExecution: async () => {
+            const columns = [
+              ...tracesTableUiColumnDefinitions,
+              {
+                uiTableName: "Created At",
+                uiTableId: "createdAt",
+                clickhouseTableName: "traces",
+                clickhouseSelect: "timestamp",
+              },
+            ];
+            const [userIds, tags] = await Promise.all([
+              getTracesGroupedByUserIds({
+                projectId: input.projectId,
+                filter: timestampFilter ? [timestampFilter] : [],
+                sessionIdNullFilter: true,
+                columns,
+              }),
+              getTracesGroupedByTags({
+                projectId: input.projectId,
+                filter: timestampFilter ? [timestampFilter] : [],
+                sessionIdNullFilter: true,
+                columns,
+              }),
+            ]);
 
-        if (input.queryClickhouse) {
-          const columns = [
-            ...tracesTableUiColumnDefinitions,
-            {
-              uiTableName: "Created At",
-              uiTableId: "createdAt",
-              clickhouseTableName: "traces",
-              clickhouseSelect: "timestamp",
-            },
-          ];
-          const [userIds, tags] = await Promise.all([
-            getTracesGroupedByUserIds({
-              projectId: input.projectId,
-              filter: timestampFilter ? [timestampFilter] : [],
-              sessionIdNullFilter: true,
-              columns,
-            }),
-            getTracesGroupedByTags({
-              projectId: input.projectId,
-              filter: timestampFilter ? [timestampFilter] : [],
-              sessionIdNullFilter: true,
-              columns,
-            }),
-          ]);
-
-          return {
-            userIds: userIds.map((row) => ({
-              value: row.user_id,
-            })),
-            tags: tags.map((row) => ({
-              value: row.value,
-            })),
-          };
-        }
-
-        const rawTimestampFilter =
-          timestampFilter && timestampFilter.type === "datetime"
-            ? datetimeFilterToPrismaSql(
-                "timestamp",
-                timestampFilter.operator,
-                timestampFilter.value,
-              )
-            : Prisma.empty;
-        const [userIds, tags] = await Promise.all([
-          ctx.prisma.$queryRaw<Array<{ value: string }>>(Prisma.sql`
-            SELECT 
-              traces.user_id AS value
-            FROM traces
-            WHERE 
-              traces.session_id IS NOT NULL
-              AND traces.user_id IS NOT NULL
-              AND traces.project_id = ${input.projectId} ${rawTimestampFilter}
-            GROUP BY traces.user_id 
-            ORDER BY traces.user_id ASC
-            LIMIT 1000;
-          `),
-          ctx.prisma.$queryRaw<
-            Array<{
-              value: string;
-            }>
-          >(Prisma.sql`
-            SELECT DISTINCT tag AS value
-            FROM traces t
-            JOIN observations o ON o.trace_id = t.id,
-            UNNEST(t.tags) AS tag
-            WHERE o.type = 'GENERATION'
-              AND o.project_id = ${input.projectId}
-              AND t.project_id = ${input.projectId} ${rawTimestampFilter}
-            LIMIT 1000;
-          `),
-        ]);
-
-        const res: SessionOptions = {
-          userIds: userIds,
-          tags: tags,
-        };
-        return res;
+            return {
+              userIds: userIds.map((row) => ({
+                value: row.user_id,
+              })),
+              tags: tags.map((row) => ({
+                value: row.value,
+              })),
+            };
+          },
+        });
       } catch (e) {
         console.error(e);
         throw new TRPCError({
@@ -391,131 +389,134 @@ export const sessionRouter = createTRPCRouter({
     )
     .query(async ({ input, ctx }) => {
       try {
-        if (input.queryClickhouse && !isClickhouseEligible(ctx.session.user)) {
-          throw new TRPCError({
-            code: "UNAUTHORIZED",
-            message: "Not eligible to query clickhouse",
-          });
-        }
-
-        if (input.queryClickhouse) {
-          const postgresSession = await ctx.prisma.traceSession.findFirst({
-            where: {
-              id: input.sessionId,
-              projectId: input.projectId,
-            },
-          });
-
-          if (!postgresSession) {
-            throw new TRPCError({
-              code: "NOT_FOUND",
-              message: "Session not found in project",
+        return await measureAndReturnApi({
+          input,
+          operation: "sessions.byId",
+          user: ctx.session.user,
+          pgExecution: async () => {
+            const session = await ctx.prisma.traceSession.findFirst({
+              where: {
+                id: input.sessionId,
+                projectId: input.projectId,
+              },
+              include: {
+                traces: {
+                  orderBy: {
+                    timestamp: "asc",
+                  },
+                  select: {
+                    id: true,
+                    userId: true,
+                    name: true,
+                    timestamp: true,
+                  },
+                },
+              },
             });
-          }
+            if (!session) {
+              throw new TRPCError({
+                code: "NOT_FOUND",
+                message: "Session not found in project",
+              });
+            }
 
-          const clickhouseTraces = await getTracesForSession(
-            input.projectId,
-            input.sessionId,
-          );
+            const totalCostQuery = Prisma.sql`
+              SELECT
+                SUM(COALESCE(o."calculated_total_cost", 0)) AS "totalCost"
+              FROM observations_view o
+              JOIN traces t ON t.id = o.trace_id
+              WHERE
+                t."session_id" = ${input.sessionId}
+                AND t."project_id" = ${input.projectId}
+            `;
 
-          const [scores, costData] = await Promise.all([
-            getScoresForTraces(
-              input.projectId,
-              clickhouseTraces.map((t) => t.id),
-            ),
-            getCostForTraces(
-              input.projectId,
-              clickhouseTraces.map((t) => t.id),
-            ),
-          ]);
-
-          const validatedScores = filterAndValidateDbScoreList(
-            scores,
-            traceException,
-          );
-
-          return {
-            ...postgresSession,
-            traces: clickhouseTraces.map((t) => ({
-              ...t,
-              scores: validatedScores.filter((s) => s.traceId === t.id),
-            })),
-            totalCost: costData,
-            users: [
-              ...new Set(
-                clickhouseTraces.map((t) => t.userId).filter((t) => t !== null),
+            const [scores, costData] = await Promise.all([
+              ctx.prisma.score.findMany({
+                where: {
+                  traceId: {
+                    in: session.traces.map((t) => t.id),
+                  },
+                  projectId: input.projectId,
+                },
+              }),
+              // costData
+              ctx.prisma.$queryRaw<Array<{ totalCost: number }>>(
+                totalCostQuery,
               ),
-            ],
-          };
-        }
+            ]);
 
-        const session = await ctx.prisma.traceSession.findFirst({
-          where: {
-            id: input.sessionId,
-            projectId: input.projectId,
+            const validatedScores = filterAndValidateDbScoreList(
+              scores,
+              traceException,
+            );
+
+            return {
+              ...session,
+              traces: session.traces.map((t) => ({
+                ...t,
+                scores: validatedScores.filter((s) => s.traceId === t.id),
+              })),
+              totalCost: costData[0].totalCost ?? 0,
+              users: [
+                ...new Set(
+                  session.traces.map((t) => t.userId).filter((t) => t !== null),
+                ),
+              ],
+            };
           },
-          include: {
-            traces: {
-              orderBy: {
-                timestamp: "asc",
+          clickhouseExecution: async () => {
+            const postgresSession = await ctx.prisma.traceSession.findFirst({
+              where: {
+                id: input.sessionId,
+                projectId: input.projectId,
               },
-              select: {
-                id: true,
-                userId: true,
-                name: true,
-                timestamp: true,
-              },
-            },
+            });
+
+            if (!postgresSession) {
+              throw new TRPCError({
+                code: "NOT_FOUND",
+                message: "Session not found in project",
+              });
+            }
+
+            const clickhouseTraces = await getTracesForSession(
+              input.projectId,
+              input.sessionId,
+            );
+
+            const [scores, costData] = await Promise.all([
+              getScoresForTraces(
+                input.projectId,
+                clickhouseTraces.map((t) => t.id),
+              ),
+              getCostForTraces(
+                input.projectId,
+                clickhouseTraces.map((t) => t.id),
+              ),
+            ]);
+
+            const validatedScores = filterAndValidateDbScoreList(
+              scores,
+              traceException,
+            );
+
+            return {
+              ...postgresSession,
+              traces: clickhouseTraces.map((t) => ({
+                ...t,
+                scores: validatedScores.filter((s) => s.traceId === t.id),
+              })),
+              totalCost: costData,
+              users: [
+                ...new Set(
+                  clickhouseTraces
+                    .map((t) => t.userId)
+                    .filter((t) => t !== null),
+                ),
+              ],
+            };
           },
         });
-        if (!session) {
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Session not found in project",
-          });
-        }
-
-        const totalCostQuery = Prisma.sql`
-          SELECT
-            SUM(COALESCE(o."calculated_total_cost", 0)) AS "totalCost"
-          FROM observations_view o
-          JOIN traces t ON t.id = o.trace_id
-          WHERE
-            t."session_id" = ${input.sessionId}
-            AND t."project_id" = ${input.projectId}
-        `;
-
-        const [scores, costData] = await Promise.all([
-          ctx.prisma.score.findMany({
-            where: {
-              traceId: {
-                in: session.traces.map((t) => t.id),
-              },
-              projectId: input.projectId,
-            },
-          }),
-          // costData
-          ctx.prisma.$queryRaw<Array<{ totalCost: number }>>(totalCostQuery),
-        ]);
-
-        const validatedScores = filterAndValidateDbScoreList(
-          scores,
-          traceException,
-        );
-
-        return {
-          ...session,
-          traces: session.traces.map((t) => ({
-            ...t,
-            scores: validatedScores.filter((s) => s.traceId === t.id),
-          })),
-          totalCost: costData[0].totalCost ?? 0,
-          users: [
-            ...new Set(
-              session.traces.map((t) => t.userId).filter((t) => t !== null),
-            ),
-          ],
-        };
       } catch (e) {
         console.error(e);
         throw new TRPCError({

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -141,7 +141,7 @@ export const sessionRouter = createTRPCRouter({
       try {
         return await measureAndReturnApi({
           input,
-          operation: "traces.countAll",
+          operation: "sessions.countAll",
           user: ctx.session.user,
           pgExecution: async () => {
             const inputForTotal: z.infer<typeof SessionFilterOptions> = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `sessions.ts` to use `measureAndReturnApi` for unified database operations, improving maintainability and consistency.
> 
>   - **Refactoring**:
>     - Introduced `measureAndReturnApi` in `sessions.ts` for unified database operations across PostgreSQL and Clickhouse.
>     - Refactored `all`, `countAll`, `metrics`, `filterOptions`, and `byId` queries to use `measureAndReturnApi`.
>   - **Behavior**:
>     - Unified database access logic for session-related operations, improving maintainability.
>     - Ensured consistent error handling and logging across refactored functions.
>   - **Misc**:
>     - Removed redundant Clickhouse eligibility checks in favor of centralized handling within `measureAndReturnApi`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 69f0dddc11f4f63b294ed5e9ba621a63e40ef593. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->