### PR TITLE
chore(evals/experiments): support retries via bullmq; set 2 minute LLM call completion timeouts

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -163,7 +163,7 @@ export async function fetchLLMCompletion(
       maxTokens: modelParams.max_tokens,
       topP: modelParams.top_p,
       callbacks: finalCallbacks,
-      clientOptions: { maxRetries },
+      clientOptions: { maxRetries, timeout: 1000 * 60 * 2 }, // 2 minutes timeout
     });
   } else if (modelParams.adapter === LLMAdapter.OpenAI) {
     chatModel = new ChatOpenAI({
@@ -178,6 +178,7 @@ export async function fetchLLMCompletion(
       configuration: {
         baseURL,
       },
+      timeout: 1000 * 60 * 2, // 2 minutes timeout
     });
   } else if (modelParams.adapter === LLMAdapter.Azure) {
     chatModel = new ChatOpenAI({
@@ -190,6 +191,7 @@ export async function fetchLLMCompletion(
       topP: modelParams.top_p,
       callbacks: finalCallbacks,
       maxRetries,
+      timeout: 1000 * 60 * 2, // 2 minutes timeout
     });
   } else if (modelParams.adapter === LLMAdapter.Bedrock) {
     const { region } = BedrockConfigSchema.parse(config);
@@ -204,10 +206,13 @@ export async function fetchLLMCompletion(
       topP: modelParams.top_p,
       callbacks: finalCallbacks,
       maxRetries,
+      timeout: 1000 * 60 * 2, // 2 minutes timeout
     });
   } else if (modelParams.adapter === LLMAdapter.VertexAI) {
     const credentials = GCPServiceAccountKeySchema.parse(JSON.parse(apiKey));
 
+    // Requests time out after 60 seconds for both public and private endpoints by default
+    // Reference: https://cloud.google.com/vertex-ai/docs/predictions/get-online-predictions#send-request
     chatModel = new ChatVertexAI({
       modelName: modelParams.model,
       temperature: modelParams.temperature,
@@ -266,6 +271,7 @@ export async function fetchLLMCompletion(
         configuration: {
           baseURL,
         },
+        timeout: 1000 * 60 * 2, // 2 minutes timeout
       })
         .pipe(new StringOutputParser())
         .invoke(

--- a/packages/shared/src/server/redis/evalExecutionQueue.ts
+++ b/packages/shared/src/server/redis/evalExecutionQueue.ts
@@ -29,7 +29,7 @@ export class EvalExecutionQueue {
               attempts: 10,
               backoff: {
                 type: "exponential",
-                delay: 5000,
+                delay: 1000,
               },
             },
           },

--- a/packages/shared/src/server/redis/experimentCreateQueue.ts
+++ b/packages/shared/src/server/redis/experimentCreateQueue.ts
@@ -26,10 +26,10 @@ export class ExperimentCreateQueue {
             defaultJobOptions: {
               removeOnComplete: true,
               removeOnFail: 10_000,
-              attempts: 2,
+              attempts: 10,
               backoff: {
                 type: "exponential",
-                delay: 5000,
+                delay: 1000,
               },
             },
           },

--- a/worker/src/ee/evaluation/evalService.ts
+++ b/worker/src/ee/evaluation/evalService.ts
@@ -451,7 +451,7 @@ export const evaluate = async ({
         evalScoreSchema,
       ),
     {
-      numOfAttempts: 5, // turn off retries as Langchain is doing that for us already.
+      numOfAttempts: 1, // turn off retries as Langchain is doing that for us already.
     },
   );
 

--- a/worker/src/ee/experiments/experimentService.ts
+++ b/worker/src/ee/experiments/experimentService.ts
@@ -12,7 +12,6 @@ import { kyselyPrisma, prisma } from "@langfuse/shared/src/db";
 import { ExperimentCreateEventSchema } from "@langfuse/shared/src/server";
 import {
   ForbiddenError,
-  InternalServerError,
   InvalidRequestError,
   LangfuseNotFoundError,
   Prisma,
@@ -148,7 +147,7 @@ export const createExperimentJob = async ({
     logger.error(
       `Prompt content not in expected format ${prompt_id} not found for project ${projectId}`,
     );
-    throw new InternalServerError(
+    throw new InvalidRequestError(
       `Prompt ${prompt_id} not found in expected format for project ${projectId}`,
     );
   }

--- a/worker/src/ee/experiments/experimentService.ts
+++ b/worker/src/ee/experiments/experimentService.ts
@@ -263,7 +263,7 @@ export const createExperimentJob = async ({
           traceParams,
         ),
       {
-        numOfAttempts: 5, // turn off retries as Langchain is doing that for us already.
+        numOfAttempts: 1, // turn off retries as Langchain is doing that for us already.
       },
     );
 

--- a/worker/src/features/utilities.ts
+++ b/worker/src/features/utilities.ts
@@ -37,6 +37,7 @@ export async function callStructuredLLM<T extends ZodSchema>(
       traceParams: traceParams
         ? { ...traceParams, tokenCountDelegate: tokenCount }
         : undefined,
+      maxRetries: 1,
     });
 
     if (traceParams) {
@@ -75,6 +76,7 @@ export async function callLLM(
       traceParams: traceParams
         ? { ...traceParams, tokenCountDelegate: tokenCount }
         : undefined,
+      maxRetries: 1,
     });
 
     if (traceParams) {

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -1,5 +1,5 @@
 import { Job } from "bullmq";
-import { ApiError, BaseError } from "@langfuse/shared";
+import { BaseError } from "@langfuse/shared";
 import { kyselyPrisma } from "@langfuse/shared/src/db";
 import { sql } from "kysely";
 import {

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -70,8 +70,7 @@ export const evalJobExecutorQueueProcessor = async (
         e.message.includes(
           "Please ensure the mapped data exists and consider extending the job delay.",
         )
-      ) &&
-      !(e instanceof ApiError) // API errors are expected (e.g. wrong API key or rate limit or invalid return data)
+      )
     ) {
       traceException(e);
       logger.error(

--- a/worker/src/queues/experimentQueue.ts
+++ b/worker/src/queues/experimentQueue.ts
@@ -6,7 +6,11 @@ import {
   traceException,
 } from "@langfuse/shared/src/server";
 import { createExperimentJob } from "../ee/experiments/experimentService";
-import { ForbiddenError, InvalidRequestError } from "@langfuse/shared";
+import {
+  ForbiddenError,
+  InvalidRequestError,
+  LangfuseNotFoundError,
+} from "@langfuse/shared";
 
 export const experimentCreateQueueProcessor = async (
   job: Job<TQueueJobTypes[QueueName.ExperimentCreate]>,
@@ -22,8 +26,13 @@ export const experimentCreateQueueProcessor = async (
     });
     return true;
   } catch (e) {
-    if (e instanceof ForbiddenError || e instanceof InvalidRequestError) {
+    if (
+      e instanceof ForbiddenError ||
+      e instanceof InvalidRequestError ||
+      e instanceof LangfuseNotFoundError
+    ) {
       logger.info("Failed to process experiment create job", e);
+      // LFE-3174: improve error reporting to the user for experiment create job
       return;
     }
 

--- a/worker/src/queues/experimentQueue.ts
+++ b/worker/src/queues/experimentQueue.ts
@@ -6,6 +6,7 @@ import {
   traceException,
 } from "@langfuse/shared/src/server";
 import { createExperimentJob } from "../ee/experiments/experimentService";
+import { ForbiddenError, InvalidRequestError } from "@langfuse/shared";
 
 export const experimentCreateQueueProcessor = async (
   job: Job<TQueueJobTypes[QueueName.ExperimentCreate]>,
@@ -21,6 +22,11 @@ export const experimentCreateQueueProcessor = async (
     });
     return true;
   } catch (e) {
+    if (e instanceof ForbiddenError || e instanceof InvalidRequestError) {
+      logger.info("Failed to process experiment create job", e);
+      return;
+    }
+
     logger.error("Failed to process experiment create job", e);
     traceException(e);
     throw e;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Support retries via BullMQ and set 2-minute LLM call timeouts across various services.
> 
>   - **LLM Completion**:
>     - Set 2-minute timeout for LLM calls in `fetchLLMCompletion()` in `fetchLLMCompletion.ts`.
>   - **Redis Queues**:
>     - Change retry attempts to 10 and delay to 1000ms in `evalExecutionQueue.ts` and `experimentCreateQueue.ts`.
>   - **Evaluation Services**:
>     - Set `numOfAttempts` to 1 in `evaluate()` in `evalService.ts` and `createExperimentJob()` in `experimentService.ts`.
>   - **Queue Processors**:
>     - Handle `ForbiddenError` and `InvalidRequestError` without throwing in `experimentQueue.ts` and `evalQueue.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0043bef424de33309fa95d64e4fc1880bb592f69. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->