### PR TITLE
fix: only read trace and score from prisma if `LANGFUSE_POSTGRES_INGESTION_ENABLED`

### DIFF
--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -308,32 +308,6 @@ export const scoresRouter = createTRPCRouter({
         scope: "scores:CUD",
       });
 
-      const trace = await ctx.prisma.trace.findFirst({
-        where: {
-          id: input.traceId,
-          projectId: input.projectId,
-        },
-      });
-      if (!trace) {
-        throw new Error("No trace with this id in this project.");
-      }
-
-      const existingScore = await ctx.prisma.score.findFirst({
-        where: {
-          projectId: input.projectId,
-          traceId: input.traceId,
-          observationId: input.observationId ?? null,
-          source: "ANNOTATION",
-          // configId functions as unique constraint for scores with source ANNOTATION
-          configId: input.configId,
-        },
-      });
-
-      if (existingScore) {
-        throw new Error(
-          `Score for name ${input.name} already exists for trace ${input.traceId} in project ${input.projectId}`,
-        );
-      }
       const score = {
         id: v4(),
         projectId: input.projectId,

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -328,6 +328,33 @@ export const scoresRouter = createTRPCRouter({
       };
 
       if (env.LANGFUSE_POSTGRES_INGESTION_ENABLED) {
+        const trace = await ctx.prisma.trace.findFirst({
+          where: {
+            id: input.traceId,
+            projectId: input.projectId,
+          },
+        });
+        if (!trace) {
+          throw new Error("No trace with this id in this project.");
+        }
+
+        const existingScore = await ctx.prisma.score.findFirst({
+          where: {
+            projectId: input.projectId,
+            traceId: input.traceId,
+            observationId: input.observationId ?? null,
+            source: "ANNOTATION",
+            // configId functions as unique constraint for scores with source ANNOTATION
+            configId: input.configId,
+          },
+        });
+
+        if (existingScore) {
+          throw new Error(
+            `Score for name ${input.name} already exists for trace ${input.traceId} in project ${input.projectId}`,
+          );
+        }
+
         await ctx.prisma.score.create({
           data: score,
         });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Conditionally read from Prisma in `scores.ts` based on `LANGFUSE_POSTGRES_INGESTION_ENABLED`, with improved error handling.
> 
>   - **Behavior**:
>     - `createAnnotationScore`, `updateAnnotationScore`, and `deleteAnnotationScore` in `scores.ts` now conditionally read from Prisma only if `LANGFUSE_POSTGRES_INGESTION_ENABLED` is true.
>     - Relies on Clickhouse for trace and score data when `LANGFUSE_POSTGRES_INGESTION_ENABLED` is false.
>   - **Error Handling**:
>     - Replaces silent error logging with `LangfuseNotFoundError` and `InvalidRequestError` exceptions in `scores.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9f53f387d4067ac3161d8e0ad09a0f0690868970. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->