### PR TITLE
feat(cloud): move hobby plan usage info to sidebar

### DIFF
--- a/web/src/components/app-sidebar.tsx
+++ b/web/src/components/app-sidebar.tsx
@@ -16,6 +16,7 @@ import Link from "next/link";
 import { Alert, AlertDescription } from "@/src/components/ui/alert";
 import { LangfuseLogo } from "@/src/components/LangfuseLogo";
 import { SidebarNotifications } from "@/src/components/sidebar-notifications";
+import { UsageTracker } from "@/src/ee/features/billing/components/UsageTracker";
 
 type AppSidebarProps = {
   navItems: NavMainItem[];
@@ -41,6 +42,7 @@ export function AppSidebar({
         <NavMain items={navItems} />
         <div className="flex-1" />
         <div className="flex flex-col gap-2 p-2">
+          <UsageTracker />
           <SidebarNotifications />
         </div>
         <NavMain items={secondaryNavItems} showFeedbackButton />

--- a/web/src/components/layouts/routes.tsx
+++ b/web/src/components/layouts/routes.tsx
@@ -20,7 +20,6 @@ import { type Entitlement } from "@/src/features/entitlements/constants/entitlem
 import { type UiCustomizationOption } from "@/src/ee/features/ui-customization/useUiCustomization";
 import { type User } from "next-auth";
 import { type OrganizationScope } from "@/src/features/rbac/constants/organizationAccessRights";
-import { UsageTracker } from "@/src/ee/features/billing/components/UsageTracker";
 
 export type Route = {
   title: string;
@@ -130,7 +129,6 @@ export const ROUTES: Route[] = [
     entitlements: ["cloud-billing"],
     organizationRbacScope: "langfuseCloudBilling:CRUD",
     show: ({ organization }) => organization?.plan === "cloud:hobby",
-    label: <UsageTracker />,
   },
   {
     title: "Upgrade",
@@ -140,7 +138,6 @@ export const ROUTES: Route[] = [
     entitlements: ["cloud-billing"],
     organizationRbacScope: "langfuseCloudBilling:CRUD",
     show: ({ organization }) => organization?.plan === "cloud:hobby",
-    label: <UsageTracker />,
   },
   {
     title: "Settings",

--- a/web/src/components/sidebar-notifications.tsx
+++ b/web/src/components/sidebar-notifications.tsx
@@ -72,7 +72,7 @@ export function SidebarNotifications() {
   const currentNotification = notifications[currentNotificationIndex];
 
   return (
-    <Card className="relative overflow-hidden rounded-md bg-opacity-50 shadow-none group-data-[collapsible=icon]:hidden">
+    <Card className="relative max-h-44 overflow-hidden rounded-md bg-opacity-50 shadow-none group-data-[collapsible=icon]:hidden">
       <Button
         variant="ghost"
         size="sm"

--- a/web/src/ee/features/billing/components/UsageTracker.tsx
+++ b/web/src/ee/features/billing/components/UsageTracker.tsx
@@ -1,15 +1,17 @@
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/src/components/ui/hover-card";
 import { api } from "@/src/utils/api";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
-import { AlertTriangle } from "lucide-react";
-import { cn } from "@/src/utils/tailwind";
 import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 import { MAX_OBSERVATIONS_FREE_PLAN } from "@/src/ee/features/billing/constants";
 import { useHasOrgEntitlement } from "@/src/features/entitlements/hooks";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/src/components/ui/card";
+import { Button } from "@/src/components/ui/button";
+import Link from "next/link";
 
 export const UsageTracker = () => {
   const { organization } = useQueryProjectOrOrganization();
@@ -49,25 +51,20 @@ export const UsageTracker = () => {
   }
 
   return (
-    <HoverCard>
-      <HoverCardTrigger>
-        <AlertTriangle
-          className={cn(
-            "h-4 w-4",
-            percentage >= 100 ? "text-destructive" : "text-dark-yellow",
-          )}
-        />
-      </HoverCardTrigger>
-      <HoverCardContent className="w-80">
-        <div className="flex justify-between space-x-4">
-          <div className="space-y-1">
-            <h4 className="text-sm font-semibold">Free Plan Usage Limit</h4>
-            <p className="text-sm font-normal">
-              {`You've used ${usage.toLocaleString()} out of ${MAX_OBSERVATIONS_FREE_PLAN.toLocaleString()} included observations (${percentage.toFixed(2)}%) over the last 30 days. Please upgrade your plan to avoid interruptions.`}
-            </p>
-          </div>
-        </div>
-      </HoverCardContent>
-    </HoverCard>
+    <Card className="relative max-h-48 overflow-hidden rounded-md bg-opacity-50 shadow-none group-data-[collapsible=icon]:hidden">
+      <CardHeader className="p-4 pb-0">
+        <CardTitle className="text-sm">Hobby Plan Usage Limit</CardTitle>
+        <CardDescription>
+          {`${usage.toLocaleString()} / ${MAX_OBSERVATIONS_FREE_PLAN.toLocaleString()} (${percentage.toFixed(0)}%) observations in last 30 days. Please upgrade your plan to avoid interruptions.`}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="p-4 pt-2">
+        <Button variant="secondary" size="sm" asChild>
+          <Link href={`/organization/${organization?.id}/settings/billing`}>
+            Upgrade plan
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
   );
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `UsageTracker` to `AppSidebar`, remove from `ROUTES`, and update its UI with `Card` components.
> 
>   - **UI Changes**:
>     - Add `UsageTracker` to `AppSidebar` in `app-sidebar.tsx`.
>     - Remove `UsageTracker` from `ROUTES` in `routes.tsx`.
>     - Update `UsageTracker` UI in `UsageTracker.tsx` to use `Card` components.
>   - **Styling**:
>     - Limit `SidebarNotifications` card height to `max-h-44` in `sidebar-notifications.tsx`.
>     - Limit `UsageTracker` card height to `max-h-48` in `UsageTracker.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2602b5653a6bb0a56b3aac5d252ac957a75422c3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->