### PR TITLE
fix: show dataset run if not run item exists yet

### DIFF
--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -234,7 +234,7 @@ export const getDatasetRunsFromPostgres = async (
       FROM
         datasets d
         JOIN dataset_runs runs ON d.id = runs.dataset_id AND d.project_id = runs.project_id
-        JOIN dataset_run_items ri ON ri.dataset_run_id = runs.id
+        LEFT JOIN dataset_run_items ri ON ri.dataset_run_id = runs.id
           AND ri.project_id = runs.project_id
       WHERE
         d.id = ${input.datasetId}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `INNER JOIN` to `LEFT JOIN` in `getDatasetRunsFromPostgres()` to show dataset runs without run items.
> 
>   - **Behavior**:
>     - Change `INNER JOIN` to `LEFT JOIN` in `getDatasetRunsFromPostgres()` in `service.ts` to show dataset runs even if no run items exist.
>   - **SQL Query**:
>     - Modify SQL query in `getDatasetRunsFromPostgres()` to use `LEFT JOIN` for `dataset_run_items` table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5437d7869f54b4838618524826f5d35e4ee5438d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->