### PR TITLE
fix(media): use db upserts instead of prisma

### DIFF
--- a/web/src/pages/api/public/media/index.ts
+++ b/web/src/pages/api/public/media/index.ts
@@ -80,43 +80,19 @@ export default withMiddlewares({
                     existingMedia.contentType === contentType
                   ) {
                     if (observationId) {
-                      await tx.observationMedia.upsert({
-                        where: {
-                          projectId_traceId_observationId_mediaId_field: {
-                            projectId,
-                            traceId,
-                            observationId,
-                            mediaId: existingMedia.id,
-                            field,
-                          },
-                        },
-                        update: {},
-                        create: {
-                          projectId,
-                          traceId,
-                          observationId,
-                          mediaId: existingMedia.id,
-                          field,
-                        },
-                      });
+                      // Use raw upserts to avoid deadlocks
+                      await tx.$queryRaw`
+                        INSERT INTO "observation_media" ("id", "project_id", "trace_id", "observation_id", "media_id", "field")
+                        VALUES (${randomUUID()}, ${projectId}, ${traceId}, ${observationId}, ${existingMedia.id}, ${field})
+                        ON CONFLICT DO NOTHING;
+                      `;
                     } else {
-                      await tx.traceMedia.upsert({
-                        where: {
-                          projectId_traceId_mediaId_field: {
-                            projectId,
-                            traceId,
-                            mediaId: existingMedia.id,
-                            field,
-                          },
-                        },
-                        update: {},
-                        create: {
-                          projectId,
-                          traceId,
-                          field,
-                          mediaId: existingMedia.id,
-                        },
-                      });
+                      // Use raw upserts to avoid deadlocks
+                      await tx.$queryRaw`
+                        INSERT INTO "trace_media" ("id", "project_id", "trace_id", "media_id", "field")
+                        VALUES (${randomUUID()}, ${projectId}, ${traceId}, ${existingMedia.id}, ${field})
+                        ON CONFLICT DO NOTHING;
+                      `;
                     }
 
                     return {
@@ -157,66 +133,44 @@ export default withMiddlewares({
                   });
 
                   await Promise.all([
-                    tx.media.upsert({
-                      where: {
-                        projectId_sha256Hash: {
-                          projectId,
-                          sha256Hash,
-                        },
-                      },
-                      update: {
-                        bucketName: env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
-                        bucketPath,
-                        contentType,
-                        contentLength,
-                      },
-                      create: {
-                        id: mediaId,
-                        projectId,
-                        sha256Hash,
-                        bucketPath,
-                        bucketName: env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
-                        contentType,
-                        contentLength,
-                      },
-                    }),
+                    // Use raw upserts to avoid deadlocks
+                    tx.$queryRaw`
+                      INSERT INTO "media" (
+                          "id", 
+                          "project_id", 
+                          "sha_256_hash", 
+                          "bucket_path", 
+                          "bucket_name", 
+                          "content_type", 
+                          "content_length"
+                        )
+                        VALUES (
+                          ${mediaId},
+                          ${projectId},
+                          ${sha256Hash},
+                          ${bucketPath},
+                          ${env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET},
+                          ${contentType},
+                          ${contentLength}
+                        )
+                        ON CONFLICT ("project_id", "sha_256_hash") 
+                        DO UPDATE SET
+                          "bucket_name" = ${env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET},
+                          "bucket_path" = ${bucketPath},
+                          "content_type" = ${contentType},
+                          "content_length" = ${contentLength}
+                    `,
                     observationId
-                      ? tx.observationMedia.upsert({
-                          where: {
-                            projectId_traceId_observationId_mediaId_field: {
-                              projectId,
-                              traceId,
-                              observationId,
-                              mediaId,
-                              field,
-                            },
-                          },
-                          update: {},
-                          create: {
-                            projectId,
-                            traceId,
-                            observationId,
-                            mediaId,
-                            field,
-                          },
-                        })
-                      : tx.traceMedia.upsert({
-                          where: {
-                            projectId_traceId_mediaId_field: {
-                              projectId,
-                              traceId,
-                              mediaId,
-                              field,
-                            },
-                          },
-                          update: {},
-                          create: {
-                            projectId,
-                            traceId,
-                            field,
-                            mediaId,
-                          },
-                        }),
+                      ? tx.$queryRaw`
+                          INSERT INTO "observation_media" ("id", "project_id", "trace_id", "observation_id", "media_id", "field")
+                          VALUES (${randomUUID()}, ${projectId}, ${traceId}, ${observationId}, ${mediaId}, ${field})
+                          ON CONFLICT DO NOTHING;
+                      `
+                      : tx.$queryRaw`
+                          INSERT INTO "trace_media" ("id", "project_id", "trace_id", "media_id", "field")
+                          VALUES (${randomUUID()}, ${projectId}, ${traceId}, ${mediaId}, ${field})
+                          ON CONFLICT DO NOTHING;
+                      `,
                   ]);
 
                   return {
@@ -233,16 +187,8 @@ export default withMiddlewares({
                 `Failed to get media upload URL for trace ${traceId} and observation ${observationId}. Retrying...`,
                 error,
               );
-              if (
-                // See https://www.prisma.io/docs/orm/prisma-client/queries/transactions#transaction-timing-issues
-                error instanceof Prisma.PrismaClientKnownRequestError &&
-                error.code === "P2034"
-              ) {
-                retries++;
-                continue;
-              }
-
-              throw error;
+              retries++;
+              continue;
             }
           }
           logger.error(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces Prisma upserts with raw SQL upserts in media API to avoid deadlocks and improve error handling.
> 
>   - **Behavior**:
>     - Replaces Prisma `upsert` with raw SQL `INSERT ... ON CONFLICT DO NOTHING` for `observation_media` and `trace_media` tables to avoid deadlocks.
>     - Replaces Prisma `upsert` with raw SQL `INSERT ... ON CONFLICT DO UPDATE` for `media` table to handle updates on conflict.
>   - **Error Handling**:
>     - Removes specific handling for `PrismaClientKnownRequestError` with code `P2034`, now retries on any error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 00a2a08b8f30f631dd7f8382f9893605ec462921. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->