### PR TITLE
fix: always restart all docker services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   langfuse-worker:
     image: langfuse/langfuse-worker:main # TODO: Switch to :3 after go-live
+    restart: always
     depends_on: &langfuse-depends-on
       postgres:
         condition: service_healthy
@@ -43,6 +44,7 @@ services:
 
   langfuse-web:
     image: langfuse/langfuse:main # TODO: Switch to :3 after go-live
+    restart: always
     depends_on: *langfuse-depends-on
     ports:
       - "3000:3000"
@@ -66,6 +68,7 @@ services:
 
   clickhouse:
     image: clickhouse/clickhouse-server
+    restart: always
     user: "101:101"
     container_name: clickhouse
     hostname: clickhouse
@@ -88,6 +91,7 @@ services:
 
   minio:
     image: minio/minio
+    restart: always
     container_name: minio
     entrypoint: sh
     # create the 'langfuse' bucket before starting the service


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `restart: always` policy to all services in `docker-compose.yml` to ensure automatic restarts.
> 
>   - **Docker Compose**:
>     - Add `restart: always` policy to `langfuse-worker`, `langfuse-web`, and `clickhouse` services in `docker-compose.yml`.
>     - Add `restart: always` policy to `minio`, `redis`, and `postgres` services in `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6e78b98adc99a06bbc3128a0f151e91a5c2049a0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->