### PR TITLE
perf: improve single trace public API performance

### DIFF
--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -84,15 +84,19 @@ export default withMiddlewares({
           };
         },
         clickhouseExecution: async () => {
-          const [trace, observations, scores] = await Promise.all([
-            getTraceById(traceId, auth.scope.projectId),
+          const trace = await getTraceById(traceId, auth.scope.projectId);
+          const [observations, scores] = await Promise.all([
             getObservationsViewForTrace(
               traceId,
               auth.scope.projectId,
-              undefined,
+              trace?.timestamp,
               true,
             ),
-            getScoresForTraces(auth.scope.projectId, [traceId]),
+            getScoresForTraces(
+              auth.scope.projectId,
+              [traceId],
+              trace?.timestamp,
+            ),
           ]);
 
           const uniqueModels: string[] = Array.from(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improved performance in `clickhouseExecution` by awaiting `getTraceById` separately in `web/src/pages/api/public/traces/[traceId].ts`.
> 
>   - **Performance**:
>     - In `web/src/pages/api/public/traces/[traceId].ts`, improved performance by awaiting `getTraceById` separately before `Promise.all` in `clickhouseExecution`.
>     - Pass `trace?.timestamp` to `getObservationsViewForTrace` and `getScoresForTraces` for more precise data retrieval.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1b2ff6a4df23f0301597e6b30a1736f34320d08a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->