### PR TITLE
fix(ui): disallow creation of projects if project name already exists in the org

### DIFF
--- a/web/src/features/projects/server/projectsRouter.ts
+++ b/web/src/features/projects/server/projectsRouter.ts
@@ -26,6 +26,22 @@ export const projectsRouter = createTRPCRouter({
         organizationId: input.orgId,
         scope: "projects:create",
       });
+
+      const existingProject = await ctx.prisma.project.findFirst({
+        where: {
+          name: input.name,
+          orgId: input.orgId,
+        },
+      });
+
+      if (existingProject) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message:
+            "A project with this name already exists in your organization",
+        });
+      }
+
       const project = await ctx.prisma.project.create({
         data: {
           name: input.name,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds duplicate project name check in `projectsRouter` `create` mutation, throwing `CONFLICT` error if name exists.
> 
>   - **Behavior**:
>     - In `projectsRouter`, `create` mutation now checks for existing project names within the same organization using `ctx.prisma.project.findFirst`.
>     - Throws `TRPCError` with `CONFLICT` code if a project with the same name exists.
>   - **Error Handling**:
>     - Adds error message "A project with this name already exists in your organization" for duplicate project names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b3e544598de1554fa0e268ab8a57bb6abc631d1e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->