### PR TITLE
fix: do not log stack trace in trpc checkupdate when no internet access

### DIFF
--- a/web/src/server/api/routers/public.ts
+++ b/web/src/server/api/routers/public.ts
@@ -1,6 +1,7 @@
 import { VERSION } from "@/src/constants/VERSION";
 import { env } from "@/src/env.mjs";
 import { createTRPCRouter, publicProcedure } from "@/src/server/api/trpc";
+import { logger } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
@@ -58,11 +59,10 @@ export const publicRouter = createTRPCRouter({
       );
       body = await response.json();
     } catch (error) {
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message: "Failed to fetch or json parse the latest releases",
-        cause: error,
-      });
+      logger.info(
+        "[trpc.public.checkUpdate] failed to fetch latest-release api",
+      );
+      return null;
     }
 
     const releases = ReleaseApiRes.safeParse(body);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve error handling in `checkUpdate` function in `public.ts` by logging errors and returning null instead of throwing exceptions.
> 
>   - **Error Handling**:
>     - In `public.ts`, replace `TRPCError` with `logger.info` and return `null` when fetching the latest release fails in `checkUpdate` function.
>   - **Logging**:
>     - Add `logger` import from `@langfuse/shared/src/server` to log errors instead of throwing exceptions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1a3729291a3dd92609e15616fbb05679ac1f1e59. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->