### PR TITLE
chore(cost-tracking): add gpt-4o-2024-11-20 prices

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1177,5 +1177,22 @@
       "tokensPerMessage": 3
     },
     "tokenizer_id": "openai"
+  },
+  {
+    "id": "cm48akqgo000008ldbia24qg0",
+    "model_name": "gpt-4o-2024-11-20",
+    "match_pattern": "(?i)^(gpt-4o-2024-11-20)$",
+    "created_at": "2024-12-03T10:06:12.000Z",
+    "updated_at": "2024-12-03T10:06:12.000Z",
+    "prices": {
+      "input": 2.5e-6,
+      "output": 10e-6
+    },
+    "tokenizer_config": {
+      "tokensPerName": 1,
+      "tokenizerModel": "gpt-4o",
+      "tokensPerMessage": 3
+    },
+    "tokenizer_id": "openai"
   }
 ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `gpt-4o-2024-11-20` model pricing to `default-model-prices.json`.
> 
>   - **Behavior**:
>     - Added new model `gpt-4o-2024-11-20` to `default-model-prices.json` with specific pricing.
>     - Input price set to `2.5e-6` and output price set to `10e-6`.
>     - Tokenizer configuration includes `tokensPerName: 1`, `tokenizerModel: gpt-4o`, and `tokensPerMessage: 3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 47e26963c140673407c091fe95a0e2763d3e201d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->