### PR TITLE
fix: fix trace tagging without postgres

### DIFF
--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -904,6 +904,9 @@ export const traceRouter = createTRPCRouter({
         }
       } catch (error) {
         console.error(error);
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+        });
       }
     }),
 });

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -874,17 +874,19 @@ export const traceRouter = createTRPCRouter({
           after: input.tags,
         });
 
-        await ctx.prisma.trace.update({
-          where: {
-            id: input.traceId,
-            projectId: input.projectId,
-          },
-          data: {
-            tags: {
-              set: input.tags,
+        if (env.LANGFUSE_POSTGRES_INGESTION_ENABLED === "true") {
+          await ctx.prisma.trace.update({
+            where: {
+              id: input.traceId,
+              projectId: input.projectId,
             },
-          },
-        });
+            data: {
+              tags: {
+                set: input.tags,
+              },
+            },
+          });
+        }
 
         if (env.CLICKHOUSE_URL) {
           const clickhouseTrace = await getTraceById(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Conditional `trace.update` in `traces.ts` based on `LANGFUSE_POSTGRES_INGESTION_ENABLED` to prevent errors when Postgres is not used.
> 
>   - **Behavior**:
>     - Conditional `trace.update` in `traces.ts` based on `LANGFUSE_POSTGRES_INGESTION_ENABLED`.
>     - Skips updating tags if Postgres ingestion is disabled.
>   - **Environment**:
>     - Checks `env.LANGFUSE_POSTGRES_INGESTION_ENABLED` to determine if Postgres operations should be executed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 96cae430609c08cb9a0f19e049c9ae13cb105809. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->