### PR TITLE
fix: fix front end confirmations to delete traces

### DIFF
--- a/web/src/components/deleteButton.tsx
+++ b/web/src/components/deleteButton.tsx
@@ -103,7 +103,10 @@ export function DeleteButton({
               variant="destructive"
               loading={traceMutation.isLoading || isDeleted}
               onClick={() => {
-                if (deleteConfirmationInput !== deleteConfirmation) {
+                if (
+                  deleteConfirmation &&
+                  deleteConfirmationInput !== deleteConfirmation
+                ) {
                   alert("Please type the correct confirmation");
                   return;
                 }
@@ -124,7 +127,10 @@ export function DeleteButton({
               variant="destructive"
               loading={datasetMutation.isLoading || isDeleted}
               onClick={() => {
-                if (deleteConfirmationInput !== deleteConfirmation) {
+                if (
+                  deleteConfirmation &&
+                  deleteConfirmationInput !== deleteConfirmation
+                ) {
                   alert("Please type the correct confirmation");
                   return;
                 }

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -379,6 +379,7 @@ export function TracePage({
               invalidateFunc={() => void utils.traces.all.invalidate()}
               type="trace"
               redirectUrl={`/project/${router.query.projectId as string}/traces`}
+              deleteConfirmation={trace.data.name ?? ""}
             />
           </>
         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves delete confirmation logic by checking for non-empty `deleteConfirmation` before comparison and setting it to trace name in `TracePage`.
> 
>   - **Behavior**:
>     - In `deleteButton.tsx`, added a check to ensure `deleteConfirmation` is not empty before comparing with `deleteConfirmationInput`.
>     - In `index.tsx`, set `deleteConfirmation` to `trace.data.name` in `TracePage`.
>   - **UI**:
>     - Alerts user to type the correct confirmation only if `deleteConfirmation` is provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2fdd9ebbbd256b9d715d57eff4b704f595cc4b04. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->