### PR TITLE
feat: add all scores to run items UI

### DIFF
--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -317,7 +317,7 @@ describe("Fetch datasets for UI presentation", () => {
 
     await createTraces([trace1, trace2]);
 
-    const obervation = createObservation({
+    const observation = createObservation({
       id: observationId,
       trace_id: traceId2,
       project_id: projectId,
@@ -329,7 +329,7 @@ describe("Fetch datasets for UI presentation", () => {
       trace_id: traceId,
     });
 
-    await createObservations([obervation]);
+    await createObservations([observation]);
 
     const score = createScore({
       observation_id: observation2.id,

--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -246,7 +246,148 @@ describe("Fetch datasets for UI presentation", () => {
     expect(JSON.stringify(secondRun.scores)).toEqual(JSON.stringify({}));
   });
 
-  it("should fetch dataset runs for UI with missing tracing data", async () => {
+  it.only("should fetch dataset run items for UI", async () => {
+    const datasetId = v4();
+
+    await prisma.dataset.create({
+      data: {
+        id: datasetId,
+        name: v4(),
+        projectId: projectId,
+      },
+    });
+    const datasetRunId = v4();
+    await prisma.datasetRuns.create({
+      data: {
+        id: datasetRunId,
+        name: v4(),
+        datasetId,
+        metadata: {},
+        projectId,
+      },
+    });
+
+    const datasetItemId = v4();
+    await prisma.datasetItem.create({
+      data: {
+        id: datasetItemId,
+        datasetId,
+        metadata: {},
+        projectId,
+      },
+    });
+
+    const datasetRunItemId = v4();
+    const traceId = v4();
+
+    await prisma.datasetRunItems.create({
+      data: {
+        id: datasetRunItemId,
+        datasetRunId: datasetRunId,
+        traceId: traceId,
+        projectId,
+        datasetItemId,
+      },
+    });
+
+    const traceId2 = v4();
+    const observationId = v4();
+    const datasetRunItemId2 = v4();
+
+    await prisma.datasetRunItems.create({
+      data: {
+        id: datasetRunItemId2,
+        datasetRunId: datasetRunId,
+        traceId: traceId2,
+        projectId,
+        datasetItemId,
+        observationId,
+      },
+    });
+
+    const trace1 = createTrace({
+      id: traceId,
+      project_id: projectId,
+    });
+
+    const trace2 = createTrace({
+      id: traceId2,
+      project_id: projectId,
+    });
+
+    await createTraces([trace1, trace2]);
+
+    const obervation = createObservation({
+      id: observationId,
+      trace_id: traceId2,
+      project_id: projectId,
+      start_time: new Date().getTime() - 1000 * 60 * 60, // minus 1 min
+      end_time: new Date().getTime(),
+    });
+
+    const observation2 = createObservation({
+      trace_id: traceId,
+    });
+
+    await createObservations([obervation]);
+
+    const score = createScore({
+      observation_id: observation2.id,
+      trace_id: traceId2,
+      project_id: projectId,
+    });
+
+    await createScores([score]);
+
+    const runs = await getRunItemsByRunIdOrItemId(
+      projectId,
+      // fetch directly from the db to have realistic data.
+      await prisma.datasetRunItems.findMany({
+        where: {
+          id: {
+            in: [datasetRunItemId, datasetRunItemId2],
+          },
+        },
+      }),
+    );
+
+    expect(runs).toHaveLength(2);
+
+    const firstRun = runs.find((run) => run.id === datasetRunItemId);
+    expect(firstRun).toBeDefined();
+    if (!firstRun) {
+      throw new Error("first run is not defined");
+    }
+
+    expect(firstRun.id).toEqual(datasetRunItemId);
+    expect(firstRun.datasetItemId).toEqual(datasetItemId);
+    expect(firstRun.observation).toBeUndefined();
+    expect(firstRun.trace).toBeDefined();
+    expect(firstRun.trace?.id).toEqual(traceId);
+
+    const secondRun = runs.find((run) => run.id === datasetRunItemId2);
+    expect(secondRun).toBeDefined();
+    if (!secondRun) {
+      throw new Error("secondRun is not defined");
+    }
+
+    expect(secondRun.id).toEqual(datasetRunItemId2);
+    expect(secondRun.datasetItemId).toEqual(datasetItemId);
+    expect(secondRun.trace?.id).toEqual(traceId2);
+    expect(secondRun.observation?.id).toEqual(observationId);
+
+    const expectedObject = {
+      [`${score.name.replaceAll("-", "_")}-API-NUMERIC`]: {
+        type: "NUMERIC",
+        values: expect.arrayContaining([1, 100.5]),
+        average: 50.75,
+      },
+    };
+
+    expect(secondRun.scores).toEqual(expectedObject);
+  });
+
+  it("should fetch dataset run items for UI with missing tracing data", async () => {
     const datasetId = v4();
 
     await prisma.dataset.create({

--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -379,8 +379,9 @@ describe("Fetch datasets for UI presentation", () => {
     const expectedObject = {
       [`${score.name.replaceAll("-", "_")}-API-NUMERIC`]: {
         type: "NUMERIC",
-        values: expect.arrayContaining([1, 100.5]),
-        average: 50.75,
+        values: expect.arrayContaining([100.5]),
+        average: 100.5,
+        comment: "comment",
       },
     };
 

--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -246,7 +246,7 @@ describe("Fetch datasets for UI presentation", () => {
     expect(JSON.stringify(secondRun.scores)).toEqual(JSON.stringify({}));
   });
 
-  it.only("should fetch dataset run items for UI", async () => {
+  it("should fetch dataset run items for UI", async () => {
     const datasetId = v4();
 
     await prisma.dataset.create({

--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -518,6 +518,8 @@ export const getRunItemsByRunIdOrItemId = async (
       ),
     ]);
 
+  console.log(traceScores);
+
   const validatedTraceScores = filterAndValidateDbScoreList(
     traceScores,
     traceException,
@@ -562,9 +564,7 @@ export const getRunItemsByRunIdOrItemId = async (
       observation,
       trace,
       scores: aggregateScores([
-        ...validatedTraceScores.filter(
-          (s) => s.traceId === ri.traceId && ri.observationId === null,
-        ),
+        ...validatedTraceScores.filter((s) => s.traceId === ri.traceId),
       ]),
     };
   });

--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -518,8 +518,6 @@ export const getRunItemsByRunIdOrItemId = async (
       ),
     ]);
 
-  console.log(traceScores);
-
   const validatedTraceScores = filterAndValidateDbScoreList(
     traceScores,
     traceException,

--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -16,7 +16,6 @@ import {
   getLatencyAndTotalCostForObservations,
   getLatencyAndTotalCostForObservationsByTraces,
   getObservationsById,
-  getScoresForObservations,
   getScoresForTraces,
   getTracesByIds,
   logger,
@@ -501,42 +500,26 @@ export const getRunItemsByRunIdOrItemId = async (
   projectId: string,
   runItems: DatasetRunItems[],
 ) => {
-  const [
-    traceScores,
-    observationScores,
-    observationAggregates,
-    traceAggregate,
-  ] = await Promise.all([
-    getScoresForTraces(
-      projectId,
-      runItems
-        .filter((ri) => ri.observationId === null) // only include trace scores if run is not linked to an observation
-        .map((ri) => ri.traceId),
-    ),
-    getScoresForObservations(
-      projectId,
-      runItems
-        .filter((ri) => ri.observationId !== null)
-        .map((ri) => ri.observationId) as string[],
-    ),
-    getLatencyAndTotalCostForObservations(
-      projectId,
-      runItems
-        .filter((ri) => ri.observationId !== null)
-        .map((ri) => ri.observationId) as string[],
-    ),
-    getLatencyAndTotalCostForObservationsByTraces(
-      projectId,
-      runItems.map((ri) => ri.traceId),
-    ),
-  ]);
+  const [traceScores, observationAggregates, traceAggregate] =
+    await Promise.all([
+      getScoresForTraces(
+        projectId,
+        runItems.map((ri) => ri.traceId),
+      ),
+      getLatencyAndTotalCostForObservations(
+        projectId,
+        runItems
+          .filter((ri) => ri.observationId !== null)
+          .map((ri) => ri.observationId) as string[],
+      ),
+      getLatencyAndTotalCostForObservationsByTraces(
+        projectId,
+        runItems.map((ri) => ri.traceId),
+      ),
+    ]);
 
   const validatedTraceScores = filterAndValidateDbScoreList(
     traceScores,
-    traceException,
-  );
-  const validatedObservationScores = filterAndValidateDbScoreList(
-    observationScores,
     traceException,
   );
 
@@ -581,10 +564,6 @@ export const getRunItemsByRunIdOrItemId = async (
       scores: aggregateScores([
         ...validatedTraceScores.filter(
           (s) => s.traceId === ri.traceId && ri.observationId === null,
-        ),
-        ...validatedObservationScores.filter(
-          (s) =>
-            s.observationId === ri.observationId && s.traceId === ri.traceId,
         ),
       ]),
     };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances UI to display all scores for dataset run items by updating data fetching logic in `service.ts` and tests in `dataset-service.servertest.ts`.
> 
>   - **Behavior**:
>     - Updates `getRunItemsByRunIdOrItemId` in `service.ts` to fetch scores for traces only, excluding observation scores.
>     - Modifies UI to display all scores for dataset run items.
>   - **Tests**:
>     - Adds a new test case in `dataset-service.servertest.ts` to verify fetching dataset run items with scores.
>     - Updates existing test cases to align with the new behavior of displaying all scores.
>   - **Misc**:
>     - Removes `getScoresForObservations` from imports in `service.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 23d7ca98dd3c098742c1e5199d31fc7ac81996e5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->