### PR TITLE
fix: do not use temp tables for dataset runs

### DIFF
--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -137,7 +137,7 @@ export const createTempTableInClickhouse = async (
   clickhouseSession: string,
 ) => {
   const query = `
-      CREATE TEMPORARY TABLE IF NOT EXISTS ${tableName}
+      CREATE TABLE IF NOT EXISTS ${tableName}
       (
           project_id String,    
           run_id String,  


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `CREATE TEMPORARY TABLE` to `CREATE TABLE` in `createTempTableInClickhouse()` in `service.ts`, affecting dataset run storage in Clickhouse.
> 
>   - **Behavior**:
>     - Change `CREATE TEMPORARY TABLE` to `CREATE TABLE` in `createTempTableInClickhouse()` in `service.ts`.
>     - Affects how dataset runs are stored in Clickhouse, using regular tables instead of temporary ones.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4e7d8b0d3abfbc66d055fc27204b641bfb079b22. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->