### PR TITLE
feat(datasets): update launch notification in sidebar to day 2

### DIFF
--- a/web/src/components/sidebar-notifications.tsx
+++ b/web/src/components/sidebar-notifications.tsx
@@ -32,9 +32,9 @@ const notifications: SidebarNotification[] = [
   },
   {
     id: "lw2-1",
-    title: "Launch Week 2 – Day 1",
-    description: "New side-by-side comparison view for dataset experiment runs",
-    link: "https://langfuse.com/changelog/2024-11-18-dataset-runs-comparison-view",
+    title: "Launch Week 2 – Day 2",
+    description: "LLM-as-a-judge Evaluators for Dataset Experiments",
+    link: "https://langfuse.com/changelog/2024-11-19-llm-as-a-judge-for-datasets",
     linkTitle: "Changelog",
   },
   {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update sidebar notification to reflect Launch Week 2 Day 2 content in `sidebar-notifications.tsx`.
> 
>   - **Behavior**:
>     - Update sidebar notification title from "Launch Week 2 – Day 1" to "Launch Week 2 – Day 2" in `sidebar-notifications.tsx`.
>     - Change description to "LLM-as-a-judge Evaluators for Dataset Experiments".
>     - Update link to "https://langfuse.com/changelog/2024-11-19-llm-as-a-judge-for-datasets".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1c9d808c2808cf2aacb4b00d3a51098f6adf501f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->