### PR TITLE
fix: show correct scores if dataset runs link same traces

### DIFF
--- a/packages/shared/prisma/seed.ts
+++ b/packages/shared/prisma/seed.ts
@@ -513,6 +513,9 @@ export async function createDatasets(
               Math.floor(Math.random() * relevantObservations.length)
             ];
 
+          if (!observation) {
+            continue;
+          }
           await prisma.datasetRunItems.create({
             data: {
               projectId,

--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -197,8 +197,6 @@ describe("Fetch datasets for UI presentation", () => {
       limit: 10,
     });
 
-    console.log("runs", JSON.stringify(runs));
-
     expect(runs).toHaveLength(2);
 
     const firstRun = runs.find((run) => run.run_id === datasetRunId);
@@ -244,6 +242,137 @@ describe("Fetch datasets for UI presentation", () => {
     expect(secondRun.avgTotalCost.toString()).toStrictEqual("300");
 
     expect(JSON.stringify(secondRun.scores)).toEqual(JSON.stringify({}));
+  });
+
+  it.only("should test that dataset runs can link to the same traces", async () => {
+    const datasetId = v4();
+
+    await prisma.dataset.create({
+      data: {
+        id: datasetId,
+        name: v4(),
+        projectId: projectId,
+      },
+    });
+    const datasetRunId = v4();
+    const datasetRun2Id = v4();
+    await prisma.datasetRuns.create({
+      data: {
+        id: datasetRunId,
+        name: v4(),
+        datasetId,
+        metadata: {},
+        projectId,
+      },
+    });
+
+    await prisma.datasetRuns.create({
+      data: {
+        id: datasetRun2Id,
+        name: v4(),
+        datasetId,
+        metadata: {},
+        projectId,
+      },
+    });
+
+    const datasetItemId = v4();
+
+    await prisma.datasetItem.create({
+      data: {
+        id: datasetItemId,
+        datasetId,
+        metadata: {},
+        projectId,
+      },
+    });
+
+    const datasetRunItemId = v4();
+    const datasetRunItemId2 = v4();
+    const traceId = v4();
+    const scoreId = v4();
+
+    await prisma.datasetRunItems.create({
+      data: {
+        id: datasetRunItemId,
+        datasetRunId: datasetRunId,
+        traceId: traceId,
+        projectId,
+        datasetItemId,
+      },
+    });
+
+    // linked to the second run
+    await prisma.datasetRunItems.create({
+      data: {
+        id: datasetRunItemId2,
+        datasetRunId: datasetRun2Id,
+        observationId: null,
+        traceId: traceId,
+        projectId,
+        datasetItemId,
+      },
+    });
+
+    const scoreName = v4();
+    const score = createScore({
+      id: scoreId,
+      observation_id: null,
+      trace_id: traceId,
+      project_id: projectId,
+      name: scoreName,
+    });
+
+    await createScoresCh([score]);
+
+    const runs = await createDatasetRunsTable({
+      projectId,
+      datasetId,
+      queryClickhouse: false,
+      page: 0,
+      limit: 10,
+    });
+
+    expect(runs).toHaveLength(2);
+
+    const firstRun = runs.find((run) => run.run_id === datasetRunId);
+    expect(firstRun).toBeDefined();
+    if (!firstRun) {
+      throw new Error("first run is not defined");
+    }
+    expect(firstRun.run_id).toEqual(datasetRunId);
+
+    expect(firstRun.run_description).toBeNull();
+    expect(firstRun.run_metadata).toEqual({});
+
+    expect(firstRun.avgLatency).toBeGreaterThanOrEqual(0);
+    expect(firstRun.avgTotalCost.toString()).toStrictEqual("0");
+
+    const expectedObject = {
+      [`${scoreName.replaceAll("-", "_")}-API-NUMERIC`]: {
+        type: "NUMERIC",
+        values: expect.arrayContaining([100.5]),
+        average: 100.5,
+        comment: "comment",
+      },
+    };
+
+    expect(firstRun.scores).toEqual(expectedObject);
+
+    const secondRun = runs.find((run) => run.run_id === datasetRun2Id);
+
+    expect(secondRun).toBeDefined();
+    if (!secondRun) {
+      throw new Error("second run is not defined");
+    }
+
+    expect(secondRun.run_id).toEqual(datasetRun2Id);
+    expect(secondRun.run_description).toBeNull();
+    expect(secondRun.run_metadata).toEqual({});
+    expect(secondRun.avgLatency).toEqual(0);
+    expect(secondRun.avgTotalCost.toString()).toStrictEqual("0");
+
+    expect(firstRun.scores).toEqual(expectedObject);
   });
 
   it("should fetch dataset run items for UI", async () => {

--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -100,9 +100,6 @@ export const createDatasetRunsTable = async (input: DatasetRunsTableInput) => {
       tableName,
       clickhouseSession,
     );
-    logger.info(
-      `Fetched ${scores.length} scores for dataset runs with ids ${scores.map((s) => JSON.stringify({ id: s.id, runId: s.run_id, v: s.value, tr: s.traceId })).join(", ")}`,
-    );
 
     const obsAgg = await getObservationLatencyAndCostForDataset(
       input,

--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -264,7 +264,7 @@ const getScoresFromTempTable = async (
       AND tmp.project_id = {projectId: String}
       AND tmp.dataset_id = {datasetId: String}
       ORDER BY s.event_ts DESC
-      LIMIT 1 BY s.id, s.project_id
+      LIMIT 1 BY s.id, s.project_id, tmp.run_id
       SETTINGS select_sequential_consistency = 1;
   `;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes dataset run score display issue when runs link to the same traces by updating score retrieval logic and adding test coverage.
> 
>   - **Behavior**:
>     - Fixes issue in `createDatasetRunsTable` in `service.ts` where dataset runs could link to the same traces, causing incorrect score displays.
>     - Updates `getScoresFromTempTable` to limit scores by `run_id`.
>   - **Tests**:
>     - Adds test case in `dataset-service.servertest.ts` to verify dataset runs can link to the same traces without score duplication.
>     - Removes unnecessary `console.log` in `dataset-service.servertest.ts`.
>   - **Misc**:
>     - Adds null check for `observation` in `createDatasets` in `seed.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5c11ef7242e803337bb554798fc2a38f5e6bd2a5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->