### PR TITLE
feat: move traces.hasany to clickhouse

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -313,6 +313,24 @@ export const getTracesByIds = async (
   return records.map(convertClickhouseToDomain);
 };
 
+export const hasAnyTrace = async (projectId: string) => {
+  const query = `
+    SELECT count(*) as count
+    FROM traces
+    WHERE project_id = {projectId: String}
+    LIMIT 1
+  `;
+
+  const rows = await queryClickhouse<{ count: string }>({
+    query,
+    params: {
+      projectId,
+    },
+  });
+
+  return rows.length > 0 && Number(rows[0].count) > 0;
+};
+
 export const getTraceByIdOrThrow = async (
   traceId: string,
   projectId: string,

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -45,6 +45,7 @@ import {
   logger,
   upsertTrace,
   convertTraceDomainToClickhouse,
+  hasAnyTrace,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 import { measureAndReturnApi } from "@/src/server/utils/checkClickhouseAccess";
@@ -68,17 +69,32 @@ export type ObservationReturnType = Omit<
 
 export const traceRouter = createTRPCRouter({
   hasAny: protectedProjectProcedure
-    .input(z.object({ projectId: z.string() }))
+    .input(
+      z.object({
+        projectId: z.string(),
+        queryClickhouse: z.boolean().default(false),
+      }),
+    )
     .query(async ({ input, ctx }) => {
-      const hasAny = await ctx.prisma.trace.findFirst({
-        where: {
-          projectId: input.projectId,
+      return await measureAndReturnApi({
+        input,
+        operation: "traces.hasAny",
+        user: ctx.session.user,
+        pgExecution: async () => {
+          const hasAny = await ctx.prisma.trace.findFirst({
+            where: {
+              projectId: input.projectId,
+            },
+            select: {
+              id: true,
+            },
+          });
+          return hasAny !== null;
         },
-        select: {
-          id: true,
+        clickhouseExecution: async () => {
+          return await hasAnyTrace(input.projectId);
         },
       });
-      return hasAny !== null;
     }),
   all: protectedProjectProcedure
     .input(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move `traces.hasAny` functionality to Clickhouse with a new `hasAnyTrace` function and update `traceRouter` to support Clickhouse queries.
> 
>   - **Behavior**:
>     - Adds `hasAnyTrace` function in `traces.ts` to check for trace existence in Clickhouse.
>     - Updates `traceRouter` in `traces.ts` to use `hasAnyTrace` for `traces.hasAny` query, with an option to query Clickhouse or PostgreSQL.
>   - **Misc**:
>     - Adds `queryClickhouse` boolean input to `traces.hasAny` in `traces.ts` to toggle between Clickhouse and PostgreSQL execution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9c6600f217126709cf1c14ff1e37260e6ce850e7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->