### PR TITLE
fix: fix observations order by

### DIFF
--- a/packages/shared/src/tableDefinitions/mapTracesTable.ts
+++ b/packages/shared/src/tableDefinitions/mapTracesTable.ts
@@ -91,7 +91,7 @@ export const tracesTableUiColumnDefinitions: UiColumnMapping[] = [
   },
   {
     uiTableName: "Usage",
-    uiTableId: "totalTokens",
+    uiTableId: "usage",
     clickhouseTableName: "traces",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'total'), usage_details), usage_details['total'], NULL)",
@@ -106,7 +106,7 @@ export const tracesTableUiColumnDefinitions: UiColumnMapping[] = [
     uiTableName: "Latency (s)",
     uiTableId: "latency",
     clickhouseTableName: "traces",
-    clickhouseSelect: "latency",
+    clickhouseSelect: "latency_milliseconds",
   },
   {
     uiTableName: "Input Cost ($)",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes column identifier names in `tracesTableUiColumnDefinitions` by renaming `uiTableId` and `clickhouseSelect` fields.
> 
>   - **Renames**:
>     - `uiTableId` from `totalTokens` to `usage` in `tracesTableUiColumnDefinitions`.
>     - `clickhouseSelect` from `latency` to `latency_milliseconds` in `tracesTableUiColumnDefinitions`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7ba29f8d175921f335ea541f6656d771a5266503. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->