### PR TITLE
chore: update latency calculation for clickhouse dashboard queries

### DIFF
--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -364,8 +364,8 @@ export const getObservationLatencies = async (
   const appliedFilter = chFilter.apply();
 
   const query = `
-    SELECT 
-      quantilesExact(0.5, 0.9, 0.95, 0.99)(date_diff('milliseconds', o.start_time, o.end_time)) as quantiles,
+    SELECT
+      quantilesExactLow(0.5, 0.9, 0.95, 0.99)(date_diff('milliseconds', o.start_time, o.end_time)) as quantiles,
       name
     FROM observations o FINAL
     ${chFilter.find((f) => f.clickhouseTable === "traces") ? "LEFT JOIN traces t ON o.trace_id = t.id AND o.project_id = t.project_id" : ""}
@@ -422,7 +422,7 @@ export const getTracesLatencies = async (
     )
 
     SELECT
-      quantilesExact(0.5, 0.9, 0.95, 0.99)(duration) as quantiles,
+      quantilesExactLow(0.5, 0.9, 0.95, 0.99)(duration) as quantiles,
       name
     FROM trace_latencies
     GROUP BY name
@@ -466,7 +466,7 @@ export const getModelLatenciesOverTime = async (
   SELECT 
     ${selectTimeseriesColumn(groupBy, "o.start_time", "start_time_bucket")},
     provided_model_name,
-    quantilesExact(0.5, 0.75, 0.9, 0.95, 0.99)(date_diff('milliseconds', o.start_time, o.end_time)) as quantiles
+    quantilesExactLow(0.5, 0.75, 0.9, 0.95, 0.99)(date_diff('milliseconds', o.start_time, o.end_time)) as quantiles
   FROM observations o FINAL
   ${traceFilter ? "JOIN traces t ON o.trace_id = t.id AND o.project_id = t.project_id" : ""}
   WHERE project_id = {projectId: String}

--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -411,38 +411,37 @@ export const getTracesLatencies = async (
   const appliedFilter = chFilter.apply();
 
   const query = `
-    SELECT 
-      quantile(0.5)(date_diff('milliseconds',o.start_time, o.end_time )) as p50,
-      quantile(0.9)(date_diff('milliseconds',o.start_time, o.end_time )) as p90,
-      quantile(0.95)(date_diff('milliseconds',o.start_time, o.end_time )) as p95,
-      quantile(0.99)(date_diff('milliseconds',o.start_time, o.end_time )) as p99,
-      t.name as name
-    FROM traces t FINAL JOIN observations o FINAL ON o.trace_id = t.id AND o.project_id = t.project_id
-    WHERE project_id = {projectId: String}
-    AND ${appliedFilter.query}
-    GROUP BY t.name
-    ORDER BY p95 DESC
-    `;
+    WITH trace_latencies as (
+      select o.trace_id,
+             t.name,
+             o.project_id,
+             date_diff('milliseconds', min(o.start_time), coalesce(max(o.end_time), max(o.start_time))) as duration
+      FROM traces t FINAL 
+      JOIN observations o FINAL
+      ON o.trace_id = t.id AND o.project_id = t.project_id
+      WHERE project_id = {projectId: String}
+      AND ${appliedFilter.query}
+      GROUP BY o.project_id, o.trace_id, t.name
+    )
 
-  const result = await queryClickhouse<{
-    p50: string;
-    p90: string;
-    p95: string;
-    p99: string;
-    name: string;
-  }>({
+    SELECT
+      quantilesExact(0.5, 0.9, 0.95, 0.99)(duration) as quantiles,
+      name
+    FROM trace_latencies
+    GROUP BY name
+    ORDER BY p95 DESC
+  `;
+
+  const result = await queryClickhouse<{ quantiles: string[]; name: string }>({
     query,
-    params: {
-      projectId,
-      ...appliedFilter.params,
-    },
+    params: { projectId, ...appliedFilter.params },
   });
 
   return result.map((row) => ({
-    p50: Number(row.p50) / 1000,
-    p90: Number(row.p90) / 1000,
-    p95: Number(row.p95) / 1000,
-    p99: Number(row.p99) / 1000,
+    p50: Number(row.quantiles[0]) / 1000,
+    p90: Number(row.quantiles[1]) / 1000,
+    p95: Number(row.quantiles[2]) / 1000,
+    p99: Number(row.quantiles[3]) / 1000,
     name: row.name,
   }));
 };

--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -365,38 +365,26 @@ export const getObservationLatencies = async (
 
   const query = `
     SELECT 
-      quantile(0.5)(date_diff('milliseconds',o.start_time, o.end_time )) as p50,
-      quantile(0.9)(date_diff('milliseconds',o.start_time, o.end_time )) as p90,
-      quantile(0.95)(date_diff('milliseconds',o.start_time, o.end_time )) as p95,
-      quantile(0.99)(date_diff('milliseconds',o.start_time, o.end_time )) as p99,
+      quantilesExact(0.5, 0.9, 0.95, 0.99)(date_diff('milliseconds', o.start_time, o.end_time)) as quantiles,
       name
     FROM observations o FINAL
     ${chFilter.find((f) => f.clickhouseTable === "traces") ? "LEFT JOIN traces t ON o.trace_id = t.id AND o.project_id = t.project_id" : ""}
     WHERE project_id = {projectId: String}
     AND ${appliedFilter.query}
     GROUP BY name
-    ORDER BY p95 DESC
+    ORDER BY quantiles[2] DESC
     `;
 
-  const result = await queryClickhouse<{
-    p50: string;
-    p90: string;
-    p95: string;
-    p99: string;
-    name: string;
-  }>({
+  const result = await queryClickhouse<{ quantiles: string[]; name: string }>({
     query,
-    params: {
-      projectId,
-      ...appliedFilter.params,
-    },
+    params: { projectId, ...appliedFilter.params },
   });
 
   return result.map((row) => ({
-    p50: Number(row.p50) / 1000,
-    p90: Number(row.p90) / 1000,
-    p95: Number(row.p95) / 1000,
-    p99: Number(row.p99) / 1000,
+    p50: Number(row.quantiles[0]) / 1000,
+    p90: Number(row.quantiles[1]) / 1000,
+    p95: Number(row.quantiles[2]) / 1000,
+    p99: Number(row.quantiles[3]) / 1000,
     name: row.name,
   }));
 };
@@ -438,18 +426,18 @@ export const getTracesLatencies = async (
       name
     FROM trace_latencies
     GROUP BY name
-    ORDER BY p95 DESC
+    ORDER BY quantiles[2] DESC
   `;
 
   const result = await queryClickhouse<{ quantiles: string[]; name: string }>({
     query,
-      params: {
-          projectId,
-          ...appliedFilter.params,
-          ...(timestampFilter
-              ? { dateTimeFilterObservations: timestampFilter.value }
-              : {}),
-      },
+    params: {
+      projectId,
+      ...appliedFilter.params,
+      ...(timestampFilter
+        ? { dateTimeFilterObservations: timestampFilter.value }
+        : {}),
+    },
   });
 
   return result.map((row) => ({
@@ -478,11 +466,7 @@ export const getModelLatenciesOverTime = async (
   SELECT 
     ${selectTimeseriesColumn(groupBy, "o.start_time", "start_time_bucket")},
     provided_model_name,
-    quantile(0.5)(date_diff('milliseconds', o.start_time, o.end_time)) as p50,
-    quantile(0.75)(date_diff('milliseconds', o.start_time, o.end_time)) as p75,
-    quantile(0.9)(date_diff('milliseconds', o.start_time, o.end_time)) as p90,
-    quantile(0.95)(date_diff('milliseconds', o.start_time, o.end_time)) as p95,
-    quantile(0.99)(date_diff('milliseconds', o.start_time, o.end_time)) as p99
+    quantilesExact(0.5, 0.75, 0.9, 0.95, 0.99)(date_diff('milliseconds', o.start_time, o.end_time)) as quantiles
   FROM observations o FINAL
   ${traceFilter ? "JOIN traces t ON o.trace_id = t.id AND o.project_id = t.project_id" : ""}
   WHERE project_id = {projectId: String}
@@ -494,25 +478,15 @@ export const getModelLatenciesOverTime = async (
   const result = await queryClickhouse<{
     start_time_bucket: string;
     provided_model_name: string;
-    p50: string;
-    p75: string;
-    p90: string;
-    p95: string;
-    p99: string;
-  }>({
-    query,
-    params: {
-      projectId,
-      ...appliedFilter.params,
-    },
-  });
+    quantiles: string[];
+  }>({ query, params: { projectId, ...appliedFilter.params } });
 
   return result.map((row) => ({
-    p50: Number(row.p50) / 1000,
-    p75: Number(row.p75) / 1000,
-    p90: Number(row.p90) / 1000,
-    p95: Number(row.p95) / 1000,
-    p99: Number(row.p99) / 1000,
+    p50: Number(row.quantiles[0]) / 1000,
+    p75: Number(row.quantiles[1]) / 1000,
+    p90: Number(row.quantiles[2]) / 1000,
+    p95: Number(row.quantiles[3]) / 1000,
+    p99: Number(row.quantiles[4]) / 1000,
     model: row.provided_model_name,
     start_time: new Date(row.start_time_bucket),
   }));


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update latency calculations in `dashboards.ts` to use `quantilesExactLow` for efficiency and simplicity.
> 
>   - **Behavior**:
>     - Update latency calculations in `getObservationLatencies`, `getTracesLatencies`, and `getModelLatenciesOverTime` to use `quantilesExactLow` for multiple quantiles.
>     - Change ordering in queries to use `quantiles[2]` instead of `p95`.
>   - **Code Simplification**:
>     - Replace individual quantile calculations with `quantilesExactLow` in `dashboards.ts`.
>     - Update result mapping to extract quantiles from `quantiles` array instead of individual fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4414941fc4e6bd2bc2b3ccb803db8f2dd9e6d9f6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->