### PR TITLE
fix(experiments): don't require name in experiment creation

### DIFF
--- a/web/src/ee/features/experiments/components/CreateExperimentsForm.tsx
+++ b/web/src/ee/features/experiments/components/CreateExperimentsForm.tsx
@@ -70,8 +70,9 @@ import { EvaluatorStatus } from "@/src/ee/features/evals/types";
 const CreateExperimentData = z.object({
   name: z
     .union([z.string().length(0), z.string().min(1)])
-    .optional()
-    .transform((str) => (str === "" ? undefined : str)),
+    .transform((str) => str.trim())
+    .transform((str) => (str === "" ? undefined : str))
+    .optional(),
   promptId: z.string().min(1, "Please select a prompt"),
   datasetId: z.string().min(1, "Please select a dataset"),
   description: z.string().max(1000).optional(),

--- a/web/src/ee/features/experiments/components/CreateExperimentsForm.tsx
+++ b/web/src/ee/features/experiments/components/CreateExperimentsForm.tsx
@@ -70,9 +70,9 @@ import { EvaluatorStatus } from "@/src/ee/features/evals/types";
 const CreateExperimentData = z.object({
   name: z
     .union([z.string().length(0), z.string().min(1)])
-    .transform((str) => str.trim())
-    .transform((str) => (str === "" ? undefined : str))
-    .optional(),
+    .optional()
+    .transform((str) => str?.trim())
+    .transform((str) => (str === "" ? undefined : str)),
   promptId: z.string().min(1, "Please select a prompt"),
   datasetId: z.string().min(1, "Please select a dataset"),
   description: z.string().max(1000).optional(),

--- a/web/src/ee/features/experiments/components/CreateExperimentsForm.tsx
+++ b/web/src/ee/features/experiments/components/CreateExperimentsForm.tsx
@@ -69,10 +69,9 @@ import { EvaluatorStatus } from "@/src/ee/features/evals/types";
 
 const CreateExperimentData = z.object({
   name: z
-    .string()
-    .trim()
-    .transform((str) => str || undefined)
-    .optional(),
+    .union([z.string().length(0), z.string().min(1)])
+    .optional()
+    .transform((str) => (str === "" ? undefined : str)),
   promptId: z.string().min(1, "Please select a prompt"),
   datasetId: z.string().min(1, "Please select a dataset"),
   description: z.string().max(1000).optional(),

--- a/web/src/ee/features/experiments/components/CreateExperimentsForm.tsx
+++ b/web/src/ee/features/experiments/components/CreateExperimentsForm.tsx
@@ -68,7 +68,11 @@ import { Input } from "@/src/components/ui/input";
 import { EvaluatorStatus } from "@/src/ee/features/evals/types";
 
 const CreateExperimentData = z.object({
-  name: z.string().min(1, "Please enter a name").optional(),
+  name: z
+    .string()
+    .transform((str) => str.trim())
+    .transform((str) => (str === "" ? undefined : str))
+    .optional(),
   promptId: z.string().min(1, "Please select a prompt"),
   datasetId: z.string().min(1, "Please select a dataset"),
   description: z.string().max(1000).optional(),

--- a/web/src/ee/features/experiments/components/CreateExperimentsForm.tsx
+++ b/web/src/ee/features/experiments/components/CreateExperimentsForm.tsx
@@ -70,8 +70,8 @@ import { EvaluatorStatus } from "@/src/ee/features/evals/types";
 const CreateExperimentData = z.object({
   name: z
     .string()
-    .transform((str) => str.trim())
-    .transform((str) => (str === "" ? undefined : str))
+    .trim()
+    .transform((str) => str || undefined)
     .optional(),
   promptId: z.string().min(1, "Please select a prompt"),
   datasetId: z.string().min(1, "Please select a dataset"),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Make `name` field optional in `CreateExperimentData` schema, transforming empty strings to `undefined`.
> 
>   - **Behavior**:
>     - `name` field in `CreateExperimentData` schema is now optional and trimmed, transforming empty strings to `undefined`.
>   - **Validation**:
>     - Updated `CreateExperimentData` in `CreateExperimentsForm.tsx` to handle optional `name` field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 800a14481225db9918d0b34a14459baa0d7de4d5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->