### PR TITLE
fix: do not fail on invalid prompt templates for evals

### DIFF
--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -4,6 +4,7 @@ import {
   createDatasetEvalJobs,
   createTraceEvalJobs,
   evaluate,
+  extractVariablesFromTracingData,
 } from "../features/evaluation/evalService";
 import { kyselyPrisma, prisma } from "@langfuse/shared/src/db";
 import { randomUUID } from "crypto";
@@ -35,1255 +36,1242 @@ beforeAll(openAIServer.setup);
 afterEach(openAIServer.reset);
 afterAll(openAIServer.teardown);
 
-describe("compile prompt", () => {
-  test("compile handlebars template", async () => {
-    const template = "Please evaluate toxicity {{input}} {{output}}";
-    const compiledString = compileHandlebarString(template, {
-      input: "foo",
-      output: "bar",
+describe("eval service tests", () => {
+  describe("compile prompt", () => {
+    test("compile handlebars template", async () => {
+      const template = "Please evaluate toxicity {{input}} {{output}}";
+      const compiledString = compileHandlebarString(template, {
+        input: "foo",
+        output: "bar",
+      });
+      expect(compiledString).toBe("Please evaluate toxicity foo bar");
     });
-    expect(compiledString).toBe("Please evaluate toxicity foo bar");
   });
 
-  test("escape template to deal with invalid templates", async () => {
-    const template =
-      "Please evaluate toxicity {{'measures': ['some-stuff'],'dimensions': ['doesnotwork'],}} {{output}}";
+  describe("create eval jobs", () => {
+    test("creates new 'trace' eval job", async () => {
+      await pruneDatabase();
+      const traceId = randomUUID();
 
-    // console.log(Handlebars.escapeExpression(template));
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        })
+        .execute();
 
-    const compiledString = compileHandlebarString(template, [
-      "input",
-      "output",
-    ]);
-    expect(compiledString).toBe(
-      "Please evaluate toxicity {{input}} {{output}}",
-    );
+      await prisma.jobConfiguration.create({
+        data: {
+          id: randomUUID(),
+          projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          filter: JSON.parse("[]"),
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: "trace",
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+        },
+      });
+
+      const payload = {
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        traceId: traceId,
+      };
+
+      await createTraceEvalJobs({ event: payload });
+
+      const jobs = await kyselyPrisma.$kysely
+        .selectFrom("job_executions")
+        .selectAll()
+        .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+        .execute();
+
+      expect(jobs.length).toBe(1);
+      expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+      expect(jobs[0].job_input_trace_id).toBe(traceId);
+      expect(jobs[0].status.toString()).toBe("PENDING");
+      expect(jobs[0].start_time).not.toBeNull();
+    }, 10_000);
+
+    test("creates new 'dataset' eval job", async () => {
+      await pruneDatabase();
+      const traceId = randomUUID();
+      const observationId = randomUUID();
+      const datasetId = randomUUID();
+      const datasetItemId = randomUUID();
+
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        })
+        .execute();
+
+      await kyselyPrisma.$kysely
+        .insertInto("observations")
+        .values({
+          id: observationId,
+          trace_id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          type: sql`'GENERATION'::"ObservationType"`,
+        })
+        .execute();
+
+      await kyselyPrisma.$kysely
+        .insertInto("datasets")
+        .values({
+          id: datasetId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          name: "test-dataset",
+        })
+        .execute();
+
+      await kyselyPrisma.$kysely
+        .insertInto("dataset_items")
+        .values({
+          id: datasetItemId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          dataset_id: datasetId,
+        })
+        .execute();
+
+      await prisma.jobConfiguration.create({
+        data: {
+          id: randomUUID(),
+          projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          filter: JSON.parse("[]"),
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: "dataset",
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+        },
+      });
+
+      const payload = {
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        traceId: traceId,
+        datasetItemId: datasetItemId,
+        observationId: observationId,
+      };
+
+      await createDatasetEvalJobs({ event: payload });
+
+      const jobs = await kyselyPrisma.$kysely
+        .selectFrom("job_executions")
+        .selectAll()
+        .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+        .execute();
+
+      expect(jobs.length).toBe(1);
+      expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+      expect(jobs[0].job_input_trace_id).toBe(traceId);
+      expect(jobs[0].job_input_observation_id).toBe(observationId);
+      expect(jobs[0].job_input_dataset_item_id).toBe(datasetItemId);
+      expect(jobs[0].status.toString()).toBe("PENDING");
+      expect(jobs[0].start_time).not.toBeNull();
+    }, 10_000);
+
+    test("does not create job for inactive config", async () => {
+      await pruneDatabase();
+      const traceId = randomUUID();
+
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        })
+        .execute();
+
+      await prisma.jobConfiguration.create({
+        data: {
+          id: randomUUID(),
+          projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          filter: JSON.parse("[]"),
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: "trace",
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+          status: "INACTIVE",
+        },
+      });
+
+      const payload = {
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        traceId: traceId,
+      };
+
+      await createTraceEvalJobs({ event: payload });
+
+      const jobs = await kyselyPrisma.$kysely
+        .selectFrom("job_executions")
+        .selectAll()
+        .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+        .execute();
+
+      expect(jobs.length).toBe(0);
+    }, 10_000);
+
+    test("does not create eval job for existing job execution", async () => {
+      await pruneDatabase();
+      const traceId = randomUUID();
+
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        })
+        .execute();
+
+      await kyselyPrisma.$kysely
+        .insertInto("llm_api_keys")
+        .values({
+          id: randomUUID(),
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          secret_key: encrypt(String(OPENAI_API_KEY)),
+          provider: "openai",
+          adapter: LLMAdapter.OpenAI,
+          custom_models: [],
+          display_secret_key: "123456",
+        })
+        .execute();
+
+      await prisma.jobConfiguration.create({
+        data: {
+          id: randomUUID(),
+          projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          filter: JSON.parse("[]"),
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: "trace",
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+        },
+      });
+
+      const payload = {
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        traceId: traceId,
+      };
+
+      await createTraceEvalJobs({ event: payload });
+      await createTraceEvalJobs({ event: payload }); // calling it twice to check it is only generated once
+
+      const jobs = await kyselyPrisma.$kysely
+        .selectFrom("job_executions")
+        .selectAll()
+        .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+        .execute();
+
+      expect(jobs.length).toBe(1);
+      expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+      expect(jobs[0].job_input_trace_id).toBe(traceId);
+      expect(jobs[0].status.toString()).toBe("PENDING");
+      expect(jobs[0].start_time).not.toBeNull();
+      expect(jobs[0].end_time).to.be.null;
+    }, 10_000);
+
+    test("does not create job for inactive config", async () => {
+      await pruneDatabase();
+      const traceId = randomUUID();
+
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        })
+        .execute();
+
+      await prisma.jobConfiguration.create({
+        data: {
+          id: randomUUID(),
+          projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          filter: JSON.parse("[]"),
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: "trace",
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+          status: "INACTIVE",
+        },
+      });
+
+      const payload = {
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        traceId: traceId,
+      };
+
+      await createTraceEvalJobs({ event: payload });
+
+      const jobs = await kyselyPrisma.$kysely
+        .selectFrom("job_executions")
+        .selectAll()
+        .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+        .execute();
+
+      expect(jobs.length).toBe(0);
+    }, 10_000);
+
+    test("does not create eval job for 0 sample rate", async () => {
+      await pruneDatabase();
+      const traceId = randomUUID();
+
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        })
+        .execute();
+
+      await kyselyPrisma.$kysely
+        .insertInto("llm_api_keys")
+        .values({
+          id: randomUUID(),
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          secret_key: encrypt(String(OPENAI_API_KEY)),
+          provider: "openai",
+          adapter: LLMAdapter.OpenAI,
+          custom_models: [],
+          display_secret_key: "123456",
+        })
+        .execute();
+
+      await prisma.jobConfiguration.create({
+        data: {
+          id: randomUUID(),
+          projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          filter: JSON.parse("[]"),
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("0"),
+          targetObject: "trace",
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+        },
+      });
+
+      const payload = {
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        traceId: traceId,
+      };
+
+      await createTraceEvalJobs({ event: payload });
+
+      const jobs = await kyselyPrisma.$kysely
+        .selectFrom("job_executions")
+        .selectAll()
+        .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+        .execute();
+
+      expect(jobs.length).toBe(0);
+    }, 10_000);
+
+    test("cancels a job if the second event deselects", async () => {
+      await pruneDatabase();
+      const traceId = randomUUID();
+
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          user_id: "a",
+        })
+        .execute();
+
+      await kyselyPrisma.$kysely
+        .insertInto("llm_api_keys")
+        .values({
+          id: randomUUID(),
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          secret_key: encrypt(String(OPENAI_API_KEY)),
+          provider: "openai",
+          adapter: LLMAdapter.OpenAI,
+          custom_models: [],
+          display_secret_key: "123456",
+        })
+        .execute();
+
+      const templateId = randomUUID();
+      await kyselyPrisma.$kysely
+        .insertInto("eval_templates")
+        .values({
+          id: templateId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          name: "test-template",
+          version: 1,
+          prompt: "Please evaluate toxicity {{input}} {{output}}",
+          model: "gpt-3.5-turbo",
+          provider: "openai",
+          model_params: {},
+          output_schema: {
+            reasoning: "Please explain your reasoning",
+            score: "Please provide a score between 0 and 1",
+          },
+        })
+        .executeTakeFirst();
+
+      await prisma.jobConfiguration.create({
+        data: {
+          id: randomUUID(),
+          projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          filter: [
+            {
+              type: "string",
+              value: "a",
+              column: "User ID",
+              operator: "contains",
+            },
+          ],
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: "trace",
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+          evalTemplateId: templateId,
+        },
+      });
+
+      const payload = {
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        traceId: traceId,
+      };
+
+      await createTraceEvalJobs({ event: payload });
+
+      // update the trace to deselect the trace
+      await kyselyPrisma.$kysely
+        .updateTable("traces")
+        .set("user_id", "b")
+        .where("id", "=", traceId)
+        .execute();
+
+      await createTraceEvalJobs({
+        event: payload,
+      }); // calling it twice to check it is only generated once
+
+      const jobs = await kyselyPrisma.$kysely
+        .selectFrom("job_executions")
+        .selectAll()
+        .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+        .execute();
+
+      expect(jobs.length).toBe(1);
+      expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+      expect(jobs[0].job_input_trace_id).toBe(traceId);
+      expect(jobs[0].status.toString()).toBe("CANCELLED");
+      expect(jobs[0].start_time).not.toBeNull();
+      expect(jobs[0].end_time).not.toBeNull();
+    }, 10_000);
   });
-});
 
-describe("create eval jobs", () => {
-  test("creates new 'trace' eval job", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
+  describe("execute evals", () => {
+    test("evals a valid 'trace' event", async () => {
+      await pruneDatabase();
+      openAIServer.respondWithDefault();
+      const traceId = randomUUID();
 
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      })
-      .execute();
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          user_id: "a",
+          input: { input: "This is a great prompt" },
+          output: { output: "This is a great response" },
+        })
+        .execute();
 
-    await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: JSON.parse("[]"),
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-      },
-    });
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      traceId: traceId,
-    };
-
-    await createTraceEvalJobs({ event: payload });
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(1);
-    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-    expect(jobs[0].job_input_trace_id).toBe(traceId);
-    expect(jobs[0].status.toString()).toBe("PENDING");
-    expect(jobs[0].start_time).not.toBeNull();
-  }, 10_000);
-
-  test("creates new 'dataset' eval job", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-    const observationId = randomUUID();
-    const datasetId = randomUUID();
-    const datasetItemId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      })
-      .execute();
-
-    await kyselyPrisma.$kysely
-      .insertInto("observations")
-      .values({
-        id: observationId,
-        trace_id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        type: sql`'GENERATION'::"ObservationType"`,
-      })
-      .execute();
-
-    await kyselyPrisma.$kysely
-      .insertInto("datasets")
-      .values({
-        id: datasetId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        name: "test-dataset",
-      })
-      .execute();
-
-    await kyselyPrisma.$kysely
-      .insertInto("dataset_items")
-      .values({
-        id: datasetItemId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        dataset_id: datasetId,
-      })
-      .execute();
-
-    await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: JSON.parse("[]"),
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "dataset",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-      },
-    });
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      traceId: traceId,
-      datasetItemId: datasetItemId,
-      observationId: observationId,
-    };
-
-    await createDatasetEvalJobs({ event: payload });
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(1);
-    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-    expect(jobs[0].job_input_trace_id).toBe(traceId);
-    expect(jobs[0].job_input_observation_id).toBe(observationId);
-    expect(jobs[0].job_input_dataset_item_id).toBe(datasetItemId);
-    expect(jobs[0].status.toString()).toBe("PENDING");
-    expect(jobs[0].start_time).not.toBeNull();
-  }, 10_000);
-
-  test("does not create job for inactive config", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      })
-      .execute();
-
-    await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: JSON.parse("[]"),
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-        status: "INACTIVE",
-      },
-    });
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      traceId: traceId,
-    };
-
-    await createTraceEvalJobs({ event: payload });
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(0);
-  }, 10_000);
-
-  test("does not create eval job for existing job execution", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      })
-      .execute();
-
-    await kyselyPrisma.$kysely
-      .insertInto("llm_api_keys")
-      .values({
-        id: randomUUID(),
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        secret_key: encrypt(String(OPENAI_API_KEY)),
-        provider: "openai",
-        adapter: LLMAdapter.OpenAI,
-        custom_models: [],
-        display_secret_key: "123456",
-      })
-      .execute();
-
-    await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: JSON.parse("[]"),
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-      },
-    });
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      traceId: traceId,
-    };
-
-    await createTraceEvalJobs({ event: payload });
-    await createTraceEvalJobs({ event: payload }); // calling it twice to check it is only generated once
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(1);
-    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-    expect(jobs[0].job_input_trace_id).toBe(traceId);
-    expect(jobs[0].status.toString()).toBe("PENDING");
-    expect(jobs[0].start_time).not.toBeNull();
-    expect(jobs[0].end_time).to.be.null;
-  }, 10_000);
-
-  test("does not create job for inactive config", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      })
-      .execute();
-
-    await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: JSON.parse("[]"),
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-        status: "INACTIVE",
-      },
-    });
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      traceId: traceId,
-    };
-
-    await createTraceEvalJobs({ event: payload });
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(0);
-  }, 10_000);
-
-  test("does not create eval job for 0 sample rate", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      })
-      .execute();
-
-    await kyselyPrisma.$kysely
-      .insertInto("llm_api_keys")
-      .values({
-        id: randomUUID(),
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        secret_key: encrypt(String(OPENAI_API_KEY)),
-        provider: "openai",
-        adapter: LLMAdapter.OpenAI,
-        custom_models: [],
-        display_secret_key: "123456",
-      })
-      .execute();
-
-    await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: JSON.parse("[]"),
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("0"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-      },
-    });
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      traceId: traceId,
-    };
-
-    await createTraceEvalJobs({ event: payload });
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(0);
-  }, 10_000);
-
-  test("cancels a job if the second event deselects", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-      })
-      .execute();
-
-    await kyselyPrisma.$kysely
-      .insertInto("llm_api_keys")
-      .values({
-        id: randomUUID(),
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        secret_key: encrypt(String(OPENAI_API_KEY)),
-        provider: "openai",
-        adapter: LLMAdapter.OpenAI,
-        custom_models: [],
-        display_secret_key: "123456",
-      })
-      .execute();
-
-    const templateId = randomUUID();
-    await kyselyPrisma.$kysely
-      .insertInto("eval_templates")
-      .values({
-        id: templateId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        name: "test-template",
-        version: 1,
-        prompt: "Please evaluate toxicity {{input}} {{output}}",
-        model: "gpt-3.5-turbo",
-        provider: "openai",
-        model_params: {},
-        output_schema: {
-          reasoning: "Please explain your reasoning",
-          score: "Please provide a score between 0 and 1",
-        },
-      })
-      .executeTakeFirst();
-
-    await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: [
-          {
-            type: "string",
-            value: "a",
-            column: "User ID",
-            operator: "contains",
+      const templateId = randomUUID();
+      await kyselyPrisma.$kysely
+        .insertInto("eval_templates")
+        .values({
+          id: templateId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          name: "test-template",
+          version: 1,
+          prompt: "Please evaluate toxicity {{input}} {{output}}",
+          model: "gpt-3.5-turbo",
+          provider: "openai",
+          model_params: {},
+          output_schema: {
+            reasoning: "Please explain your reasoning",
+            score: "Please provide a score between 0 and 1",
           },
-        ],
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-        evalTemplateId: templateId,
-      },
-    });
+        })
+        .executeTakeFirst();
 
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      traceId: traceId,
-    };
-
-    await createTraceEvalJobs({ event: payload });
-
-    // update the trace to deselect the trace
-    await kyselyPrisma.$kysely
-      .updateTable("traces")
-      .set("user_id", "b")
-      .where("id", "=", traceId)
-      .execute();
-
-    await createTraceEvalJobs({
-      event: payload,
-    }); // calling it twice to check it is only generated once
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(1);
-    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-    expect(jobs[0].job_input_trace_id).toBe(traceId);
-    expect(jobs[0].status.toString()).toBe("CANCELLED");
-    expect(jobs[0].start_time).not.toBeNull();
-    expect(jobs[0].end_time).not.toBeNull();
-  }, 10_000);
-});
-
-describe("execute evals", () => {
-  test("evals a valid 'trace' event", async () => {
-    await pruneDatabase();
-    openAIServer.respondWithDefault();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
-
-    const templateId = randomUUID();
-    await kyselyPrisma.$kysely
-      .insertInto("eval_templates")
-      .values({
-        id: templateId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        name: "test-template",
-        version: 1,
-        prompt: "Please evaluate toxicity {{input}} {{output}}",
-        model: "gpt-3.5-turbo",
-        provider: "openai",
-        model_params: {},
-        output_schema: {
-          reasoning: "Please explain your reasoning",
-          score: "Please provide a score between 0 and 1",
+      const jobConfiguration = await prisma.jobConfiguration.create({
+        data: {
+          id: randomUUID(),
+          projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          filter: [
+            {
+              type: "string",
+              value: "a",
+              column: "User ID",
+              operator: "contains",
+            },
+          ],
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: "trace",
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+          evalTemplateId: templateId,
         },
-      })
-      .executeTakeFirst();
+      });
 
-    const jobConfiguration = await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
+      const jobExecutionId = randomUUID();
+
+      await kyselyPrisma.$kysely
+        .insertInto("job_executions")
+        .values({
+          id: jobExecutionId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          job_configuration_id: jobConfiguration.id,
+          status: sql`'PENDING'::"JobExecutionStatus"`,
+          start_time: new Date(),
+          job_input_trace_id: traceId,
+        })
+        .execute();
+
+      await kyselyPrisma.$kysely
+        .insertInto("llm_api_keys")
+        .values({
+          id: randomUUID(),
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          secret_key: encrypt(String(OPENAI_API_KEY)),
+          provider: "openai",
+          adapter: LLMAdapter.OpenAI,
+          custom_models: [],
+          display_secret_key: "123456",
+        })
+        .execute();
+
+      const payload = {
         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: [
-          {
-            type: "string",
-            value: "a",
-            column: "User ID",
-            operator: "contains",
+        jobExecutionId: jobExecutionId,
+        delay: 1000,
+      };
+
+      await evaluate({ event: payload });
+
+      const jobs = await kyselyPrisma.$kysely
+        .selectFrom("job_executions")
+        .selectAll()
+        .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+        .execute();
+
+      expect(jobs.length).toBe(1);
+      expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+      expect(jobs[0].job_input_trace_id).toBe(traceId);
+      expect(jobs[0].status.toString()).toBe("COMPLETED");
+      expect(jobs[0].start_time).not.toBeNull();
+      expect(jobs[0].end_time).not.toBeNull();
+
+      const scores = await kyselyPrisma.$kysely
+        .selectFrom("scores")
+        .selectAll()
+        .where("trace_id", "=", traceId)
+        .execute();
+
+      expect(scores.length).toBe(1);
+      expect(scores[0].trace_id).toBe(traceId);
+      expect(scores[0].comment).not.toBeNull();
+      expect(scores[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+    }, 10_000);
+
+    test("fails to eval without llm api key", async () => {
+      await pruneDatabase();
+      const traceId = randomUUID();
+
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          user_id: "a",
+          input: { input: "This is a great prompt" },
+          output: { output: "This is a great response" },
+        })
+        .execute();
+
+      const templateId = randomUUID();
+      await kyselyPrisma.$kysely
+        .insertInto("eval_templates")
+        .values({
+          id: templateId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          name: "test-template",
+          version: 1,
+          prompt: "Please evaluate toxicity {{input}} {{output}}",
+          model: "gpt-3.5-turbo",
+          provider: "openai",
+          model_params: {},
+          output_schema: {
+            reasoning: "Please explain your reasoning",
+            score: "Please provide a score between 0 and 1",
           },
-        ],
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-        evalTemplateId: templateId,
-      },
-    });
+        })
+        .executeTakeFirst();
 
-    const jobExecutionId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("job_executions")
-      .values({
-        id: jobExecutionId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        job_configuration_id: jobConfiguration.id,
-        status: sql`'PENDING'::"JobExecutionStatus"`,
-        start_time: new Date(),
-        job_input_trace_id: traceId,
-      })
-      .execute();
-
-    await kyselyPrisma.$kysely
-      .insertInto("llm_api_keys")
-      .values({
-        id: randomUUID(),
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        secret_key: encrypt(String(OPENAI_API_KEY)),
-        provider: "openai",
-        adapter: LLMAdapter.OpenAI,
-        custom_models: [],
-        display_secret_key: "123456",
-      })
-      .execute();
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      jobExecutionId: jobExecutionId,
-      delay: 1000,
-    };
-
-    await evaluate({ event: payload });
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(1);
-    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-    expect(jobs[0].job_input_trace_id).toBe(traceId);
-    expect(jobs[0].status.toString()).toBe("COMPLETED");
-    expect(jobs[0].start_time).not.toBeNull();
-    expect(jobs[0].end_time).not.toBeNull();
-
-    const scores = await kyselyPrisma.$kysely
-      .selectFrom("scores")
-      .selectAll()
-      .where("trace_id", "=", traceId)
-      .execute();
-
-    expect(scores.length).toBe(1);
-    expect(scores[0].trace_id).toBe(traceId);
-    expect(scores[0].comment).not.toBeNull();
-    expect(scores[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-  }, 10_000);
-
-  test("fails to eval without llm api key", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
-
-    const templateId = randomUUID();
-    await kyselyPrisma.$kysely
-      .insertInto("eval_templates")
-      .values({
-        id: templateId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        name: "test-template",
-        version: 1,
-        prompt: "Please evaluate toxicity {{input}} {{output}}",
-        model: "gpt-3.5-turbo",
-        provider: "openai",
-        model_params: {},
-        output_schema: {
-          reasoning: "Please explain your reasoning",
-          score: "Please provide a score between 0 and 1",
+      const jobConfiguration = await prisma.jobConfiguration.create({
+        data: {
+          id: randomUUID(),
+          projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          filter: [
+            {
+              type: "string",
+              value: "a",
+              column: "User ID",
+              operator: "contains",
+            },
+          ],
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: "trace",
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+          evalTemplateId: templateId,
         },
-      })
-      .executeTakeFirst();
+      });
 
-    const jobConfiguration = await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
+      const jobExecutionId = randomUUID();
+
+      await kyselyPrisma.$kysely
+        .insertInto("job_executions")
+        .values({
+          id: jobExecutionId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          job_configuration_id: jobConfiguration.id,
+          status: sql`'PENDING'::"JobExecutionStatus"`,
+          start_time: new Date(),
+          job_input_trace_id: traceId,
+        })
+        .execute();
+
+      const payload = {
         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: [
-          {
-            type: "string",
-            value: "a",
-            column: "User ID",
-            operator: "contains",
+        jobExecutionId: jobExecutionId,
+        delay: 1000,
+      };
+
+      await expect(evaluate({ event: payload })).rejects.toThrowError(
+        new LangfuseNotFoundError(
+          "API key for provider openai and project 7a88fb47-b4e2-43b8-a06c-a5ce950dc53a not found.",
+        ),
+      );
+
+      const jobs = await kyselyPrisma.$kysely
+        .selectFrom("job_executions")
+        .selectAll()
+        .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+        .execute();
+
+      expect(jobs.length).toBe(1);
+      expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+      expect(jobs[0].job_input_trace_id).toBe(traceId);
+      // the job will be failed when the exception is caught in the worker consumer
+      expect(jobs[0].status.toString()).toBe("PENDING");
+    }, 10_000);
+
+    test("evals should cancel if job is cancelled", async () => {
+      await pruneDatabase();
+      const traceId = randomUUID();
+
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          user_id: "a",
+          input: { input: "This is a great prompt" },
+          output: { output: "This is a great response" },
+        })
+        .execute();
+
+      const templateId = randomUUID();
+      await kyselyPrisma.$kysely
+        .insertInto("eval_templates")
+        .values({
+          id: templateId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          name: "test-template",
+          version: 1,
+          prompt: "Please evaluate toxicity {{input}} {{output}}",
+          model: "gpt-3.5-turbo",
+          provider: "openai",
+          model_params: {},
+          output_schema: {
+            reasoning: "Please explain your reasoning",
+            score: "Please provide a score between 0 and 1",
           },
-        ],
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-        evalTemplateId: templateId,
-      },
-    });
+        })
+        .executeTakeFirst();
 
-    const jobExecutionId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("job_executions")
-      .values({
-        id: jobExecutionId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        job_configuration_id: jobConfiguration.id,
-        status: sql`'PENDING'::"JobExecutionStatus"`,
-        start_time: new Date(),
-        job_input_trace_id: traceId,
-      })
-      .execute();
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      jobExecutionId: jobExecutionId,
-      delay: 1000,
-    };
-
-    await expect(evaluate({ event: payload })).rejects.toThrowError(
-      new LangfuseNotFoundError(
-        "API key for provider openai and project 7a88fb47-b4e2-43b8-a06c-a5ce950dc53a not found.",
-      ),
-    );
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(1);
-    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-    expect(jobs[0].job_input_trace_id).toBe(traceId);
-    // the job will be failed when the exception is caught in the worker consumer
-    expect(jobs[0].status.toString()).toBe("PENDING");
-  }, 10_000);
-
-  test("evals should cancel if job is cancelled", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
-
-    const templateId = randomUUID();
-    await kyselyPrisma.$kysely
-      .insertInto("eval_templates")
-      .values({
-        id: templateId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        name: "test-template",
-        version: 1,
-        prompt: "Please evaluate toxicity {{input}} {{output}}",
-        model: "gpt-3.5-turbo",
-        provider: "openai",
-        model_params: {},
-        output_schema: {
-          reasoning: "Please explain your reasoning",
-          score: "Please provide a score between 0 and 1",
+      const jobConfiguration = await prisma.jobConfiguration.create({
+        data: {
+          id: randomUUID(),
+          projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          filter: [
+            {
+              type: "string",
+              value: "a",
+              column: "User ID",
+              operator: "contains",
+            },
+          ],
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: "trace",
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+          evalTemplateId: templateId,
         },
-      })
-      .executeTakeFirst();
+      });
 
-    const jobConfiguration = await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
+      const jobExecutionId = randomUUID();
+      await kyselyPrisma.$kysely
+        .insertInto("job_executions")
+        .values({
+          id: jobExecutionId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          job_configuration_id: jobConfiguration.id,
+          status: sql`'CANCELLED'::"JobExecutionStatus"`,
+          start_time: new Date(),
+          job_input_trace_id: traceId,
+        })
+        .execute();
+
+      const payload = {
         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: [
-          {
-            type: "string",
-            value: "a",
-            column: "User ID",
-            operator: "contains",
+        jobExecutionId: jobExecutionId,
+        delay: 1000,
+      };
+
+      await evaluate({ event: payload });
+
+      const jobs = await kyselyPrisma.$kysely
+        .selectFrom("job_executions")
+        .selectAll()
+        .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+        .execute();
+
+      expect(jobs.length).toBe(0);
+    }, 10_000);
+
+    test("evals a valid 'trace' event and inserts score to ingestion pipeline", async () => {
+      await pruneDatabase();
+      openAIServer.respondWithDefault();
+      const traceId = randomUUID();
+
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          user_id: "a",
+          input: { input: "This is a great prompt" },
+          output: { output: "This is a great response" },
+        })
+        .execute();
+
+      const templateId = randomUUID();
+      await kyselyPrisma.$kysely
+        .insertInto("eval_templates")
+        .values({
+          id: templateId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          name: "test-template",
+          version: 1,
+          prompt: "Please evaluate toxicity {{input}} {{output}}",
+          model: "gpt-3.5-turbo",
+          provider: "openai",
+          model_params: {},
+          output_schema: {
+            reasoning: "Please explain your reasoning",
+            score: "Please provide a score between 0 and 1",
           },
-        ],
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-        evalTemplateId: templateId,
-      },
-    });
+        })
+        .executeTakeFirst();
 
-    const jobExecutionId = randomUUID();
-    await kyselyPrisma.$kysely
-      .insertInto("job_executions")
-      .values({
-        id: jobExecutionId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        job_configuration_id: jobConfiguration.id,
-        status: sql`'CANCELLED'::"JobExecutionStatus"`,
-        start_time: new Date(),
-        job_input_trace_id: traceId,
-      })
-      .execute();
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      jobExecutionId: jobExecutionId,
-      delay: 1000,
-    };
-
-    await evaluate({ event: payload });
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(0);
-  }, 10_000);
-
-  test("evals a valid 'trace' event and inserts score to ingestion pipeline", async () => {
-    await pruneDatabase();
-    openAIServer.respondWithDefault();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
-
-    const templateId = randomUUID();
-    await kyselyPrisma.$kysely
-      .insertInto("eval_templates")
-      .values({
-        id: templateId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        name: "test-template",
-        version: 1,
-        prompt: "Please evaluate toxicity {{input}} {{output}}",
-        model: "gpt-3.5-turbo",
-        provider: "openai",
-        model_params: {},
-        output_schema: {
-          reasoning: "Please explain your reasoning",
-          score: "Please provide a score between 0 and 1",
+      const jobConfiguration = await prisma.jobConfiguration.create({
+        data: {
+          id: randomUUID(),
+          projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          filter: [
+            {
+              type: "string",
+              value: "a",
+              column: "User ID",
+              operator: "contains",
+            },
+          ],
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: "trace",
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+          evalTemplateId: templateId,
         },
-      })
-      .executeTakeFirst();
+      });
 
-    const jobConfiguration = await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
+      const jobExecutionId = randomUUID();
+
+      await kyselyPrisma.$kysely
+        .insertInto("job_executions")
+        .values({
+          id: jobExecutionId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          job_configuration_id: jobConfiguration.id,
+          status: sql`'PENDING'::"JobExecutionStatus"`,
+          start_time: new Date(),
+          job_input_trace_id: traceId,
+        })
+        .execute();
+
+      await kyselyPrisma.$kysely
+        .insertInto("llm_api_keys")
+        .values({
+          id: randomUUID(),
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          secret_key: encrypt(String(OPENAI_API_KEY)),
+          provider: "openai",
+          adapter: LLMAdapter.OpenAI,
+          custom_models: [],
+          display_secret_key: "123456",
+        })
+        .execute();
+
+      const payload = {
         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: [
-          {
-            type: "string",
-            value: "a",
-            column: "User ID",
-            operator: "contains",
+        jobExecutionId: jobExecutionId,
+        delay: 1000,
+      };
+
+      await evaluate({ event: payload });
+
+      const jobs = await kyselyPrisma.$kysely
+        .selectFrom("job_executions")
+        .selectAll()
+        .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+        .execute();
+
+      expect(jobs.length).toBe(1);
+      expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+      expect(jobs[0].job_input_trace_id).toBe(traceId);
+      expect(jobs[0].status.toString()).toBe("COMPLETED");
+      expect(jobs[0].start_time).not.toBeNull();
+      expect(jobs[0].end_time).not.toBeNull();
+
+      const scores = await kyselyPrisma.$kysely
+        .selectFrom("scores")
+        .selectAll()
+        .where("trace_id", "=", traceId)
+        .execute();
+
+      expect(scores.length).toBe(1);
+      expect(scores[0].trace_id).toBe(traceId);
+      expect(scores[0].comment).not.toBeNull();
+      expect(scores[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+
+      await new Promise<void>((resolve, reject) => {
+        new Worker(
+          QueueName.IngestionQueue,
+          async (job: Job) => {
+            try {
+              expect(job.name).toBe("ingestion-job");
+              expect(job.data.payload.data.type).toBe("score-create");
+              resolve();
+            } catch (e) {
+              reject(e);
+            }
           },
-        ],
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-        evalTemplateId: templateId,
-      },
-    });
+          {
+            connection: redis as ConnectionOptions,
+          },
+        );
+      });
+    }, 10_000);
+  });
 
-    const jobExecutionId = randomUUID();
+  describe("test variable extraction", () => {
+    test("extracts variables from a dataset item", async () => {
+      await pruneDatabase();
+      const datasetId = randomUUID();
+      const datasetItemId = randomUUID();
+      const traceId = randomUUID();
 
-    await kyselyPrisma.$kysely
-      .insertInto("job_executions")
-      .values({
-        id: jobExecutionId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        job_configuration_id: jobConfiguration.id,
-        status: sql`'PENDING'::"JobExecutionStatus"`,
-        start_time: new Date(),
-        job_input_trace_id: traceId,
-      })
-      .execute();
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          user_id: "a",
+          input: { input: "This is a great prompt" },
+          output: { output: "This is a great response" },
+        })
+        .execute();
 
-    await kyselyPrisma.$kysely
-      .insertInto("llm_api_keys")
-      .values({
-        id: randomUUID(),
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        secret_key: encrypt(String(OPENAI_API_KEY)),
-        provider: "openai",
-        adapter: LLMAdapter.OpenAI,
-        custom_models: [],
-        display_secret_key: "123456",
-      })
-      .execute();
+      await kyselyPrisma.$kysely
+        .insertInto("datasets")
+        .values({
+          id: datasetId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          name: "test-dataset",
+        })
+        .execute();
 
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      jobExecutionId: jobExecutionId,
-      delay: 1000,
-    };
+      await kyselyPrisma.$kysely
+        .insertInto("dataset_items")
+        .values({
+          id: datasetItemId,
+          input: { input: "This is a great prompt" },
+          expected_output: { expected_output: "This is a great response" },
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          dataset_id: datasetId,
+        })
+        .execute();
 
-    await evaluate({ event: payload });
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(1);
-    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-    expect(jobs[0].job_input_trace_id).toBe(traceId);
-    expect(jobs[0].status.toString()).toBe("COMPLETED");
-    expect(jobs[0].start_time).not.toBeNull();
-    expect(jobs[0].end_time).not.toBeNull();
-
-    const scores = await kyselyPrisma.$kysely
-      .selectFrom("scores")
-      .selectAll()
-      .where("trace_id", "=", traceId)
-      .execute();
-
-    expect(scores.length).toBe(1);
-    expect(scores[0].trace_id).toBe(traceId);
-    expect(scores[0].comment).not.toBeNull();
-    expect(scores[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-
-    await new Promise<void>((resolve, reject) => {
-      new Worker(
-        QueueName.IngestionQueue,
-        async (job: Job) => {
-          try {
-            expect(job.name).toBe("ingestion-job");
-            expect(job.data.payload.data.type).toBe("score-create");
-            resolve();
-          } catch (e) {
-            reject(e);
-          }
+      const variableMapping = variableMappingList.parse([
+        {
+          langfuseObject: "dataset_item",
+          selectedColumnId: "input",
+          templateVariable: "input",
         },
         {
-          connection: redis as ConnectionOptions,
+          langfuseObject: "dataset_item",
+          selectedColumnId: "expected_output",
+          templateVariable: "output",
         },
-      );
-    });
-  }, 10_000);
-});
+      ]);
 
-describe("test variable extraction", () => {
-  test("extracts variables from a dataset item", async () => {
-    await pruneDatabase();
-    const datasetId = randomUUID();
-    const datasetItemId = randomUUID();
-    const traceId = randomUUID();
+      const result = await extractVariablesFromTracingData({
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        variables: ["input", "output"],
+        traceId: traceId,
+        datasetItemId: datasetItemId,
+        variableMapping: variableMapping,
+      });
 
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
+      expect(result).toEqual([
+        {
+          value: '{"input":"This is a great prompt"}',
+          var: "input",
+        },
+        {
+          value: '{"expected_output":"This is a great response"}',
+          var: "output",
+        },
+      ]);
+    }, 10_000);
 
-    await kyselyPrisma.$kysely
-      .insertInto("datasets")
-      .values({
-        id: datasetId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        name: "test-dataset",
-      })
-      .execute();
+    test("extracts variables from a trace", async () => {
+      await pruneDatabase();
+      const traceId = randomUUID();
 
-    await kyselyPrisma.$kysely
-      .insertInto("dataset_items")
-      .values({
-        id: datasetItemId,
-        input: { input: "This is a great prompt" },
-        expected_output: { expected_output: "This is a great response" },
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        dataset_id: datasetId,
-      })
-      .execute();
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          user_id: "a",
+          input: { input: "This is a great prompt" },
+          output: { output: "This is a great response" },
+        })
+        .execute();
 
-    const variableMapping = variableMappingList.parse([
-      {
-        langfuseObject: "dataset_item",
-        selectedColumnId: "input",
-        templateVariable: "input",
-      },
-      {
-        langfuseObject: "dataset_item",
-        selectedColumnId: "expected_output",
-        templateVariable: "output",
-      },
-    ]);
+      const variableMapping = variableMappingList.parse([
+        {
+          langfuseObject: "trace",
+          selectedColumnId: "input",
+          templateVariable: "input",
+        },
+        {
+          langfuseObject: "trace",
+          selectedColumnId: "output",
+          templateVariable: "output",
+        },
+      ]);
 
-    const result = await extractVariablesFromTracingData({
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      variables: ["input", "output"],
-      traceId: traceId,
-      datasetItemId: datasetItemId,
-      variableMapping: variableMapping,
-    });
-
-    expect(result).toEqual([
-      {
-        value: '{"input":"This is a great prompt"}',
-        var: "input",
-      },
-      {
-        value: '{"expected_output":"This is a great response"}',
-        var: "output",
-      },
-    ]);
-  }, 10_000);
-
-  test("extracts variables from a trace", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
-
-    const variableMapping = variableMappingList.parse([
-      {
-        langfuseObject: "trace",
-        selectedColumnId: "input",
-        templateVariable: "input",
-      },
-      {
-        langfuseObject: "trace",
-        selectedColumnId: "output",
-        templateVariable: "output",
-      },
-    ]);
-
-    const result = await extractVariablesFromTracingData({
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      variables: ["input", "output"],
-      traceId: traceId,
-      variableMapping: variableMapping,
-    });
-
-    expect(result).toEqual([
-      {
-        value: '{"input":"This is a great prompt"}',
-        var: "input",
-      },
-      {
-        value: '{"output":"This is a great response"}',
-        var: "output",
-      },
-    ]);
-  }, 10_000);
-
-  test("extracts variables from a observation", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
-
-    await kyselyPrisma.$kysely
-      .insertInto("observations")
-      .values({
-        id: randomUUID(),
-        trace_id: traceId,
-        name: "great-llm-name",
-        type: sql`'GENERATION'::"ObservationType"`,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        input: { huhu: "This is a great prompt" },
-        output: { haha: "This is a great response" },
-      })
-      .execute();
-
-    const variableMapping = variableMappingList.parse([
-      {
-        langfuseObject: "generation",
-        selectedColumnId: "input",
-        templateVariable: "input",
-        objectName: "great-llm-name",
-      },
-      {
-        langfuseObject: "generation",
-        selectedColumnId: "output",
-        templateVariable: "output",
-        objectName: "great-llm-name",
-      },
-    ]);
-
-    const result = await extractVariablesFromTracingData({
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      variables: ["input", "output"],
-      traceId: traceId,
-      variableMapping: variableMapping,
-    });
-
-    expect(result).toEqual([
-      {
-        value: '{"huhu":"This is a great prompt"}',
-        var: "input",
-      },
-      {
-        value: '{"haha":"This is a great response"}',
-        var: "output",
-      },
-    ]);
-  }, 10_000);
-
-  test("fails if observation is not present", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
-
-    const variableMapping = variableMappingList.parse([
-      {
-        langfuseObject: "generation",
-        selectedColumnId: "input",
-        templateVariable: "input",
-        objectName: "great-llm-name",
-      },
-      {
-        langfuseObject: "generation",
-        selectedColumnId: "output",
-        templateVariable: "output",
-        objectName: "great-llm-name",
-      },
-    ]);
-
-    await expect(
-      extractVariablesFromTracingData({
+      const result = await extractVariablesFromTracingData({
         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
         variables: ["input", "output"],
         traceId: traceId,
         variableMapping: variableMapping,
-      }),
-    ).rejects.toThrowError(
-      new LangfuseNotFoundError(
-        `Observation great-llm-name for trace ${traceId} not found. Please ensure the mapped data exists and consider extending the job delay.`,
-      ),
-    );
-  }, 10_000);
+      });
 
-  test("does not fail if observation data is null", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
+      expect(result).toEqual([
+        {
+          value: '{"input":"This is a great prompt"}',
+          var: "input",
+        },
+        {
+          value: '{"output":"This is a great response"}',
+          var: "output",
+        },
+      ]);
+    }, 10_000);
 
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
+    test("extracts variables from a observation", async () => {
+      await pruneDatabase();
+      const traceId = randomUUID();
 
-    // fetching input and output for an observation which has NULL values
-    await kyselyPrisma.$kysely
-      .insertInto("observations")
-      .values({
-        id: randomUUID(),
-        trace_id: traceId,
-        name: "great-llm-name",
-        type: sql`'GENERATION'::"ObservationType"`,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      })
-      .execute();
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          user_id: "a",
+          input: { input: "This is a great prompt" },
+          output: { output: "This is a great response" },
+        })
+        .execute();
 
-    const variableMapping = variableMappingList.parse([
-      {
-        langfuseObject: "generation",
-        selectedColumnId: "input",
-        templateVariable: "input",
-        objectName: "great-llm-name",
-      },
-      {
-        langfuseObject: "generation",
-        selectedColumnId: "output",
-        templateVariable: "output",
-        objectName: "great-llm-name",
-      },
-    ]);
+      await kyselyPrisma.$kysely
+        .insertInto("observations")
+        .values({
+          id: randomUUID(),
+          trace_id: traceId,
+          name: "great-llm-name",
+          type: sql`'GENERATION'::"ObservationType"`,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          input: { huhu: "This is a great prompt" },
+          output: { haha: "This is a great response" },
+        })
+        .execute();
 
-    const result = await extractVariablesFromTracingData({
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      variables: ["input", "output"],
-      traceId: traceId,
-      variableMapping: variableMapping,
-    });
+      const variableMapping = variableMappingList.parse([
+        {
+          langfuseObject: "generation",
+          selectedColumnId: "input",
+          templateVariable: "input",
+          objectName: "great-llm-name",
+        },
+        {
+          langfuseObject: "generation",
+          selectedColumnId: "output",
+          templateVariable: "output",
+          objectName: "great-llm-name",
+        },
+      ]);
 
-    expect(result).toEqual([
-      {
-        value: "",
-        var: "input",
-      },
-      {
-        value: "",
-        var: "output",
-      },
-    ]);
-  }, 10_000);
+      const result = await extractVariablesFromTracingData({
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        variables: ["input", "output"],
+        traceId: traceId,
+        variableMapping: variableMapping,
+      });
 
-  test("extracts variables from a youngest observation", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
+      expect(result).toEqual([
+        {
+          value: '{"huhu":"This is a great prompt"}',
+          var: "input",
+        },
+        {
+          value: '{"haha":"This is a great response"}',
+          var: "output",
+        },
+      ]);
+    }, 10_000);
 
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
+    test("fails if observation is not present", async () => {
+      await pruneDatabase();
+      const traceId = randomUUID();
 
-    await kyselyPrisma.$kysely
-      .insertInto("observations")
-      .values({
-        id: randomUUID(),
-        trace_id: traceId,
-        name: "great-llm-name",
-        start_time: new Date("2022-01-01T00:00:00.000Z"),
-        type: sql`'GENERATION'::"ObservationType"`,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        input: { huhu: "This is a great prompt" },
-        output: { haha: "This is a great response" },
-      })
-      .execute();
-    await kyselyPrisma.$kysely
-      .insertInto("observations")
-      .values({
-        id: randomUUID(),
-        trace_id: traceId,
-        name: "great-llm-name",
-        start_time: new Date("2022-01-02T00:00:00.000Z"),
-        type: sql`'GENERATION'::"ObservationType"`,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        input: { huhu: "This is a great prompt again" },
-        output: { haha: "This is a great response again" },
-      })
-      .execute();
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          user_id: "a",
+          input: { input: "This is a great prompt" },
+          output: { output: "This is a great response" },
+        })
+        .execute();
 
-    const variableMapping = variableMappingList.parse([
-      {
-        langfuseObject: "generation",
-        selectedColumnId: "input",
-        templateVariable: "input",
-        objectName: "great-llm-name",
-      },
-      {
-        langfuseObject: "generation",
-        selectedColumnId: "output",
-        templateVariable: "output",
-        objectName: "great-llm-name",
-      },
-    ]);
+      const variableMapping = variableMappingList.parse([
+        {
+          langfuseObject: "generation",
+          selectedColumnId: "input",
+          templateVariable: "input",
+          objectName: "great-llm-name",
+        },
+        {
+          langfuseObject: "generation",
+          selectedColumnId: "output",
+          templateVariable: "output",
+          objectName: "great-llm-name",
+        },
+      ]);
 
-    const result = await extractVariablesFromTracingData({
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      variables: ["input", "output"],
-      traceId: traceId,
-      variableMapping: variableMapping,
-    });
+      await expect(
+        extractVariablesFromTracingData({
+          projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          variables: ["input", "output"],
+          traceId: traceId,
+          variableMapping: variableMapping,
+        }),
+      ).rejects.toThrowError(
+        new LangfuseNotFoundError(
+          `Observation great-llm-name for trace ${traceId} not found. Please ensure the mapped data exists and consider extending the job delay.`,
+        ),
+      );
+    }, 10_000);
 
-    expect(result).toEqual([
-      {
-        value: '{"huhu":"This is a great prompt again"}',
-        var: "input",
-      },
-      {
-        value: '{"haha":"This is a great response again"}',
-        var: "output",
-      },
-    ]);
-  }, 10_000);
+    test("does not fail if observation data is null", async () => {
+      await pruneDatabase();
+      const traceId = randomUUID();
+
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          user_id: "a",
+          input: { input: "This is a great prompt" },
+          output: { output: "This is a great response" },
+        })
+        .execute();
+
+      // fetching input and output for an observation which has NULL values
+      await kyselyPrisma.$kysely
+        .insertInto("observations")
+        .values({
+          id: randomUUID(),
+          trace_id: traceId,
+          name: "great-llm-name",
+          type: sql`'GENERATION'::"ObservationType"`,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        })
+        .execute();
+
+      const variableMapping = variableMappingList.parse([
+        {
+          langfuseObject: "generation",
+          selectedColumnId: "input",
+          templateVariable: "input",
+          objectName: "great-llm-name",
+        },
+        {
+          langfuseObject: "generation",
+          selectedColumnId: "output",
+          templateVariable: "output",
+          objectName: "great-llm-name",
+        },
+      ]);
+
+      const result = await extractVariablesFromTracingData({
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        variables: ["input", "output"],
+        traceId: traceId,
+        variableMapping: variableMapping,
+      });
+
+      expect(result).toEqual([
+        {
+          value: "",
+          var: "input",
+        },
+        {
+          value: "",
+          var: "output",
+        },
+      ]);
+    }, 10_000);
+
+    test("extracts variables from a youngest observation", async () => {
+      await pruneDatabase();
+      const traceId = randomUUID();
+
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          user_id: "a",
+          input: { input: "This is a great prompt" },
+          output: { output: "This is a great response" },
+        })
+        .execute();
+
+      await kyselyPrisma.$kysely
+        .insertInto("observations")
+        .values({
+          id: randomUUID(),
+          trace_id: traceId,
+          name: "great-llm-name",
+          start_time: new Date("2022-01-01T00:00:00.000Z"),
+          type: sql`'GENERATION'::"ObservationType"`,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          input: { huhu: "This is a great prompt" },
+          output: { haha: "This is a great response" },
+        })
+        .execute();
+      await kyselyPrisma.$kysely
+        .insertInto("observations")
+        .values({
+          id: randomUUID(),
+          trace_id: traceId,
+          name: "great-llm-name",
+          start_time: new Date("2022-01-02T00:00:00.000Z"),
+          type: sql`'GENERATION'::"ObservationType"`,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          input: { huhu: "This is a great prompt again" },
+          output: { haha: "This is a great response again" },
+        })
+        .execute();
+
+      const variableMapping = variableMappingList.parse([
+        {
+          langfuseObject: "generation",
+          selectedColumnId: "input",
+          templateVariable: "input",
+          objectName: "great-llm-name",
+        },
+        {
+          langfuseObject: "generation",
+          selectedColumnId: "output",
+          templateVariable: "output",
+          objectName: "great-llm-name",
+        },
+      ]);
+
+      const result = await extractVariablesFromTracingData({
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        variables: ["input", "output"],
+        traceId: traceId,
+        variableMapping: variableMapping,
+      });
+
+      expect(result).toEqual([
+        {
+          value: '{"huhu":"This is a great prompt again"}',
+          var: "input",
+        },
+        {
+          value: '{"haha":"This is a great response again"}',
+          var: "output",
+        },
+      ]);
+    }, 10_000);
+  });
 });

--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -1,9 +1,9 @@
 import { expect, test, describe, afterAll, beforeAll, vi } from "vitest";
 import {
+  compileHandlebarString,
   createDatasetEvalJobs,
   createTraceEvalJobs,
   evaluate,
-  extractVariables,
 } from "../features/evaluation/evalService";
 import { kyselyPrisma, prisma } from "@langfuse/shared/src/db";
 import { randomUUID } from "crypto";
@@ -35,1229 +35,1255 @@ beforeAll(openAIServer.setup);
 afterEach(openAIServer.reset);
 afterAll(openAIServer.teardown);
 
-describe("create eval jobs", () => {
-  test("creates new 'trace' eval job", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      })
-      .execute();
-
-    await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: JSON.parse("[]"),
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-      },
+describe("compile prompt", () => {
+  test("compile handlebars template", async () => {
+    const template = "Please evaluate toxicity {{input}} {{output}}";
+    const compiledString = compileHandlebarString(template, {
+      input: "foo",
+      output: "bar",
     });
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      traceId: traceId,
-    };
-
-    await createTraceEvalJobs({ event: payload });
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(1);
-    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-    expect(jobs[0].job_input_trace_id).toBe(traceId);
-    expect(jobs[0].status.toString()).toBe("PENDING");
-    expect(jobs[0].start_time).not.toBeNull();
-  }, 10_000);
-
-  test("creates new 'dataset' eval job", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-    const observationId = randomUUID();
-    const datasetId = randomUUID();
-    const datasetItemId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      })
-      .execute();
-
-    await kyselyPrisma.$kysely
-      .insertInto("observations")
-      .values({
-        id: observationId,
-        trace_id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        type: sql`'GENERATION'::"ObservationType"`,
-      })
-      .execute();
-
-    await kyselyPrisma.$kysely
-      .insertInto("datasets")
-      .values({
-        id: datasetId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        name: "test-dataset",
-      })
-      .execute();
-
-    await kyselyPrisma.$kysely
-      .insertInto("dataset_items")
-      .values({
-        id: datasetItemId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        dataset_id: datasetId,
-      })
-      .execute();
-
-    await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: JSON.parse("[]"),
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "dataset",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-      },
-    });
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      traceId: traceId,
-      datasetItemId: datasetItemId,
-      observationId: observationId,
-    };
-
-    await createDatasetEvalJobs({ event: payload });
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(1);
-    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-    expect(jobs[0].job_input_trace_id).toBe(traceId);
-    expect(jobs[0].job_input_observation_id).toBe(observationId);
-    expect(jobs[0].job_input_dataset_item_id).toBe(datasetItemId);
-    expect(jobs[0].status.toString()).toBe("PENDING");
-    expect(jobs[0].start_time).not.toBeNull();
-  }, 10_000);
-
-  test("does not create job for inactive config", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      })
-      .execute();
-
-    await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: JSON.parse("[]"),
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-        status: "INACTIVE",
-      },
-    });
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      traceId: traceId,
-    };
-
-    await createTraceEvalJobs({ event: payload });
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(0);
-  }, 10_000);
-
-  test("does not create eval job for existing job execution", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      })
-      .execute();
-
-    await kyselyPrisma.$kysely
-      .insertInto("llm_api_keys")
-      .values({
-        id: randomUUID(),
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        secret_key: encrypt(String(OPENAI_API_KEY)),
-        provider: "openai",
-        adapter: LLMAdapter.OpenAI,
-        custom_models: [],
-        display_secret_key: "123456",
-      })
-      .execute();
-
-    await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: JSON.parse("[]"),
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-      },
-    });
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      traceId: traceId,
-    };
-
-    await createTraceEvalJobs({ event: payload });
-    await createTraceEvalJobs({ event: payload }); // calling it twice to check it is only generated once
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(1);
-    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-    expect(jobs[0].job_input_trace_id).toBe(traceId);
-    expect(jobs[0].status.toString()).toBe("PENDING");
-    expect(jobs[0].start_time).not.toBeNull();
-    expect(jobs[0].end_time).to.be.null;
-  }, 10_000);
-
-  test("does not create job for inactive config", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      })
-      .execute();
-
-    await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: JSON.parse("[]"),
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-        status: "INACTIVE",
-      },
-    });
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      traceId: traceId,
-    };
-
-    await createTraceEvalJobs({ event: payload });
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(0);
-  }, 10_000);
-
-  test("does not create eval job for 0 sample rate", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      })
-      .execute();
-
-    await kyselyPrisma.$kysely
-      .insertInto("llm_api_keys")
-      .values({
-        id: randomUUID(),
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        secret_key: encrypt(String(OPENAI_API_KEY)),
-        provider: "openai",
-        adapter: LLMAdapter.OpenAI,
-        custom_models: [],
-        display_secret_key: "123456",
-      })
-      .execute();
-
-    await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: JSON.parse("[]"),
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("0"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-      },
-    });
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      traceId: traceId,
-    };
-
-    await createTraceEvalJobs({ event: payload });
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(0);
-  }, 10_000);
-
-  test("cancels a job if the second event deselects", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-      })
-      .execute();
-
-    await kyselyPrisma.$kysely
-      .insertInto("llm_api_keys")
-      .values({
-        id: randomUUID(),
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        secret_key: encrypt(String(OPENAI_API_KEY)),
-        provider: "openai",
-        adapter: LLMAdapter.OpenAI,
-        custom_models: [],
-        display_secret_key: "123456",
-      })
-      .execute();
-
-    const templateId = randomUUID();
-    await kyselyPrisma.$kysely
-      .insertInto("eval_templates")
-      .values({
-        id: templateId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        name: "test-template",
-        version: 1,
-        prompt: "Please evaluate toxicity {{input}} {{output}}",
-        model: "gpt-3.5-turbo",
-        provider: "openai",
-        model_params: {},
-        output_schema: {
-          reasoning: "Please explain your reasoning",
-          score: "Please provide a score between 0 and 1",
-        },
-      })
-      .executeTakeFirst();
-
-    await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: [
-          {
-            type: "string",
-            value: "a",
-            column: "User ID",
-            operator: "contains",
-          },
-        ],
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-        evalTemplateId: templateId,
-      },
-    });
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      traceId: traceId,
-    };
-
-    await createTraceEvalJobs({ event: payload });
-
-    // update the trace to deselect the trace
-    await kyselyPrisma.$kysely
-      .updateTable("traces")
-      .set("user_id", "b")
-      .where("id", "=", traceId)
-      .execute();
-
-    await createTraceEvalJobs({
-      event: payload,
-    }); // calling it twice to check it is only generated once
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(1);
-    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-    expect(jobs[0].job_input_trace_id).toBe(traceId);
-    expect(jobs[0].status.toString()).toBe("CANCELLED");
-    expect(jobs[0].start_time).not.toBeNull();
-    expect(jobs[0].end_time).not.toBeNull();
-  }, 10_000);
-});
-
-describe("execute evals", () => {
-  test("evals a valid 'trace' event", async () => {
-    await pruneDatabase();
-    openAIServer.respondWithDefault();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
-
-    const templateId = randomUUID();
-    await kyselyPrisma.$kysely
-      .insertInto("eval_templates")
-      .values({
-        id: templateId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        name: "test-template",
-        version: 1,
-        prompt: "Please evaluate toxicity {{input}} {{output}}",
-        model: "gpt-3.5-turbo",
-        provider: "openai",
-        model_params: {},
-        output_schema: {
-          reasoning: "Please explain your reasoning",
-          score: "Please provide a score between 0 and 1",
-        },
-      })
-      .executeTakeFirst();
-
-    const jobConfiguration = await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: [
-          {
-            type: "string",
-            value: "a",
-            column: "User ID",
-            operator: "contains",
-          },
-        ],
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-        evalTemplateId: templateId,
-      },
-    });
-
-    const jobExecutionId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("job_executions")
-      .values({
-        id: jobExecutionId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        job_configuration_id: jobConfiguration.id,
-        status: sql`'PENDING'::"JobExecutionStatus"`,
-        start_time: new Date(),
-        job_input_trace_id: traceId,
-      })
-      .execute();
-
-    await kyselyPrisma.$kysely
-      .insertInto("llm_api_keys")
-      .values({
-        id: randomUUID(),
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        secret_key: encrypt(String(OPENAI_API_KEY)),
-        provider: "openai",
-        adapter: LLMAdapter.OpenAI,
-        custom_models: [],
-        display_secret_key: "123456",
-      })
-      .execute();
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      jobExecutionId: jobExecutionId,
-      delay: 1000,
-    };
-
-    await evaluate({ event: payload });
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(1);
-    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-    expect(jobs[0].job_input_trace_id).toBe(traceId);
-    expect(jobs[0].status.toString()).toBe("COMPLETED");
-    expect(jobs[0].start_time).not.toBeNull();
-    expect(jobs[0].end_time).not.toBeNull();
-
-    const scores = await kyselyPrisma.$kysely
-      .selectFrom("scores")
-      .selectAll()
-      .where("trace_id", "=", traceId)
-      .execute();
-
-    expect(scores.length).toBe(1);
-    expect(scores[0].trace_id).toBe(traceId);
-    expect(scores[0].comment).not.toBeNull();
-    expect(scores[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-  }, 10_000);
-
-  test("fails to eval without llm api key", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
-
-    const templateId = randomUUID();
-    await kyselyPrisma.$kysely
-      .insertInto("eval_templates")
-      .values({
-        id: templateId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        name: "test-template",
-        version: 1,
-        prompt: "Please evaluate toxicity {{input}} {{output}}",
-        model: "gpt-3.5-turbo",
-        provider: "openai",
-        model_params: {},
-        output_schema: {
-          reasoning: "Please explain your reasoning",
-          score: "Please provide a score between 0 and 1",
-        },
-      })
-      .executeTakeFirst();
-
-    const jobConfiguration = await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: [
-          {
-            type: "string",
-            value: "a",
-            column: "User ID",
-            operator: "contains",
-          },
-        ],
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-        evalTemplateId: templateId,
-      },
-    });
-
-    const jobExecutionId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("job_executions")
-      .values({
-        id: jobExecutionId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        job_configuration_id: jobConfiguration.id,
-        status: sql`'PENDING'::"JobExecutionStatus"`,
-        start_time: new Date(),
-        job_input_trace_id: traceId,
-      })
-      .execute();
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      jobExecutionId: jobExecutionId,
-      delay: 1000,
-    };
-
-    await expect(evaluate({ event: payload })).rejects.toThrowError(
-      new LangfuseNotFoundError(
-        "API key for provider openai and project 7a88fb47-b4e2-43b8-a06c-a5ce950dc53a not found.",
-      ),
+    expect(compiledString).toBe("Please evaluate toxicity foo bar");
+  });
+
+  test("escape template to deal with invalid templates", async () => {
+    const template =
+      "Please evaluate toxicity {{'measures': ['some-stuff'],'dimensions': ['doesnotwork'],}} {{output}}";
+
+    // console.log(Handlebars.escapeExpression(template));
+
+    const compiledString = compileHandlebarString(template, [
+      "input",
+      "output",
+    ]);
+    expect(compiledString).toBe(
+      "Please evaluate toxicity {{input}} {{output}}",
     );
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(1);
-    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-    expect(jobs[0].job_input_trace_id).toBe(traceId);
-    // the job will be failed when the exception is caught in the worker consumer
-    expect(jobs[0].status.toString()).toBe("PENDING");
-  }, 10_000);
-
-  test("evals should cancel if job is cancelled", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
-
-    const templateId = randomUUID();
-    await kyselyPrisma.$kysely
-      .insertInto("eval_templates")
-      .values({
-        id: templateId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        name: "test-template",
-        version: 1,
-        prompt: "Please evaluate toxicity {{input}} {{output}}",
-        model: "gpt-3.5-turbo",
-        provider: "openai",
-        model_params: {},
-        output_schema: {
-          reasoning: "Please explain your reasoning",
-          score: "Please provide a score between 0 and 1",
-        },
-      })
-      .executeTakeFirst();
-
-    const jobConfiguration = await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: [
-          {
-            type: "string",
-            value: "a",
-            column: "User ID",
-            operator: "contains",
-          },
-        ],
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-        evalTemplateId: templateId,
-      },
-    });
-
-    const jobExecutionId = randomUUID();
-    await kyselyPrisma.$kysely
-      .insertInto("job_executions")
-      .values({
-        id: jobExecutionId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        job_configuration_id: jobConfiguration.id,
-        status: sql`'CANCELLED'::"JobExecutionStatus"`,
-        start_time: new Date(),
-        job_input_trace_id: traceId,
-      })
-      .execute();
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      jobExecutionId: jobExecutionId,
-      delay: 1000,
-    };
-
-    await evaluate({ event: payload });
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(0);
-  }, 10_000);
-
-  test("evals a valid 'trace' event and inserts score to ingestion pipeline", async () => {
-    await pruneDatabase();
-    openAIServer.respondWithDefault();
-    const traceId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
-
-    const templateId = randomUUID();
-    await kyselyPrisma.$kysely
-      .insertInto("eval_templates")
-      .values({
-        id: templateId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        name: "test-template",
-        version: 1,
-        prompt: "Please evaluate toxicity {{input}} {{output}}",
-        model: "gpt-3.5-turbo",
-        provider: "openai",
-        model_params: {},
-        output_schema: {
-          reasoning: "Please explain your reasoning",
-          score: "Please provide a score between 0 and 1",
-        },
-      })
-      .executeTakeFirst();
-
-    const jobConfiguration = await prisma.jobConfiguration.create({
-      data: {
-        id: randomUUID(),
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        filter: [
-          {
-            type: "string",
-            value: "a",
-            column: "User ID",
-            operator: "contains",
-          },
-        ],
-        jobType: "EVAL",
-        delay: 0,
-        sampling: new Decimal("1"),
-        targetObject: "trace",
-        scoreName: "score",
-        variableMapping: JSON.parse("[]"),
-        evalTemplateId: templateId,
-      },
-    });
-
-    const jobExecutionId = randomUUID();
-
-    await kyselyPrisma.$kysely
-      .insertInto("job_executions")
-      .values({
-        id: jobExecutionId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        job_configuration_id: jobConfiguration.id,
-        status: sql`'PENDING'::"JobExecutionStatus"`,
-        start_time: new Date(),
-        job_input_trace_id: traceId,
-      })
-      .execute();
-
-    await kyselyPrisma.$kysely
-      .insertInto("llm_api_keys")
-      .values({
-        id: randomUUID(),
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        secret_key: encrypt(String(OPENAI_API_KEY)),
-        provider: "openai",
-        adapter: LLMAdapter.OpenAI,
-        custom_models: [],
-        display_secret_key: "123456",
-      })
-      .execute();
-
-    const payload = {
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      jobExecutionId: jobExecutionId,
-      delay: 1000,
-    };
-
-    await evaluate({ event: payload });
-
-    const jobs = await kyselyPrisma.$kysely
-      .selectFrom("job_executions")
-      .selectAll()
-      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-      .execute();
-
-    expect(jobs.length).toBe(1);
-    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-    expect(jobs[0].job_input_trace_id).toBe(traceId);
-    expect(jobs[0].status.toString()).toBe("COMPLETED");
-    expect(jobs[0].start_time).not.toBeNull();
-    expect(jobs[0].end_time).not.toBeNull();
-
-    const scores = await kyselyPrisma.$kysely
-      .selectFrom("scores")
-      .selectAll()
-      .where("trace_id", "=", traceId)
-      .execute();
-
-    expect(scores.length).toBe(1);
-    expect(scores[0].trace_id).toBe(traceId);
-    expect(scores[0].comment).not.toBeNull();
-    expect(scores[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-
-    await new Promise<void>((resolve, reject) => {
-      new Worker(
-        QueueName.IngestionQueue,
-        async (job: Job) => {
-          try {
-            expect(job.name).toBe("ingestion-job");
-            expect(job.data.payload.data.type).toBe("score-create");
-            resolve();
-          } catch (e) {
-            reject(e);
-          }
-        },
-        {
-          connection: redis as ConnectionOptions,
-        },
-      );
-    });
-  }, 10_000);
+  });
 });
 
-describe("test variable extraction", () => {
-  test("extracts variables from a dataset item", async () => {
-    await pruneDatabase();
-    const datasetId = randomUUID();
-    const datasetItemId = randomUUID();
-    const traceId = randomUUID();
+// describe("create eval jobs", () => {
+//   test("creates new 'trace' eval job", async () => {
+//     await pruneDatabase();
+//     const traceId = randomUUID();
 
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
+//     await kyselyPrisma.$kysely
+//       .insertInto("traces")
+//       .values({
+//         id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       })
+//       .execute();
 
-    await kyselyPrisma.$kysely
-      .insertInto("datasets")
-      .values({
-        id: datasetId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        name: "test-dataset",
-      })
-      .execute();
+//     await prisma.jobConfiguration.create({
+//       data: {
+//         id: randomUUID(),
+//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         filter: JSON.parse("[]"),
+//         jobType: "EVAL",
+//         delay: 0,
+//         sampling: new Decimal("1"),
+//         targetObject: "trace",
+//         scoreName: "score",
+//         variableMapping: JSON.parse("[]"),
+//       },
+//     });
 
-    await kyselyPrisma.$kysely
-      .insertInto("dataset_items")
-      .values({
-        id: datasetItemId,
-        input: { input: "This is a great prompt" },
-        expected_output: { expected_output: "This is a great response" },
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        dataset_id: datasetId,
-      })
-      .execute();
+//     const payload = {
+//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       traceId: traceId,
+//     };
 
-    const variableMapping = variableMappingList.parse([
-      {
-        langfuseObject: "dataset_item",
-        selectedColumnId: "input",
-        templateVariable: "input",
-      },
-      {
-        langfuseObject: "dataset_item",
-        selectedColumnId: "expected_output",
-        templateVariable: "output",
-      },
-    ]);
+//     await createTraceEvalJobs({ event: payload });
 
-    const result = await extractVariables({
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      variables: ["input", "output"],
-      traceId: traceId,
-      datasetItemId: datasetItemId,
-      variableMapping: variableMapping,
-    });
+//     const jobs = await kyselyPrisma.$kysely
+//       .selectFrom("job_executions")
+//       .selectAll()
+//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+//       .execute();
 
-    expect(result).toEqual([
-      {
-        value: '{"input":"This is a great prompt"}',
-        var: "input",
-      },
-      {
-        value: '{"expected_output":"This is a great response"}',
-        var: "output",
-      },
-    ]);
-  }, 10_000);
+//     expect(jobs.length).toBe(1);
+//     expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+//     expect(jobs[0].job_input_trace_id).toBe(traceId);
+//     expect(jobs[0].status.toString()).toBe("PENDING");
+//     expect(jobs[0].start_time).not.toBeNull();
+//   }, 10_000);
 
-  test("extracts variables from a trace", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
+//   test("creates new 'dataset' eval job", async () => {
+//     await pruneDatabase();
+//     const traceId = randomUUID();
+//     const observationId = randomUUID();
+//     const datasetId = randomUUID();
+//     const datasetItemId = randomUUID();
 
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
+//     await kyselyPrisma.$kysely
+//       .insertInto("traces")
+//       .values({
+//         id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       })
+//       .execute();
 
-    const variableMapping = variableMappingList.parse([
-      {
-        langfuseObject: "trace",
-        selectedColumnId: "input",
-        templateVariable: "input",
-      },
-      {
-        langfuseObject: "trace",
-        selectedColumnId: "output",
-        templateVariable: "output",
-      },
-    ]);
+//     await kyselyPrisma.$kysely
+//       .insertInto("observations")
+//       .values({
+//         id: observationId,
+//         trace_id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         type: sql`'GENERATION'::"ObservationType"`,
+//       })
+//       .execute();
 
-    const result = await extractVariables({
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      variables: ["input", "output"],
-      traceId: traceId,
-      variableMapping: variableMapping,
-    });
+//     await kyselyPrisma.$kysely
+//       .insertInto("datasets")
+//       .values({
+//         id: datasetId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         name: "test-dataset",
+//       })
+//       .execute();
 
-    expect(result).toEqual([
-      {
-        value: '{"input":"This is a great prompt"}',
-        var: "input",
-      },
-      {
-        value: '{"output":"This is a great response"}',
-        var: "output",
-      },
-    ]);
-  }, 10_000);
+//     await kyselyPrisma.$kysely
+//       .insertInto("dataset_items")
+//       .values({
+//         id: datasetItemId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         dataset_id: datasetId,
+//       })
+//       .execute();
 
-  test("extracts variables from a observation", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
+//     await prisma.jobConfiguration.create({
+//       data: {
+//         id: randomUUID(),
+//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         filter: JSON.parse("[]"),
+//         jobType: "EVAL",
+//         delay: 0,
+//         sampling: new Decimal("1"),
+//         targetObject: "dataset",
+//         scoreName: "score",
+//         variableMapping: JSON.parse("[]"),
+//       },
+//     });
 
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
+//     const payload = {
+//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       traceId: traceId,
+//       datasetItemId: datasetItemId,
+//       observationId: observationId,
+//     };
 
-    await kyselyPrisma.$kysely
-      .insertInto("observations")
-      .values({
-        id: randomUUID(),
-        trace_id: traceId,
-        name: "great-llm-name",
-        type: sql`'GENERATION'::"ObservationType"`,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        input: { huhu: "This is a great prompt" },
-        output: { haha: "This is a great response" },
-      })
-      .execute();
+//     await createDatasetEvalJobs({ event: payload });
 
-    const variableMapping = variableMappingList.parse([
-      {
-        langfuseObject: "generation",
-        selectedColumnId: "input",
-        templateVariable: "input",
-        objectName: "great-llm-name",
-      },
-      {
-        langfuseObject: "generation",
-        selectedColumnId: "output",
-        templateVariable: "output",
-        objectName: "great-llm-name",
-      },
-    ]);
+//     const jobs = await kyselyPrisma.$kysely
+//       .selectFrom("job_executions")
+//       .selectAll()
+//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+//       .execute();
 
-    const result = await extractVariables({
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      variables: ["input", "output"],
-      traceId: traceId,
-      variableMapping: variableMapping,
-    });
+//     expect(jobs.length).toBe(1);
+//     expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+//     expect(jobs[0].job_input_trace_id).toBe(traceId);
+//     expect(jobs[0].job_input_observation_id).toBe(observationId);
+//     expect(jobs[0].job_input_dataset_item_id).toBe(datasetItemId);
+//     expect(jobs[0].status.toString()).toBe("PENDING");
+//     expect(jobs[0].start_time).not.toBeNull();
+//   }, 10_000);
 
-    expect(result).toEqual([
-      {
-        value: '{"huhu":"This is a great prompt"}',
-        var: "input",
-      },
-      {
-        value: '{"haha":"This is a great response"}',
-        var: "output",
-      },
-    ]);
-  }, 10_000);
+//   test("does not create job for inactive config", async () => {
+//     await pruneDatabase();
+//     const traceId = randomUUID();
 
-  test("fails if observation is not present", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
+//     await kyselyPrisma.$kysely
+//       .insertInto("traces")
+//       .values({
+//         id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       })
+//       .execute();
 
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
+//     await prisma.jobConfiguration.create({
+//       data: {
+//         id: randomUUID(),
+//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         filter: JSON.parse("[]"),
+//         jobType: "EVAL",
+//         delay: 0,
+//         sampling: new Decimal("1"),
+//         targetObject: "trace",
+//         scoreName: "score",
+//         variableMapping: JSON.parse("[]"),
+//         status: "INACTIVE",
+//       },
+//     });
 
-    const variableMapping = variableMappingList.parse([
-      {
-        langfuseObject: "generation",
-        selectedColumnId: "input",
-        templateVariable: "input",
-        objectName: "great-llm-name",
-      },
-      {
-        langfuseObject: "generation",
-        selectedColumnId: "output",
-        templateVariable: "output",
-        objectName: "great-llm-name",
-      },
-    ]);
+//     const payload = {
+//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       traceId: traceId,
+//     };
 
-    await expect(
-      extractVariables({
-        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        variables: ["input", "output"],
-        traceId: traceId,
-        variableMapping: variableMapping,
-      }),
-    ).rejects.toThrowError(
-      new LangfuseNotFoundError(
-        `Observation great-llm-name for trace ${traceId} not found. Please ensure the mapped data exists and consider extending the job delay.`,
-      ),
-    );
-  }, 10_000);
+//     await createTraceEvalJobs({ event: payload });
 
-  test("does not fail if observation data is null", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
+//     const jobs = await kyselyPrisma.$kysely
+//       .selectFrom("job_executions")
+//       .selectAll()
+//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+//       .execute();
 
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
+//     expect(jobs.length).toBe(0);
+//   }, 10_000);
 
-    // fetching input and output for an observation which has NULL values
-    await kyselyPrisma.$kysely
-      .insertInto("observations")
-      .values({
-        id: randomUUID(),
-        trace_id: traceId,
-        name: "great-llm-name",
-        type: sql`'GENERATION'::"ObservationType"`,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      })
-      .execute();
+//   test("does not create eval job for existing job execution", async () => {
+//     await pruneDatabase();
+//     const traceId = randomUUID();
 
-    const variableMapping = variableMappingList.parse([
-      {
-        langfuseObject: "generation",
-        selectedColumnId: "input",
-        templateVariable: "input",
-        objectName: "great-llm-name",
-      },
-      {
-        langfuseObject: "generation",
-        selectedColumnId: "output",
-        templateVariable: "output",
-        objectName: "great-llm-name",
-      },
-    ]);
+//     await kyselyPrisma.$kysely
+//       .insertInto("traces")
+//       .values({
+//         id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       })
+//       .execute();
 
-    const result = await extractVariables({
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      variables: ["input", "output"],
-      traceId: traceId,
-      variableMapping: variableMapping,
-    });
+//     await kyselyPrisma.$kysely
+//       .insertInto("llm_api_keys")
+//       .values({
+//         id: randomUUID(),
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         secret_key: encrypt(String(OPENAI_API_KEY)),
+//         provider: "openai",
+//         adapter: LLMAdapter.OpenAI,
+//         custom_models: [],
+//         display_secret_key: "123456",
+//       })
+//       .execute();
 
-    expect(result).toEqual([
-      {
-        value: "",
-        var: "input",
-      },
-      {
-        value: "",
-        var: "output",
-      },
-    ]);
-  }, 10_000);
+//     await prisma.jobConfiguration.create({
+//       data: {
+//         id: randomUUID(),
+//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         filter: JSON.parse("[]"),
+//         jobType: "EVAL",
+//         delay: 0,
+//         sampling: new Decimal("1"),
+//         targetObject: "trace",
+//         scoreName: "score",
+//         variableMapping: JSON.parse("[]"),
+//       },
+//     });
 
-  test("extracts variables from a youngest observation", async () => {
-    await pruneDatabase();
-    const traceId = randomUUID();
+//     const payload = {
+//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       traceId: traceId,
+//     };
 
-    await kyselyPrisma.$kysely
-      .insertInto("traces")
-      .values({
-        id: traceId,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        user_id: "a",
-        input: { input: "This is a great prompt" },
-        output: { output: "This is a great response" },
-      })
-      .execute();
+//     await createTraceEvalJobs({ event: payload });
+//     await createTraceEvalJobs({ event: payload }); // calling it twice to check it is only generated once
 
-    await kyselyPrisma.$kysely
-      .insertInto("observations")
-      .values({
-        id: randomUUID(),
-        trace_id: traceId,
-        name: "great-llm-name",
-        start_time: new Date("2022-01-01T00:00:00.000Z"),
-        type: sql`'GENERATION'::"ObservationType"`,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        input: { huhu: "This is a great prompt" },
-        output: { haha: "This is a great response" },
-      })
-      .execute();
-    await kyselyPrisma.$kysely
-      .insertInto("observations")
-      .values({
-        id: randomUUID(),
-        trace_id: traceId,
-        name: "great-llm-name",
-        start_time: new Date("2022-01-02T00:00:00.000Z"),
-        type: sql`'GENERATION'::"ObservationType"`,
-        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-        input: { huhu: "This is a great prompt again" },
-        output: { haha: "This is a great response again" },
-      })
-      .execute();
+//     const jobs = await kyselyPrisma.$kysely
+//       .selectFrom("job_executions")
+//       .selectAll()
+//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+//       .execute();
 
-    const variableMapping = variableMappingList.parse([
-      {
-        langfuseObject: "generation",
-        selectedColumnId: "input",
-        templateVariable: "input",
-        objectName: "great-llm-name",
-      },
-      {
-        langfuseObject: "generation",
-        selectedColumnId: "output",
-        templateVariable: "output",
-        objectName: "great-llm-name",
-      },
-    ]);
+//     expect(jobs.length).toBe(1);
+//     expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+//     expect(jobs[0].job_input_trace_id).toBe(traceId);
+//     expect(jobs[0].status.toString()).toBe("PENDING");
+//     expect(jobs[0].start_time).not.toBeNull();
+//     expect(jobs[0].end_time).to.be.null;
+//   }, 10_000);
 
-    const result = await extractVariables({
-      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      variables: ["input", "output"],
-      traceId: traceId,
-      variableMapping: variableMapping,
-    });
+//   test("does not create job for inactive config", async () => {
+//     await pruneDatabase();
+//     const traceId = randomUUID();
 
-    expect(result).toEqual([
-      {
-        value: '{"huhu":"This is a great prompt again"}',
-        var: "input",
-      },
-      {
-        value: '{"haha":"This is a great response again"}',
-        var: "output",
-      },
-    ]);
-  }, 10_000);
-});
+//     await kyselyPrisma.$kysely
+//       .insertInto("traces")
+//       .values({
+//         id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       })
+//       .execute();
+
+//     await prisma.jobConfiguration.create({
+//       data: {
+//         id: randomUUID(),
+//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         filter: JSON.parse("[]"),
+//         jobType: "EVAL",
+//         delay: 0,
+//         sampling: new Decimal("1"),
+//         targetObject: "trace",
+//         scoreName: "score",
+//         variableMapping: JSON.parse("[]"),
+//         status: "INACTIVE",
+//       },
+//     });
+
+//     const payload = {
+//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       traceId: traceId,
+//     };
+
+//     await createTraceEvalJobs({ event: payload });
+
+//     const jobs = await kyselyPrisma.$kysely
+//       .selectFrom("job_executions")
+//       .selectAll()
+//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+//       .execute();
+
+//     expect(jobs.length).toBe(0);
+//   }, 10_000);
+
+//   test("does not create eval job for 0 sample rate", async () => {
+//     await pruneDatabase();
+//     const traceId = randomUUID();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("traces")
+//       .values({
+//         id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       })
+//       .execute();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("llm_api_keys")
+//       .values({
+//         id: randomUUID(),
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         secret_key: encrypt(String(OPENAI_API_KEY)),
+//         provider: "openai",
+//         adapter: LLMAdapter.OpenAI,
+//         custom_models: [],
+//         display_secret_key: "123456",
+//       })
+//       .execute();
+
+//     await prisma.jobConfiguration.create({
+//       data: {
+//         id: randomUUID(),
+//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         filter: JSON.parse("[]"),
+//         jobType: "EVAL",
+//         delay: 0,
+//         sampling: new Decimal("0"),
+//         targetObject: "trace",
+//         scoreName: "score",
+//         variableMapping: JSON.parse("[]"),
+//       },
+//     });
+
+//     const payload = {
+//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       traceId: traceId,
+//     };
+
+//     await createTraceEvalJobs({ event: payload });
+
+//     const jobs = await kyselyPrisma.$kysely
+//       .selectFrom("job_executions")
+//       .selectAll()
+//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+//       .execute();
+
+//     expect(jobs.length).toBe(0);
+//   }, 10_000);
+
+//   test("cancels a job if the second event deselects", async () => {
+//     await pruneDatabase();
+//     const traceId = randomUUID();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("traces")
+//       .values({
+//         id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         user_id: "a",
+//       })
+//       .execute();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("llm_api_keys")
+//       .values({
+//         id: randomUUID(),
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         secret_key: encrypt(String(OPENAI_API_KEY)),
+//         provider: "openai",
+//         adapter: LLMAdapter.OpenAI,
+//         custom_models: [],
+//         display_secret_key: "123456",
+//       })
+//       .execute();
+
+//     const templateId = randomUUID();
+//     await kyselyPrisma.$kysely
+//       .insertInto("eval_templates")
+//       .values({
+//         id: templateId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         name: "test-template",
+//         version: 1,
+//         prompt: "Please evaluate toxicity {{input}} {{output}}",
+//         model: "gpt-3.5-turbo",
+//         provider: "openai",
+//         model_params: {},
+//         output_schema: {
+//           reasoning: "Please explain your reasoning",
+//           score: "Please provide a score between 0 and 1",
+//         },
+//       })
+//       .executeTakeFirst();
+
+//     await prisma.jobConfiguration.create({
+//       data: {
+//         id: randomUUID(),
+//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         filter: [
+//           {
+//             type: "string",
+//             value: "a",
+//             column: "User ID",
+//             operator: "contains",
+//           },
+//         ],
+//         jobType: "EVAL",
+//         delay: 0,
+//         sampling: new Decimal("1"),
+//         targetObject: "trace",
+//         scoreName: "score",
+//         variableMapping: JSON.parse("[]"),
+//         evalTemplateId: templateId,
+//       },
+//     });
+
+//     const payload = {
+//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       traceId: traceId,
+//     };
+
+//     await createTraceEvalJobs({ event: payload });
+
+//     // update the trace to deselect the trace
+//     await kyselyPrisma.$kysely
+//       .updateTable("traces")
+//       .set("user_id", "b")
+//       .where("id", "=", traceId)
+//       .execute();
+
+//     await createTraceEvalJobs({
+//       event: payload,
+//     }); // calling it twice to check it is only generated once
+
+//     const jobs = await kyselyPrisma.$kysely
+//       .selectFrom("job_executions")
+//       .selectAll()
+//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+//       .execute();
+
+//     expect(jobs.length).toBe(1);
+//     expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+//     expect(jobs[0].job_input_trace_id).toBe(traceId);
+//     expect(jobs[0].status.toString()).toBe("CANCELLED");
+//     expect(jobs[0].start_time).not.toBeNull();
+//     expect(jobs[0].end_time).not.toBeNull();
+//   }, 10_000);
+// });
+
+// describe("execute evals", () => {
+//   test("evals a valid 'trace' event", async () => {
+//     await pruneDatabase();
+//     openAIServer.respondWithDefault();
+//     const traceId = randomUUID();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("traces")
+//       .values({
+//         id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         user_id: "a",
+//         input: { input: "This is a great prompt" },
+//         output: { output: "This is a great response" },
+//       })
+//       .execute();
+
+//     const templateId = randomUUID();
+//     await kyselyPrisma.$kysely
+//       .insertInto("eval_templates")
+//       .values({
+//         id: templateId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         name: "test-template",
+//         version: 1,
+//         prompt: "Please evaluate toxicity {{input}} {{output}}",
+//         model: "gpt-3.5-turbo",
+//         provider: "openai",
+//         model_params: {},
+//         output_schema: {
+//           reasoning: "Please explain your reasoning",
+//           score: "Please provide a score between 0 and 1",
+//         },
+//       })
+//       .executeTakeFirst();
+
+//     const jobConfiguration = await prisma.jobConfiguration.create({
+//       data: {
+//         id: randomUUID(),
+//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         filter: [
+//           {
+//             type: "string",
+//             value: "a",
+//             column: "User ID",
+//             operator: "contains",
+//           },
+//         ],
+//         jobType: "EVAL",
+//         delay: 0,
+//         sampling: new Decimal("1"),
+//         targetObject: "trace",
+//         scoreName: "score",
+//         variableMapping: JSON.parse("[]"),
+//         evalTemplateId: templateId,
+//       },
+//     });
+
+//     const jobExecutionId = randomUUID();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("job_executions")
+//       .values({
+//         id: jobExecutionId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         job_configuration_id: jobConfiguration.id,
+//         status: sql`'PENDING'::"JobExecutionStatus"`,
+//         start_time: new Date(),
+//         job_input_trace_id: traceId,
+//       })
+//       .execute();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("llm_api_keys")
+//       .values({
+//         id: randomUUID(),
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         secret_key: encrypt(String(OPENAI_API_KEY)),
+//         provider: "openai",
+//         adapter: LLMAdapter.OpenAI,
+//         custom_models: [],
+//         display_secret_key: "123456",
+//       })
+//       .execute();
+
+//     const payload = {
+//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       jobExecutionId: jobExecutionId,
+//       delay: 1000,
+//     };
+
+//     await evaluate({ event: payload });
+
+//     const jobs = await kyselyPrisma.$kysely
+//       .selectFrom("job_executions")
+//       .selectAll()
+//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+//       .execute();
+
+//     expect(jobs.length).toBe(1);
+//     expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+//     expect(jobs[0].job_input_trace_id).toBe(traceId);
+//     expect(jobs[0].status.toString()).toBe("COMPLETED");
+//     expect(jobs[0].start_time).not.toBeNull();
+//     expect(jobs[0].end_time).not.toBeNull();
+
+//     const scores = await kyselyPrisma.$kysely
+//       .selectFrom("scores")
+//       .selectAll()
+//       .where("trace_id", "=", traceId)
+//       .execute();
+
+//     expect(scores.length).toBe(1);
+//     expect(scores[0].trace_id).toBe(traceId);
+//     expect(scores[0].comment).not.toBeNull();
+//     expect(scores[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+//   }, 10_000);
+
+//   test("fails to eval without llm api key", async () => {
+//     await pruneDatabase();
+//     const traceId = randomUUID();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("traces")
+//       .values({
+//         id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         user_id: "a",
+//         input: { input: "This is a great prompt" },
+//         output: { output: "This is a great response" },
+//       })
+//       .execute();
+
+//     const templateId = randomUUID();
+//     await kyselyPrisma.$kysely
+//       .insertInto("eval_templates")
+//       .values({
+//         id: templateId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         name: "test-template",
+//         version: 1,
+//         prompt: "Please evaluate toxicity {{input}} {{output}}",
+//         model: "gpt-3.5-turbo",
+//         provider: "openai",
+//         model_params: {},
+//         output_schema: {
+//           reasoning: "Please explain your reasoning",
+//           score: "Please provide a score between 0 and 1",
+//         },
+//       })
+//       .executeTakeFirst();
+
+//     const jobConfiguration = await prisma.jobConfiguration.create({
+//       data: {
+//         id: randomUUID(),
+//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         filter: [
+//           {
+//             type: "string",
+//             value: "a",
+//             column: "User ID",
+//             operator: "contains",
+//           },
+//         ],
+//         jobType: "EVAL",
+//         delay: 0,
+//         sampling: new Decimal("1"),
+//         targetObject: "trace",
+//         scoreName: "score",
+//         variableMapping: JSON.parse("[]"),
+//         evalTemplateId: templateId,
+//       },
+//     });
+
+//     const jobExecutionId = randomUUID();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("job_executions")
+//       .values({
+//         id: jobExecutionId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         job_configuration_id: jobConfiguration.id,
+//         status: sql`'PENDING'::"JobExecutionStatus"`,
+//         start_time: new Date(),
+//         job_input_trace_id: traceId,
+//       })
+//       .execute();
+
+//     const payload = {
+//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       jobExecutionId: jobExecutionId,
+//       delay: 1000,
+//     };
+
+//     await expect(evaluate({ event: payload })).rejects.toThrowError(
+//       new LangfuseNotFoundError(
+//         "API key for provider openai and project 7a88fb47-b4e2-43b8-a06c-a5ce950dc53a not found.",
+//       ),
+//     );
+
+//     const jobs = await kyselyPrisma.$kysely
+//       .selectFrom("job_executions")
+//       .selectAll()
+//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+//       .execute();
+
+//     expect(jobs.length).toBe(1);
+//     expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+//     expect(jobs[0].job_input_trace_id).toBe(traceId);
+//     // the job will be failed when the exception is caught in the worker consumer
+//     expect(jobs[0].status.toString()).toBe("PENDING");
+//   }, 10_000);
+
+//   test("evals should cancel if job is cancelled", async () => {
+//     await pruneDatabase();
+//     const traceId = randomUUID();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("traces")
+//       .values({
+//         id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         user_id: "a",
+//         input: { input: "This is a great prompt" },
+//         output: { output: "This is a great response" },
+//       })
+//       .execute();
+
+//     const templateId = randomUUID();
+//     await kyselyPrisma.$kysely
+//       .insertInto("eval_templates")
+//       .values({
+//         id: templateId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         name: "test-template",
+//         version: 1,
+//         prompt: "Please evaluate toxicity {{input}} {{output}}",
+//         model: "gpt-3.5-turbo",
+//         provider: "openai",
+//         model_params: {},
+//         output_schema: {
+//           reasoning: "Please explain your reasoning",
+//           score: "Please provide a score between 0 and 1",
+//         },
+//       })
+//       .executeTakeFirst();
+
+//     const jobConfiguration = await prisma.jobConfiguration.create({
+//       data: {
+//         id: randomUUID(),
+//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         filter: [
+//           {
+//             type: "string",
+//             value: "a",
+//             column: "User ID",
+//             operator: "contains",
+//           },
+//         ],
+//         jobType: "EVAL",
+//         delay: 0,
+//         sampling: new Decimal("1"),
+//         targetObject: "trace",
+//         scoreName: "score",
+//         variableMapping: JSON.parse("[]"),
+//         evalTemplateId: templateId,
+//       },
+//     });
+
+//     const jobExecutionId = randomUUID();
+//     await kyselyPrisma.$kysely
+//       .insertInto("job_executions")
+//       .values({
+//         id: jobExecutionId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         job_configuration_id: jobConfiguration.id,
+//         status: sql`'CANCELLED'::"JobExecutionStatus"`,
+//         start_time: new Date(),
+//         job_input_trace_id: traceId,
+//       })
+//       .execute();
+
+//     const payload = {
+//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       jobExecutionId: jobExecutionId,
+//       delay: 1000,
+//     };
+
+//     await evaluate({ event: payload });
+
+//     const jobs = await kyselyPrisma.$kysely
+//       .selectFrom("job_executions")
+//       .selectAll()
+//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+//       .execute();
+
+//     expect(jobs.length).toBe(0);
+//   }, 10_000);
+
+//   test("evals a valid 'trace' event and inserts score to ingestion pipeline", async () => {
+//     await pruneDatabase();
+//     openAIServer.respondWithDefault();
+//     const traceId = randomUUID();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("traces")
+//       .values({
+//         id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         user_id: "a",
+//         input: { input: "This is a great prompt" },
+//         output: { output: "This is a great response" },
+//       })
+//       .execute();
+
+//     const templateId = randomUUID();
+//     await kyselyPrisma.$kysely
+//       .insertInto("eval_templates")
+//       .values({
+//         id: templateId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         name: "test-template",
+//         version: 1,
+//         prompt: "Please evaluate toxicity {{input}} {{output}}",
+//         model: "gpt-3.5-turbo",
+//         provider: "openai",
+//         model_params: {},
+//         output_schema: {
+//           reasoning: "Please explain your reasoning",
+//           score: "Please provide a score between 0 and 1",
+//         },
+//       })
+//       .executeTakeFirst();
+
+//     const jobConfiguration = await prisma.jobConfiguration.create({
+//       data: {
+//         id: randomUUID(),
+//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         filter: [
+//           {
+//             type: "string",
+//             value: "a",
+//             column: "User ID",
+//             operator: "contains",
+//           },
+//         ],
+//         jobType: "EVAL",
+//         delay: 0,
+//         sampling: new Decimal("1"),
+//         targetObject: "trace",
+//         scoreName: "score",
+//         variableMapping: JSON.parse("[]"),
+//         evalTemplateId: templateId,
+//       },
+//     });
+
+//     const jobExecutionId = randomUUID();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("job_executions")
+//       .values({
+//         id: jobExecutionId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         job_configuration_id: jobConfiguration.id,
+//         status: sql`'PENDING'::"JobExecutionStatus"`,
+//         start_time: new Date(),
+//         job_input_trace_id: traceId,
+//       })
+//       .execute();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("llm_api_keys")
+//       .values({
+//         id: randomUUID(),
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         secret_key: encrypt(String(OPENAI_API_KEY)),
+//         provider: "openai",
+//         adapter: LLMAdapter.OpenAI,
+//         custom_models: [],
+//         display_secret_key: "123456",
+//       })
+//       .execute();
+
+//     const payload = {
+//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       jobExecutionId: jobExecutionId,
+//       delay: 1000,
+//     };
+
+//     await evaluate({ event: payload });
+
+//     const jobs = await kyselyPrisma.$kysely
+//       .selectFrom("job_executions")
+//       .selectAll()
+//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+//       .execute();
+
+//     expect(jobs.length).toBe(1);
+//     expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+//     expect(jobs[0].job_input_trace_id).toBe(traceId);
+//     expect(jobs[0].status.toString()).toBe("COMPLETED");
+//     expect(jobs[0].start_time).not.toBeNull();
+//     expect(jobs[0].end_time).not.toBeNull();
+
+//     const scores = await kyselyPrisma.$kysely
+//       .selectFrom("scores")
+//       .selectAll()
+//       .where("trace_id", "=", traceId)
+//       .execute();
+
+//     expect(scores.length).toBe(1);
+//     expect(scores[0].trace_id).toBe(traceId);
+//     expect(scores[0].comment).not.toBeNull();
+//     expect(scores[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+
+//     await new Promise<void>((resolve, reject) => {
+//       new Worker(
+//         QueueName.IngestionQueue,
+//         async (job: Job) => {
+//           try {
+//             expect(job.name).toBe("ingestion-job");
+//             expect(job.data.payload.data.type).toBe("score-create");
+//             resolve();
+//           } catch (e) {
+//             reject(e);
+//           }
+//         },
+//         {
+//           connection: redis as ConnectionOptions,
+//         },
+//       );
+//     });
+//   }, 10_000);
+// });
+
+// describe("test variable extraction", () => {
+//   test("extracts variables from a dataset item", async () => {
+//     await pruneDatabase();
+//     const datasetId = randomUUID();
+//     const datasetItemId = randomUUID();
+//     const traceId = randomUUID();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("traces")
+//       .values({
+//         id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         user_id: "a",
+//         input: { input: "This is a great prompt" },
+//         output: { output: "This is a great response" },
+//       })
+//       .execute();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("datasets")
+//       .values({
+//         id: datasetId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         name: "test-dataset",
+//       })
+//       .execute();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("dataset_items")
+//       .values({
+//         id: datasetItemId,
+//         input: { input: "This is a great prompt" },
+//         expected_output: { expected_output: "This is a great response" },
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         dataset_id: datasetId,
+//       })
+//       .execute();
+
+//     const variableMapping = variableMappingList.parse([
+//       {
+//         langfuseObject: "dataset_item",
+//         selectedColumnId: "input",
+//         templateVariable: "input",
+//       },
+//       {
+//         langfuseObject: "dataset_item",
+//         selectedColumnId: "expected_output",
+//         templateVariable: "output",
+//       },
+//     ]);
+
+//     const result = await extractVariablesFromTracingData({
+//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       variables: ["input", "output"],
+//       traceId: traceId,
+//       datasetItemId: datasetItemId,
+//       variableMapping: variableMapping,
+//     });
+
+//     expect(result).toEqual([
+//       {
+//         value: '{"input":"This is a great prompt"}',
+//         var: "input",
+//       },
+//       {
+//         value: '{"expected_output":"This is a great response"}',
+//         var: "output",
+//       },
+//     ]);
+//   }, 10_000);
+
+//   test("extracts variables from a trace", async () => {
+//     await pruneDatabase();
+//     const traceId = randomUUID();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("traces")
+//       .values({
+//         id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         user_id: "a",
+//         input: { input: "This is a great prompt" },
+//         output: { output: "This is a great response" },
+//       })
+//       .execute();
+
+//     const variableMapping = variableMappingList.parse([
+//       {
+//         langfuseObject: "trace",
+//         selectedColumnId: "input",
+//         templateVariable: "input",
+//       },
+//       {
+//         langfuseObject: "trace",
+//         selectedColumnId: "output",
+//         templateVariable: "output",
+//       },
+//     ]);
+
+//     const result = await extractVariablesFromTracingData({
+//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       variables: ["input", "output"],
+//       traceId: traceId,
+//       variableMapping: variableMapping,
+//     });
+
+//     expect(result).toEqual([
+//       {
+//         value: '{"input":"This is a great prompt"}',
+//         var: "input",
+//       },
+//       {
+//         value: '{"output":"This is a great response"}',
+//         var: "output",
+//       },
+//     ]);
+//   }, 10_000);
+
+//   test("extracts variables from a observation", async () => {
+//     await pruneDatabase();
+//     const traceId = randomUUID();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("traces")
+//       .values({
+//         id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         user_id: "a",
+//         input: { input: "This is a great prompt" },
+//         output: { output: "This is a great response" },
+//       })
+//       .execute();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("observations")
+//       .values({
+//         id: randomUUID(),
+//         trace_id: traceId,
+//         name: "great-llm-name",
+//         type: sql`'GENERATION'::"ObservationType"`,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         input: { huhu: "This is a great prompt" },
+//         output: { haha: "This is a great response" },
+//       })
+//       .execute();
+
+//     const variableMapping = variableMappingList.parse([
+//       {
+//         langfuseObject: "generation",
+//         selectedColumnId: "input",
+//         templateVariable: "input",
+//         objectName: "great-llm-name",
+//       },
+//       {
+//         langfuseObject: "generation",
+//         selectedColumnId: "output",
+//         templateVariable: "output",
+//         objectName: "great-llm-name",
+//       },
+//     ]);
+
+//     const result = await extractVariablesFromTracingData({
+//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       variables: ["input", "output"],
+//       traceId: traceId,
+//       variableMapping: variableMapping,
+//     });
+
+//     expect(result).toEqual([
+//       {
+//         value: '{"huhu":"This is a great prompt"}',
+//         var: "input",
+//       },
+//       {
+//         value: '{"haha":"This is a great response"}',
+//         var: "output",
+//       },
+//     ]);
+//   }, 10_000);
+
+//   test("fails if observation is not present", async () => {
+//     await pruneDatabase();
+//     const traceId = randomUUID();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("traces")
+//       .values({
+//         id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         user_id: "a",
+//         input: { input: "This is a great prompt" },
+//         output: { output: "This is a great response" },
+//       })
+//       .execute();
+
+//     const variableMapping = variableMappingList.parse([
+//       {
+//         langfuseObject: "generation",
+//         selectedColumnId: "input",
+//         templateVariable: "input",
+//         objectName: "great-llm-name",
+//       },
+//       {
+//         langfuseObject: "generation",
+//         selectedColumnId: "output",
+//         templateVariable: "output",
+//         objectName: "great-llm-name",
+//       },
+//     ]);
+
+//     await expect(
+//       extractVariablesFromTracingData({
+//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         variables: ["input", "output"],
+//         traceId: traceId,
+//         variableMapping: variableMapping,
+//       }),
+//     ).rejects.toThrowError(
+//       new LangfuseNotFoundError(
+//         `Observation great-llm-name for trace ${traceId} not found. Please ensure the mapped data exists and consider extending the job delay.`,
+//       ),
+//     );
+//   }, 10_000);
+
+//   test("does not fail if observation data is null", async () => {
+//     await pruneDatabase();
+//     const traceId = randomUUID();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("traces")
+//       .values({
+//         id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         user_id: "a",
+//         input: { input: "This is a great prompt" },
+//         output: { output: "This is a great response" },
+//       })
+//       .execute();
+
+//     // fetching input and output for an observation which has NULL values
+//     await kyselyPrisma.$kysely
+//       .insertInto("observations")
+//       .values({
+//         id: randomUUID(),
+//         trace_id: traceId,
+//         name: "great-llm-name",
+//         type: sql`'GENERATION'::"ObservationType"`,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       })
+//       .execute();
+
+//     const variableMapping = variableMappingList.parse([
+//       {
+//         langfuseObject: "generation",
+//         selectedColumnId: "input",
+//         templateVariable: "input",
+//         objectName: "great-llm-name",
+//       },
+//       {
+//         langfuseObject: "generation",
+//         selectedColumnId: "output",
+//         templateVariable: "output",
+//         objectName: "great-llm-name",
+//       },
+//     ]);
+
+//     const result = await extractVariablesFromTracingData({
+//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       variables: ["input", "output"],
+//       traceId: traceId,
+//       variableMapping: variableMapping,
+//     });
+
+//     expect(result).toEqual([
+//       {
+//         value: "",
+//         var: "input",
+//       },
+//       {
+//         value: "",
+//         var: "output",
+//       },
+//     ]);
+//   }, 10_000);
+
+//   test("extracts variables from a youngest observation", async () => {
+//     await pruneDatabase();
+//     const traceId = randomUUID();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("traces")
+//       .values({
+//         id: traceId,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         user_id: "a",
+//         input: { input: "This is a great prompt" },
+//         output: { output: "This is a great response" },
+//       })
+//       .execute();
+
+//     await kyselyPrisma.$kysely
+//       .insertInto("observations")
+//       .values({
+//         id: randomUUID(),
+//         trace_id: traceId,
+//         name: "great-llm-name",
+//         start_time: new Date("2022-01-01T00:00:00.000Z"),
+//         type: sql`'GENERATION'::"ObservationType"`,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         input: { huhu: "This is a great prompt" },
+//         output: { haha: "This is a great response" },
+//       })
+//       .execute();
+//     await kyselyPrisma.$kysely
+//       .insertInto("observations")
+//       .values({
+//         id: randomUUID(),
+//         trace_id: traceId,
+//         name: "great-llm-name",
+//         start_time: new Date("2022-01-02T00:00:00.000Z"),
+//         type: sql`'GENERATION'::"ObservationType"`,
+//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//         input: { huhu: "This is a great prompt again" },
+//         output: { haha: "This is a great response again" },
+//       })
+//       .execute();
+
+//     const variableMapping = variableMappingList.parse([
+//       {
+//         langfuseObject: "generation",
+//         selectedColumnId: "input",
+//         templateVariable: "input",
+//         objectName: "great-llm-name",
+//       },
+//       {
+//         langfuseObject: "generation",
+//         selectedColumnId: "output",
+//         templateVariable: "output",
+//         objectName: "great-llm-name",
+//       },
+//     ]);
+
+//     const result = await extractVariablesFromTracingData({
+//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+//       variables: ["input", "output"],
+//       traceId: traceId,
+//       variableMapping: variableMapping,
+//     });
+
+//     expect(result).toEqual([
+//       {
+//         value: '{"huhu":"This is a great prompt again"}',
+//         var: "input",
+//       },
+//       {
+//         value: '{"haha":"This is a great response again"}',
+//         var: "output",
+//       },
+//     ]);
+//   }, 10_000);
+// });

--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -61,1229 +61,1229 @@ describe("compile prompt", () => {
   });
 });
 
-// describe("create eval jobs", () => {
-//   test("creates new 'trace' eval job", async () => {
-//     await pruneDatabase();
-//     const traceId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("traces")
-//       .values({
-//         id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       })
-//       .execute();
-
-//     await prisma.jobConfiguration.create({
-//       data: {
-//         id: randomUUID(),
-//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         filter: JSON.parse("[]"),
-//         jobType: "EVAL",
-//         delay: 0,
-//         sampling: new Decimal("1"),
-//         targetObject: "trace",
-//         scoreName: "score",
-//         variableMapping: JSON.parse("[]"),
-//       },
-//     });
-
-//     const payload = {
-//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       traceId: traceId,
-//     };
-
-//     await createTraceEvalJobs({ event: payload });
-
-//     const jobs = await kyselyPrisma.$kysely
-//       .selectFrom("job_executions")
-//       .selectAll()
-//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-//       .execute();
-
-//     expect(jobs.length).toBe(1);
-//     expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-//     expect(jobs[0].job_input_trace_id).toBe(traceId);
-//     expect(jobs[0].status.toString()).toBe("PENDING");
-//     expect(jobs[0].start_time).not.toBeNull();
-//   }, 10_000);
-
-//   test("creates new 'dataset' eval job", async () => {
-//     await pruneDatabase();
-//     const traceId = randomUUID();
-//     const observationId = randomUUID();
-//     const datasetId = randomUUID();
-//     const datasetItemId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("traces")
-//       .values({
-//         id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       })
-//       .execute();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("observations")
-//       .values({
-//         id: observationId,
-//         trace_id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         type: sql`'GENERATION'::"ObservationType"`,
-//       })
-//       .execute();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("datasets")
-//       .values({
-//         id: datasetId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         name: "test-dataset",
-//       })
-//       .execute();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("dataset_items")
-//       .values({
-//         id: datasetItemId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         dataset_id: datasetId,
-//       })
-//       .execute();
-
-//     await prisma.jobConfiguration.create({
-//       data: {
-//         id: randomUUID(),
-//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         filter: JSON.parse("[]"),
-//         jobType: "EVAL",
-//         delay: 0,
-//         sampling: new Decimal("1"),
-//         targetObject: "dataset",
-//         scoreName: "score",
-//         variableMapping: JSON.parse("[]"),
-//       },
-//     });
-
-//     const payload = {
-//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       traceId: traceId,
-//       datasetItemId: datasetItemId,
-//       observationId: observationId,
-//     };
-
-//     await createDatasetEvalJobs({ event: payload });
-
-//     const jobs = await kyselyPrisma.$kysely
-//       .selectFrom("job_executions")
-//       .selectAll()
-//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-//       .execute();
-
-//     expect(jobs.length).toBe(1);
-//     expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-//     expect(jobs[0].job_input_trace_id).toBe(traceId);
-//     expect(jobs[0].job_input_observation_id).toBe(observationId);
-//     expect(jobs[0].job_input_dataset_item_id).toBe(datasetItemId);
-//     expect(jobs[0].status.toString()).toBe("PENDING");
-//     expect(jobs[0].start_time).not.toBeNull();
-//   }, 10_000);
-
-//   test("does not create job for inactive config", async () => {
-//     await pruneDatabase();
-//     const traceId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("traces")
-//       .values({
-//         id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       })
-//       .execute();
-
-//     await prisma.jobConfiguration.create({
-//       data: {
-//         id: randomUUID(),
-//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         filter: JSON.parse("[]"),
-//         jobType: "EVAL",
-//         delay: 0,
-//         sampling: new Decimal("1"),
-//         targetObject: "trace",
-//         scoreName: "score",
-//         variableMapping: JSON.parse("[]"),
-//         status: "INACTIVE",
-//       },
-//     });
-
-//     const payload = {
-//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       traceId: traceId,
-//     };
-
-//     await createTraceEvalJobs({ event: payload });
-
-//     const jobs = await kyselyPrisma.$kysely
-//       .selectFrom("job_executions")
-//       .selectAll()
-//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-//       .execute();
-
-//     expect(jobs.length).toBe(0);
-//   }, 10_000);
-
-//   test("does not create eval job for existing job execution", async () => {
-//     await pruneDatabase();
-//     const traceId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("traces")
-//       .values({
-//         id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       })
-//       .execute();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("llm_api_keys")
-//       .values({
-//         id: randomUUID(),
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         secret_key: encrypt(String(OPENAI_API_KEY)),
-//         provider: "openai",
-//         adapter: LLMAdapter.OpenAI,
-//         custom_models: [],
-//         display_secret_key: "123456",
-//       })
-//       .execute();
-
-//     await prisma.jobConfiguration.create({
-//       data: {
-//         id: randomUUID(),
-//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         filter: JSON.parse("[]"),
-//         jobType: "EVAL",
-//         delay: 0,
-//         sampling: new Decimal("1"),
-//         targetObject: "trace",
-//         scoreName: "score",
-//         variableMapping: JSON.parse("[]"),
-//       },
-//     });
-
-//     const payload = {
-//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       traceId: traceId,
-//     };
-
-//     await createTraceEvalJobs({ event: payload });
-//     await createTraceEvalJobs({ event: payload }); // calling it twice to check it is only generated once
-
-//     const jobs = await kyselyPrisma.$kysely
-//       .selectFrom("job_executions")
-//       .selectAll()
-//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-//       .execute();
-
-//     expect(jobs.length).toBe(1);
-//     expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-//     expect(jobs[0].job_input_trace_id).toBe(traceId);
-//     expect(jobs[0].status.toString()).toBe("PENDING");
-//     expect(jobs[0].start_time).not.toBeNull();
-//     expect(jobs[0].end_time).to.be.null;
-//   }, 10_000);
-
-//   test("does not create job for inactive config", async () => {
-//     await pruneDatabase();
-//     const traceId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("traces")
-//       .values({
-//         id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       })
-//       .execute();
-
-//     await prisma.jobConfiguration.create({
-//       data: {
-//         id: randomUUID(),
-//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         filter: JSON.parse("[]"),
-//         jobType: "EVAL",
-//         delay: 0,
-//         sampling: new Decimal("1"),
-//         targetObject: "trace",
-//         scoreName: "score",
-//         variableMapping: JSON.parse("[]"),
-//         status: "INACTIVE",
-//       },
-//     });
-
-//     const payload = {
-//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       traceId: traceId,
-//     };
-
-//     await createTraceEvalJobs({ event: payload });
-
-//     const jobs = await kyselyPrisma.$kysely
-//       .selectFrom("job_executions")
-//       .selectAll()
-//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-//       .execute();
-
-//     expect(jobs.length).toBe(0);
-//   }, 10_000);
-
-//   test("does not create eval job for 0 sample rate", async () => {
-//     await pruneDatabase();
-//     const traceId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("traces")
-//       .values({
-//         id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       })
-//       .execute();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("llm_api_keys")
-//       .values({
-//         id: randomUUID(),
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         secret_key: encrypt(String(OPENAI_API_KEY)),
-//         provider: "openai",
-//         adapter: LLMAdapter.OpenAI,
-//         custom_models: [],
-//         display_secret_key: "123456",
-//       })
-//       .execute();
-
-//     await prisma.jobConfiguration.create({
-//       data: {
-//         id: randomUUID(),
-//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         filter: JSON.parse("[]"),
-//         jobType: "EVAL",
-//         delay: 0,
-//         sampling: new Decimal("0"),
-//         targetObject: "trace",
-//         scoreName: "score",
-//         variableMapping: JSON.parse("[]"),
-//       },
-//     });
-
-//     const payload = {
-//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       traceId: traceId,
-//     };
-
-//     await createTraceEvalJobs({ event: payload });
-
-//     const jobs = await kyselyPrisma.$kysely
-//       .selectFrom("job_executions")
-//       .selectAll()
-//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-//       .execute();
-
-//     expect(jobs.length).toBe(0);
-//   }, 10_000);
-
-//   test("cancels a job if the second event deselects", async () => {
-//     await pruneDatabase();
-//     const traceId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("traces")
-//       .values({
-//         id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         user_id: "a",
-//       })
-//       .execute();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("llm_api_keys")
-//       .values({
-//         id: randomUUID(),
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         secret_key: encrypt(String(OPENAI_API_KEY)),
-//         provider: "openai",
-//         adapter: LLMAdapter.OpenAI,
-//         custom_models: [],
-//         display_secret_key: "123456",
-//       })
-//       .execute();
-
-//     const templateId = randomUUID();
-//     await kyselyPrisma.$kysely
-//       .insertInto("eval_templates")
-//       .values({
-//         id: templateId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         name: "test-template",
-//         version: 1,
-//         prompt: "Please evaluate toxicity {{input}} {{output}}",
-//         model: "gpt-3.5-turbo",
-//         provider: "openai",
-//         model_params: {},
-//         output_schema: {
-//           reasoning: "Please explain your reasoning",
-//           score: "Please provide a score between 0 and 1",
-//         },
-//       })
-//       .executeTakeFirst();
-
-//     await prisma.jobConfiguration.create({
-//       data: {
-//         id: randomUUID(),
-//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         filter: [
-//           {
-//             type: "string",
-//             value: "a",
-//             column: "User ID",
-//             operator: "contains",
-//           },
-//         ],
-//         jobType: "EVAL",
-//         delay: 0,
-//         sampling: new Decimal("1"),
-//         targetObject: "trace",
-//         scoreName: "score",
-//         variableMapping: JSON.parse("[]"),
-//         evalTemplateId: templateId,
-//       },
-//     });
-
-//     const payload = {
-//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       traceId: traceId,
-//     };
-
-//     await createTraceEvalJobs({ event: payload });
-
-//     // update the trace to deselect the trace
-//     await kyselyPrisma.$kysely
-//       .updateTable("traces")
-//       .set("user_id", "b")
-//       .where("id", "=", traceId)
-//       .execute();
-
-//     await createTraceEvalJobs({
-//       event: payload,
-//     }); // calling it twice to check it is only generated once
-
-//     const jobs = await kyselyPrisma.$kysely
-//       .selectFrom("job_executions")
-//       .selectAll()
-//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-//       .execute();
-
-//     expect(jobs.length).toBe(1);
-//     expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-//     expect(jobs[0].job_input_trace_id).toBe(traceId);
-//     expect(jobs[0].status.toString()).toBe("CANCELLED");
-//     expect(jobs[0].start_time).not.toBeNull();
-//     expect(jobs[0].end_time).not.toBeNull();
-//   }, 10_000);
-// });
-
-// describe("execute evals", () => {
-//   test("evals a valid 'trace' event", async () => {
-//     await pruneDatabase();
-//     openAIServer.respondWithDefault();
-//     const traceId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("traces")
-//       .values({
-//         id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         user_id: "a",
-//         input: { input: "This is a great prompt" },
-//         output: { output: "This is a great response" },
-//       })
-//       .execute();
-
-//     const templateId = randomUUID();
-//     await kyselyPrisma.$kysely
-//       .insertInto("eval_templates")
-//       .values({
-//         id: templateId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         name: "test-template",
-//         version: 1,
-//         prompt: "Please evaluate toxicity {{input}} {{output}}",
-//         model: "gpt-3.5-turbo",
-//         provider: "openai",
-//         model_params: {},
-//         output_schema: {
-//           reasoning: "Please explain your reasoning",
-//           score: "Please provide a score between 0 and 1",
-//         },
-//       })
-//       .executeTakeFirst();
-
-//     const jobConfiguration = await prisma.jobConfiguration.create({
-//       data: {
-//         id: randomUUID(),
-//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         filter: [
-//           {
-//             type: "string",
-//             value: "a",
-//             column: "User ID",
-//             operator: "contains",
-//           },
-//         ],
-//         jobType: "EVAL",
-//         delay: 0,
-//         sampling: new Decimal("1"),
-//         targetObject: "trace",
-//         scoreName: "score",
-//         variableMapping: JSON.parse("[]"),
-//         evalTemplateId: templateId,
-//       },
-//     });
-
-//     const jobExecutionId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("job_executions")
-//       .values({
-//         id: jobExecutionId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         job_configuration_id: jobConfiguration.id,
-//         status: sql`'PENDING'::"JobExecutionStatus"`,
-//         start_time: new Date(),
-//         job_input_trace_id: traceId,
-//       })
-//       .execute();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("llm_api_keys")
-//       .values({
-//         id: randomUUID(),
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         secret_key: encrypt(String(OPENAI_API_KEY)),
-//         provider: "openai",
-//         adapter: LLMAdapter.OpenAI,
-//         custom_models: [],
-//         display_secret_key: "123456",
-//       })
-//       .execute();
-
-//     const payload = {
-//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       jobExecutionId: jobExecutionId,
-//       delay: 1000,
-//     };
-
-//     await evaluate({ event: payload });
-
-//     const jobs = await kyselyPrisma.$kysely
-//       .selectFrom("job_executions")
-//       .selectAll()
-//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-//       .execute();
-
-//     expect(jobs.length).toBe(1);
-//     expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-//     expect(jobs[0].job_input_trace_id).toBe(traceId);
-//     expect(jobs[0].status.toString()).toBe("COMPLETED");
-//     expect(jobs[0].start_time).not.toBeNull();
-//     expect(jobs[0].end_time).not.toBeNull();
-
-//     const scores = await kyselyPrisma.$kysely
-//       .selectFrom("scores")
-//       .selectAll()
-//       .where("trace_id", "=", traceId)
-//       .execute();
-
-//     expect(scores.length).toBe(1);
-//     expect(scores[0].trace_id).toBe(traceId);
-//     expect(scores[0].comment).not.toBeNull();
-//     expect(scores[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-//   }, 10_000);
-
-//   test("fails to eval without llm api key", async () => {
-//     await pruneDatabase();
-//     const traceId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("traces")
-//       .values({
-//         id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         user_id: "a",
-//         input: { input: "This is a great prompt" },
-//         output: { output: "This is a great response" },
-//       })
-//       .execute();
-
-//     const templateId = randomUUID();
-//     await kyselyPrisma.$kysely
-//       .insertInto("eval_templates")
-//       .values({
-//         id: templateId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         name: "test-template",
-//         version: 1,
-//         prompt: "Please evaluate toxicity {{input}} {{output}}",
-//         model: "gpt-3.5-turbo",
-//         provider: "openai",
-//         model_params: {},
-//         output_schema: {
-//           reasoning: "Please explain your reasoning",
-//           score: "Please provide a score between 0 and 1",
-//         },
-//       })
-//       .executeTakeFirst();
-
-//     const jobConfiguration = await prisma.jobConfiguration.create({
-//       data: {
-//         id: randomUUID(),
-//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         filter: [
-//           {
-//             type: "string",
-//             value: "a",
-//             column: "User ID",
-//             operator: "contains",
-//           },
-//         ],
-//         jobType: "EVAL",
-//         delay: 0,
-//         sampling: new Decimal("1"),
-//         targetObject: "trace",
-//         scoreName: "score",
-//         variableMapping: JSON.parse("[]"),
-//         evalTemplateId: templateId,
-//       },
-//     });
-
-//     const jobExecutionId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("job_executions")
-//       .values({
-//         id: jobExecutionId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         job_configuration_id: jobConfiguration.id,
-//         status: sql`'PENDING'::"JobExecutionStatus"`,
-//         start_time: new Date(),
-//         job_input_trace_id: traceId,
-//       })
-//       .execute();
-
-//     const payload = {
-//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       jobExecutionId: jobExecutionId,
-//       delay: 1000,
-//     };
-
-//     await expect(evaluate({ event: payload })).rejects.toThrowError(
-//       new LangfuseNotFoundError(
-//         "API key for provider openai and project 7a88fb47-b4e2-43b8-a06c-a5ce950dc53a not found.",
-//       ),
-//     );
-
-//     const jobs = await kyselyPrisma.$kysely
-//       .selectFrom("job_executions")
-//       .selectAll()
-//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-//       .execute();
-
-//     expect(jobs.length).toBe(1);
-//     expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-//     expect(jobs[0].job_input_trace_id).toBe(traceId);
-//     // the job will be failed when the exception is caught in the worker consumer
-//     expect(jobs[0].status.toString()).toBe("PENDING");
-//   }, 10_000);
-
-//   test("evals should cancel if job is cancelled", async () => {
-//     await pruneDatabase();
-//     const traceId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("traces")
-//       .values({
-//         id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         user_id: "a",
-//         input: { input: "This is a great prompt" },
-//         output: { output: "This is a great response" },
-//       })
-//       .execute();
-
-//     const templateId = randomUUID();
-//     await kyselyPrisma.$kysely
-//       .insertInto("eval_templates")
-//       .values({
-//         id: templateId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         name: "test-template",
-//         version: 1,
-//         prompt: "Please evaluate toxicity {{input}} {{output}}",
-//         model: "gpt-3.5-turbo",
-//         provider: "openai",
-//         model_params: {},
-//         output_schema: {
-//           reasoning: "Please explain your reasoning",
-//           score: "Please provide a score between 0 and 1",
-//         },
-//       })
-//       .executeTakeFirst();
-
-//     const jobConfiguration = await prisma.jobConfiguration.create({
-//       data: {
-//         id: randomUUID(),
-//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         filter: [
-//           {
-//             type: "string",
-//             value: "a",
-//             column: "User ID",
-//             operator: "contains",
-//           },
-//         ],
-//         jobType: "EVAL",
-//         delay: 0,
-//         sampling: new Decimal("1"),
-//         targetObject: "trace",
-//         scoreName: "score",
-//         variableMapping: JSON.parse("[]"),
-//         evalTemplateId: templateId,
-//       },
-//     });
-
-//     const jobExecutionId = randomUUID();
-//     await kyselyPrisma.$kysely
-//       .insertInto("job_executions")
-//       .values({
-//         id: jobExecutionId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         job_configuration_id: jobConfiguration.id,
-//         status: sql`'CANCELLED'::"JobExecutionStatus"`,
-//         start_time: new Date(),
-//         job_input_trace_id: traceId,
-//       })
-//       .execute();
-
-//     const payload = {
-//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       jobExecutionId: jobExecutionId,
-//       delay: 1000,
-//     };
-
-//     await evaluate({ event: payload });
-
-//     const jobs = await kyselyPrisma.$kysely
-//       .selectFrom("job_executions")
-//       .selectAll()
-//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-//       .execute();
-
-//     expect(jobs.length).toBe(0);
-//   }, 10_000);
-
-//   test("evals a valid 'trace' event and inserts score to ingestion pipeline", async () => {
-//     await pruneDatabase();
-//     openAIServer.respondWithDefault();
-//     const traceId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("traces")
-//       .values({
-//         id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         user_id: "a",
-//         input: { input: "This is a great prompt" },
-//         output: { output: "This is a great response" },
-//       })
-//       .execute();
-
-//     const templateId = randomUUID();
-//     await kyselyPrisma.$kysely
-//       .insertInto("eval_templates")
-//       .values({
-//         id: templateId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         name: "test-template",
-//         version: 1,
-//         prompt: "Please evaluate toxicity {{input}} {{output}}",
-//         model: "gpt-3.5-turbo",
-//         provider: "openai",
-//         model_params: {},
-//         output_schema: {
-//           reasoning: "Please explain your reasoning",
-//           score: "Please provide a score between 0 and 1",
-//         },
-//       })
-//       .executeTakeFirst();
-
-//     const jobConfiguration = await prisma.jobConfiguration.create({
-//       data: {
-//         id: randomUUID(),
-//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         filter: [
-//           {
-//             type: "string",
-//             value: "a",
-//             column: "User ID",
-//             operator: "contains",
-//           },
-//         ],
-//         jobType: "EVAL",
-//         delay: 0,
-//         sampling: new Decimal("1"),
-//         targetObject: "trace",
-//         scoreName: "score",
-//         variableMapping: JSON.parse("[]"),
-//         evalTemplateId: templateId,
-//       },
-//     });
-
-//     const jobExecutionId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("job_executions")
-//       .values({
-//         id: jobExecutionId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         job_configuration_id: jobConfiguration.id,
-//         status: sql`'PENDING'::"JobExecutionStatus"`,
-//         start_time: new Date(),
-//         job_input_trace_id: traceId,
-//       })
-//       .execute();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("llm_api_keys")
-//       .values({
-//         id: randomUUID(),
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         secret_key: encrypt(String(OPENAI_API_KEY)),
-//         provider: "openai",
-//         adapter: LLMAdapter.OpenAI,
-//         custom_models: [],
-//         display_secret_key: "123456",
-//       })
-//       .execute();
-
-//     const payload = {
-//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       jobExecutionId: jobExecutionId,
-//       delay: 1000,
-//     };
-
-//     await evaluate({ event: payload });
-
-//     const jobs = await kyselyPrisma.$kysely
-//       .selectFrom("job_executions")
-//       .selectAll()
-//       .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
-//       .execute();
-
-//     expect(jobs.length).toBe(1);
-//     expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-//     expect(jobs[0].job_input_trace_id).toBe(traceId);
-//     expect(jobs[0].status.toString()).toBe("COMPLETED");
-//     expect(jobs[0].start_time).not.toBeNull();
-//     expect(jobs[0].end_time).not.toBeNull();
-
-//     const scores = await kyselyPrisma.$kysely
-//       .selectFrom("scores")
-//       .selectAll()
-//       .where("trace_id", "=", traceId)
-//       .execute();
-
-//     expect(scores.length).toBe(1);
-//     expect(scores[0].trace_id).toBe(traceId);
-//     expect(scores[0].comment).not.toBeNull();
-//     expect(scores[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-
-//     await new Promise<void>((resolve, reject) => {
-//       new Worker(
-//         QueueName.IngestionQueue,
-//         async (job: Job) => {
-//           try {
-//             expect(job.name).toBe("ingestion-job");
-//             expect(job.data.payload.data.type).toBe("score-create");
-//             resolve();
-//           } catch (e) {
-//             reject(e);
-//           }
-//         },
-//         {
-//           connection: redis as ConnectionOptions,
-//         },
-//       );
-//     });
-//   }, 10_000);
-// });
-
-// describe("test variable extraction", () => {
-//   test("extracts variables from a dataset item", async () => {
-//     await pruneDatabase();
-//     const datasetId = randomUUID();
-//     const datasetItemId = randomUUID();
-//     const traceId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("traces")
-//       .values({
-//         id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         user_id: "a",
-//         input: { input: "This is a great prompt" },
-//         output: { output: "This is a great response" },
-//       })
-//       .execute();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("datasets")
-//       .values({
-//         id: datasetId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         name: "test-dataset",
-//       })
-//       .execute();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("dataset_items")
-//       .values({
-//         id: datasetItemId,
-//         input: { input: "This is a great prompt" },
-//         expected_output: { expected_output: "This is a great response" },
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         dataset_id: datasetId,
-//       })
-//       .execute();
-
-//     const variableMapping = variableMappingList.parse([
-//       {
-//         langfuseObject: "dataset_item",
-//         selectedColumnId: "input",
-//         templateVariable: "input",
-//       },
-//       {
-//         langfuseObject: "dataset_item",
-//         selectedColumnId: "expected_output",
-//         templateVariable: "output",
-//       },
-//     ]);
-
-//     const result = await extractVariablesFromTracingData({
-//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       variables: ["input", "output"],
-//       traceId: traceId,
-//       datasetItemId: datasetItemId,
-//       variableMapping: variableMapping,
-//     });
-
-//     expect(result).toEqual([
-//       {
-//         value: '{"input":"This is a great prompt"}',
-//         var: "input",
-//       },
-//       {
-//         value: '{"expected_output":"This is a great response"}',
-//         var: "output",
-//       },
-//     ]);
-//   }, 10_000);
-
-//   test("extracts variables from a trace", async () => {
-//     await pruneDatabase();
-//     const traceId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("traces")
-//       .values({
-//         id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         user_id: "a",
-//         input: { input: "This is a great prompt" },
-//         output: { output: "This is a great response" },
-//       })
-//       .execute();
-
-//     const variableMapping = variableMappingList.parse([
-//       {
-//         langfuseObject: "trace",
-//         selectedColumnId: "input",
-//         templateVariable: "input",
-//       },
-//       {
-//         langfuseObject: "trace",
-//         selectedColumnId: "output",
-//         templateVariable: "output",
-//       },
-//     ]);
-
-//     const result = await extractVariablesFromTracingData({
-//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       variables: ["input", "output"],
-//       traceId: traceId,
-//       variableMapping: variableMapping,
-//     });
-
-//     expect(result).toEqual([
-//       {
-//         value: '{"input":"This is a great prompt"}',
-//         var: "input",
-//       },
-//       {
-//         value: '{"output":"This is a great response"}',
-//         var: "output",
-//       },
-//     ]);
-//   }, 10_000);
-
-//   test("extracts variables from a observation", async () => {
-//     await pruneDatabase();
-//     const traceId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("traces")
-//       .values({
-//         id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         user_id: "a",
-//         input: { input: "This is a great prompt" },
-//         output: { output: "This is a great response" },
-//       })
-//       .execute();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("observations")
-//       .values({
-//         id: randomUUID(),
-//         trace_id: traceId,
-//         name: "great-llm-name",
-//         type: sql`'GENERATION'::"ObservationType"`,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         input: { huhu: "This is a great prompt" },
-//         output: { haha: "This is a great response" },
-//       })
-//       .execute();
-
-//     const variableMapping = variableMappingList.parse([
-//       {
-//         langfuseObject: "generation",
-//         selectedColumnId: "input",
-//         templateVariable: "input",
-//         objectName: "great-llm-name",
-//       },
-//       {
-//         langfuseObject: "generation",
-//         selectedColumnId: "output",
-//         templateVariable: "output",
-//         objectName: "great-llm-name",
-//       },
-//     ]);
-
-//     const result = await extractVariablesFromTracingData({
-//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       variables: ["input", "output"],
-//       traceId: traceId,
-//       variableMapping: variableMapping,
-//     });
-
-//     expect(result).toEqual([
-//       {
-//         value: '{"huhu":"This is a great prompt"}',
-//         var: "input",
-//       },
-//       {
-//         value: '{"haha":"This is a great response"}',
-//         var: "output",
-//       },
-//     ]);
-//   }, 10_000);
-
-//   test("fails if observation is not present", async () => {
-//     await pruneDatabase();
-//     const traceId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("traces")
-//       .values({
-//         id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         user_id: "a",
-//         input: { input: "This is a great prompt" },
-//         output: { output: "This is a great response" },
-//       })
-//       .execute();
-
-//     const variableMapping = variableMappingList.parse([
-//       {
-//         langfuseObject: "generation",
-//         selectedColumnId: "input",
-//         templateVariable: "input",
-//         objectName: "great-llm-name",
-//       },
-//       {
-//         langfuseObject: "generation",
-//         selectedColumnId: "output",
-//         templateVariable: "output",
-//         objectName: "great-llm-name",
-//       },
-//     ]);
-
-//     await expect(
-//       extractVariablesFromTracingData({
-//         projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         variables: ["input", "output"],
-//         traceId: traceId,
-//         variableMapping: variableMapping,
-//       }),
-//     ).rejects.toThrowError(
-//       new LangfuseNotFoundError(
-//         `Observation great-llm-name for trace ${traceId} not found. Please ensure the mapped data exists and consider extending the job delay.`,
-//       ),
-//     );
-//   }, 10_000);
-
-//   test("does not fail if observation data is null", async () => {
-//     await pruneDatabase();
-//     const traceId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("traces")
-//       .values({
-//         id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         user_id: "a",
-//         input: { input: "This is a great prompt" },
-//         output: { output: "This is a great response" },
-//       })
-//       .execute();
-
-//     // fetching input and output for an observation which has NULL values
-//     await kyselyPrisma.$kysely
-//       .insertInto("observations")
-//       .values({
-//         id: randomUUID(),
-//         trace_id: traceId,
-//         name: "great-llm-name",
-//         type: sql`'GENERATION'::"ObservationType"`,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       })
-//       .execute();
-
-//     const variableMapping = variableMappingList.parse([
-//       {
-//         langfuseObject: "generation",
-//         selectedColumnId: "input",
-//         templateVariable: "input",
-//         objectName: "great-llm-name",
-//       },
-//       {
-//         langfuseObject: "generation",
-//         selectedColumnId: "output",
-//         templateVariable: "output",
-//         objectName: "great-llm-name",
-//       },
-//     ]);
-
-//     const result = await extractVariablesFromTracingData({
-//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       variables: ["input", "output"],
-//       traceId: traceId,
-//       variableMapping: variableMapping,
-//     });
-
-//     expect(result).toEqual([
-//       {
-//         value: "",
-//         var: "input",
-//       },
-//       {
-//         value: "",
-//         var: "output",
-//       },
-//     ]);
-//   }, 10_000);
-
-//   test("extracts variables from a youngest observation", async () => {
-//     await pruneDatabase();
-//     const traceId = randomUUID();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("traces")
-//       .values({
-//         id: traceId,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         user_id: "a",
-//         input: { input: "This is a great prompt" },
-//         output: { output: "This is a great response" },
-//       })
-//       .execute();
-
-//     await kyselyPrisma.$kysely
-//       .insertInto("observations")
-//       .values({
-//         id: randomUUID(),
-//         trace_id: traceId,
-//         name: "great-llm-name",
-//         start_time: new Date("2022-01-01T00:00:00.000Z"),
-//         type: sql`'GENERATION'::"ObservationType"`,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         input: { huhu: "This is a great prompt" },
-//         output: { haha: "This is a great response" },
-//       })
-//       .execute();
-//     await kyselyPrisma.$kysely
-//       .insertInto("observations")
-//       .values({
-//         id: randomUUID(),
-//         trace_id: traceId,
-//         name: "great-llm-name",
-//         start_time: new Date("2022-01-02T00:00:00.000Z"),
-//         type: sql`'GENERATION'::"ObservationType"`,
-//         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//         input: { huhu: "This is a great prompt again" },
-//         output: { haha: "This is a great response again" },
-//       })
-//       .execute();
-
-//     const variableMapping = variableMappingList.parse([
-//       {
-//         langfuseObject: "generation",
-//         selectedColumnId: "input",
-//         templateVariable: "input",
-//         objectName: "great-llm-name",
-//       },
-//       {
-//         langfuseObject: "generation",
-//         selectedColumnId: "output",
-//         templateVariable: "output",
-//         objectName: "great-llm-name",
-//       },
-//     ]);
-
-//     const result = await extractVariablesFromTracingData({
-//       projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-//       variables: ["input", "output"],
-//       traceId: traceId,
-//       variableMapping: variableMapping,
-//     });
-
-//     expect(result).toEqual([
-//       {
-//         value: '{"huhu":"This is a great prompt again"}',
-//         var: "input",
-//       },
-//       {
-//         value: '{"haha":"This is a great response again"}',
-//         var: "output",
-//       },
-//     ]);
-//   }, 10_000);
-// });
+describe("create eval jobs", () => {
+  test("creates new 'trace' eval job", async () => {
+    await pruneDatabase();
+    const traceId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("traces")
+      .values({
+        id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      })
+      .execute();
+
+    await prisma.jobConfiguration.create({
+      data: {
+        id: randomUUID(),
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        filter: JSON.parse("[]"),
+        jobType: "EVAL",
+        delay: 0,
+        sampling: new Decimal("1"),
+        targetObject: "trace",
+        scoreName: "score",
+        variableMapping: JSON.parse("[]"),
+      },
+    });
+
+    const payload = {
+      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      traceId: traceId,
+    };
+
+    await createTraceEvalJobs({ event: payload });
+
+    const jobs = await kyselyPrisma.$kysely
+      .selectFrom("job_executions")
+      .selectAll()
+      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+      .execute();
+
+    expect(jobs.length).toBe(1);
+    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+    expect(jobs[0].job_input_trace_id).toBe(traceId);
+    expect(jobs[0].status.toString()).toBe("PENDING");
+    expect(jobs[0].start_time).not.toBeNull();
+  }, 10_000);
+
+  test("creates new 'dataset' eval job", async () => {
+    await pruneDatabase();
+    const traceId = randomUUID();
+    const observationId = randomUUID();
+    const datasetId = randomUUID();
+    const datasetItemId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("traces")
+      .values({
+        id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      })
+      .execute();
+
+    await kyselyPrisma.$kysely
+      .insertInto("observations")
+      .values({
+        id: observationId,
+        trace_id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        type: sql`'GENERATION'::"ObservationType"`,
+      })
+      .execute();
+
+    await kyselyPrisma.$kysely
+      .insertInto("datasets")
+      .values({
+        id: datasetId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        name: "test-dataset",
+      })
+      .execute();
+
+    await kyselyPrisma.$kysely
+      .insertInto("dataset_items")
+      .values({
+        id: datasetItemId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        dataset_id: datasetId,
+      })
+      .execute();
+
+    await prisma.jobConfiguration.create({
+      data: {
+        id: randomUUID(),
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        filter: JSON.parse("[]"),
+        jobType: "EVAL",
+        delay: 0,
+        sampling: new Decimal("1"),
+        targetObject: "dataset",
+        scoreName: "score",
+        variableMapping: JSON.parse("[]"),
+      },
+    });
+
+    const payload = {
+      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      traceId: traceId,
+      datasetItemId: datasetItemId,
+      observationId: observationId,
+    };
+
+    await createDatasetEvalJobs({ event: payload });
+
+    const jobs = await kyselyPrisma.$kysely
+      .selectFrom("job_executions")
+      .selectAll()
+      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+      .execute();
+
+    expect(jobs.length).toBe(1);
+    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+    expect(jobs[0].job_input_trace_id).toBe(traceId);
+    expect(jobs[0].job_input_observation_id).toBe(observationId);
+    expect(jobs[0].job_input_dataset_item_id).toBe(datasetItemId);
+    expect(jobs[0].status.toString()).toBe("PENDING");
+    expect(jobs[0].start_time).not.toBeNull();
+  }, 10_000);
+
+  test("does not create job for inactive config", async () => {
+    await pruneDatabase();
+    const traceId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("traces")
+      .values({
+        id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      })
+      .execute();
+
+    await prisma.jobConfiguration.create({
+      data: {
+        id: randomUUID(),
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        filter: JSON.parse("[]"),
+        jobType: "EVAL",
+        delay: 0,
+        sampling: new Decimal("1"),
+        targetObject: "trace",
+        scoreName: "score",
+        variableMapping: JSON.parse("[]"),
+        status: "INACTIVE",
+      },
+    });
+
+    const payload = {
+      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      traceId: traceId,
+    };
+
+    await createTraceEvalJobs({ event: payload });
+
+    const jobs = await kyselyPrisma.$kysely
+      .selectFrom("job_executions")
+      .selectAll()
+      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+      .execute();
+
+    expect(jobs.length).toBe(0);
+  }, 10_000);
+
+  test("does not create eval job for existing job execution", async () => {
+    await pruneDatabase();
+    const traceId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("traces")
+      .values({
+        id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      })
+      .execute();
+
+    await kyselyPrisma.$kysely
+      .insertInto("llm_api_keys")
+      .values({
+        id: randomUUID(),
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        secret_key: encrypt(String(OPENAI_API_KEY)),
+        provider: "openai",
+        adapter: LLMAdapter.OpenAI,
+        custom_models: [],
+        display_secret_key: "123456",
+      })
+      .execute();
+
+    await prisma.jobConfiguration.create({
+      data: {
+        id: randomUUID(),
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        filter: JSON.parse("[]"),
+        jobType: "EVAL",
+        delay: 0,
+        sampling: new Decimal("1"),
+        targetObject: "trace",
+        scoreName: "score",
+        variableMapping: JSON.parse("[]"),
+      },
+    });
+
+    const payload = {
+      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      traceId: traceId,
+    };
+
+    await createTraceEvalJobs({ event: payload });
+    await createTraceEvalJobs({ event: payload }); // calling it twice to check it is only generated once
+
+    const jobs = await kyselyPrisma.$kysely
+      .selectFrom("job_executions")
+      .selectAll()
+      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+      .execute();
+
+    expect(jobs.length).toBe(1);
+    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+    expect(jobs[0].job_input_trace_id).toBe(traceId);
+    expect(jobs[0].status.toString()).toBe("PENDING");
+    expect(jobs[0].start_time).not.toBeNull();
+    expect(jobs[0].end_time).to.be.null;
+  }, 10_000);
+
+  test("does not create job for inactive config", async () => {
+    await pruneDatabase();
+    const traceId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("traces")
+      .values({
+        id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      })
+      .execute();
+
+    await prisma.jobConfiguration.create({
+      data: {
+        id: randomUUID(),
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        filter: JSON.parse("[]"),
+        jobType: "EVAL",
+        delay: 0,
+        sampling: new Decimal("1"),
+        targetObject: "trace",
+        scoreName: "score",
+        variableMapping: JSON.parse("[]"),
+        status: "INACTIVE",
+      },
+    });
+
+    const payload = {
+      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      traceId: traceId,
+    };
+
+    await createTraceEvalJobs({ event: payload });
+
+    const jobs = await kyselyPrisma.$kysely
+      .selectFrom("job_executions")
+      .selectAll()
+      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+      .execute();
+
+    expect(jobs.length).toBe(0);
+  }, 10_000);
+
+  test("does not create eval job for 0 sample rate", async () => {
+    await pruneDatabase();
+    const traceId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("traces")
+      .values({
+        id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      })
+      .execute();
+
+    await kyselyPrisma.$kysely
+      .insertInto("llm_api_keys")
+      .values({
+        id: randomUUID(),
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        secret_key: encrypt(String(OPENAI_API_KEY)),
+        provider: "openai",
+        adapter: LLMAdapter.OpenAI,
+        custom_models: [],
+        display_secret_key: "123456",
+      })
+      .execute();
+
+    await prisma.jobConfiguration.create({
+      data: {
+        id: randomUUID(),
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        filter: JSON.parse("[]"),
+        jobType: "EVAL",
+        delay: 0,
+        sampling: new Decimal("0"),
+        targetObject: "trace",
+        scoreName: "score",
+        variableMapping: JSON.parse("[]"),
+      },
+    });
+
+    const payload = {
+      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      traceId: traceId,
+    };
+
+    await createTraceEvalJobs({ event: payload });
+
+    const jobs = await kyselyPrisma.$kysely
+      .selectFrom("job_executions")
+      .selectAll()
+      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+      .execute();
+
+    expect(jobs.length).toBe(0);
+  }, 10_000);
+
+  test("cancels a job if the second event deselects", async () => {
+    await pruneDatabase();
+    const traceId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("traces")
+      .values({
+        id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        user_id: "a",
+      })
+      .execute();
+
+    await kyselyPrisma.$kysely
+      .insertInto("llm_api_keys")
+      .values({
+        id: randomUUID(),
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        secret_key: encrypt(String(OPENAI_API_KEY)),
+        provider: "openai",
+        adapter: LLMAdapter.OpenAI,
+        custom_models: [],
+        display_secret_key: "123456",
+      })
+      .execute();
+
+    const templateId = randomUUID();
+    await kyselyPrisma.$kysely
+      .insertInto("eval_templates")
+      .values({
+        id: templateId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        name: "test-template",
+        version: 1,
+        prompt: "Please evaluate toxicity {{input}} {{output}}",
+        model: "gpt-3.5-turbo",
+        provider: "openai",
+        model_params: {},
+        output_schema: {
+          reasoning: "Please explain your reasoning",
+          score: "Please provide a score between 0 and 1",
+        },
+      })
+      .executeTakeFirst();
+
+    await prisma.jobConfiguration.create({
+      data: {
+        id: randomUUID(),
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        filter: [
+          {
+            type: "string",
+            value: "a",
+            column: "User ID",
+            operator: "contains",
+          },
+        ],
+        jobType: "EVAL",
+        delay: 0,
+        sampling: new Decimal("1"),
+        targetObject: "trace",
+        scoreName: "score",
+        variableMapping: JSON.parse("[]"),
+        evalTemplateId: templateId,
+      },
+    });
+
+    const payload = {
+      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      traceId: traceId,
+    };
+
+    await createTraceEvalJobs({ event: payload });
+
+    // update the trace to deselect the trace
+    await kyselyPrisma.$kysely
+      .updateTable("traces")
+      .set("user_id", "b")
+      .where("id", "=", traceId)
+      .execute();
+
+    await createTraceEvalJobs({
+      event: payload,
+    }); // calling it twice to check it is only generated once
+
+    const jobs = await kyselyPrisma.$kysely
+      .selectFrom("job_executions")
+      .selectAll()
+      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+      .execute();
+
+    expect(jobs.length).toBe(1);
+    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+    expect(jobs[0].job_input_trace_id).toBe(traceId);
+    expect(jobs[0].status.toString()).toBe("CANCELLED");
+    expect(jobs[0].start_time).not.toBeNull();
+    expect(jobs[0].end_time).not.toBeNull();
+  }, 10_000);
+});
+
+describe("execute evals", () => {
+  test("evals a valid 'trace' event", async () => {
+    await pruneDatabase();
+    openAIServer.respondWithDefault();
+    const traceId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("traces")
+      .values({
+        id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        user_id: "a",
+        input: { input: "This is a great prompt" },
+        output: { output: "This is a great response" },
+      })
+      .execute();
+
+    const templateId = randomUUID();
+    await kyselyPrisma.$kysely
+      .insertInto("eval_templates")
+      .values({
+        id: templateId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        name: "test-template",
+        version: 1,
+        prompt: "Please evaluate toxicity {{input}} {{output}}",
+        model: "gpt-3.5-turbo",
+        provider: "openai",
+        model_params: {},
+        output_schema: {
+          reasoning: "Please explain your reasoning",
+          score: "Please provide a score between 0 and 1",
+        },
+      })
+      .executeTakeFirst();
+
+    const jobConfiguration = await prisma.jobConfiguration.create({
+      data: {
+        id: randomUUID(),
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        filter: [
+          {
+            type: "string",
+            value: "a",
+            column: "User ID",
+            operator: "contains",
+          },
+        ],
+        jobType: "EVAL",
+        delay: 0,
+        sampling: new Decimal("1"),
+        targetObject: "trace",
+        scoreName: "score",
+        variableMapping: JSON.parse("[]"),
+        evalTemplateId: templateId,
+      },
+    });
+
+    const jobExecutionId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("job_executions")
+      .values({
+        id: jobExecutionId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        job_configuration_id: jobConfiguration.id,
+        status: sql`'PENDING'::"JobExecutionStatus"`,
+        start_time: new Date(),
+        job_input_trace_id: traceId,
+      })
+      .execute();
+
+    await kyselyPrisma.$kysely
+      .insertInto("llm_api_keys")
+      .values({
+        id: randomUUID(),
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        secret_key: encrypt(String(OPENAI_API_KEY)),
+        provider: "openai",
+        adapter: LLMAdapter.OpenAI,
+        custom_models: [],
+        display_secret_key: "123456",
+      })
+      .execute();
+
+    const payload = {
+      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      jobExecutionId: jobExecutionId,
+      delay: 1000,
+    };
+
+    await evaluate({ event: payload });
+
+    const jobs = await kyselyPrisma.$kysely
+      .selectFrom("job_executions")
+      .selectAll()
+      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+      .execute();
+
+    expect(jobs.length).toBe(1);
+    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+    expect(jobs[0].job_input_trace_id).toBe(traceId);
+    expect(jobs[0].status.toString()).toBe("COMPLETED");
+    expect(jobs[0].start_time).not.toBeNull();
+    expect(jobs[0].end_time).not.toBeNull();
+
+    const scores = await kyselyPrisma.$kysely
+      .selectFrom("scores")
+      .selectAll()
+      .where("trace_id", "=", traceId)
+      .execute();
+
+    expect(scores.length).toBe(1);
+    expect(scores[0].trace_id).toBe(traceId);
+    expect(scores[0].comment).not.toBeNull();
+    expect(scores[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+  }, 10_000);
+
+  test("fails to eval without llm api key", async () => {
+    await pruneDatabase();
+    const traceId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("traces")
+      .values({
+        id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        user_id: "a",
+        input: { input: "This is a great prompt" },
+        output: { output: "This is a great response" },
+      })
+      .execute();
+
+    const templateId = randomUUID();
+    await kyselyPrisma.$kysely
+      .insertInto("eval_templates")
+      .values({
+        id: templateId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        name: "test-template",
+        version: 1,
+        prompt: "Please evaluate toxicity {{input}} {{output}}",
+        model: "gpt-3.5-turbo",
+        provider: "openai",
+        model_params: {},
+        output_schema: {
+          reasoning: "Please explain your reasoning",
+          score: "Please provide a score between 0 and 1",
+        },
+      })
+      .executeTakeFirst();
+
+    const jobConfiguration = await prisma.jobConfiguration.create({
+      data: {
+        id: randomUUID(),
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        filter: [
+          {
+            type: "string",
+            value: "a",
+            column: "User ID",
+            operator: "contains",
+          },
+        ],
+        jobType: "EVAL",
+        delay: 0,
+        sampling: new Decimal("1"),
+        targetObject: "trace",
+        scoreName: "score",
+        variableMapping: JSON.parse("[]"),
+        evalTemplateId: templateId,
+      },
+    });
+
+    const jobExecutionId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("job_executions")
+      .values({
+        id: jobExecutionId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        job_configuration_id: jobConfiguration.id,
+        status: sql`'PENDING'::"JobExecutionStatus"`,
+        start_time: new Date(),
+        job_input_trace_id: traceId,
+      })
+      .execute();
+
+    const payload = {
+      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      jobExecutionId: jobExecutionId,
+      delay: 1000,
+    };
+
+    await expect(evaluate({ event: payload })).rejects.toThrowError(
+      new LangfuseNotFoundError(
+        "API key for provider openai and project 7a88fb47-b4e2-43b8-a06c-a5ce950dc53a not found.",
+      ),
+    );
+
+    const jobs = await kyselyPrisma.$kysely
+      .selectFrom("job_executions")
+      .selectAll()
+      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+      .execute();
+
+    expect(jobs.length).toBe(1);
+    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+    expect(jobs[0].job_input_trace_id).toBe(traceId);
+    // the job will be failed when the exception is caught in the worker consumer
+    expect(jobs[0].status.toString()).toBe("PENDING");
+  }, 10_000);
+
+  test("evals should cancel if job is cancelled", async () => {
+    await pruneDatabase();
+    const traceId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("traces")
+      .values({
+        id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        user_id: "a",
+        input: { input: "This is a great prompt" },
+        output: { output: "This is a great response" },
+      })
+      .execute();
+
+    const templateId = randomUUID();
+    await kyselyPrisma.$kysely
+      .insertInto("eval_templates")
+      .values({
+        id: templateId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        name: "test-template",
+        version: 1,
+        prompt: "Please evaluate toxicity {{input}} {{output}}",
+        model: "gpt-3.5-turbo",
+        provider: "openai",
+        model_params: {},
+        output_schema: {
+          reasoning: "Please explain your reasoning",
+          score: "Please provide a score between 0 and 1",
+        },
+      })
+      .executeTakeFirst();
+
+    const jobConfiguration = await prisma.jobConfiguration.create({
+      data: {
+        id: randomUUID(),
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        filter: [
+          {
+            type: "string",
+            value: "a",
+            column: "User ID",
+            operator: "contains",
+          },
+        ],
+        jobType: "EVAL",
+        delay: 0,
+        sampling: new Decimal("1"),
+        targetObject: "trace",
+        scoreName: "score",
+        variableMapping: JSON.parse("[]"),
+        evalTemplateId: templateId,
+      },
+    });
+
+    const jobExecutionId = randomUUID();
+    await kyselyPrisma.$kysely
+      .insertInto("job_executions")
+      .values({
+        id: jobExecutionId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        job_configuration_id: jobConfiguration.id,
+        status: sql`'CANCELLED'::"JobExecutionStatus"`,
+        start_time: new Date(),
+        job_input_trace_id: traceId,
+      })
+      .execute();
+
+    const payload = {
+      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      jobExecutionId: jobExecutionId,
+      delay: 1000,
+    };
+
+    await evaluate({ event: payload });
+
+    const jobs = await kyselyPrisma.$kysely
+      .selectFrom("job_executions")
+      .selectAll()
+      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+      .execute();
+
+    expect(jobs.length).toBe(0);
+  }, 10_000);
+
+  test("evals a valid 'trace' event and inserts score to ingestion pipeline", async () => {
+    await pruneDatabase();
+    openAIServer.respondWithDefault();
+    const traceId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("traces")
+      .values({
+        id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        user_id: "a",
+        input: { input: "This is a great prompt" },
+        output: { output: "This is a great response" },
+      })
+      .execute();
+
+    const templateId = randomUUID();
+    await kyselyPrisma.$kysely
+      .insertInto("eval_templates")
+      .values({
+        id: templateId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        name: "test-template",
+        version: 1,
+        prompt: "Please evaluate toxicity {{input}} {{output}}",
+        model: "gpt-3.5-turbo",
+        provider: "openai",
+        model_params: {},
+        output_schema: {
+          reasoning: "Please explain your reasoning",
+          score: "Please provide a score between 0 and 1",
+        },
+      })
+      .executeTakeFirst();
+
+    const jobConfiguration = await prisma.jobConfiguration.create({
+      data: {
+        id: randomUUID(),
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        filter: [
+          {
+            type: "string",
+            value: "a",
+            column: "User ID",
+            operator: "contains",
+          },
+        ],
+        jobType: "EVAL",
+        delay: 0,
+        sampling: new Decimal("1"),
+        targetObject: "trace",
+        scoreName: "score",
+        variableMapping: JSON.parse("[]"),
+        evalTemplateId: templateId,
+      },
+    });
+
+    const jobExecutionId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("job_executions")
+      .values({
+        id: jobExecutionId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        job_configuration_id: jobConfiguration.id,
+        status: sql`'PENDING'::"JobExecutionStatus"`,
+        start_time: new Date(),
+        job_input_trace_id: traceId,
+      })
+      .execute();
+
+    await kyselyPrisma.$kysely
+      .insertInto("llm_api_keys")
+      .values({
+        id: randomUUID(),
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        secret_key: encrypt(String(OPENAI_API_KEY)),
+        provider: "openai",
+        adapter: LLMAdapter.OpenAI,
+        custom_models: [],
+        display_secret_key: "123456",
+      })
+      .execute();
+
+    const payload = {
+      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      jobExecutionId: jobExecutionId,
+      delay: 1000,
+    };
+
+    await evaluate({ event: payload });
+
+    const jobs = await kyselyPrisma.$kysely
+      .selectFrom("job_executions")
+      .selectAll()
+      .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+      .execute();
+
+    expect(jobs.length).toBe(1);
+    expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+    expect(jobs[0].job_input_trace_id).toBe(traceId);
+    expect(jobs[0].status.toString()).toBe("COMPLETED");
+    expect(jobs[0].start_time).not.toBeNull();
+    expect(jobs[0].end_time).not.toBeNull();
+
+    const scores = await kyselyPrisma.$kysely
+      .selectFrom("scores")
+      .selectAll()
+      .where("trace_id", "=", traceId)
+      .execute();
+
+    expect(scores.length).toBe(1);
+    expect(scores[0].trace_id).toBe(traceId);
+    expect(scores[0].comment).not.toBeNull();
+    expect(scores[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+
+    await new Promise<void>((resolve, reject) => {
+      new Worker(
+        QueueName.IngestionQueue,
+        async (job: Job) => {
+          try {
+            expect(job.name).toBe("ingestion-job");
+            expect(job.data.payload.data.type).toBe("score-create");
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        {
+          connection: redis as ConnectionOptions,
+        },
+      );
+    });
+  }, 10_000);
+});
+
+describe("test variable extraction", () => {
+  test("extracts variables from a dataset item", async () => {
+    await pruneDatabase();
+    const datasetId = randomUUID();
+    const datasetItemId = randomUUID();
+    const traceId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("traces")
+      .values({
+        id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        user_id: "a",
+        input: { input: "This is a great prompt" },
+        output: { output: "This is a great response" },
+      })
+      .execute();
+
+    await kyselyPrisma.$kysely
+      .insertInto("datasets")
+      .values({
+        id: datasetId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        name: "test-dataset",
+      })
+      .execute();
+
+    await kyselyPrisma.$kysely
+      .insertInto("dataset_items")
+      .values({
+        id: datasetItemId,
+        input: { input: "This is a great prompt" },
+        expected_output: { expected_output: "This is a great response" },
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        dataset_id: datasetId,
+      })
+      .execute();
+
+    const variableMapping = variableMappingList.parse([
+      {
+        langfuseObject: "dataset_item",
+        selectedColumnId: "input",
+        templateVariable: "input",
+      },
+      {
+        langfuseObject: "dataset_item",
+        selectedColumnId: "expected_output",
+        templateVariable: "output",
+      },
+    ]);
+
+    const result = await extractVariablesFromTracingData({
+      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      variables: ["input", "output"],
+      traceId: traceId,
+      datasetItemId: datasetItemId,
+      variableMapping: variableMapping,
+    });
+
+    expect(result).toEqual([
+      {
+        value: '{"input":"This is a great prompt"}',
+        var: "input",
+      },
+      {
+        value: '{"expected_output":"This is a great response"}',
+        var: "output",
+      },
+    ]);
+  }, 10_000);
+
+  test("extracts variables from a trace", async () => {
+    await pruneDatabase();
+    const traceId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("traces")
+      .values({
+        id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        user_id: "a",
+        input: { input: "This is a great prompt" },
+        output: { output: "This is a great response" },
+      })
+      .execute();
+
+    const variableMapping = variableMappingList.parse([
+      {
+        langfuseObject: "trace",
+        selectedColumnId: "input",
+        templateVariable: "input",
+      },
+      {
+        langfuseObject: "trace",
+        selectedColumnId: "output",
+        templateVariable: "output",
+      },
+    ]);
+
+    const result = await extractVariablesFromTracingData({
+      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      variables: ["input", "output"],
+      traceId: traceId,
+      variableMapping: variableMapping,
+    });
+
+    expect(result).toEqual([
+      {
+        value: '{"input":"This is a great prompt"}',
+        var: "input",
+      },
+      {
+        value: '{"output":"This is a great response"}',
+        var: "output",
+      },
+    ]);
+  }, 10_000);
+
+  test("extracts variables from a observation", async () => {
+    await pruneDatabase();
+    const traceId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("traces")
+      .values({
+        id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        user_id: "a",
+        input: { input: "This is a great prompt" },
+        output: { output: "This is a great response" },
+      })
+      .execute();
+
+    await kyselyPrisma.$kysely
+      .insertInto("observations")
+      .values({
+        id: randomUUID(),
+        trace_id: traceId,
+        name: "great-llm-name",
+        type: sql`'GENERATION'::"ObservationType"`,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        input: { huhu: "This is a great prompt" },
+        output: { haha: "This is a great response" },
+      })
+      .execute();
+
+    const variableMapping = variableMappingList.parse([
+      {
+        langfuseObject: "generation",
+        selectedColumnId: "input",
+        templateVariable: "input",
+        objectName: "great-llm-name",
+      },
+      {
+        langfuseObject: "generation",
+        selectedColumnId: "output",
+        templateVariable: "output",
+        objectName: "great-llm-name",
+      },
+    ]);
+
+    const result = await extractVariablesFromTracingData({
+      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      variables: ["input", "output"],
+      traceId: traceId,
+      variableMapping: variableMapping,
+    });
+
+    expect(result).toEqual([
+      {
+        value: '{"huhu":"This is a great prompt"}',
+        var: "input",
+      },
+      {
+        value: '{"haha":"This is a great response"}',
+        var: "output",
+      },
+    ]);
+  }, 10_000);
+
+  test("fails if observation is not present", async () => {
+    await pruneDatabase();
+    const traceId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("traces")
+      .values({
+        id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        user_id: "a",
+        input: { input: "This is a great prompt" },
+        output: { output: "This is a great response" },
+      })
+      .execute();
+
+    const variableMapping = variableMappingList.parse([
+      {
+        langfuseObject: "generation",
+        selectedColumnId: "input",
+        templateVariable: "input",
+        objectName: "great-llm-name",
+      },
+      {
+        langfuseObject: "generation",
+        selectedColumnId: "output",
+        templateVariable: "output",
+        objectName: "great-llm-name",
+      },
+    ]);
+
+    await expect(
+      extractVariablesFromTracingData({
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        variables: ["input", "output"],
+        traceId: traceId,
+        variableMapping: variableMapping,
+      }),
+    ).rejects.toThrowError(
+      new LangfuseNotFoundError(
+        `Observation great-llm-name for trace ${traceId} not found. Please ensure the mapped data exists and consider extending the job delay.`,
+      ),
+    );
+  }, 10_000);
+
+  test("does not fail if observation data is null", async () => {
+    await pruneDatabase();
+    const traceId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("traces")
+      .values({
+        id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        user_id: "a",
+        input: { input: "This is a great prompt" },
+        output: { output: "This is a great response" },
+      })
+      .execute();
+
+    // fetching input and output for an observation which has NULL values
+    await kyselyPrisma.$kysely
+      .insertInto("observations")
+      .values({
+        id: randomUUID(),
+        trace_id: traceId,
+        name: "great-llm-name",
+        type: sql`'GENERATION'::"ObservationType"`,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      })
+      .execute();
+
+    const variableMapping = variableMappingList.parse([
+      {
+        langfuseObject: "generation",
+        selectedColumnId: "input",
+        templateVariable: "input",
+        objectName: "great-llm-name",
+      },
+      {
+        langfuseObject: "generation",
+        selectedColumnId: "output",
+        templateVariable: "output",
+        objectName: "great-llm-name",
+      },
+    ]);
+
+    const result = await extractVariablesFromTracingData({
+      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      variables: ["input", "output"],
+      traceId: traceId,
+      variableMapping: variableMapping,
+    });
+
+    expect(result).toEqual([
+      {
+        value: "",
+        var: "input",
+      },
+      {
+        value: "",
+        var: "output",
+      },
+    ]);
+  }, 10_000);
+
+  test("extracts variables from a youngest observation", async () => {
+    await pruneDatabase();
+    const traceId = randomUUID();
+
+    await kyselyPrisma.$kysely
+      .insertInto("traces")
+      .values({
+        id: traceId,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        user_id: "a",
+        input: { input: "This is a great prompt" },
+        output: { output: "This is a great response" },
+      })
+      .execute();
+
+    await kyselyPrisma.$kysely
+      .insertInto("observations")
+      .values({
+        id: randomUUID(),
+        trace_id: traceId,
+        name: "great-llm-name",
+        start_time: new Date("2022-01-01T00:00:00.000Z"),
+        type: sql`'GENERATION'::"ObservationType"`,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        input: { huhu: "This is a great prompt" },
+        output: { haha: "This is a great response" },
+      })
+      .execute();
+    await kyselyPrisma.$kysely
+      .insertInto("observations")
+      .values({
+        id: randomUUID(),
+        trace_id: traceId,
+        name: "great-llm-name",
+        start_time: new Date("2022-01-02T00:00:00.000Z"),
+        type: sql`'GENERATION'::"ObservationType"`,
+        project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        input: { huhu: "This is a great prompt again" },
+        output: { haha: "This is a great response again" },
+      })
+      .execute();
+
+    const variableMapping = variableMappingList.parse([
+      {
+        langfuseObject: "generation",
+        selectedColumnId: "input",
+        templateVariable: "input",
+        objectName: "great-llm-name",
+      },
+      {
+        langfuseObject: "generation",
+        selectedColumnId: "output",
+        templateVariable: "output",
+        objectName: "great-llm-name",
+      },
+    ]);
+
+    const result = await extractVariablesFromTracingData({
+      projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      variables: ["input", "output"],
+      traceId: traceId,
+      variableMapping: variableMapping,
+    });
+
+    expect(result).toEqual([
+      {
+        value: '{"huhu":"This is a great prompt again"}',
+        var: "input",
+      },
+      {
+        value: '{"haha":"This is a great response again"}',
+        var: "output",
+      },
+    ]);
+  }, 10_000);
+});

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -458,7 +458,7 @@ export const evaluate = async ({
   );
 
   // extract the variables which need to be inserted into the prompt
-  const mappingResult = await extractVariables({
+  const mappingResult = await extractVariablesFromTracingData({
     projectId: event.projectId,
     variables: template.vars,
     traceId: job.job_input_trace_id,
@@ -686,7 +686,7 @@ export function compileHandlebarString(
   return template(context);
 }
 
-export async function extractVariables({
+export async function extractVariablesFromTracingData({
   projectId,
   variables,
   traceId,

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -471,11 +471,20 @@ export const evaluate = async ({
   );
 
   // compile the prompt and send out the LLM request
-  const prompt = compileHandlebarString(template.prompt, {
-    ...Object.fromEntries(
-      mappingResult.map(({ var: key, value }) => [key, value]),
-    ),
-  });
+  let prompt;
+  try {
+    prompt = compileHandlebarString(template.prompt, {
+      ...Object.fromEntries(
+        mappingResult.map(({ var: key, value }) => [key, value]),
+      ),
+    });
+  } catch (e) {
+    // in case of a compilation error, we use the original prompt without adding variables.
+    logger.error(
+      `Evaluating job ${event.jobExecutionId} failed to compile prompt. Eval will fail. ${e}`,
+    );
+    prompt = template.prompt;
+  }
 
   logger.debug(
     `Evaluating job ${event.jobExecutionId} compiled prompt ${prompt}`,
@@ -673,7 +682,7 @@ export function compileHandlebarString(
   handlebarString: string,
   context: Record<string, any>,
 ): string {
-  const template = Handlebars.compile(handlebarString, { noEscape: true });
+  const template = Handlebars.compile(handlebarString);
   return template(context);
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes evaluation job failures by handling invalid prompt templates and renaming a function for clarity.
> 
>   - **Behavior**:
>     - `evaluate()` in `evalService.ts` now catches errors in `compileHandlebarString()` and logs them, using the original prompt if compilation fails.
>     - `compileHandlebarString()` in `evalService.ts` no longer uses `noEscape` option.
>   - **Tests**:
>     - Added tests in `evalService.test.ts` for handling invalid templates in `compileHandlebarString()`.
>     - Renamed `extractVariables()` to `extractVariablesFromTracingData()` in `evalService.test.ts` and `evalService.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1b17235f8f7231085e09f9aa18b95bf5cc426feb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->