### PR TITLE
build: adjust docker actions to handle v2 branch

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -441,6 +441,8 @@ jobs:
           images: |
             ghcr.io/langfuse/langfuse # GitHub
             langfuse/langfuse # Docker Hub
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -448,6 +450,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v3') }}
       - name: Build and push Docker image (web)
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   push:
     # Pattern matched against refs/tags
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+" # Semantic version tags
+      - "v3.[0-9]+.[0-9]+" # Semantic version tags
 
 jobs:
   release:


### PR DESCRIPTION
## What

Adjust GitHub actions to only build an image for v2 tags without a push to prod and to only tag v3 tags as latest.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adjust GitHub Actions to build Docker images for v2 tags without marking as latest and only tag v3 tags as latest.
> 
>   - **GitHub Actions**:
>     - In `pipeline.yml`, added `flavor: latest=false` to prevent v2 tags from being marked as latest.
>     - Modified `tags` in `pipeline.yml` to enable `latest` only for v3 tags using `type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v3') }}`.
>     - In `release.yml`, changed tag pattern to `v3.[0-9]+.[0-9]+` to only trigger on v3 tags.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6ccb95873860d064b2d32ab802502adc2d8c171a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->