### PR TITLE
docs: add link to experimentation docs; fix: datasets run items query 

### DIFF
--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -729,18 +729,44 @@ export const datasetRouter = createTRPCRouter({
         ),
     )
     .query(async ({ input, ctx }) => {
-      const runItems = await ctx.prisma.datasetRunItems.findMany({
-        where: {
-          projectId: input.projectId,
-          datasetRunId: input.datasetRunId,
-          datasetItemId: input.datasetItemId,
-        },
-        orderBy: {
-          datasetItemId: "asc", // Order by dataset item ID instead of createdAt
-        },
-        take: input.limit,
-        skip: input.page * input.limit,
-      });
+      const runItems = await ctx.prisma.$queryRaw<
+        Array<{
+          id: string;
+          traceId: string;
+          observationId: string | null;
+          createdAt: Date;
+          updatedAt: Date;
+          datasetItemCreatedAt: Date;
+          datasetItemId: string;
+          projectId: string;
+          datasetRunId: string;
+        }>
+      >`
+        SELECT 
+          di.id AS "datasetItemId",
+          di.created_at AS "datasetItemCreatedAt",
+          dri.id,
+          dri.trace_id AS "traceId",
+          dri.observation_id AS "observationId",
+          dri.created_at AS "createdAt",
+          dri.updated_at AS "updatedAt",
+          dri.project_id AS "projectId",
+          dri.dataset_run_id AS "datasetRunId"
+        FROM dataset_items di
+        LEFT JOIN dataset_run_items dri
+          ON dri.dataset_item_id = di.id 
+          AND dri.project_id = di.project_id
+          AND (
+            dri.dataset_run_id = ${input.datasetRunId}
+            OR dri.dataset_item_id = ${input.datasetItemId}
+          )
+        WHERE 
+          di.project_id = ${input.projectId}
+        ORDER BY 
+          di.created_at DESC
+        LIMIT ${input.limit}
+        OFFSET ${input.page * input.limit}
+      `;
 
       if (runItems.length === 0) return { totalRunItems: 0, runItems: [] };
 

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -182,7 +182,15 @@ export const PromptDetail = () => {
                         <DialogTitle>Set up experiment</DialogTitle>
                         <DialogDescription>
                           Create an experiment to test a prompt version on a
-                          dataset.
+                          dataset. See{" "}
+                          <Link
+                            href="https://langfuse.com/docs/datasets/prompt-experiments"
+                            target="_blank"
+                            className="underline"
+                          >
+                            documentation
+                          </Link>{" "}
+                          to learn more.
                         </DialogDescription>
                       </DialogHeader>
                       <CreateExperimentsForm

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
@@ -25,6 +25,7 @@ import {
 import { CreateExperimentsForm } from "@/src/ee/features/experiments/components/CreateExperimentsForm";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { useHasOrgEntitlement } from "@/src/features/entitlements/hooks";
+import Link from "next/link";
 
 export default function DatasetCompare() {
   const router = useRouter();
@@ -131,6 +132,15 @@ export default function DatasetCompare() {
                   <DialogTitle>Set up experiment</DialogTitle>
                   <DialogDescription>
                     Create an experiment to test a prompt version on a dataset.
+                    See{" "}
+                    <Link
+                      href="https://langfuse.com/docs/datasets/prompt-experiments"
+                      target="_blank"
+                      className="underline"
+                    >
+                      documentation
+                    </Link>{" "}
+                    to learn more.
                   </DialogDescription>
                 </DialogHeader>
                 <CreateExperimentsForm

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
@@ -127,7 +127,15 @@ export default function Dataset() {
                     <DialogTitle>Set up experiment</DialogTitle>
                     <DialogDescription>
                       Create an experiment to test a prompt version on a
-                      dataset.
+                      dataset. See{" "}
+                      <Link
+                        href="https://langfuse.com/docs/datasets/prompt-experiments"
+                        target="_blank"
+                        className="underline"
+                      >
+                        documentation
+                      </Link>{" "}
+                      to learn more.
                     </DialogDescription>
                   </DialogHeader>
                   <CreateExperimentsForm


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimizes query in `dataset-router.ts` and adds prompt experiment documentation links in three files.
> 
>   - **Query Optimization**:
>     - Replaced Prisma `findMany` with raw SQL query in `dataset-router.ts` for fetching dataset run items, improving performance and flexibility.
>   - **Documentation Links**:
>     - Added link to prompt experiment documentation in `prompt-detail.tsx`.
>     - Added link to prompt experiment documentation in `compare.tsx`.
>     - Added link to prompt experiment documentation in `index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 10f3b3c97515931e46e288d58522de17bb35ad4f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->