### PR TITLE
fix(cloud): usage indicator only on hobby plan

### DIFF
--- a/web/src/ee/features/billing/components/UsageTracker.tsx
+++ b/web/src/ee/features/billing/components/UsageTracker.tsx
@@ -2,7 +2,10 @@ import { api } from "@/src/utils/api";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 import { MAX_OBSERVATIONS_FREE_PLAN } from "@/src/ee/features/billing/constants";
-import { useHasOrgEntitlement } from "@/src/features/entitlements/hooks";
+import {
+  useHasOrgEntitlement,
+  useOrganizationPlan,
+} from "@/src/features/entitlements/hooks";
 import {
   Card,
   CardContent,
@@ -16,6 +19,7 @@ import Link from "next/link";
 export const UsageTracker = () => {
   const { organization } = useQueryProjectOrOrganization();
   const hasEntitlement = useHasOrgEntitlement("cloud-billing");
+  const plan = useOrganizationPlan();
   const hasAccess = useHasOrganizationAccess({
     organizationId: organization?.id,
     scope: "langfuseCloudBilling:CRUD",
@@ -38,7 +42,8 @@ export const UsageTracker = () => {
     usageQuery.isLoading ||
     !usageQuery.data ||
     !hasAccess ||
-    !hasEntitlement
+    !hasEntitlement ||
+    plan !== "cloud:hobby"
   ) {
     return null;
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `UsageTracker` component now only displays usage indicator for `cloud:hobby` plan.
> 
>   - **Behavior**:
>     - `UsageTracker` component now only shows usage indicator for `cloud:hobby` plan.
>     - Checks `plan !== "cloud:hobby"` to conditionally render the component.
>   - **Imports**:
>     - Add `useOrganizationPlan` to import statements in `UsageTracker.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e388307a4ab3aec3df72c5bd8b8287becebad271. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->