### PR TITLE
fix: increase dataset item delay

### DIFF
--- a/web/src/ee/features/evals/server/addDatasetRunItemsToEvalQueue.ts
+++ b/web/src/ee/features/evals/server/addDatasetRunItemsToEvalQueue.ts
@@ -32,12 +32,12 @@ export const addDatasetRunItemsToEvalQueue = async ({
           name: QueueJobs.DatasetRunItemUpsert as const,
         },
         {
-          attempts: 3, // retry 3 times
+          attempts: 5, // retry 3 times
           backoff: {
             type: "exponential",
             delay: 1000,
           },
-          delay: 10000, // 10 seconds
+          delay: 30000, // 10 seconds
           removeOnComplete: true,
           removeOnFail: 1_000,
         },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase retry attempts and initial delay in `addDatasetRunItemsToEvalQueue` for queue processing.
> 
>   - **Behavior**:
>     - In `addDatasetRunItemsToEvalQueue`, increase retry attempts from 3 to 5.
>     - Increase initial delay from 10 seconds to 30 seconds for queue processing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8a90505b148f21bb90e7b220acd5ef25748297c7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->