### PR TITLE
chore: check early whether clickhouse url is configured

### DIFF
--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -14,6 +14,12 @@ if [ -z "$DATABASE_URL" ]; then
     fi
 fi
 
+# Check if CLICKHOUSE_URL is not set
+if [ -z "CLICKHOUSE_URL" ]; then
+    echo "Error: CLICKHOUSE_URL is not configured. Migrating from V2? Check out migration guide at https://langfuse.com/docs/deployment/v3/migrate-v2-to-v3."
+    exit 1
+fi
+
 # Set DIRECT_URL to the value of DATABASE_URL if it is not set, required for migrations
 if [ -z "$DIRECT_URL" ]; then
     export DIRECT_URL=$DATABASE_URL

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -15,7 +15,7 @@ if [ -z "$DATABASE_URL" ]; then
 fi
 
 # Check if CLICKHOUSE_URL is not set
-if [ -z "CLICKHOUSE_URL" ]; then
+if [ -z "$CLICKHOUSE_URL" ]; then
     echo "Error: CLICKHOUSE_URL is not configured. Migrating from V2? Check out migration guide at https://langfuse.com/docs/deployment/v3/migrate-v2-to-v3."
     exit 1
 fi


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a check in `web/entrypoint.sh` to ensure `CLICKHOUSE_URL` is set, exiting with an error if not.
> 
>   - **Behavior**:
>     - Adds a check in `web/entrypoint.sh` to ensure `CLICKHOUSE_URL` is set.
>     - If `CLICKHOUSE_URL` is not set, the script exits with an error message and a link to the migration guide.
>   - **Misc**:
>     - No other changes or refactoring in the script.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5c2e450fee76af0a091aeb2c69efb7fa6c61940d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->