### PR TITLE
fix(playground): unique prompt names in save to prompt

### DIFF
--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -552,6 +552,7 @@ export const promptRouter = createTRPCRouter({
           id: true,
           name: true,
         },
+        distinct: ["name"],
       });
     }),
   updateTags: protectedProjectProcedure


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure unique prompt names are returned in `allNames` function by adding `distinct` clause in `promptRouter.ts`.
> 
>   - **Behavior**:
>     - Ensures unique prompt names are returned in `allNames` function in `promptRouter.ts` by adding `distinct: ["name"]`.
>   - **Misc**:
>     - No other changes or refactoring in the file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for dd69a2bd6e0dd7d1f56e4da72bfba213946b8069. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->