### PR TITLE
feat: move datasets results to logs only

### DIFF
--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -167,7 +167,7 @@ export const datasetRouter = createTRPCRouter({
     .query(async ({ input, ctx }) => {
       return await measureAndReturnApi({
         input,
-        operation: "scores.runsByDatasetId",
+        operation: "datasets.runsByDatasetId",
         user: ctx.session.user,
         pgExecution: async () => {
           const scoresByRunId = await ctx.prisma.$queryRaw<

--- a/web/src/server/utils/checkClickhouseAccess.ts
+++ b/web/src/server/utils/checkClickhouseAccess.ts
@@ -49,7 +49,10 @@ export const measureAndReturnApi = async <T, Y>(args: {
         return await clickhouseExecution(input);
       }
 
-      if (env.LANGFUSE_READ_FROM_CLICKHOUSE_ONLY === "true") {
+      if (
+        env.LANGFUSE_READ_FROM_CLICKHOUSE_ONLY === "true" &&
+        !args.operation.includes("dataset")
+      ) {
         return await clickhouseExecution(input);
       }
 
@@ -101,6 +104,13 @@ export const measureAndReturnApi = async <T, Y>(args: {
           operation: args.operation,
           database: "postgres",
         });
+
+        if (args.operation.includes("dataset")) {
+          logger.info(
+            `operation: ${args.operation} pg result: ${JSON.stringify(pgResult)}, ch result: ${JSON.stringify(chResult)}`,
+          );
+          return pgResult;
+        }
 
         return env.LANGFUSE_RETURN_FROM_CLICKHOUSE === "true"
           ? chResult


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Logs dataset operation results to logger and returns Postgres result instead of Clickhouse for dataset operations.
> 
>   - **Behavior**:
>     - Logs dataset operation results to logger in `measureAndReturnApi` in `checkClickhouseAccess.ts` when operation includes "dataset".
>     - Returns Postgres result for dataset operations instead of Clickhouse result.
>   - **Code Changes**:
>     - Update operation name from `scores.runsByDatasetId` to `datasets.runsByDatasetId` in `dataset-router.ts`.
>     - Add logging for dataset operations in `measureAndReturnApi` in `checkClickhouseAccess.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a7d277911dddd22723fcdf8e623b2cbc59e952d8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->