### PR TITLE
fix: don't show error message to user if trace is not yet available for dataset

### DIFF
--- a/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
+++ b/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
@@ -83,7 +83,10 @@ const DatasetAggregateCell = ({
       {variant === "peek" && actionButtons}
       <div className="flex flex-row items-center justify-center gap-1">
         <IOTableCell
-          isLoading={!!!observationId ? trace.isLoading : observation.isLoading}
+          isLoading={
+            (!!!observationId ? trace.isLoading : observation.isLoading) ||
+            !data
+          }
           data={data?.output}
           className={"bg-accent-light-green"}
           singleLine={singleLine}

--- a/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
+++ b/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
@@ -45,10 +45,10 @@ export const constructDatasetRunAggregateColumns = ({
       cell: ({ row }: { row: Row<DatasetCompareRunRowData> }) => {
         const runData: RunAggregate = row.getValue("runs") ?? {};
 
-        // if cell is loading or if run created at timestamp is less than 5 seconds ago, show skeleton
+        // if cell is loading or if run created at timestamp is less than 20 seconds ago, show skeleton
         if (
           cellsLoading ||
-          (createdAt && createdAt.getTime() + 10000 > Date.now())
+          (createdAt && createdAt.getTime() + 20000 > Date.now())
         )
           return <Skeleton className="h-full min-h-0 w-full" />;
 

--- a/web/src/features/datasets/components/DatasetRunItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsTable.tsx
@@ -328,6 +328,7 @@ const TraceObservationIOCell = ({
         },
       },
       refetchOnMount: false, // prevents refetching loops
+      onError: () => {},
     },
   );
   const observation = api.observations.byId.useQuery(
@@ -344,6 +345,7 @@ const TraceObservationIOCell = ({
         },
       },
       refetchOnMount: false, // prevents refetching loops
+      onError: () => {},
     },
   );
 
@@ -351,7 +353,9 @@ const TraceObservationIOCell = ({
 
   return (
     <IOTableCell
-      isLoading={!!!observationId ? trace.isLoading : observation.isLoading}
+      isLoading={
+        (!!!observationId ? trace.isLoading : observation.isLoading) || !data
+      }
       data={io === "output" ? data?.output : data?.input}
       className={cn(io === "output" && "bg-accent-light-green")}
       singleLine={singleLine}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevents error messages for unavailable trace data and adjusts loading conditions in dataset components.
> 
>   - **Behavior**:
>     - Prevents error messages when trace data is unavailable by adding `onError: () => {}` in `TraceObservationIOCell` and `DatasetAggregateCell`.
>     - Updates `isLoading` condition in `IOTableCell` in `DatasetAggregateTableCell.tsx` and `DatasetRunItemsTable.tsx` to include `!data` check.
>   - **Timing**:
>     - Changes skeleton display condition in `constructDatasetRunAggregateColumns` to 20 seconds from 10 seconds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for dd85a297f3d180fc738f99f6c6ea7d8a30b03fce. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->