### PR TITLE
chore: include projectId in event processing error message

### DIFF
--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -224,6 +224,7 @@ export const processEventBatch = async (
         return aggregateBatchResult(
           [...validationErrors, ...authenticationErrors],
           sortedBatch.map((event) => ({ id: event.id, result: event })),
+          authCheck.scope.projectId,
         );
       }
     }
@@ -272,6 +273,7 @@ export const processEventBatch = async (
             // we are not sending additional server errors to the client in case of early return
             [...validationErrors, ...authenticationErrors],
             sortedBatch.map((event) => ({ id: event.id, result: event })),
+            authCheck.scope.projectId,
           );
         }
       } else {
@@ -294,6 +296,7 @@ export const processEventBatch = async (
     return aggregateBatchResult(
       [...validationErrors, ...authenticationErrors, ...result.errors],
       result.results,
+      authCheck.scope.projectId,
     );
   }
 
@@ -342,6 +345,7 @@ const sortBatch = (batch: Array<z.infer<typeof ingestionEvent>>) => {
 export const aggregateBatchResult = (
   errors: Array<{ id: string; error: unknown }>,
   results: Array<{ id: string; result: unknown }>,
+  projectId?: string,
 ) => {
   const returnedErrors: {
     id: string;
@@ -388,7 +392,10 @@ export const aggregateBatchResult = (
 
   if (returnedErrors.length > 0) {
     traceException(errors);
-    logger.error("Error processing events", returnedErrors);
+    logger.error("Error processing events", {
+      errors: returnedErrors,
+      "langfuse.project.id": projectId,
+    });
   }
 
   results.forEach((result) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Include `projectId` in error logs in `processEventBatch.ts` for better context during event processing.
> 
>   - **Behavior**:
>     - Include `projectId` in error logs in `processEventBatch()` in `processEventBatch.ts` for better context.
>     - Updates `aggregateBatchResult()` to accept `projectId` and log it with errors.
>   - **Functions**:
>     - Modify `aggregateBatchResult()` to include `projectId` in error logging.
>     - Pass `authCheck.scope.projectId` to `aggregateBatchResult()` in `processEventBatch()` at three return points.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 61e1b0ebb6ec20ffc72c16d5a9d085ea83904649. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->