### PR TITLE
chore: add timestamp filter for dashboard queries

### DIFF
--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -186,12 +186,14 @@ export const getObservationUsageByTime = async (
   const appliedFilter = chFilter.apply();
 
   const tracesFilter = chFilter.find((f) => f.clickhouseTable === "traces");
-  const timeFilter = chFilter.find(
-    (f) =>
-      f.clickhouseTable === "observations" &&
-      f.field.includes("start_time") &&
-      (f.operator === ">=" || f.operator === ">"),
-  ) as DateTimeFilter | undefined;
+  const timeFilter = tracesFilter
+    ? (chFilter.find(
+        (f) =>
+          f.clickhouseTable === "observations" &&
+          f.field.includes("start_time") &&
+          (f.operator === ">=" || f.operator === ">"),
+      ) as DateTimeFilter | undefined)
+    : undefined;
 
   const query = `
     SELECT 
@@ -243,12 +245,14 @@ export const getDistinctModels = async (
   const appliedFilter = chFilter.apply();
 
   const tracesFilter = chFilter.find((f) => f.clickhouseTable === "traces");
-  const timeFilter = chFilter.find(
-    (f) =>
-      f.clickhouseTable === "observations" &&
-      f.field.includes("start_time") &&
-      (f.operator === ">=" || f.operator === ">"),
-  ) as DateTimeFilter | undefined;
+  const timeFilter = tracesFilter
+    ? (chFilter.find(
+        (f) =>
+          f.clickhouseTable === "observations" &&
+          f.field.includes("start_time") &&
+          (f.operator === ">=" || f.operator === ">"),
+      ) as DateTimeFilter | undefined)
+    : undefined;
 
   const query = `
     SELECT distinct(provided_model_name) as model


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add timestamp filter to `getObservationUsageByTime` and `getDistinctModels` in `dashboards.ts` to optimize queries by filtering based on `start_time`.
> 
>   - **Behavior**:
>     - Add `timeFilter` to `getObservationUsageByTime` and `getDistinctModels` in `dashboards.ts` to filter queries by timestamp.
>     - Applies timestamp condition to queries when `start_time` field is present in `observations` table and operator is `>=` or `>`.
>   - **Queries**:
>     - Modify queries in `getObservationUsageByTime` and `getDistinctModels` to include `AND t.timestamp >= {traceTimestamp: DateTime64(3)} - OBSERVATIONS_TO_TRACE_INTERVAL` when `timeFilter` is applied.
>   - **Parameters**:
>     - Add `traceTimestamp` parameter to query parameters in `getObservationUsageByTime` and `getDistinctModels` when `timeFilter` is present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 46bbebf60d59d6ad7071bcd6ed0ff8789d492e41. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->