### PR TITLE
fix: allow userId filter on /api/public/observations again

### DIFF
--- a/web/src/__tests__/async/observation-api.servertest.ts
+++ b/web/src/__tests__/async/observation-api.servertest.ts
@@ -8,7 +8,6 @@ import { makeZodVerifiedAPICall } from "@/src/__tests__/test-utils";
 import { GetObservationV1Response } from "@/src/features/public-api/types/observations";
 import { v4 as uuidv4 } from "uuid";
 import { GetObservationsV1Response } from "@/src/features/public-api/types/observations";
-import { randomUUID } from "crypto";
 import { snakeCase } from "lodash";
 
 const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
@@ -152,10 +151,10 @@ describe("/api/public/observations API Endpoint", () => {
   });
 
   it.each([
-    ["userId", randomUUID()],
-    ["traceId", randomUUID()],
-    ["name", randomUUID()],
-    ["version", randomUUID()],
+    ["userId", uuidv4()],
+    ["traceId", uuidv4()],
+    ["name", uuidv4()],
+    ["version", uuidv4()],
   ])(
     "should fetch all observations filtered by a value (%s, %s)",
     async (prop: string, value: string) => {

--- a/web/src/features/public-api/server/observations.ts
+++ b/web/src/features/public-api/server/observations.ts
@@ -21,8 +21,9 @@ type QueryType = {
 };
 
 export const generateObservationsForPublicApi = async (props: QueryType) => {
-  const filter = generateFilter(props);
-  const appliedFilter = filter.apply();
+  const chFilter = generateFilter(props);
+  const appliedFilter = chFilter.apply();
+  const traceFilter = chFilter.find((f) => f.clickhouseTable === "traces");
 
   const query = `
         SELECT
@@ -56,7 +57,9 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
         updated_at,
         event_ts
       FROM observations o
-      WHERE project_id = {projectId: String}
+      ${traceFilter ? `LEFT JOIN traces t ON o.trace_id = t.id AND t.project_id = o.project_id` : ""}
+      WHERE o.project_id = {projectId: String}
+      ${traceFilter ? `AND t.project_id = {projectId: String}` : ""}
       AND ${appliedFilter.query}
       ORDER BY start_time desc
       LIMIT 1 by id, project_id
@@ -78,15 +81,18 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
 };
 
 export const getObservationsCountForPublicApi = async (props: QueryType) => {
-  const filter = generateFilter(props).apply();
+  const chFilter = generateFilter(props);
+  const filter = chFilter.apply();
+  const traceFilter = chFilter.find((f) => f.clickhouseTable === "traces");
 
   const query = `
-        SELECT
-        count() as count
-      FROM observations o
-      WHERE project_id = {projectId: String}
-      AND ${filter.query}
-      `;
+    SELECT count() as count
+    FROM observations o
+    ${traceFilter ? `LEFT JOIN traces t ON o.trace_id = t.id AND t.project_id = o.project_id` : ""}
+    WHERE o.project_id = {projectId: String}
+    ${traceFilter ? `AND t.project_id = {projectId: String}` : ""}
+    AND ${filter.query}
+  `;
 
   const records = await queryClickhouse<{ count: string }>({
     query,
@@ -100,8 +106,8 @@ const filterParams = [
     id: "userId",
     clickhouseSelect: "user_id",
     filterType: "StringFilter",
-    clickhouseTable: "observations",
-    clickhousePrefix: "o",
+    clickhouseTable: "traces",
+    clickhousePrefix: "t",
   },
   {
     id: "traceId",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reintroduces `userId` filter in `/api/public/observations` endpoint with updated tests and server logic for filtering by `userId`.
> 
>   - **Behavior**:
>     - Reintroduces `userId` filter in `/api/public/observations` endpoint.
>     - Filters observations by `userId` using a join with `traces` table in `observations.ts`.
>   - **Tests**:
>     - Adds test cases in `observation-api.servertest.ts` for filtering by `userId`, `traceId`, `name`, and `version`.
>     - Uses `uuidv4` and `randomUUID` for generating test IDs.
>   - **Misc**:
>     - Removes `console.log` statement from `observation-api.servertest.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e1d17a3af021b67dd149346a1cc2dfa3834a502e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->