### PR TITLE
chore: restrict trace.name length to 1000 characters

### DIFF
--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -59,7 +59,7 @@ export const usage = MixedUsage.nullish()
 export const TraceBody = z.object({
   id: z.string().nullish(),
   timestamp: stringDateTime,
-  name: z.string().nullish(),
+  name: z.string().max(1000).nullish(),
   externalId: z.string().nullish(),
   input: jsonSchema.nullish(),
   output: jsonSchema.nullish(),

--- a/web/src/__tests__/ingestion.servertest.ts
+++ b/web/src/__tests__/ingestion.servertest.ts
@@ -978,6 +978,40 @@ describe("/api/public/ingestion API Endpoint", () => {
     expect(dbTrace.length).toBe(1);
   });
 
+  it("should fail for long trace name", async () => {
+    const traceId = v4();
+
+    const baseString =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ";
+    const repeatCount = Math.ceil(1500 / baseString.length);
+    const name = baseString.repeat(repeatCount);
+
+    const response = await makeAPICall("POST", "/api/public/ingestion", {
+      batch: [
+        {
+          id: v4(),
+          type: "trace-create",
+          timestamp: new Date().toISOString(),
+          body: {
+            id: traceId,
+            name,
+            userId: "user-1",
+            metadata: { key: "value" },
+            release: "1.0.0",
+            version: "2.0.0",
+          },
+        },
+      ],
+    });
+
+    expect(response.status).toBe(207);
+    console.log(JSON.stringify(response.body));
+    expect(true).toBe(false);
+    expect("errors" in response.body).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(response.body.errors.length).toBe(1);
+  });
+
   it("should update all token counts if update does not contain model name", async () => {
     const traceId = v4();
     const generationId = v4();

--- a/web/src/__tests__/ingestion.servertest.ts
+++ b/web/src/__tests__/ingestion.servertest.ts
@@ -1005,11 +1005,10 @@ describe("/api/public/ingestion API Endpoint", () => {
     });
 
     expect(response.status).toBe(207);
-    console.log(JSON.stringify(response.body));
-    expect(true).toBe(false);
     expect("errors" in response.body).toBe(true);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(response.body.errors.length).toBe(1);
+    expect(response.body.errors[0].message).toBe("Invalid request data");
   });
 
   it("should update all token counts if update does not contain model name", async () => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Restrict `trace.name` length to 1000 characters in `TraceBody` schema and add a test for validation.
> 
>   - **Behavior**:
>     - Restrict `trace.name` length to 1000 characters in `TraceBody` schema in `types.ts`.
>     - Add test in `ingestion.servertest.ts` to verify failure when `trace.name` exceeds 1000 characters.
>   - **Tests**:
>     - New test case in `ingestion.servertest.ts` checks for error when `trace.name` is too long.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ae7406db7ee22f9df86865d72904e07d36877e92. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->