### PR TITLE
fix: fix score source public api filter

### DIFF
--- a/web/src/pages/api/public/scores/index.ts
+++ b/web/src/pages/api/public/scores/index.ts
@@ -111,7 +111,7 @@ export default withMiddlewares({
             ? Prisma.sql`AND s."timestamp" < ${toTimestamp}::timestamp with time zone at time zone 'UTC'`
             : Prisma.empty;
           const sourceCondition = source
-            ? Prisma.sql`AND s."source" = ${source}`
+            ? Prisma.sql`AND s."source" = ${source}::"ScoreSource"`
             : Prisma.empty;
           const valueCondition =
             operator && value !== null && value !== undefined


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes SQL query in `index.ts` to cast `source` to `ScoreSource` for type safety in the public scores API.
> 
>   - **Behavior**:
>     - Fixes SQL query in `index.ts` to cast `source` to `ScoreSource` for type safety in the public scores API.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8637bf908e7d6678e91ac06b0c83a93ef460ce18. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->