### PR TITLE
fix: increase attempts for evals

### DIFF
--- a/worker/src/ee/experiments/experimentService.ts
+++ b/worker/src/ee/experiments/experimentService.ts
@@ -235,7 +235,7 @@ export const createExperimentJob = async ({
           traceParams,
         ),
       {
-        numOfAttempts: 1, // turn off retries as Langchain is doing that for us already.
+        numOfAttempts: 5, // turn off retries as Langchain is doing that for us already.
       },
     );
 

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -448,7 +448,7 @@ export const evaluate = async ({
         evalScoreSchema,
       ),
     {
-      numOfAttempts: 1, // turn off retries as Langchain is doing that for us already.
+      numOfAttempts: 5, // turn off retries as Langchain is doing that for us already.
     },
   );
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase retry attempts from 1 to 5 for LLM calls in `createExperimentJob` and `evaluate`.
> 
>   - **Behavior**:
>     - Increase `numOfAttempts` from 1 to 5 in `createExperimentJob` in `experimentService.ts` for LLM calls.
>     - Increase `numOfAttempts` from 1 to 5 in `evaluate` in `evalService.ts` for LLM calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5de063b8251cbde0b2793b8160568db7c7aa8ccd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->