### PR TITLE
feat(datasets): add header to peek view

### DIFF
--- a/web/src/components/layouts/peek-view.tsx
+++ b/web/src/components/layouts/peek-view.tsx
@@ -11,8 +11,11 @@ import Link from "next/link";
 import { type ReactNode } from "react";
 
 export default function PeekView(props: {
-  itemName: string;
-  itemType: string;
+  item: {
+    name: string;
+    type: string;
+    link: string;
+  };
   open: boolean;
   onClose: () => void;
   children: ReactNode;
@@ -26,14 +29,14 @@ export default function PeekView(props: {
             <div className="mb-2 mt-2 flex flex-wrap items-center justify-between gap-2">
               {props.actionButtons ?? null}
               <h3 className="text-xl font-bold leading-7 sm:tracking-tight">
-                {`${props.itemType}:`}
+                {`${props.item.type}:`}
               </h3>
               <Link
                 className="inline-block h-5 max-w-full overflow-hidden text-ellipsis text-nowrap rounded bg-primary-accent/20 px-2 py-0.5 text-base font-semibold text-accent-dark-blue shadow-sm hover:bg-accent-light-blue/45"
-                href=""
-                title={props.itemName}
+                href={props.item.link}
+                title={props.item.name}
               >
-                {props.itemName}
+                {props.item.name}
               </Link>
             </div>
           </DrawerTitle>

--- a/web/src/components/layouts/peek-view.tsx
+++ b/web/src/components/layouts/peek-view.tsx
@@ -1,4 +1,3 @@
-import Header from "@/src/components/layouts/header";
 import { Button } from "@/src/components/ui/button";
 import {
   Drawer,
@@ -8,11 +7,12 @@ import {
   DrawerTitle,
 } from "@/src/components/ui/drawer";
 import { X } from "lucide-react";
+import Link from "next/link";
 import { type ReactNode } from "react";
 
 export default function PeekView(props: {
-  key: string;
-  title: string;
+  itemName: string;
+  itemType: string;
   open: boolean;
   onClose: () => void;
   children: ReactNode;
@@ -21,10 +21,21 @@ export default function PeekView(props: {
   return (
     <Drawer open={props.open} modal={false} onClose={props.onClose}>
       <DrawerContent size="lg" className="mx-auto">
-        <DrawerHeader className="sticky top-0 z-10 flex flex-row items-center justify-between rounded-sm bg-background">
+        <DrawerHeader className="sticky top-0 z-10 mb-2 flex flex-row items-center justify-between rounded-tl-xl border-b bg-background p-3">
           <DrawerTitle className="flex flex-row items-center gap-2">
-            {props.actionButtons ?? null}
-            <Header title={props.title} level="h3"></Header>
+            <div className="mb-2 mt-2 flex flex-wrap items-center justify-between gap-2">
+              {props.actionButtons ?? null}
+              <h3 className="text-xl font-bold leading-7 sm:tracking-tight">
+                {`${props.itemType}:`}
+              </h3>
+              <Link
+                className="inline-block h-5 max-w-full overflow-hidden text-ellipsis text-nowrap rounded bg-primary-accent/20 px-2 py-0.5 text-base font-semibold text-accent-dark-blue shadow-sm hover:bg-accent-light-blue/45"
+                href=""
+                title={props.itemName}
+              >
+                {props.itemName}
+              </Link>
+            </div>
           </DrawerTitle>
           <DrawerClose asChild onClick={props.onClose}>
             <Button variant="outline" size="icon">

--- a/web/src/components/layouts/peek-view.tsx
+++ b/web/src/components/layouts/peek-view.tsx
@@ -1,0 +1,44 @@
+import Header from "@/src/components/layouts/header";
+import { Button } from "@/src/components/ui/button";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/src/components/ui/drawer";
+import { X } from "lucide-react";
+import { type ReactNode } from "react";
+
+export default function PeekView(props: {
+  key: string;
+  title: string;
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  actionButtons?: ReactNode;
+}) {
+  return (
+    <Drawer open={props.open} modal={false} onClose={props.onClose}>
+      <DrawerContent size="lg" className="mx-auto">
+        <DrawerHeader className="sticky top-0 z-10 flex flex-row items-center justify-between rounded-sm bg-background">
+          <DrawerTitle className="flex flex-row items-center gap-2">
+            {props.actionButtons ?? null}
+            <Header title={props.title} level="h3"></Header>
+          </DrawerTitle>
+          <DrawerClose asChild onClick={props.onClose}>
+            <Button variant="outline" size="icon">
+              <X className="h-4 w-4" />
+            </Button>
+          </DrawerClose>
+        </DrawerHeader>
+        <div
+          data-vaul-no-drag
+          className="mb-4 h-full flex-1 gap-4 overflow-hidden px-4"
+        >
+          {props.children}
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/web/src/features/datasets/components/DatasetCompareRunPeekView.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunPeekView.tsx
@@ -1,17 +1,10 @@
 import { useClickhouse } from "@/src/components/layouts/ClickhouseAdminToggle";
 import DocPopup from "@/src/components/layouts/doc-popup";
-import Header from "@/src/components/layouts/header";
+import PeekView from "@/src/components/layouts/peek-view";
 import { IOPreview } from "@/src/components/trace/IOPreview";
 import { ObservationTree } from "@/src/components/trace/ObservationTree";
 import { Button } from "@/src/components/ui/button";
 import { Card } from "@/src/components/ui/card";
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerHeader,
-  DrawerTitle,
-} from "@/src/components/ui/drawer";
 import {
   ResizablePanelGroup,
   ResizablePanel,
@@ -77,190 +70,173 @@ export function DatasetCompareRunPeekView({
   };
 
   return (
-    <Drawer
+    <PeekView
+      onClose={onClose}
       key={clickedRow?.id ?? "closed"}
       open={!!clickedRow}
-      modal={false}
-      onClose={onClose}
-    >
-      <DrawerContent size="lg" className="mx-auto">
-        <DrawerHeader className="sticky top-0 z-10 flex flex-row items-center justify-between rounded-sm bg-background">
-          <DrawerTitle className="flex flex-row items-center gap-2">
-            {traceAndObservationId?.traceId && (
-              <Button
-                variant="outline"
-                size="icon"
-                onClick={() => setTraceAndObservationId(null)}
-              >
-                <PanelLeftClose className="h-4 w-4" />
-              </Button>
-            )}
-            <Header title="Comparing traces" level="h3"></Header>
-          </DrawerTitle>
-          <DrawerClose asChild onClick={onClose}>
-            <Button variant="outline" size="icon">
-              <X className="h-4 w-4" />
+      title="Comparing traces"
+      actionButtons={
+        <>
+          {traceAndObservationId?.traceId && (
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => setTraceAndObservationId(null)}
+            >
+              <PanelLeftClose className="h-4 w-4" />
             </Button>
-          </DrawerClose>
-        </DrawerHeader>
-        <div
-          data-vaul-no-drag
-          className="mb-4 h-full flex-1 gap-4 overflow-hidden px-4"
-        >
-          <div
-            className={cn(
-              "grid gap-4 md:h-full",
-              traceAndObservationId?.traceId
-                ? "grid-cols-[1fr,3fr]"
-                : "grid-cols-1",
+          )}
+        </>
+      }
+    >
+      <div
+        className={cn(
+          "grid gap-4 md:h-full",
+          traceAndObservationId?.traceId
+            ? "grid-cols-[1fr,3fr]"
+            : "grid-cols-1",
+        )}
+      >
+        {traceAndObservationId?.traceId && (
+          <Card className="h-full overflow-y-auto p-2">
+            {trace.data ? (
+              <ObservationTree
+                observations={trace.data?.observations ?? []}
+                collapsedObservations={[]}
+                toggleCollapsedObservation={() => {}}
+                collapseAll={() => {}}
+                expandAll={() => {}}
+                trace={trace.data}
+                scores={trace.data?.scores ?? []}
+                currentObservationId={undefined}
+                setCurrentObservationId={(id) => {
+                  if (id)
+                    window.open(
+                      `/project/${projectId}/traces/${encodeURIComponent(traceAndObservationId?.traceId)}?observation=${encodeURIComponent(id)}`,
+                      "_blank",
+                      "noopener noreferrer",
+                    );
+                }}
+                showMetrics={false}
+                showScores={true}
+                colorCodeMetrics={false}
+                className="flex w-full flex-col overflow-y-auto"
+                showExpandControls={false}
+              />
+            ) : (
+              <Skeleton className="min-h-full w-full" />
             )}
-          >
-            {traceAndObservationId?.traceId && (
-              <Card className="h-full overflow-y-auto p-2">
-                {trace.data ? (
-                  <ObservationTree
-                    observations={trace.data?.observations ?? []}
-                    collapsedObservations={[]}
-                    toggleCollapsedObservation={() => {}}
-                    collapseAll={() => {}}
-                    expandAll={() => {}}
-                    trace={trace.data}
-                    scores={trace.data?.scores ?? []}
-                    currentObservationId={undefined}
-                    setCurrentObservationId={(id) => {
-                      if (id)
-                        window.open(
-                          `/project/${projectId}/traces/${encodeURIComponent(traceAndObservationId?.traceId)}?observation=${encodeURIComponent(id)}`,
-                          "_blank",
-                          "noopener noreferrer",
-                        );
-                    }}
-                    showMetrics={false}
-                    showScores={true}
-                    colorCodeMetrics={false}
-                    className="flex w-full flex-col overflow-y-auto"
-                    showExpandControls={false}
-                  />
-                ) : (
-                  <Skeleton className="min-h-full w-full" />
-                )}
-              </Card>
-            )}
-            <div className="grid h-full grid-rows-[minmax(0,1fr)] overflow-hidden">
-              <ResizablePanelGroup
-                direction="vertical"
-                className="overflow-hidden"
-              >
-                <ResizablePanel
-                  minSize={30}
-                  className="mb-2 min-h-0 overflow-hidden"
-                >
-                  <div className="grid h-full grid-cols-2 gap-4">
-                    <div className="min-h-0 overflow-hidden">
-                      <h3 className="font-lg mb-1 font-semibold">Input</h3>
-                      <div className="h-[calc(100%-1.75rem)] space-y-2 overflow-y-auto">
-                        <IOPreview
-                          key={clickedRow?.id + "-input"}
-                          input={clickedRow?.input ?? null}
-                          hideOutput
-                        />
-                      </div>
-                    </div>
-                    <div className="min-h-0 overflow-hidden">
-                      <h3 className="font-lg mb-1 font-semibold">
-                        Expected output
-                      </h3>
-                      <div className="h-[calc(100%-1.75rem)] space-y-2 overflow-y-auto">
-                        <IOPreview
-                          key={clickedRow?.id + "-output"}
-                          output={clickedRow?.expectedOutput ?? null}
-                          hideInput
-                        />
-                      </div>
-                    </div>
+          </Card>
+        )}
+        <div className="grid h-full grid-rows-[minmax(0,1fr)] overflow-hidden">
+          <ResizablePanelGroup direction="vertical" className="overflow-hidden">
+            <ResizablePanel
+              minSize={30}
+              className="mb-2 min-h-0 overflow-hidden"
+            >
+              <div className="grid h-full grid-cols-2 gap-4">
+                <div className="min-h-0 overflow-hidden">
+                  <h3 className="font-lg mb-1 font-semibold">Input</h3>
+                  <div className="h-[calc(100%-1.75rem)] space-y-2 overflow-y-auto">
+                    <IOPreview
+                      key={clickedRow?.id + "-input"}
+                      input={clickedRow?.input ?? null}
+                      hideOutput
+                    />
                   </div>
-                </ResizablePanel>
-                <ResizableHandle withHandle className="bg-border" />
-                <ResizablePanel
-                  minSize={30}
-                  defaultSize={50}
-                  className="mt-2 min-h-0 overflow-hidden"
-                >
-                  <h3 className="font-lg mb-1 font-semibold">Run outputs</h3>
-                  {clickedRow?.runs && (
-                    <div className="flex h-[calc(100%-2rem)] w-full gap-4 overflow-x-auto">
-                      {Object.entries(clickedRow.runs).map(([id, run]) => {
-                        const runData = runsData?.find((r) => r.id === id);
-                        return (
-                          <div
-                            key={id}
-                            className="flex w-[45%] flex-none flex-col overflow-hidden"
-                          >
-                            <div className="mb-1 flex items-center text-sm font-medium">
-                              {runData?.name ?? id}
-                              {runData?.description && (
-                                <DocPopup description={runData?.description} />
-                              )}
-                            </div>
-                            <DatasetAggregateTableCell
-                              value={run}
-                              projectId={projectId}
-                              scoreKeyToDisplayName={scoreKeyToDisplayName}
-                              selectedMetrics={["scores", "resourceMetrics"]}
-                              singleLine={false}
-                              variant="peek"
-                              className={cn(
-                                "relative flex-1 overflow-y-auto",
-                                traceAndObservationId?.runId === id &&
-                                  "border-4",
-                              )}
-                              actionButtons={
-                                <div className="absolute right-1 top-1 z-10 hidden items-center justify-center gap-1 group-hover:flex">
-                                  <Button
-                                    variant="outline"
-                                    size="icon"
-                                    title="View full trace"
-                                    onClick={() =>
-                                      window.open(
-                                        run?.observationId
-                                          ? `/project/${projectId}/traces/${encodeURIComponent(run.traceId)}?observation=${encodeURIComponent(run.observationId)}`
-                                          : `/project/${projectId}/traces/${encodeURIComponent(run.traceId)}`,
-                                        "_blank",
-                                        "noopener noreferrer",
-                                      )
-                                    }
-                                  >
-                                    <ListTree className="h-4 w-4" />
-                                  </Button>
+                </div>
+                <div className="min-h-0 overflow-hidden">
+                  <h3 className="font-lg mb-1 font-semibold">
+                    Expected output
+                  </h3>
+                  <div className="h-[calc(100%-1.75rem)] space-y-2 overflow-y-auto">
+                    <IOPreview
+                      key={clickedRow?.id + "-output"}
+                      output={clickedRow?.expectedOutput ?? null}
+                      hideInput
+                    />
+                  </div>
+                </div>
+              </div>
+            </ResizablePanel>
+            <ResizableHandle withHandle className="bg-border" />
+            <ResizablePanel
+              minSize={30}
+              defaultSize={50}
+              className="mt-2 min-h-0 overflow-hidden"
+            >
+              <h3 className="font-lg mb-1 font-semibold">Run outputs</h3>
+              {clickedRow?.runs && (
+                <div className="flex h-[calc(100%-2rem)] w-full gap-4 overflow-x-auto">
+                  {Object.entries(clickedRow.runs).map(([id, run]) => {
+                    const runData = runsData?.find((r) => r.id === id);
+                    return (
+                      <div
+                        key={id}
+                        className="flex w-[45%] flex-none flex-col overflow-hidden"
+                      >
+                        <div className="mb-1 flex items-center text-sm font-medium">
+                          {runData?.name ?? id}
+                          {runData?.description && (
+                            <DocPopup description={runData?.description} />
+                          )}
+                        </div>
+                        <DatasetAggregateTableCell
+                          value={run}
+                          projectId={projectId}
+                          scoreKeyToDisplayName={scoreKeyToDisplayName}
+                          selectedMetrics={["scores", "resourceMetrics"]}
+                          singleLine={false}
+                          variant="peek"
+                          className={cn(
+                            "relative flex-1 overflow-y-auto",
+                            traceAndObservationId?.runId === id && "border-4",
+                          )}
+                          actionButtons={
+                            <div className="absolute right-1 top-1 z-10 hidden items-center justify-center gap-1 group-hover:flex">
+                              <Button
+                                variant="outline"
+                                size="icon"
+                                title="View full trace"
+                                onClick={() =>
+                                  window.open(
+                                    run?.observationId
+                                      ? `/project/${projectId}/traces/${encodeURIComponent(run.traceId)}?observation=${encodeURIComponent(run.observationId)}`
+                                      : `/project/${projectId}/traces/${encodeURIComponent(run.traceId)}`,
+                                    "_blank",
+                                    "noopener noreferrer",
+                                  )
+                                }
+                              >
+                                <ListTree className="h-4 w-4" />
+                              </Button>
 
-                                  <Button
-                                    variant="outline"
-                                    size="icon"
-                                    title="View trace tree"
-                                    onClick={() =>
-                                      setTraceAndObservationId({
-                                        traceId: run.traceId,
-                                        observationId: run.observationId,
-                                        runId: id,
-                                      })
-                                    }
-                                  >
-                                    <PanelLeftOpen className="h-4 w-4" />
-                                  </Button>
-                                </div>
-                              }
-                            />
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </ResizablePanel>
-              </ResizablePanelGroup>
-            </div>
-          </div>
+                              <Button
+                                variant="outline"
+                                size="icon"
+                                title="View trace tree"
+                                onClick={() =>
+                                  setTraceAndObservationId({
+                                    traceId: run.traceId,
+                                    observationId: run.observationId,
+                                    runId: id,
+                                  })
+                                }
+                              >
+                                <PanelLeftOpen className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          }
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </ResizablePanel>
+          </ResizablePanelGroup>
         </div>
-      </DrawerContent>
-    </Drawer>
+      </div>
+    </PeekView>
   );
 }

--- a/web/src/features/datasets/components/DatasetCompareRunPeekView.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunPeekView.tsx
@@ -72,9 +72,9 @@ export function DatasetCompareRunPeekView({
   return (
     <PeekView
       onClose={onClose}
-      key={clickedRow?.id ?? "closed"}
+      itemName={clickedRow?.id ?? "item"}
+      itemType="Dataset item"
       open={!!clickedRow}
-      title="Comparing traces"
       actionButtons={
         <>
           {traceAndObservationId?.traceId && (

--- a/web/src/features/datasets/components/DatasetCompareRunPeekView.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunPeekView.tsx
@@ -15,11 +15,12 @@ import { DatasetAggregateTableCell } from "@/src/features/datasets/components/Da
 import { type DatasetCompareRunRowData } from "@/src/features/datasets/components/DatasetCompareRunsTable";
 import { api, type RouterOutputs } from "@/src/utils/api";
 import { cn } from "@/src/utils/tailwind";
-import { PanelLeftOpen, PanelLeftClose, X, ListTree } from "lucide-react";
+import { PanelLeftOpen, PanelLeftClose, ListTree } from "lucide-react";
 import { useRouter } from "next/router";
 
 export function DatasetCompareRunPeekView({
   projectId,
+  datasetId,
   scoreKeyToDisplayName,
   clickedRow,
   setClickedRow,
@@ -28,6 +29,7 @@ export function DatasetCompareRunPeekView({
   runsData,
 }: {
   projectId: string;
+  datasetId: string;
   scoreKeyToDisplayName: Map<string, string>;
   clickedRow: DatasetCompareRunRowData | null;
   setClickedRow: (row: DatasetCompareRunRowData | null) => void;
@@ -72,8 +74,11 @@ export function DatasetCompareRunPeekView({
   return (
     <PeekView
       onClose={onClose}
-      itemName={clickedRow?.id ?? "item"}
-      itemType="Dataset item"
+      item={{
+        name: clickedRow?.id ?? "item",
+        type: "Dataset item",
+        link: `/project/${projectId}/datasets/${datasetId}/items/${clickedRow?.id}`,
+      }}
       open={!!clickedRow}
       actionButtons={
         <>

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -365,6 +365,7 @@ export function DatasetCompareRunsTable(props: {
       {scoreKeysAndProps.isSuccess && (
         <DatasetCompareRunPeekView
           projectId={props.projectId}
+          datasetId={props.datasetId}
           scoreKeyToDisplayName={scoreKeyToDisplayName}
           clickedRow={clickedRow}
           setClickedRow={setClickedRow}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduce `PeekView` component with header to replace `Drawer` in `DatasetCompareRunPeekView` for enhanced UI.
> 
>   - **Components**:
>     - Add `PeekView` component in `peek-view.tsx` with header, title, and optional action buttons.
>     - Replace `Drawer` with `PeekView` in `DatasetCompareRunPeekView.tsx`.
>   - **Behavior**:
>     - `PeekView` uses `Drawer` for layout and includes a header with `Header` component for titles.
>     - Supports optional `actionButtons` prop for additional controls in the header.
>   - **Integration**:
>     - Update `DatasetCompareRunsTable.tsx` to use `PeekView` in `DatasetCompareRunPeekView`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f50a641e1f4684a6848948a1a48eba6c3dca6ac3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->