### PR TITLE
build: add latest tags to v3 tags

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -461,7 +461,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-          # type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v3') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v3') }}
       - name: Build and push Docker image (web)
         uses: docker/build-push-action@v4
         with:
@@ -489,7 +489,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-          # type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v3') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v3') }}
       - name: Build and push Docker image (worker)
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable 'latest' tag for Docker images when GitHub ref starts with 'refs/tags/v3' in `pipeline.yml`.
> 
>   - **Docker Tags**:
>     - Enable 'latest' tag for Docker images when GitHub ref starts with 'refs/tags/v3' in `pipeline.yml`.
>     - Affects both 'web' and 'worker' Docker image build and push steps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ea9ca2ef401556103f9350ffc862a2f71881b45c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->