### PR TITLE
fix: sessions metrics query

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -279,6 +279,32 @@ export class ArrayOptionsFilter implements Filter {
   }
 }
 
+export class NullFilter implements Filter {
+  public clickhouseTable: string;
+  public field: string;
+  public operator: (typeof filterOperators)["null"][number];
+  protected tablePrefix?: string;
+
+  constructor(opts: {
+    clickhouseTable: string;
+    field: string;
+    operator: (typeof filterOperators)["null"][number];
+    tablePrefix?: string;
+  }) {
+    this.clickhouseTable = opts.clickhouseTable;
+    this.field = opts.field;
+    this.operator = opts.operator;
+    this.tablePrefix = opts.tablePrefix;
+  }
+
+  apply(): ClickhouseFilter {
+    return {
+      query: `${this.tablePrefix ? this.tablePrefix + "." : ""}${this.field} ${this.operator}`,
+      params: {},
+    };
+  }
+}
+
 export class NumberObjectFilter implements Filter {
   public clickhouseTable: string;
   public field: string;

--- a/packages/shared/src/server/queries/clickhouse-sql/factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/factory.ts
@@ -14,6 +14,7 @@ import {
   BooleanFilter,
   NumberObjectFilter,
   StringObjectFilter,
+  NullFilter,
 } from "./clickhouse-filter";
 
 export class QueryBuilderError extends Error {
@@ -101,9 +102,16 @@ export const createFilterFromFilterState = (
           value: frontEndFilter.value,
           tablePrefix: column.queryPrefix,
         });
-
+      case "null":
+        return new NullFilter({
+          clickhouseTable: column.clickhouseTableName,
+          field: column.clickhouseSelect,
+          operator: frontEndFilter.operator,
+          tablePrefix: column.queryPrefix,
+        });
       default:
-        logger.error(`Invalid filter type: ${JSON.stringify(frontEndFilter)}`);
+        const exhaustiveCheck: never = frontEndFilter;
+        logger.error(`Invalid filter type: ${JSON.stringify(exhaustiveCheck)}`);
         throw new QueryBuilderError(`Invalid filter type`);
     }
   });

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -404,7 +404,10 @@ export const getTracesGroupedByUsers = async (
   });
 
   tracesFilter.push(
-    ...createFilterFromFilterState(filter, tracesTableUiColumnDefinitions),
+    ...createFilterFromFilterState(
+      filter,
+      columns ?? tracesTableUiColumnDefinitions,
+    ),
   );
 
   const tracesFilterRes = tracesFilter.apply();

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -356,7 +356,7 @@ export const sessionRouter = createTRPCRouter({
             ];
             const filter: FilterState = [
               {
-                column: "t.session_id",
+                column: "sessionId",
                 operator: "is not null",
                 type: "null",
                 value: "",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `NullFilter` to handle null checks in Clickhouse queries, updating session metrics queries to use it.
> 
>   - **Behavior**:
>     - Add `NullFilter` class in `clickhouse-filter.ts` to handle null checks in Clickhouse queries.
>     - Update `createFilterFromFilterState` in `factory.ts` to support `NullFilter`.
>     - Modify `sessionRouter` in `sessions.ts` to use `NullFilter` for `sessionId` checks.
>   - **Misc**:
>     - Update `getTracesGroupedByUsers` in `traces.ts` to accept dynamic column definitions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3a79873ea6c6454cad7cd808399aceb00f097064. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->