### PR TITLE
chore: move eval to correct ee directory

### DIFF
--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -10,7 +10,7 @@ import {
   createEvalJobs,
   evaluate,
   extractVariablesFromTracingData,
-} from "../features/evaluation/evalService";
+} from "../ee/evaluation/evalService";
 import { kyselyPrisma, prisma } from "@langfuse/shared/src/db";
 import { randomUUID } from "crypto";
 import Decimal from "decimal.js";

--- a/worker/src/ee/evaluation/evalService.ts
+++ b/worker/src/ee/evaluation/evalService.ts
@@ -40,7 +40,10 @@ import {
 import { kyselyPrisma, prisma } from "@langfuse/shared/src/db";
 import { backOff } from "exponential-backoff";
 import { env } from "../../env";
-import { callStructuredLLM, compileHandlebarString } from "../utilities";
+import {
+  callStructuredLLM,
+  compileHandlebarString,
+} from "../../features/utilities";
 
 let s3StorageServiceClient: StorageService;
 

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -1,6 +1,5 @@
 import { Job } from "bullmq";
 import { ApiError, BaseError } from "@langfuse/shared";
-import { createEvalJobs, evaluate } from "../features/evaluation/evalService";
 import { kyselyPrisma } from "@langfuse/shared/src/db";
 import { sql } from "kysely";
 import {
@@ -9,6 +8,7 @@ import {
   logger,
   traceException,
 } from "@langfuse/shared/src/server";
+import { createEvalJobs } from "../ee/evaluation/evalService";
 
 export const evalJobTraceCreatorQueueProcessor = async (
   job: Job<TQueueJobTypes[QueueName.TraceUpsert]>,

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -8,7 +8,7 @@ import {
   logger,
   traceException,
 } from "@langfuse/shared/src/server";
-import { createEvalJobs } from "../ee/evaluation/evalService";
+import { createEvalJobs, evaluate } from "../ee/evaluation/evalService";
 
 export const evalJobTraceCreatorQueueProcessor = async (
   job: Job<TQueueJobTypes[QueueName.TraceUpsert]>,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Move `evalService.ts` to `worker/src/ee/evaluation/` and update import paths in related files.
> 
>   - **Refactor**:
>     - Move `evalService.ts` from `worker/src/features/evaluation/` to `worker/src/ee/evaluation/`.
>     - Update import paths in `evalService.test.ts` and `evalQueue.ts` to reflect new directory structure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2cabe2e3b26c4ba7ba1954f2bc96e7715507570d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->