### PR TITLE
perf: fetch observations using timestamps

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -210,11 +210,13 @@ export const getObservationById = async (
   id: string,
   projectId: string,
   fetchWithInputOutput: boolean = false,
+  startTime?: Date,
 ) => {
   const records = await getObservationByIdInternal(
     id,
     projectId,
     fetchWithInputOutput,
+    startTime,
   );
   const mapped = records.map(convertObservation);
 
@@ -311,6 +313,7 @@ const getObservationByIdInternal = async (
   id: string,
   projectId: string,
   fetchWithInputOutput: boolean = false,
+  startTime?: Date,
 ) => {
   const query = `
   SELECT
@@ -345,11 +348,18 @@ const getObservationByIdInternal = async (
   FROM observations
   WHERE id = {id: String}
   AND project_id = {projectId: String}
+  ${startTime ? `AND start_time = {startTime: DateTime64(3)}` : ""}
   ORDER BY event_ts desc
   LIMIT 1 by id, project_id`;
   return await queryClickhouse<ObservationRecordReadType>({
     query,
-    params: { id, projectId },
+    params: {
+      id,
+      projectId,
+      ...(startTime
+        ? { startTime: convertDateToClickhouseDateTime(startTime) }
+        : {}),
+    },
   });
 };
 

--- a/web/src/components/table/use-cases/generations.tsx
+++ b/web/src/components/table/use-cases/generations.tsx
@@ -590,6 +590,7 @@ export default function GenerationsTable({
             observationId={observationId}
             traceId={traceId}
             projectId={projectId}
+            startTime={row.getValue("startTime")}
             col="input"
             singleLine={rowHeight === "s"}
           />
@@ -611,6 +612,7 @@ export default function GenerationsTable({
             observationId={observationId}
             traceId={traceId}
             projectId={projectId}
+            startTime={row.getValue("startTime")}
             col="output"
             singleLine={rowHeight === "s"}
           />
@@ -635,6 +637,7 @@ export default function GenerationsTable({
             observationId={observationId}
             traceId={traceId}
             projectId={projectId}
+            startTime={row.getValue("startTime")}
             col="metadata"
             singleLine={rowHeight === "s"}
           />
@@ -854,12 +857,14 @@ const GenerationsDynamicCell = ({
   traceId,
   observationId,
   projectId,
+  startTime,
   col,
   singleLine = false,
 }: {
   traceId: string;
   observationId: string;
   projectId: string;
+  startTime?: Date;
   col: "input" | "output" | "metadata";
   singleLine: boolean;
 }) => {
@@ -868,6 +873,7 @@ const GenerationsDynamicCell = ({
       observationId,
       traceId,
       projectId,
+      startTime,
       queryClickhouse: useClickhouse(),
     },
     {

--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -69,8 +69,13 @@ export const ObservationPreview = ({
   const isAuthenticatedAndProjectMember =
     useIsAuthenticatedAndProjectMember(projectId);
 
+  const currentObservation = observations.find(
+    (o) => o.id === currentObservationId,
+  );
+
   const observationWithInputAndOutput = api.observations.byId.useQuery({
     observationId: currentObservationId,
+    startTime: currentObservation?.startTime,
     traceId: traceId,
     projectId: projectId,
     queryClickhouse: useClickhouse(),

--- a/web/src/server/api/routers/observations.ts
+++ b/web/src/server/api/routers/observations.ts
@@ -14,6 +14,7 @@ export const observationsRouter = createTRPCRouter({
         observationId: z.string(),
         traceId: z.string(), // required for protectedGetTraceProcedure
         projectId: z.string(), // required for protectedGetTraceProcedure
+        startTime: z.date().nullish(),
         queryClickhouse: z.boolean().default(false),
       }),
     )
@@ -36,6 +37,7 @@ export const observationsRouter = createTRPCRouter({
             input.observationId,
             input.projectId,
             true,
+            input.startTime ?? undefined,
           );
           if (!obs) {
             throw new TRPCError({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `startTime` filtering to observation queries, updating components and API routes to support this feature.
> 
>   - **Behavior**:
>     - Add `startTime` parameter to `getObservationById` in `observations.ts` to filter observations by timestamp.
>     - Update SQL query in `getObservationByIdInternal` to include `startTime` condition.
>   - **Components**:
>     - Pass `startTime` to `GenerationsDynamicCell` in `generations.tsx` for input, output, and metadata columns.
>     - Update `ObservationPreview` in `ObservationPreview.tsx` to use `startTime` when querying observations.
>   - **API**:
>     - Modify `observationsRouter` in `observations.ts` to accept `startTime` as input and pass it to `getObservationById`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cd13fc711a2036933eeff868ea327a5562372acc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->