### PR TITLE
perf: do not fetch models for UI

### DIFF
--- a/packages/shared/src/server/queries/createGenerationsQuery.ts
+++ b/packages/shared/src/server/queries/createGenerationsQuery.ts
@@ -12,7 +12,11 @@ type AdditionalObservationFields = {
   traceTags: Array<string>;
 };
 
-export type FullObservation = AdditionalObservationFields & ObservationView;
+export type FullObservation = AdditionalObservationFields &
+  Omit<
+    ObservationView,
+    "modelId" | "inputPrice" | "outputPrice" | "totalPrice"
+  >;
 
 export type FullObservations = Array<FullObservation>;
 

--- a/packages/shared/src/server/queries/createGenerationsQuery.ts
+++ b/packages/shared/src/server/queries/createGenerationsQuery.ts
@@ -12,11 +12,7 @@ type AdditionalObservationFields = {
   traceTags: Array<string>;
 };
 
-export type FullObservation = AdditionalObservationFields &
-  Omit<
-    ObservationView,
-    "modelId" | "inputPrice" | "outputPrice" | "totalPrice"
-  >;
+export type FullObservation = AdditionalObservationFields & ObservationView;
 
 export type FullObservations = Array<FullObservation>;
 

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -91,7 +91,7 @@ export const getObservationsViewForTrace = async (
     },
   });
 
-  return await Promise.all(records.map(convertObservationToView));
+  return records.map(convertObservationToView);
 };
 
 export const getObservationById = async (

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -264,13 +264,9 @@ export const getObservationsTable = async (
 
   return await Promise.all(
     observationRecords.map(async (o) => {
-      const model = models.find((p) => p.id === o.internal_model_id);
       const trace = traces.find((t) => t.id === o.trace_id);
       return {
-        ...(await convertObservationToView(
-          { ...o, type: "GENERATION" },
-          model,
-        )),
+        ...(await convertObservationToView({ ...o, type: "GENERATION" })),
         latency: o.latency ? Number(o.latency) / 1000 : null,
         timeToFirstToken: o.time_to_first_token
           ? Number(o.time_to_first_token) / 1000

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -333,7 +333,7 @@ export const getObservationsTableWithModelData = async (
       const trace = traces.find((t) => t.id === o.trace_id);
       const model = models.find((m) => m.id === o.internal_model_id);
       return {
-        ...(await convertObservationToView({ ...o, type: "GENERATION" })),
+        ...convertObservationToView({ ...o, type: "GENERATION" }),
         latency: o.latency ? Number(o.latency) / 1000 : null,
         timeToFirstToken: o.time_to_first_token
           ? Number(o.time_to_first_token) / 1000

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -91,9 +91,7 @@ export const getObservationsViewForTrace = async (
     },
   });
 
-  return await Promise.all(
-    records.map(async (o) => await convertObservationToView(o)),
-  );
+  return await Promise.all(records.map(convertObservationToView));
 };
 
 export const getObservationById = async (
@@ -141,9 +139,7 @@ export const getObservationById = async (
     params: { id, projectId },
   });
 
-  const mapped = await Promise.all(
-    records.map(async (r) => await convertObservation(r)),
-  );
+  const mapped = records.map(convertObservation);
 
   if (mapped.length === 0) {
     throw new LangfuseNotFoundError(`Observation with id ${id} not found`);

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -14,7 +14,10 @@ import {
   FilterList,
   StringFilter,
 } from "../queries/clickhouse-sql/clickhouse-filter";
-import { FullObservations } from "../queries/createGenerationsQuery";
+import {
+  FullObservation,
+  FullObservations,
+} from "../queries/createGenerationsQuery";
 import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
 import {
   observationsTableTraceUiColumnDefinitions,
@@ -196,7 +199,72 @@ export const getObservationsTableCount = async (opts: ObservationTableQuery) =>
     select: "count(*) as count",
   });
 
+export type ObservationsTableRow = Omit<
+  FullObservation,
+  "modelId" | "inputPrice" | "outputPrice" | "totalPrice"
+>;
+
 export const getObservationsTable = async (
+  opts: ObservationTableQuery,
+): Promise<Array<ObservationsTableRow>> => {
+  const observationRecords = await getObservationsTableInternal<
+    Omit<
+      ObservationsTableQueryResult,
+      "trace_tags" | "trace_name" | "trace_user_id" | "type"
+    >
+  >({
+    ...opts,
+    select: `
+        o.id as id,
+        o.name as name,
+        o."model_parameters" as model_parameters,
+        o.start_time as "start_time",
+        o.end_time as "end_time",
+        o.trace_id as "trace_id",
+        o.completion_start_time as "completion_start_time",
+        o.provided_usage_details as "provided_usage_details",
+        o.usage_details as "usage_details",
+        o.provided_cost_details as "provided_cost_details",
+        o.cost_details as "cost_details",
+        o.level as level,
+        o.status_message as "status_message",
+        o.version as version,
+        o.parent_observation_id as "parent_observation_id",
+        o.created_at as "created_at",
+        o.updated_at as "updated_at",
+        o.provided_model_name as "provided_model_name",
+        o.total_cost as "total_cost",
+        internal_model_id as "internal_model_id",
+        provided_model_name as "provided_model_name",
+        if(isNull(end_time), NULL, date_diff('milliseconds', start_time, end_time)) as latency,
+        if(isNull(completion_start_time), NULL,  date_diff('milliseconds', start_time, completion_start_time)) as "time_to_first_token"`,
+  });
+
+  const traces = await getTracesByIds(
+    observationRecords
+      .map((o) => o.trace_id)
+      .filter((o): o is string => Boolean(o)),
+    opts.projectId,
+  );
+
+  return await Promise.all(
+    observationRecords.map(async (o) => {
+      const trace = traces.find((t) => t.id === o.trace_id);
+      return {
+        ...convertObservationToView({ ...o, type: "GENERATION" }),
+        latency: o.latency ? Number(o.latency) / 1000 : null,
+        timeToFirstToken: o.time_to_first_token
+          ? Number(o.time_to_first_token) / 1000
+          : null,
+        traceName: trace?.name ?? null,
+        traceTags: trace?.tags ?? [],
+        userId: trace?.userId ?? null,
+      };
+    }),
+  );
+};
+
+export const getObservationsTableWithModelData = async (
   opts: ObservationTableQuery,
 ): Promise<FullObservations> => {
   const observationRecords = await getObservationsTableInternal<
@@ -265,6 +333,7 @@ export const getObservationsTable = async (
   return await Promise.all(
     observationRecords.map(async (o) => {
       const trace = traces.find((t) => t.id === o.trace_id);
+      const model = models.find((m) => m.id === o.internal_model_id);
       return {
         ...(await convertObservationToView({ ...o, type: "GENERATION" })),
         latency: o.latency ? Number(o.latency) / 1000 : null,
@@ -274,6 +343,13 @@ export const getObservationsTable = async (
         traceName: trace?.name ?? null,
         traceTags: trace?.tags ?? [],
         userId: trace?.userId ?? null,
+        modelId: model?.id ?? null,
+        inputPrice:
+          model?.Price?.find((m) => m.usageType === "input")?.price ?? null,
+        outputPrice:
+          model?.Price?.find((m) => m.usageType === "output")?.price ?? null,
+        totalPrice:
+          model?.Price?.find((m) => m.usageType === "total")?.price ?? null,
       };
     }),
   );

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -235,7 +235,6 @@ export const getObservationsTable = async (
         o.provided_model_name as "provided_model_name",
         o.total_cost as "total_cost",
         internal_model_id as "internal_model_id",
-        provided_model_name as "provided_model_name",
         if(isNull(end_time), NULL, date_diff('milliseconds', start_time, end_time)) as latency,
         if(isNull(completion_start_time), NULL,  date_diff('milliseconds', start_time, completion_start_time)) as "time_to_first_token"`,
   });
@@ -295,7 +294,6 @@ export const getObservationsTableWithModelData = async (
         o.provided_model_name as "provided_model_name",
         o.total_cost as "total_cost",
         internal_model_id as "internal_model_id",
-        provided_model_name as "provided_model_name",
         if(isNull(end_time), NULL, date_diff('milliseconds', start_time, end_time)) as latency,
         if(isNull(completion_start_time), NULL,  date_diff('milliseconds', start_time, completion_start_time)) as "time_to_first_token"`,
   });

--- a/packages/shared/src/server/repositories/observations_converters.ts
+++ b/packages/shared/src/server/repositories/observations_converters.ts
@@ -9,10 +9,6 @@ import { jsonSchema } from "../../utils/zod";
 import { parseClickhouseUTCDateTimeFormat } from "./clickhouse";
 import { ObservationRecordReadType } from "./definitions";
 
-export const convertObservation = async (record: ObservationRecordReadType) => {
-  return convertObservationAndModel(record);
-};
-
 export const convertObservationToView = (
   record: ObservationRecordReadType,
 ): Omit<
@@ -20,7 +16,7 @@ export const convertObservationToView = (
   "inputPrice" | "outputPrice" | "totalPrice" | "modelId"
 > => {
   return {
-    ...convertObservationAndModel(record ?? undefined),
+    ...convertObservation(record ?? undefined),
     latency: record.end_time
       ? parseClickhouseUTCDateTimeFormat(record.end_time).getTime() -
         parseClickhouseUTCDateTimeFormat(record.start_time).getTime()
@@ -34,7 +30,7 @@ export const convertObservationToView = (
   };
 };
 
-export const convertObservationAndModel = (
+export const convertObservation = (
   record: ObservationRecordReadType,
 ): Omit<Observation, "internalModel"> => {
   return {

--- a/web/src/server/api/routers/generations/db/getAllGenerationsSqlQuery.ts
+++ b/web/src/server/api/routers/generations/db/getAllGenerationsSqlQuery.ts
@@ -4,7 +4,7 @@ import { prisma } from "@langfuse/shared/src/db";
 import { type GetAllGenerationsInput } from "../getAllQueries";
 import {
   createGenerationsQuery,
-  getObservationsTable,
+  getObservationsTableWithModelData,
   getScoresForObservations,
   parseGetAllGenerationsInput,
   traceException,
@@ -27,7 +27,7 @@ export async function getAllGenerations({
   let generations: FullObservations | IOAndMetadataOmittedObservations;
   let scores: Score[] = [];
   if (queryClickhouse) {
-    generations = await getObservationsTable({
+    generations = await getObservationsTableWithModelData({
       projectId: input.projectId,
       filter: input.filter,
       orderBy: input.orderBy,

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -62,7 +62,13 @@ type TraceFilterOptions = z.infer<typeof TraceFilterOptions>;
 
 export type ObservationReturnType = Omit<
   ObservationView,
-  "input" | "output" | "modelId" | "inputPrice" | "outputPrice" | "totalPrice"
+  | "input"
+  | "output"
+  | "modelId"
+  | "inputPrice"
+  | "outputPrice"
+  | "totalPrice"
+  | "metadata"
 > & {
   traceId: string;
 };
@@ -505,6 +511,10 @@ export const traceRouter = createTRPCRouter({
                 calculatedInputCost: true,
                 calculatedOutputCost: true,
                 calculatedTotalCost: true,
+                promptName: true,
+                promptVersion: true,
+                latency: true,
+                updatedAt: true,
               },
               where: {
                 traceId: {

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -62,7 +62,7 @@ type TraceFilterOptions = z.infer<typeof TraceFilterOptions>;
 
 export type ObservationReturnType = Omit<
   ObservationView,
-  "input" | "output"
+  "input" | "output" | "modelId" | "inputPrice" | "outputPrice" | "totalPrice"
 > & {
   traceId: string;
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimize performance by omitting model-related fields and removing unnecessary model fetching for UI components.
> 
>   - **Behavior**:
>     - Omits `modelId`, `inputPrice`, `outputPrice`, and `totalPrice` from `FullObservation` in `createGenerationsQuery.ts`.
>     - Removes fetching of models in `getObservationsTable` in `observations.ts`.
>     - Updates `convertObservationToView` in `observations_converters.ts` to omit model-related fields.
>   - **Types**:
>     - Updates `ObservationReturnType` in `traces.ts` to omit `modelId`, `inputPrice`, `outputPrice`, and `totalPrice`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f2de4c593f45664c7dde941b12226bc0172c806a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->