### PR TITLE
feat(evals_on_datasets): remove feature flag 

### DIFF
--- a/web/src/ee/features/evals/components/evaluator-form.tsx
+++ b/web/src/ee/features/evals/components/evaluator-form.tsx
@@ -65,7 +65,6 @@ import { cn } from "@/src/utils/tailwind";
 import { Dialog, DialogContent, DialogTitle } from "@/src/components/ui/dialog";
 import { EvalTemplateForm } from "@/src/ee/features/evals/components/template-form";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
-import useIsFeatureEnabled from "@/src/features/feature-flags/hooks/useIsFeatureEnabled";
 
 const formSchema = z.object({
   scoreName: z.string(),
@@ -293,7 +292,6 @@ export const InnerEvalConfigForm = (props: {
 }) => {
   const [formError, setFormError] = useState<string | null>(null);
   const capture = usePostHogClientCapture();
-  const isFeatureFlagEnabled = useIsFeatureEnabled("evaluatorsOnDatasetRuns");
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -512,13 +510,8 @@ export const InnerEvalConfigForm = (props: {
                         <TabsTrigger value="trace" disabled={props.disabled}>
                           Trace
                         </TabsTrigger>
-                        <TabsTrigger
-                          value="dataset"
-                          disabled={props.disabled || !isFeatureFlagEnabled}
-                        >
-                          {isFeatureFlagEnabled
-                            ? "Dataset"
-                            : "Dataset (coming soon)"}
+                        <TabsTrigger value="dataset" disabled={props.disabled}>
+                          Dataset
                         </TabsTrigger>
                       </TabsList>
                     </Tabs>

--- a/web/src/features/feature-flags/available-flags.ts
+++ b/web/src/features/feature-flags/available-flags.ts
@@ -1,5 +1,4 @@
 export const availableFlags = [
   "templateFlag",
-  "evaluatorsOnDatasetRuns",
   "excludeClickhouseRead",
 ] as const;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `evaluatorsOnDatasetRuns` feature flag, simplifying `TabsTrigger` logic in `InnerEvalConfigForm`.
> 
>   - **Feature Flag Removal**:
>     - Remove `evaluatorsOnDatasetRuns` feature flag from `evaluator-form.tsx` and `available-flags.ts`.
>     - Simplifies `TabsTrigger` logic in `InnerEvalConfigForm` by removing conditional rendering based on the feature flag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cbf9ea2600e701527416ccccb1ccac27120047ec. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->