### PR TITLE
fix: handle non-existent projects gracefully on delete

### DIFF
--- a/worker/src/queues/projectDelete.ts
+++ b/worker/src/queues/projectDelete.ts
@@ -8,6 +8,7 @@ import {
   TQueueJobTypes,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
+import { Prisma } from "@prisma/client";
 
 export const projectDeleteProcessor: Processor = async (
   job: Job<TQueueJobTypes[QueueName.ProjectDelete]>,
@@ -44,12 +45,23 @@ export const projectDeleteProcessor: Processor = async (
 
   // Finally, delete the project itself which should delete all related
   // resources due to the referential actions defined via Prisma
-  await prisma.project.delete({
-    where: {
-      id: projectId,
-      orgId,
-    },
-  });
+  try {
+    await prisma.project.delete({
+      where: {
+        id: projectId,
+        orgId,
+      },
+    });
+  } catch (e) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError) {
+      if (e.code === "P2025" || e.code === "P2016") {
+        logger.warning(
+          `Tried to delete project ${projectId} in org ${orgId}, but it does not exist`,
+        );
+      }
+    }
+    throw e;
+  }
 
   logger.info(`Deleted ${projectId} in org ${orgId}`);
 };

--- a/worker/src/queues/projectDelete.ts
+++ b/worker/src/queues/projectDelete.ts
@@ -58,6 +58,7 @@ export const projectDeleteProcessor: Processor = async (
         logger.warning(
           `Tried to delete project ${projectId} in org ${orgId}, but it does not exist`,
         );
+        return;
       }
     }
     throw e;


### PR DESCRIPTION
## What

Handle project deletion gracefully until https://github.com/prisma/prisma/issues/4072 gets implemented.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds error handling in `projectDeleteProcessor` to log warnings for non-existent projects during deletion.
> 
>   - **Behavior**:
>     - Adds try-catch block in `projectDeleteProcessor` in `projectDelete.ts` to handle non-existent projects during deletion.
>     - Catches `PrismaClientKnownRequestError` with codes `P2025` and `P2016` to log a warning if the project does not exist.
>   - **Logging**:
>     - Logs a warning message when attempting to delete a non-existent project.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 15f2ffd1b6d7621392caaa7b64e369037a85dea6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->