### PR TITLE
perf: extract traces table metrics from clickhouse traces.all query

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -424,7 +424,17 @@ export const getSessionsTable = async (props: {
   return rows;
 };
 
-const getSessionsTableGeneric = async <T>(props: FetchTracesTableProps) => {
+export type FetchSessionsTableProps = {
+  select: string;
+  projectId: string;
+  filter: FilterState;
+  searchQuery?: string;
+  orderBy?: OrderByState;
+  limit?: number;
+  page?: number;
+};
+
+const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
   const { select, projectId, filter, orderBy, limit, page } = props;
 
   const { tracesFilter, scoresFilter, observationsFilter } =

--- a/packages/shared/src/server/repositories/traces_converters.ts
+++ b/packages/shared/src/server/repositories/traces_converters.ts
@@ -1,10 +1,7 @@
-import { ObservationLevel, Trace } from "@prisma/client";
+import { Trace } from "@prisma/client";
 import { parseClickhouseUTCDateTimeFormat } from "./clickhouse";
 import { TraceRecordReadType } from "./definitions";
-import Decimal from "decimal.js";
-import { ScoreAggregate } from "../../features/scores";
 import { convertDateToClickhouseDateTime } from "../clickhouse/client";
-import { TracesTableReturnType } from "../services/traces-ui-table-service";
 
 export const convertTraceDomainToClickhouse = (
   trace: Trace,
@@ -53,54 +50,4 @@ export const convertClickhouseToDomain = (
     updatedAt: parseClickhouseUTCDateTimeFormat(record.updated_at),
     externalId: null,
   };
-};
-
-export type TracesAllReturnType = {
-  id: string;
-  timestamp: Date;
-  name: string | null;
-  projectId: string;
-  userId: string | null;
-  release: string | null;
-  version: string | null;
-  public: boolean;
-  bookmarked: boolean;
-  sessionId: string | null;
-  tags: string[];
-};
-
-export const convertToDomain = (row: TracesTableReturnType) => {
-  return {
-    id: row.id,
-    projectId: row.project_id,
-    timestamp: parseClickhouseUTCDateTimeFormat(row.timestamp),
-    tags: row.tags,
-    bookmarked: row.bookmarked,
-    name: row.name ?? null,
-    release: row.release ?? null,
-    version: row.version ?? null,
-    userId: row.user_id ?? null,
-    sessionId: row.session_id ?? null,
-    latency: Number(row.latency),
-    usageDetails: row.usage_details,
-    costDetails: row.cost_details,
-    level: row.level,
-    observationCount: Number(row.observation_count),
-    scoresAvg: row.scores_avg,
-    public: row.public,
-  };
-};
-
-export type TracesMetricsReturnType = {
-  id: string;
-  promptTokens: bigint;
-  completionTokens: bigint;
-  totalTokens: bigint;
-  latency: number | null;
-  level: ObservationLevel;
-  observationCount: bigint;
-  calculatedTotalCost: Decimal | null;
-  calculatedInputCost: Decimal | null;
-  calculatedOutputCost: Decimal | null;
-  scores: ScoreAggregate;
 };

--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -13,13 +13,17 @@ import {
 } from "../queries/clickhouse-sql/factory";
 import { orderByToClickhouseSql } from "../queries/clickhouse-sql/orderby-factory";
 import { clickhouseSearchCondition } from "../queries/clickhouse-sql/search";
-import { convertToDomain } from "../repositories";
-import { queryClickhouse } from "../repositories/clickhouse";
+import {
+  parseClickhouseUTCDateTimeFormat,
+  queryClickhouse,
+} from "../repositories/clickhouse";
 import { TraceRecordReadType } from "../repositories/definitions";
 import {
   OBSERVATIONS_TO_TRACE_INTERVAL,
   SCORE_TO_TRACE_OBSERVATIONS_INTERVAL,
 } from "../repositories/constants";
+import Decimal from "decimal.js";
+import { ScoreAggregate } from "../../features/scores";
 
 export type TracesTableReturnType = Pick<
   TraceRecordReadType,
@@ -34,7 +38,81 @@ export type TracesTableReturnType = Pick<
   | "session_id"
   | "tags"
   | "public"
-> & {
+>;
+
+export type TracesAllUiReturnType = {
+  id: string;
+  timestamp: Date;
+  name: string | null;
+  projectId: string;
+  userId: string | null;
+  release: string | null;
+  version: string | null;
+  public: boolean;
+  bookmarked: boolean;
+  sessionId: string | null;
+  tags: string[];
+};
+
+export type TracesMetricsUiReturnType = {
+  id: string;
+  projectId: string;
+  promptTokens: bigint;
+  completionTokens: bigint;
+  totalTokens: bigint;
+  latency: number | null;
+  level: ObservationLevel;
+  observationCount: bigint;
+  calculatedTotalCost: Decimal | null;
+  calculatedInputCost: Decimal | null;
+  calculatedOutputCost: Decimal | null;
+  scores: ScoreAggregate;
+};
+
+export const convertToUiTableRows = (row: TracesTableReturnType) => {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    timestamp: parseClickhouseUTCDateTimeFormat(row.timestamp),
+    tags: row.tags,
+    bookmarked: row.bookmarked,
+    name: row.name ?? null,
+    release: row.release ?? null,
+    version: row.version ?? null,
+    userId: row.user_id ?? null,
+    sessionId: row.session_id ?? null,
+    public: row.public,
+  };
+};
+
+export const convertToUITableMetrics = (
+  row: TracesTableMetricsClickhouseReturnType,
+): Omit<TracesMetricsUiReturnType, "scores"> => {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    latency: Number(row.latency),
+    promptTokens: BigInt(row.usage_details?.input ?? 0),
+    completionTokens: BigInt(row.usage_details?.output ?? 0),
+    totalTokens: BigInt(row.usage_details?.total ?? 0),
+    observationCount: BigInt(row.observation_count ?? 0),
+    calculatedTotalCost: row.cost_details?.total
+      ? new Decimal(row.cost_details.total)
+      : null,
+    calculatedInputCost: row.cost_details?.input
+      ? new Decimal(row.cost_details.input)
+      : null,
+    calculatedOutputCost: row.cost_details?.output
+      ? new Decimal(row.cost_details.output)
+      : null,
+    level: row.level,
+  };
+};
+
+export type TracesTableMetricsClickhouseReturnType = {
+  id: string;
+  project_id: string;
+  timestamp: Date;
   level: ObservationLevel;
   observation_count: number | null;
   latency: string | null;
@@ -44,7 +122,7 @@ export type TracesTableReturnType = Pick<
 };
 
 export type FetchTracesTableProps = {
-  select: string;
+  select: "count" | "rows" | "metrics";
   projectId: string;
   filter: FilterState;
   searchQuery?: string;
@@ -62,7 +140,7 @@ export const getTracesTableCount = async (props: {
   page?: number;
 }) => {
   const countRows = await getTracesTableGeneric<{ count: string }>({
-    select: "count(*) as count",
+    select: "count",
     ...props,
   });
 
@@ -71,6 +149,23 @@ export const getTracesTableCount = async (props: {
   }));
 
   return converted.length > 0 ? converted[0].count : 0;
+};
+
+export const getTracesTableMetrics = async (props: {
+  projectId: string;
+  filter: FilterState;
+  searchQuery?: string;
+  orderBy?: OrderByState;
+  limit?: number;
+  page?: number;
+}): Promise<Array<Omit<TracesMetricsUiReturnType, "scores">>> => {
+  const countRows =
+    await getTracesTableGeneric<TracesTableMetricsClickhouseReturnType>({
+      select: "metrics",
+      ...props,
+    });
+
+  return countRows.map(convertToUITableMetrics);
 };
 
 export const getTracesTable = async (
@@ -82,24 +177,7 @@ export const getTracesTable = async (
   page?: number,
 ) => {
   const rows = await getTracesTableGeneric<TracesTableReturnType>({
-    select: `
-    t.id as id,
-    t.project_id as project_id,
-    t.timestamp as timestamp,
-    t.tags as tags,
-    t.bookmarked as bookmarked,
-    t.name as name,
-    t.release as release,
-    t.version as version,
-    t.user_id as user_id,
-    t.session_id as session_id,
-    os.latency_milliseconds / 1000 as latency,
-    os.cost_details as cost_details,
-    os.usage_details as usage_details,
-    os.level as level,
-    os.observation_count as observation_count,
-    s.scores_avg as scores_avg,
-    t.public as public`,
+    select: "rows",
     projectId,
     filter,
     searchQuery,
@@ -108,12 +186,49 @@ export const getTracesTable = async (
     page,
   });
 
-  return rows.map(convertToDomain);
+  return rows.map(convertToUiTableRows);
 };
 
 const getTracesTableGeneric = async <T>(props: FetchTracesTableProps) => {
   const { select, projectId, filter, orderBy, limit, page, searchQuery } =
     props;
+
+  let sqlSelect: string;
+  switch (select) {
+    case "count":
+      sqlSelect = "count(*) as count";
+      break;
+    case "metrics":
+      sqlSelect = `
+        t.id as id,
+        t.project_id as project_id,
+        t.timestamp as timestamp,
+        os.latency_milliseconds / 1000 as latency,
+        os.cost_details as cost_details,
+        os.usage_details as usage_details,
+        os.level as level,
+        os.observation_count as observation_count,
+        s.scores_avg as scores_avg,
+        t.public as public`;
+      break;
+    case "rows":
+      sqlSelect = `
+        t.id as id,
+        t.project_id as project_id,
+        t.timestamp as timestamp,
+        t.tags as tags,
+        t.bookmarked as bookmarked,
+        t.name as name,
+        t.release as release,
+        t.version as version,
+        t.user_id as user_id,
+        t.session_id as session_id,
+        t.public as public`;
+      break;
+    default:
+      const exhaustiveCheckDefault: never = select;
+      throw new Error(`Unknown select type: ${select}`);
+  }
 
   const { tracesFilter, scoresFilter, observationsFilter } =
     getProjectIdDefaultFilter(projectId, { tracesPrefix: "t" });
@@ -160,13 +275,13 @@ const getTracesTableGeneric = async <T>(props: FetchTracesTableProps) => {
       f.field === "timestamp" && (f.operator === ">=" || f.operator === ">"),
   ) as DateTimeFilter | undefined;
 
-  // const hasScoresFilter = tracesFilter.find(
-  //   (f) => f.clickhouseTable === "scores",
-  // );
+  const hasScoresFilter = tracesFilter.find(
+    (f) => f.clickhouseTable === "scores",
+  );
 
-  // const hasObservationsFilter = tracesFilter.find(
-  //   (f) => f.clickhouseTable === "observations",
-  // );
+  const hasObservationsFilter = tracesFilter.find(
+    (f) => f.clickhouseTable === "observations",
+  );
 
   const tracesFilterRes = tracesFilter.apply();
   const scoresFilterRes = scoresFilter.apply();
@@ -236,10 +351,10 @@ const getTracesTableGeneric = async <T>(props: FetchTracesTableProps) => {
       ) tmp
       GROUP BY project_id, trace_id
     )
-    SELECT ${select}
+    SELECT ${sqlSelect}
     FROM traces t FINAL 
-    LEFT JOIN observations_stats os on os.project_id = t.project_id and os.trace_id = t.id
-    LEFT JOIN scores_avg s on s.project_id = t.project_id and s.trace_id = t.id
+    ${hasObservationsFilter ? `LEFT JOIN observations_stats os on os.project_id = t.project_id and os.trace_id = t.id` : ""}
+    ${hasScoresFilter ? `LEFT JOIN scores_avg s on s.project_id = t.project_id and s.trace_id = t.id` : ""}
     WHERE t.project_id = {projectId: String}
     ${tracesFilterRes ? `AND ${tracesFilterRes.query}` : ""}
     ${search.query}

--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -69,7 +69,9 @@ export type TracesMetricsUiReturnType = {
   scores: ScoreAggregate;
 };
 
-export const convertToUiTableRows = (row: TracesTableReturnType) => {
+export const convertToUiTableRows = (
+  row: TracesTableReturnType,
+): TracesAllUiReturnType => {
   return {
     id: row.id,
     projectId: row.project_id,

--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -353,8 +353,8 @@ const getTracesTableGeneric = async <T>(props: FetchTracesTableProps) => {
     )
     SELECT ${sqlSelect}
     FROM traces t FINAL 
-    ${hasObservationsFilter ? `LEFT JOIN observations_stats os on os.project_id = t.project_id and os.trace_id = t.id` : ""}
-    ${hasScoresFilter ? `LEFT JOIN scores_avg s on s.project_id = t.project_id and s.trace_id = t.id` : ""}
+    ${select === "metrics" || hasObservationsFilter ? `LEFT JOIN observations_stats os on os.project_id = t.project_id and os.trace_id = t.id` : ""}
+    ${select === "metrics" || hasScoresFilter ? `LEFT JOIN scores_avg s on s.project_id = t.project_id and s.trace_id = t.id` : ""}
     WHERE t.project_id = {projectId: String}
     ${tracesFilterRes ? `AND ${tracesFilterRes.query}` : ""}
     ${search.query}

--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -290,13 +290,6 @@ const getTracesTableGeneric = async <T>(props: FetchTracesTableProps) => {
         c.uiTableName === orderBy?.column || c.uiTableId === orderBy?.column,
     )?.clickhouseTableName === "observations";
 
-  console.log(
-    "hasScoresFilter",
-    tracesFilter,
-    requiresScoresJoin,
-    requiresObservationsJoin,
-  );
-
   const tracesFilterRes = tracesFilter.apply();
   const scoresFilterRes = scoresFilter.apply();
   const observationFilterRes = observationsFilter.apply();

--- a/packages/shared/src/tableDefinitions/mapTracesTable.ts
+++ b/packages/shared/src/tableDefinitions/mapTracesTable.ts
@@ -71,28 +71,28 @@ export const tracesTableUiColumnDefinitions: UiColumnMapping[] = [
   {
     uiTableName: "Input Tokens",
     uiTableId: "inputTokens",
-    clickhouseTableName: "traces",
+    clickhouseTableName: "observations",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'input'), usage_details), usage_details['input'], NULL)",
   },
   {
     uiTableName: "Output Tokens",
     uiTableId: "outputTokens",
-    clickhouseTableName: "traces",
+    clickhouseTableName: "observations",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'output'), usage_details), usage_details['output'], NULL)",
   },
   {
     uiTableName: "Total Tokens",
     uiTableId: "totalTokens",
-    clickhouseTableName: "traces",
+    clickhouseTableName: "observations",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'total'), usage_details), usage_details['total'], NULL)",
   },
   {
     uiTableName: "Usage",
     uiTableId: "usage",
-    clickhouseTableName: "traces",
+    clickhouseTableName: "observations",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'total'), usage_details), usage_details['total'], NULL)",
   },
@@ -105,7 +105,7 @@ export const tracesTableUiColumnDefinitions: UiColumnMapping[] = [
   {
     uiTableName: "Latency (s)",
     uiTableId: "latency",
-    clickhouseTableName: "traces",
+    clickhouseTableName: "observations",
     clickhouseSelect: "latency_milliseconds / 1000",
     // If we use the default of Decimal64(12), we cannot filter for more than ~40min due to an overflow
     clickhouseTypeOverwrite: "Decimal64(3)",
@@ -113,19 +113,19 @@ export const tracesTableUiColumnDefinitions: UiColumnMapping[] = [
   {
     uiTableName: "Input Cost ($)",
     uiTableId: "inputCost",
-    clickhouseTableName: "traces",
+    clickhouseTableName: "observations",
     clickhouseSelect: "cost_details['input']",
   },
   {
     uiTableName: "Output Cost ($)",
     uiTableId: "outputCost",
-    clickhouseTableName: "traces",
+    clickhouseTableName: "observations",
     clickhouseSelect: "cost_details['output']",
   },
   {
     uiTableName: "Total Cost ($)",
     uiTableId: "totalCost",
-    clickhouseTableName: "traces",
+    clickhouseTableName: "observations",
     clickhouseSelect: "cost_details['total']",
   },
 ];

--- a/web/src/__tests__/async/traces-ui-table.servertest.ts
+++ b/web/src/__tests__/async/traces-ui-table.servertest.ts
@@ -9,9 +9,9 @@ import {
 } from "@/src/__tests__/fixtures/tracing-factory";
 import {
   getTracesTable,
+  type TracesAllUiReturnType,
   type ObservationRecordInsertType,
   type TraceRecordInsertType,
-  type TracesTableReturnType,
 } from "@langfuse/shared/src/server";
 import { type FilterState } from "@langfuse/shared";
 
@@ -43,12 +43,6 @@ describe("Traces table API test", () => {
     expect(tableRows[0].userId).toEqual(trace.user_id);
     expect(tableRows[0].sessionId).toEqual(trace.session_id);
     expect(tableRows[0].public).toEqual(trace.public);
-    expect(tableRows[0].latency).toBeGreaterThanOrEqual(0);
-    expect(tableRows[0].usageDetails).toEqual({});
-    expect(tableRows[0].costDetails).toEqual({});
-    expect(tableRows[0].level).toBeDefined();
-    expect(tableRows[0].observationCount).toBeGreaterThanOrEqual(0);
-    expect(tableRows[0].scoresAvg).toEqual([]);
   });
 
   it("should get a correct trace with observations", async () => {
@@ -82,29 +76,13 @@ describe("Traces table API test", () => {
     expect(tableRows[0].userId).toEqual(trace.user_id);
     expect(tableRows[0].sessionId).toEqual(trace.session_id);
     expect(tableRows[0].public).toEqual(trace.public);
-    expect(tableRows[0].latency).toBeGreaterThanOrEqual(0);
-    expect(tableRows[0].usageDetails).toEqual({
-      input: (obs1.usage_details.input + obs2.usage_details.input).toString(),
-      output: (
-        obs1.usage_details.output + obs2.usage_details.output
-      ).toString(),
-      total: (obs1.usage_details.total + obs2.usage_details.total).toString(),
-    });
-    expect(tableRows[0].costDetails).toEqual({
-      input: obs1.cost_details.input + obs2.cost_details.input,
-      output: obs1.cost_details.output + obs2.cost_details.output,
-      total: obs1.cost_details.total + obs2.cost_details.total,
-    });
-    expect(tableRows[0].level).toBeDefined();
-    expect(tableRows[0].observationCount).toBeGreaterThanOrEqual(0);
-    expect(tableRows[0].scoresAvg).toEqual([]);
   });
 
   type TestCase = {
     traceInput: Partial<TraceRecordInsertType>;
     observationInput: Partial<ObservationRecordInsertType>[];
     filterstate: FilterState;
-    expected: Partial<TracesTableReturnType>[];
+    expected: Partial<TracesAllUiReturnType>[];
   };
 
   [
@@ -246,30 +224,6 @@ describe("Traces table API test", () => {
         }
         if (expectedTrace.public !== undefined) {
           expect(tableRows[index].public).toEqual(expectedTrace.public);
-        }
-        if (expectedTrace.latency !== undefined) {
-          expect(tableRows[index].latency).toEqual(expectedTrace.latency);
-        }
-        if (expectedTrace.usage_details !== undefined) {
-          expect(tableRows[index].usageDetails).toEqual(
-            expectedTrace.usage_details,
-          );
-        }
-        if (expectedTrace.cost_details !== undefined) {
-          expect(tableRows[index].costDetails).toEqual(
-            expectedTrace.cost_details,
-          );
-        }
-        if (expectedTrace.level !== undefined) {
-          expect(tableRows[index].level).toEqual(expectedTrace.level);
-        }
-        if (expectedTrace.observation_count !== undefined) {
-          expect(tableRows[index].observationCount).toEqual(
-            expectedTrace.observation_count,
-          );
-        }
-        if (expectedTrace.scores_avg !== undefined) {
-          expect(tableRows[index].scoresAvg).toEqual(expectedTrace.scores_avg);
         }
       });
     });

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -47,7 +47,7 @@ import {
   TraceDeleteQueue,
   getTracesTableMetrics,
   type TracesAllUiReturnType,
-  TracesMetricsUiReturnType,
+  type TracesMetricsUiReturnType,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 import { measureAndReturnApi } from "@/src/server/utils/checkClickhouseAccess";

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -38,8 +38,6 @@ import {
   deleteTraces,
   deleteScoresByTraceIds,
   deleteObservationsByTraceIds,
-  type TracesMetricsReturnType,
-  type TracesAllReturnType,
   getTraceById,
   logger,
   upsertTrace,
@@ -47,10 +45,12 @@ import {
   hasAnyTrace,
   QueueJobs,
   TraceDeleteQueue,
+  getTracesTableMetrics,
+  type TracesAllUiReturnType,
+  TracesMetricsUiReturnType,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 import { measureAndReturnApi } from "@/src/server/utils/checkClickhouseAccess";
-import Decimal from "decimal.js";
 import { randomUUID } from "crypto";
 
 const TraceFilterOptions = z.object({
@@ -141,7 +141,7 @@ export const traceRouter = createTRPCRouter({
           const traces = await ctx.prisma.$queryRaw<Array<Trace>>(tracesQuery);
 
           return {
-            traces: traces.map<TracesAllReturnType>(
+            traces: traces.map<TracesAllUiReturnType>(
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               ({ input, output, metadata, ...trace }) => ({
                 ...trace,
@@ -257,7 +257,7 @@ export const traceRouter = createTRPCRouter({
 
           const [traceMetrics, scores] = await Promise.all([
             // traceMetrics
-            ctx.prisma.$queryRaw<Array<TracesMetricsReturnType>>(tracesQuery),
+            ctx.prisma.$queryRaw<Array<TracesMetricsUiReturnType>>(tracesQuery),
             // scores
             ctx.prisma.score.findMany({
               where: {
@@ -282,15 +282,18 @@ export const traceRouter = createTRPCRouter({
           }));
         },
         clickhouseExecution: async () => {
-          const res = await getTracesTable(ctx.session.projectId, [
-            ...(input.filter ?? []),
-            {
-              type: "stringOptions",
-              operator: "any of",
-              column: "ID",
-              value: input.traceIds,
-            },
-          ]);
+          const res = await getTracesTableMetrics({
+            projectId: ctx.session.projectId,
+            filter: [
+              ...(input.filter ?? []),
+              {
+                type: "stringOptions",
+                operator: "any of",
+                column: "ID",
+                value: input.traceIds,
+              },
+            ],
+          });
 
           const scores = await getScoresForTraces(
             ctx.session.projectId,
@@ -306,22 +309,7 @@ export const traceRouter = createTRPCRouter({
           );
 
           return res.map((row) => ({
-            id: row.id,
-            promptTokens: BigInt(row.usageDetails?.input ?? 0),
-            completionTokens: BigInt(row.usageDetails?.output ?? 0),
-            totalTokens: BigInt(row.usageDetails?.total ?? 0),
-            latency: row.latency,
-            level: row.level,
-            observationCount: BigInt(row.observationCount ?? 0),
-            calculatedTotalCost: row.costDetails?.total
-              ? new Decimal(row.costDetails.total)
-              : null,
-            calculatedInputCost: row.costDetails?.input
-              ? new Decimal(row.costDetails.input)
-              : null,
-            calculatedOutputCost: row.costDetails?.output
-              ? new Decimal(row.costDetails.output)
-              : null,
+            ...row,
             scores: aggregateScores(
               validatedScores.filter((s) => s.traceId === row.id),
             ),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimizes trace metrics extraction by separating metrics from trace data and refactoring query handling in `traces-ui-table-service.ts` and `traces.ts`.
> 
>   - **Behavior**:
>     - Extracts trace metrics separately from trace data in Clickhouse queries, improving performance.
>     - Introduces `getTracesTableMetrics` in `traces-ui-table-service.ts` for fetching trace metrics.
>     - Refactors `getTracesTableGeneric` to handle different select types (`count`, `rows`, `metrics`).
>   - **Types**:
>     - Adds `TracesMetricsUiReturnType` and `TracesAllUiReturnType` in `traces-ui-table-service.ts`.
>     - Removes `TracesMetricsReturnType` and `TracesAllReturnType` from `traces_converters.ts`.
>   - **Functions**:
>     - Adds `convertToUITableMetrics` and `convertToUiTableRows` in `traces-ui-table-service.ts` for converting Clickhouse data to UI format.
>     - Updates `traceRouter` in `traces.ts` to use new metric extraction functions.
>   - **Misc**:
>     - Cleans up unused imports and types in `traces_converters.ts` and `traces.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 873ea23d20edccd50c8822ab33e3a900e8133097. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->