### PR TITLE
fix: experimentation should not use structured output

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -258,7 +258,7 @@ export async function fetchLLMCompletion(
 
   return {
     completion: await chatModel
-      //.pipe(new StringOutputParser())
+      .pipe(new StringOutputParser())
       .invoke(finalMessages, runConfig),
     processTracedEvents,
   };

--- a/worker/src/__tests__/experimentsService.test.ts
+++ b/worker/src/__tests__/experimentsService.test.ts
@@ -400,7 +400,6 @@ describe("create experiment job calls with langfuse server side tracing", async 
       expect.any(Object),
       expect.any(String),
       expect.any(String),
-      expect.any(Object),
       expect.objectContaining({
         tags: ["langfuse-prompt-experiment"],
         traceName: expect.stringMatching(/^dataset-run-item-/),

--- a/worker/src/ee/experiments/experimentService.ts
+++ b/worker/src/ee/experiments/experimentService.ts
@@ -232,9 +232,6 @@ export const createExperimentJob = async ({
           model_params,
           provider,
           model,
-          z.object({
-            output: z.string(),
-          }),
           traceParams,
         ),
       {

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -36,7 +36,7 @@ import {
 import { kyselyPrisma, prisma } from "@langfuse/shared/src/db";
 import { backOff } from "exponential-backoff";
 import { env } from "../../env";
-import { callLLM, compileHandlebarString } from "../utilities";
+import { callStructuredLLM, compileHandlebarString } from "../utilities";
 
 let s3StorageServiceClient: S3StorageService;
 
@@ -533,7 +533,7 @@ export const evaluate = async ({
 
   const parsedLLMOutput = await backOff(
     async () =>
-      await callLLM(
+      await callStructuredLLM(
         event.jobExecutionId,
         parsedKey.data,
         messages,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor experimentation to remove structured output usage, update related functions, and adjust tests accordingly.
> 
>   - **Behavior**:
>     - Removed `structuredOutputSchema` from `createExperimentJob` in `experimentService.ts`.
>     - Updated `fetchLLMCompletion` calls in `fetchLLMCompletion.ts` to use `runConfig`.
>   - **Functions**:
>     - Renamed `callLLM` to `callStructuredLLM` in `evalService.ts` and `utilities.ts`.
>     - Added new `callLLM` function in `utilities.ts` without structured output.
>   - **Tests**:
>     - Removed `expect.any(Object)` from `experimentsService.test.ts` to reflect changes in `createExperimentJob`.
>   - **Misc**:
>     - Removed unused schema in `experimentService.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 051ef530657118867f22505b445e1e8e5339c0ba. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->