### PR TITLE
feat: use timestamp to link single traces from navigation

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -132,7 +132,7 @@ const getTracesTableGeneric = async <T>(props: FetchTracesTableProps) => {
 
   const traceIdFilter = tracesFilter.find(
     (f) => f.clickhouseTable === "traces" && f.field === "id",
-  ) as StringFilter | undefined;
+  ) as StringFilter | StringOptionsFilter | undefined;
 
   traceIdFilter
     ? scoresFilter.push(
@@ -140,7 +140,10 @@ const getTracesTableGeneric = async <T>(props: FetchTracesTableProps) => {
           clickhouseTable: "scores",
           field: "trace_id",
           operator: "any of",
-          values: [traceIdFilter.value],
+          values:
+            traceIdFilter instanceof StringFilter
+              ? [traceIdFilter.value]
+              : traceIdFilter.values,
         }),
       )
     : null;
@@ -150,7 +153,10 @@ const getTracesTableGeneric = async <T>(props: FetchTracesTableProps) => {
           clickhouseTable: "observations",
           field: "trace_id",
           operator: "any of",
-          values: [traceIdFilter.value],
+          values:
+            traceIdFilter instanceof StringFilter
+              ? [traceIdFilter.value]
+              : traceIdFilter.values,
         }),
       )
     : null;

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -188,6 +188,7 @@ export default function TracesTable({
         "traces",
         traces.data.traces.map((t) => ({
           id: t.id,
+          params: { timestamp: t.timestamp.toISOString() },
         })),
       );
     }

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -344,7 +344,13 @@ export function TracePage({
                 const queryParamString = Boolean(queryParams.size)
                   ? `?${queryParams.toString()}`
                   : "";
-                return `/project/${projectId as string}/traces/${entry.id}${queryParamString}`;
+
+                const timestamp =
+                  entry.params && entry.params.timestamp
+                    ? encodeURIComponent(entry.params.timestamp)
+                    : undefined;
+
+                return `/project/${projectId as string}/traces/${entry.id}${queryParamString}${timestamp ? `?timestamp=${timestamp}` : ""}`;
               }}
               listKey="traces"
             />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance trace linking by incorporating timestamps into trace filtering and URL generation.
> 
>   - **Behavior**:
>     - Update `getTracesTableGeneric` in `traces.ts` to handle `StringOptionsFilter` for trace ID filtering.
>     - Modify URL generation in `TracePage` and `TracesTable` to include `timestamp` as a query parameter.
>   - **Components**:
>     - Add `timestamp` to trace link paths in `TracesTable` and `TracePage`.
>     - Update `TracesDynamicCell` to pass `timestamp` to API queries.
>   - **Misc**:
>     - Adjust `traceIdFilter` logic in `traces.ts` to support multiple values.
>     - Minor refactoring in `traces.tsx` to handle new timestamp parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 25698b3bbab934b1b5098b0164b393ecb77149d3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->