### PR TITLE
fix(dataset_compare): show latency only if not null

### DIFF
--- a/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
+++ b/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
@@ -110,7 +110,7 @@ const DatasetAggregateCell = ({
       {selectedMetrics.includes("resourceMetrics") &&
         (resourceMetrics.latency || resourceMetrics.totalCost) && (
           <div className="flex w-full flex-row flex-wrap gap-1">
-            {resourceMetrics.latency && (
+            {!!resourceMetrics.latency && (
               <Badge variant="outline" className="p-0.5 px-1 font-normal">
                 <ClockIcon className="mb-0.5 mr-1 h-3 w-3" />
                 <span className="capitalize">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes latency display in `DatasetAggregateTableCell.tsx` to show only if not null using double negation.
> 
>   - **Behavior**:
>     - Fixes display of latency in `DatasetAggregateTableCell.tsx` to show only if `resourceMetrics.latency` is not null using double negation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fedec99a785146d3691e77c4ddf48309e8c33dba. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->