### PR TITLE
feat: set v3 default variables

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -112,6 +112,7 @@ jobs:
         run: |
           cp .env.dev.example .env
           grep -v -e '^LANGFUSE_S3_BATCH_EXPORT_ENABLED=' -e '^REDIS_HOST=' -e '^NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT=' .env.dev.legacy.example > .env
+          echo "LANGFUSE_POSTGRES_INGESTION_ENABLED=true" >> .env
       - name: Run + migrate
         run: |
           docker compose -f docker-compose.dev.yml up -d

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -39,7 +39,7 @@ const EnvSchema = z.object({
   // TODO: Disable Postgres before go-live
   LANGFUSE_POSTGRES_INGESTION_ENABLED: z
     .enum(["true", "false"])
-    .default("true"),
+    .default("false"),
 
   LANGFUSE_INGESTION_QUEUE_DELAY_MS: z.coerce
     .number()

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -36,7 +36,6 @@ const EnvSchema = z.object({
   LANGFUSE_CLICKHOUSE_INGESTION_ENABLED: z
     .enum(["true", "false"])
     .default("true"),
-  // TODO: Disable Postgres before go-live
   LANGFUSE_POSTGRES_INGESTION_ENABLED: z
     .enum(["true", "false"])
     .default("false"),

--- a/web/src/__e2e__/api.servertest.ts
+++ b/web/src/__e2e__/api.servertest.ts
@@ -2,6 +2,7 @@ import { v4 } from "uuid";
 import { JobExecutionStatus, Prisma, prisma } from "@langfuse/shared/src/db";
 import {
   clickhouseClient,
+  getTraceById,
   OrgEnrichedApiKey,
   redis,
 } from "@langfuse/shared/src/server";
@@ -15,6 +16,7 @@ const generateAuth = (username: string, password: string) => {
 const workerAdminAuth = generateAuth("admin", "myworkerpassword");
 
 const userApiKeyAuth = generateAuth("pk-lf-1234567890", "sk-lf-1234567890");
+const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
 
 describe("Health endpoints", () => {
   it("web container returns healthy", async () => {
@@ -112,11 +114,7 @@ describe("Ingestion Pipeline", () => {
         expect(traceResponse.body).not.toBeNull();
         expect((await traceResponse.json()).id).toBe(traceId);
 
-        const trace = await prisma.trace.findUnique({
-          where: {
-            id: traceId,
-          },
-        });
+        const trace = await getTraceById(traceId, projectId);
         expect(trace).not.toBeNull();
         expect(trace?.name).toBe("test trace");
 

--- a/web/src/__e2e__/api.servertest.ts
+++ b/web/src/__e2e__/api.servertest.ts
@@ -165,90 +165,90 @@ describe("Ingestion Pipeline", () => {
     expect(response.status).toBe(207);
   }, 70000);
 
-  // it("rate limit ingestion", async () => {
-  //   // update the org in the database and set the rate limit to 1 for ingestion
-  //   const org = await prisma.organization.findUnique({
-  //     where: {
-  //       id: "seed-org-id",
-  //     },
-  //   });
-  //   await prisma.organization.update({
-  //     where: {
-  //       id: "seed-org-id",
-  //     },
-  //     data: {
-  //       cloudConfig: {
-  //         ...(typeof org?.cloudConfig === "object" ? org.cloudConfig : {}),
-  //         rateLimitOverrides: [
-  //           {
-  //             resource: "ingestion",
-  //             points: 1,
-  //             durationInSec: 60,
-  //           },
-  //         ],
-  //       },
-  //     },
-  //   });
+  it("rate limit ingestion", async () => {
+    // update the org in the database and set the rate limit to 1 for ingestion
+    const org = await prisma.organization.findUnique({
+      where: {
+        id: "seed-org-id",
+      },
+    });
+    await prisma.organization.update({
+      where: {
+        id: "seed-org-id",
+      },
+      data: {
+        cloudConfig: {
+          ...(typeof org?.cloudConfig === "object" ? org.cloudConfig : {}),
+          rateLimitOverrides: [
+            {
+              resource: "ingestion",
+              points: 1,
+              durationInSec: 60,
+            },
+          ],
+        },
+      },
+    });
 
-  //   const traceId = v4();
-  //   const spanId = v4();
+    const traceId = v4();
+    const spanId = v4();
 
-  //   const event = {
-  //     batch: [
-  //       {
-  //         id: v4(),
-  //         type: "trace-create",
-  //         timestamp: new Date().toISOString(),
-  //         body: {
-  //           name: "test trace",
-  //           id: traceId,
-  //           userId: "user-1", // triggers the eval
-  //         },
-  //       },
-  //       {
-  //         id: v4(),
-  //         type: "span-create",
-  //         timestamp: new Date().toISOString(),
-  //         body: {
-  //           id: spanId,
-  //           traceId: traceId,
-  //           name: "test span",
-  //         },
-  //       },
-  //     ],
-  //   };
-  //   // Arrange
-  //   const url = "http://localhost:3000/api/public/ingestion";
+    const event = {
+      batch: [
+        {
+          id: v4(),
+          type: "trace-create",
+          timestamp: new Date().toISOString(),
+          body: {
+            name: "test trace",
+            id: traceId,
+            userId: "user-1", // triggers the eval
+          },
+        },
+        {
+          id: v4(),
+          type: "span-create",
+          timestamp: new Date().toISOString(),
+          body: {
+            id: spanId,
+            traceId: traceId,
+            name: "test span",
+          },
+        },
+      ],
+    };
+    // Arrange
+    const url = "http://localhost:3000/api/public/ingestion";
 
-  //   // Act
-  //   let responses = [];
-  //   for (let i = 0; i < 10; i++) {
-  //     responses.push(
-  //       await fetch(url, {
-  //         method: "POST",
-  //         headers: {
-  //           "Content-Type": "application/json",
-  //           Authorization: userApiKeyAuth,
-  //         },
-  //         body: JSON.stringify(event),
-  //       }),
-  //     );
-  //   }
+    // Act
+    let responses = [];
+    for (let i = 0; i < 10; i++) {
+      responses.push(
+        await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: userApiKeyAuth,
+          },
+          body: JSON.stringify(event),
+        }),
+      );
+    }
 
-  //   // check that at least one of the responses is a 429
-  //   const rateLimitedResponse = responses.find((r) => r.status === 429);
-  //   expect(rateLimitedResponse).not.toBeNull();
+    // check that at least one of the responses is a 429
+    const rateLimitedResponse = responses.find((r) => r.status === 429);
+    expect(rateLimitedResponse).not.toBeNull();
 
-  //   // revert the rate limit on the org
-  //   await prisma.organization.update({
-  //     where: {
-  //       id: "seed-org-id",
-  //     },
-  //     data: {
-  //       cloudConfig: org?.cloudConfig ?? Prisma.JsonNull,
-  //     },
-  //   });
-  // });
+    // revert the rate limit on the org
+    await prisma.organization.update({
+      where: {
+        id: "seed-org-id",
+      },
+      data: {
+        cloudConfig: org?.cloudConfig ?? Prisma.JsonNull,
+      },
+    });
+  });
 });
 
 describe("Prompts endpoint", () => {

--- a/web/src/__e2e__/api.servertest.ts
+++ b/web/src/__e2e__/api.servertest.ts
@@ -1,14 +1,12 @@
 import { v4 } from "uuid";
 import { JobExecutionStatus, Prisma, prisma } from "@langfuse/shared/src/db";
 import {
-  clickhouseClient,
   getObservationById,
   getTraceById,
   OrgEnrichedApiKey,
   redis,
 } from "@langfuse/shared/src/server";
 import waitForExpect from "wait-for-expect";
-import { startTime } from "@/src/server/api/services/tableDefinitions";
 
 const generateAuth = (username: string, password: string) => {
   const auth = Buffer.from(`${username}:${password}`).toString("base64");

--- a/web/src/__e2e__/api.servertest.ts
+++ b/web/src/__e2e__/api.servertest.ts
@@ -53,7 +53,7 @@ describe("Ingestion Pipeline", () => {
     }
   });
 
-  it.only("ingest a trace", async () => {
+  it("ingest a trace", async () => {
     const traceId = v4();
     const spanId = v4();
 

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -217,7 +217,7 @@ export const env = createEnv({
         );
       }, "LANGFUSE_ALLOWED_ORGANIZATION_CREATORS must be a comma separated list of valid email addresses"),
 
-    // TODO: Remove entire block for go-live
+    // TODO: Remove entire block during V3 clean up
     // Settings to toggle Clickhouse vs Postgres behaviour
     LANGFUSE_READ_FROM_POSTGRES_ONLY: z
       .enum(["true", "false"])

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -231,6 +231,9 @@ export const env = createEnv({
     LANGFUSE_READ_FROM_CLICKHOUSE_ONLY: z
       .enum(["true", "false"])
       .default("true"),
+    LANGFUSE_POSTGRES_INGESTION_ENABLED: z
+      .enum(["true", "false"])
+      .default("false"),
 
     STRIPE_SECRET_KEY: z.string().optional(),
     STRIPE_WEBHOOK_SIGNING_SECRET: z.string().optional(),
@@ -463,6 +466,8 @@ export const env = createEnv({
       process.env.LANGFUSE_ALLOWED_ORGANIZATION_CREATORS,
     LANGFUSE_READ_FROM_POSTGRES_ONLY:
       process.env.LANGFUSE_READ_FROM_POSTGRES_ONLY,
+    LANGFUSE_POSTGRES_INGESTION_ENABLED:
+      process.env.LANGFUSE_POSTGRES_INGESTION_ENABLED,
     LANGFUSE_READ_FROM_CLICKHOUSE_ONLY:
       process.env.LANGFUSE_READ_FROM_CLICKHOUSE_ONLY,
     LANGFUSE_RETURN_FROM_CLICKHOUSE:

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -142,6 +142,9 @@ const EnvSchema = z.object({
   QUEUE_CONSUMER_EXPERIMENT_CREATE_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])
     .default("true"),
+  LANGFUSE_POSTGRES_INGESTION_ENABLED: z
+    .enum(["true", "false"])
+    .default("false"),
 });
 
 export const env: z.infer<typeof EnvSchema> =

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -106,10 +106,9 @@ const EnvSchema = z.object({
   OTEL_EXPORTER_OTLP_ENDPOINT: z.string().default("http://localhost:4318"),
   OTEL_SERVICE_NAME: z.string().default("worker"),
 
-  // TODO: Toggle for go-live and overwrite for Langfuse Cloud
   LANGFUSE_ENABLE_BACKGROUND_MIGRATIONS: z
     .enum(["true", "false"])
-    .default("false"),
+    .default("true"),
 
   // Flags to toggle queue consumers on or off.
   QUEUE_CONSUMER_LEGACY_INGESTION_QUEUE_IS_ENABLED: z

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -470,12 +470,14 @@ export const evaluate = async ({
   };
 
   // TODO: Remove foreign key on jobExecutions when removing this
-  await prisma.score.create({
-    data: {
-      ...baseScore,
-      projectId: event.projectId,
-    },
-  });
+  if (env.LANGFUSE_POSTGRES_INGESTION_ENABLED) {
+    await prisma.score.create({
+      data: {
+        ...baseScore,
+        projectId: event.projectId,
+      },
+    });
+  }
 
   // Write score to S3 and ingest into queue for Clickhouse processing
   try {

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -469,7 +469,6 @@ export const evaluate = async ({
     source: ScoreSource.EVAL,
   };
 
-  // TODO: Remove foreign key on jobExecutions when removing this
   if (env.LANGFUSE_POSTGRES_INGESTION_ENABLED) {
     await prisma.score.create({
       data: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Set `LANGFUSE_POSTGRES_INGESTION_ENABLED` default to `false` and update related logic for Postgres score creation.
> 
>   - **Behavior**:
>     - Change default of `LANGFUSE_POSTGRES_INGESTION_ENABLED` to `false` in `env.ts`, `env.mjs`, and `worker/src/env.ts`.
>     - Conditional Postgres score creation in `scores.ts` and `evalService.ts` based on `LANGFUSE_POSTGRES_INGESTION_ENABLED`.
>   - **Comments**:
>     - Update comment in `env.mjs` to indicate removal during V3 cleanup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1c6098c4959b974b8cef442a6a012d7576833fd9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->