### PR TITLE
[cherry-pick][2.93.x] feat: optionally disable csp headers via `LANGFUSE_CSP_DISABLE=true`

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -97,34 +97,39 @@ const nextConfig = {
           ...(env.SENTRY_CSP_REPORT_URI ? [reportToHeader] : []),
         ],
       },
-      {
-        source: "/:path((?!api).*)*",
-        headers: [
+      // CSP header
+      ...(env.LANGFUSE_CSP_DISABLE !== "true"
+        ? [
           {
-            key: "Content-Security-Policy",
-            value: cspHeader.replace(/\n/g, ""),
+            source: "/:path((?!api).*)*",
+            headers: [
+              {
+                key: "Content-Security-Policy",
+                value: cspHeader.replace(/\n/g, ""),
+              },
+            ],
           },
-        ],
-      },
+        ]
+        : []),
       // Required to check authentication status from langfuse.com
       ...(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== undefined
         ? [
-            {
-              source: "/api/auth/session",
-              headers: [
-                {
-                  key: "Access-Control-Allow-Origin",
-                  value: "https://langfuse.com",
-                },
-                { key: "Access-Control-Allow-Credentials", value: "true" },
-                { key: "Access-Control-Allow-Methods", value: "GET,POST" },
-                {
-                  key: "Access-Control-Allow-Headers",
-                  value: "Content-Type, Authorization",
-                },
-              ],
-            },
-          ]
+          {
+            source: "/api/auth/session",
+            headers: [
+              {
+                key: "Access-Control-Allow-Origin",
+                value: "https://langfuse.com",
+              },
+              { key: "Access-Control-Allow-Credentials", value: "true" },
+              { key: "Access-Control-Allow-Methods", value: "GET,POST" },
+              {
+                key: "Access-Control-Allow-Headers",
+                value: "Content-Type, Authorization",
+              },
+            ],
+          },
+        ]
         : []),
       // all files in /public/generated are public and can be accessed from any origin, e.g. to render an API reference based on our openapi schema
       {

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -46,7 +46,8 @@ export const env = createEnv({
     LANGFUSE_DEFAULT_PROJECT_ROLE: z
       .enum(["OWNER", "ADMIN", "MEMBER", "VIEWER"])
       .optional(),
-    LANGFUSE_CSP_ENFORCE_HTTPS: z.enum(["true", "false"]).optional(),
+    LANGFUSE_CSP_ENFORCE_HTTPS: z.enum(["true", "false"]).optional().default("false"),
+    LANGFUSE_CSP_DISABLE: z.enum(["true", "false"]).optional().default("false"),
     // Telemetry
     TELEMETRY_ENABLED: z.enum(["true", "false"]).optional(),
     // AUTH
@@ -275,6 +276,7 @@ export const env = createEnv({
       process.env.LANGFUSE_NEW_USER_SIGNUP_WEBHOOK,
     SALT: process.env.SALT,
     LANGFUSE_CSP_ENFORCE_HTTPS: process.env.LANGFUSE_CSP_ENFORCE_HTTPS,
+    LANGFUSE_CSP_DISABLE: process.env.LANGFUSE_CSP_DISABLE,
     TELEMETRY_ENABLED: process.env.TELEMETRY_ENABLED,
     // Default org, project and role
     LANGFUSE_DEFAULT_ORG_ID: process.env.LANGFUSE_DEFAULT_ORG_ID,


### PR DESCRIPTION
cherry-pick this for v2 branch

Source: #4529

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `LANGFUSE_CSP_DISABLE` environment variable to optionally disable CSP headers in `next.config.mjs`.
> 
>   - **Behavior**:
>     - Add `LANGFUSE_CSP_DISABLE` environment variable in `env.mjs` to optionally disable CSP headers.
>     - Modify `next.config.mjs` to conditionally include CSP headers based on `LANGFUSE_CSP_DISABLE` value.
>   - **Environment**:
>     - Default value for `LANGFUSE_CSP_DISABLE` set to `false` in `env.mjs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3b328cf77ffa70555be65810bccc83b3a174e658. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->