### PR TITLE
chore: overwrite numerical type for second filters on observations table

### DIFF
--- a/packages/shared/src/tableDefinitions/mapObservationsTable.ts
+++ b/packages/shared/src/tableDefinitions/mapObservationsTable.ts
@@ -69,6 +69,8 @@ export const observationsTableUiColumnDefinitions: UiColumnMapping[] = [
     clickhouseTableName: "observations",
     clickhouseSelect:
       "if(isNull(completion_start_time), NULL,  date_diff('seconds', start_time, completion_start_time))",
+    // If we use the default of Decimal64(12), we cannot filter for more than ~40min due to an overflow
+    clickhouseTypeOverwrite: "Decimal64(3)",
   },
   {
     uiTableName: "Latency (s)",
@@ -76,6 +78,8 @@ export const observationsTableUiColumnDefinitions: UiColumnMapping[] = [
     clickhouseTableName: "observations",
     clickhouseSelect:
       "if(isNull(end_time), NULL, date_diff('seconds', start_time, end_time))",
+    // If we use the default of Decimal64(12), we cannot filter for more than ~40min due to an overflow
+    clickhouseTypeOverwrite: "Decimal64(3)",
   },
   {
     uiTableName: "Tokens per second",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Overwrite `clickhouseTypeOverwrite` to `Decimal64(3)` for specific columns in `observationsTableUiColumnDefinitions` to prevent overflow issues.
> 
>   - **Behavior**:
>     - Overwrites `clickhouseTypeOverwrite` to `Decimal64(3)` for `Time To First Token (s)` and `Latency (s)` columns in `observationsTableUiColumnDefinitions` to prevent overflow when filtering durations longer than 40 minutes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 801e79d1923c336d2dc3f360874cb4530a207e1f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->