### PR TITLE
perf: add a user_id bloom filter

### DIFF
--- a/packages/shared/clickhouse/migrations/clustered/0006_add_user_id_index.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0006_add_user_id_index.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE traces ON CLUSTER default DROP INDEX IF EXISTS idx_user_id;

--- a/packages/shared/clickhouse/migrations/clustered/0006_add_user_id_index.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0006_add_user_id_index.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE traces ON CLUSTER default ADD INDEX IF NOT EXISTS idx_user_id session_id TYPE bloom_filter() GRANULARITY 1;
+ALTER TABLE traces ON CLUSTER default ADD INDEX IF NOT EXISTS idx_user_id user_id TYPE bloom_filter() GRANULARITY 1;
 ALTER TABLE traces ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_user_id;

--- a/packages/shared/clickhouse/migrations/clustered/0006_add_user_id_index.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0006_add_user_id_index.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE traces ON CLUSTER default ADD INDEX IF NOT EXISTS idx_user_id session_id TYPE bloom_filter() GRANULARITY 1;
+ALTER TABLE traces ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_user_id;

--- a/packages/shared/clickhouse/migrations/unclustered/0006_add_user_id_index.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0006_add_user_id_index.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE traces ON CLUSTER default DROP INDEX IF EXISTS idx_user_id;

--- a/packages/shared/clickhouse/migrations/unclustered/0006_add_user_id_index.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0006_add_user_id_index.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE traces ON CLUSTER default ADD INDEX IF NOT EXISTS idx_user_id user_id TYPE bloom_filter() GRANULARITY 1;
-ALTER TABLE traces ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_user_id;
+ALTER TABLE traces ADD INDEX IF NOT EXISTS idx_user_id user_id TYPE bloom_filter() GRANULARITY 1;
+ALTER TABLE traces MATERIALIZE INDEX IF EXISTS idx_user_id;

--- a/packages/shared/clickhouse/migrations/unclustered/0006_add_user_id_index.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0006_add_user_id_index.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE traces ON CLUSTER default ADD INDEX IF NOT EXISTS idx_user_id session_id TYPE bloom_filter() GRANULARITY 1;
+ALTER TABLE traces ON CLUSTER default ADD INDEX IF NOT EXISTS idx_user_id user_id TYPE bloom_filter() GRANULARITY 1;
 ALTER TABLE traces ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_user_id;

--- a/packages/shared/clickhouse/migrations/unclustered/0006_add_user_id_index.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0006_add_user_id_index.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE traces ON CLUSTER default ADD INDEX IF NOT EXISTS idx_user_id session_id TYPE bloom_filter() GRANULARITY 1;
+ALTER TABLE traces ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_user_id;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add bloom filter index `idx_user_id` on `user_id` in `traces` table for ClickHouse clustered and unclustered setups.
> 
>   - **Migrations**:
>     - Add bloom filter index `idx_user_id` on `user_id` in `traces` table for ClickHouse.
>     - Create `0006_add_user_id_index.up.sql` and `0006_add_user_id_index.down.sql` for both clustered and unclustered setups.
>     - `up.sql` files add and materialize the index with granularity 1.
>     - `down.sql` files drop the index if it exists.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ca7e104343c3e3378b36a46a159e4f1119061437. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->