### PR TITLE
perf(cloud): add 60 min stale time for usage indicator

### DIFF
--- a/web/src/ee/features/billing/components/UsageTracker.tsx
+++ b/web/src/ee/features/billing/components/UsageTracker.tsx
@@ -28,6 +28,7 @@ export const UsageTracker = () => {
       refetchOnMount: false,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
+      staleTime: 60 * 60 * 1000,
     },
   );
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `staleTime` to 60 minutes in `useQuery` for `UsageTracker` to reduce data refetching frequency.
> 
>   - **Behavior**:
>     - Set `staleTime` to 60 minutes in `useQuery` for `UsageTracker` in `UsageTracker.tsx`, reducing frequency of data refetching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 90f11a49091ea6b97beed522d9f7fad3b1a95747. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->