### PR TITLE
fix: use todate for trace timestamps

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -108,6 +108,8 @@ export const getTracesTable = async (
     offset,
   });
 
+  console.log("getTracesTable", rows);
+
   return rows.map(convertToDomain);
 };
 
@@ -325,7 +327,7 @@ export const getTraceByIdOrThrow = async (
     FROM traces
     WHERE id = {traceId: String} 
     AND project_id = {projectId: String}
-    ${timestamp ? `AND timestamp = {timestamp: DateTime64(3)}` : ""} 
+    ${timestamp ? `AND toDate(timestamp) = toDate({timestamp: DateTime64(3)})` : ""} 
     ORDER BY event_ts DESC LIMIT 1
   `;
 
@@ -343,7 +345,7 @@ export const getTraceByIdOrThrow = async (
   const res = records.map(convertClickhouseToDomain);
 
   if (res.length === 0) {
-    const errorMessage = `Trace not found for traceId: ${traceId}, projectId: ${projectId}`;
+    const errorMessage = `Trace not found for traceId: ${traceId}, projectId: ${projectId}, and timestamp: ${timestamp}`;
     logger.error(errorMessage);
     throw new Error(errorMessage);
   }

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -108,8 +108,6 @@ export const getTracesTable = async (
     offset,
   });
 
-  console.log("getTracesTable", rows);
-
   return rows.map(convertToDomain);
 };
 

--- a/web/src/__tests__/server/repositories/trace-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/trace-repository.servertest.ts
@@ -38,6 +38,53 @@ describe("Clickhouse Traces Repository Test", () => {
 
     await createTrace(trace);
 
+    const result = await getTraceByIdOrThrow(
+      traceId,
+      projectId,
+      new Date(trace.timestamp),
+    );
+    expect(result.id).toEqual(trace.id);
+    expect(result.projectId).toEqual(trace.project_id);
+    expect(result.name).toEqual(trace.name);
+    expect(result.timestamp).toEqual(new Date(trace.timestamp));
+    expect(result.tags).toEqual(trace.tags);
+    expect(result.bookmarked).toEqual(trace.bookmarked);
+    expect(result.release).toEqual(trace.release);
+    expect(result.version).toEqual(trace.version);
+    expect(result.userId).toEqual(trace.user_id);
+    expect(result.sessionId).toEqual(trace.session_id);
+    expect(result.public).toEqual(trace.public);
+    expect(result.input).toEqual(null);
+    expect(result.output).toEqual(null);
+    expect(result.metadata).toEqual(trace.metadata);
+    expect(result.createdAt).toEqual(new Date(trace.created_at));
+    expect(result.updatedAt).toEqual(new Date(trace.updated_at));
+  });
+
+  it("should find a trace if no timestamp is provided", async () => {
+    const traceId = v4();
+
+    const trace = {
+      id: traceId,
+      project_id: projectId,
+      session_id: v4(),
+      timestamp: Date.now(),
+      metadata: {},
+      public: false,
+      bookmarked: false,
+      name: "Test Trace",
+      tags: [],
+      release: null,
+      version: null,
+      user_id: null,
+      created_at: Date.now(),
+      updated_at: Date.now(),
+      event_ts: Date.now(),
+      is_deleted: 0,
+    };
+
+    await createTrace(trace);
+
     const result = await getTraceByIdOrThrow(traceId, projectId);
     expect(result.id).toEqual(trace.id);
     expect(result.projectId).toEqual(trace.project_id);

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -153,7 +153,6 @@ export default function TracesTable({
 
   const tracesAllQueryFilter = {
     ...tracesAllCountFilter,
-    page: paginationState.pageIndex,
     limit: paginationState.pageSize,
     orderBy: orderByState,
     queryClickhouse: useClickhouse(),

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -153,6 +153,7 @@ export default function TracesTable({
 
   const tracesAllQueryFilter = {
     ...tracesAllCountFilter,
+    page: paginationState.pageIndex,
     limit: paginationState.pageSize,
     orderBy: orderByState,
     queryClickhouse: useClickhouse(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix trace timestamp handling in `getTraceByIdOrThrow` by using `toDate` for date-only comparison, update tests, and remove unused code.
> 
>   - **Behavior**:
>     - Modify `getTraceByIdOrThrow` in `traces.ts` to use `toDate` for timestamp comparison, ensuring date-only matching.
>     - Update error message in `getTraceByIdOrThrow` to include `timestamp`.
>   - **Tests**:
>     - Add test in `trace-repository.servertest.ts` to verify trace retrieval with and without timestamp.
>   - **Misc**:
>     - Add console log in `getTracesTable` in `traces.ts`.
>     - Remove unused `page` property from `tracesAllQueryFilter` in `traces.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 893981f08da83a6ee105839994257f1309437214. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->