### PR TITLE
docs: add sidebar notification for dataset comparison view

### DIFF
--- a/web/src/components/sidebar-notifications.tsx
+++ b/web/src/components/sidebar-notifications.tsx
@@ -24,6 +24,14 @@ type SidebarNotification = {
 
 const notifications: SidebarNotification[] = [
   {
+    id: "lw2-1",
+    title: "Launch Week 2 – Day 1",
+    description:
+      "New side-by-side comparison view for dataset experiment runs.",
+    link: "https://langfuse.com/changelog/2024-11-18-dataset-runs-comparison-view",
+    linkTitle: "Changelog",
+  },
+  {
     id: "github-star",
     title: "Star Langfuse",
     description:
@@ -51,13 +59,17 @@ export function SidebarNotifications() {
     string[]
   >(STORAGE_KEY, []);
 
-  // Find the first non-dismissed notification on mount or when dismissed list changes
+  // Find the oldest non-dismissed notification on mount or when dismissed list changes
   useEffect(() => {
-    const firstAvailableIndex = notifications.findIndex(
-      (notif) => !dismissedNotifications.includes(notif.id),
-    );
+    const lastAvailableIndex = notifications
+      .slice()
+      .reverse()
+      .findIndex((notif) => !dismissedNotifications.includes(notif.id));
+
     setCurrentNotificationIndex(
-      firstAvailableIndex === -1 ? null : firstAvailableIndex,
+      lastAvailableIndex === -1
+        ? null
+        : notifications.length - 1 - lastAvailableIndex,
     );
   }, [dismissedNotifications]);
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a new sidebar notification for "Launch Week 2 – Day 1" and changes logic to display the oldest non-dismissed notification.
> 
>   - **Behavior**:
>     - Adds a new notification for "Launch Week 2 – Day 1" with a link to the changelog in `sidebar-notifications.tsx`.
>     - Changes logic to display the oldest non-dismissed notification instead of the first available one in `SidebarNotifications` component.
>   - **Functions**:
>     - Modifies `useEffect` in `SidebarNotifications` to find the oldest non-dismissed notification using `reverse()` and `findIndex()`.
>   - **Misc**:
>     - Updates comments in `SidebarNotifications` to reflect changes in notification selection logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3c51512bdfb53d6917de3352f6f327cb2e5838d8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->