### PR TITLE
chore: improve clickhouse experimentation

### DIFF
--- a/web/src/server/utils/checkClickhouseAccess.ts
+++ b/web/src/server/utils/checkClickhouseAccess.ts
@@ -2,7 +2,6 @@ import { env } from "@/src/env.mjs";
 import {
   instrumentAsync,
   logger,
-  recordGauge,
   recordHistogram,
 } from "@langfuse/shared/src/server";
 import { type User } from "next-auth";

--- a/web/src/server/utils/checkClickhouseAccess.ts
+++ b/web/src/server/utils/checkClickhouseAccess.ts
@@ -3,6 +3,7 @@ import {
   instrumentAsync,
   logger,
   recordGauge,
+  recordHistogram,
 } from "@langfuse/shared/src/server";
 import { type User } from "next-auth";
 import * as opentelemetry from "@opentelemetry/api";
@@ -75,11 +76,13 @@ export const measureAndReturnApi = async <T, Y>(args: {
         currentSpan?.setAttribute("pg-duration", pgDuration);
         currentSpan?.setAttribute("ch-duration", chDuration);
 
-        recordGauge("langfuse.clickhouse_execution_time", chDuration, {
+        recordHistogram("langfuse.clickhouse_experiment", chDuration, {
           operation: args.operation,
+          database: "clickhouse",
         });
-        recordGauge("langfuse.postgres_execution_time", pgDuration, {
+        recordHistogram("langfuse.clickhouse_experiment", pgDuration, {
           operation: args.operation,
+          database: "postgres",
         });
 
         return env.LANGFUSE_RETURN_FROM_CLICKHOUSE === "true"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replace `recordGauge` with `recordHistogram` in `measureAndReturnApi` for Clickhouse and Postgres execution time logging.
> 
>   - **Metrics**:
>     - Replace `recordGauge` with `recordHistogram` in `measureAndReturnApi` to log execution times for Clickhouse and Postgres.
>     - Affects `langfuse.clickhouse_experiment` metric for both databases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a5c20afdb202b46bc9ba1e528817d79e97e7d710. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->