### PR TITLE
fix: convert json strings to json in traces api metadata field

### DIFF
--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -130,8 +130,6 @@ describe("/api/public/traces API Endpoint", () => {
     expect(trace.release).toBe("1.0.0");
     expect(trace.metadata.key).toBe("value");
     expect(trace.metadata.jsonKey).toEqual({ foo: "bar" });
-      JSON.stringify({ foo: "bar" }),
-    );
     expect(trace.externalId).toBeNull();
     expect(trace.version).toBe("2.0.0");
     expect(trace.projectId).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");

--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -84,7 +84,7 @@ describe("/api/public/traces API Endpoint", () => {
       name: "trace-name",
       user_id: "user-1",
       project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      metadata: { key: "value" },
+      metadata: { key: "value", jsonKey: JSON.stringify({ foo: "bar" }) },
       release: "1.0.0",
       version: "2.0.0",
     });
@@ -128,6 +128,10 @@ describe("/api/public/traces API Endpoint", () => {
     }
     expect(trace.name).toBe("trace-name");
     expect(trace.release).toBe("1.0.0");
+    expect(trace.metadata.key).toBe("value");
+    expect(JSON.stringify(trace.metadata.jsonKey)).toBe(
+      JSON.stringify({ foo: "bar" }),
+    );
     expect(trace.externalId).toBeNull();
     expect(trace.version).toBe("2.0.0");
     expect(trace.projectId).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");

--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -129,7 +129,7 @@ describe("/api/public/traces API Endpoint", () => {
     expect(trace.name).toBe("trace-name");
     expect(trace.release).toBe("1.0.0");
     expect(trace.metadata.key).toBe("value");
-    expect(JSON.stringify(trace.metadata.jsonKey)).toBe(
+    expect(trace.metadata.jsonKey).toEqual({ foo: "bar" });
       JSON.stringify({ foo: "bar" }),
     );
     expect(trace.externalId).toBeNull();

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -12,7 +12,7 @@ import {
   type Trace,
 } from "@langfuse/shared";
 import { snakeCase } from "lodash";
-import { JsonValue } from "@prisma/client/runtime/binary";
+import { type JsonValue } from "@prisma/client/runtime/binary";
 
 type QueryType = {
   page: number;

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -12,6 +12,7 @@ import {
   type Trace,
 } from "@langfuse/shared";
 import { snakeCase } from "lodash";
+import { JsonValue } from "@prisma/client/runtime/binary";
 
 type QueryType = {
   page: number;
@@ -133,9 +134,10 @@ export const generateTracesForPublicApi = async (
 
   return result.map((trace) => ({
     ...trace,
+    // Parse metadata values to JSON and make TypeScript happy
     metadata: convertRecordToJsonSchema(
       (trace.metadata as Record<string, string>) || {},
-    ),
+    ) as JsonValue,
   }));
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Converts JSON strings to JSON objects in traces API `metadata` field using `convertRecordToJsonSchema()` in `generateTracesForPublicApi()` and updates tests.
> 
>   - **Behavior**:
>     - Converts JSON strings to JSON objects in `metadata` field in `generateTracesForPublicApi()` in `traces.ts` using `convertRecordToJsonSchema()`.
>   - **Tests**:
>     - Updates `traces-api.servertest.ts` to include JSON string in `metadata` and verify conversion to JSON object.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 54d1af25b833eefc91ee5414250b71534f095678. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->