### PR TITLE
fix: fix level filter on trace upsert queue

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -59,8 +59,6 @@ export const checkTraceExists = async (
   const tracesFilterRes = tracesFilter.apply();
   const observationFilterRes = observationFilter?.apply();
 
-  console.log(JSON.stringify(observationFilter, null, 2));
-
   const query = `
     WITH observations_agg AS (
         SELECT
@@ -88,9 +86,6 @@ export const checkTraceExists = async (
     ${timestamp ? `AND timestamp >= {timestamp: DateTime64(3)} - ${TRACE_TO_OBSERVATIONS_INTERVAL}` : ""}
     GROUP BY t.id, t.project_id
   `;
-
-  console.log(JSON.stringify(tracesFilter, null, 2));
-  console.log(query);
 
   const rows = await queryClickhouse<{ id: string; project_id: string }>({
     query,

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -23,7 +23,10 @@ import { sessionCols } from "../../tableDefinitions/mapSessionTable";
 import { convertDateToClickhouseDateTime } from "../clickhouse/client";
 import { convertClickhouseToDomain } from "./traces_converters";
 import { clickhouseSearchCondition } from "../queries/clickhouse-sql/search";
-import { TRACE_TO_OBSERVATIONS_INTERVAL } from "./constants";
+import {
+  OBSERVATIONS_TO_TRACE_INTERVAL,
+  TRACE_TO_OBSERVATIONS_INTERVAL,
+} from "./constants";
 
 export const checkTraceExists = async (
   projectId: string,
@@ -35,6 +38,11 @@ export const checkTraceExists = async (
     tracesPrefix: "t",
   });
 
+  const timeStampFilter = tracesFilter.find(
+    (f) =>
+      f.field === "timestamp" && (f.operator === ">=" || f.operator === ">"),
+  ) as DateTimeFilter | undefined;
+
   tracesFilter.push(
     ...createFilterFromFilterState(filter, tracesTableUiColumnDefinitions),
     new StringFilter({
@@ -45,19 +53,51 @@ export const checkTraceExists = async (
     }),
   );
 
+  const observationFilter = tracesFilter.find(
+    (f) => f.clickhouseTable === "observations",
+  );
   const tracesFilterRes = tracesFilter.apply();
+  const observationFilterRes = observationFilter?.apply();
+
+  console.log(JSON.stringify(observationFilter, null, 2));
 
   const query = `
-    SELECT id, project_id
-    FROM traces t FINAL
+    WITH observations_agg AS (
+        SELECT
+          
+            multiIf(
+              arrayExists(x -> x = 'ERROR', groupArray(level)), 'ERROR',
+              arrayExists(x -> x = 'WARNING', groupArray(level)), 'WARNING',
+              arrayExists(x -> x = 'DEFAULT', groupArray(level)), 'DEFAULT',
+              'DEBUG'
+            ) AS level,
+            trace_id,
+            project_id
+        FROM observations o FINAL 
+        WHERE o.project_id = {projectId: String}
+        ${timeStampFilter ? `AND o.start_time >= {traceTimestamp: DateTime64(3)} - ${OBSERVATIONS_TO_TRACE_INTERVAL}` : ""}
+        GROUP BY trace_id, project_id
+      )
+    SELECT 
+      t.id as id, 
+      t.project_id as project_id
+    FROM traces t FINAL 
+    ${observationFilterRes ? `INNER JOIN observations_agg o ON t.id = o.trace_id AND t.project_id = o.project_id` : ""}
     WHERE ${tracesFilterRes.query}
+    AND t.project_id = {projectId: String}
     ${timestamp ? `AND timestamp >= {timestamp: DateTime64(3)} - ${TRACE_TO_OBSERVATIONS_INTERVAL}` : ""}
+    GROUP BY t.id, t.project_id
   `;
+
+  console.log(JSON.stringify(tracesFilter, null, 2));
+  console.log(query);
 
   const rows = await queryClickhouse<{ id: string; project_id: string }>({
     query,
     params: {
+      projectId,
       ...tracesFilterRes.params,
+      ...(observationFilterRes ? observationFilterRes.params : {}),
       ...(timestamp
         ? { timestamp: convertDateToClickhouseDateTime(timestamp) }
         : {}),

--- a/web/src/__tests__/async/repositories/trace-repository.servertest.ts
+++ b/web/src/__tests__/async/repositories/trace-repository.servertest.ts
@@ -1,10 +1,12 @@
-import { createTracesCh } from "@langfuse/shared/src/server";
+import { checkTraceExists, createTracesCh } from "@langfuse/shared/src/server";
 import { pruneDatabase } from "@/src/__tests__/test-utils";
 import {
   getTraceById,
   getTracesBySessionId,
 } from "@langfuse/shared/src/server";
 import { v4 } from "uuid";
+import { createObservation, createTrace } from "@langfuse/shared/src/server";
+import { createObservationsCh } from "@langfuse/shared/src/server";
 
 const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
 
@@ -162,5 +164,144 @@ describe("Clickhouse Traces Repository Test", () => {
     const resultIds = results.map((result) => result.id);
     expect(resultIds).toContain(trace1.id);
     expect(resultIds).toContain(trace2.id);
+  });
+
+  it("should check if trace exists with level filter", async () => {
+    const traceId = v4();
+    const trace = createTrace({
+      id: traceId,
+      user_id: "user-1",
+      project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      metadata: { key: "value" },
+      release: "1.0.0",
+      version: "2.0.0",
+    });
+
+    const observations = [
+      createObservation({
+        trace_id: trace.id,
+        project_id: trace.project_id,
+        name: "observation-name",
+        end_time: new Date().getTime(),
+        start_time: new Date().getTime() - 1000,
+        input: "input",
+        output: "output",
+        provided_model_name: "model-1",
+        level: "ERROR",
+      }),
+      createObservation({
+        trace_id: trace.id,
+        project_id: trace.project_id,
+        name: "observation-name-2",
+        end_time: new Date().getTime(),
+        start_time: new Date().getTime() - 100000,
+        input: "input-2",
+        output: "output-2",
+        provided_model_name: "model-2",
+      }),
+    ];
+
+    await createTracesCh([trace]);
+    await createObservationsCh(observations);
+
+    const exists = await checkTraceExists(projectId, traceId, new Date(), [
+      {
+        type: "stringOptions",
+        column: "level",
+        operator: "any of",
+        value: ["ERROR"],
+      },
+    ]);
+    expect(exists).toBe(true);
+  });
+
+  it("should check if trace exists with level filter none of", async () => {
+    const traceId = v4();
+    const trace = createTrace({
+      id: traceId,
+      user_id: "user-1",
+      project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      metadata: { key: "value" },
+      release: "1.0.0",
+      version: "2.0.0",
+    });
+
+    const observations = [
+      createObservation({
+        trace_id: trace.id,
+        project_id: trace.project_id,
+        name: "observation-name",
+        end_time: new Date().getTime(),
+        start_time: new Date().getTime() - 1000,
+        input: "input",
+        output: "output",
+        provided_model_name: "model-1",
+        level: "ERROR",
+      }),
+      createObservation({
+        trace_id: trace.id,
+        project_id: trace.project_id,
+        name: "observation-name-2",
+        end_time: new Date().getTime(),
+        start_time: new Date().getTime() - 100000,
+        input: "input-2",
+        output: "output-2",
+        provided_model_name: "model-2",
+      }),
+    ];
+
+    await createTracesCh([trace]);
+    await createObservationsCh(observations);
+
+    const exists = await checkTraceExists(projectId, traceId, new Date(), [
+      {
+        type: "stringOptions",
+        column: "level",
+        operator: "none of",
+        value: ["ERROR"],
+      },
+    ]);
+    expect(exists).toBe(false);
+  });
+  it("should check if trace exists without level filter", async () => {
+    const traceId = v4();
+    const trace = createTrace({
+      id: traceId,
+      user_id: "user-1",
+      project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      metadata: { key: "value" },
+      release: "1.0.0",
+      version: "2.0.0",
+    });
+
+    const observations = [
+      createObservation({
+        trace_id: trace.id,
+        project_id: trace.project_id,
+        name: "observation-name",
+        end_time: new Date().getTime(),
+        start_time: new Date().getTime() - 1000,
+        input: "input",
+        output: "output",
+        provided_model_name: "model-1",
+        level: "ERROR",
+      }),
+      createObservation({
+        trace_id: trace.id,
+        project_id: trace.project_id,
+        name: "observation-name-2",
+        end_time: new Date().getTime(),
+        start_time: new Date().getTime() - 100000,
+        input: "input-2",
+        output: "output-2",
+        provided_model_name: "model-2",
+      }),
+    ];
+
+    await createTracesCh([trace]);
+    await createObservationsCh(observations);
+
+    const exists = await checkTraceExists(projectId, traceId, new Date(), []);
+    expect(exists).toBe(true);
   });
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes level filter logic in `checkTraceExists()` in `traces.ts` and adds tests to verify trace existence with various level filters.
> 
>   - **Behavior**:
>     - Fixes level filter logic in `checkTraceExists()` in `traces.ts` to correctly handle level conditions for traces.
>     - Adds handling for `timestamp` and `observation` filters in the query.
>   - **Tests**:
>     - Adds tests in `trace-repository.servertest.ts` to verify trace existence with different level filters (`any of`, `none of`, and without filter).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 561f4e71e5b5f42199663b82447320034de89c4f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->