### PR TITLE
chore: move invalid tokenizer errors to warning

### DIFF
--- a/web/src/features/ingest/usage.ts
+++ b/web/src/features/ingest/usage.ts
@@ -7,6 +7,7 @@ import {
   encodingForModel,
 } from "js-tiktoken";
 import { z } from "zod";
+import { logger } from "@langfuse/shared/src/server";
 
 const chatModels = [
   "gpt-4",
@@ -125,7 +126,7 @@ export function tokenCount(p: {
   } else if (p.model.tokenizerId === "claude") {
     return claudeTokenCount(p.text);
   } else {
-    console.error(`Unknown tokenizer ${p.model.tokenizerId}`);
+    logger.error(`Unknown tokenizer ${p.model.tokenizerId}`);
     return undefined;
   }
 }
@@ -139,7 +140,7 @@ type ChatMessage = {
 function openAiTokenCount(p: { model: Model; text: unknown }) {
   const config = OpenAiTokenConfig.safeParse(p.model.tokenizerConfig);
   if (!config.success) {
-    console.error(
+    logger.warn(
       `Invalid tokenizer config for model ${p.model.id}: ${JSON.stringify(
         p.model.tokenizerConfig,
       )}, ${JSON.stringify(config.error)}`,
@@ -155,7 +156,7 @@ function openAiTokenCount(p: { model: Model; text: unknown }) {
       p.model.tokenizerConfig,
     );
     if (!parsedConfig.success) {
-      console.error(
+      logger.error(
         `Invalid tokenizer config for chat model ${
           p.model.id
         }: ${JSON.stringify(p.model.tokenizerConfig)}`,
@@ -228,7 +229,7 @@ const getTokensByModel = (model: TiktokenModel, text: string) => {
 
     encoding = cachedTokenizerByModel[model];
   } catch (KeyError) {
-    console.log("Warning: model not found. Using cl100k_base encoding.");
+    logger.warn("Model not found. Using cl100k_base encoding.");
 
     encoding = getEncoding("cl100k_base");
   }

--- a/worker/src/features/tokenisation/usage.ts
+++ b/worker/src/features/tokenisation/usage.ts
@@ -90,7 +90,7 @@ type ChatMessage = {
 function openAiTokenCount(p: { model: Model; text: unknown }) {
   const config = OpenAiTokenConfig.safeParse(p.model.tokenizerConfig);
   if (!config.success) {
-    logger.error(
+    logger.warn(
       `Invalid tokenizer config for model ${p.model.id}: ${JSON.stringify(
         p.model.tokenizerConfig,
       )}, ${JSON.stringify(config.error)}`,


### PR DESCRIPTION
## What

This spams error logs and seems to be a recurring and expected behaviour. We have multiple models where an invalid config is stored. Hence, we should only warn on this.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change invalid tokenizer errors to warnings in `usage.ts` files to reduce log spam.
> 
>   - **Logging Changes**:
>     - Change `console.error` to `logger.error` for unknown tokenizer in `tokenCount()` in `web/src/features/ingest/usage.ts`.
>     - Change `console.error` to `logger.warn` for invalid tokenizer config in `openAiTokenCount()` in `web/src/features/ingest/usage.ts` and `worker/src/features/tokenisation/usage.ts`.
>     - Change `console.log` to `logger.warn` for model not found in `getTokensByModel()` in `web/src/features/ingest/usage.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 38dc595624c64c200988ac484007c2cc1e5e188c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->