### PR TITLE
fix: correctly retrieve scores for datasets

### DIFF
--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -188,7 +188,7 @@ describe("Fetch datasets for UI presentation", () => {
       comment: "some other comment for non run related score",
     });
     await createScores([score, score2, score3]);
-    console.log("createdscores", JSON.stringify([score, score2, score3]));
+
     const runs = await createDatasetRunsTable({
       projectId,
       datasetId,

--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -73,6 +73,7 @@ describe("Fetch datasets for UI presentation", () => {
     const traceId4 = v4();
     const scoreId = v4();
     const scoreId2 = v4();
+    const scoreId3 = v4();
     const scoreName = v4();
 
     await prisma.datasetRunItems.create({
@@ -174,8 +175,20 @@ describe("Fetch datasets for UI presentation", () => {
       value: 1,
       comment: "some other comment",
     });
-    await createScores([score, score2]);
+    const observationId2 = v4(); // this one is not related to a run
+    const anotherScoreName = v4();
 
+    const score3 = createScore({
+      id: scoreId3,
+      observation_id: observationId2,
+      trace_id: traceId,
+      project_id: projectId,
+      name: anotherScoreName,
+      value: 1,
+      comment: "some other comment for non run related score",
+    });
+    await createScores([score, score2, score3]);
+    console.log("createdscores", JSON.stringify([score, score2, score3]));
     const runs = await createDatasetRunsTable({
       projectId,
       datasetId,
@@ -206,6 +219,12 @@ describe("Fetch datasets for UI presentation", () => {
         type: "NUMERIC",
         values: expect.arrayContaining([1, 100.5]),
         average: 50.75,
+      },
+      [`${anotherScoreName.replaceAll("-", "_")}-API-NUMERIC`]: {
+        type: "NUMERIC",
+        values: expect.arrayContaining([1]),
+        average: 1,
+        comment: "some other comment for non run related score",
       },
     };
 

--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -246,7 +246,6 @@ const getScoresFromTempTable = async (
     clickhouseConfigs: { session_id: clickhouseSession },
   });
 
-  console.log("scoresreturned", rows);
   return rows.map((row) => ({ ...convertToScore(row), run_id: row.run_id }));
 };
 

--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -174,14 +174,14 @@ export const deleteTempTableInClickhouse = async (
   tableName: string,
   sessionId: string,
 ) => {
-  // const query = `
-  //     DROP TABLE IF EXISTS ${tableName}
-  // `;
-  // await commandClickhouse({
-  //   query,
-  //   params: { tableName },
-  //   clickhouseConfigs: { session_id: sessionId },
-  // });
+  const query = `
+      DROP TABLE IF EXISTS ${tableName}
+  `;
+  await commandClickhouse({
+    query,
+    params: { tableName },
+    clickhouseConfigs: { session_id: sessionId },
+  });
 };
 
 export const getDatasetRunsFromPostgres = async (

--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -174,14 +174,14 @@ export const deleteTempTableInClickhouse = async (
   tableName: string,
   sessionId: string,
 ) => {
-  const query = `
-      DROP TABLE IF EXISTS ${tableName}
-  `;
-  await commandClickhouse({
-    query,
-    params: { tableName },
-    clickhouseConfigs: { session_id: sessionId },
-  });
+  // const query = `
+  //     DROP TABLE IF EXISTS ${tableName}
+  // `;
+  // await commandClickhouse({
+  //   query,
+  //   params: { tableName },
+  //   clickhouseConfigs: { session_id: sessionId },
+  // });
 };
 
 export const getDatasetRunsFromPostgres = async (
@@ -231,7 +231,6 @@ const getScoresFromTempTable = async (
       WHERE s.project_id = {projectId: String}
       AND tmp.project_id = {projectId: String}
       AND tmp.dataset_id = {datasetId: String}
-      AND (tmp.observation_id = s.observation_id OR s.observation_id IS NULL)
       ORDER BY s.event_ts DESC
       LIMIT 1 BY s.id, s.project_id
   `;
@@ -247,6 +246,7 @@ const getScoresFromTempTable = async (
     clickhouseConfigs: { session_id: clickhouseSession },
   });
 
+  console.log("scoresreturned", rows);
   return rows.map((row) => ({ ...convertToScore(row), run_id: row.run_id }));
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes score retrieval for datasets by updating logic in `getScoresFromTempTable` and test cases in `dataset-service.servertest.ts`.
> 
>   - **Behavior**:
>     - Fixes score retrieval logic in `getScoresFromTempTable` by removing condition on `observation_id`.
>     - Updates test in `dataset-service.servertest.ts` to include scores not directly linked to a run.
>   - **Functions**:
>     - Comments out `deleteTempTableInClickhouse` logic in `service.ts`, indicating a change in temporary table management.
>   - **Misc**:
>     - Adds logging for scores returned in `getScoresFromTempTable`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b0cff6a85d9fb353d525bd36863e6f0984e2109a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->