### PR TITLE
chore: apply trace timestamp filter correctly on user model query

### DIFF
--- a/packages/shared/src/server/repositories/constants.ts
+++ b/packages/shared/src/server/repositories/constants.ts
@@ -1,3 +1,5 @@
+// Rule of thumb: If you join observations from left, use observations to trace and vice versa
+
 // t.timestamp > observation.start_time - 2 days
 export const OBSERVATIONS_TO_TRACE_INTERVAL = "INTERVAL 2 DAY";
 // observation.start_time > t.timestamp - 1 hour

--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -8,6 +8,7 @@ import {
 import { dashboardColumnDefinitions } from "../../tableDefinitions/mapDashboards";
 import { convertDateToClickhouseDateTime } from "../clickhouse/client";
 import {
+  OBSERVATIONS_TO_TRACE_INTERVAL,
   SCORE_TO_TRACE_OBSERVATIONS_INTERVAL,
   TRACE_TO_OBSERVATIONS_INTERVAL,
 } from "./constants";
@@ -333,7 +334,7 @@ export const getModelUsageByUser = async (
     WHERE project_id = {projectId: String}
     AND t.user_id IS NOT NULL
     AND ${appliedFilter.query}
-    ${timeFilter ? `AND t.timestamp >= {traceTimestamp: DateTime64(3)} - ${TRACE_TO_OBSERVATIONS_INTERVAL}` : ""}
+    ${timeFilter ? `AND t.timestamp >= {traceTimestamp: DateTime64(3)} - ${OBSERVATIONS_TO_TRACE_INTERVAL}` : ""}
     GROUP BY user_id
     ORDER BY sum_cost_details DESC
     `;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix timestamp filter in `getModelUsageByUser` by checking `field.includes("start_time")` and using `DateTime64(3)`.
> 
>   - **Behavior**:
>     - In `getModelUsageByUser`, change `f.field === "start_time"` to `f.field.includes("start_time")` to correctly apply timestamp filters.
>     - Update timestamp format to `DateTime64(3)` in `getModelUsageByUser` for accurate filtering.
>   - **Misc**:
>     - Minor formatting changes in SQL query for readability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 370742d084c0a0a47df355263910796fa9ca4b91. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->