### PR TITLE
feat: serve datasets from clickhouse

### DIFF
--- a/web/src/server/utils/checkClickhouseAccess.ts
+++ b/web/src/server/utils/checkClickhouseAccess.ts
@@ -50,8 +50,9 @@ export const measureAndReturnApi = async <T, Y>(args: {
       }
 
       if (
-        env.LANGFUSE_READ_FROM_CLICKHOUSE_ONLY === "true" &&
-        !args.operation.includes("dataset")
+        env.LANGFUSE_READ_FROM_CLICKHOUSE_ONLY === "true"
+        //  &&
+        // !args.operation.includes("dataset")
       ) {
         return await clickhouseExecution(input);
       }
@@ -105,12 +106,12 @@ export const measureAndReturnApi = async <T, Y>(args: {
           database: "postgres",
         });
 
-        if (args.operation.includes("dataset")) {
-          logger.info(
-            `operation: ${args.operation} pg result: ${JSON.stringify(pgResult)}, ch result: ${JSON.stringify(chResult)}`,
-          );
-          return pgResult;
-        }
+        // if (args.operation.includes("dataset")) {
+        //   logger.info(
+        //     `operation: ${args.operation} pg result: ${JSON.stringify(pgResult)}, ch result: ${JSON.stringify(chResult)}`,
+        //   );
+        //   return pgResult;
+        // }
 
         return env.LANGFUSE_RETURN_FROM_CLICKHOUSE === "true"
           ? chResult


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `measureAndReturnApi` in `checkClickhouseAccess.ts` to prioritize Clickhouse execution and comment out dataset-specific logic.
> 
>   - **Behavior**:
>     - Modify `measureAndReturnApi` in `checkClickhouseAccess.ts` to prioritize Clickhouse execution when `LANGFUSE_READ_FROM_CLICKHOUSE_ONLY` is true, removing dataset operation exclusion.
>     - Comment out logic that previously returned Postgres results for dataset operations.
>   - **Logging**:
>     - Comment out logging of Postgres and Clickhouse results for dataset operations in `measureAndReturnApi`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 32f9e671c1a8bab1d571fc957470976c552c6eef. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->