### PR TITLE
perf: increase performance for traces default table

### DIFF
--- a/packages/shared/clickhouse/scripts/seed.ts
+++ b/packages/shared/clickhouse/scripts/seed.ts
@@ -2,7 +2,7 @@ import {
   clickhouseClient,
   ObservationRecordReadType,
 } from "@langfuse/shared/src/server";
-import { Prisma, prisma } from "../../src/db";
+import { prisma } from "../../src/db";
 import { redis } from "@langfuse/shared/src/server";
 import { prepareClickhouse } from "../../scripts/prepareClickhouse";
 import { createDatasets } from "../../prisma/seed";

--- a/packages/shared/prisma/seed.ts
+++ b/packages/shared/prisma/seed.ts
@@ -450,6 +450,9 @@ export async function createDatasets(
           Math.random() > 0.3
             ? observations[Math.floor(Math.random() * observations.length)]
             : undefined;
+        if (!sourceObservation) {
+          continue;
+        }
         const datasetItem = await prisma.datasetItem.create({
           data: {
             projectId,

--- a/packages/shared/scripts/prepareClickhouse.ts
+++ b/packages/shared/scripts/prepareClickhouse.ts
@@ -110,7 +110,7 @@ export const prepareClickhouse = async (
       map('input', toDecimal64(randUniform(0, 1000), 12), 'output', toDecimal64(randUniform(0, 1000), 12), 'total', toDecimal64(randUniform(0, 2000), 12)) AS provided_cost_details,
       map('input', toDecimal64(randUniform(0, 1000), 12), 'output', toDecimal64(randUniform(0, 1000), 12), 'total', toDecimal64(randUniform(0, 2000), 12)) AS cost_details,
       toDecimal64(randUniform(0, 2000), 12) AS total_cost,
-      start_time AS completion_start_time,
+      addMilliseconds(start_time, if(rand() < 0.6, floor(randUniform(0, 500)), floor(randUniform(0, 600)))) AS completion_start_time,
       array(${SEED_PROMPTS.map((p) => `concat('${p.id}',project_id)`).join(
         ",",
       )})[(number % ${SEED_PROMPTS.length})+1] AS prompt_id,

--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -176,13 +176,13 @@ const getTracesTableGeneric = async <T>(props: FetchTracesTableProps) => {
 
   const chOrderBy = orderByToClickhouseSql(
     [
-      orderBy ?? null,
       orderBy?.order && orderBy?.column === "timestamp"
         ? {
             column: "timestamp_to_date",
             order: orderBy.order,
           }
         : null,
+      orderBy ?? null,
     ],
     [
       ...tracesTableUiColumnDefinitions,

--- a/packages/shared/src/tableDefinitions/mapObservationsTable.ts
+++ b/packages/shared/src/tableDefinitions/mapObservationsTable.ts
@@ -86,7 +86,7 @@ export const observationsTableUiColumnDefinitions: UiColumnMapping[] = [
     uiTableId: "tokensPerSecond",
     clickhouseTableName: "observations",
     clickhouseSelect:
-      "usage_details['input'] / date_diff('milliseconds', start_time, end_time)",
+      "(usage_details['input'] / date_diff('milliseconds', start_time, end_time))",
   },
   {
     uiTableName: "Input Cost ($)",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve performance by skipping dataset item creation for undefined observations, optimizing query order logic, and adjusting completion start time calculation.
> 
>   - **Behavior**:
>     - Skip dataset item creation if `sourceObservation` is undefined in `createDatasets()` in `seed.ts`.
>     - Adjust `completion_start_time` calculation in `prepareClickhouse()` to add milliseconds based on a random condition.
>   - **Query Optimization**:
>     - Reorder `orderBy` logic in `getTracesTableGeneric()` in `traces-ui-table-service.ts` for better performance.
>   - **Imports**:
>     - Remove unused `Prisma` import from `seed.ts`.
>   - **Misc**:
>     - Add parentheses around division in `tokensPerSecond` calculation in `mapObservationsTable.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e42933547ba25c2bf84d5fd99001480cbbad9e2a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->