### PR TITLE
fix: session id filter on session table

### DIFF
--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -197,7 +197,7 @@ export default function SessionsTable({
           />
         ) : undefined;
       },
-      enableSorting: true,
+      enableSorting: false,
     },
     {
       accessorKey: "id",

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -673,7 +673,7 @@ const getPublicSessions = async (
         sessionsBookmarkedFilter.operator === "<>"))
       ? [
           {
-            column: "sessionId",
+            column: "id",
             type: "stringOptions" as const,
             operator: "any of" as const,
             value: filteredSessions.map((s) => s.id),
@@ -686,7 +686,7 @@ const getPublicSessions = async (
               sessionsBookmarkedFilter.operator === "<>"))
         ? [
             {
-              column: "sessionId",
+              column: "id",
               type: "stringOptions" as const,
               operator: "none of" as const,
               value: filteredSessions.map((s) => s.id),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix session ID filtering by renaming `sessionId` to `id` and disable sorting for `bookmarked` column in session table.
> 
>   - **Behavior**:
>     - Disables sorting for the `bookmarked` column in `sessions.tsx`.
>     - Corrects session ID filtering by renaming `sessionId` to `id` in `sessions.ts`.
>   - **Misc**:
>     - Minor adjustment to session table configuration in `sessions.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1228774c6d3c7beeabae3844c14adc52af4da5c4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->