### PR TITLE
fix: fix dataset runs api

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -755,8 +755,8 @@ export const getLatencyAndTotalCostForObservations = async (
         id,
         cost_details['total'] AS total_cost,
         dateDiff('milliseconds', start_time, end_time) AS latency_ms
-    FROM observations
-    FINAL project_id = {projectId: String} 
+    FROM observations FINAL 
+    WHERE project_id = {projectId: String} 
     AND id IN ({observationIds: Array(String)})
 `;
   const rows = await queryClickhouse<{

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -461,13 +461,13 @@ export const datasetRouter = createTRPCRouter({
 
               const avgLatency =
                 validAgg.length > 0
-                  ? validAgg.reduce((sum, a) => sum + (a.latency || 0), 0) /
+                  ? validAgg.reduce((sum, a) => sum + (a?.latency ?? 0), 0) /
                     validAgg.length
                   : 0;
 
               const avgTotalCost =
                 validAgg.length > 0
-                  ? validAgg.reduce((sum, a) => sum + (a.totalCost || 0), 0) /
+                  ? validAgg.reduce((sum, a) => sum + (a?.totalCost || 0), 0) /
                     validAgg.length
                   : 0;
 

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -24,8 +24,6 @@ import {
   getScoresForObservations,
   getScoresForTraces,
   traceException,
-  getAggregatedLatencyAndTotalCostForObservationsByTraces,
-  getAggregatedLatencyAndTotalCostForObservations,
   getTracesByIds,
 } from "@langfuse/shared/src/server";
 import { measureAndReturnApi } from "@/src/server/utils/checkClickhouseAccess";
@@ -369,7 +367,7 @@ export const datasetRouter = createTRPCRouter({
               .filter((runItem) => runItem.observation_id === null);
 
             const traceData =
-              await getAggregatedLatencyAndTotalCostForObservationsByTraces(
+              await getLatencyAndTotalCostForObservationsByTraces(
                 input.projectId,
                 traceOnlyRunItems.map((ri) => ri.trace_id),
               );
@@ -389,11 +387,10 @@ export const datasetRouter = createTRPCRouter({
               .flatMap((r) => r.run_items)
               .filter((runItem) => runItem.observation_id !== null);
 
-            const observationData =
-              await getAggregatedLatencyAndTotalCostForObservations(
-                input.projectId,
-                observationRunItems.map((ri) => ri.observation_id),
-              );
+            const observationData = await getLatencyAndTotalCostForObservations(
+              input.projectId,
+              observationRunItems.map((ri) => ri.observation_id),
+            );
             return observationRunItems.map((ri) => {
               const data = observationData.find(
                 (d) => d.id === ri.observation_id,

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -363,12 +363,6 @@ export const datasetRouter = createTRPCRouter({
           `,
           );
 
-          console.log(
-            JSON.stringify(
-              runs.flatMap((r) => r.run_items).map((ri) => ri.trace_id),
-            ),
-          );
-
           async function getTraceAggregates() {
             const traceOnlyRunItems = runs
               .flatMap((r) => r.run_items)

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -317,6 +317,10 @@ export const datasetRouter = createTRPCRouter({
           };
         },
         clickhouseExecution: async () => {
+          // we cannot easily join all the tracing data with the dataset run items
+          // hence, we pull the trace_ids and observation_ids separately for all run items
+          // afterwards, we aggregate them per run
+
           const runs = await ctx.prisma.$queryRaw<
             {
               run_id: string;
@@ -325,9 +329,11 @@ export const datasetRouter = createTRPCRouter({
               run_metadata: Prisma.JsonValue;
               run_created_at: Date;
               run_updated_at: Date;
-              trace_ids: string[];
-              observation_ids: string[];
-              count: BigInt;
+              run_items: {
+                trace_id: string;
+                observation_id: string;
+                ri_id: string;
+              }[];
             }[]
           >(
             Prisma.sql`
@@ -338,9 +344,11 @@ export const datasetRouter = createTRPCRouter({
               runs.metadata as run_metadata,
               runs.created_at as run_created_at,
               runs.updated_at as run_updated_at,
-              ARRAY_AGG(ri.trace_id) AS trace_ids,
-              ARRAY_AGG(ri.observation_id) AS observation_ids,
-              COUNT(ri.id) AS count
+              JSON_AGG(JSON_BUILD_OBJECT(
+                'trace_id', ri.trace_id,
+                'observation_id', ri.observation_id,
+                'ri_id', ri.id
+              )) AS run_items
             FROM
               datasets d
               JOIN dataset_runs runs ON d.id = runs.dataset_id AND d.project_id = runs.project_id
@@ -355,44 +363,53 @@ export const datasetRouter = createTRPCRouter({
           `,
           );
 
-          async function getTraceAggregates() {
-            const traceOnlyRuns = runs.filter((ri) =>
-              ri.observation_ids.some(
-                (observationId) => observationId === null,
-              ),
-            );
+          console.log(
+            JSON.stringify(
+              runs.flatMap((r) => r.run_items).map((ri) => ri.trace_id),
+            ),
+          );
 
-            return await Promise.all(
-              traceOnlyRuns.map((run) =>
-                getAggregatedLatencyAndTotalCostForObservationsByTraces(
-                  input.projectId,
-                  run.trace_ids,
-                ).then((agg) => ({
-                  runId: run.run_id,
-                  agg,
-                })),
-              ),
-            );
+          async function getTraceAggregates() {
+            const traceOnlyRunItems = runs
+              .flatMap((r) => r.run_items)
+              .filter((runItem) => runItem.observation_id === null);
+
+            const traceData =
+              await getAggregatedLatencyAndTotalCostForObservationsByTraces(
+                input.projectId,
+                traceOnlyRunItems.map((ri) => ri.trace_id),
+              );
+
+            return traceOnlyRunItems.map((ri) => {
+              const data = traceData.find((d) => d.id === ri.trace_id);
+              return {
+                runItemId: ri.ri_id,
+                latency: data?.latency,
+                totalCost: data?.totalCost,
+              };
+            });
           }
 
           async function getObservationAggregates() {
-            const observationRuns = runs.filter((ri) =>
-              ri.observation_ids.every(
-                (observationId) => observationId !== null,
-              ),
-            );
+            const observationRunItems = runs
+              .flatMap((r) => r.run_items)
+              .filter((runItem) => runItem.observation_id !== null);
 
-            return await Promise.all(
-              observationRuns.map((run) =>
-                getAggregatedLatencyAndTotalCostForObservations(
-                  input.projectId,
-                  run.observation_ids,
-                ).then((agg) => ({
-                  runId: run.run_id,
-                  agg,
-                })),
-              ),
-            );
+            const observationData =
+              await getAggregatedLatencyAndTotalCostForObservations(
+                input.projectId,
+                observationRunItems.map((ri) => ri.observation_id),
+              );
+            return observationRunItems.map((ri) => {
+              const data = observationData.find(
+                (d) => d.id === ri.observation_id,
+              );
+              return {
+                runItemId: ri.ri_id,
+                latency: data?.latency,
+                totalCost: data?.totalCost,
+              };
+            });
           }
 
           const [
@@ -405,14 +422,22 @@ export const datasetRouter = createTRPCRouter({
             getScoresForTraces(
               input.projectId,
               Array.from(
-                new Set(runs.flatMap((ri) => ri.trace_ids).filter(Boolean)),
+                new Set(
+                  runs
+                    .flatMap((r) => r.run_items)
+                    .map((i) => i.trace_id)
+                    .filter(Boolean),
+                ),
               ),
             ),
             getScoresForObservations(
               input.projectId,
               Array.from(
                 new Set(
-                  runs.flatMap((ri) => ri.observation_ids).filter(Boolean),
+                  runs
+                    .flatMap((r) => r.run_items)
+                    .map((i) => i.observation_id)
+                    .filter(Boolean),
                 ),
               ),
             ),
@@ -431,9 +456,30 @@ export const datasetRouter = createTRPCRouter({
           return {
             totalRuns,
             runs: runs.map((run) => {
-              const agg =
-                traceAggregate.find((agg) => agg.runId === run.run_id) ??
-                observationAggregate.find((agg) => agg.runId === run.run_id);
+              const agg = run.run_items.map((ri) => {
+                if (ri.observation_id) {
+                  return observationAggregate.find(
+                    (a) => a.runItemId === ri.ri_id,
+                  );
+                } else {
+                  return traceAggregate.find((a) => a.runItemId === ri.ri_id);
+                }
+              });
+
+              const validAgg = agg.filter((a) => a !== undefined);
+
+              const avgLatency =
+                validAgg.length > 0
+                  ? validAgg.reduce((sum, a) => sum + (a.latency || 0), 0) /
+                    validAgg.length
+                  : 0;
+
+              const avgTotalCost =
+                validAgg.length > 0
+                  ? validAgg.reduce((sum, a) => sum + (a.totalCost || 0), 0) /
+                    validAgg.length
+                  : 0;
+
               return {
                 id: run.run_id,
                 projectId: input.projectId,
@@ -443,13 +489,13 @@ export const datasetRouter = createTRPCRouter({
                 metadata: run.run_metadata,
                 createdAt: run.run_created_at,
                 updatedAt: run.run_updated_at,
-                countRunItems: Number(run.count),
-                avgLatency: agg?.agg ? agg.agg.avgLatency : 0,
-                avgTotalCost: agg?.agg
-                  ? new Decimal(agg.agg.avgTotalCost)
-                  : new Decimal(0),
+                countRunItems: run.run_items.length,
+                avgLatency: avgLatency,
+                avgTotalCost: new Decimal(avgTotalCost),
                 scores: aggregateScores(
-                  joinedScores.filter((s) => run.trace_ids.includes(s.traceId)),
+                  joinedScores.filter((s) =>
+                    run.run_items.map((i) => i.trace_id).includes(s.traceId),
+                  ),
                 ),
               };
             }),

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -373,7 +373,7 @@ export const datasetRouter = createTRPCRouter({
               );
 
             return traceOnlyRunItems.map((ri) => {
-              const data = traceData.find((d) => d.id === ri.trace_id);
+              const data = traceData.find((d) => d.traceId === ri.trace_id);
               return {
                 runItemId: ri.ri_id,
                 latency: data?.latency,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix dataset runs API by modifying SQL queries and data aggregation logic in `observations.ts` and `dataset-router.ts` to handle trace and observation data accurately.
> 
>   - **Behavior**:
>     - Fix dataset runs API by modifying SQL queries in `observations.ts` and `dataset-router.ts`.
>     - Remove unnecessary CTEs in `getAggregatedLatencyAndTotalCostForObservationsByTraces` and `getAggregatedLatencyAndTotalCostForObservations`.
>     - Adjust data aggregation logic to handle trace and observation data separately and aggregate them per run.
>     - Ensure accurate calculation of average latency and total cost for dataset runs.
>   - **Data Handling**:
>     - Modify return structure in `getAggregatedLatencyAndTotalCostForObservationsByTraces` and `getAggregatedLatencyAndTotalCostForObservations` to include `id`, `totalCost`, and `latency`.
>     - Update `dataset-router.ts` to handle trace and observation data separately, aggregate them, and calculate average values.
>   - **Misc**:
>     - Add comments in `dataset-router.ts` to explain the logic behind data aggregation and handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e845755877e4a0c43bc7e8eb543b1141bfc3d8b9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->