### PR TITLE
chore: don't create traces in evaluation service

### DIFF
--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -639,7 +639,7 @@ async function callLLM(
   evalScoreSchema: z.ZodObject<{ score: z.ZodNumber; reasoning: z.ZodString }>,
 ): Promise<z.infer<typeof evalScoreSchema>> {
   try {
-    const { completion, processTracedEvents } = await fetchLLMCompletion({
+    const { completion } = await fetchLLMCompletion({
       streaming: false,
       apiKey: decrypt(llmApiKey.secretKey), // decrypt the secret key
       baseURL: llmApiKey.baseURL || undefined,
@@ -658,23 +658,8 @@ async function callLLM(
       },
       structuredOutputSchema: evalScoreSchema,
       config: llmApiKey.config,
-      traceParams: {
-        tags: ["langfuse:evaluation:llm-as-a-judge"],
-        traceName: `eval-llm-${jeId.slice(0, 5)}`,
-        traceId: jeId,
-        projectId: template.projectId,
-        authCheck: {
-          validKey: true,
-          scope: {
-            projectId: template.projectId,
-            accessLevel: "all",
-          } as any,
-        },
-        tokenCountDelegate: tokenCount,
-      },
     });
 
-    await processTracedEvents();
     return evalScoreSchema.parse(completion);
   } catch (e) {
     logger.error(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove trace creation in `callLLM()` in `evalService.ts` by eliminating `processTracedEvents` and `traceParams`.
> 
>   - **Behavior**:
>     - Removed `processTracedEvents` call in `callLLM()` in `evalService.ts`, stopping trace creation during evaluation.
>     - Removed `traceParams` from `fetchLLMCompletion` call in `callLLM()`.
>   - **Misc**:
>     - Minor refactoring in `callLLM()` to remove unused variables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c4bef229bd2b1cac7bf1483ec91d23bdb29981b2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->