### PR TITLE
fix: correct traces pagination

### DIFF
--- a/packages/shared/src/server/queries/createTracesQuery.ts
+++ b/packages/shared/src/server/queries/createTracesQuery.ts
@@ -11,13 +11,13 @@ export function parseTraceAllFilters(input: TableFilters) {
   const filterCondition = tableColumnsToSqlFilterAndPrefix(
     input.filter ?? [],
     tracesTableCols,
-    "traces"
+    "traces",
   );
   const orderByCondition = orderByToPrismaSql(input.orderBy, tracesTableCols);
 
   // to improve query performance, add timeseries filter to observation queries as well
   const timeseriesFilter = input.filter?.find(
-    (f) => f.column === "Timestamp" && f.type === "datetime"
+    (f) => f.column === "Timestamp" && f.type === "datetime",
   );
 
   const observationTimeseriesFilter =
@@ -25,7 +25,7 @@ export function parseTraceAllFilters(input: TableFilters) {
       ? datetimeFilterToPrismaSql(
           "start_time",
           timeseriesFilter.operator,
-          timeseriesFilter.value
+          timeseriesFilter.value,
         )
       : Prisma.empty;
 
@@ -130,6 +130,6 @@ export function createTracesQuery({
     ${filterCondition}
   ${orderByCondition}
   ${limit ? Prisma.sql`LIMIT ${limit}` : Prisma.empty}
-  ${page && limit ? Prisma.sql`OFFSET ${page * limit}` : Prisma.empty}
+  ${page !== undefined && limit !== undefined ? Prisma.sql`OFFSET ${page * limit}` : Prisma.empty}
 `;
 }

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -557,7 +557,7 @@ export const getSessionsTable = async (props: {
   filter: FilterState;
   orderBy?: OrderByState;
   limit?: number;
-  offset?: number;
+  page?: number;
 }) => {
   const rows = await getSessionsTableGeneric<SessionDataReturnType>({
     select: `
@@ -583,7 +583,7 @@ export const getSessionsTable = async (props: {
     filter: props.filter,
     orderBy: props.orderBy,
     limit: props.limit,
-    page: props.offset,
+    page: props.page,
   });
 
   return rows;

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -187,7 +187,7 @@ export const sessionRouter = createTRPCRouter({
               projectId: input.projectId,
               filter: finalFilter,
               orderBy: input.orderBy,
-              offset: input.page * input.limit,
+              page: input.page,
               limit: input.limit,
             });
 

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -88,7 +88,7 @@ export const sessionRouter = createTRPCRouter({
               projectId: input.projectId,
               filter: finalFilter,
               orderBy: input.orderBy,
-              offset: input.page * input.limit,
+              page: input.page,
               limit: input.limit,
             });
 
@@ -187,8 +187,8 @@ export const sessionRouter = createTRPCRouter({
               projectId: input.projectId,
               filter: finalFilter,
               orderBy: input.orderBy,
-              page: input.page,
-              limit: input.limit,
+              page: 0,
+              limit: 1,
             });
 
             return {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes pagination by replacing `offset` with `page` and refactoring related functions to ensure correct `OFFSET` calculation.
> 
>   - **Behavior**:
>     - Fixes pagination in `createTracesQuery` by applying `OFFSET` only when `page` and `limit` are defined.
>   - **Refactoring**:
>     - Replaces `offset` with `page` in `getTracesTable`, `getSessionsTable`, and `getTracesTableGeneric`.
>     - Updates `getSessionsTableGeneric` to calculate `offset` using `page` and `limit`.
>   - **Code Quality**:
>     - Adds missing commas in `parseTraceAllFilters` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for dbc587aba8d56753ca5b7c6a1e1f9359f9980dd8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->