### PR TITLE
fix(media): increase retries

### DIFF
--- a/web/src/pages/api/public/media/index.ts
+++ b/web/src/pages/api/public/media/index.ts
@@ -44,7 +44,7 @@ export default withMiddlewares({
 
       // Retry up to 3 times to avoid race conditions for concurrent media uploads
       // Multiple observations can reference the same media, so we need to make sure no deadlock occurs
-      const MAX_RETRIES = 3;
+      const MAX_RETRIES = 6;
       let retries = 0;
 
       while (retries < MAX_RETRIES) {

--- a/web/src/pages/api/public/media/index.ts
+++ b/web/src/pages/api/public/media/index.ts
@@ -17,6 +17,7 @@ import {
   Prisma,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
+import { instrumentAsync } from "@langfuse/shared/src/server";
 
 export default withMiddlewares({
   POST: createAuthedAPIRoute({
@@ -47,188 +48,201 @@ export default withMiddlewares({
       const MAX_RETRIES = 6;
       let retries = 0;
 
-      while (retries < MAX_RETRIES) {
-        try {
-          return await prisma.$transaction<{
-            mediaId: string;
-            uploadUrl: string | null;
-          }>(
-            async (tx) => {
-              const existingMedia = await prisma.media.findUnique({
-                where: {
-                  projectId_sha256Hash: {
-                    projectId,
-                    sha256Hash,
-                  },
-                },
-              });
+      return await instrumentAsync(
+        { name: "media-create-upload-url" },
+        async (span) => {
+          span.setAttribute("projectId", projectId);
+          span.setAttribute("traceId", traceId);
+          span.setAttribute("observationId", observationId ?? "");
+          span.setAttribute("field", field);
 
-              if (
-                existingMedia &&
-                existingMedia.uploadHttpStatus === 200 &&
-                existingMedia.contentType === contentType
-              ) {
-                if (observationId) {
-                  await tx.observationMedia.upsert({
+          while (retries < MAX_RETRIES) {
+            try {
+              return await prisma.$transaction<{
+                mediaId: string;
+                uploadUrl: string | null;
+              }>(
+                async (tx) => {
+                  const existingMedia = await prisma.media.findUnique({
                     where: {
-                      projectId_traceId_observationId_mediaId_field: {
+                      projectId_sha256Hash: {
                         projectId,
-                        traceId,
-                        observationId,
-                        mediaId: existingMedia.id,
-                        field,
+                        sha256Hash,
                       },
                     },
-                    update: {},
-                    create: {
-                      projectId,
-                      traceId,
-                      observationId,
-                      mediaId: existingMedia.id,
-                      field,
-                    },
                   });
-                } else {
-                  await tx.traceMedia.upsert({
-                    where: {
-                      projectId_traceId_mediaId_field: {
-                        projectId,
-                        traceId,
-                        mediaId: existingMedia.id,
-                        field,
-                      },
-                    },
-                    update: {},
-                    create: {
-                      projectId,
-                      traceId,
-                      field,
-                      mediaId: existingMedia.id,
-                    },
-                  });
-                }
 
-                return {
-                  mediaId: existingMedia.id,
-                  uploadUrl: null,
-                };
-              }
-
-              const mediaId = existingMedia?.id ?? randomUUID();
-
-              if (
-                !(
-                  env.LANGFUSE_S3_MEDIA_UPLOAD_ENABLED === "true" &&
-                  env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET
-                )
-              )
-                throw new InternalServerError(
-                  "Media upload to blob storage not enabled or no bucket configured",
-                );
-
-              const s3Client = getMediaStorageServiceClient(
-                env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
-              );
-
-              const bucketPath = getBucketPath({
-                projectId,
-                mediaId,
-                contentType,
-              });
-
-              const uploadUrl = await s3Client.getSignedUploadUrl({
-                path: bucketPath,
-                ttlSeconds: 60 * 60, // 1 hour
-                sha256Hash,
-                contentType,
-                contentLength,
-              });
-
-              await Promise.all([
-                tx.media.upsert({
-                  where: {
-                    projectId_sha256Hash: {
-                      projectId,
-                      sha256Hash,
-                    },
-                  },
-                  update: {
-                    bucketName: env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
-                    bucketPath,
-                    contentType,
-                    contentLength,
-                  },
-                  create: {
-                    id: mediaId,
-                    projectId,
-                    sha256Hash,
-                    bucketPath,
-                    bucketName: env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
-                    contentType,
-                    contentLength,
-                  },
-                }),
-                observationId
-                  ? tx.observationMedia.upsert({
-                      where: {
-                        projectId_traceId_observationId_mediaId_field: {
+                  if (
+                    existingMedia &&
+                    existingMedia.uploadHttpStatus === 200 &&
+                    existingMedia.contentType === contentType
+                  ) {
+                    if (observationId) {
+                      await tx.observationMedia.upsert({
+                        where: {
+                          projectId_traceId_observationId_mediaId_field: {
+                            projectId,
+                            traceId,
+                            observationId,
+                            mediaId: existingMedia.id,
+                            field,
+                          },
+                        },
+                        update: {},
+                        create: {
                           projectId,
                           traceId,
                           observationId,
-                          mediaId,
+                          mediaId: existingMedia.id,
                           field,
                         },
-                      },
-                      update: {},
-                      create: {
-                        projectId,
-                        traceId,
-                        observationId,
-                        mediaId,
-                        field,
-                      },
-                    })
-                  : tx.traceMedia.upsert({
-                      where: {
-                        projectId_traceId_mediaId_field: {
+                      });
+                    } else {
+                      await tx.traceMedia.upsert({
+                        where: {
+                          projectId_traceId_mediaId_field: {
+                            projectId,
+                            traceId,
+                            mediaId: existingMedia.id,
+                            field,
+                          },
+                        },
+                        update: {},
+                        create: {
                           projectId,
                           traceId,
-                          mediaId,
                           field,
+                          mediaId: existingMedia.id,
+                        },
+                      });
+                    }
+
+                    return {
+                      mediaId: existingMedia.id,
+                      uploadUrl: null,
+                    };
+                  }
+
+                  const mediaId = existingMedia?.id ?? randomUUID();
+                  span.setAttribute("mediaId", mediaId);
+
+                  if (
+                    !(
+                      env.LANGFUSE_S3_MEDIA_UPLOAD_ENABLED === "true" &&
+                      env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET
+                    )
+                  )
+                    throw new InternalServerError(
+                      "Media upload to blob storage not enabled or no bucket configured",
+                    );
+
+                  const s3Client = getMediaStorageServiceClient(
+                    env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
+                  );
+
+                  const bucketPath = getBucketPath({
+                    projectId,
+                    mediaId,
+                    contentType,
+                  });
+
+                  const uploadUrl = await s3Client.getSignedUploadUrl({
+                    path: bucketPath,
+                    ttlSeconds: 60 * 60, // 1 hour
+                    sha256Hash,
+                    contentType,
+                    contentLength,
+                  });
+
+                  await Promise.all([
+                    tx.media.upsert({
+                      where: {
+                        projectId_sha256Hash: {
+                          projectId,
+                          sha256Hash,
                         },
                       },
-                      update: {},
+                      update: {
+                        bucketName: env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
+                        bucketPath,
+                        contentType,
+                        contentLength,
+                      },
                       create: {
+                        id: mediaId,
                         projectId,
-                        traceId,
-                        field,
-                        mediaId,
+                        sha256Hash,
+                        bucketPath,
+                        bucketName: env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
+                        contentType,
+                        contentLength,
                       },
                     }),
-              ]);
+                    observationId
+                      ? tx.observationMedia.upsert({
+                          where: {
+                            projectId_traceId_observationId_mediaId_field: {
+                              projectId,
+                              traceId,
+                              observationId,
+                              mediaId,
+                              field,
+                            },
+                          },
+                          update: {},
+                          create: {
+                            projectId,
+                            traceId,
+                            observationId,
+                            mediaId,
+                            field,
+                          },
+                        })
+                      : tx.traceMedia.upsert({
+                          where: {
+                            projectId_traceId_mediaId_field: {
+                              projectId,
+                              traceId,
+                              mediaId,
+                              field,
+                            },
+                          },
+                          update: {},
+                          create: {
+                            projectId,
+                            traceId,
+                            field,
+                            mediaId,
+                          },
+                        }),
+                  ]);
 
-              return {
-                mediaId,
-                uploadUrl,
-              };
-            },
-            { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
-          );
-        } catch (error) {
-          if (
-            // See https://www.prisma.io/docs/orm/prisma-client/queries/transactions#transaction-timing-issues
-            error instanceof Prisma.PrismaClientKnownRequestError &&
-            error.code === "P2034"
-          ) {
-            retries++;
-            continue;
+                  return {
+                    mediaId,
+                    uploadUrl,
+                  };
+                },
+                {
+                  isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+                },
+              );
+            } catch (error) {
+              if (
+                // See https://www.prisma.io/docs/orm/prisma-client/queries/transactions#transaction-timing-issues
+                error instanceof Prisma.PrismaClientKnownRequestError &&
+                error.code === "P2034"
+              ) {
+                retries++;
+                continue;
+              }
+
+              throw error;
+            }
           }
 
-          throw error;
-        }
-      }
-
-      throw new InternalServerError("Failed to get media upload URL");
+          throw new InternalServerError("Failed to get media upload URL");
+        },
+      );
     },
   }),
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase media upload retries and add tracing in `index.ts` to handle race conditions and improve monitoring.
> 
>   - **Behavior**:
>     - Increase `MAX_RETRIES` from 3 to 6 in `index.ts` to handle race conditions in media uploads.
>     - Wrap transaction logic in `instrumentAsync` for better tracing.
>   - **Error Handling**:
>     - Continue retry loop on `PrismaClientKnownRequestError` with code `P2034`.
>     - Throw `InternalServerError` if retries are exhausted or media upload is not enabled.
>   - **Misc**:
>     - Add tracing attributes for `projectId`, `traceId`, `observationId`, `field`, and `mediaId` in `instrumentAsync`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a6103bc5b78fd67cab748f13c713fecb832df693. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->