### PR TITLE
feat(ui): add editable note for each api key

### DIFF
--- a/web/src/features/public-api/components/ApiKeyList.tsx
+++ b/web/src/features/public-api/components/ApiKeyList.tsx
@@ -127,7 +127,7 @@ function DeleteApiKeyButton(props: { projectId: string; apiKeyId: string }) {
   const capture = usePostHogClientCapture();
   const hasAccess = useHasProjectAccess({
     projectId: props.projectId,
-    scope: "apiKeys:delete",
+    scope: "apiKeys:CUD",
   });
 
   const utils = api.useUtils();
@@ -196,6 +196,10 @@ function ApiKeyNote({
       utils.apiKeys.invalidate();
     },
   });
+  const hasEditAccess = useHasProjectAccess({
+    projectId,
+    scope: "apiKeys:CUD",
+  });
 
   const [note, setNote] = useState(apiKey.note ?? "");
   const [isEditing, setIsEditing] = useState(false);
@@ -210,6 +214,8 @@ function ApiKeyNote({
       });
     }
   };
+
+  if (!hasEditAccess) return note ?? "";
 
   if (isEditing) {
     return (

--- a/web/src/features/public-api/components/ApiKeyList.tsx
+++ b/web/src/features/public-api/components/ApiKeyList.tsx
@@ -2,6 +2,7 @@ import Header from "@/src/components/layouts/header";
 import { Button } from "@/src/components/ui/button";
 import { Card } from "@/src/components/ui/card";
 import { CodeView } from "@/src/components/ui/CodeJsonViewer";
+import { Input } from "@/src/components/ui/input";
 import {
   Dialog,
   DialogContent,
@@ -66,7 +67,7 @@ export function ApiKeyList(props: { projectId: string }) {
               <TableHead className="hidden text-primary md:table-cell">
                 Created
               </TableHead>
-              {/* <TableHead className="text-primary">Note</TableHead> */}
+              <TableHead className="text-primary">Note</TableHead>
               <TableHead className="text-primary">Public Key</TableHead>
               <TableHead className="text-primary">Secret Key</TableHead>
               {/* <TableHead className="text-primary">Last used</TableHead> */}
@@ -89,7 +90,9 @@ export function ApiKeyList(props: { projectId: string }) {
                   <TableCell className="hidden md:table-cell">
                     {apiKey.createdAt.toLocaleDateString()}
                   </TableCell>
-                  {/* <TableCell>{apiKey.note ?? ""}</TableCell> */}
+                  <TableCell>
+                    <ApiKeyNote apiKey={apiKey} projectId={props.projectId} />
+                  </TableCell>
                   <TableCell className="font-mono">
                     <CodeView
                       className="inline-block text-xs"
@@ -177,5 +180,55 @@ function DeleteApiKeyButton(props: { projectId: string; apiKeyId: string }) {
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function ApiKeyNote({
+  apiKey,
+  projectId,
+}: {
+  apiKey: { id: string; note: string | null };
+  projectId: string;
+}) {
+  const utils = api.useUtils();
+  const updateNote = api.apiKeys.updateNote.useMutation({
+    onSuccess: () => {
+      utils.apiKeys.invalidate();
+    },
+  });
+
+  const [note, setNote] = useState(apiKey.note ?? "");
+  const [isEditing, setIsEditing] = useState(false);
+
+  const handleBlur = () => {
+    setIsEditing(false);
+    if (note !== apiKey.note) {
+      updateNote.mutate({
+        projectId,
+        keyId: apiKey.id,
+        note,
+      });
+    }
+  };
+
+  if (isEditing) {
+    return (
+      <Input
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+        onBlur={handleBlur}
+        autoFocus
+        className="h-8"
+      />
+    );
+  }
+
+  return (
+    <div
+      onClick={() => setIsEditing(true)}
+      className="-mx-2 cursor-pointer rounded px-2 py-1 hover:bg-secondary/50"
+    >
+      {note || "Click to add note"}
+    </div>
   );
 }

--- a/web/src/features/public-api/components/CreateApiKeyButton.tsx
+++ b/web/src/features/public-api/components/CreateApiKeyButton.tsx
@@ -20,7 +20,7 @@ export function CreateApiKeyButton(props: { projectId: string }) {
   const capture = usePostHogClientCapture();
   const hasAccess = useHasProjectAccess({
     projectId: props.projectId,
-    scope: "apiKeys:create",
+    scope: "apiKeys:CUD",
   });
 
   const mutCreateApiKey = api.apiKeys.create.useMutation({

--- a/web/src/features/public-api/server/apiKeyRouter.ts
+++ b/web/src/features/public-api/server/apiKeyRouter.ts
@@ -70,6 +70,41 @@ export const apiKeysRouter = createTRPCRouter({
 
       return apiKeyMeta;
     }),
+  updateNote: protectedProjectProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        keyId: z.string(),
+        note: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "apiKeys:create",
+      });
+
+      await auditLog({
+        session: ctx.session,
+        resourceType: "apiKey",
+        resourceId: input.keyId,
+        action: "update",
+      });
+
+      await ctx.prisma.apiKey.update({
+        where: {
+          id: input.keyId,
+          projectId: input.projectId,
+        },
+        data: {
+          note: input.note,
+        },
+      });
+
+      // do not return the api key
+      return;
+    }),
   delete: protectedProjectProcedure
     .input(
       z.object({

--- a/web/src/features/public-api/server/apiKeyRouter.ts
+++ b/web/src/features/public-api/server/apiKeyRouter.ts
@@ -52,7 +52,7 @@ export const apiKeysRouter = createTRPCRouter({
       throwIfNoProjectAccess({
         session: ctx.session,
         projectId: input.projectId,
-        scope: "apiKeys:create",
+        scope: "apiKeys:CUD",
       });
 
       const apiKeyMeta = await createAndAddApiKeysToDb({
@@ -82,7 +82,7 @@ export const apiKeysRouter = createTRPCRouter({
       throwIfNoProjectAccess({
         session: ctx.session,
         projectId: input.projectId,
-        scope: "apiKeys:create",
+        scope: "apiKeys:CUD",
       });
 
       await auditLog({
@@ -116,7 +116,7 @@ export const apiKeysRouter = createTRPCRouter({
       throwIfNoProjectAccess({
         session: ctx.session,
         projectId: input.projectId,
-        scope: "apiKeys:delete",
+        scope: "apiKeys:CUD",
       });
       await auditLog({
         session: ctx.session,

--- a/web/src/features/rbac/constants/projectAccessRights.ts
+++ b/web/src/features/rbac/constants/projectAccessRights.ts
@@ -3,9 +3,9 @@ import { type Role } from "@langfuse/shared/src/db";
 const projectScopes = [
   "projectMembers:read",
   "projectMembers:CUD",
+
   "apiKeys:read",
-  "apiKeys:create",
-  "apiKeys:delete",
+  "apiKeys:CUD",
 
   "objects:publish",
   "objects:bookmark",
@@ -64,8 +64,7 @@ export const projectRoleAccessRights: Record<Role, ProjectScope[]> = {
     "projectMembers:read",
     "projectMembers:CUD",
     "apiKeys:read",
-    "apiKeys:create",
-    "apiKeys:delete",
+    "apiKeys:CUD",
     "integrations:CRUD",
     "objects:publish",
     "objects:bookmark",
@@ -100,8 +99,7 @@ export const projectRoleAccessRights: Record<Role, ProjectScope[]> = {
     "projectMembers:read",
     "projectMembers:CUD",
     "apiKeys:read",
-    "apiKeys:create",
-    "apiKeys:delete",
+    "apiKeys:CUD",
     "integrations:CRUD",
     "objects:publish",
     "objects:bookmark",

--- a/web/src/features/setup/components/SetupTracingButton.tsx
+++ b/web/src/features/setup/components/SetupTracingButton.tsx
@@ -36,7 +36,7 @@ const SetupTracingButton = () => {
 
   const hasAccess = useHasProjectAccess({
     projectId: project?.id,
-    scope: "apiKeys:create",
+    scope: "apiKeys:CUD",
   });
 
   if (isLoading || hasAnyTrace || !project) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add editable notes for API keys with frontend and backend support, including access control updates.
> 
>   - **Frontend**:
>     - Add `ApiKeyNote` component in `ApiKeyList.tsx` for editing API key notes.
>     - Display "Click to add note" when no note is present.
>     - Use `Input` component for editing notes, with `onBlur` to save changes.
>     - Unhide "Note" column in API key table in `ApiKeyList.tsx`.
>   - **Backend**:
>     - Add `updateNote` mutation in `apiKeyRouter.ts` to update API key notes in the database.
>     - Ensure project access and log updates with `auditLog`.
>   - **Access Control**:
>     - Consolidate `apiKeys:create` and `apiKeys:delete` into `apiKeys:CUD` in `projectAccessRights.ts` and other affected files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cad80646b12568ed6847e1bdbba25f53ce390bf0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->