### PR TITLE
fix(cloud): only active evals count towards free plan limit

### DIFF
--- a/web/src/ee/features/evals/pages/evaluators.tsx
+++ b/web/src/ee/features/evals/pages/evaluators.tsx
@@ -23,7 +23,6 @@ export default function EvaluatorsPage() {
     page: 0,
     limit: 50,
   });
-  console.log("evaluatorsFirstPage", evaluatorsFirstPage.data);
   const evaluatorCountFirstPage = evaluatorsFirstPage.data?.configs.filter(
     (e) => e.status === "ACTIVE",
   ).length;

--- a/web/src/ee/features/evals/pages/evaluators.tsx
+++ b/web/src/ee/features/evals/pages/evaluators.tsx
@@ -15,9 +15,19 @@ export default function EvaluatorsPage() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
   const capture = usePostHogClientCapture();
-  const evaluatorCount = api.evals.allConfigs.useQuery({
+
+  // only fetched first page to get count of active evaluators
+  // ok as this includes the first 50 active evaluators
+  const evaluatorsFirstPage = api.evals.allConfigs.useQuery({
     projectId,
-  }).data?.totalCount;
+    page: 0,
+    limit: 50,
+  });
+  console.log("evaluatorsFirstPage", evaluatorsFirstPage.data);
+  const evaluatorCountFirstPage = evaluatorsFirstPage.data?.configs.filter(
+    (e) => e.status === "ACTIVE",
+  ).length;
+
   const evaluatorLimit = useEntitlementLimit(
     "model-based-evaluations-count-evaluators",
   );
@@ -51,7 +61,7 @@ export default function EvaluatorsPage() {
             variant="secondary"
             onClick={() => capture("eval_config:new_form_open")}
             href={`/project/${projectId}/evals/new`}
-            limitValue={evaluatorCount ?? 0}
+            limitValue={evaluatorCountFirstPage ?? 0}
             limit={evaluatorLimit}
           >
             New evaluator


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modify evaluator count logic in `evaluators.tsx` to only include active evaluators for free plan limit, fetching only the first page.
> 
>   - **Behavior**:
>     - Modify evaluator count logic in `evaluators.tsx` to only include active evaluators for free plan limit.
>     - Fetch only the first page (up to 50 evaluators) to determine active evaluator count.
>   - **Misc**:
>     - Update `limitValue` in `ActionButton` to use `evaluatorCountFirstPage`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cf9cc86011d4eb9e9e076d042584a738bc728610. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->