### PR TITLE
chore: fix typo in ingestion queue concurrency and adjust default

### DIFF
--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -99,7 +99,7 @@ if (env.QUEUE_CONSUMER_BATCH_EXPORT_QUEUE_IS_ENABLED === "true") {
 
 if (env.QUEUE_CONSUMER_INGESTION_QUEUE_IS_ENABLED === "true") {
   WorkerManager.register(QueueName.IngestionQueue, ingestionQueueProcessor, {
-    concurrency: env.LANGFUSE_INGESTION_QEUEUE_PROCESSING_CONCURRENCY,
+    concurrency: env.LANGFUSE_INGESTION_QUEUE_PROCESSING_CONCURRENCY,
   });
 }
 

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -37,14 +37,10 @@ const EnvSchema = z.object({
     .default(24),
   EMAIL_FROM_ADDRESS: z.string().optional(),
   SMTP_CONNECTION_URL: z.string().optional(),
-  LANGFUSE_INGESTION_FLUSH_PROCESSING_CONCURRENCY: z.coerce
+  LANGFUSE_INGESTION_QUEUE_PROCESSING_CONCURRENCY: z.coerce
     .number()
     .positive()
-    .default(100),
-  LANGFUSE_INGESTION_QEUEUE_PROCESSING_CONCURRENCY: z.coerce
-    .number()
-    .positive()
-    .default(100),
+    .default(20),
   LANGFUSE_INGESTION_CLICKHOUSE_WRITE_BATCH_SIZE: z.coerce
     .number()
     .positive()
@@ -76,7 +72,7 @@ const EnvSchema = z.object({
   LANGFUSE_LEGACY_INGESTION_WORKER_CONCURRENCY: z.coerce
     .number()
     .positive()
-    .default(25),
+    .default(15),
   LANGFUSE_EVAL_CREATOR_WORKER_CONCURRENCY: z.coerce
     .number()
     .positive()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes typo in ingestion queue concurrency variable and adjusts default concurrency values in `env.ts`.
> 
>   - **Typo Fix**:
>     - Corrects `LANGFUSE_INGESTION_QEUEUE_PROCESSING_CONCURRENCY` to `LANGFUSE_INGESTION_QUEUE_PROCESSING_CONCURRENCY` in `app.ts`.
>   - **Concurrency Defaults**:
>     - Changes default for `LANGFUSE_INGESTION_QUEUE_PROCESSING_CONCURRENCY` from 100 to 20 in `env.ts`.
>     - Changes default for `LANGFUSE_LEGACY_INGESTION_WORKER_CONCURRENCY` from 25 to 15 in `env.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8436fdd9b091d0a729f27a6bb89ee93deeddbd4d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->