### PR TITLE
fix: fix dataset run item api to always return traceid

### DIFF
--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -13,6 +13,7 @@ import {
 import {
   createDatasetRunsTable,
   fetchDatasetItems,
+  getRunItemsByRunIdOrItemId,
 } from "@/src/features/datasets/server/service";
 
 const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
@@ -215,6 +216,84 @@ describe("Fetch datasets for UI presentation", () => {
     expect(secondRun.avgTotalCost.toString()).toStrictEqual("300");
 
     expect(JSON.stringify(secondRun.scores)).toEqual(JSON.stringify({}));
+  });
+
+  it("should fetch dataset runs for UI in case of trace only without observation", async () => {
+    const datasetId = v4();
+
+    await prisma.dataset.create({
+      data: {
+        id: datasetId,
+        name: v4(),
+        projectId: projectId,
+      },
+    });
+    const datasetRunId = v4();
+    await prisma.datasetRuns.create({
+      data: {
+        id: datasetRunId,
+        name: v4(),
+        datasetId,
+        metadata: {},
+        projectId,
+      },
+    });
+
+    const datasetItemId = v4();
+    await prisma.datasetItem.create({
+      data: {
+        id: datasetItemId,
+        datasetId,
+        metadata: {},
+        projectId,
+      },
+    });
+
+    const datasetRunItemId = v4();
+    const traceId = v4();
+
+    await prisma.datasetRunItems.create({
+      data: {
+        id: datasetRunItemId,
+        datasetRunId: datasetRunId,
+        traceId: traceId,
+        projectId,
+        datasetItemId,
+      },
+    });
+
+    const trace = createTrace({
+      id: traceId,
+      project_id: projectId,
+    });
+
+    await createTraces([trace]);
+
+    const runs = await getRunItemsByRunIdOrItemId(
+      projectId,
+      // fetch directly from the db to have realistic data.
+      await prisma.datasetRunItems.findMany({
+        where: {
+          id: datasetRunItemId,
+        },
+      }),
+    );
+
+    console.log("runs", JSON.stringify(runs));
+
+    expect(runs).toHaveLength(1);
+
+    const firstRun = runs.find((run) => run.id === datasetRunItemId);
+    expect(firstRun).toBeDefined();
+    if (!firstRun) {
+      throw new Error("first run is not defined");
+    }
+
+    expect(firstRun.id).toEqual(datasetRunItemId);
+    expect(firstRun.datasetItemId).toEqual(datasetItemId);
+    expect(firstRun.observation).toBeUndefined();
+    expect(firstRun.trace).toBeDefined();
+    expect(firstRun.trace?.id).toEqual(traceId);
   });
 
   it("should fetch dataset items correctly", async () => {

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -31,6 +31,7 @@ import {
   createDatasetRunsTable,
   datasetRunsTableSchema,
   fetchDatasetItems,
+  getRunItemsByRunIdOrItemId,
 } from "@/src/features/datasets/server/service";
 
 export const datasetRouter = createTRPCRouter({
@@ -872,81 +873,13 @@ export const datasetRouter = createTRPCRouter({
           };
         },
         clickhouseExecution: async () => {
-          const [
-            traceScores,
-            observationScores,
-            observationAggregates,
-            traceAggregate,
-          ] = await Promise.all([
-            getScoresForTraces(
-              input.projectId,
-              runItems
-                .filter((ri) => ri.observationId === null) // only include trace scores if run is not linked to an observation
-                .map((ri) => ri.traceId),
-            ),
-            getScoresForObservations(
-              input.projectId,
-              runItems
-                .filter((ri) => ri.observationId !== null)
-                .map((ri) => ri.observationId) as string[],
-            ),
-            getLatencyAndTotalCostForObservations(
-              input.projectId,
-              runItems
-                .filter((ri) => ri.observationId !== null)
-                .map((ri) => ri.observationId) as string[],
-            ),
-            getLatencyAndTotalCostForObservationsByTraces(
-              input.projectId,
-              runItems.map((ri) => ri.traceId),
-            ),
-          ]);
-
-          const validatedTraceScores = filterAndValidateDbScoreList(
-            traceScores,
-            traceException,
-          );
-          const validatedObservationScores = filterAndValidateDbScoreList(
-            observationScores,
-            traceException,
-          );
-
-          const items = runItems.map((ri) => {
-            return {
-              id: ri.id,
-              createdAt: ri.createdAt,
-              datasetItemId: ri.datasetItemId,
-              observation: observationAggregates
-                .map((o) => ({
-                  id: o.id,
-                  latency: o.latency,
-                  calculatedTotalCost: new Decimal(o.totalCost),
-                }))
-                .find((o) => o.id === ri.observationId),
-              trace: traceAggregate
-                .map((t) => ({
-                  id: t.traceId,
-                  duration: t.latency,
-                  totalCost: t.totalCost,
-                }))
-                .find((t) => t.id === ri.traceId),
-              scores: aggregateScores([
-                ...validatedTraceScores.filter(
-                  (s) => s.traceId === ri.traceId && ri.observationId === null,
-                ),
-                ...validatedObservationScores.filter(
-                  (s) =>
-                    s.observationId === ri.observationId &&
-                    s.traceId === ri.traceId,
-                ),
-              ]),
-            };
-          });
-
           // Note: We early return in case of no run items, when adding parameters here, make sure to update the early return above
           return {
             totalRunItems,
-            runItems: items,
+            runItems: await getRunItemsByRunIdOrItemId(
+              input.projectId,
+              runItems,
+            ),
           };
         },
       });

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -18,21 +18,14 @@ import {
   paginationZod,
 } from "@langfuse/shared";
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
-import {
-  getLatencyAndTotalCostForObservations,
-  getLatencyAndTotalCostForObservationsByTraces,
-  getScoresForObservations,
-  getScoresForTraces,
-  traceException,
-} from "@langfuse/shared/src/server";
 import { measureAndReturnApi } from "@/src/server/utils/checkClickhouseAccess";
-import Decimal from "decimal.js";
 import {
   createDatasetRunsTable,
   datasetRunsTableSchema,
   fetchDatasetItems,
   getRunItemsByRunIdOrItemId,
 } from "@/src/features/datasets/server/service";
+import { traceException } from "@langfuse/shared/src/server";
 
 export const datasetRouter = createTRPCRouter({
   allDatasetMeta: protectedProjectProcedure

--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -549,17 +549,29 @@ export const getRunItemsByRunIdOrItemId = async (
       duration: 0,
     };
 
-    return {
-      id: ri.id,
-      createdAt: ri.createdAt,
-      datasetItemId: ri.datasetItemId,
-      observation: observationAggregates
+    const observation =
+      observationAggregates
         .map((o) => ({
           id: o.id,
           latency: o.latency,
           calculatedTotalCost: new Decimal(o.totalCost),
         }))
-        .find((o) => o.id === ri.observationId),
+        .find((o) => o.id === ri.observationId) ??
+      (ri.observationId
+        ? // we default to the observationId provided. The observationId must not be missing
+          // in case it is on the dataset run item.
+          {
+            id: ri.observationId,
+            calculatedTotalCost: new Decimal(0),
+            latency: 0,
+          }
+        : undefined);
+
+    return {
+      id: ri.id,
+      createdAt: ri.createdAt,
+      datasetItemId: ri.datasetItemId,
+      observation,
       trace,
       scores: aggregateScores([
         ...validatedTraceScores.filter(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `getRunItemsByRunIdOrItemId` to ensure trace IDs are returned even without observations, updating related logic and tests.
> 
>   - **Behavior**:
>     - Added `getRunItemsByRunIdOrItemId` in `service.ts` to ensure trace IDs are always returned, even without observations.
>     - Updated `clickhouseExecution` in `dataset-router.ts` to use `getRunItemsByRunIdOrItemId` for fetching run items.
>   - **Tests**:
>     - Added test case in `dataset-service.servertest.ts` to verify fetching dataset runs with trace only, without observation.
>   - **Misc**:
>     - Minor refactoring in `dataset-router.ts` to streamline run item fetching logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d34c0aea9f0ff11a11684afe0d833571f80480d0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->