### PR TITLE
fix: fix order by in clickhouse

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -302,6 +302,15 @@ const getObservationsTableInternal = async <T>(
         .includes(f.column),
   );
 
+  const orderByTraces = opts.orderBy
+    ? observationsTableTraceUiColumnDefinitions
+        .map((c) => c.uiTableId)
+        .includes(opts.orderBy.column) ||
+      observationsTableTraceUiColumnDefinitions
+        .map((c) => c.uiTableName)
+        .includes(opts.orderBy.column)
+    : undefined;
+
   timeFilter
     ? scoresFilter.push(
         new DateTimeFilter({
@@ -363,7 +372,7 @@ const getObservationsTableInternal = async <T>(
       observation_id
   )`;
 
-  if (traceTableFilter.length > 0) {
+  if (traceTableFilter.length > 0 || orderByTraces) {
     // joins with traces are very expensive. We need to filter by time as well.
     // We assume that a trace has to have been within the last 2 days to be relevant.
 

--- a/packages/shared/src/tableDefinitions/mapObservationsTable.ts
+++ b/packages/shared/src/tableDefinitions/mapObservationsTable.ts
@@ -19,7 +19,7 @@ export const observationsTableTraceUiColumnDefinitions: UiColumnMapping[] = [
   {
     uiTableName: "Trace Name",
     uiTableId: "traceName",
-    clickhouseTableName: "observations",
+    clickhouseTableName: "traces",
     clickhouseSelect: 't."name"',
   },
 ];

--- a/packages/shared/src/tableDefinitions/mapScoresTable.ts
+++ b/packages/shared/src/tableDefinitions/mapScoresTable.ts
@@ -69,13 +69,13 @@ export const scoresTableUiColumnDefinitions: UiColumnMapping[] = [
   },
   {
     uiTableName: "Trace Name",
-    uiTableId: "trace_name",
+    uiTableId: "traceName",
     clickhouseTableName: "traces",
     clickhouseSelect: "t.name",
   },
   {
     uiTableName: "User ID",
-    uiTableId: "user_id",
+    uiTableId: "userId",
     clickhouseTableName: "traces",
     clickhouseSelect: "t.user_id",
   },

--- a/packages/shared/src/tableDefinitions/mapSessionTable.ts
+++ b/packages/shared/src/tableDefinitions/mapSessionTable.ts
@@ -119,7 +119,7 @@ export const sessionCols: UiColumnMapping[] = [
   },
   {
     uiTableName: "ID",
-    uiTableId: "sessionId",
+    uiTableId: "id",
     clickhouseTableName: "traces",
     clickhouseSelect: "session_id",
   },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes order by handling in Clickhouse queries and updates column IDs for consistency across table definitions.
> 
>   - **Behavior**:
>     - Fixes order by handling in `getObservationsTableInternal` in `observations.ts` by checking if `opts.orderBy.column` is in `observationsTableTraceUiColumnDefinitions`.
>   - **Table Definitions**:
>     - Changes `clickhouseTableName` from `observations` to `traces` for `Trace Name` in `mapObservationsTable.ts`.
>     - Renames `uiTableId` from `trace_name` to `traceName` and `user_id` to `userId` in `mapScoresTable.ts`.
>     - Renames `uiTableId` from `sessionId` to `id` in `mapSessionTable.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2ac8fb31ea2c0e558056abf2fce44904bc523a9f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->