### PR TITLE
Revert "fix(dataset_runs): ensure consistent ordering to fetch score data for dataset run aggregation metrics table"

### DIFF
--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -156,39 +156,34 @@ export const datasetRouter = createTRPCRouter({
       const scoresByRunId = await ctx.prisma.$queryRaw<
         Array<{ scores: Array<ScoreSimplified>; runId: string }>
       >(Prisma.sql`
-        WITH paginated_runs AS (
-          SELECT id
-          FROM dataset_runs
-          WHERE dataset_id = ${input.datasetId}
-            AND project_id = ${input.projectId}
-          ORDER BY created_at DESC
-          LIMIT ${input.limit}
-          OFFSET ${input.page * input.limit}
-        )    
         SELECT
           runs.id "runId",
           array_agg(s.score) AS "scores"
         FROM
-          paginated_runs
-          JOIN dataset_runs runs ON runs.id = paginated_runs.id AND runs.project_id = ${input.projectId}
+          dataset_runs runs
           JOIN datasets ON datasets.id = runs.dataset_id AND datasets.project_id = ${input.projectId}
           LEFT JOIN LATERAL (
               SELECT
               jsonb_build_object ('name', s.name, 'stringValue', s.string_value, 'value', s.value, 'source', s."source", 'dataType', s.data_type, 'comment', s.comment) AS "score"
               FROM
                 dataset_run_items ri
-                LEFT JOIN scores s 
+                JOIN scores s 
                   ON s.trace_id = ri.trace_id 
                   AND (ri.observation_id IS NULL OR s.observation_id = ri.observation_id)
                   AND s.project_id = ${input.projectId}
-                LEFT JOIN traces t ON t.id = s.trace_id AND t.project_id = ${input.projectId}
+                JOIN traces t ON t.id = s.trace_id AND t.project_id = ${input.projectId}
               WHERE 
                 ri.project_id = ${input.projectId}
                 AND ri.dataset_run_id = runs.id
-                AND s.name IS NOT NULL
           ) s ON true
+        WHERE 
+          runs.dataset_id = ${input.datasetId}
+          AND runs.project_id = ${input.projectId}
+          AND s.score IS NOT NULL
         GROUP BY
           runs.id
+        LIMIT ${input.limit}
+        OFFSET ${input.page * input.limit}
       `);
 
       const runs = await ctx.prisma.$queryRaw<


### PR DESCRIPTION
Reverts langfuse/langfuse#4176
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts SQL query changes in `runsByDatasetId` in `dataset-router.ts`, removing `WITH paginated_runs` CTE and adjusting joins and conditions.
> 
>   - **Revert Changes**:
>     - Reverts SQL query changes in `runsByDatasetId` in `dataset-router.ts`.
>     - Removes `WITH paginated_runs` CTE and reverts to direct filtering and limiting of `dataset_runs`.
>     - Adjusts joins and conditions to previous state, ensuring scores are not null.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2a4f38962ed7a686b90be80b929fa5da22be5ec9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->