### PR TITLE
feat: exclude project_ids from clickhouse experimentation

### DIFF
--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -225,6 +225,7 @@ export const env = createEnv({
       .default(15_000),
     LANGFUSE_READ_FROM_POSTGRES_ONLY: z.enum(["true", "false"]).default("true"),
     LANGFUSE_RETURN_FROM_CLICKHOUSE: z.enum(["true", "false"]).default("false"),
+    LANGFUSE_EXPERIMENT_EXCLUDED_PROJECT_IDS: z.string().optional(),
     LANGFUSE_READ_DASHBOARDS_FROM_CLICKHOUSE: z
       .enum(["true", "false"])
       .default("false"),
@@ -458,6 +459,8 @@ export const env = createEnv({
       process.env.LANGFUSE_READ_FROM_POSTGRES_ONLY,
     LANGFUSE_RETURN_FROM_CLICKHOUSE:
       process.env.LANGFUSE_RETURN_FROM_CLICKHOUSE,
+    LANGFUSE_EXPERIMENT_EXCLUDED_PROJECT_IDS:
+      process.env.LANGFUSE_EXPERIMENT_EXCLUDED_PROJECT_IDS,
     LANGFUSE_READ_DASHBOARDS_FROM_CLICKHOUSE:
       process.env.LANGFUSE_READ_DASHBOARDS_FROM_CLICKHOUSE,
     STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,

--- a/web/src/server/utils/checkClickhouseAccess.ts
+++ b/web/src/server/utils/checkClickhouseAccess.ts
@@ -21,7 +21,7 @@ export const isClickhouseAdminEligible = (user?: User | null) => {
 };
 
 export const measureAndReturnApi = async <T, Y>(args: {
-  input: T & { queryClickhouse: boolean };
+  input: T & { queryClickhouse: boolean; projectId?: string };
   user: User | undefined | null;
   operation: string;
   pgExecution: (input: T) => Promise<Y>;
@@ -57,9 +57,17 @@ export const measureAndReturnApi = async <T, Y>(args: {
       const isExcludedFromClickhouse =
         user?.featureFlags.excludeClickhouseRead ?? false;
 
+      const excludedProjects =
+        env.LANGFUSE_EXPERIMENT_EXCLUDED_PROJECT_IDS?.split(",") ?? [];
+
+      const isExcludedProject = excludedProjects.includes(
+        input.projectId ?? "",
+      );
+
       if (
         env.LANGFUSE_READ_FROM_POSTGRES_ONLY === "true" ||
-        isExcludedFromClickhouse
+        isExcludedFromClickhouse ||
+        isExcludedProject
       ) {
         logger.info("Read from postgres only");
         return await pgExecution(input);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `LANGFUSE_EXPERIMENT_EXCLUDED_PROJECT_IDS` to exclude specific project IDs from Clickhouse experimentation, affecting query behavior in `measureAndReturnApi`.
> 
>   - **Behavior**:
>     - Adds `LANGFUSE_EXPERIMENT_EXCLUDED_PROJECT_IDS` to `env.mjs` to specify project IDs excluded from Clickhouse experimentation.
>     - Updates `measureAndReturnApi` in `checkClickhouseAccess.ts` to check `projectId` against `LANGFUSE_EXPERIMENT_EXCLUDED_PROJECT_IDS`.
>     - If `projectId` is excluded, defaults to Postgres execution.
>   - **Environment**:
>     - Adds `LANGFUSE_EXPERIMENT_EXCLUDED_PROJECT_IDS` as an optional string in `env.mjs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e79ca89dea7b1b81426e93464b2843eaffc41dcd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->