### PR TITLE
fix: do not authenticate with Docker Hub for pull request CI. (#4476)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME_READ && secrets.DOCKERHUB_TOKEN_READ }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
@@ -89,6 +90,7 @@ jobs:
         with:
           version: 9.5.0
       - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME_READ && secrets.DOCKERHUB_TOKEN_READ }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
@@ -158,6 +160,7 @@ jobs:
         with:
           version: 9.5.0
       - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME_READ && secrets.DOCKERHUB_TOKEN_READ }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
@@ -222,6 +225,7 @@ jobs:
         with:
           version: 9.5.0
       - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME_READ && secrets.DOCKERHUB_TOKEN_READ }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
@@ -281,6 +285,7 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME_READ && secrets.DOCKERHUB_TOKEN_READ }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
@@ -313,6 +318,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME_READ && secrets.DOCKERHUB_TOKEN_READ }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
@@ -424,6 +430,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME_READ && secrets.DOCKERHUB_TOKEN_READ }}
+        if: github.repository == 'langfuse/langfuse'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
@@ -90,7 +90,7 @@ jobs:
         with:
           version: 9.5.0
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME_READ && secrets.DOCKERHUB_TOKEN_READ }}
+        if: github.repository == 'langfuse/langfuse'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
@@ -160,7 +160,7 @@ jobs:
         with:
           version: 9.5.0
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME_READ && secrets.DOCKERHUB_TOKEN_READ }}
+        if: github.repository == 'langfuse/langfuse'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
@@ -225,7 +225,7 @@ jobs:
         with:
           version: 9.5.0
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME_READ && secrets.DOCKERHUB_TOKEN_READ }}
+        if: github.repository == 'langfuse/langfuse'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
@@ -285,7 +285,7 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME_READ && secrets.DOCKERHUB_TOKEN_READ }}
+        if: github.repository == 'langfuse/langfuse'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
@@ -318,7 +318,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME_READ && secrets.DOCKERHUB_TOKEN_READ }}
+        if: github.repository == 'langfuse/langfuse'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
@@ -430,7 +430,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Add conditional Docker Hub login to CI pipelines.

* Modify `.github/workflows/pipeline.yml` to include an if condition for Docker Hub login, ensuring it only uses credentials if available and defaults to unauthenticated access if not set.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds conditional Docker Hub login to CI pipeline based on repository context in `.github/workflows/pipeline.yml`.
> 
>   - **CI Pipeline**:
>     - Adds conditional Docker Hub login in `.github/workflows/pipeline.yml`.
>     - Uses `if` condition to check for `github.repository == 'langfuse/langfuse'` before logging in.
>     - Applied to `test-docker-build`, `tests-web-sync`, `tests-web-async`, `tests-worker`, `e2e-tests`, and `e2e-server-tests` jobs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ea25344327ac40c2dfd793aca6d7cfcee835af75. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->