### PR TITLE
fix(IO-ui): render additional input in pretty view

### DIFF
--- a/web/src/components/trace/IOPreview.tsx
+++ b/web/src/components/trace/IOPreview.tsx
@@ -150,6 +150,14 @@ export const IOPreview: React.FC<{
   const isPrettyViewAvailable =
     inChatMlArray.success || inMarkdown.success || outMarkdown.success;
 
+  // If there are additional input fields beyond the messages, render them
+  const additionalInput =
+    typeof input === "object"
+      ? Object.fromEntries(
+          Object.entries(input as object).filter(([key]) => key !== "messages"),
+        )
+      : undefined;
+
   // default I/O
   return (
     <>
@@ -190,6 +198,11 @@ export const IOPreview: React.FC<{
                     ]),
               ]}
               shouldRenderMarkdown
+              additionalInput={
+                Object.keys(additionalInput ?? {}).length > 0
+                  ? additionalInput
+                  : undefined
+              }
               media={media ?? []}
             />
           ) : (
@@ -245,7 +258,14 @@ export const OpenAiMessageView: React.FC<{
   title?: string;
   shouldRenderMarkdown?: boolean;
   media?: MediaReturnType[];
-}> = ({ title, messages, shouldRenderMarkdown = false, media }) => {
+  additionalInput?: Record<string, unknown>;
+}> = ({
+  title,
+  messages,
+  shouldRenderMarkdown = false,
+  media,
+  additionalInput,
+}) => {
   const COLLAPSE_THRESHOLD = 3;
   const [isCollapsed, setCollapsed] = useState(
     messages.length > COLLAPSE_THRESHOLD ? true : null,
@@ -334,6 +354,11 @@ export const OpenAiMessageView: React.FC<{
             </Fragment>
           ))}
       </div>
+      {additionalInput && (
+        <div className="p-3">
+          <JSONView title="Additional Input" json={additionalInput} />
+        </div>
+      )}
       {media && media.length > 0 && (
         <>
           <div className="mx-3 border-t px-2 py-1 text-xs text-muted-foreground">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `IOPreview` to render additional input fields in pretty view by updating `IOPreview` and `OpenAiMessageView` components.
> 
>   - **Behavior**:
>     - `IOPreview` component now extracts additional input fields from `input` object, excluding `messages`.
>     - `OpenAiMessageView` renders `additionalInput` using `JSONView` if present.
>   - **Components**:
>     - `IOPreview` and `OpenAiMessageView` updated to handle `additionalInput`.
>     - `OpenAiMessageView` checks for non-empty `additionalInput` and renders it.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 016b2dabae4dc21c33c5f1e309effb1dc798c588. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->