### PR TITLE
fix: correctly filter observations by generations for generations ui table

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -370,6 +370,7 @@ const getObservationsTableInternal = async <T>(
         LEFT JOIN traces t FINAL ON t.id = o.trace_id AND t.project_id = o.project_id
         LEFT JOIN scores_avg AS s_avg ON s_avg.trace_id = o.trace_id and s_avg.observation_id = o.id
       WHERE ${appliedObservationsFilter.query}
+        AND o.type = 'GENERATION'
         ${timeFilter ? `AND t.timestamp > {tracesTimestampFilter: DateTime} - INTERVAL 2 DAY` : ""}
         ${search.query}
       ${orderByToClickhouseSql(orderBy ?? null, observationsTableUiColumnDefinitions)}
@@ -445,6 +446,7 @@ export const getObservationsGroupedByModel = async (
       o.provided_model_name as name
     FROM observations o FINAL
     WHERE ${appliedObservationsFilter.query}
+    AND o.type = 'GENERATION'
     GROUP BY o.provided_model_name
     ORDER BY count() DESC
     LIMIT 1000;
@@ -488,6 +490,7 @@ export const getObservationsGroupedByName = async (
       o.name as name
     FROM observations o FINAL
     WHERE ${appliedObservationsFilter.query}
+    AND o.type = 'GENERATION'
     GROUP BY o.name
     ORDER BY count() DESC
     LIMIT 1000;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add filter to include only 'GENERATION' type observations in specific queries in `observations.ts`.
> 
>   - **Behavior**:
>     - Add filter `o.type = 'GENERATION'` to `getObservationsTableInternal()` in `observations.ts` to ensure only 'GENERATION' type observations are included.
>     - Add filter `o.type = 'GENERATION'` to `getObservationsGroupedByModel()` in `observations.ts`.
>     - Add filter `o.type = 'GENERATION'` to `getObservationsGroupedByName()` in `observations.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9be3ce4ebe34772d598ae44262dd04b6f636e847. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->