### PR TITLE
fix: export i/o for traces

### DIFF
--- a/worker/src/__tests__/batch-export.test.ts
+++ b/worker/src/__tests__/batch-export.test.ts
@@ -332,7 +332,7 @@ describe("batch export test suite", () => {
     );
   });
 
-  it.only("should export traces", async () => {
+  it("should export traces", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
 
     const traces = [

--- a/worker/src/__tests__/batch-export.test.ts
+++ b/worker/src/__tests__/batch-export.test.ts
@@ -332,17 +332,27 @@ describe("batch export test suite", () => {
     );
   });
 
-  it("should export traces", async () => {
+  it.only("should export traces", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
 
     const traces = [
       createTrace({
         project_id: projectId,
         id: randomUUID(),
+        input: "test",
+        output: "test",
+        metadata: {
+          test: "test",
+        },
       }),
       createTrace({
         project_id: projectId,
         id: randomUUID(),
+        input: "test",
+        output: "test",
+        metadata: {
+          test: "test",
+        },
       }),
     ];
 
@@ -398,9 +408,20 @@ describe("batch export test suite", () => {
         expect.objectContaining({
           id: traces[0].id,
           test: [score.value],
+          input: "test",
+          output: "test",
+          metadata: {
+            test: "test",
+          },
         }),
+
         expect.objectContaining({
           id: traces[1].id,
+          input: "test",
+          output: "test",
+          metadata: {
+            test: "test",
+          },
         }),
       ]),
     );

--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -392,7 +392,9 @@ export const getDatabaseReadStream = async ({
 
               const outputScores: Record<string, string[] | number[]> =
                 prepareScoresForOutput(filteredScores);
-              const fullTrace = fullTraces.find((t) => t.id === t.id);
+              const fullTrace = fullTraces.find(
+                (fullTrace) => fullTrace.id === t.id,
+              );
 
               return {
                 ...t,

--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -32,6 +32,7 @@ import {
   getTracesTableMetrics,
   getScoresForTraces,
   logger,
+  getTracesByIds,
 } from "@langfuse/shared/src/server";
 import { env } from "../../env";
 import { BatchExportSessionsRow, BatchExportTracesRow } from "./types";
@@ -358,18 +359,28 @@ export const getDatabaseReadStream = async ({
               Math.floor(offset / pageSize),
             );
 
-            const metrics = await getTracesTableMetrics({
-              projectId,
-              filter: [
-                ...(filter ?? []),
-                {
-                  type: "stringOptions",
-                  operator: "any of",
-                  column: "ID",
-                  value: traces.map((t) => t.id),
-                },
-              ],
-            });
+            const [metrics, fullTraces] = await Promise.all([
+              getTracesTableMetrics({
+                projectId,
+                filter: [
+                  ...(filter ?? []),
+                  {
+                    type: "stringOptions",
+                    operator: "any of",
+                    column: "ID",
+                    value: traces.map((t) => t.id),
+                  },
+                ],
+              }),
+              getTracesByIds(
+                traces.map((t) => t.id),
+                projectId,
+                traces.reduce(
+                  (min, t) => (!min || t.timestamp < min ? t.timestamp : min),
+                  undefined as Date | undefined,
+                ),
+              ),
+            ]);
 
             const scores = await getScoresForTraces(
               projectId,
@@ -381,9 +392,13 @@ export const getDatabaseReadStream = async ({
 
               const outputScores: Record<string, string[] | number[]> =
                 prepareScoresForOutput(filteredScores);
+              const fullTrace = fullTraces.find((t) => t.id === t.id);
 
               return {
                 ...t,
+                input: fullTrace?.input,
+                output: fullTrace?.output,
+                metadata: fullTrace?.metadata,
                 name: t.name ?? "",
                 usage: {
                   promptTokens: metric?.promptTokens,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance trace export to include `input`, `output`, and `metadata` fields, updating both export logic and tests.
> 
>   - **Behavior**:
>     - `getDatabaseReadStream` in `handleBatchExportJob.ts` now fetches `input`, `output`, and `metadata` for traces.
>     - Updates trace export test in `batch-export.test.ts` to include `input`, `output`, and `metadata` fields.
>   - **Functions**:
>     - Adds `getTracesByIds` to fetch full trace details in `handleBatchExportJob.ts`.
>   - **Tests**:
>     - Modifies `should export traces` test in `batch-export.test.ts` to check for `input`, `output`, and `metadata`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2eaa029d7cd7169ab430ac4db13b8a82525c12b7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->