### PR TITLE
fix: fix dataset item api for self-hosters

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -121,6 +121,53 @@ export const getObservationById = async (
   return mapped.shift();
 };
 
+export const getObservationsById = async (
+  ids: string[],
+  projectId: string,
+  fetchWithInputOutput: boolean = false,
+) => {
+  const query = `
+  SELECT
+    id,
+    trace_id,
+    project_id,
+    type,
+    parent_observation_id,
+    start_time,
+    end_time,
+    name,
+    metadata,
+    level,
+    status_message,
+    version,
+    ${fetchWithInputOutput ? "input, output," : ""}
+    provided_model_name,
+    internal_model_id,
+    model_parameters,
+    provided_usage_details,
+    usage_details,
+    provided_cost_details,
+    cost_details,
+    total_cost,
+    completion_start_time,
+    prompt_id,
+    prompt_name,
+    prompt_version,
+    created_at,
+    updated_at,
+    event_ts
+  FROM observations
+  WHERE id IN ({ids: Array(String)})
+  AND project_id = {projectId: String}
+  ORDER BY event_ts desc
+  LIMIT 1 by id, project_id`;
+  const records = await queryClickhouse<ObservationRecordReadType>({
+    query,
+    params: { ids, projectId },
+  });
+  return records.map(convertObservation);
+};
+
 export const getObservationViewById = async (
   id: string,
   projectId: string,

--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -298,8 +298,8 @@ describe("Fetch datasets for UI presentation", () => {
 
     const result = await fetchDatasetItems(input);
 
-    expect(result.totalDatasetItems).toEqual(2);
-    expect(result.datasetItems).toHaveLength(2);
+    expect(result.totalDatasetItems).toEqual(3);
+    expect(result.datasetItems).toHaveLength(3);
 
     const firstDatasetItem = result.datasetItems.find(
       (item) => item.id === datasetItemId,

--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -1,21 +1,26 @@
 import {
   createObservations,
   createScores,
+  createTraces,
 } from "@/src/__tests__/server/repositories/clickhouse-helpers";
 import { v4 } from "uuid";
 import { prisma } from "@langfuse/shared/src/db";
 import {
   createObservation,
   createScore,
+  createTrace,
 } from "@/src/__tests__/fixtures/tracing-factory";
-import { createDatasetRunsTable } from "@/src/features/datasets/server/service";
+import {
+  createDatasetRunsTable,
+  fetchDatasetItems,
+} from "@/src/features/datasets/server/service";
 
 const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
 
-describe("dataset service", () => {
-  it("should be able to fetch data for dataset run UI", async () => {
+describe("Fetch datasets for UI presentation", () => {
+  it("should fetch dataset runs for UI", async () => {
     const datasetId = v4();
-    console.log("datasetId", datasetId);
+
     await prisma.dataset.create({
       data: {
         id: datasetId,
@@ -210,5 +215,100 @@ describe("dataset service", () => {
     expect(secondRun.avgTotalCost.toString()).toStrictEqual("300");
 
     expect(JSON.stringify(secondRun.scores)).toEqual(JSON.stringify({}));
+  });
+
+  it("should fetch dataset items correctly", async () => {
+    // Create test data in the database
+
+    const datasetId = v4();
+
+    await prisma.dataset.create({
+      data: {
+        id: datasetId,
+        name: v4(),
+        projectId: projectId,
+      },
+    });
+
+    const traceId1 = v4();
+    const traceId2 = v4();
+    const observationId2 = v4();
+
+    const datasetItemId = v4();
+    await prisma.datasetItem.create({
+      data: {
+        id: datasetItemId,
+        datasetId,
+        metadata: {},
+        projectId,
+        sourceTraceId: traceId1,
+      },
+    });
+
+    const datasetItemId2 = v4();
+    await prisma.datasetItem.create({
+      data: {
+        id: datasetItemId2,
+        datasetId,
+        metadata: {},
+        projectId,
+        sourceTraceId: traceId2,
+        sourceObservationId: observationId2,
+      },
+    });
+
+    const observation = createObservation({
+      id: observationId2,
+      trace_id: traceId2,
+      project_id: projectId,
+      start_time: new Date().getTime() - 1000 * 60 * 60, // minus 1 min
+      end_time: new Date().getTime(),
+    });
+
+    await createObservations([observation]);
+
+    const trace1 = createTrace({
+      id: traceId1,
+      project_id: projectId,
+    });
+    const trace2 = createTrace({
+      id: traceId2,
+      project_id: projectId,
+    });
+
+    await createTraces([trace1, trace2]);
+
+    const input = {
+      projectId: projectId,
+      datasetId: datasetId,
+      limit: 10,
+      page: 0,
+      prisma: prisma,
+    };
+
+    const result = await fetchDatasetItems(input);
+
+    expect(result.totalDatasetItems).toEqual(2);
+    expect(result.datasetItems).toHaveLength(2);
+
+    const firstDatasetItem = result.datasetItems.find(
+      (item) => item.id === datasetItemId,
+    );
+    expect(firstDatasetItem).toBeDefined();
+    if (!firstDatasetItem) {
+      throw new Error("firstDatasetItem is not defined");
+    }
+    expect(firstDatasetItem.sourceTraceId).toEqual(traceId1);
+    expect(firstDatasetItem.sourceObservationId).toBeNull();
+
+    const secondDatasetItem = result.datasetItems.find(
+      (item) => item.id === datasetItemId2,
+    );
+    expect(secondDatasetItem).toBeDefined();
+    if (!secondDatasetItem) {
+      throw new Error("secondDatasetItem is not defined");
+    }
+    expect(secondDatasetItem.sourceTraceId).toEqual(traceId2);
+    expect(secondDatasetItem.sourceObservationId).toEqual(observationId2);
   });
 });

--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -257,6 +257,16 @@ describe("Fetch datasets for UI presentation", () => {
       },
     });
 
+    const datasetItemId3 = v4();
+    await prisma.datasetItem.create({
+      data: {
+        id: datasetItemId3,
+        datasetId,
+        metadata: {},
+        projectId,
+      },
+    });
+
     const observation = createObservation({
       id: observationId2,
       trace_id: traceId2,
@@ -310,5 +320,15 @@ describe("Fetch datasets for UI presentation", () => {
     }
     expect(secondDatasetItem.sourceTraceId).toEqual(traceId2);
     expect(secondDatasetItem.sourceObservationId).toEqual(observationId2);
+
+    const thirdDatasetItem = result.datasetItems.find(
+      (item) => item.id === datasetItemId3,
+    );
+    expect(thirdDatasetItem).toBeDefined();
+    if (!thirdDatasetItem) {
+      throw new Error("thirdDatasetItem is not defined");
+    }
+    expect(thirdDatasetItem.sourceTraceId).toBeNull();
+    expect(thirdDatasetItem.sourceObservationId).toBeNull();
   });
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces `getObservationsById` to fetch multiple observations and refactors dataset item fetching logic to use it, with updated tests.
> 
>   - **New Functionality**:
>     - Added `getObservationsById` in `observations.ts` to fetch multiple observations by IDs.
>   - **Refactoring**:
>     - Refactored `fetchDatasetItems` in `service.ts` to use `getObservationsById` for fetching observations.
>     - Updated `itemsByDatasetId` in `dataset-router.ts` to utilize the refactored `fetchDatasetItems`.
>   - **Testing**:
>     - Added tests in `dataset-service.servertest.ts` to verify correct fetching of dataset items using the new logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9b37f1d36582b1e14fa822a085bf8b6833f8d5d6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->