### PR TITLE
fix(dataset_runs): ensure consistent ordering to fetch score data for dataset run aggregation metrics table

### DIFF
--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -170,7 +170,7 @@ export const datasetRouter = createTRPCRouter({
           array_agg(s.score) AS "scores"
         FROM
           paginated_runs
-          JOIN dataset_runs runs ON runs.id = paginated_runs.id
+          JOIN dataset_runs runs ON runs.id = paginated_runs.id AND runs.project_id = ${input.projectId}
           JOIN datasets ON datasets.id = runs.dataset_id AND datasets.project_id = ${input.projectId}
           LEFT JOIN LATERAL (
               SELECT

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -167,7 +167,7 @@ export const datasetRouter = createTRPCRouter({
         )    
         SELECT
           runs.id "runId",
-          array_remove(array_agg(s.score), NULL) AS "scores"
+          array_agg(s.score) AS "scores"
         FROM
           paginated_runs
           JOIN dataset_runs runs ON runs.id = paginated_runs.id
@@ -185,6 +185,7 @@ export const datasetRouter = createTRPCRouter({
               WHERE 
                 ri.project_id = ${input.projectId}
                 AND ri.dataset_run_id = runs.id
+                AND s.name IS NOT NULL
           ) s ON true
         GROUP BY
           runs.id


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces CTE `paginated_runs` in `dataset-router.ts` for consistent ordering of dataset runs by `created_at`, ensuring accurate score aggregation and handling missing scores or traces.
> 
>   - **Behavior**:
>     - Introduced CTE `paginated_runs` in `dataset-router.ts` for consistent ordering of dataset runs by `created_at`.
>     - Modified SQL query to join `paginated_runs` with `dataset_runs` and `datasets` for score aggregation.
>     - Ensures scores are only aggregated for non-null `s.name` values.
>   - **SQL Changes**:
>     - Replaced direct `dataset_runs` selection with `paginated_runs` CTE for better pagination handling.
>     - Changed `JOIN` to `LEFT JOIN` for `scores` and `traces` to handle cases where scores or traces might not exist.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2b69d3cd1bc993f3b3082df87f3a293d56413b72. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->