### PR TITLE
fix: order datasets API correctly

### DIFF
--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -213,6 +213,7 @@ export const getDatasetRunsFromPostgres = async (
         d.id = ${input.datasetId}
         AND d.project_id = ${input.projectId}
       GROUP BY runs.id, runs.name, runs.description, runs.metadata, runs.created_at, runs.updated_at
+      ORDER BY runs.created_at DESC
       LIMIT ${input.limit}
       OFFSET ${input.page * input.limit}
     `,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `ORDER BY runs.created_at DESC` to order dataset runs by creation date in `getDatasetRunsFromPostgres()` in `service.ts`.
> 
>   - **Behavior**:
>     - Adds `ORDER BY runs.created_at DESC` to the SQL query in `getDatasetRunsFromPostgres()` in `service.ts` to order dataset runs by creation date in descending order.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 52b821a3301a29796853b66f5de26e3ab9173d41. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->