### PR TITLE
chore: increase timeout for daily metrics query

### DIFF
--- a/web/src/features/public-api/server/dailyMetrics.ts
+++ b/web/src/features/public-api/server/dailyMetrics.ts
@@ -45,6 +45,7 @@ export const generateDailyMetrics = async (props: QueryType) => {
       FROM traces t FINAL
       LEFT JOIN observations o FINAL on o.trace_id = t.id AND o.project_id = t.project_id
       WHERE o.project_id = {projectId: String} 
+      AND t.project_id = {projectId: String}
       ${filter.length() > 0 ? `AND ${appliedFilter.query}` : ""}
       ${timeFilter ? `AND start_time >= {cteTimeFilter: DateTime64(3)} - ${TRACE_TO_OBSERVATIONS_INTERVAL}` : ""}
       GROUP BY date, model
@@ -106,6 +107,9 @@ export const generateDailyMetrics = async (props: QueryType) => {
             cteTimeFilter: convertDateToClickhouseDateTime(timeFilter.value),
           }
         : {}),
+    },
+    clickhouseConfigs: {
+      request_timeout: 60_000, // Use 1 minute timeout for daily metrics
     },
   });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase timeout and add project filtering condition in `generateDailyMetrics()` in `dailyMetrics.ts`.
> 
>   - **Behavior**:
>     - Increase `request_timeout` to 60 seconds in `generateDailyMetrics()` in `dailyMetrics.ts` for Clickhouse queries.
>     - Add condition `AND t.project_id = {projectId: String}` to SQL query in `generateDailyMetrics()` to ensure correct project filtering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ea8ce21da7990e22b4c615b60a541b0e6dd7e41a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->