### PR TITLE
chore: remove superfluous isClickhouseAdminEligible checks

### DIFF
--- a/web/src/server/api/routers/generations/getAllQueries.ts
+++ b/web/src/server/api/routers/generations/getAllQueries.ts
@@ -8,11 +8,7 @@ import {
   getObservationsTableCount,
   parseGetAllGenerationsInput,
 } from "@langfuse/shared/src/server";
-import { TRPCError } from "@trpc/server";
-import {
-  isClickhouseAdminEligible,
-  measureAndReturnApi,
-} from "@/src/server/utils/checkClickhouseAccess";
+import { measureAndReturnApi } from "@/src/server/utils/checkClickhouseAccess";
 
 const GetAllGenerationsInput = GenerationTableOptions.extend({
   ...paginationZod,
@@ -112,13 +108,6 @@ export const getAllQueries = {
           };
         },
         clickhouseExecution: async () => {
-          if (!isClickhouseAdminEligible(ctx.session.user)) {
-            throw new TRPCError({
-              code: "UNAUTHORIZED",
-              message: "Not eligible to query clickhouse",
-            });
-          }
-
           const countQuery = await getObservationsTableCount({
             projectId: ctx.session.projectId,
             filter: input.filter ?? [],

--- a/web/src/server/api/routers/observations.ts
+++ b/web/src/server/api/routers/observations.ts
@@ -2,14 +2,13 @@ import {
   createTRPCRouter,
   protectedGetTraceProcedure,
 } from "@/src/server/api/trpc";
-import { isClickhouseAdminEligible } from "@/src/server/utils/checkClickhouseAccess";
+import { measureAndReturnApi } from "@/src/server/utils/checkClickhouseAccess";
 import {
   type jsonSchema,
   type ObservationLevel,
   type ObservationType,
 } from "@langfuse/shared";
 import { getObservationById } from "@langfuse/shared/src/server";
-import { TRPCError } from "@trpc/server";
 import type Decimal from "decimal.js";
 import { z } from "zod";
 
@@ -59,26 +58,22 @@ export const observationsRouter = createTRPCRouter({
       }),
     )
     .query(async ({ input, ctx }) => {
-      if (!input.queryClickhouse) {
-        return ctx.prisma.observation.findFirstOrThrow({
-          where: {
-            id: input.observationId,
-            traceId: input.traceId,
-            projectId: input.projectId,
-          },
-        });
-      } else {
-        if (!isClickhouseAdminEligible(ctx.session.user)) {
-          throw new TRPCError({
-            code: "UNAUTHORIZED",
-            message: "Not eligible to query clickhouse",
+      return measureAndReturnApi({
+        input,
+        operation: "observations.byId",
+        user: ctx.session.user,
+        pgExecution: async () => {
+          return ctx.prisma.observation.findFirstOrThrow({
+            where: {
+              id: input.observationId,
+              traceId: input.traceId,
+              projectId: input.projectId,
+            },
           });
-        }
-        return await getObservationById(
-          input.observationId,
-          input.projectId,
-          true,
-        );
-      }
+        },
+        clickhouseExecution: async () => {
+          return getObservationById(input.observationId, input.projectId, true);
+        },
+      });
     }),
 });

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -44,11 +44,7 @@ import {
   convertDateToClickhouseDateTime,
   searchExistingAnnotationScore,
 } from "@langfuse/shared/src/server";
-import {
-  isClickhouseAdminEligible,
-  measureAndReturnApi,
-} from "@/src/server/utils/checkClickhouseAccess";
-import { TRPCError } from "@trpc/server";
+import { measureAndReturnApi } from "@/src/server/utils/checkClickhouseAccess";
 import { env } from "@/src/env.mjs";
 
 const ScoreFilterOptions = z.object({
@@ -571,13 +567,6 @@ export const scoresRouter = createTRPCRouter({
           }));
         },
         clickhouseExecution: async () => {
-          if (!isClickhouseAdminEligible(ctx.session.user)) {
-            throw new TRPCError({
-              code: "UNAUTHORIZED",
-              message: "Not eligible to query clickhouse",
-            });
-          }
-
           const res = await getScoresGroupedByNameSourceType(input.projectId);
 
           return res.map(({ name, source, dataType }) => ({

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -47,10 +47,7 @@ import {
   convertTraceDomainToClickhouse,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
-import {
-  isClickhouseAdminEligible,
-  measureAndReturnApi,
-} from "@/src/server/utils/checkClickhouseAccess";
+import { measureAndReturnApi } from "@/src/server/utils/checkClickhouseAccess";
 import Decimal from "decimal.js";
 
 const TraceFilterOptions = z.object({
@@ -135,13 +132,6 @@ export const traceRouter = createTRPCRouter({
           };
         },
         clickhouseExecution: async () => {
-          if (!isClickhouseAdminEligible(ctx.session.user)) {
-            throw new TRPCError({
-              code: "UNAUTHORIZED",
-              message: "Not eligible to query clickhouse",
-            });
-          }
-
           const res = await getTracesTable(
             ctx.session.projectId,
             input.filter ?? [],
@@ -194,13 +184,6 @@ export const traceRouter = createTRPCRouter({
           };
         },
         clickhouseExecution: async () => {
-          if (!isClickhouseAdminEligible(ctx.session.user)) {
-            throw new TRPCError({
-              code: "UNAUTHORIZED",
-              message: "Not eligible to query clickhouse",
-            });
-          }
-
           const countQuery = await getTracesTableCount({
             projectId: ctx.session.projectId,
             filter: input.filter ?? [],
@@ -275,13 +258,6 @@ export const traceRouter = createTRPCRouter({
           }));
         },
         clickhouseExecution: async () => {
-          if (!isClickhouseAdminEligible(ctx.session.user)) {
-            throw new TRPCError({
-              code: "UNAUTHORIZED",
-              message: "Not eligible to query clickhouse",
-            });
-          }
-
           const res = await getTracesTable(ctx.session.projectId, [
             ...(input.filter ?? []),
             {
@@ -402,13 +378,6 @@ export const traceRouter = createTRPCRouter({
           return res;
         },
         clickhouseExecution: async () => {
-          if (!isClickhouseAdminEligible(ctx.session.user)) {
-            throw new TRPCError({
-              code: "UNAUTHORIZED",
-              message: "Not eligible to query clickhouse",
-            });
-          }
-
           const { timestampFilter } = input;
 
           const [scoreNames, traceNames, tags] = await Promise.all([
@@ -451,7 +420,7 @@ export const traceRouter = createTRPCRouter({
         operation: "traces.byId",
         user: ctx.session.user ?? undefined,
         pgExecution: async () => {
-          return await ctx.prisma.trace.findFirstOrThrow({
+          return ctx.prisma.trace.findFirstOrThrow({
             where: {
               id: input.traceId,
               projectId: input.projectId,
@@ -459,14 +428,7 @@ export const traceRouter = createTRPCRouter({
           });
         },
         clickhouseExecution: async () => {
-          if (!isClickhouseAdminEligible(ctx.session.user)) {
-            throw new TRPCError({
-              code: "UNAUTHORIZED",
-              message: "Not eligible to query clickhouse",
-            });
-          }
-
-          return await getTraceByIdOrThrow(
+          return getTraceByIdOrThrow(
             input.traceId,
             input.projectId,
             input.timestamp ?? undefined,

--- a/web/src/server/utils/checkClickhouseAccess.ts
+++ b/web/src/server/utils/checkClickhouseAccess.ts
@@ -18,7 +18,7 @@ export const isClickhouseAdminEligible = (user?: User | null) => {
 
 export const measureAndReturnApi = async <T, Y>(args: {
   input: T & { queryClickhouse: boolean };
-  user: User | undefined;
+  user: User | undefined | null;
   operation: string;
   pgExecution: (input: T) => Promise<Y>;
   clickhouseExecution: (input: T) => Promise<Y>;


### PR DESCRIPTION
## What

Currently, we execute the clickhouseExecution for all users if read from postgres only is disabled. This will throw unauthorized errors for non-admin users as we perform a second isAdmin check in some of the endpoints. With this PR, we remove the additional check and rely fully on the `measureAndReturnApi` validations.