### PR TITLE
chore: add wait time during validation of clickhouse background migra…

### DIFF
--- a/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
@@ -54,13 +54,44 @@ export default class MigrateObservationsFromPostgresToClickhouse
 
   async validate(
     args: Record<string, unknown>,
+    attempts = 5,
   ): Promise<{ valid: boolean; invalidReason: string | undefined }> {
-    if (!env.CLICKHOUSE_URL) {
+    // Check if Clickhouse credentials are configured
+    if (
+      !env.CLICKHOUSE_URL ||
+      !env.CLICKHOUSE_USER ||
+      !env.CLICKHOUSE_PASSWORD
+    ) {
       return {
         valid: false,
-        invalidReason: "Clickhouse URL must be configured to perform migration",
+        invalidReason:
+          "Clickhouse credentials must be configured to perform migration",
       };
     }
+
+    // Check if ClickHouse observations table exists
+    const tables = await clickhouseClient().query({
+      query: "SHOW TABLES",
+    });
+    const tableNames = (await tables.json()).data as { name: string }[];
+    if (!tableNames.some((r) => r.name === "observations")) {
+      // Retry if the table does not exist as this may mean migrations are still pending
+      if (attempts > 0) {
+        logger.info(
+          `ClickHouse observations table does not exist. Retrying in 10s...`,
+        );
+        return new Promise((resolve) => {
+          setTimeout(() => resolve(this.validate(args, attempts - 1)), 10_000);
+        });
+      }
+
+      // If all retries are exhausted, return as invalid
+      return {
+        valid: false,
+        invalidReason: "ClickHouse observations table does not exist",
+      };
+    }
+
     return { valid: true, invalidReason: undefined };
   }
 

--- a/worker/src/backgroundMigrations/migrateTracesFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateTracesFromPostgresToClickhouse.ts
@@ -19,13 +19,44 @@ export default class MigrateTracesFromPostgresToClickhouse
 
   async validate(
     args: Record<string, unknown>,
+    attempts = 5,
   ): Promise<{ valid: boolean; invalidReason: string | undefined }> {
-    if (!env.CLICKHOUSE_URL) {
+    // Check if Clickhouse credentials are configured
+    if (
+      !env.CLICKHOUSE_URL ||
+      !env.CLICKHOUSE_USER ||
+      !env.CLICKHOUSE_PASSWORD
+    ) {
       return {
         valid: false,
-        invalidReason: "Clickhouse URL must be configured to perform migration",
+        invalidReason:
+          "Clickhouse credentials must be configured to perform migration",
       };
     }
+
+    // Check if ClickHouse traces table exists
+    const tables = await clickhouseClient().query({
+      query: "SHOW TABLES",
+    });
+    const tableNames = (await tables.json()).data as { name: string }[];
+    if (!tableNames.some((r) => r.name === "traces")) {
+      // Retry if the table does not exist as this may mean migrations are still pending
+      if (attempts > 0) {
+        logger.info(
+          `ClickHouse traces table does not exist. Retrying in 10s...`,
+        );
+        return new Promise((resolve) => {
+          setTimeout(() => resolve(this.validate(args, attempts - 1)), 10_000);
+        });
+      }
+
+      // If all retries are exhausted, return as invalid
+      return {
+        valid: false,
+        invalidReason: "ClickHouse traces table does not exist",
+      };
+    }
+
     return { valid: true, invalidReason: undefined };
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added retry mechanism and enhanced credential checks in Clickhouse table validation for migration scripts.
> 
>   - **Validation Enhancements**:
>     - Added retry mechanism in `validate()` for `MigrateObservationsFromPostgresToClickhouse`, `MigrateScoresFromPostgresToClickhouse`, and `MigrateTracesFromPostgresToClickhouse`.
>     - Retries up to 5 times with a 10-second wait if Clickhouse tables (`observations`, `scores`, `traces`) do not exist.
>   - **Credential Checks**:
>     - Updated validation to check for `CLICKHOUSE_USER` and `CLICKHOUSE_PASSWORD` in addition to `CLICKHOUSE_URL` in all three migration scripts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 31feb5262baa24d44e5dfd9641a08f7666a3590a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->