### PR TITLE
chore: add logging for datasets router

### DIFF
--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -101,6 +101,10 @@ export const createDatasetRunsTable = async (input: DatasetRunsTableInput) => {
       clickhouseSession,
     );
 
+    logger.info(
+      `Fetched ${scores.length} scores for dataset runs with ids ${scores.map((s) => s.id).join(", ")}`,
+    );
+
     const obsAgg = await getObservationLatencyAndCostForDataset(
       input,
       tableName,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add logging to `createDatasetRunsTable` in `service.ts` to log fetched scores count and IDs.
> 
>   - **Logging**:
>     - Add info log in `createDatasetRunsTable` in `service.ts` to log the number of scores fetched and their IDs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d823c37a0f1ed5ee9866fa1204030f4d6f6de668. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->