### PR TITLE
fix: support reading observations from clickhouse for observations in annotation queue

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1137,3 +1137,30 @@ export const getObservationCountOfProjectsSinceCreationDate = async ({
 
   return Number(rows[0]?.count ?? 0);
 };
+
+export const getTraceIdsForObservations = async (
+  projectId: string,
+  observationIds: string[],
+) => {
+  const query = `
+    SELECT 
+      trace_id,
+      id
+    FROM observations
+    WHERE project_id = {projectId: String}
+    AND id IN ({observationIds: Array(String)})
+  `;
+
+  const rows = await queryClickhouse<{ id: string; trace_id: string }>({
+    query,
+    params: {
+      projectId,
+      observationIds,
+    },
+  });
+
+  return rows.map((row) => ({
+    id: row.id,
+    traceId: row.trace_id,
+  }));
+};

--- a/web/src/ee/features/annotation-queues/server/annotationQueueItems.ts
+++ b/web/src/ee/features/annotation-queues/server/annotationQueueItems.ts
@@ -1,4 +1,3 @@
-import { env } from "@/src/env.mjs";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { throwIfNoEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";

--- a/web/src/ee/features/annotation-queues/server/annotationQueues.ts
+++ b/web/src/ee/features/annotation-queues/server/annotationQueues.ts
@@ -1,4 +1,3 @@
-import { env } from "@/src/env.mjs";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { throwIfNoEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for reading observations from ClickHouse in annotation queues when Postgres ingestion is disabled, with new function `getTraceIdsForObservations`.
> 
>   - **Behavior**:
>     - Support reading observations from ClickHouse when `LANGFUSE_POSTGRES_INGESTION_ENABLED` is false in `annotationQueueItems.ts` and `annotationQueues.ts`.
>     - Use `getObservationById` for fetching observations from ClickHouse.
>   - **Functions**:
>     - Add `getTraceIdsForObservations` to `observations.ts` for fetching trace IDs from ClickHouse.
>   - **Imports**:
>     - Import `env` from `env.mjs` in `annotationQueueItems.ts` and `annotationQueues.ts`.
>     - Import `getObservationById` from `@langfuse/shared/src/server` in `annotationQueueItems.ts` and `annotationQueues.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8ec339d42fe78a8725630c7f799787a9cc61a338. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->