### PR TITLE
fix: on cache schema change, delete cached api keys

### DIFF
--- a/web/src/features/public-api/server/apiAuth.ts
+++ b/web/src/features/public-api/server/apiAuth.ts
@@ -342,7 +342,11 @@ export class ApiAuthService {
       }
 
       if (!parsedApiKey.success) {
-        logger.error("Failed to parse API key from Redis:", parsedApiKey.error);
+        logger.error(
+          "Failed to parse API key from Redis, deleting existing key from cache",
+          parsedApiKey.error,
+        );
+        await this.redis.del(this.createRedisKey(hash));
       }
       return null;
     } catch (error: unknown) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `apiAuth.ts`, delete cached API keys from Redis when parsing fails to maintain cache consistency.
> 
>   - **Behavior**:
>     - In `apiAuth.ts`, when failing to parse an API key from Redis, the key is now deleted from the cache to maintain consistency.
>   - **Logging**:
>     - Enhanced error logging in `apiAuth.ts` to include cache deletion information when parsing fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 612834191985ed8a7452e27c631948e4c5978934. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->