### PR TITLE
fix: downgrade dd-trace

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -73,7 +73,7 @@
     "axios": "^1.7.7",
     "bcryptjs": "^2.4.3",
     "bullmq": "^5.12.10",
-    "dd-trace": "^5.25.0",
+    "dd-trace": "^5.24.0",
     "decimal.js": "^10.4.3",
     "exponential-backoff": "^3.1.1",
     "ioredis": "^5.4.1",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -73,7 +73,7 @@
     "axios": "^1.7.7",
     "bcryptjs": "^2.4.3",
     "bullmq": "^5.12.10",
-    "dd-trace": "^5.24.0",
+    "dd-trace": "^5.23.1",
     "decimal.js": "^10.4.3",
     "exponential-backoff": "^3.1.1",
     "ioredis": "^5.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,7 +177,7 @@ importers:
         specifier: ^5.12.10
         version: 5.12.10
       dd-trace:
-        specifier: ^5.25.0
+        specifier: ^5.24.0
         version: 5.25.0
       decimal.js:
         specifier: ^10.4.3
@@ -544,7 +544,7 @@ importers:
         specifier: ^3.3.1
         version: 3.6.0
       dd-trace:
-        specifier: ^5.25.0
+        specifier: ^5.24.0
         version: 5.25.0
       decimal.js:
         specifier: ^10.4.3
@@ -840,7 +840,7 @@ importers:
         specifier: ^2.8.5
         version: 2.8.5
       dd-trace:
-        specifier: ^5.25.0
+        specifier: ^5.24.0
         version: 5.25.0
       decimal.js:
         specifier: ^10.4.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,7 +177,7 @@ importers:
         specifier: ^5.12.10
         version: 5.12.10
       dd-trace:
-        specifier: ^5.24.0
+        specifier: ^5.23.1
         version: 5.25.0
       decimal.js:
         specifier: ^10.4.3
@@ -544,7 +544,7 @@ importers:
         specifier: ^3.3.1
         version: 3.6.0
       dd-trace:
-        specifier: ^5.24.0
+        specifier: ^5.23.1
         version: 5.25.0
       decimal.js:
         specifier: ^10.4.3
@@ -840,7 +840,7 @@ importers:
         specifier: ^2.8.5
         version: 2.8.5
       dd-trace:
-        specifier: ^5.24.0
+        specifier: ^5.23.1
         version: 5.25.0
       decimal.js:
         specifier: ^10.4.3
@@ -11574,7 +11574,7 @@ snapshots:
       '@aws-sdk/client-sso-oidc': 3.675.0(@aws-sdk/client-sts@3.675.0)
       '@aws-sdk/client-sts': 3.675.0
       '@aws-sdk/core': 3.667.0
-      '@aws-sdk/credential-provider-node': 3.675.0(@aws-sdk/client-sso-oidc@3.675.0(@aws-sdk/client-sts@3.668.0))(@aws-sdk/client-sts@3.675.0)
+      '@aws-sdk/credential-provider-node': 3.675.0(@aws-sdk/client-sso-oidc@3.675.0(@aws-sdk/client-sts@3.675.0))(@aws-sdk/client-sts@3.675.0)
       '@aws-sdk/middleware-host-header': 3.667.0
       '@aws-sdk/middleware-logger': 3.667.0
       '@aws-sdk/middleware-recursion-detection': 3.667.0
@@ -12078,7 +12078,7 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/credential-provider-ini@3.675.0(@aws-sdk/client-sso-oidc@3.675.0(@aws-sdk/client-sts@3.668.0))(@aws-sdk/client-sts@3.675.0)':
+  '@aws-sdk/credential-provider-ini@3.675.0(@aws-sdk/client-sso-oidc@3.675.0(@aws-sdk/client-sts@3.675.0))(@aws-sdk/client-sts@3.675.0)':
     dependencies:
       '@aws-sdk/client-sts': 3.675.0
       '@aws-sdk/core': 3.667.0
@@ -12155,30 +12155,11 @@ snapshots:
       - '@aws-sdk/client-sts'
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.675.0(@aws-sdk/client-sso-oidc@3.675.0(@aws-sdk/client-sts@3.668.0))(@aws-sdk/client-sts@3.675.0)':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.667.0
-      '@aws-sdk/credential-provider-http': 3.667.0
-      '@aws-sdk/credential-provider-ini': 3.675.0(@aws-sdk/client-sso-oidc@3.675.0(@aws-sdk/client-sts@3.668.0))(@aws-sdk/client-sts@3.675.0)
-      '@aws-sdk/credential-provider-process': 3.667.0
-      '@aws-sdk/credential-provider-sso': 3.675.0(@aws-sdk/client-sso-oidc@3.675.0(@aws-sdk/client-sts@3.668.0))
-      '@aws-sdk/credential-provider-web-identity': 3.667.0(@aws-sdk/client-sts@3.675.0)
-      '@aws-sdk/types': 3.667.0
-      '@smithy/credential-provider-imds': 3.2.4
-      '@smithy/property-provider': 3.1.7
-      '@smithy/shared-ini-file-loader': 3.1.8
-      '@smithy/types': 3.5.0
-      tslib: 2.6.3
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - '@aws-sdk/client-sts'
-      - aws-crt
-
   '@aws-sdk/credential-provider-node@3.675.0(@aws-sdk/client-sso-oidc@3.675.0(@aws-sdk/client-sts@3.675.0))(@aws-sdk/client-sts@3.675.0)':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.667.0
       '@aws-sdk/credential-provider-http': 3.667.0
-      '@aws-sdk/credential-provider-ini': 3.675.0(@aws-sdk/client-sso-oidc@3.675.0(@aws-sdk/client-sts@3.668.0))(@aws-sdk/client-sts@3.675.0)
+      '@aws-sdk/credential-provider-ini': 3.675.0(@aws-sdk/client-sso-oidc@3.675.0(@aws-sdk/client-sts@3.675.0))(@aws-sdk/client-sts@3.675.0)
       '@aws-sdk/credential-provider-process': 3.667.0
       '@aws-sdk/credential-provider-sso': 3.675.0(@aws-sdk/client-sso-oidc@3.675.0(@aws-sdk/client-sts@3.668.0))
       '@aws-sdk/credential-provider-web-identity': 3.667.0(@aws-sdk/client-sts@3.675.0)
@@ -18999,7 +18980,7 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
       eslint: 8.57.0
-      ignore: 5.3.1
+      ignore: 5.3.2
 
   eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:

--- a/web/package.json
+++ b/web/package.json
@@ -104,7 +104,7 @@
     "core-js": "^3.38.1",
     "cors": "^2.8.5",
     "date-fns": "^3.3.1",
-    "dd-trace": "^5.25.0",
+    "dd-trace": "^5.24.0",
     "decimal.js": "^10.4.3",
     "dompurify": "^3.1.5",
     "graphql": "^16.9.0",

--- a/web/package.json
+++ b/web/package.json
@@ -104,7 +104,7 @@
     "core-js": "^3.38.1",
     "cors": "^2.8.5",
     "date-fns": "^3.3.1",
-    "dd-trace": "^5.24.0",
+    "dd-trace": "^5.23.1",
     "decimal.js": "^10.4.3",
     "dompurify": "^3.1.5",
     "graphql": "^16.9.0",

--- a/worker/package.json
+++ b/worker/package.json
@@ -38,7 +38,7 @@
     "backoff": "^2.5.0",
     "bullmq": "^5.12.10",
     "cors": "^2.8.5",
-    "dd-trace": "^5.24.0",
+    "dd-trace": "^5.23.1",
     "decimal.js": "^10.4.3",
     "dotenv": "^16.4.5",
     "exponential-backoff": "^3.1.1",

--- a/worker/package.json
+++ b/worker/package.json
@@ -38,7 +38,7 @@
     "backoff": "^2.5.0",
     "bullmq": "^5.12.10",
     "cors": "^2.8.5",
-    "dd-trace": "^5.25.0",
+    "dd-trace": "^5.24.0",
     "decimal.js": "^10.4.3",
     "dotenv": "^16.4.5",
     "exponential-backoff": "^3.1.1",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Downgrade `dd-trace` from `^5.25.0` to `^5.23.1` in `shared`, `web`, and `worker` packages.
> 
>   - **Dependencies**:
>     - Downgrade `dd-trace` from `^5.25.0` to `^5.23.1` in `shared/package.json`, `web/package.json`, and `worker/package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 280b391a17669ad66b897b5e4b8404328b4c5ea5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->