### PR TITLE
chore: hide background migrations on cloud and show queued status

### DIFF
--- a/web/src/components/VersionLabel.tsx
+++ b/web/src/components/VersionLabel.tsx
@@ -130,19 +130,21 @@ export const VersionLabel = ({ className }: { className?: string }) => {
             Releases
           </Link>
         </DropdownMenuItem>
-        <DropdownMenuItem asChild>
-          <Link href="/background-migrations">
-            <ArrowUp10 size={16} className="mr-2" />
-            Background Migrations
-            {showBackgroundMigrationStatus && (
-              <StatusBadge
-                type={backgroundMigrationStatus.data?.status.toLowerCase()}
-                showText={false}
-                className="bg-transparent"
-              />
-            )}
-          </Link>
-        </DropdownMenuItem>
+        {!isLangfuseCloud && (
+          <DropdownMenuItem asChild>
+            <Link href="/background-migrations">
+              <ArrowUp10 size={16} className="mr-2" />
+              Background Migrations
+              {showBackgroundMigrationStatus && (
+                <StatusBadge
+                  type={backgroundMigrationStatus.data?.status.toLowerCase()}
+                  showText={false}
+                  className="bg-transparent"
+                />
+              )}
+            </Link>
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem asChild>
           <Link href="https://langfuse.com/changelog" target="_blank">
             <Newspaper size={16} className="mr-2" />

--- a/web/src/features/background-migrations/components/background-migrations.tsx
+++ b/web/src/features/background-migrations/components/background-migrations.tsx
@@ -44,7 +44,12 @@ export default function BackgroundMigrationsTable() {
         if (finishedAt) {
           return <StatusBadge type={"finished"} className="capitalize" />;
         }
-        return <StatusBadge type={"active"} className="capitalize" />;
+        const workerId = row.row.original.workerId;
+        if (workerId) {
+          return <StatusBadge type={"active"} className="capitalize" />;
+        }
+
+        return <StatusBadge type={"queued"} className="capitalize" />;
       },
     },
     {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Hide background migrations on cloud and update status logic to show "queued" when no `workerId` in `background-migrations.tsx`.
> 
>   - **UI Changes**:
>     - In `VersionLabel.tsx`, hide "Background Migrations" menu item when `isLangfuseCloud` is true.
>   - **Status Logic**:
>     - In `background-migrations.tsx`, update status logic to show "queued" status if `workerId` is not present and `finishedAt` is null.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7b71bbc578c80206620188cb1a2f3b33dc917c2d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->