### PR TITLE
fix: fix dataset run items api

### DIFF
--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -1063,9 +1063,7 @@ export const datasetRouter = createTRPCRouter({
             ),
             getLatencyAndTotalCostForObservationsByTraces(
               input.projectId,
-              runItems
-                .filter((ri) => ri.observationId === null) // only include trace scores if run is not linked to an observation
-                .map((ri) => ri.traceId),
+              runItems.map((ri) => ri.traceId),
             ),
           ]);
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `dataset-router.ts` to include all `traceId`s in `getLatencyAndTotalCostForObservationsByTraces`, not just those with `observationId === null`.
> 
>   - **Behavior**:
>     - In `dataset-router.ts`, modify `getLatencyAndTotalCostForObservationsByTraces` to include all `traceId`s from `runItems`, not just those with `observationId === null`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ad03b38262339dc50b732280cc4e5c4fd90b923f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->