### PR TITLE
refactor(cloud): move usage metering job to clickhouse

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1091,3 +1091,32 @@ export const getLatencyAndTotalCostForObservationsByTraces = async (
     latency: Number(r.latency_ms) / 1000,
   }));
 };
+
+export const getObservationCountInCreationInterval = async ({
+  projectIds,
+  start,
+  end,
+}: {
+  projectIds: string[];
+  start: Date;
+  end: Date;
+}) => {
+  const query = `
+    SELECT count(*) as count
+    FROM observations
+    WHERE project_id IN ({projectIds: Array(String)})
+    AND created_at >= {start: DateTime64(3)}
+    AND created_at < {end: DateTime64(3)}
+  `;
+
+  const rows = await queryClickhouse<{ count: string }>({
+    query,
+    params: {
+      projectIds,
+      start: convertDateToClickhouseDateTime(start),
+      end: convertDateToClickhouseDateTime(end),
+    },
+  });
+
+  return rows.length > 0 ? Number(rows[0].count) : 0;
+};

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -549,3 +549,32 @@ export const getAggregatedScoresForPrompts = async (
     promptId: row.prompt_id,
   }));
 };
+
+export const getScoreCountInCreationInterval = async ({
+  projectIds,
+  start,
+  end,
+}: {
+  projectIds: string[];
+  start: Date;
+  end: Date;
+}) => {
+  const query = `
+    SELECT count(*) as count
+    FROM scores
+    WHERE project_id IN ({projectIds: Array(String)})
+    AND created_at >= {start: DateTime64(3)}
+    AND created_at < {end: DateTime64(3)}
+  `;
+
+  const rows = await queryClickhouse<{ count: string }>({
+    query,
+    params: {
+      projectIds,
+      start: convertDateToClickhouseDateTime(start),
+      end: convertDateToClickhouseDateTime(end),
+    },
+  });
+
+  return rows.length > 0 ? Number(rows[0].count) : 0;
+};

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -151,6 +151,35 @@ export const hasAnyTrace = async (projectId: string) => {
   return rows.length > 0 && Number(rows[0].count) > 0;
 };
 
+export const getTraceCountInCreationInterval = async ({
+  projectIds,
+  start,
+  end,
+}: {
+  projectIds: string[];
+  start: Date;
+  end: Date;
+}) => {
+  const query = `
+    SELECT count(*) as count
+    FROM traces
+    WHERE project_id IN ({projectIds: Array(String)})
+    AND created_at >= {start: DateTime64(3)}
+    AND created_at < {end: DateTime64(3)}
+  `;
+
+  const rows = await queryClickhouse<{ count: string }>({
+    query,
+    params: {
+      projectIds,
+      start: convertDateToClickhouseDateTime(start),
+      end: convertDateToClickhouseDateTime(end),
+    },
+  });
+
+  return rows.length > 0 ? Number(rows[0].count) : 0;
+};
+
 export const getTraceById = async (
   traceId: string,
   projectId: string,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor cloud usage metering job to use Clickhouse for counting observations, scores, and traces.
> 
>   - **Behavior**:
>     - Refactor `handleCloudUsageMeteringJob` in `handleCloudUsageMeteringJob.ts` to use Clickhouse for counting observations, scores, and traces.
>     - Replace Prisma count queries with `getObservationCountInCreationInterval`, `getScoreCountInCreationInterval`, and `getTraceCountInCreationInterval`.
>   - **Functions**:
>     - Add `getObservationCountInCreationInterval` to `observations.ts` for counting observations in a time interval.
>     - Add `getScoreCountInCreationInterval` to `scores.ts` for counting scores in a time interval.
>     - Add `getTraceCountInCreationInterval` to `traces.ts` for counting traces in a time interval.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 62b0aaa4fbeede60d25c36fe2f2abc8b3169f8a6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->