### PR TITLE
fix: fix numeric chart for dashboards

### DIFF
--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -534,10 +534,14 @@ export const getNumericScoreHistogram = async (
   );
   const chFilterRes = chFilter.apply();
 
+  const traceFilter = chFilter.find((f) => f.clickhouseTable === "traces");
+
   const query = `
     select s.value
     from scores s
+    ${traceFilter ? `LEFT JOIN traces t ON s.trace_id = t.id AND t.project_id = s.project_id` : ""}
     WHERE s.project_id = {projectId: String}
+    ${traceFilter ? `AND t.project_id = {projectId: String}` : ""}
     ${chFilterRes?.query ? `AND ${chFilterRes.query}` : ""}
     ORDER BY s.event_ts DESC
     LIMIT 1 BY s.id, s.project_id


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds conditional LEFT JOIN with `traces` table in `getNumericScoreHistogram` in `scores.ts` based on `traceFilter`.
> 
>   - **Behavior**:
>     - In `getNumericScoreHistogram` in `scores.ts`, added conditional `LEFT JOIN` with `traces` table if `traceFilter` is present.
>     - Ensures `project_id` match in `traces` table when `traceFilter` is applied.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f4564a0c1e77dfd30b4776327042fde8c998d859. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->