### PR TITLE
fix: return timestamps in API response as ISO strings

### DIFF
--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -80,9 +80,11 @@ describe("/api/public/traces API Endpoint", () => {
   });
 
   it("should fetch all traces", async () => {
+    const timestamp = new Date();
     const createdTrace = createTrace({
       name: "trace-name",
       user_id: "user-1",
+      timestamp: timestamp.getTime(),
       project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
       metadata: { key: "value", jsonKey: JSON.stringify({ foo: "bar" }) },
       release: "1.0.0",
@@ -94,8 +96,8 @@ describe("/api/public/traces API Endpoint", () => {
         trace_id: createdTrace.id,
         project_id: createdTrace.project_id,
         name: "observation-name",
-        end_time: new Date().getTime(),
-        start_time: new Date().getTime() - 1000,
+        end_time: timestamp.getTime(),
+        start_time: timestamp.getTime() - 1000,
         input: "input",
         output: "output",
       }),
@@ -103,8 +105,8 @@ describe("/api/public/traces API Endpoint", () => {
         trace_id: createdTrace.id,
         project_id: createdTrace.project_id,
         name: "observation-name-2",
-        end_time: new Date().getTime(),
-        start_time: new Date().getTime() - 100000,
+        end_time: timestamp.getTime(),
+        start_time: timestamp.getTime() - 100000,
         input: "input-2",
         output: "output-2",
       }),
@@ -136,6 +138,7 @@ describe("/api/public/traces API Endpoint", () => {
     expect(trace.latency).toBe(100);
     expect(trace.observations.length).toBe(2);
     expect(trace.scores.length).toBe(0);
+    expect(trace.timestamp).toBe(timestamp.toISOString());
   });
 
   it.each([

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -5,6 +5,7 @@ import {
   TRACE_TO_OBSERVATIONS_INTERVAL,
   orderByToClickhouseSql,
   type DateTimeFilter,
+  parseClickhouseUTCDateTimeFormat,
 } from "@langfuse/shared/src/server";
 import {
   convertRecordToJsonSchema,
@@ -134,6 +135,9 @@ export const generateTracesForPublicApi = async (
 
   return result.map((trace) => ({
     ...trace,
+    timestamp: parseClickhouseUTCDateTimeFormat(trace.timestamp.toString()),
+    createdAt: parseClickhouseUTCDateTimeFormat(trace.createdAt.toString()),
+    updatedAt: parseClickhouseUTCDateTimeFormat(trace.updatedAt.toString()),
     // Parse metadata values to JSON and make TypeScript happy
     metadata: convertRecordToJsonSchema(
       (trace.metadata as Record<string, string>) || {},


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Convert timestamps in API responses to ISO strings and update tests to verify the format.
> 
>   - **Behavior**:
>     - Convert timestamps to ISO strings in `generateTracesForPublicApi()` in `traces.ts`.
>     - Update test `should fetch all traces` in `traces-api.servertest.ts` to check for ISO string format.
>   - **Functions**:
>     - Use `parseClickhouseUTCDateTimeFormat()` to format `timestamp`, `createdAt`, and `updatedAt` in `generateTracesForPublicApi()`.
>   - **Tests**:
>     - Modify timestamps in `traces-api.servertest.ts` to use a consistent `Date` object for testing.
>     - Add expectation for `trace.timestamp` to be in ISO format in `traces-api.servertest.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 60642e8c0e786e8f5ae1965016ec49f298c021fb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->