### PR TITLE
fix(organizations): block org deletion in case of active projects

### DIFF
--- a/web/src/features/organizations/components/DeleteOrganizationButton.tsx
+++ b/web/src/features/organizations/components/DeleteOrganizationButton.tsx
@@ -43,6 +43,7 @@ export function DeleteOrganizationButton() {
   });
 
   const deleteOrganization = api.organizations.delete.useMutation();
+  const hasProjects = !!organization && organization.projects.length > 0;
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -52,7 +53,7 @@ export function DeleteOrganizationButton() {
   });
 
   const onSubmit = async () => {
-    if (!organization) return;
+    if (!organization || hasProjects) return;
     try {
       await deleteOrganization.mutateAsync({
         orgId: organization.id,
@@ -82,7 +83,9 @@ export function DeleteOrganizationButton() {
             Delete Organization
           </DialogTitle>
           <DialogDescription>
-            {`To confirm, type "${confirmMessage}" in the input box `}
+            {hasProjects
+              ? "You can only delete an organization if it has no projects associated with it. Please delete all projects first."
+              : `To confirm, type "${confirmMessage}" in the input box `}
           </DialogDescription>
         </DialogHeader>
         <Form {...form}>
@@ -91,22 +94,25 @@ export function DeleteOrganizationButton() {
             onSubmit={form.handleSubmit(onSubmit)}
             className="space-y-8"
           >
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItem>
-                  <FormControl>
-                    <Input placeholder={confirmMessage} {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            {!hasProjects && (
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <Input placeholder={confirmMessage} {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
             <Button
               type="submit"
               variant="destructive"
               loading={deleteOrganization.isLoading}
+              disabled={hasProjects}
               className="w-full"
             >
               Delete Organization

--- a/web/src/features/organizations/components/DeleteOrganizationButton.tsx
+++ b/web/src/features/organizations/components/DeleteOrganizationButton.tsx
@@ -84,7 +84,7 @@ export function DeleteOrganizationButton() {
           </DialogTitle>
           <DialogDescription>
             {hasProjects
-              ? "You can only delete an organization if it has no projects associated with it. Please delete all projects first."
+              ? "You can only delete an organization if it has no projects associated with it. Please delete or transfer all projects first. Deleting projects may take a few minutes."
               : `To confirm, type "${confirmMessage}" in the input box `}
           </DialogDescription>
         </DialogHeader>

--- a/web/src/features/organizations/server/organizationRouter.ts
+++ b/web/src/features/organizations/server/organizationRouter.ts
@@ -98,10 +98,10 @@ export const organizationsRouter = createTRPCRouter({
         scope: "organization:delete",
       });
 
+      // count soft and hard deleted projects
       const countProjects = await ctx.prisma.project.count({
         where: {
           orgId: input.orgId,
-          deletedAt: null,
         },
       });
       if (countProjects > 0) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Block organization deletion if active projects exist, with UI and server-side checks in `DeleteOrganizationButton.tsx` and `organizationRouter.ts`.
> 
>   - **Behavior**:
>     - Block organization deletion if it has active projects in `DeleteOrganizationButton.tsx` and `organizationRouter.ts`.
>     - Display message in `DeleteOrganizationButton.tsx` if projects exist, instructing to delete or transfer projects first.
>     - Disable delete button in `DeleteOrganizationButton.tsx` if projects exist.
>   - **Server Logic**:
>     - In `organizationRouter.ts`, count projects regardless of deletion status and throw `TRPCError` if any exist.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c5bed0be8f325ffd6c76ab7e11692be034a90a48. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->