### PR TITLE
docs: add launch week day 2 note

### DIFF
--- a/web/src/components/sidebar-notifications.tsx
+++ b/web/src/components/sidebar-notifications.tsx
@@ -24,10 +24,16 @@ type SidebarNotification = {
 
 const notifications: SidebarNotification[] = [
   {
+    id: "lw2-2",
+    title: "Launch Week 2 – Day 2",
+    description: "LLM-as-a-Judge Evaluators for Dataset Experiments",
+    link: "https://langfuse.com/changelog/2024-11-19-llm-as-a-judge-for-datasets",
+    linkTitle: "Changelog",
+  },
+  {
     id: "lw2-1",
     title: "Launch Week 2 – Day 1",
-    description:
-      "New side-by-side comparison view for dataset experiment runs.",
+    description: "New side-by-side comparison view for dataset experiment runs",
     link: "https://langfuse.com/changelog/2024-11-18-dataset-runs-comparison-view",
     linkTitle: "Changelog",
   },
@@ -35,7 +41,7 @@ const notifications: SidebarNotification[] = [
     id: "github-star",
     title: "Star Langfuse",
     description:
-      "See the latest releases and help grow the community on GitHub.",
+      "See the latest releases and help grow the community on GitHub",
     link: "https://github.com/langfuse/langfuse",
     linkContent: (
       // eslint-disable-next-line @next/next/no-img-element


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add "Launch Week 2 – Day 2" notification and update description for Day 1 in `sidebar-notifications.tsx`.
> 
>   - **Notifications**:
>     - Add "Launch Week 2 – Day 2" notification to `notifications` array in `sidebar-notifications.tsx`.
>     - Update description of "Launch Week 2 – Day 1" notification to remove period.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7772f1a18e477a27bad0ea1c0f925d9288e661c9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->