### PR TITLE
fix: fix traces publishing in V3 without postgres

### DIFF
--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -827,7 +827,7 @@ export const traceRouter = createTRPCRouter({
             );
             throw new TRPCError({
               code: "NOT_FOUND",
-              message: "Trace not found in Clickhouse",
+              message: "Trace not found",
             });
           }
           clickhouseTrace.public = input.public;

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -804,15 +804,17 @@ export const traceRouter = createTRPCRouter({
           after: input.public,
         });
 
-        const trace = await ctx.prisma.trace.update({
-          where: {
-            id: input.traceId,
-            projectId: input.projectId,
-          },
-          data: {
-            public: input.public,
-          },
-        });
+        if (env.LANGFUSE_POSTGRES_INGESTION_ENABLED === "true") {
+          await ctx.prisma.trace.update({
+            where: {
+              id: input.traceId,
+              projectId: input.projectId,
+            },
+            data: {
+              public: input.public,
+            },
+          });
+        }
 
         if (env.CLICKHOUSE_URL) {
           const clickhouseTrace = await getTraceById(
@@ -823,13 +825,15 @@ export const traceRouter = createTRPCRouter({
             logger.error(
               `Trace not found in Clickhouse: ${input.traceId}. Skipping publishing.`,
             );
-            return trace;
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Trace not found in Clickhouse",
+            });
           }
           clickhouseTrace.public = input.public;
           await upsertTrace(convertTraceDomainToClickhouse(clickhouseTrace));
+          return clickhouseTrace;
         }
-
-        return trace;
       } catch (error) {
         console.error(error);
         if (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `publish` mutation in `traces.ts` to conditionally update Postgres and improve Clickhouse error handling.
> 
>   - **Behavior**:
>     - In `publish` mutation in `traces.ts`, update trace in Postgres only if `LANGFUSE_POSTGRES_INGESTION_ENABLED` is "true".
>     - If trace not found in Clickhouse, throw `TRPCError` with code "NOT_FOUND".
>   - **Error Handling**:
>     - Improved error handling for missing traces in Clickhouse by throwing `TRPCError`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 45fe07bfcaa3cfe6c4e4511872f184910989daea. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->