### PR TITLE
fix: fix trace filter on score analytics charts

### DIFF
--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -510,12 +510,15 @@ export const getNumericScoreTimeSeries = async (
   );
   const chFilterRes = chFilter.apply();
 
+  const traceFilter = chFilter.find((f) => f.clickhouseTable === "traces");
+
   const query = `
     SELECT
     ${selectTimeseriesColumn(groupBy, "s.timestamp", "score_timestamp")},
     s.name as score_name,
     AVG(s.value) as avg_value
     FROM scores s final
+    ${traceFilter ? "JOIN traces t ON s.trace_id = t.id AND s.project_id = t.project_id" : ""}
     WHERE s.project_id = {projectId: String}
     ${chFilterRes?.query ? `AND ${chFilterRes.query}` : ""}
     GROUP BY score_name, score_timestamp
@@ -545,6 +548,8 @@ export const getCategoricalScoreTimeSeries = async (
   );
   const chFilterRes = chFilter.apply();
 
+  const traceFilter = chFilter.find((f) => f.clickhouseTable === "traces");
+
   const query = `
     SELECT
     ${groupBy ? selectTimeseriesColumn(groupBy, "s.timestamp", "score_timestamp") + ", " : ""}
@@ -554,6 +559,7 @@ export const getCategoricalScoreTimeSeries = async (
     s.string_value as score_value,
     count(s.string_value) as count
     FROM scores s final
+    ${traceFilter ? "JOIN traces t ON s.trace_id = t.id AND s.project_id = t.project_id" : ""}
     WHERE s.project_id = {projectId: String}
     ${chFilterRes?.query ? `AND ${chFilterRes.query}` : ""}
     GROUP BY score_name, score_data_type, score_source, score_value ${groupBy ? ", score_timestamp" : ""}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes trace filter issue in score analytics charts by adding JOIN with `traces` table in `getNumericScoreTimeSeries` and `getCategoricalScoreTimeSeries`.
> 
>   - **Behavior**:
>     - Fixes trace filter issue in `getNumericScoreTimeSeries` and `getCategoricalScoreTimeSeries` in `dashboards.ts`.
>     - Adds JOIN with `traces` table when trace filter is present, ensuring correct data linkage.
>   - **Functions**:
>     - `getNumericScoreTimeSeries`: Adds JOIN condition with `traces` table.
>     - `getCategoricalScoreTimeSeries`: Adds JOIN condition with `traces` table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0164b7d9cb48b0a07e2691b68c43f035b1cf1ebd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->