### PR TITLE
fix(ui): trace timeline peek drawer should not be full-width

### DIFF
--- a/web/src/components/trace/TraceTimelineView.tsx
+++ b/web/src/components/trace/TraceTimelineView.tsx
@@ -138,7 +138,7 @@ function TreeItemInner({
                 <PanelRightOpen className="h-4 w-4"></PanelRightOpen>
               </Button>
             </DrawerTrigger>
-            <DrawerContent className="w-full overflow-hidden" size="md">
+            <DrawerContent className="overflow-hidden" size="md">
               {children}
             </DrawerContent>
           </Drawer>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `DrawerContent` in `TraceTimelineView.tsx` to prevent the drawer from being full-width.
> 
>   - **UI Adjustment**:
>     - Modify `DrawerContent` in `TraceTimelineView.tsx` to remove `w-full` class, preventing the drawer from being full-width.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7b49733884986da840afcc2f2c26f05d9184e536. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->