### PR TITLE
chore: centralize lookback guarantees

### DIFF
--- a/packages/shared/src/server/repositories/Readme.md
+++ b/packages/shared/src/server/repositories/Readme.md
@@ -1,15 +1,15 @@
-## Reposoitory docs
+## Repository docs
 
 ### Guarantees for relating data within Langfuse
 
 - Finding a Trace based on an observation [Linear](https://linear.app/langfuse/issue/LFE-2745/improve-generations-table-query-performance)
   - Traces can occur earlier than an observation.
-  - 96% of observations.start_time ocurr 2 mins later than the trace.timestamp
+  - 96% of observations.start_time occur 2 mins later than the trace.timestamp
   - There is a very large long-tail. Hence we will use a 2-day (2880 min) look back for now.
 - Finding an Observation based on a Trace [Linear](https://linear.app/langfuse/issue/LFE-2409/table-queries)
   - Observations have a very high likelihood of happening after the trace.
-  - 97% of traces.timestamp ocurr 2 mins earlier than the observation.start_time
+  - 97% of traces.timestamp occur 2 mins earlier than the observation.start_time
   - We will maintain a 1 hour cutoff for now.
 - Finding traces/observations based on a Score timestamp
-  - For scores we have very likelihood of happening after the trace / observation.
+  - For scores we have a very high likelihood of happening after the trace / observation.
   - We maintain a 1 hour cutoff for now.

--- a/packages/shared/src/server/repositories/Readme.md
+++ b/packages/shared/src/server/repositories/Readme.md
@@ -1,0 +1,15 @@
+## Reposoitory docs
+
+### Guarantees for relating data within Langfuse
+
+- Finding a Trace based on an observation [Linear](https://linear.app/langfuse/issue/LFE-2745/improve-generations-table-query-performance)
+  - Traces can occurr earlier than an observation.
+  - 96% of observations.start_time ocurr 2 mins later than the trace.timestamp
+  - There is a very large long-tail. Hence we will use a 2-day (2880 min) look back for now.
+- Finding an Observation based on a Trace [Linear](https://linear.app/langfuse/issue/LFE-2409/table-queries)
+  - Observations have a very high likelihood of happening after the trace.
+  - 97% of traces.timestamp ocurr 2 mins earlier than the observation.start_time
+  - We will maintain a 1 hour cutoff for now.
+- Finding traces/observations based on a Score timestamp
+  - For scores we have very likelihood of happening after the trace / observation.
+  - We maintain a 1 hour cutoff for now.

--- a/packages/shared/src/server/repositories/Readme.md
+++ b/packages/shared/src/server/repositories/Readme.md
@@ -3,7 +3,7 @@
 ### Guarantees for relating data within Langfuse
 
 - Finding a Trace based on an observation [Linear](https://linear.app/langfuse/issue/LFE-2745/improve-generations-table-query-performance)
-  - Traces can occurr earlier than an observation.
+  - Traces can occur earlier than an observation.
   - 96% of observations.start_time ocurr 2 mins later than the trace.timestamp
   - There is a very large long-tail. Hence we will use a 2-day (2880 min) look back for now.
 - Finding an Observation based on a Trace [Linear](https://linear.app/langfuse/issue/LFE-2409/table-queries)

--- a/packages/shared/src/server/repositories/constants.ts
+++ b/packages/shared/src/server/repositories/constants.ts
@@ -1,0 +1,7 @@
+// t.timestamp > observation.start_time - 2 days
+export const OBSERVATIONS_TO_TRACE_INTERVAL = "INTERVAL 2 DAY";
+// observation.start_time > t.timestamp - 1 hour
+export const TRACE_TO_OBSERVATIONS_INTERVAL = "INTERVAL 1 HOUR";
+// observation.start_time > s.timestamp - 1 hour
+// t.timestamp > s.timestamp - 1 hour
+export const SCORE_TO_TRACE_OBSERVATIONS_INTERVAL = "INTERVAL 1 HOUR";

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -26,6 +26,7 @@ import {
   convertObservation,
 } from "./observations_converters";
 import { clickhouseSearchCondition } from "../queries/clickhouse-sql/search";
+import { OBSERVATIONS_TO_TRACE_INTERVAL } from "./constants";
 
 export const getObservationsViewForTrace = async (
   traceId: string,
@@ -371,7 +372,7 @@ const getObservationsTableInternal = async <T>(
         LEFT JOIN scores_avg AS s_avg ON s_avg.trace_id = o.trace_id and s_avg.observation_id = o.id
       WHERE ${appliedObservationsFilter.query}
         AND o.type = 'GENERATION'
-        ${timeFilter ? `AND t.timestamp > {tracesTimestampFilter: DateTime} - INTERVAL 2 DAY` : ""}
+        ${timeFilter ? `AND t.timestamp > {tracesTimestampFilter: DateTime} - ${OBSERVATIONS_TO_TRACE_INTERVAL}` : ""}
         ${search.query}
       ${orderByToClickhouseSql(orderBy ?? null, observationsTableUiColumnDefinitions)}
       ${limit !== undefined && offset !== undefined ? `LIMIT ${limit} OFFSET ${offset}` : ""};`;

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -26,6 +26,7 @@ import { sessionCols } from "../../tableDefinitions/mapSessionTable";
 import { convertDateToClickhouseDateTime } from "../clickhouse/client";
 import { convertClickhouseToDomain } from "./traces_converters";
 import { clickhouseSearchCondition } from "../queries/clickhouse-sql/search";
+import { TRACE_TO_OBSERVATIONS_INTERVAL } from "./constants";
 
 export type TracesTableReturnType = Pick<
   TraceRecordReadType,
@@ -620,7 +621,7 @@ const getSessionsTableGeneric = async <T>(props: FetchTracesTableProps) => {
               anyLast(project_id) as project_id
         FROM observations o FINAL
         WHERE o.project_id = {projectId: String}
-        ${traceTimestampFilter ? `AND o.start_time >= {observationsStartTime: DateTime} - INTERVAL 1 DAY` : ""}
+        ${traceTimestampFilter ? `AND o.start_time >= {observationsStartTime: DateTime} - ${TRACE_TO_OBSERVATIONS_INTERVAL}` : ""}
         GROUP BY o.trace_id
     ),
     session_data AS (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Centralize lookback guarantees by defining constants for time intervals and using them across various files.
> 
>   - **Constants**:
>     - Add `OBSERVATIONS_TO_TRACE_INTERVAL`, `TRACE_TO_OBSERVATIONS_INTERVAL`, and `SCORE_TO_TRACE_OBSERVATIONS_INTERVAL` in `constants.ts`.
>   - **Dashboards**:
>     - Replace hardcoded intervals with constants in `getScoreAggregate()`, `getModelUsageByUser()`, and `getTracesLatencies()`.
>   - **Observations**:
>     - Use `OBSERVATIONS_TO_TRACE_INTERVAL` in `getObservationsTableInternal()`.
>   - **Traces**:
>     - Use `TRACE_TO_OBSERVATIONS_INTERVAL` in `getSessionsTableGeneric()`.
>   - **Documentation**:
>     - Add `Readme.md` to document lookback guarantees.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d452d73d0b99a3a1ec19da3bdf29786967ab766f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->