### PR TITLE
fix(experiments): don't create experiment run items for archived dataset items

### DIFF
--- a/web/src/components/trace/IOPreview.tsx
+++ b/web/src/components/trace/IOPreview.tsx
@@ -152,7 +152,7 @@ export const IOPreview: React.FC<{
 
   // If there are additional input fields beyond the messages, render them
   const additionalInput =
-    typeof input === "object"
+    typeof input === "object" && input !== null
       ? Object.fromEntries(
           Object.entries(input as object).filter(([key]) => key !== "messages"),
         )

--- a/web/src/ee/features/experiments/server/router.ts
+++ b/web/src/ee/features/experiments/server/router.ts
@@ -15,6 +15,7 @@ import {
 import { PromptType } from "@/src/features/prompts/server/utils/validation";
 import {
   type DatasetItem,
+  DatasetStatus,
   extractVariables,
   UnauthorizedError,
 } from "@langfuse/shared";
@@ -114,13 +115,14 @@ export const experimentsRouter = createTRPCRouter({
         where: {
           datasetId: input.datasetId,
           projectId: input.projectId,
+          status: DatasetStatus.ACTIVE,
         },
       });
 
       if (!Boolean(datasetItems.length)) {
         return {
           isValid: false,
-          message: "Selected dataset is empty.",
+          message: "Selected dataset is empty or all items are inactive.",
         };
       }
 

--- a/worker/src/ee/experiments/experimentService.ts
+++ b/worker/src/ee/experiments/experimentService.ts
@@ -24,6 +24,7 @@ import { QueueJobs, redis } from "@langfuse/shared/src/server";
 import { randomUUID } from "crypto";
 import { v4 } from "uuid";
 import { compileHandlebarString } from "../../features/utilities";
+import { DatasetStatus } from "../../../../packages/shared/dist/prisma/generated/types";
 
 const isValidPrismaJsonObject = (
   input: Prisma.JsonValue,
@@ -142,6 +143,7 @@ export const createExperimentJob = async ({
     where: {
       datasetId,
       projectId,
+      status: DatasetStatus.ACTIVE,
     },
     orderBy: {
       createdAt: "desc",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add filter for active dataset items in `router.ts` and `experimentService.ts` to prevent experiment run items for archived datasets.
> 
>   - **Behavior**:
>     - Add `status: DatasetStatus.ACTIVE` filter to dataset item queries in `experimentsRouter` in `router.ts` and `createExperimentJob` in `experimentService.ts`.
>     - Update error message in `experimentsRouter` to "Selected dataset is empty or all items are inactive."
>   - **Code Quality**:
>     - Fix null check for `input` in `IOPreview.tsx` to prevent errors when `input` is null.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for edde3d0bcc5de3aa1e97c228a8a5ca26a09eada9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->