### PR TITLE
chore: add tests for traces table UI

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -24,7 +24,10 @@ import { orderByToClickhouseSql } from "../queries/clickhouse-sql/orderby-factor
 import { UiColumnMapping } from "../../tableDefinitions";
 import { sessionCols } from "../../tableDefinitions/mapSessionTable";
 import { convertDateToClickhouseDateTime } from "../clickhouse/client";
-import { convertClickhouseToDomain } from "./traces_converters";
+import {
+  convertClickhouseToDomain,
+  convertToDomain,
+} from "./traces_converters";
 import { clickhouseSearchCondition } from "../queries/clickhouse-sql/search";
 import { TRACE_TO_OBSERVATIONS_INTERVAL } from "./constants";
 
@@ -40,7 +43,6 @@ export type TracesTableReturnType = Pick<
   | "user_id"
   | "session_id"
   | "tags"
-  | "metadata"
   | "public"
 > & {
   level: ObservationLevel;
@@ -82,7 +84,7 @@ export const getTracesTable = async (
   const rows = await getTracesTableGeneric<TracesTableReturnType>({
     select: `
     t.id, 
-    t.project_id, 
+    t.project_id as project_id, 
     t.timestamp, 
     t.tags, 
     t.bookmarked, 
@@ -107,7 +109,7 @@ export const getTracesTable = async (
     offset,
   });
 
-  return rows;
+  return rows.map(convertToDomain);
 };
 
 type FetchTracesTableProps = {

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -99,7 +99,6 @@ export const getTracesTable = async (
     os.level as level,
     os.observation_count as observation_count,
     s.scores_avg as scores_avg,
-    t.metadata,
     t.public`,
     projectId,
     filter,

--- a/packages/shared/src/server/repositories/traces_converters.ts
+++ b/packages/shared/src/server/repositories/traces_converters.ts
@@ -69,20 +69,24 @@ export type TracesAllReturnType = {
   tags: string[];
 };
 
-export const convertToReturnType = (
-  row: TracesTableReturnType,
-): TracesAllReturnType => {
+export const convertToDomain = (row: TracesTableReturnType) => {
   return {
     id: row.id,
-    name: row.name ?? null,
+    projectId: row.project_id,
     timestamp: parseClickhouseUTCDateTimeFormat(row.timestamp),
     tags: row.tags,
     bookmarked: row.bookmarked,
+    name: row.name ?? null,
     release: row.release ?? null,
     version: row.version ?? null,
-    projectId: row.project_id,
     userId: row.user_id ?? null,
     sessionId: row.session_id ?? null,
+    latencyMilliseconds: Number(row.latency_milliseconds),
+    usageDetails: row.usage_details,
+    costDetails: row.cost_details,
+    level: row.level,
+    observationCount: Number(row.observation_count),
+    scoresAvg: row.scores_avg,
     public: row.public,
   };
 };
@@ -99,30 +103,4 @@ export type TracesMetricsReturnType = {
   calculatedInputCost: Decimal | null;
   calculatedOutputCost: Decimal | null;
   scores: ScoreAggregate;
-};
-
-export const convertMetricsReturnType = (
-  row: TracesTableReturnType & { scores: ScoreAggregate },
-): TracesMetricsReturnType => {
-  return {
-    id: row.id,
-    promptTokens: BigInt(row.usage_details?.input ?? 0),
-    completionTokens: BigInt(row.usage_details?.output ?? 0),
-    totalTokens: BigInt(row.usage_details?.total ?? 0),
-    latency: row.latency_milliseconds
-      ? Number(row.latency_milliseconds) / 1000
-      : null,
-    level: row.level,
-    observationCount: BigInt(row.observation_count ?? 0),
-    calculatedTotalCost: row.cost_details?.total
-      ? new Decimal(row.cost_details.total)
-      : null,
-    calculatedInputCost: row.cost_details?.input
-      ? new Decimal(row.cost_details.input)
-      : null,
-    calculatedOutputCost: row.cost_details?.output
-      ? new Decimal(row.cost_details.output)
-      : null,
-    scores: row.scores,
-  };
 };

--- a/web/src/__tests__/server/api/tables/traces-ui.servertest.ts
+++ b/web/src/__tests__/server/api/tables/traces-ui.servertest.ts
@@ -1,0 +1,157 @@
+import {
+  createObservation,
+  createTrace,
+} from "@/src/__tests__/server/repositories/clickhouse-helpers";
+import { pruneDatabase } from "@/src/__tests__/test-utils";
+import { getTracesTable } from "@langfuse/shared/src/server";
+import { v4 } from "uuid";
+
+const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
+
+describe("UI Traces table", () => {
+  beforeEach(async () => {
+    await pruneDatabase();
+  });
+
+  it("should return a single trace", async () => {
+    const traceId = v4();
+
+    const trace = {
+      id: traceId,
+      project_id: projectId,
+      session_id: v4(),
+      timestamp: Date.now(),
+      metadata: {},
+      public: false,
+      bookmarked: false,
+      name: "Test Trace",
+      tags: ["tag-alpha", "tag-beta"],
+      release: "alpha",
+      version: "1.0.0",
+      user_id: "user-id-1",
+      created_at: Date.now(),
+      updated_at: Date.now(),
+      event_ts: Date.now(),
+      is_deleted: 0,
+    };
+
+    await createTrace(trace);
+
+    const result = await getTracesTable(
+      projectId,
+      [],
+      undefined,
+      undefined,
+      10,
+      0,
+    );
+
+    expect(result.length).toEqual(1);
+
+    expect(result[0].id).toEqual(trace.id);
+    expect(result[0].projectId).toEqual(trace.project_id);
+    expect(result[0].name).toEqual(trace.name);
+    expect(result[0].timestamp).toEqual(new Date(trace.timestamp));
+    expect(result[0].tags).toEqual(trace.tags);
+    expect(result[0].bookmarked).toEqual(trace.bookmarked);
+    expect(result[0].release).toEqual(trace.release);
+    expect(result[0].version).toEqual(trace.version);
+    expect(result[0].userId).toEqual(trace.user_id);
+    expect(result[0].sessionId).toEqual(trace.session_id);
+    expect(result[0].public).toEqual(trace.public);
+    expect(result[0].tags).toEqual(trace.tags);
+  });
+
+  it("should return a trace joined with an observation", async () => {
+    const traceId = v4();
+
+    const trace = {
+      id: traceId,
+      project_id: projectId,
+      session_id: v4(),
+      timestamp: Date.now(),
+      metadata: {},
+      public: false,
+      bookmarked: false,
+      name: "Test Trace",
+      tags: ["tag-alpha", "tag-beta"],
+      release: "alpha",
+      version: "1.0.0",
+      user_id: "user-id-1",
+      created_at: Date.now(),
+      updated_at: Date.now(),
+      event_ts: Date.now(),
+      is_deleted: 0,
+    };
+
+    const observation = {
+      id: v4(),
+      project_id: projectId,
+      trace_id: traceId,
+      prompt_id: v4(),
+      type: "GENERATION",
+      created_at: Date.now(),
+      updated_at: Date.now(),
+      event_ts: Date.now(),
+      is_deleted: 0,
+      metadata: {
+        some: "metadata",
+      },
+      start_time: Date.now(),
+      provided_usage_details: {},
+      provided_cost_details: {},
+      usage_details: { input: 100, output: 200 },
+      cost_details: { input: 100, output: 200 },
+      name: "Test Observation",
+      level: "WARNING",
+      input: "some llm input",
+      output: "some llm output",
+      version: "1.2.0",
+      parent_observation_id: null,
+      status_message: "this is an error",
+      provided_model_name: "anthropic",
+      internal_model_id: "some-model-id",
+      model_parameters: JSON.stringify({
+        model: "test-model",
+        model_version: "1",
+        model_parameters: {},
+      }),
+      total_cost: 100,
+      prompt_name: "Test Prompt",
+      prompt_version: 1,
+      end_time: Date.now(),
+      completion_start_time: Date.now(),
+    };
+
+    await createTrace(trace);
+    await createObservation(observation);
+
+    const result = await getTracesTable(
+      projectId,
+      [],
+      undefined,
+      undefined,
+      10,
+      0,
+    );
+
+    expect(result.length).toEqual(1);
+
+    expect(result[0].id).toEqual(trace.id);
+    expect(result[0].projectId).toEqual(trace.project_id);
+    expect(result[0].name).toEqual(trace.name);
+    expect(result[0].timestamp).toEqual(new Date(trace.timestamp));
+    expect(result[0].tags).toEqual(trace.tags);
+    expect(result[0].bookmarked).toEqual(trace.bookmarked);
+    expect(result[0].release).toEqual(trace.release);
+    expect(result[0].version).toEqual(trace.version);
+    expect(result[0].userId).toEqual(trace.user_id);
+    expect(result[0].sessionId).toEqual(trace.session_id);
+    expect(result[0].public).toEqual(trace.public);
+    expect(result[0].observationCount).toEqual(1);
+    expect(result[0].costDetails).toEqual({
+      input: 100,
+      output: 200,
+    });
+  });
+});

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -39,10 +39,8 @@ import {
   deleteTraces,
   deleteScoresByTraceIds,
   deleteObservationsByTraceIds,
-  convertMetricsReturnType,
   type TracesMetricsReturnType,
   type TracesAllReturnType,
-  convertToReturnType,
   getTraceById,
   logger,
   upsertTrace,
@@ -53,6 +51,7 @@ import {
   isClickhouseAdminEligible,
   measureAndReturnApi,
 } from "@/src/server/utils/checkClickhouseAccess";
+import Decimal from "decimal.js";
 
 const TraceFilterOptions = z.object({
   projectId: z.string(), // Required for protectedProjectProcedure
@@ -153,7 +152,7 @@ export const traceRouter = createTRPCRouter({
           );
 
           return {
-            traces: res.map(convertToReturnType),
+            traces: res,
           };
         },
       });
@@ -305,14 +304,29 @@ export const traceRouter = createTRPCRouter({
             traceException,
           );
 
-          return res.map((r) =>
-            convertMetricsReturnType({
-              ...r,
-              scores: aggregateScores(
-                validatedScores.filter((s) => s.traceId === r.id),
-              ),
-            }),
-          );
+          return res.map((row) => ({
+            id: row.id,
+            promptTokens: BigInt(row.usageDetails?.input ?? 0),
+            completionTokens: BigInt(row.usageDetails?.output ?? 0),
+            totalTokens: BigInt(row.usageDetails?.total ?? 0),
+            latency: row.latencyMilliseconds
+              ? row.latencyMilliseconds / 1000
+              : null,
+            level: row.level,
+            observationCount: BigInt(row.observationCount ?? 0),
+            calculatedTotalCost: row.costDetails?.total
+              ? new Decimal(row.costDetails.total)
+              : null,
+            calculatedInputCost: row.costDetails?.input
+              ? new Decimal(row.costDetails.input)
+              : null,
+            calculatedOutputCost: row.costDetails?.output
+              ? new Decimal(row.costDetails.output)
+              : null,
+            scores: aggregateScores(
+              validatedScores.filter((s) => s.traceId === row.id),
+            ),
+          }));
         },
       });
     }),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add tests for traces table UI, update conversion functions, and modify traces router for Clickhouse queries.
> 
>   - **Tests**:
>     - Add `traces-ui.servertest.ts` to test `getTracesTable` for single trace and trace with observation.
>   - **Conversion Functions**:
>     - Add `convertToDomain` in `traces_converters.ts` to map `TracesTableReturnType` to domain model.
>     - Remove `convertToReturnType` and `convertMetricsReturnType` from `traces_converters.ts`.
>   - **Traces Router**:
>     - Update `traceRouter` in `traces.ts` to use `getTracesTable` and `getTracesTableCount` for Clickhouse queries.
>     - Modify `metrics` query to directly map results without conversion functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 17ecb02da88889b08326f2cc12dae30c2dfff0b7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->