### PR TITLE
feat: add observations status chart

### DIFF
--- a/packages/shared/src/server/repositories/dashboards.ts
+++ b/packages/shared/src/server/repositories/dashboards.ts
@@ -1,4 +1,7 @@
-import { queryClickhouse } from "./clickhouse";
+import {
+  parseClickhouseUTCDateTimeFormat,
+  queryClickhouse,
+} from "./clickhouse";
 import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
 import { FilterState } from "../../types";
 import {
@@ -614,6 +617,50 @@ export const getCategoricalScoreTimeSeries = async (
       ...(chFilterRes ? chFilterRes.params : {}),
     },
   });
+};
+
+export const getObservationsStatusTimeSeries = async (
+  projectId: string,
+  filter: FilterState,
+  groupBy: DateTrunc | undefined,
+) => {
+  const chFilter = new FilterList(
+    createFilterFromFilterState(filter, dashboardColumnDefinitions),
+  );
+  const chFilterRes = chFilter.apply();
+
+  const traceFilter = chFilter.find((f) => f.clickhouseTable === "traces");
+
+  const query = `
+    SELECT 
+      ${groupBy ? selectTimeseriesColumn(groupBy, "o.start_time", "start_time_bucket") + ", " : ""}
+      count(*) as observation_count,
+      level as level
+    FROM observations o
+    ${traceFilter ? "JOIN traces t ON o.trace_id = t.id AND o.project_id = t.project_id" : ""}
+    WHERE project_id = {projectId: String}
+    AND o.level IS NOT NULL
+    AND ${chFilterRes?.query}
+    GROUP BY level ${groupBy ? ", start_time_bucket" : ""}
+    ${groupBy ? orderByTimeSeries(groupBy, "start_time_bucket") : ""}
+  `;
+
+  const result = await queryClickhouse<{
+    start_time_bucket?: string;
+    observation_count: string;
+    level: string;
+  }>({
+    query,
+    params: { projectId, ...(chFilterRes ? chFilterRes.params : {}) },
+  });
+
+  return result.map((row) => ({
+    start_time_bucket: row.start_time_bucket
+      ? parseClickhouseUTCDateTimeFormat(row.start_time_bucket)
+      : undefined,
+    count: Number(row.observation_count),
+    level: row.level,
+  }));
 };
 
 const orderByTimeSeries = (dateTrunc: DateTrunc, col: string) => {

--- a/web/src/features/dashboard/components/TracesTimeSeriesChart.tsx
+++ b/web/src/features/dashboard/components/TracesTimeSeriesChart.tsx
@@ -11,8 +11,9 @@ import {
 } from "@/src/utils/date-range-utils";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 import { useClickhouse } from "@/src/components/layouts/ClickhouseAdminToggle";
+import { TabComponent } from "@/src/features/dashboard/components/TabsComponent";
 
-export const TracesTimeSeriesChart = ({
+export const TracesAndObservationsTimeSeriesChart = ({
   className,
   projectId,
   globalFilterState,
@@ -71,34 +72,123 @@ export const TracesTimeSeriesChart = ({
     return acc + (item.countTraceId as number);
   }, 0);
 
+  const observations = api.dashboard.chart.useQuery(
+    {
+      projectId,
+      from: "traces",
+      select: [{ column: "traceId", agg: "COUNT" }],
+      filter: globalFilterState.map((f) =>
+        f.type === "datetime" ? { ...f, column: "timestamp" } : f,
+      ),
+      groupBy: [
+        {
+          type: "datetime",
+          column: "timestamp",
+          temporalUnit: dashboardDateRangeAggregationSettings[agg].date_trunc,
+        },
+      ],
+      queryClickhouse: useClickhouse(),
+      queryName: "observations-status-timeseries",
+    },
+    {
+      trpc: {
+        context: {
+          skipBatch: true,
+        },
+      },
+    },
+  );
+
+  const transformedObservations = observations.data
+    ? Object.values(
+        observations.data.reduce(
+          (acc, item) => {
+            const ts = (item.start_time_bucket as Date).getTime();
+            if (!acc[ts]) {
+              acc[ts] = {
+                ts,
+                values: [],
+              };
+            }
+            acc[ts].values.push({
+              label: item.level as string,
+              value: typeof item.count === "number" ? item.count : undefined,
+            });
+            return acc;
+          },
+          {} as Record<
+            number,
+            {
+              ts: number;
+              values: { label: string; value: number | undefined }[];
+            }
+          >,
+        ),
+      )
+    : [];
+
+  const totalObservations = observations.data?.reduce((acc, item) => {
+    return acc + (item.count as number);
+  }, 0);
+
+  const data = [
+    {
+      tabTitle: "Traces",
+      data: transformedTraces,
+      totalMetric: total,
+      metricDescription: `Traces tracked`,
+      // formatter: oneValueUsdFormatter,
+    },
+    {
+      tabTitle: "Observations",
+      data: transformedObservations,
+      totalMetric: totalObservations,
+      metricDescription: `Observations tracked`,
+      // formatter: oneValueUsdFormatter,
+    },
+  ];
+
   return (
     <DashboardCard
       className={className}
-      title="Traces"
+      title="Traces by time"
       isLoading={traces.isLoading}
       cardContentClassName="flex flex-col content-end "
     >
-      <TotalMetric
-        description={`Traces tracked`}
-        metric={
-          total ? compactNumberFormatter(total) : compactNumberFormatter(0)
-        }
+      <TabComponent
+        tabs={data.map((item) => {
+          return {
+            tabTitle: item.tabTitle,
+            content: (
+              <>
+                <TotalMetric
+                  description={item.metricDescription}
+                  metric={
+                    item.totalMetric
+                      ? compactNumberFormatter(item.totalMetric)
+                      : compactNumberFormatter(0)
+                  }
+                />
+                {!isEmptyTimeSeries({ data: item.data }) ? (
+                  <BaseTimeSeriesChart
+                    className="h-full min-h-80 self-stretch"
+                    agg={agg}
+                    data={item.data}
+                    connectNulls={true}
+                    chartType="area"
+                  />
+                ) : (
+                  <NoDataOrLoading
+                    isLoading={traces.isLoading}
+                    description="Traces contain details about LLM applications and can be created using the SDK."
+                    href="https://langfuse.com/docs/tracing"
+                  />
+                )}
+              </>
+            ),
+          };
+        })}
       />
-      {!isEmptyTimeSeries({ data: transformedTraces }) ? (
-        <BaseTimeSeriesChart
-          className="h-full min-h-80 self-stretch"
-          agg={agg}
-          data={transformedTraces}
-          connectNulls={true}
-          chartType="area"
-        />
-      ) : (
-        <NoDataOrLoading
-          isLoading={traces.isLoading}
-          description="Traces contain details about LLM applications and can be created using the SDK."
-          href="https://langfuse.com/docs/tracing"
-        />
-      )}
     </DashboardCard>
   );
 };

--- a/web/src/features/dashboard/server/dashboard-router.ts
+++ b/web/src/features/dashboard/server/dashboard-router.ts
@@ -29,6 +29,7 @@ import {
   getNumericScoreHistogram,
   getNumericScoreTimeSeries,
   getCategoricalScoreTimeSeries,
+  getObservationsStatusTimeSeries,
 } from "@langfuse/shared/src/server";
 import { type DatabaseRow } from "@/src/server/api/services/queryBuilder";
 import { dashboardColumnDefinitions } from "@langfuse/shared";
@@ -58,6 +59,7 @@ export const dashboardRouter = createTRPCRouter({
             "model-latencies-over-time",
             "numeric-score-time-series",
             "categorical-score-chart",
+            "observations-status-timeseries",
           ])
           .nullish(),
       }),
@@ -282,6 +284,14 @@ export const dashboardRouter = createTRPCRouter({
               stringValue: row.score_value || null,
               countStringValue: Number(row.count) || 0,
             })) as DatabaseRow[];
+          case "observations-status-timeseries":
+            const timeSeriesGroupBy = extractTimeSeries(input.groupBy);
+
+            return (await getObservationsStatusTimeSeries(
+              input.projectId,
+              input.filter ?? [],
+              timeSeriesGroupBy,
+            )) as DatabaseRow[];
 
           default:
             throw new TRPCError({

--- a/web/src/pages/project/[projectId]/index.tsx
+++ b/web/src/pages/project/[projectId]/index.tsx
@@ -6,7 +6,7 @@ import { TracesBarListChart } from "@/src/features/dashboard/components/TracesBa
 import { ModelCostTable } from "@/src/features/dashboard/components/ModelCostTable";
 import { ScoresTable } from "@/src/features/dashboard/components/ScoresTable";
 import { ModelUsageChart } from "@/src/features/dashboard/components/ModelUsageChart";
-import { TracesTimeSeriesChart } from "@/src/features/dashboard/components/TracesTimeSeriesChart";
+import { TracesAndObservationsTimeSeriesChart } from "@/src/features/dashboard/components/TracesTimeSeriesChart";
 import { UserChart } from "@/src/features/dashboard/components/UserChart";
 import { DatePickerWithRange } from "@/src/components/date-picker";
 import { api } from "@/src/utils/api";
@@ -213,7 +213,7 @@ export default function Dashboard() {
           projectId={projectId}
           globalFilterState={mergedFilterState}
         />
-        <TracesTimeSeriesChart
+        <TracesAndObservationsTimeSeriesChart
           className="col-span-1 xl:col-span-3"
           projectId={projectId}
           globalFilterState={mergedFilterState}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add observation status time series chart to the dashboard, including backend data fetching and frontend display updates.
> 
>   - **Backend**:
>     - Add `getObservationsStatusTimeSeries` function in `dashboards.ts` to fetch observation status data.
>     - Update `dashboard-router.ts` to handle `observations-status-timeseries` query.
>   - **Frontend**:
>     - Rename `TracesTimeSeriesChart` to `TracesAndObservationsTimeSeriesChart` in `TracesTimeSeriesChart.tsx`.
>     - Add logic to fetch and transform observation data in `TracesAndObservationsTimeSeriesChart`.
>     - Update `index.tsx` to use `TracesAndObservationsTimeSeriesChart`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bff1b55cf6f90fcf32faed5bee1987840af9d6e3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->