### PR TITLE
fix: perform batch trace deletion on clickhouse

### DIFF
--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -67,6 +67,10 @@ export const TraceQueueEventSchema = z.object({
   projectId: z.string(),
   traceId: z.string(),
 });
+export const TracesQueueEventSchema = z.object({
+  projectId: z.string(),
+  traceIds: z.array(z.string()),
+});
 export const DatasetRunItemUpsertEventSchema = z.object({
   projectId: z.string(),
   datasetItemId: z.string(),
@@ -88,6 +92,7 @@ export const ExperimentCreateEventSchema = z.object({
 
 export type BatchExportJobType = z.infer<typeof BatchExportJobSchema>;
 export type TraceQueueEventType = z.infer<typeof TraceQueueEventSchema>;
+export type TracesQueueEventType = z.infer<typeof TracesQueueEventSchema>;
 export type DatasetRunItemUpsertEventType = z.infer<
   typeof DatasetRunItemUpsertEventSchema
 >;
@@ -153,7 +158,7 @@ export type TQueueJobTypes = {
   [QueueName.TraceDelete]: {
     timestamp: Date;
     id: string;
-    payload: TraceQueueEventType;
+    payload: TracesQueueEventType | TraceQueueEventType;
     name: QueueJobs.TraceDelete;
   };
   [QueueName.DatasetRunItemUpsert]: {

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -889,6 +889,9 @@ export const deleteObservationsByTraceIds = async (
       projectId,
       traceIds,
     },
+    clickhouseConfigs: {
+      request_timeout: 120_000, // 2 minutes
+    },
   });
 };
 

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -476,6 +476,9 @@ export const deleteScoresByTraceIds = async (
       projectId,
       traceIds,
     },
+    clickhouseConfigs: {
+      request_timeout: 120_000, // 2 minutes
+    },
   });
 };
 

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -589,6 +589,9 @@ export const deleteTraces = async (projectId: string, traceIds: string[]) => {
       projectId,
       traceIds,
     },
+    clickhouseConfigs: {
+      request_timeout: 120_000, // 2 minutes
+    },
   });
 };
 

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -705,19 +705,15 @@ export const traceRouter = createTRPCRouter({
         return;
       }
 
-      await Promise.all(
-        input.traceIds.map(async (traceId) =>
-          traceDeleteQueue.add(QueueJobs.TraceDelete, {
-            timestamp: new Date(),
-            id: randomUUID(),
-            payload: {
-              projectId: input.projectId,
-              traceId,
-            },
-            name: QueueJobs.TraceDelete,
-          }),
-        ),
-      );
+      await traceDeleteQueue.add(QueueJobs.TraceDelete, {
+        timestamp: new Date(),
+        id: randomUUID(),
+        payload: {
+          projectId: input.projectId,
+          traceIds: input.traceIds,
+        },
+        name: QueueJobs.TraceDelete,
+      });
     }),
   bookmark: protectedProjectProcedure
     .input(

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -87,7 +87,7 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(25),
-  LANGFUSE_TRACE_DELETE_CONCURRENCY: z.coerce.number().positive().default(5),
+  LANGFUSE_TRACE_DELETE_CONCURRENCY: z.coerce.number().positive().default(1),
   LANGFUSE_EVAL_EXECUTION_WORKER_CONCURRENCY: z.coerce
     .number()
     .positive()


### PR DESCRIPTION
## What

Move trace deletions back into batch processing on the worker. Also, increase the query timeout and reduce concurrency.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize trace deletion by implementing batch processing and adjusting configurations for improved performance.
> 
>   - **Behavior**:
>     - Batch processing for trace deletions in `traceDeleteProcessor` in `traceDelete.ts`.
>     - Increased ClickHouse query timeout to 2 minutes in `deleteObservationsByTraceIds`, `deleteScoresByTraceIds`, and `deleteTraces`.
>     - Reduced `LANGFUSE_TRACE_DELETE_CONCURRENCY` to 1 in `env.ts`.
>   - **Schemas**:
>     - Added `TracesQueueEventSchema` in `queues.ts` for batch trace deletion.
>     - Updated `TQueueJobTypes` in `queues.ts` to support both single and batch trace deletion.
>   - **API**:
>     - Updated `deleteMany` mutation in `traces.ts` to use batch processing for trace deletions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for aa6fec01480cbbb9225a1a6bceafee06e7443234. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->