### PR TITLE
build: cancel concurrent PR jobs on new commit

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,6 +12,10 @@ on:
     branches:
       - "*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,7 +10,7 @@ on:
   merge_group:
   pull_request:
     branches:
-      - "*"
+      - "**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -8,6 +8,10 @@ on:
       - main
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   snyk:
     runs-on: ubuntu-latest

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -2,7 +2,7 @@ name: Snyk Container
 on:
   pull_request:
     branches:
-      - "**"
+      - "*"
   push:
     branches:
       - main

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -2,7 +2,7 @@ name: Snyk Container
 on:
   pull_request:
     branches:
-      - "*"
+      - "**"
   push:
     branches:
       - main


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds concurrency control to cancel in-progress GitHub Actions jobs on new commits for pull requests in `pipeline.yml` and `snyk.yml`.
> 
>   - **Concurrency Control**:
>     - Added `concurrency` to `pipeline.yml` and `snyk.yml` to cancel in-progress jobs on new commits for pull requests.
>     - Uses `group: ${{ github.workflow }}-${{ github.ref }}` and `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0171a89d59a7b7f3e618e678f2346102e1813ed5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->