### PR TITLE
fix(playground): disable stream_options for openai adapter

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -99,6 +99,7 @@ export async function fetchLLMCompletion(
       temperature: modelParams.temperature,
       maxTokens: modelParams.max_tokens,
       topP: modelParams.top_p,
+      streamUsage: false, // https://github.com/langchain-ai/langchainjs/issues/6533
       callbacks,
       maxRetries,
       configuration: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Disable stream options for OpenAI adapter in `fetchLLMCompletion()` by setting `streamUsage: false`.
> 
>   - **Behavior**:
>     - Sets `streamUsage: false` in `ChatOpenAI` instantiation in `fetchLLMCompletion()` to disable stream options for OpenAI adapter.
>     - References issue `#6533` in the comment for context.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d5f27d0700244985bb8f40037cb439c67ce684e4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->