### PR TITLE
fix(media): increase isolationLevel on concurrent upserts

### DIFF
--- a/web/src/pages/api/public/media/index.ts
+++ b/web/src/pages/api/public/media/index.ts
@@ -212,7 +212,7 @@ export default withMiddlewares({
                 uploadUrl,
               };
             },
-            { isolationLevel: Prisma.TransactionIsolationLevel.RepeatableRead },
+            { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
           );
         } catch (error) {
           if (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase transaction isolation level to `Serializable` for concurrent upserts in `index.ts`.
> 
>   - **Behavior**:
>     - Increase transaction isolation level from `RepeatableRead` to `Serializable` in `web/src/pages/api/public/media/index.ts` to handle concurrent upserts more reliably.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ffad01f0a519bade2a16abb01d2ed58b8c2bf17e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->