### PR TITLE
chore: read dashboards form clickhouse flag

### DIFF
--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -193,6 +193,9 @@ export const env = createEnv({
       .default(15_000),
     LANGFUSE_READ_FROM_POSTGRES_ONLY: z.enum(["true", "false"]).default("true"),
     LANGFUSE_RETURN_FROM_CLICKHOUSE: z.enum(["true", "false"]).default("false"),
+    LANGFUSE_READ_DASHBOARDS_FROM_CLICKHOUSE: z
+      .enum(["true", "false"])
+      .default("false"),
     STRIPE_SECRET_KEY: z.string().optional(),
     STRIPE_WEBHOOK_SIGNING_SECRET: z.string().optional(),
     SENTRY_AUTH_TOKEN: z.string().optional(),
@@ -401,6 +404,8 @@ export const env = createEnv({
       process.env.LANGFUSE_READ_FROM_POSTGRES_ONLY,
     LANGFUSE_RETURN_FROM_CLICKHOUSE:
       process.env.LANGFUSE_RETURN_FROM_CLICKHOUSE,
+    LANGFUSE_READ_DASHBOARDS_FROM_CLICKHOUSE:
+      process.env.LANGFUSE_READ_DASHBOARDS_FROM_CLICKHOUSE,
     STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
     STRIPE_WEBHOOK_SIGNING_SECRET: process.env.STRIPE_WEBHOOK_SIGNING_SECRET,
     SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,

--- a/web/src/features/dashboard/server/dashboard-router.ts
+++ b/web/src/features/dashboard/server/dashboard-router.ts
@@ -66,184 +66,183 @@ export const dashboardRouter = createTRPCRouter({
       }
 
       if (
-        !input.queryClickhouse &&
+        input.queryClickhouse ||
         env.LANGFUSE_READ_DASHBOARDS_FROM_CLICKHOUSE === "true"
       ) {
-        return await executeQuery(ctx.prisma, input.projectId, input);
-      }
-
-      switch (input.queryName) {
-        case "traces-total":
-          const count = await getTotalTraces(
-            input.projectId,
-            input.filter ?? [],
-          );
-          return count as DatabaseRow[];
-        case "traces-grouped-by-name":
-          return (
-            await getTracesGroupedByName(
+        switch (input.queryName) {
+          case "traces-total":
+            const count = await getTotalTraces(
               input.projectId,
+              input.filter ?? [],
+            );
+            return count as DatabaseRow[];
+          case "traces-grouped-by-name":
+            return (
+              await getTracesGroupedByName(
+                input.projectId,
+                dashboardColumnDefinitions,
+                input.filter,
+              )
+            ).map(
+              (row) =>
+                ({
+                  traceName: row.name,
+                  countTraceId: row.count,
+                }) as DatabaseRow,
+            );
+          case "observations-model-cost":
+            const cost = await getObservationsCostGroupedByName(
+              input.projectId,
+              input.filter ?? [],
+            );
+
+            return cost.map((row) => ({
+              model: row.name,
+              sumCalculatedTotalCost: row.sum_cost_details,
+              sumTotalTokens: row.sum_usage_details,
+            })) as DatabaseRow[];
+          case "score-aggregate":
+            const scores = await getScoreAggregate(
+              input.projectId,
+              input.filter ?? [],
+            );
+
+            return scores.map((row) => ({
+              scoreName: row.name,
+              scoreSource: row.source,
+              scoreDataType: row.data_type,
+              avgValue: row.avg_value,
+              countScoreId: Number(row.count),
+            })) as DatabaseRow[];
+
+          case "traces-timeseries":
+            const dateTrunc = extractTimeSeries(input.groupBy);
+            if (!dateTrunc) {
+              return [];
+            }
+            const rows = await groupTracesByTime(
+              input.projectId,
+              input.filter ?? [],
+              dateTrunc,
+            );
+
+            return rows as DatabaseRow[];
+          case "observations-usage-timeseries":
+            const dateTruncObs = extractTimeSeries(input.groupBy);
+            if (!dateTruncObs) {
+              return [];
+            }
+            const rowsObs = await getObservationUsageByTime(
+              input.projectId,
+              input.filter ?? [],
+              dateTruncObs,
+            );
+
+            return rowsObs.map((row) => ({
+              startTime: row.start_time,
+              sumTotalTokens: row.sum_usage_details,
+              sumCalculatedTotalCost: row.sum_cost_details,
+              model: row.provided_model_name,
+            })) as DatabaseRow[];
+
+          case "distinct-models":
+            const models = await getDistinctModels(
+              input.projectId,
+              input.filter ?? [],
+            );
+            return models as DatabaseRow[];
+
+          case "scores-aggregate-timeseries":
+            const dateTruncScores = extractTimeSeries(input.groupBy);
+            if (!dateTruncScores) {
+              return [];
+            }
+            const aggregatedScores = await getScoresAggregateOverTime(
+              input.projectId,
+              input.filter ?? [],
+              dateTruncScores,
+            );
+
+            return aggregatedScores as DatabaseRow[];
+
+          case "observations-usage-by-users":
+            const rowsUsers = await getModelUsageByUser(
+              input.projectId,
+              input.filter ?? [],
+            );
+
+            return rowsUsers.map((row) => ({
+              sumTotalTokens: row.sumUsageDetails,
+              sumCalculatedTotalCost: row.sumCostDetails,
+              user: row.userId,
+            })) as DatabaseRow[];
+
+          case "traces-grouped-by-user":
+            const traces = await getTracesGroupedByUsers(
+              input.projectId,
+              input.filter ?? [],
               dashboardColumnDefinitions,
-              input.filter,
-            )
-          ).map(
-            (row) =>
-              ({
-                traceName: row.name,
-                countTraceId: row.count,
-              }) as DatabaseRow,
-          );
-        case "observations-model-cost":
-          const cost = await getObservationsCostGroupedByName(
-            input.projectId,
-            input.filter ?? [],
-          );
+            );
 
-          return cost.map((row) => ({
-            model: row.name,
-            sumCalculatedTotalCost: row.sum_cost_details,
-            sumTotalTokens: row.sum_usage_details,
-          })) as DatabaseRow[];
-        case "score-aggregate":
-          const scores = await getScoreAggregate(
-            input.projectId,
-            input.filter ?? [],
-          );
+            return traces.map((row) => ({
+              user: row.user,
+              countTraceId: Number(row.count),
+            })) as DatabaseRow[];
+          case "observation-latencies-aggregated":
+            const latencies = await getObservationLatencies(
+              input.projectId,
+              input.filter ?? [],
+            );
 
-          return scores.map((row) => ({
-            scoreName: row.name,
-            scoreSource: row.source,
-            scoreDataType: row.data_type,
-            avgValue: row.avg_value,
-            countScoreId: Number(row.count),
-          })) as DatabaseRow[];
+            return latencies.map((row) => ({
+              name: row.name,
+              percentile50Duration: row.p50,
+              percentile90Duration: row.p90,
+              percentile95Duration: row.p95,
+              percentile99Duration: row.p99,
+            })) as DatabaseRow[];
+          case "model-latencies-over-time":
+            const dateTruncModels = extractTimeSeries(input.groupBy);
+            if (!dateTruncModels) {
+              return [];
+            }
+            const modelLatencies = await getModelLatenciesOverTime(
+              input.projectId,
+              input.filter ?? [],
+              dateTruncModels,
+            );
 
-        case "traces-timeseries":
-          const dateTrunc = extractTimeSeries(input.groupBy);
-          if (!dateTrunc) {
-            return [];
-          }
-          const rows = await groupTracesByTime(
-            input.projectId,
-            input.filter ?? [],
-            dateTrunc,
-          );
+            return modelLatencies.map((row) => ({
+              model: row.model,
+              startTime: row.start_time,
+              percentile50Duration: row.p50,
+              percentile75Duration: row.p75,
+              percentile90Duration: row.p90,
+              percentile95Duration: row.p95,
+              percentile99Duration: row.p99,
+            })) as DatabaseRow[];
+          case "traces-latencies-aggregated":
+            const traceLatencies = await getTracesLatencies(
+              input.projectId,
+              input.filter ?? [],
+            );
 
-          return rows as DatabaseRow[];
-        case "observations-usage-timeseries":
-          const dateTruncObs = extractTimeSeries(input.groupBy);
-          if (!dateTruncObs) {
-            return [];
-          }
-          const rowsObs = await getObservationUsageByTime(
-            input.projectId,
-            input.filter ?? [],
-            dateTruncObs,
-          );
+            return traceLatencies.map((row) => ({
+              traceName: row.name,
+              percentile50Duration: row.p50,
+              percentile90Duration: row.p90,
+              percentile95Duration: row.p95,
+              percentile99Duration: row.p99,
+            })) as DatabaseRow[];
 
-          return rowsObs.map((row) => ({
-            startTime: row.start_time,
-            sumTotalTokens: row.sum_usage_details,
-            sumCalculatedTotalCost: row.sum_cost_details,
-            model: row.provided_model_name,
-          })) as DatabaseRow[];
-
-        case "distinct-models":
-          const models = await getDistinctModels(
-            input.projectId,
-            input.filter ?? [],
-          );
-          return models as DatabaseRow[];
-
-        case "scores-aggregate-timeseries":
-          const dateTruncScores = extractTimeSeries(input.groupBy);
-          if (!dateTruncScores) {
-            return [];
-          }
-          const aggregatedScores = await getScoresAggregateOverTime(
-            input.projectId,
-            input.filter ?? [],
-            dateTruncScores,
-          );
-
-          return aggregatedScores as DatabaseRow[];
-
-        case "observations-usage-by-users":
-          const rowsUsers = await getModelUsageByUser(
-            input.projectId,
-            input.filter ?? [],
-          );
-
-          return rowsUsers.map((row) => ({
-            sumTotalTokens: row.sumUsageDetails,
-            sumCalculatedTotalCost: row.sumCostDetails,
-            user: row.userId,
-          })) as DatabaseRow[];
-
-        case "traces-grouped-by-user":
-          const traces = await getTracesGroupedByUsers(
-            input.projectId,
-            input.filter ?? [],
-            dashboardColumnDefinitions,
-          );
-
-          return traces.map((row) => ({
-            user: row.user,
-            countTraceId: Number(row.count),
-          })) as DatabaseRow[];
-        case "observation-latencies-aggregated":
-          const latencies = await getObservationLatencies(
-            input.projectId,
-            input.filter ?? [],
-          );
-
-          return latencies.map((row) => ({
-            name: row.name,
-            percentile50Duration: row.p50,
-            percentile90Duration: row.p90,
-            percentile95Duration: row.p95,
-            percentile99Duration: row.p99,
-          })) as DatabaseRow[];
-        case "model-latencies-over-time":
-          const dateTruncModels = extractTimeSeries(input.groupBy);
-          if (!dateTruncModels) {
-            return [];
-          }
-          const modelLatencies = await getModelLatenciesOverTime(
-            input.projectId,
-            input.filter ?? [],
-            dateTruncModels,
-          );
-
-          return modelLatencies.map((row) => ({
-            model: row.model,
-            startTime: row.start_time,
-            percentile50Duration: row.p50,
-            percentile75Duration: row.p75,
-            percentile90Duration: row.p90,
-            percentile95Duration: row.p95,
-            percentile99Duration: row.p99,
-          })) as DatabaseRow[];
-        case "traces-latencies-aggregated":
-          const traceLatencies = await getTracesLatencies(
-            input.projectId,
-            input.filter ?? [],
-          );
-
-          return traceLatencies.map((row) => ({
-            traceName: row.name,
-            percentile50Duration: row.p50,
-            percentile90Duration: row.p90,
-            percentile95Duration: row.p95,
-            percentile99Duration: row.p99,
-          })) as DatabaseRow[];
-
-        default:
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Query not found",
-          });
+          default:
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Query not found",
+            });
+        }
       }
+      return await executeQuery(ctx.prisma, input.projectId, input);
     }),
   scoreHistogram: protectedProjectProcedure
     .input(

--- a/web/src/features/dashboard/server/dashboard-router.ts
+++ b/web/src/features/dashboard/server/dashboard-router.ts
@@ -29,6 +29,7 @@ import {
 } from "@langfuse/shared/src/server";
 import { type DatabaseRow } from "@/src/server/api/services/queryBuilder";
 import { dashboardColumnDefinitions } from "@langfuse/shared";
+import { env } from "@/src/env.mjs";
 
 export const dashboardRouter = createTRPCRouter({
   chart: protectedProjectProcedure
@@ -64,7 +65,10 @@ export const dashboardRouter = createTRPCRouter({
         });
       }
 
-      if (!input.queryClickhouse) {
+      if (
+        !input.queryClickhouse &&
+        env.LANGFUSE_READ_DASHBOARDS_FROM_CLICKHOUSE === "true"
+      ) {
         return await executeQuery(ctx.prisma, input.projectId, input);
       }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `LANGFUSE_READ_DASHBOARDS_FROM_CLICKHOUSE` flag to control dashboard data source in `dashboard-router.ts`.
> 
>   - **Behavior**:
>     - Adds `LANGFUSE_READ_DASHBOARDS_FROM_CLICKHOUSE` flag in `env.mjs` to control reading dashboards from Clickhouse.
>     - In `dashboard-router.ts`, modifies query execution to use Clickhouse if `LANGFUSE_READ_DASHBOARDS_FROM_CLICKHOUSE` is "true" and `queryClickhouse` is false.
>   - **Environment**:
>     - Adds `LANGFUSE_READ_DASHBOARDS_FROM_CLICKHOUSE` to `env.mjs` with default "false".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2241306d10ed4ea809467c74c667e73bd4bfdddd. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->