### PR TITLE
perf: improve performance for latency dashboard

### DIFF
--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -417,7 +417,6 @@ export const getTracesLatencies = async (
       (f.operator === ">=" || f.operator === ">"),
   ) as DateTimeFilter | undefined;
 
-  console.log("allFilter", JSON.stringify(chFilter));
 
   const query = `
 

--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -410,16 +410,27 @@ export const getTracesLatencies = async (
 
   const appliedFilter = chFilter.apply();
 
+  const timestampFilter = chFilter.find(
+    (f) =>
+      f.clickhouseTable === "traces" &&
+      f.field === 't."timestamp"' &&
+      (f.operator === ">=" || f.operator === ">"),
+  ) as DateTimeFilter | undefined;
+
+  console.log("allFilter", JSON.stringify(chFilter));
+
   const query = `
+
     SELECT 
       quantile(0.5)(date_diff('milliseconds',o.start_time, o.end_time )) as p50,
       quantile(0.9)(date_diff('milliseconds',o.start_time, o.end_time )) as p90,
       quantile(0.95)(date_diff('milliseconds',o.start_time, o.end_time )) as p95,
       quantile(0.99)(date_diff('milliseconds',o.start_time, o.end_time )) as p99,
       t.name as name
-    FROM traces t FINAL JOIN observations o FINAL ON o.trace_id = t.id AND o.project_id = t.project_id
+    FROM observations o FINAL JOIN  traces t FINAL  ON o.trace_id = t.id AND o.project_id = t.project_id
     WHERE project_id = {projectId: String}
     AND ${appliedFilter.query}
+    ${timestampFilter ? `AND o.start_time > {dateTimeFilterObservations: DateTime64(3)} - interval 5 minute` : ""}
     GROUP BY t.name
     ORDER BY p95 DESC
     `;
@@ -435,6 +446,9 @@ export const getTracesLatencies = async (
     params: {
       projectId,
       ...appliedFilter.params,
+      ...(timestampFilter
+        ? { dateTimeFilterObservations: timestampFilter.value }
+        : {}),
     },
   });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves performance of `getTracesLatencies` by adding a timestamp filter and optimizing SQL JOIN order.
> 
>   - **Performance Improvement**:
>     - In `getTracesLatencies` function, added `timestampFilter` to limit data range by filtering `o.start_time` to be within 5 minutes of `timestampFilter` value.
>     - Changed JOIN order in SQL query to `FROM observations o FINAL JOIN traces t FINAL` to potentially optimize query execution.
>   - **Logging**:
>     - Added `console.log` to output all filters applied in `getTracesLatencies`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 08ca7b635702e8ebc036ad3bc594b9a8011932ff. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->