### PR TITLE
fix: default to empty string for csv export in case of null

### DIFF
--- a/packages/shared/src/server/utils/transforms/transformStreamToCsv.ts
+++ b/packages/shared/src/server/utils/transforms/transformStreamToCsv.ts
@@ -12,7 +12,7 @@ export function transformStreamToCsv(): Transform {
     transform(
       row: Record<string, any>,
       encoding: BufferEncoding,
-      callback: TransformCallback
+      callback: TransformCallback,
     ): void {
       if (isFirstChunk) {
         // Extract headers from the first object
@@ -23,7 +23,7 @@ export function transformStreamToCsv(): Transform {
 
       // Convert the object to a CSV line and push it
       const csvRow = headers.map((header) => {
-        const field = row[header];
+        const field = row[header] ?? "";
         let str = stringify(field);
 
         // escape and format fields that contain commas


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Defaults to empty string for null fields in CSV export in `transformStreamToCsv()`.
> 
>   - **Behavior**:
>     - In `transformStreamToCsv()` in `transformStreamToCsv.ts`, defaults to an empty string for null fields during CSV export.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3d87b05c62577264124a52fdc6f9b15386c9e74f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->