### PR TITLE
feat: add service endpoint for failed bull events

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -33,3 +33,4 @@ export * from "./instrumentation";
 export * from "./logger";
 export * from "./queries";
 export * from "./repositories";
+export * from "./redis/evalExecutionQueue";

--- a/packages/shared/src/server/redis/evalExecutionQueue.ts
+++ b/packages/shared/src/server/redis/evalExecutionQueue.ts
@@ -1,4 +1,7 @@
 import { Queue } from "bullmq";
+import { logger } from "../logger";
+import { TQueueJobTypes, QueueName } from "../queues";
+import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
 
 export class EvalExecutionQueue {
   private static instance: Queue<

--- a/packages/shared/src/server/redis/evalExecutionQueue.ts
+++ b/packages/shared/src/server/redis/evalExecutionQueue.ts
@@ -1,11 +1,4 @@
 import { Queue } from "bullmq";
-import {
-  createNewRedisInstance,
-  QueueName,
-  TQueueJobTypes,
-  logger,
-  redisQueueRetryOptions,
-} from "@langfuse/shared/src/server";
 
 export class EvalExecutionQueue {
   private static instance: Queue<

--- a/packages/shared/src/server/redis/evalExecutionQueue.ts
+++ b/packages/shared/src/server/redis/evalExecutionQueue.ts
@@ -1,0 +1,49 @@
+import { Queue } from "bullmq";
+import {
+  createNewRedisInstance,
+  QueueName,
+  TQueueJobTypes,
+  logger,
+  redisQueueRetryOptions,
+} from "@langfuse/shared/src/server";
+
+export class EvalExecutionQueue {
+  private static instance: Queue<
+    TQueueJobTypes[QueueName.EvaluationExecution]
+  > | null = null;
+
+  public static getInstance(): Queue<
+    TQueueJobTypes[QueueName.EvaluationExecution]
+  > | null {
+    if (EvalExecutionQueue.instance) return EvalExecutionQueue.instance;
+
+    const newRedis = createNewRedisInstance({
+      enableOfflineQueue: false,
+      ...redisQueueRetryOptions,
+    });
+
+    EvalExecutionQueue.instance = newRedis
+      ? new Queue<TQueueJobTypes[QueueName.EvaluationExecution]>(
+          QueueName.EvaluationExecution,
+          {
+            connection: newRedis,
+            defaultJobOptions: {
+              removeOnComplete: true,
+              removeOnFail: 10_000,
+              attempts: 2,
+              backoff: {
+                type: "exponential",
+                delay: 5000,
+              },
+            },
+          },
+        )
+      : null;
+
+    EvalExecutionQueue.instance?.on("error", (err) => {
+      logger.error("EvalExecutionQueue error", err);
+    });
+
+    return EvalExecutionQueue.instance;
+  }
+}

--- a/web/src/pages/api/admin/bullmq/index.ts
+++ b/web/src/pages/api/admin/bullmq/index.ts
@@ -76,7 +76,7 @@ export default async function handler(
         let count = 0;
         let failed;
         let loopCount = 0;
-        const maxLoops = 100;
+        const maxLoops = 200;
 
         do {
           if (loopCount >= maxLoops) {
@@ -86,7 +86,7 @@ export default async function handler(
             break;
           }
 
-          failed = await queue?.getJobs(["failed"], 0, 100, true);
+          failed = await queue?.getJobs(["failed"], 0, 1000, true);
           logger.info(`Retrying jobs for queue ${JSON.stringify(failed)}`);
           if (failed && failed.length > 0) {
             await Promise.all(failed.map((job) => job.retry()));

--- a/web/src/pages/api/admin/bullmq/index.ts
+++ b/web/src/pages/api/admin/bullmq/index.ts
@@ -73,6 +73,9 @@ export default async function handler(
 
       for (const queueName of body.data.queueNames) {
         const queue = getQueue(queueName as QueueName);
+        const jobCount = queue?.getJobCounts("failed");
+        logger.info(`Retrying ${jobCount} jobs for queue ${queueName}`);
+
         let count = 0;
         let failed;
         let loopCount = 0;

--- a/web/src/pages/api/admin/bullmq/index.ts
+++ b/web/src/pages/api/admin/bullmq/index.ts
@@ -87,7 +87,6 @@ export default async function handler(
           }
 
           failed = await queue?.getJobs(["failed"], 0, 1000, true);
-          logger.info(`Retrying jobs for queue ${JSON.stringify(failed)}`);
           if (failed && failed.length > 0) {
             await Promise.all(failed.map((job) => job.retry()));
             count += failed.length;

--- a/web/src/pages/api/admin/bullmq/index.ts
+++ b/web/src/pages/api/admin/bullmq/index.ts
@@ -8,15 +8,13 @@ import {
   QueueName,
   TraceUpsertQueue,
   DatasetRunItemUpsertQueue,
-  CloudUsageMeteringQueue,
   EvalExecutionQueue,
 } from "@langfuse/shared/src/server";
 import { env } from "@/src/env.mjs";
 import { type Queue } from "bullmq";
 
 /* 
-This API route is used by Langfuse Cloud to delete API keys for a project. It will return 403 for self-hosters.
-We will work on admin APIs in the future. See the discussion here: https://github.com/orgs/langfuse/discussions/3243
+This API route is used by Langfuse Cloud to retry failed bullmq jobs.
 */
 
 const RetryBullMqJobs = z.object({

--- a/web/src/pages/api/admin/bullmq/index.ts
+++ b/web/src/pages/api/admin/bullmq/index.ts
@@ -1,0 +1,129 @@
+import { type NextApiRequest, type NextApiResponse } from "next";
+import { z } from "zod";
+import {
+  BatchExportQueue,
+  IngestionQueue,
+  LegacyIngestionQueue,
+  logger,
+  QueueName,
+  TraceUpsertQueue,
+  DatasetRunItemUpsertQueue,
+  CloudUsageMeteringQueue,
+  EvalExecutionQueue,
+} from "@langfuse/shared/src/server";
+import { env } from "@/src/env.mjs";
+import { type Queue } from "bullmq";
+
+/* 
+This API route is used by Langfuse Cloud to delete API keys for a project. It will return 403 for self-hosters.
+We will work on admin APIs in the future. See the discussion here: https://github.com/orgs/langfuse/discussions/3243
+*/
+
+const RetryBullMqJobs = z.object({
+  action: z.literal("retry"),
+  queueNames: z.array(z.string()),
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  try {
+    // allow only POST requests
+    if (req.method !== "POST") {
+      res.status(405).json({ error: "Method Not Allowed" });
+      return;
+    }
+
+    if (!env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
+      res.status(403).json({ error: "Only accessible on Langfuse cloud" });
+      return;
+    }
+
+    // check if ADMIN_API_KEY is set
+    if (!env.ADMIN_API_KEY) {
+      logger.error("ADMIN_API_KEY is not set");
+      res.status(500).json({ error: "ADMIN_API_KEY is not set" });
+      return;
+    }
+
+    // check bearer token
+    const { authorization } = req.headers;
+    if (!authorization) {
+      res
+        .status(401)
+        .json({ error: "Unauthorized: No authorization header provided" });
+      return;
+    }
+    const [scheme, token] = authorization.split(" ");
+    if (scheme !== "Bearer" || !token || token !== env.ADMIN_API_KEY) {
+      res.status(401).json({ error: "Unauthorized: Invalid token" });
+      return;
+    }
+
+    const body = RetryBullMqJobs.safeParse(req.body);
+
+    if (!body.success) {
+      res.status(400).json({ error: body.error });
+      return;
+    }
+
+    if (body.data.action === "retry") {
+      logger.info(
+        `Retrying jobs for queues ${body.data.queueNames.join(", ")}`,
+      );
+
+      for (const queueName of body.data.queueNames) {
+        const queue = getQueue(queueName as QueueName);
+        let count = 0;
+        let failed;
+        let loopCount = 0;
+        const maxLoops = 100;
+
+        do {
+          if (loopCount >= maxLoops) {
+            logger.warn(
+              `Circuit breaker activated: Stopped after ${maxLoops} iterations for queue ${queueName}`,
+            );
+            break;
+          }
+
+          failed = await queue?.getJobs(["failed"], 0, 100, true);
+          if (failed && failed.length > 0) {
+            await queue?.addBulk(failed);
+            count += failed.length;
+          }
+          loopCount++;
+        } while (failed && failed.length > 0);
+
+        logger.info(`Retried ${count} jobs for queue ${queueName}`);
+      }
+
+      return res.status(200).json({ message: "API keys deleted" });
+    }
+
+    // return not implemented error
+    res.status(404).json({ error: "Action does not exist" });
+  } catch (e) {
+    logger.error("failed to remove API keys", e);
+    res.status(500).json({ error: e });
+  }
+}
+function getQueue(queueName: QueueName): Queue | null {
+  switch (queueName) {
+    case QueueName.LegacyIngestionQueue:
+      return LegacyIngestionQueue.getInstance();
+    case QueueName.BatchExport:
+      return BatchExportQueue.getInstance();
+    case QueueName.DatasetRunItemUpsert:
+      return DatasetRunItemUpsertQueue.getInstance();
+    case QueueName.EvaluationExecution:
+      return EvalExecutionQueue.getInstance();
+    case QueueName.TraceUpsert:
+      return TraceUpsertQueue.getInstance();
+    case QueueName.IngestionQueue:
+      return IngestionQueue.getInstance();
+    default:
+      throw new Error(`Queue ${queueName} not found`);
+  }
+}

--- a/web/src/pages/api/admin/bullmq/index.ts
+++ b/web/src/pages/api/admin/bullmq/index.ts
@@ -89,8 +89,9 @@ export default async function handler(
           }
 
           failed = await queue?.getJobs(["failed"], 0, 100, true);
+          logger.info(`Retrying jobs for queue ${JSON.stringify(failed)}`);
           if (failed && failed.length > 0) {
-            await queue?.addBulk(failed);
+            await Promise.all(failed.map((job) => job.retry()));
             count += failed.length;
           }
           loopCount++;
@@ -99,7 +100,7 @@ export default async function handler(
         logger.info(`Retried ${count} jobs for queue ${queueName}`);
       }
 
-      return res.status(200).json({ message: "API keys deleted" });
+      return res.status(200).json({ message: "Retried all jobs" });
     }
 
     // return not implemented error

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -15,6 +15,7 @@ import {
   eventTypes,
   redis,
   IngestionQueue,
+  EvalExecutionQueue,
 } from "@langfuse/shared/src/server";
 import {
   ApiError,
@@ -36,7 +37,6 @@ import {
 import { decrypt } from "@langfuse/shared/encryption";
 import { kyselyPrisma, prisma } from "@langfuse/shared/src/db";
 import { fetchLLMCompletion, logger } from "@langfuse/shared/src/server";
-import { EvalExecutionQueue } from "../../queues/evalQueue";
 import { backOff } from "exponential-backoff";
 import { env } from "../../env";
 import { JobConfigState } from "../../../../packages/shared/dist/prisma/generated/types";

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -1,4 +1,4 @@
-import { Job, Queue } from "bullmq";
+import { Job } from "bullmq";
 import { ApiError, BaseError } from "@langfuse/shared";
 import {
   createDatasetEvalJobs,
@@ -8,54 +8,11 @@ import {
 import { kyselyPrisma } from "@langfuse/shared/src/db";
 import { sql } from "kysely";
 import {
-  createNewRedisInstance,
   QueueName,
   TQueueJobTypes,
   logger,
   traceException,
-  redisQueueRetryOptions,
 } from "@langfuse/shared/src/server";
-
-export class EvalExecutionQueue {
-  private static instance: Queue<
-    TQueueJobTypes[QueueName.EvaluationExecution]
-  > | null = null;
-
-  public static getInstance(): Queue<
-    TQueueJobTypes[QueueName.EvaluationExecution]
-  > | null {
-    if (EvalExecutionQueue.instance) return EvalExecutionQueue.instance;
-
-    const newRedis = createNewRedisInstance({
-      enableOfflineQueue: false,
-      ...redisQueueRetryOptions,
-    });
-
-    EvalExecutionQueue.instance = newRedis
-      ? new Queue<TQueueJobTypes[QueueName.EvaluationExecution]>(
-          QueueName.EvaluationExecution,
-          {
-            connection: newRedis,
-            defaultJobOptions: {
-              removeOnComplete: true,
-              removeOnFail: 10_000,
-              attempts: 2,
-              backoff: {
-                type: "exponential",
-                delay: 5000,
-              },
-            },
-          },
-        )
-      : null;
-
-    EvalExecutionQueue.instance?.on("error", (err) => {
-      logger.error("EvalExecutionQueue error", err);
-    });
-
-    return EvalExecutionQueue.instance;
-  }
-}
 
 export const evalJobTraceCreatorQueueProcessor = async (
   job: Job<TQueueJobTypes[QueueName.TraceUpsert]>,

--- a/worker/src/queues/legacyIngestionQueue.ts
+++ b/worker/src/queues/legacyIngestionQueue.ts
@@ -36,89 +36,90 @@ const getS3StorageServiceClient = (bucketName: string): S3StorageService => {
 export const legacyIngestionQueueProcessor: Processor = async (
   job: Job<TQueueJobTypes[QueueName.LegacyIngestionQueue]>,
 ) => {
-  try {
-    let ingestionEvents: IngestionEventType[] = [];
-    if (job.data.payload.useS3EventStore) {
-      if (
-        env.LANGFUSE_S3_EVENT_UPLOAD_ENABLED !== "true" ||
-        !env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET
-      ) {
-        throw new Error(
-          "S3 event store is not enabled but useS3EventStore is true",
-        );
-      }
-      // If we used the S3 store we need to fetch the ingestionEvents from S3
-      const s3Client = getS3StorageServiceClient(
-        env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
-      );
-      ingestionEvents = (
-        await Promise.all(
-          job.data.payload.data.map(async (record) => {
-            const file = await s3Client.download(
-              `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${getClickhouseEntityType(record.type)}/${record.eventBodyId}/${record.eventId}.json`,
-            );
-            const parsedFile = JSON.parse(file);
-            return Array.isArray(parsedFile) ? parsedFile : [parsedFile];
-          }),
-        )
-      ).flat();
-    } else {
-      // If we didn't use the S3 store we can consume the ingestionEvents directly from Redis
-      ingestionEvents = job.data.payload.data;
-    }
+  throw new Error("Not implemented");
+  // try {
+  //   let ingestionEvents: IngestionEventType[] = [];
+  //   if (job.data.payload.useS3EventStore) {
+  //     if (
+  //       env.LANGFUSE_S3_EVENT_UPLOAD_ENABLED !== "true" ||
+  //       !env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET
+  //     ) {
+  //       throw new Error(
+  //         "S3 event store is not enabled but useS3EventStore is true",
+  //       );
+  //     }
+  //     // If we used the S3 store we need to fetch the ingestionEvents from S3
+  //     const s3Client = getS3StorageServiceClient(
+  //       env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+  //     );
+  //     ingestionEvents = (
+  //       await Promise.all(
+  //         job.data.payload.data.map(async (record) => {
+  //           const file = await s3Client.download(
+  //             `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${getClickhouseEntityType(record.type)}/${record.eventBodyId}/${record.eventId}.json`,
+  //           );
+  //           const parsedFile = JSON.parse(file);
+  //           return Array.isArray(parsedFile) ? parsedFile : [parsedFile];
+  //         }),
+  //       )
+  //     ).flat();
+  //   } else {
+  //     // If we didn't use the S3 store we can consume the ingestionEvents directly from Redis
+  //     ingestionEvents = job.data.payload.data;
+  //   }
 
-    logger.info("Processing legacy ingestion", {
-      projectId: job.data.payload.authCheck.scope.projectId,
-      payload: ingestionEvents.map(({ body, ...rest }) => {
-        let modifiedBody = body;
-        if (body && "input" in modifiedBody) {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { input, ...restPayload } = modifiedBody || {};
-          modifiedBody = restPayload;
-        }
-        if (body && "output" in modifiedBody) {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { output, ...restPayload } = modifiedBody || {};
-          modifiedBody = restPayload;
-        }
-        return {
-          ...rest,
-          body: modifiedBody,
-        };
-      }),
-    });
+  //   logger.info("Processing legacy ingestion", {
+  //     projectId: job.data.payload.authCheck.scope.projectId,
+  //     payload: ingestionEvents.map(({ body, ...rest }) => {
+  //       let modifiedBody = body;
+  //       if (body && "input" in modifiedBody) {
+  //         // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  //         const { input, ...restPayload } = modifiedBody || {};
+  //         modifiedBody = restPayload;
+  //       }
+  //       if (body && "output" in modifiedBody) {
+  //         // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  //         const { output, ...restPayload } = modifiedBody || {};
+  //         modifiedBody = restPayload;
+  //       }
+  //       return {
+  //         ...rest,
+  //         body: modifiedBody,
+  //       };
+  //     }),
+  //   });
 
-    const result = await handleBatch(
-      ingestionEvents,
-      job.data.payload.authCheck,
-      tokenCount,
-    );
+  //   const result = await handleBatch(
+  //     ingestionEvents,
+  //     job.data.payload.authCheck,
+  //     tokenCount,
+  //   );
 
-    // Do not retry events via bullmq for auth errors
-    const processingErrors = result.errors.filter(
-      (e) =>
-        !(e.error instanceof UnauthorizedError) &&
-        !(e.error instanceof ForbiddenError),
-    );
-    if (processingErrors.length > 0) {
-      // Raise errors if any are returned to retry the batch via bullmq
-      logger.error(`Failed to process ${processingErrors.length} events`, {
-        errors: processingErrors,
-      });
-      throw new Error(`Failed to process ${processingErrors.length} events`);
-    }
+  //   // Do not retry events via bullmq for auth errors
+  //   const processingErrors = result.errors.filter(
+  //     (e) =>
+  //       !(e.error instanceof UnauthorizedError) &&
+  //       !(e.error instanceof ForbiddenError),
+  //   );
+  //   if (processingErrors.length > 0) {
+  //     // Raise errors if any are returned to retry the batch via bullmq
+  //     logger.error(`Failed to process ${processingErrors.length} events`, {
+  //       errors: processingErrors,
+  //     });
+  //     throw new Error(`Failed to process ${processingErrors.length} events`);
+  //   }
 
-    // send out REDIS requests to worker for all trace types
-    await addTracesToTraceUpsertQueue(
-      result.results,
-      job.data.payload.authCheck.scope.projectId,
-    );
-  } catch (e) {
-    logger.error(
-      `Failed job legacy ingestion processing for ${job.data.payload.authCheck.scope.projectId}`,
-      e,
-    );
-    traceException(e);
-    throw e;
-  }
+  //   // send out REDIS requests to worker for all trace types
+  //   await addTracesToTraceUpsertQueue(
+  //     result.results,
+  //     job.data.payload.authCheck.scope.projectId,
+  //   );
+  // } catch (e) {
+  //   logger.error(
+  //     `Failed job legacy ingestion processing for ${job.data.payload.authCheck.scope.projectId}`,
+  //     e,
+  //   );
+  //   traceException(e);
+  //   throw e;
+  // }
 };

--- a/worker/src/queues/legacyIngestionQueue.ts
+++ b/worker/src/queues/legacyIngestionQueue.ts
@@ -36,90 +36,90 @@ const getS3StorageServiceClient = (bucketName: string): S3StorageService => {
 export const legacyIngestionQueueProcessor: Processor = async (
   job: Job<TQueueJobTypes[QueueName.LegacyIngestionQueue]>,
 ) => {
-  throw new Error("Not implemented");
-  // try {
-  //   let ingestionEvents: IngestionEventType[] = [];
-  //   if (job.data.payload.useS3EventStore) {
-  //     if (
-  //       env.LANGFUSE_S3_EVENT_UPLOAD_ENABLED !== "true" ||
-  //       !env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET
-  //     ) {
-  //       throw new Error(
-  //         "S3 event store is not enabled but useS3EventStore is true",
-  //       );
-  //     }
-  //     // If we used the S3 store we need to fetch the ingestionEvents from S3
-  //     const s3Client = getS3StorageServiceClient(
-  //       env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
-  //     );
-  //     ingestionEvents = (
-  //       await Promise.all(
-  //         job.data.payload.data.map(async (record) => {
-  //           const file = await s3Client.download(
-  //             `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${getClickhouseEntityType(record.type)}/${record.eventBodyId}/${record.eventId}.json`,
-  //           );
-  //           const parsedFile = JSON.parse(file);
-  //           return Array.isArray(parsedFile) ? parsedFile : [parsedFile];
-  //         }),
-  //       )
-  //     ).flat();
-  //   } else {
-  //     // If we didn't use the S3 store we can consume the ingestionEvents directly from Redis
-  //     ingestionEvents = job.data.payload.data;
-  //   }
+  // throw new Error("Not implemented");
+  try {
+    let ingestionEvents: IngestionEventType[] = [];
+    if (job.data.payload.useS3EventStore) {
+      if (
+        env.LANGFUSE_S3_EVENT_UPLOAD_ENABLED !== "true" ||
+        !env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET
+      ) {
+        throw new Error(
+          "S3 event store is not enabled but useS3EventStore is true",
+        );
+      }
+      // If we used the S3 store we need to fetch the ingestionEvents from S3
+      const s3Client = getS3StorageServiceClient(
+        env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+      );
+      ingestionEvents = (
+        await Promise.all(
+          job.data.payload.data.map(async (record) => {
+            const file = await s3Client.download(
+              `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${getClickhouseEntityType(record.type)}/${record.eventBodyId}/${record.eventId}.json`,
+            );
+            const parsedFile = JSON.parse(file);
+            return Array.isArray(parsedFile) ? parsedFile : [parsedFile];
+          }),
+        )
+      ).flat();
+    } else {
+      // If we didn't use the S3 store we can consume the ingestionEvents directly from Redis
+      ingestionEvents = job.data.payload.data;
+    }
 
-  //   logger.info("Processing legacy ingestion", {
-  //     projectId: job.data.payload.authCheck.scope.projectId,
-  //     payload: ingestionEvents.map(({ body, ...rest }) => {
-  //       let modifiedBody = body;
-  //       if (body && "input" in modifiedBody) {
-  //         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  //         const { input, ...restPayload } = modifiedBody || {};
-  //         modifiedBody = restPayload;
-  //       }
-  //       if (body && "output" in modifiedBody) {
-  //         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  //         const { output, ...restPayload } = modifiedBody || {};
-  //         modifiedBody = restPayload;
-  //       }
-  //       return {
-  //         ...rest,
-  //         body: modifiedBody,
-  //       };
-  //     }),
-  //   });
+    logger.info("Processing legacy ingestion", {
+      projectId: job.data.payload.authCheck.scope.projectId,
+      payload: ingestionEvents.map(({ body, ...rest }) => {
+        let modifiedBody = body;
+        if (body && "input" in modifiedBody) {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { input, ...restPayload } = modifiedBody || {};
+          modifiedBody = restPayload;
+        }
+        if (body && "output" in modifiedBody) {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { output, ...restPayload } = modifiedBody || {};
+          modifiedBody = restPayload;
+        }
+        return {
+          ...rest,
+          body: modifiedBody,
+        };
+      }),
+    });
 
-  //   const result = await handleBatch(
-  //     ingestionEvents,
-  //     job.data.payload.authCheck,
-  //     tokenCount,
-  //   );
+    const result = await handleBatch(
+      ingestionEvents,
+      job.data.payload.authCheck,
+      tokenCount,
+    );
 
-  //   // Do not retry events via bullmq for auth errors
-  //   const processingErrors = result.errors.filter(
-  //     (e) =>
-  //       !(e.error instanceof UnauthorizedError) &&
-  //       !(e.error instanceof ForbiddenError),
-  //   );
-  //   if (processingErrors.length > 0) {
-  //     // Raise errors if any are returned to retry the batch via bullmq
-  //     logger.error(`Failed to process ${processingErrors.length} events`, {
-  //       errors: processingErrors,
-  //     });
-  //     throw new Error(`Failed to process ${processingErrors.length} events`);
-  //   }
+    // Do not retry events via bullmq for auth errors
+    const processingErrors = result.errors.filter(
+      (e) =>
+        !(e.error instanceof UnauthorizedError) &&
+        !(e.error instanceof ForbiddenError),
+    );
+    if (processingErrors.length > 0) {
+      // Raise errors if any are returned to retry the batch via bullmq
+      logger.error(`Failed to process ${processingErrors.length} events`, {
+        errors: processingErrors,
+      });
+      throw new Error(`Failed to process ${processingErrors.length} events`);
+    }
 
-  //   // send out REDIS requests to worker for all trace types
-  //   await addTracesToTraceUpsertQueue(
-  //     result.results,
-  //     job.data.payload.authCheck.scope.projectId,
-  //   );
-  // } catch (e) {
-  //   logger.error(
-  //     `Failed job legacy ingestion processing for ${job.data.payload.authCheck.scope.projectId}`,
-  //     e,
-  //   );
-  //   traceException(e);
-  //   throw e;
-  // }
+    // send out REDIS requests to worker for all trace types
+    await addTracesToTraceUpsertQueue(
+      result.results,
+      job.data.payload.authCheck.scope.projectId,
+    );
+  } catch (e) {
+    logger.error(
+      `Failed job legacy ingestion processing for ${job.data.payload.authCheck.scope.projectId}`,
+      e,
+    );
+    traceException(e);
+    throw e;
+  }
 };

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -13,9 +13,9 @@ import {
   redisQueueRetryOptions,
   TraceUpsertQueue,
   DatasetRunItemUpsertQueue,
+  EvalExecutionQueue,
 } from "@langfuse/shared/src/server";
 import { CloudUsageMeteringQueue } from "./cloudUsageMeteringQueue";
-import { EvalExecutionQueue } from "./evalQueue";
 
 export class WorkerManager {
   private static workers: { [key: string]: Worker } = {};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `EvalExecutionQueue` for managing evaluation jobs and an API endpoint for retrying failed jobs, integrating it into the system.
> 
>   - **Behavior**:
>     - Adds `EvalExecutionQueue` class in `evalExecutionQueue.ts` for managing evaluation jobs with retry logic and error handling.
>     - Introduces API endpoint in `index.ts` to retry failed BullMQ jobs, restricted to Langfuse Cloud.
>   - **Integration**:
>     - Integrates `EvalExecutionQueue` into `evalService.ts` for creating and managing evaluation jobs.
>     - Updates `workerManager.ts` to register and manage workers for `EvalExecutionQueue`.
>     - Modifies `evalQueue.ts` to use `EvalExecutionQueue` for processing evaluation jobs.
>   - **Misc**:
>     - Removes `EvalExecutionQueue` definition from `evalQueue.ts` and imports it from shared server.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0b8b9b87cfae95de92126694e520f160d6d67dfa. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->