### PR TITLE
chore: add query parameter to healthcheck which enables failure on unavailable database

### DIFF
--- a/web/src/pages/api/public/health.ts
+++ b/web/src/pages/api/public/health.ts
@@ -18,7 +18,6 @@ export default async function handler(
 
     try {
       if (failIfDatabaseUnavailable) {
-        throw new Error("test");
         await prisma.$queryRaw`SELECT 1;`;
       }
     } catch (e) {

--- a/web/src/pages/api/public/health.ts
+++ b/web/src/pages/api/public/health.ts
@@ -13,6 +13,22 @@ export default async function handler(
     await runMiddleware(req, res, cors);
     await telemetry();
     const failIfNoRecentEvents = req.query.failIfNoRecentEvents === "true";
+    const failIfDatabaseUnavailable =
+      req.query.failIfDatabaseUnavailable === "true";
+
+    try {
+      if (failIfDatabaseUnavailable) {
+        throw new Error("test");
+        await prisma.$queryRaw`SELECT 1;`;
+      }
+    } catch (e) {
+      logger.error("Couldn't connect to database", e);
+      traceException(e);
+      return res.status(503).json({
+        status: "Database not available",
+        version: VERSION.replace("v", ""),
+      });
+    }
 
     try {
       if (failIfNoRecentEvents) {
@@ -53,10 +69,10 @@ export default async function handler(
         }
       }
     } catch (e) {
-      logger.error("Couldn't fetch recent events: db not available", e);
+      logger.error("Couldn't fetch recent events", e);
       traceException(e);
       return res.status(503).json({
-        status: "Database not available",
+        status: "Couldn't fetch recent events",
         version: VERSION.replace("v", ""),
       });
     }


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/4200
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `failIfDatabaseUnavailable` query parameter to `health.ts` to return 503 if the database is unavailable and updates logging.
> 
>   - **Behavior**:
>     - Adds `failIfDatabaseUnavailable` query parameter to `health.ts` to return 503 if the database is unavailable.
>     - Logs error and traces exception if database connection fails.
>   - **Logging**:
>     - Updates error message in `health.ts` when recent events cannot be fetched.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5a090102b3a924e3e981f9984617897372eea9fc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->