### PR TITLE
docs: update upgrade guide url in entrypoint

### DIFF
--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -16,7 +16,7 @@ fi
 
 # Check if CLICKHOUSE_URL is not set
 if [ -z "$CLICKHOUSE_URL" ]; then
-    echo "Error: CLICKHOUSE_URL is not configured. Migrating from V2? Check out migration guide at https://langfuse.com/docs/deployment/v3/migrate-v2-to-v3."
+    echo "Error: CLICKHOUSE_URL is not configured. Migrating from V2? Check out migration guide: https://langfuse.com/self-hosting/upgrade-guides/upgrade-v2-to-v3"
     exit 1
 fi
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update migration guide URL in `web/entrypoint.sh` for `CLICKHOUSE_URL` error message.
> 
>   - **Documentation**:
>     - Update migration guide URL in `web/entrypoint.sh` error message for `CLICKHOUSE_URL` not configured scenario.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f142ece75ae4d5d75b76d58aa5af98b958ea66ae. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->