### PR TITLE
fix: fix public trace access

### DIFF
--- a/web/src/features/dashboard/server/dashboard-router.ts
+++ b/web/src/features/dashboard/server/dashboard-router.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { isClickhouseEligible } from "@/src/server/utils/checkClickhouseAccess";
+import { isClickhouseAdminEligible } from "@/src/server/utils/checkClickhouseAccess";
 import {
   createTRPCRouter,
   protectedProjectProcedure,
@@ -58,7 +58,10 @@ export const dashboardRouter = createTRPCRouter({
       }),
     )
     .query(async ({ input, ctx }) => {
-      if (input.queryClickhouse && !isClickhouseEligible(ctx.session.user)) {
+      if (
+        input.queryClickhouse &&
+        !isClickhouseAdminEligible(ctx.session.user)
+      ) {
         throw new TRPCError({
           code: "UNAUTHORIZED",
           message: "Not eligible to query clickhouse",

--- a/web/src/server/api/routers/generations/getAllQueries.ts
+++ b/web/src/server/api/routers/generations/getAllQueries.ts
@@ -10,7 +10,7 @@ import {
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 import {
-  isClickhouseEligible,
+  isClickhouseAdminEligible,
   measureAndReturnApi,
 } from "@/src/server/utils/checkClickhouseAccess";
 
@@ -112,7 +112,7 @@ export const getAllQueries = {
           };
         },
         clickhouseExecution: async () => {
-          if (!isClickhouseEligible(ctx.session.user)) {
+          if (!isClickhouseAdminEligible(ctx.session.user)) {
             throw new TRPCError({
               code: "UNAUTHORIZED",
               message: "Not eligible to query clickhouse",

--- a/web/src/server/api/routers/observations.ts
+++ b/web/src/server/api/routers/observations.ts
@@ -2,7 +2,7 @@ import {
   createTRPCRouter,
   protectedGetTraceProcedure,
 } from "@/src/server/api/trpc";
-import { isClickhouseEligible } from "@/src/server/utils/checkClickhouseAccess";
+import { isClickhouseAdminEligible } from "@/src/server/utils/checkClickhouseAccess";
 import {
   type jsonSchema,
   type ObservationLevel,
@@ -68,7 +68,7 @@ export const observationsRouter = createTRPCRouter({
           },
         });
       } else {
-        if (!isClickhouseEligible(ctx.session.user)) {
+        if (!isClickhouseAdminEligible(ctx.session.user)) {
           throw new TRPCError({
             code: "UNAUTHORIZED",
             message: "Not eligible to query clickhouse",

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -45,7 +45,7 @@ import {
   searchExistingAnnotationScore,
 } from "@langfuse/shared/src/server";
 import {
-  isClickhouseEligible,
+  isClickhouseAdminEligible,
   measureAndReturnApi,
 } from "@/src/server/utils/checkClickhouseAccess";
 import { TRPCError } from "@trpc/server";
@@ -571,7 +571,7 @@ export const scoresRouter = createTRPCRouter({
           }));
         },
         clickhouseExecution: async () => {
-          if (!isClickhouseEligible(ctx.session.user)) {
+          if (!isClickhouseAdminEligible(ctx.session.user)) {
             throw new TRPCError({
               code: "UNAUTHORIZED",
               message: "Not eligible to query clickhouse",

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -50,7 +50,7 @@ import {
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 import {
-  isClickhouseEligible,
+  isClickhouseAdminEligible,
   measureAndReturnApi,
 } from "@/src/server/utils/checkClickhouseAccess";
 
@@ -136,7 +136,7 @@ export const traceRouter = createTRPCRouter({
           };
         },
         clickhouseExecution: async () => {
-          if (!isClickhouseEligible(ctx.session.user)) {
+          if (!isClickhouseAdminEligible(ctx.session.user)) {
             throw new TRPCError({
               code: "UNAUTHORIZED",
               message: "Not eligible to query clickhouse",
@@ -195,7 +195,7 @@ export const traceRouter = createTRPCRouter({
           };
         },
         clickhouseExecution: async () => {
-          if (!isClickhouseEligible(ctx.session.user)) {
+          if (!isClickhouseAdminEligible(ctx.session.user)) {
             throw new TRPCError({
               code: "UNAUTHORIZED",
               message: "Not eligible to query clickhouse",
@@ -276,7 +276,7 @@ export const traceRouter = createTRPCRouter({
           }));
         },
         clickhouseExecution: async () => {
-          if (!isClickhouseEligible(ctx.session.user)) {
+          if (!isClickhouseAdminEligible(ctx.session.user)) {
             throw new TRPCError({
               code: "UNAUTHORIZED",
               message: "Not eligible to query clickhouse",
@@ -388,7 +388,7 @@ export const traceRouter = createTRPCRouter({
           return res;
         },
         clickhouseExecution: async () => {
-          if (!isClickhouseEligible(ctx.session.user)) {
+          if (!isClickhouseAdminEligible(ctx.session.user)) {
             throw new TRPCError({
               code: "UNAUTHORIZED",
               message: "Not eligible to query clickhouse",
@@ -445,7 +445,7 @@ export const traceRouter = createTRPCRouter({
           });
         },
         clickhouseExecution: async () => {
-          if (!isClickhouseEligible(ctx.session.user)) {
+          if (!isClickhouseAdminEligible(ctx.session.user)) {
             throw new TRPCError({
               code: "UNAUTHORIZED",
               message: "Not eligible to query clickhouse",

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -349,14 +349,15 @@ const enforceTraceAccess = t.middleware(async ({ ctx, rawInput, next }) => {
     result.data.queryClickhouse === true &&
     isClickhouseAdminEligible(ctx.session?.user) // basically checks if user exists and admin
   ) {
-    const chTrace = await getTraceByIdOrThrow(
+    console.log("querying clickhouse for admin");
+    trace = await getTraceByIdOrThrow(
       traceId,
       projectId,
       timestamp ?? undefined,
     );
-    if (chTrace.public) trace = chTrace;
     // check from postgres for non admins when env is set accordingly
   } else if (env.LANGFUSE_READ_FROM_POSTGRES_ONLY === "true") {
+    console.log("querying clickhouse LANGFUSE_READ_FROM_POSTGRES_ONLY");
     trace = await prisma.trace.findFirst({
       where: {
         id: traceId,
@@ -368,13 +369,15 @@ const enforceTraceAccess = t.middleware(async ({ ctx, rawInput, next }) => {
     });
     // check clickhouse otherwise
   } else {
-    const chTrace = await getTraceByIdOrThrow(
+    console.log("query clickhouse default");
+    trace = await getTraceByIdOrThrow(
       traceId,
       projectId,
       timestamp ?? undefined,
     );
-    if (chTrace.public) trace = chTrace;
   }
+
+  console.log("fonud trace", trace);
 
   if (!trace) {
     logger.error(`Trace with id ${traceId} not found for project ${projectId}`);

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -83,7 +83,8 @@ import {
   getTraceByIdOrThrow,
   logger,
 } from "@langfuse/shared/src/server";
-import { isClickhouseEligible } from "@/src/server/utils/checkClickhouseAccess";
+import { isClickhouseAdminEligible } from "@/src/server/utils/checkClickhouseAccess";
+import { env } from "@/src/env.mjs";
 
 setUpSuperjson();
 
@@ -341,22 +342,21 @@ const enforceTraceAccess = t.middleware(async ({ ctx, rawInput, next }) => {
   const projectId = result.data.projectId;
   const timestamp = result.data.timestamp;
 
-  // if the user is eligible for clickhouse, and wants to use clickhouse, do so.
   let trace;
 
+  // first check clickhoue for admin use case if sent via the API accordingly
   if (
     result.data.queryClickhouse === true &&
-    isClickhouseEligible(ctx.session?.user)
+    isClickhouseAdminEligible(ctx.session?.user) // basically checks if user exists and admin
   ) {
-    logger.info(
-      `Querying Clickhouse for traceid: ${traceId} and project: ${projectId} `,
-    );
-    trace = await getTraceByIdOrThrow(
+    const chTrace = await getTraceByIdOrThrow(
       traceId,
       projectId,
       timestamp ?? undefined,
     );
-  } else {
+    if (chTrace.public) trace = chTrace;
+    // check from postgres for non admins when env is set accordingly
+  } else if (env.LANGFUSE_READ_FROM_POSTGRES_ONLY === "true") {
     trace = await prisma.trace.findFirst({
       where: {
         id: traceId,
@@ -366,6 +366,14 @@ const enforceTraceAccess = t.middleware(async ({ ctx, rawInput, next }) => {
         public: true,
       },
     });
+    // check clickhouse otherwise
+  } else {
+    const chTrace = await getTraceByIdOrThrow(
+      traceId,
+      projectId,
+      timestamp ?? undefined,
+    );
+    if (chTrace.public) trace = chTrace;
   }
 
   if (!trace) {

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -349,7 +349,6 @@ const enforceTraceAccess = t.middleware(async ({ ctx, rawInput, next }) => {
     result.data.queryClickhouse === true &&
     isClickhouseAdminEligible(ctx.session?.user) // basically checks if user exists and admin
   ) {
-    console.log("querying clickhouse for admin");
     trace = await getTraceByIdOrThrow(
       traceId,
       projectId,
@@ -357,7 +356,6 @@ const enforceTraceAccess = t.middleware(async ({ ctx, rawInput, next }) => {
     );
     // check from postgres for non admins when env is set accordingly
   } else if (env.LANGFUSE_READ_FROM_POSTGRES_ONLY === "true") {
-    console.log("querying clickhouse LANGFUSE_READ_FROM_POSTGRES_ONLY");
     trace = await prisma.trace.findFirst({
       where: {
         id: traceId,
@@ -369,15 +367,12 @@ const enforceTraceAccess = t.middleware(async ({ ctx, rawInput, next }) => {
     });
     // check clickhouse otherwise
   } else {
-    console.log("query clickhouse default");
     trace = await getTraceByIdOrThrow(
       traceId,
       projectId,
       timestamp ?? undefined,
     );
   }
-
-  console.log("fonud trace", trace);
 
   if (!trace) {
     logger.error(`Trace with id ${traceId} not found for project ${projectId}`);

--- a/web/src/server/utils/checkClickhouseAccess.ts
+++ b/web/src/server/utils/checkClickhouseAccess.ts
@@ -5,8 +5,9 @@ import * as opentelemetry from "@opentelemetry/api";
 import { TRPCError } from "@trpc/server";
 
 export const isClickhouseEligible = (user?: User | null) => {
+  if (!user) return true; // public API access
+
   return (
-    user &&
     user.admin &&
     user.admin === true &&
     env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION &&
@@ -32,13 +33,6 @@ export const measureAndReturnApi = async <T, Y>(args: {
       const { input, user, pgExecution, clickhouseExecution } = args;
 
       currentSpan?.setAttribute("operation", args.operation);
-
-      if (!user) {
-        throw new TRPCError({
-          code: "UNAUTHORIZED",
-          message: "Did not find user in function context",
-        });
-      }
 
       if (input.queryClickhouse && !isClickhouseEligible(user)) {
         throw new TRPCError({

--- a/web/src/server/utils/checkClickhouseAccess.ts
+++ b/web/src/server/utils/checkClickhouseAccess.ts
@@ -4,10 +4,9 @@ import { type User } from "next-auth";
 import * as opentelemetry from "@opentelemetry/api";
 import { TRPCError } from "@trpc/server";
 
-export const isClickhouseEligible = (user?: User | null) => {
-  if (!user) return true; // public API access
-
+export const isClickhouseAdminEligible = (user?: User | null) => {
   return (
+    user &&
     user.admin &&
     user.admin === true &&
     env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION &&
@@ -34,7 +33,7 @@ export const measureAndReturnApi = async <T, Y>(args: {
 
       currentSpan?.setAttribute("operation", args.operation);
 
-      if (input.queryClickhouse && !isClickhouseEligible(user)) {
+      if (input.queryClickhouse && !isClickhouseAdminEligible(user)) {
         throw new TRPCError({
           code: "UNAUTHORIZED",
           message: "Not eligible to query clickhouse",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modify Clickhouse access checks to allow public API access and rename eligibility function.
> 
>   - **Behavior**:
>     - Modify `isClickhouseEligible` to `isClickhouseAdminEligible` in `checkClickhouseAccess.ts` to allow public API access when `user` is `null` or `undefined`.
>     - Remove user presence check in `measureAndReturnApi` in `checkClickhouseAccess.ts`, allowing public access without throwing an error.
>   - **Error Handling**:
>     - Remove `TRPCError` for missing user in `measureAndReturnApi` in `checkClickhouseAccess.ts`.
>   - **Renames**:
>     - Rename `isClickhouseEligible` to `isClickhouseAdminEligible` in all relevant files.
>   - **Files Affected**:
>     - `dashboard-router.ts`, `getAllQueries.ts`, `observations.ts`, `scores.ts`, `traces.ts`, `trpc.ts`, `checkClickhouseAccess.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9e98bc17a03afa71456b39933b1eccc79db86310. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->