### PR TITLE
fix: remove LANGFUSE_CSP_DISABLE (did not work) and disable csp headers on HF Spaces

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -28,9 +28,6 @@ ENCRYPTION_KEY="0000000000000000000000000000000000000000000000000000000000000000
 # Use CSP headers to enforce HTTPS, optional
 # LANGFUSE_CSP_ENFORCE_HTTPS="true"
 
-# Optionally, disable CSP headers
-# LANGFUSE_CSP_DISABLE="true"
-
 # Configure base path for self-hosting, optional
 # Note: You need to build the docker image with the base path set and cannot use the pre-built docker image if you set this.
 # NEXT_PUBLIC_BASE_PATH="/app"

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -98,19 +98,26 @@ const nextConfig = {
         ],
       },
       // CSP header
-      ...(env.LANGFUSE_CSP_DISABLE !== "true"
-        ? [
+      {
+        source: "/:path((?!api).*)*",
+        headers: [
           {
-            source: "/:path((?!api).*)*",
-            headers: [
-              {
-                key: "Content-Security-Policy",
-                value: cspHeader.replace(/\n/g, ""),
-              },
-            ],
+            key: "Content-Security-Policy",
+            value: cspHeader.replace(/\n/g, ""),
           },
-        ]
-        : []),
+        ],
+        // Disable CSP on Hugging Face to allow for embedded use of Langfuse
+        missing: [
+          {
+            type: "host",
+            value: "huggingface.co",
+          },
+          {
+            type: "host",
+            value: ".*\\.hf\\.space$", // *.hf.space
+          },
+        ],
+      },
       // Required to check authentication status from langfuse.com
       ...(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== undefined
         ? [

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -47,7 +47,6 @@ export const env = createEnv({
       .enum(["OWNER", "ADMIN", "MEMBER", "VIEWER"])
       .optional(),
     LANGFUSE_CSP_ENFORCE_HTTPS: z.enum(["true", "false"]).optional().default("false"),
-    LANGFUSE_CSP_DISABLE: z.enum(["true", "false"]).optional().default("false"),
     // Telemetry
     TELEMETRY_ENABLED: z.enum(["true", "false"]).optional(),
     // AUTH
@@ -301,7 +300,6 @@ export const env = createEnv({
       process.env.LANGFUSE_NEW_USER_SIGNUP_WEBHOOK,
     SALT: process.env.SALT,
     LANGFUSE_CSP_ENFORCE_HTTPS: process.env.LANGFUSE_CSP_ENFORCE_HTTPS,
-    LANGFUSE_CSP_DISABLE: process.env.LANGFUSE_CSP_DISABLE,
     TELEMETRY_ENABLED: process.env.TELEMETRY_ENABLED,
     // Default org, project and role
     LANGFUSE_DEFAULT_ORG_ID: process.env.LANGFUSE_DEFAULT_ORG_ID,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `LANGFUSE_CSP_DISABLE` and modify CSP headers to disable them for Hugging Face domains.
> 
>   - **Environment Variables**:
>     - Remove `LANGFUSE_CSP_DISABLE` from `.env.prod.example` and `env.mjs`.
>   - **CSP Headers**:
>     - Modify CSP header configuration in `next.config.mjs` to disable CSP for Hugging Face domains (`huggingface.co` and `*.hf.space`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e6d2160da9d0d5ebff6c73f53ae5c2ff94b96965. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->