### PR TITLE
fix(ui): account for prereleases in update check

### DIFF
--- a/web/src/server/api/routers/public.ts
+++ b/web/src/server/api/routers/public.ts
@@ -5,7 +5,7 @@ import { logger } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
-const versionSchema = z.string().regex(/^v\d+\.\d+\.\d+$/); // e.g. v1.2.3
+const versionSchema = z.string().regex(/^v\d+\.\d+\.\d+(?:[-+].+)?$/); // e.g. v1.2.3, v1.2.3-rc.1, v1.2.3+build.123
 
 const compareVersions = (
   current: string,
@@ -18,12 +18,32 @@ const compareVersions = (
     if (version.startsWith("v")) {
       version = version.slice(1);
     }
-    return version.split(".").map(Number);
+    // Split into version and pre-release parts
+    const [versionPart, ...rest] = version.split(/[-+]/);
+    const numbers = versionPart.split(".").map(Number);
+    return {
+      numbers,
+      isPreRelease: rest.length > 0,
+    };
   };
 
-  const [currentMajor, currentMinor, currentPatch] =
-    parseVersion(currentValidated);
-  const [latestMajor, latestMinor, latestPatch] = parseVersion(latestValidated);
+  const current_parsed = parseVersion(currentValidated);
+  const latest_parsed = parseVersion(latestValidated);
+
+  const [currentMajor, currentMinor, currentPatch] = current_parsed.numbers;
+  const [latestMajor, latestMinor, latestPatch] = latest_parsed.numbers;
+
+  // If current is a pre-release (RC) and latest is a full release of the same version,
+  // consider it as needing a patch update
+  if (
+    current_parsed.isPreRelease &&
+    !latest_parsed.isPreRelease &&
+    currentMajor === latestMajor &&
+    currentMinor === latestMinor &&
+    currentPatch === latestPatch
+  ) {
+    return "patch";
+  }
 
   if (latestMajor > currentMajor) return "major";
   if (latestMajor === currentMajor && latestMinor > currentMinor)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance version comparison in `public.ts` to account for pre-releases, ensuring correct update type determination.
> 
>   - **Behavior**:
>     - Update `versionSchema` regex in `public.ts` to include pre-release and build metadata (e.g., `v1.2.3-rc.1`, `v1.2.3+build.123`).
>     - Modify `compareVersions` function in `public.ts` to handle pre-releases, returning "patch" if current is a pre-release and latest is a full release of the same version.
>   - **Misc**:
>     - No changes to external interfaces or additional files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7e6be37db3c8b88840c6ba0578cbe3e08295b8c5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->