### PR TITLE
chore: upsert tracesessions from clickhouse ingestion pipeline

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -3,7 +3,6 @@ import { v4 } from "uuid";
 import { Prisma } from "@prisma/client";
 
 import { Model, Price, PrismaClient, Prompt } from "@langfuse/shared";
-import { prisma } from "@langfuse/shared/src/db";
 import {
   ClickhouseClientType,
   IngestionEntityTypes,
@@ -242,7 +241,7 @@ export class IngestionService {
 
     // If the trace has a sessionId, we upsert the corresponding session into Postgres.
     if (finalTraceRecord.session_id) {
-      await prisma.traceSession.upsert({
+      await this.prisma.traceSession.upsert({
         where: {
           id_projectId: {
             id: finalTraceRecord.session_id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `IngestionService` now upserts trace sessions into Postgres if `session_id` is present in trace events, using `prisma.traceSession.upsert`.
> 
>   - **Behavior**:
>     - `IngestionService` now upserts trace sessions into Postgres if `session_id` is present in trace events.
>     - `processTraceEventList` function handles the upsert operation.
>   - **Database**:
>     - Uses `prisma.traceSession.upsert` for session creation or update based on `session_id` and `projectId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fe46798cfaf997ab499d26270a4a0bd57fd49b4e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->