### PR TITLE
fix: always pull the project_id for generations queries

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -516,6 +516,7 @@ const getObservationsTableInternal = async <T>(
       ? "count(*) as count"
       : `
         o.id as id,
+        o.project_id as "project_id",
         o.name as name,
         o."model_parameters" as model_parameters,
         o.start_time as "start_time",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure `project_id` is always included in query results in `getObservationsTableInternal` in `observations.ts`.
> 
>   - **Behavior**:
>     - Always include `project_id` in the query results for `getObservationsTableInternal` in `observations.ts`.
>   - **Queries**:
>     - Modify SQL query in `getObservationsTableInternal` to select `o.project_id as "project_id"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 873cbf7f98cf4c27b768882c9a40964fbffeabac. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->