### PR TITLE
chore: reduce use of FINAL in clickhouse queries

### DIFF
--- a/packages/shared/src/interfaces/filters.ts
+++ b/packages/shared/src/interfaces/filters.ts
@@ -15,6 +15,7 @@ export const filterOperators = {
   ],
   numberObject: ["=", ">", "<", ">=", "<="],
   boolean: ["=", "<>"],
+  null: ["is null", "is not null"],
 } as const;
 
 export const timeFilter = z.object({
@@ -68,6 +69,12 @@ export const booleanFilter = z.object({
   operator: z.enum(filterOperators.boolean),
   value: z.boolean(),
 });
+export const nullFilter = z.object({
+  type: z.literal("null"),
+  column: z.string(),
+  operator: z.enum(filterOperators.null),
+  value: z.literal(""),
+});
 export const singleFilter = z.discriminatedUnion("type", [
   timeFilter,
   stringFilter,
@@ -77,4 +84,5 @@ export const singleFilter = z.discriminatedUnion("type", [
   stringObjectFilter,
   numberObjectFilter,
   booleanFilter,
+  nullFilter,
 ]);

--- a/packages/shared/src/server/filterToPrisma.ts
+++ b/packages/shared/src/server/filterToPrisma.ts
@@ -106,9 +106,11 @@ export function tableColumnsToSqlFilter(
           ", ",
         )}] `;
         break;
-
       case "boolean":
         valuePrisma = Prisma.sql`${filter.value}`;
+        break;
+      case "null":
+        valuePrisma = Prisma.sql``;
         break;
     }
     const jsonKeyPrisma =

--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -56,6 +56,7 @@ export const getObservationsCostGroupedByName = async (
   const appliedFilter = chFilter.apply();
 
   const hasTraceFilter = chFilter.find((f) => f.clickhouseTable === "traces");
+  // TODO: Validate whether we can filter traces on timestamp here.
 
   const query = `
     SELECT 
@@ -100,6 +101,7 @@ export const getScoreAggregate = async (
   const chFilterApplied = chFilter.apply();
 
   const hasTraceFilter = chFilter.find((f) => f.clickhouseTable === "traces");
+  // TODO: Validate whether we can filter traces on timestamp here.
 
   const query = `
     SELECT 
@@ -184,6 +186,7 @@ export const getObservationUsageByTime = async (
   );
 
   const appliedFilter = chFilter.apply();
+  // TODO: Validate whether we can filter traces on timestamp here.
 
   const query = `
     SELECT 
@@ -229,11 +232,12 @@ export const getDistinctModels = async (
   );
 
   const appliedFilter = chFilter.apply();
+  // TODO: Validate whether we can filter traces on timestamp here.
 
   const query = `
     SELECT 
       distinct(provided_model_name) as model
-    FROM observations o FINAL
+    FROM observations o
     ${chFilter.find((f) => f.clickhouseTable === "traces") ? "LEFT JOIN traces t ON o.trace_id = t.id AND o.project_id = t.project_id" : ""}
     WHERE project_id = {projectId: String}
     AND ${appliedFilter.query}
@@ -262,6 +266,7 @@ export const getScoresAggregateOverTime = async (
   const appliedFilter = chFilter.apply();
 
   const traceFilter = chFilter.find((f) => f.clickhouseTable === "traces");
+  // TODO: Validate whether we can filter traces on timestamp here.
 
   const query = `
   SELECT 
@@ -371,11 +376,12 @@ export const getObservationLatencies = async (
 
   const appliedFilter = chFilter.apply();
 
+  // Skipping FINAL here, as the quantiles are approximate to begin with.
   const query = `
     SELECT
-      quantilesExactLow(0.5, 0.9, 0.95, 0.99)(date_diff('milliseconds', o.start_time, o.end_time)) as quantiles,
+      quantiles(0.5, 0.9, 0.95, 0.99)(date_diff('milliseconds', o.start_time, o.end_time)) as quantiles,
       name
-    FROM observations o FINAL
+    FROM observations o
     ${chFilter.find((f) => f.clickhouseTable === "traces") ? "LEFT JOIN traces t ON o.trace_id = t.id AND o.project_id = t.project_id" : ""}
     WHERE project_id = {projectId: String}
     AND ${appliedFilter.query}
@@ -414,14 +420,15 @@ export const getTracesLatencies = async (
       (f.operator === ">=" || f.operator === ">"),
   ) as DateTimeFilter | undefined;
 
+  // Skipping FINAL here, as the quantiles are approximate to begin with.
   const query = `
     WITH trace_latencies as (
       select o.trace_id,
              t.name,
              o.project_id,
              date_diff('milliseconds', min(o.start_time), coalesce(max(o.end_time), max(o.start_time))) as duration
-      FROM traces t FINAL 
-      JOIN observations o FINAL
+      FROM traces t 
+      JOIN observations o
       ON o.trace_id = t.id AND o.project_id = t.project_id
       WHERE project_id = {projectId: String}
       AND ${appliedFilter.query}
@@ -430,7 +437,7 @@ export const getTracesLatencies = async (
     )
 
     SELECT
-      quantilesExactLow(0.5, 0.9, 0.95, 0.99)(duration) as quantiles,
+      quantiles(0.5, 0.9, 0.95, 0.99)(duration) as quantiles,
       name
     FROM trace_latencies
     GROUP BY name
@@ -470,12 +477,13 @@ export const getModelLatenciesOverTime = async (
 
   const traceFilter = chFilter.find((f) => f.clickhouseTable === "traces");
 
+  // Skipping FINAL here, as the quantiles are approximate to begin with.
   const query = `
   SELECT 
     ${selectTimeseriesColumn(groupBy, "o.start_time", "start_time_bucket")},
     provided_model_name,
-    quantilesExactLow(0.5, 0.75, 0.9, 0.95, 0.99)(date_diff('milliseconds', o.start_time, o.end_time)) as quantiles
-  FROM observations o FINAL
+    quantiles(0.5, 0.75, 0.9, 0.95, 0.99)(date_diff('milliseconds', o.start_time, o.end_time)) as quantiles
+  FROM observations o
   ${traceFilter ? "JOIN traces t ON o.trace_id = t.id AND o.project_id = t.project_id" : ""}
   WHERE project_id = {projectId: String}
   AND ${appliedFilter.query}

--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -234,6 +234,7 @@ export const getDistinctModels = async (
   const appliedFilter = chFilter.apply();
   // TODO: Validate whether we can filter traces on timestamp here.
 
+  // No need for final as duplicates are caught by distinct anyway.
   const query = `
     SELECT 
       distinct(provided_model_name) as model

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -362,13 +362,13 @@ export const getTracesGroupedByName = async (
     ? new FilterList(chFilter).apply()
     : undefined;
 
-  // TODO: On EU there are 50 projects with > 1000 unique trace names. We can probably skip the sort here as well and return on best effort.
-  // Alternatively, we drop the final and just accept duplicates in the count.
+  // We mainly use queries like this to retrieve filter options.
+  // Therefore, we can skip final as some inaccuracy in count is acceptable.
   const query = `
       select 
         name as name,
         count(*) as count
-      from traces t final
+      from traces t
       WHERE t.project_id = {projectId: String}
       AND t.name IS NOT NULL
       ${timestampFilterRes?.query ? `AND ${timestampFilterRes.query}` : ""}
@@ -410,12 +410,13 @@ export const getTracesGroupedByUsers = async (
   const tracesFilterRes = tracesFilter.apply();
   const search = clickhouseSearchCondition(searchQuery);
 
-  // TODO: Same here - we may just drop the final.
+  // We mainly use queries like this to retrieve filter options.
+  // Therefore, we can skip final as some inaccuracy in count is acceptable.
   const query = `
       select 
         user_id as user,
         count(*) as count
-      from traces t final
+      from traces t
       WHERE t.project_id = {projectId: String}
       AND t.user_id IS NOT NULL
       AND t.user_id != ''

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -199,55 +199,52 @@ const getTracesTableGeneric = async <T>(props: FetchTracesTableProps) => {
   const search = clickhouseSearchCondition(searchQuery);
 
   const query = `
-  WITH observations_stats AS (
-  SELECT
-    COUNT(*) AS observation_count,
-      sumMap(usage_details) as usage_details,
-      SUM(total_cost) AS total_cost,
-      date_diff('milliseconds', least(min(start_time), min(end_time)), greatest(max(start_time), max(end_time))) as latency_milliseconds,
-      multiIf(
-        arrayExists(x -> x = 'ERROR', groupArray(level)), 'ERROR',
-        arrayExists(x -> x = 'WARNING', groupArray(level)), 'WARNING',
-        arrayExists(x -> x = 'DEFAULT', groupArray(level)), 'DEFAULT',
-        'DEBUG'
-      ) AS level,
-      sumMap(cost_details) as cost_details,
-      trace_id,
-      project_id
-    FROM
-        observations final
-    WHERE ${observationFilterRes.query}
-    
-    group by trace_id, project_id
-),
-
-         scores_avg AS (SELECT project_id,
-                                trace_id,
-                                groupArray(tuple(name, avg_value)) AS "scores_avg"
-                          FROM (
-                                  SELECT project_id,
-                                          trace_id,
-                                          name,
-                                          avg(value) avg_value
-                                  FROM scores final
-                                  WHERE ${scoresFilterRes.query}
-                                  GROUP BY project_id,
-                                            trace_id,
-                                            name
-                                  ) tmp
-                          GROUP BY project_id,
-                                  trace_id)
-      select 
-       ${select}
-      from traces t final
-              left join observations_stats os on os.project_id = t.project_id and os.trace_id = t.id
-              left join scores_avg s on s.project_id = t.project_id and s.trace_id = t.id
-
-      WHERE ${tracesFilterRes.query}
-      ${search.query}
-      ${orderByToClickhouseSql(orderBy ?? null, tracesTableUiColumnDefinitions)}
-      ${limit !== undefined && offset !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
-    `;
+    WITH observations_stats AS (
+      SELECT
+        COUNT(*) AS observation_count,
+          sumMap(usage_details) as usage_details,
+          SUM(total_cost) AS total_cost,
+          date_diff('milliseconds', least(min(start_time), min(end_time)), greatest(max(start_time), max(end_time))) as latency_milliseconds,
+          multiIf(
+            arrayExists(x -> x = 'ERROR', groupArray(level)), 'ERROR',
+            arrayExists(x -> x = 'WARNING', groupArray(level)), 'WARNING',
+            arrayExists(x -> x = 'DEFAULT', groupArray(level)), 'DEFAULT',
+            'DEBUG'
+          ) AS level,
+          sumMap(cost_details) as cost_details,
+          trace_id,
+          project_id
+      FROM observations FINAL
+      WHERE ${observationFilterRes.query}
+      GROUP BY trace_id, project_id
+    ),
+    scores_avg AS (
+      SELECT
+        project_id,
+        trace_id,
+        groupArray(tuple(name, avg_value)) AS "scores_avg"
+      FROM (
+        SELECT project_id,
+                trace_id,
+                name,
+                avg(value) avg_value
+        FROM scores final
+        WHERE ${scoresFilterRes.query}
+        GROUP BY project_id,
+                  trace_id,
+                  name
+      ) tmp
+      GROUP BY project_id, trace_id
+    )
+    SELECT ${select}
+    FROM traces t final
+    LEFT JOIN observations_stats os on os.project_id = t.project_id and os.trace_id = t.id
+    LEFT JOIN scores_avg s on s.project_id = t.project_id and s.trace_id = t.id
+    WHERE ${tracesFilterRes.query}
+    ${search.query}
+    ${orderByToClickhouseSql(orderBy ?? null, tracesTableUiColumnDefinitions)}
+    ${limit !== undefined && offset !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
+  `;
 
   const res = await queryClickhouse<T>({
     query: query,
@@ -300,9 +297,10 @@ export const getTracesByIds = async (
       SELECT * 
       FROM traces
       WHERE id IN ({traceIds: Array(String)})
-        AND project_id = {projectId: String}
-        ${timestamp ? `AND timestamp >= {timestamp: DateTime64(3)}` : ""} 
-      ORDER BY event_ts DESC LIMIT 1 by id, project_id;`;
+      AND project_id = {projectId: String}
+      ${timestamp ? `AND timestamp >= {timestamp: DateTime64(3)}` : ""} 
+      ORDER BY event_ts DESC
+      LIMIT 1 by id, project_id;`;
   const records = await queryClickhouse<TraceRecordReadType>({
     query,
     params: {
@@ -326,7 +324,8 @@ export const getTraceByIdOrThrow = async (
     WHERE id = {traceId: String} 
     AND project_id = {projectId: String}
     ${timestamp ? `AND timestamp = {timestamp: DateTime64(3)}` : ""} 
-    ORDER BY event_ts DESC LIMIT 1
+    ORDER BY event_ts DESC
+    LIMIT 1
   `;
 
   const records = await queryClickhouse<TraceRecordReadType>({
@@ -363,6 +362,8 @@ export const getTracesGroupedByName = async (
     ? new FilterList(chFilter).apply()
     : undefined;
 
+  // TODO: On EU there are 50 projects with > 1000 unique trace names. We can probably skip the sort here as well and return on best effort.
+  // Alternatively, we drop the final and just accept duplicates in the count.
   const query = `
       select 
         name as name,
@@ -393,15 +394,23 @@ export const getTracesGroupedByName = async (
 export const getTracesGroupedByUsers = async (
   projectId: string,
   filter: FilterState,
+  searchQuery?: string,
+  limit?: number,
+  offset?: number,
   columns?: UiColumnMapping[],
 ) => {
-  const chFilter = createFilterFromFilterState(
-    filter,
-    columns ?? tracesTableUiColumnDefinitions,
+  const { tracesFilter } = getProjectIdDefaultFilter(projectId, {
+    tracesPrefix: "t",
+  });
+
+  tracesFilter.push(
+    ...createFilterFromFilterState(filter, tracesTableUiColumnDefinitions),
   );
 
-  const filterRes = new FilterList(chFilter).apply();
+  const tracesFilterRes = tracesFilter.apply();
+  const search = clickhouseSearchCondition(searchQuery);
 
+  // TODO: Same here - we may just drop the final.
   const query = `
       select 
         user_id as user,
@@ -409,11 +418,13 @@ export const getTracesGroupedByUsers = async (
       from traces t final
       WHERE t.project_id = {projectId: String}
       AND t.user_id IS NOT NULL
-      ${filterRes?.query ? `AND ${filterRes.query}` : ""}
+      AND t.user_id != ''
+      ${tracesFilterRes?.query ? `AND ${tracesFilterRes.query}` : ""}
+      ${search.query}
       GROUP BY user
       ORDER BY count desc
-      LIMIT 1000;
-    `;
+      ${limit !== undefined && offset !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
+  `;
 
   const rows = await queryClickhouse<{
     user: string;
@@ -421,8 +432,11 @@ export const getTracesGroupedByUsers = async (
   }>({
     query: query,
     params: {
-      projectId: projectId,
-      ...(filterRes ? filterRes.params : {}),
+      limit,
+      offset,
+      projectId,
+      ...(tracesFilterRes ? tracesFilterRes.params : {}),
+      ...(searchQuery ? search.params : {}),
     },
   });
 
@@ -432,12 +446,11 @@ export const getTracesGroupedByUsers = async (
 export type GroupedTracesQueryProp = {
   projectId: string;
   filter: FilterState;
-  sessionIdNullFilter?: boolean;
   columns?: UiColumnMapping[];
 };
 
 export const getTracesGroupedByTags = async (props: GroupedTracesQueryProp) => {
-  const { projectId, filter, sessionIdNullFilter, columns } = props;
+  const { projectId, filter, columns } = props;
 
   const chFilter = createFilterFromFilterState(
     filter,
@@ -447,14 +460,12 @@ export const getTracesGroupedByTags = async (props: GroupedTracesQueryProp) => {
   const filterRes = new FilterList(chFilter).apply();
 
   const query = `
-      select 
-        distinct(arrayJoin(tags)) as value
-      from traces t final
-      WHERE t.project_id = {projectId: String}
-      ${sessionIdNullFilter ? "AND t.session_id IS NOT NULL" : ""}
-      ${filterRes?.query ? `AND ${filterRes.query}` : ""}
-      LIMIT 1000;
-    `;
+    select distinct(arrayJoin(tags)) as value
+    from traces t
+    WHERE t.project_id = {projectId: String}
+    ${filterRes?.query ? `AND ${filterRes.query}` : ""}
+    LIMIT 1000;
+  `;
 
   const rows = await queryClickhouse<{
     value: string;
@@ -463,45 +474,6 @@ export const getTracesGroupedByTags = async (props: GroupedTracesQueryProp) => {
     params: {
       projectId: projectId,
       ...(filterRes ? filterRes.params : {}),
-    },
-  });
-
-  return rows;
-};
-
-export const getTracesGroupedByUserIds = async (
-  props: GroupedTracesQueryProp,
-) => {
-  const {
-    projectId,
-    filter,
-    sessionIdNullFilter: sessionIdNotNullFilter,
-    columns,
-  } = props;
-
-  const chFilter = createFilterFromFilterState(
-    filter,
-    columns ?? tracesTableUiColumnDefinitions,
-  );
-
-  const appliedFilter = new FilterList(chFilter).apply();
-
-  const query = `
-      select distinct user_id as user_id
-      from traces t final
-      WHERE t.project_id = {projectId: String}
-      ${sessionIdNotNullFilter ? "AND t.session_id IS NOT NULL" : ""}
-      ${appliedFilter?.query ? `AND ${appliedFilter.query}` : ""}
-      LIMIT 1000;
-    `;
-
-  const rows = await queryClickhouse<{
-    user_id: string;
-  }>({
-    query: query,
-    params: {
-      projectId: projectId,
-      ...(appliedFilter ? appliedFilter.params : {}),
     },
   });
 
@@ -651,7 +623,8 @@ const getSessionsTableGeneric = async <T>(props: FetchTracesTableProps) => {
             sumMap(o.sum_usage_details)['output'] as session_output_usage,
             sumMap(o.sum_usage_details)['total'] as session_total_usage
         FROM traces t FINAL
-        LEFT JOIN observations_agg o ON t.id = o.trace_id AND t.project_id = o.project_id
+        LEFT JOIN observations_agg o
+        ON t.id = o.trace_id AND t.project_id = o.project_id
         WHERE t.session_id IS NOT NULL
             AND t.project_id = {projectId: String}
             ${singleTraceFilter?.query ? ` AND ${singleTraceFilter.query}` : ""}
@@ -698,12 +671,11 @@ export const getTracesForSession = async (
       name,
       timestamp,
       project_id
-      FROM traces
-      WHERE (project_id = {projectId: String}) AND (session_id = {sessionId: String})
-      ORDER BY timestamp ASC
-      LIMIT 1 BY
-          id,
-          project_id;
+    FROM traces
+    WHERE (project_id = {projectId: String})
+    AND (session_id = {sessionId: String})
+    ORDER BY timestamp ASC
+    LIMIT 1 BY id, project_id;
   `;
 
   const rows = await queryClickhouse<{
@@ -742,49 +714,6 @@ export const deleteTraces = async (projectId: string, traceIds: string[]) => {
   });
 };
 
-export const getUsersAndTraceCount = async (
-  projectId: string,
-  filter: FilterState,
-  searchQuery?: string,
-  limit?: number,
-  offset?: number,
-): Promise<{ userId: string; totalTraces: bigint }[]> => {
-  const { tracesFilter } = getProjectIdDefaultFilter(projectId, {
-    tracesPrefix: "t",
-  });
-
-  tracesFilter.push(
-    ...createFilterFromFilterState(filter, tracesTableUiColumnDefinitions),
-  );
-
-  const tracesFilterRes = tracesFilter.apply();
-  const search = clickhouseSearchCondition(searchQuery);
-
-  const query = `
-    SELECT
-      t.user_id AS userId,
-      COUNT(t.id) AS totalTraces
-    FROM traces t FINAL
-    WHERE ${tracesFilterRes.query}
-    ${search.query}
-    AND t.user_id IS NOT NULL
-    AND t.user_id != ''
-    GROUP BY t.user_id
-    ORDER BY totalTraces DESC 
-    ${limit !== undefined && offset !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
-  `;
-
-  return queryClickhouse({
-    query,
-    params: {
-      limit,
-      offset,
-      ...tracesFilterRes.params,
-      ...search.params,
-    },
-  });
-};
-
 export const getTotalUserCount = async (
   projectId: string,
   filter: FilterState,
@@ -803,7 +732,7 @@ export const getTotalUserCount = async (
 
   const query = `
     SELECT COUNT(DISTINCT t.user_id) AS totalCount
-    FROM traces t FINAL
+    FROM traces t
     WHERE ${tracesFilterRes.query}
     ${search.query}
     AND t.user_id IS NOT NULL

--- a/web/src/features/dashboard/server/dashboard-router.ts
+++ b/web/src/features/dashboard/server/dashboard-router.ts
@@ -189,6 +189,9 @@ export const dashboardRouter = createTRPCRouter({
             const traces = await getTracesGroupedByUsers(
               input.projectId,
               input.filter ?? [],
+              undefined,
+              1000,
+              0,
               dashboardColumnDefinitions,
             );
 

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -9,7 +9,7 @@ import {
 } from "@/src/server/api/trpc";
 import {
   filterAndValidateDbScoreList,
-  FilterState,
+  type FilterState,
   orderBy,
   paginationZod,
   type SessionOptions,

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -9,6 +9,7 @@ import {
 } from "@/src/server/api/trpc";
 import {
   filterAndValidateDbScoreList,
+  FilterState,
   orderBy,
   paginationZod,
   type SessionOptions,
@@ -27,11 +28,11 @@ import {
   traceException,
   getSessionsTable,
   getSessionsTableCount,
-  getTracesGroupedByUserIds,
   getTracesGroupedByTags,
   getTracesForSession,
   getScoresForTraces,
   getCostForTraces,
+  getTracesGroupedByUsers,
 } from "@langfuse/shared/src/server";
 
 const SessionFilterOptions = z.object({
@@ -353,24 +354,36 @@ export const sessionRouter = createTRPCRouter({
                 clickhouseSelect: "timestamp",
               },
             ];
+            const filter: FilterState = [
+              {
+                column: "t.session_id",
+                operator: "is not null",
+                type: "null",
+                value: "",
+              },
+            ];
+            if (timestampFilter) {
+              filter.push(timestampFilter);
+            }
             const [userIds, tags] = await Promise.all([
-              getTracesGroupedByUserIds({
-                projectId: input.projectId,
-                filter: timestampFilter ? [timestampFilter] : [],
-                sessionIdNullFilter: true,
+              getTracesGroupedByUsers(
+                input.projectId,
+                filter,
+                undefined,
+                1000,
+                0,
                 columns,
-              }),
+              ),
               getTracesGroupedByTags({
                 projectId: input.projectId,
-                filter: timestampFilter ? [timestampFilter] : [],
-                sessionIdNullFilter: true,
+                filter,
                 columns,
               }),
             ]);
 
             return {
               userIds: userIds.map((row) => ({
-                value: row.user_id,
+                value: row.user,
               })),
               tags: tags.map((row) => ({
                 value: row.value,

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -271,6 +271,7 @@ export const traceRouter = createTRPCRouter({
           const scores = await getScoresForTraces(
             ctx.session.projectId,
             res.map((r) => r.id),
+            undefined,
             1000,
             0,
           );
@@ -541,10 +542,15 @@ export const traceRouter = createTRPCRouter({
               input.projectId,
               input.timestamp ?? undefined,
             ),
-            getObservationsViewForTrace(input.traceId, input.projectId),
+            getObservationsViewForTrace(
+              input.traceId,
+              input.projectId,
+              input.timestamp ?? undefined,
+            ),
             getScoresForTraces(
               input.projectId,
               [input.traceId],
+              input.timestamp ?? undefined,
               undefined,
               undefined,
             ),


### PR DESCRIPTION
## What does this PR do?

- Consolidate certain queries with a similar result characteristic into single functions (DRY).
- Reduce usage of `FINAL` across queries to save on compute overhead and enable use of skip indexes.
- Misc query optimizations.
- Outline further optimization potential.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Optimize Clickhouse queries by reducing `FINAL` usage, consolidating similar queries, and implementing query optimizations across multiple files.
> 
>   - **Behavior**:
>     - Reduce `FINAL` usage in Clickhouse queries across `dashboards.ts`, `observations.ts`, `scores.ts`, and `traces.ts` to improve performance.
>     - Consolidate similar queries into single functions for DRY compliance.
>   - **Query Optimizations**:
>     - Replace `quantilesExactLow` with `quantiles` in `getObservationLatencies` and `getTracesLatencies`.
>     - Use CTEs to optimize queries like `getCostForTraces`.
>   - **Filters**:
>     - Add `nullFilter` to `filters.ts` and handle it in `filterToPrisma.ts`.
>   - **Misc**:
>     - Add TODO comments for potential future optimizations in `dashboards.ts` and `traces.ts`.
>     - Update router files to use new query functions and optimizations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fff50d37765ed1ec82f250632bbfa622b0a1e0ca. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->