### PR TITLE
feat: adjust trace redirect to uniqueness of trace ids to projects

### DIFF
--- a/web/src/pages/trace/[traceId].tsx
+++ b/web/src/pages/trace/[traceId].tsx
@@ -1,50 +1,50 @@
-import { prisma } from "@langfuse/shared/src/db";
+import { ErrorPage } from "@/src/components/error-page";
+import { getTracesByIdsForAnyProject } from "@langfuse/shared/src/server";
 import { type GetServerSideProps } from "next";
 import { useRouter } from "next/router";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   if (!context.params) {
     return {
-      notFound: true,
+      props: {
+        notFound: true,
+      },
     };
   }
 
   const traceId = context.params.traceId as string;
 
-  const trace = await prisma.trace.findUnique({
-    where: {
-      id: traceId,
-    },
-    select: {
-      project: {
-        select: {
-          id: true,
-        },
-      },
-    },
-  });
+  const traces = await getTracesByIdsForAnyProject([traceId]);
 
-  if (!trace) {
+  if (!traces || traces.length === 0 || traces.length > 1) {
     return {
-      notFound: true,
+      props: {
+        notFound: true,
+      },
     };
   }
 
   return {
     redirect: {
-      destination: `/project/${trace.project.id}/traces/${traceId}`,
+      destination: `/project/${traces[0].projectId}/traces/${traceId}`,
       permanent: false,
     },
   };
 };
 
-const TraceRedirectPage = () => {
+const TraceRedirectPage = ({ notFound }: { notFound?: boolean }) => {
   const router = useRouter();
   if (router.isFallback) {
     return <div>Loading...</div>;
   }
 
-  return <div>Redirecting...</div>;
+  if (notFound) {
+    return (
+      <ErrorPage message="Trace not found. Please upgrade the SDK as we changed the URL schema." />
+    );
+  }
+
+  return null;
 };
 
 export default TraceRedirectPage;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `getTracesByIdsForAnyProject` to ensure trace ID uniqueness across projects and updates trace redirect logic in `trace/[traceId].tsx`.
> 
>   - **Behavior**:
>     - Adds `getTracesByIdsForAnyProject` in `traces.ts` to fetch traces by IDs across any project.
>     - Updates `getServerSideProps` in `trace/[traceId].tsx` to use `getTracesByIdsForAnyProject` for trace redirection.
>     - Handles cases where no trace or multiple traces are found by setting `notFound` to `true`.
>   - **UI**:
>     - Displays `ErrorPage` in `TraceRedirectPage` if `notFound` is `true`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9f46f824f8b193f3f2792d269e2191b2183cb3a1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->