### PR TITLE
fix: fix generations search in clickhouse

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -662,7 +662,7 @@ const getObservationsTableInternal = async <T>(
       SELECT
        ${selectString}
       FROM observations o 
-        ${traceTableFilter.length > 0 || orderByTraces ? "LEFT JOIN traces t FINAL ON t.id = o.trace_id AND t.project_id = o.project_id" : ""}
+        ${traceTableFilter.length > 0 || orderByTraces || search.query ? "LEFT JOIN traces t FINAL ON t.id = o.trace_id AND t.project_id = o.project_id" : ""}
         ${hasScoresFilter ? `LEFT JOIN scores_avg AS s_avg ON s_avg.trace_id = o.trace_id and s_avg.observation_id = o.id` : ""}
       WHERE ${appliedObservationsFilter.query}
         AND o.type = 'GENERATION'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `LEFT JOIN` condition in `getObservationsTableInternal` to include search queries, ensuring correct search results.
> 
>   - **Behavior**:
>     - Fixes `LEFT JOIN` condition in `getObservationsTableInternal` in `observations.ts` to include `search.query`.
>     - Ensures `traces` table is joined when a search query is present, affecting search results.
>   - **Misc**:
>     - No changes to other logic or functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a75353c496a62e65711045a6b8bcfd7ed7e0c342. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->