### PR TITLE
chore: update default docker compose to use `3` docker tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   langfuse-worker:
-    image: langfuse/langfuse-worker:main # TODO: Switch to :3 after go-live
+    image: langfuse/langfuse-worker:3
     restart: always
     depends_on: &langfuse-depends-on
       postgres:
@@ -43,7 +43,7 @@ services:
       REDIS_AUTH: ${REDIS_AUTH:-myredissecret}
 
   langfuse-web:
-    image: langfuse/langfuse:main # TODO: Switch to :3 after go-live
+    image: langfuse/langfuse:3
     restart: always
     depends_on: *langfuse-depends-on
     ports:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Docker image tags for `langfuse-worker` and `langfuse-web` to `3` in `docker-compose.yml`.
> 
>   - **Docker Compose**:
>     - Update `langfuse-worker` image tag from `main` to `3` in `docker-compose.yml`.
>     - Update `langfuse-web` image tag from `main` to `3` in `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d877574d86afb2ba6f9890b21fab6272f45863fe. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->