### PR TITLE
fix(playground): Model side menu in playground not scrollable

### DIFF
--- a/web/src/ee/features/playground/page/playground.tsx
+++ b/web/src/ee/features/playground/page/playground.tsx
@@ -11,12 +11,12 @@ export default function Playground() {
       <div className="h-full basis-3/4 overflow-auto">
         <Messages {...playgroundContext} />
       </div>
-      <div className="h-full basis-1/4 pr-2">
-        <div className="flex h-full flex-col">
-          <div className="basis-[55%]">
+      <div className="max-h-full min-h-0 basis-1/4 pr-2">
+        <div className="grid h-full grid-rows-[minmax(20dvh,max-content),minmax(20dvh,auto)] overflow-auto">
+          <div className="mb-4 max-h-[80dvh] min-h-[20dvh] overflow-y-auto">
             <ModelParameters {...playgroundContext} evalModelsOnly={false} />
           </div>
-          <div className="mt-4 basis-[45%] overflow-auto">
+          <div className="min-h-[20dvh]">
             <Variables />
           </div>
         </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes side menu scrollability in `playground.tsx` by adjusting CSS layout and overflow properties.
> 
>   - **Behavior**:
>     - Fixes side menu scrollability in `playground.tsx` by adjusting CSS classes.
>     - Changes `div` layout to `grid` with `minmax` for rows to ensure scrollable content.
>     - Adds `overflow-y-auto` to `ModelParameters` container for vertical scrolling.
>   - **Layout**:
>     - Replaces `flex` with `grid` for side menu layout.
>     - Sets `max-h-full` and `min-h-0` for side menu container to handle overflow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7f6d97c5d022ac5e8b8a0d5cd9d5f34341c9194a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->