### PR TITLE
chore: only build web and its dependencies in web CI tests

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -118,7 +118,7 @@ jobs:
           pnpm run db:migrate
           pnpm --filter=shared ch:up
       - name: Build
-        run: pnpm run build
+        run: pnpm --filter=web... run build
       - name: Start Langfuse
         run: (pnpm run start&)
         env:
@@ -186,7 +186,7 @@ jobs:
           pnpm run db:migrate
           pnpm --filter=shared ch:up
       - name: Build
-        run: pnpm run build
+        run: pnpm --filter=web... run build
       - name: Start Langfuse
         run: (pnpm run start&)
         env:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize CI pipeline by building only web and its dependencies in web-related tests.
> 
>   - **CI Pipeline**:
>     - In `pipeline.yml`, modify the build step in `tests-web-sync` and `tests-web-async` jobs to use `pnpm --filter=web... run build` instead of `pnpm run build`.
>     - This change ensures only the web and its dependencies are built, optimizing the CI process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 56d1e22bb94cb57335bdf62bf6c0754b97f4b1e4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->