### PR TITLE
fix: fix dataset run table to show all scores

### DIFF
--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -72,6 +72,7 @@ describe("Fetch datasets for UI presentation", () => {
     const traceId3 = v4();
     const traceId4 = v4();
     const scoreId = v4();
+    const scoreId2 = v4();
     const scoreName = v4();
 
     await prisma.datasetRunItems.create({
@@ -164,7 +165,16 @@ describe("Fetch datasets for UI presentation", () => {
       project_id: projectId,
       name: scoreName,
     });
-    await createScores([score]);
+    const score2 = createScore({
+      id: scoreId2,
+      observation_id: null,
+      trace_id: traceId,
+      project_id: projectId,
+      name: scoreName,
+      value: 1,
+      comment: "some other comment",
+    });
+    await createScores([score, score2]);
 
     const runs = await createDatasetRunsTable({
       projectId,
@@ -191,16 +201,15 @@ describe("Fetch datasets for UI presentation", () => {
     expect(firstRun.avgLatency).toBeGreaterThanOrEqual(10800);
     expect(firstRun.avgTotalCost.toString()).toStrictEqual("275");
 
-    const expectedObject = JSON.stringify({
+    const expectedObject = {
       [`${scoreName.replaceAll("-", "_")}-API-NUMERIC`]: {
         type: "NUMERIC",
-        values: [100.5],
-        average: 100.5,
-        comment: "comment",
+        values: expect.arrayContaining([1, 100.5]),
+        average: 50.75,
       },
-    });
+    };
 
-    expect(JSON.stringify(firstRun.scores)).toEqual(expectedObject);
+    expect(firstRun.scores).toEqual(expectedObject);
 
     const secondRun = runs.find((run) => run.run_id === datasetRun2Id);
 

--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -77,6 +77,7 @@ export const createDatasetRunsTable = async (input: DatasetRunsTableInput) => {
       tableName,
       clickhouseSession,
     );
+
     const obsAgg = await getObservationLatencyAndCostForDataset(
       input,
       tableName,
@@ -226,11 +227,11 @@ const getScoresFromTempTable = async (
         tmp.run_id
       FROM ${tableName} tmp JOIN scores s 
         ON tmp.project_id = s.project_id 
-        AND tmp.observation_id = s.observation_id 
         AND tmp.trace_id = s.trace_id
       WHERE s.project_id = {projectId: String}
       AND tmp.project_id = {projectId: String}
       AND tmp.dataset_id = {datasetId: String}
+      AND (tmp.observation_id = s.observation_id OR s.observation_id IS NULL)
       ORDER BY s.event_ts DESC
       LIMIT 1 BY s.id, s.project_id
   `;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes dataset run table to include scores with null observation IDs and updates tests accordingly.
> 
>   - **Behavior**:
>     - Fixes dataset run table to include scores with null `observation_id` in `getScoresFromTempTable()` in `service.ts`.
>     - Updates test in `dataset-service.servertest.ts` to verify multiple scores are handled correctly.
>   - **Tests**:
>     - Adds a second score with null `observation_id` in `dataset-service.servertest.ts` to test score aggregation.
>     - Updates expected score values and averages in `dataset-service.servertest.ts` to reflect new behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b56cbd1f75392e5ebfc6230bec0ccc5f7d81cdfb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->