### PR TITLE
chore: create dataset run items in order of dataset items timestamp

### DIFF
--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -205,7 +205,7 @@ export function DatasetCompareRunsTable(props: {
       {},
     );
 
-    return baseDatasetItems.data?.map(
+    return baseDatasetItems.data?.datasetItems.map(
       (item): DatasetCompareRunRowData => ({
         id: item.id,
         input: item.input ?? "null",
@@ -422,7 +422,7 @@ export function DatasetCompareRunsTable(props: {
                 }
         }
         pagination={{
-          totalCount: baseDatasetItems.data?.length ?? null,
+          totalCount: baseDatasetItems.data?.totalCount ?? null,
           onChange: setPaginationState,
           state: paginationState,
         }}

--- a/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
+++ b/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
@@ -48,7 +48,7 @@ export const constructDatasetRunAggregateColumns = ({
         // if cell is loading or if run created at timestamp is less than 5 seconds ago, show skeleton
         if (
           cellsLoading ||
-          (createdAt && createdAt.getTime() + 5000 > Date.now())
+          (createdAt && createdAt.getTime() + 10000 > Date.now())
         )
           return <Skeleton className="h-full min-h-0 w-full" />;
 

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -752,22 +752,22 @@ export const datasetRouter = createTRPCRouter({
         }>
       >`
         SELECT 
+          di.id AS "datasetItemId",
+          di.created_at AS "datasetItemCreatedAt",
           dri.id,
           dri.trace_id AS "traceId",
           dri.observation_id AS "observationId",
-          dri.created_at AS "createdAt",
-          di.created_at AS "datasetItemCreatedAt",
-          di.id AS "datasetItemId"
-        FROM dataset_run_items dri
-        INNER JOIN dataset_items di 
+          dri.created_at AS "createdAt"
+        FROM dataset_items di
+        LEFT JOIN dataset_run_items dri
           ON dri.dataset_item_id = di.id 
           AND dri.project_id = di.project_id
-        WHERE 
-          dri.project_id = ${input.projectId}
           AND (
             dri.dataset_run_id = ${input.datasetRunId}
-            OR dri.dataset_item_id = ${input.datasetItemId}
+            OR di.id = ${input.datasetItemId}
           )
+        WHERE 
+          di.project_id = ${input.projectId}
         ORDER BY 
           di.created_at DESC
         LIMIT ${input.limit}

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -775,8 +775,7 @@ export const datasetRouter = createTRPCRouter({
             OR dri.dataset_item_id = ${input.datasetItemId}
           )
         ORDER BY 
-          di.created_at DESC,
-          dri.created_at DESC
+          di.created_at DESC
         LIMIT ${input.limit}
         OFFSET ${input.page * input.limit}
       `;

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -745,10 +745,13 @@ export const datasetRouter = createTRPCRouter({
         Array<{
           id: string;
           traceId: string;
-          observationId: string;
+          observationId: string | null;
           createdAt: Date;
+          updatedAt: Date;
           datasetItemCreatedAt: Date;
           datasetItemId: string;
+          projectId: string;
+          datasetRunId: string;
         }>
       >`
         SELECT 
@@ -757,7 +760,10 @@ export const datasetRouter = createTRPCRouter({
           dri.id,
           dri.trace_id AS "traceId",
           dri.observation_id AS "observationId",
-          dri.created_at AS "createdAt"
+          dri.created_at AS "createdAt",
+          dri.updated_at AS "updatedAt",
+          dri.project_id AS "projectId",
+          dri.dataset_run_id AS "datasetRunId"
         FROM dataset_items di
         LEFT JOIN dataset_run_items dri
           ON dri.dataset_item_id = di.id 

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -105,6 +105,7 @@ export const PromptDetail = () => {
     setIsCreateExperimentDialogOpen(false);
     if (!data) return;
     void utils.datasets.baseRunDataByDatasetId.invalidate();
+    void utils.datasets.runsByDatasetId.invalidate();
     showSuccessToast({
       title: "Experiment run triggered successfully",
       description: "Waiting for experiment to complete...",

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
@@ -80,6 +80,7 @@ export default function Dataset() {
   }) => {
     setIsCreateExperimentDialogOpen(false);
     if (!data) return;
+    void utils.datasets.runsByDatasetId.invalidate();
     void utils.datasets.baseRunDataByDatasetId.invalidate();
     showSuccessToast({
       title: "Experiment run triggered successfully",

--- a/worker/src/ee/experiments/experimentService.ts
+++ b/worker/src/ee/experiments/experimentService.ts
@@ -143,6 +143,9 @@ export const createExperimentJob = async ({
       datasetId,
       projectId,
     },
+    orderBy: {
+      createdAt: "desc",
+    },
   });
 
   const validatedDatasetItems = datasetItems.filter(({ input }) =>
@@ -230,7 +233,7 @@ export const createExperimentJob = async ({
           provider,
           model,
           z.object({
-            response: z.string(),
+            output: z.string(),
           }),
           traceParams,
         ),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Order dataset run items by `createdAt` timestamp and update related components for improved data handling and caching.
> 
>   - **Behavior**:
>     - Order dataset run items by `createdAt` timestamp in `dataset-router.ts` and `experimentService.ts`.
>     - Update `DatasetCompareRunsTable.tsx` to use `datasetItems` and `totalCount` for pagination.
>     - Increase skeleton loading time from 5 to 10 seconds in `DatasetRunAggregateColumnHelpers.tsx`.
>   - **Invalidation**:
>     - Invalidate `runsByDatasetId` cache in `prompt-detail.tsx` and `index.tsx` after experiment success.
>   - **Misc**:
>     - Rename `response` to `output` in `experimentService.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f73b977b6957cae8b81ea53d4dbcfcd15de8d8cc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->