### PR TITLE
perf: improve clickhouse traces table perfromance

### DIFF
--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -168,8 +168,6 @@ const getTracesTableGeneric = async <T>(props: FetchTracesTableProps) => {
   //   (f) => f.clickhouseTable === "observations",
   // );
 
-  console.log("hasObservationsFilter", JSON.stringify(tracesFilter));
-
   const tracesFilterRes = tracesFilter.apply();
   const scoresFilterRes = scoresFilter.apply();
   const observationFilterRes = observationsFilter.apply();

--- a/packages/shared/src/tableDefinitions/mapObservationsTable.ts
+++ b/packages/shared/src/tableDefinitions/mapObservationsTable.ts
@@ -68,7 +68,7 @@ export const observationsTableUiColumnDefinitions: UiColumnMapping[] = [
     uiTableId: "timeToFirstToken",
     clickhouseTableName: "observations",
     clickhouseSelect:
-      "if(isNull(completion_start_time), NULL,  date_diff('seconds', start_time, completion_start_time))",
+      "if(isNull(completion_start_time), NULL,  date_diff('milliseconds', start_time, completion_start_time))",
     // If we use the default of Decimal64(12), we cannot filter for more than ~40min due to an overflow
     clickhouseTypeOverwrite: "Decimal64(3)",
   },
@@ -77,7 +77,7 @@ export const observationsTableUiColumnDefinitions: UiColumnMapping[] = [
     uiTableId: "latency",
     clickhouseTableName: "observations",
     clickhouseSelect:
-      "if(isNull(end_time), NULL, date_diff('seconds', start_time, end_time))",
+      "if(isNull(end_time), NULL, date_diff('milliseconds', start_time, end_time))",
     // If we use the default of Decimal64(12), we cannot filter for more than ~40min due to an overflow
     clickhouseTypeOverwrite: "Decimal64(3)",
   },
@@ -86,7 +86,7 @@ export const observationsTableUiColumnDefinitions: UiColumnMapping[] = [
     uiTableId: "tokensPerSecond",
     clickhouseTableName: "observations",
     clickhouseSelect:
-      "usage_details['input'] / date_diff('seconds', start_time, end_time)",
+      "usage_details['input'] / date_diff('milliseconds', start_time, end_time)",
   },
   {
     uiTableName: "Input Cost ($)",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize Clickhouse traces table query performance by refining filters and query structure in `traces-ui-table-service.ts`.
> 
>   - **Query Optimization**:
>     - Add `project_id` and `traceTimestamp` filters to `observations` and `scores` queries in `getTracesTableGeneric()`.
>     - Use `OBSERVATIONS_TO_TRACE_INTERVAL` and `SCORE_TO_TRACE_OBSERVATIONS_INTERVAL` for time-based filtering.
>     - Modify `orderByToClickhouseSql` to include `timestamp_to_date` for ordering.
>   - **Code Cleanup**:
>     - Remove unused timestamp filters for `scores` and `observations`.
>     - Add `console.log` for debugging `tracesFilter`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6dce575e02d6bbc82a6d4e281a655854cf1fe295. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->