### PR TITLE
feat: configure to read from clickhouse only

### DIFF
--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -223,6 +223,9 @@ export const env = createEnv({
     LANGFUSE_READ_DASHBOARDS_FROM_CLICKHOUSE: z
       .enum(["true", "false"])
       .default("false"),
+    LANGFUSE_READ_FROM_CLICKHOUSE_ONLY: z
+      .enum(["true", "false"])
+      .default("false"),
     STRIPE_SECRET_KEY: z.string().optional(),
     STRIPE_WEBHOOK_SIGNING_SECRET: z.string().optional(),
     SENTRY_AUTH_TOKEN: z.string().optional(),
@@ -451,6 +454,8 @@ export const env = createEnv({
       process.env.LANGFUSE_INGESTION_QUEUE_DELAY_MS,
     LANGFUSE_READ_FROM_POSTGRES_ONLY:
       process.env.LANGFUSE_READ_FROM_POSTGRES_ONLY,
+    LANGFUSE_READ_FROM_CLICKHOUSE_ONLY:
+      process.env.LANGFUSE_READ_FROM_CLICKHOUSE_ONLY,
     LANGFUSE_RETURN_FROM_CLICKHOUSE:
       process.env.LANGFUSE_RETURN_FROM_CLICKHOUSE,
     LANGFUSE_EXPERIMENT_EXCLUDED_PROJECT_IDS:

--- a/web/src/server/utils/checkClickhouseAccess.ts
+++ b/web/src/server/utils/checkClickhouseAccess.ts
@@ -49,6 +49,10 @@ export const measureAndReturnApi = async <T, Y>(args: {
         return await clickhouseExecution(input);
       }
 
+      if (env.LANGFUSE_READ_FROM_CLICKHOUSE_ONLY === "true") {
+        return await clickhouseExecution(input);
+      }
+
       // logic for regular users:
       // if env.LANGFUSE_READ_FROM_POSTGRES_ONLY is true, return postgres only
       // otherwise fetch both and compare timing


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `LANGFUSE_READ_FROM_CLICKHOUSE_ONLY` to configure exclusive Clickhouse reads in `checkClickhouseAccess.ts`.
> 
>   - **Environment Variables**:
>     - Add `LANGFUSE_READ_FROM_CLICKHOUSE_ONLY` to `env.mjs` with default value "false".
>   - **Logic Changes**:
>     - In `checkClickhouseAccess.ts`, update `measureAndReturnApi` to return Clickhouse data exclusively if `LANGFUSE_READ_FROM_CLICKHOUSE_ONLY` is "true".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c9270dc461c11afcae11144c80d5682c73d8f73c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->