### PR TITLE
chore: rename default experiment tag `langfuse-prompt-experiment`

### DIFF
--- a/worker/src/__tests__/experimentsService.test.ts
+++ b/worker/src/__tests__/experimentsService.test.ts
@@ -402,7 +402,7 @@ describe("create experiment job calls with langfuse server side tracing", async 
       expect.any(String),
       expect.any(Object),
       expect.objectContaining({
-        tags: ["langfuse:evaluation:llm-as-a-judge"],
+        tags: ["langfuse-prompt-experiment"],
         traceName: expect.stringMatching(/^dataset-run-item-/),
         traceId: expect.any(String),
         projectId: mockEvent.projectId,

--- a/worker/src/ee/experiments/experimentService.ts
+++ b/worker/src/ee/experiments/experimentService.ts
@@ -210,7 +210,7 @@ export const createExperimentJob = async ({
      ********************/
 
     const traceParams = {
-      tags: ["langfuse:evaluation:llm-as-a-judge"], // LFE-2917: filter out any trace in trace upsert queue that has this tag set
+      tags: ["langfuse-prompt-experiment"], // LFE-2917: filter out any trace in trace upsert queue that has this tag set
       traceName: `dataset-run-item-${runItem.id.slice(0, 5)}`,
       traceId: newTraceId,
       projectId: event.projectId,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename default experiment tag to `langfuse-prompt-experiment` in `experimentService.ts` and `experimentsService.test.ts`.
> 
>   - **Behavior**:
>     - Rename default experiment tag from `langfuse:evaluation:llm-as-a-judge` to `langfuse-prompt-experiment` in `experimentService.ts` and `experimentsService.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2fecbc8ae16f9e21d5c13f97b0087bc57a4df2af. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->