### PR TITLE
fix(media): add wait time before retries

### DIFF
--- a/web/src/pages/api/public/media/index.ts
+++ b/web/src/pages/api/public/media/index.ts
@@ -60,6 +60,10 @@ export default withMiddlewares({
 
           while (retries < MAX_RETRIES) {
             try {
+              if (retries > 0) {
+                await new Promise((resolve) => setTimeout(resolve, 500));
+              }
+
               return await prisma.$transaction<{
                 mediaId: string;
                 uploadUrl: string | null;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a 500ms wait time before retrying media upload URL generation in `index.ts` to handle race conditions.
> 
>   - **Behavior**:
>     - Adds a 500ms wait time before retrying the transaction in the `POST` method of `index.ts` if the first attempt fails.
>     - Affects the media upload URL generation process, ensuring retries are spaced out to reduce race conditions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0b058e18d6ea066a688cfa5425b5eb1755ab43a4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->