### PR TITLE
chore: explicitly mention worker/src/ee

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,8 +2,8 @@ Copyright (c) 2023--2024 Langfuse GmbH
 
 Portions of this software are licensed as follows:
 
-- All content that resides under the "ee/" and/or "web/src/ee" directories of this repository, if these directories exist, is licensed under the license defined in "ee/LICENSE".
-- All third party components incorporated into the Finto Technologies Software are licensed under the original license provided by the owner of the applicable component.
+- All content that resides under the "ee/", "web/src/ee/", and/or "worker/src/ee/" directories of this repository, if these directories exist, is licensed under the license defined in "ee/LICENSE".
+- All third party components incorporated into the Langfuse Software are licensed under the original license provided by the owner of the applicable component.
 - Content outside of the above mentioned directories or restrictions above is available under the "MIT Expat" license as defined below.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Explicitly mentions `worker/src/ee/` in the LICENSE file as being under the `ee/LICENSE` terms.
> 
>   - **License Update**:
>     - Explicitly mentions `worker/src/ee/` in the LICENSE file as being under the `ee/LICENSE` terms, alongside `ee/` and `web/src/ee/`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4d169ca15f2cd0e61913fccd0ede21ba8a313ce0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->