### PR TITLE
fix: fix pagination on public api

### DIFF
--- a/packages/shared/src/features/scores/scoreConfigTypes.ts
+++ b/packages/shared/src/features/scores/scoreConfigTypes.ts
@@ -6,7 +6,7 @@ import { isPresent } from "../../utils/typeChecks";
 import {
   jsonSchema,
   paginationMetaResponseZod,
-  paginationZod,
+  publicApiPaginationZod,
 } from "../../utils/zod";
 
 /**
@@ -17,7 +17,7 @@ export type ValidatedScoreConfig = z.infer<typeof ValidatedScoreConfigSchema>;
 
 const validateCategories = (
   categories: ConfigCategory[],
-  ctx: z.RefinementCtx
+  ctx: z.RefinementCtx,
 ) => {
   const uniqueNames = new Set<string>();
   const uniqueValues = new Set<number>();
@@ -94,7 +94,7 @@ const BooleanScoreConfig = z.object({
       return categories.every(
         (category, index) =>
           category.label === expectedCategories[index].label &&
-          category.value === expectedCategories[index].value
+          category.value === expectedCategories[index].value,
       );
     }),
 });
@@ -123,7 +123,7 @@ const ValidatedScoreConfigSchema = z
         minValue: z.undefined().nullish(),
         dataType: z.literal("CATEGORICAL"),
         categories: Categories.superRefine(validateCategories),
-      })
+      }),
     ),
     ScoreConfigBase.merge(BooleanScoreConfig),
   ])
@@ -150,7 +150,7 @@ const ValidatedScoreConfigSchema = z
  */
 export const filterAndValidateDbScoreConfigList = (
   scoreConfigs: ScoreConfigDbType[],
-  onParseError?: (error: z.ZodError) => void
+  onParseError?: (error: z.ZodError) => void,
 ): ValidatedScoreConfig[] =>
   scoreConfigs.reduce((acc, ts) => {
     const result = ValidatedScoreConfigSchema.safeParse(ts);
@@ -170,7 +170,7 @@ export const filterAndValidateDbScoreConfigList = (
  * @throws error if score fails validation
  */
 export const validateDbScoreConfig = (
-  scoreConfig: ScoreConfigDbType
+  scoreConfig: ScoreConfigDbType,
 ): ValidatedScoreConfig => ValidatedScoreConfigSchema.parse(scoreConfig);
 
 /**
@@ -205,7 +205,7 @@ export const PostScoreConfigBody = z
       z.object({
         dataType: z.literal("BOOLEAN"),
         categories: z.undefined().nullish(),
-      })
+      }),
     ),
   ])
   .superRefine((data, ctx) => {
@@ -227,7 +227,7 @@ export const PostScoreConfigResponse = ValidatedScoreConfigSchema;
 
 // GET /score-configs
 export const GetScoreConfigsQuery = z.object({
-  ...paginationZod,
+  ...publicApiPaginationZod,
 });
 
 export const GetScoreConfigsResponse = z.object({

--- a/packages/shared/src/features/scores/scoreTypes.ts
+++ b/packages/shared/src/features/scores/scoreTypes.ts
@@ -84,13 +84,13 @@ export const ScoreBodyWithoutConfig = z.discriminatedUnion("dataType", [
     z.object({
       value: z.number(),
       dataType: z.literal("NUMERIC"),
-    })
+    }),
   ),
   BaseScoreBody.merge(
     z.object({
       value: z.string(),
       dataType: z.literal("CATEGORICAL"),
-    })
+    }),
   ),
   BaseScoreBody.merge(
     z.object({
@@ -98,7 +98,7 @@ export const ScoreBodyWithoutConfig = z.discriminatedUnion("dataType", [
         message: "Value must be either 0 or 1",
       }),
       dataType: z.literal("BOOLEAN"),
-    })
+    }),
   ),
 ]);
 
@@ -162,7 +162,7 @@ export const ScorePropsAgainstConfig = z.union([
  */
 export const filterAndValidateDbScoreList = (
   scores: Score[],
-  onParseError?: (error: z.ZodError) => void
+  onParseError?: (error: z.ZodError) => void,
 ): APIScore[] =>
   scores.reduce((acc, ts) => {
     const result = APIScoreSchema.safeParse(ts);
@@ -199,14 +199,14 @@ export const PostScoresBody = z.discriminatedUnion("dataType", [
       value: z.number(),
       dataType: z.literal("NUMERIC"),
       configId: z.string().nullish(),
-    })
+    }),
   ),
   BaseScoreBody.merge(
     z.object({
       value: z.string(),
       dataType: z.literal("CATEGORICAL"),
       configId: z.string().nullish(),
-    })
+    }),
   ),
   BaseScoreBody.merge(
     z.object({
@@ -216,14 +216,14 @@ export const PostScoresBody = z.discriminatedUnion("dataType", [
       }),
       dataType: z.literal("BOOLEAN"),
       configId: z.string().nullish(),
-    })
+    }),
   ),
   BaseScoreBody.merge(
     z.object({
       value: z.union([z.string(), z.number()]),
       dataType: z.undefined(),
       configId: z.string().nullish(),
-    })
+    }),
   ),
 ]);
 
@@ -260,7 +260,7 @@ const LegacyGetScoreResponseDataV1 = z.intersection(
       userId: z.string().nullish(),
       tags: z.array(z.string()).nullish(),
     }),
-  })
+  }),
 );
 export const GetScoresResponse = z.object({
   data: z.array(LegacyGetScoreResponseDataV1),
@@ -269,7 +269,7 @@ export const GetScoresResponse = z.object({
 
 export const legacyFilterAndValidateV1GetScoreList = (
   scores: unknown[],
-  onParseError?: (error: z.ZodError) => void
+  onParseError?: (error: z.ZodError) => void,
 ): z.infer<typeof LegacyGetScoreResponseDataV1>[] =>
   scores.reduce(
     (acc: z.infer<typeof LegacyGetScoreResponseDataV1>[], ts) => {
@@ -282,7 +282,7 @@ export const legacyFilterAndValidateV1GetScoreList = (
       }
       return acc;
     },
-    [] as z.infer<typeof LegacyGetScoreResponseDataV1>[]
+    [] as z.infer<typeof LegacyGetScoreResponseDataV1>[],
   );
 
 // GET /scores/{scoreId}

--- a/packages/shared/src/features/scores/scoreTypes.ts
+++ b/packages/shared/src/features/scores/scoreTypes.ts
@@ -6,7 +6,7 @@ import { isPresent, stringDateTime } from "../../utils/typeChecks";
 import {
   NonEmptyString,
   paginationMetaResponseZod,
-  paginationZod,
+  publicApiPaginationZod,
 } from "../../utils/zod";
 import { Category as ConfigCategory } from "./scoreConfigTypes";
 
@@ -231,7 +231,7 @@ export const PostScoresResponse = z.object({ id: z.string() });
 
 // GET /scores
 export const GetScoresQuery = z.object({
-  ...paginationZod,
+  ...publicApiPaginationZod,
   userId: z.string().nullish(),
   dataType: z.enum(ScoreDataType).nullish(),
   configId: z.string().nullish(),

--- a/packages/shared/src/utils/zod.ts
+++ b/packages/shared/src/utils/zod.ts
@@ -41,7 +41,7 @@ export const jsonSchema: z.ZodType<Json> = z.lazy(() =>
 export const paginationZod = {
   page: z.preprocess(
     (x) => (x === "" ? undefined : x),
-    z.coerce.number().default(1),
+    z.coerce.number().gt(0).default(1),
   ),
   limit: z.preprocess(
     (x) => (x === "" ? undefined : x),

--- a/packages/shared/src/utils/zod.ts
+++ b/packages/shared/src/utils/zod.ts
@@ -41,7 +41,7 @@ export const jsonSchema: z.ZodType<Json> = z.lazy(() =>
 export const paginationZod = {
   page: z.preprocess(
     (x) => (x === "" ? undefined : x),
-    z.coerce.number().gt(0).default(1),
+    z.coerce.number().default(1),
   ),
   limit: z.preprocess(
     (x) => (x === "" ? undefined : x),

--- a/packages/shared/src/utils/zod.ts
+++ b/packages/shared/src/utils/zod.ts
@@ -49,6 +49,17 @@ export const paginationZod = {
   ),
 };
 
+export const publicApiPaginationZod = {
+  page: z.preprocess(
+    (x) => (x === "" ? undefined : x),
+    z.coerce.number().gt(0).default(1),
+  ),
+  limit: z.preprocess(
+    (x) => (x === "" ? undefined : x),
+    z.coerce.number().lte(100).default(50),
+  ),
+};
+
 export const optionalPaginationZod = {
   page: z
     .preprocess((x) => (x === "" ? undefined : x), z.coerce.number())

--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -3,7 +3,10 @@ import {
   createObservationsCh,
   createTracesCh,
 } from "@langfuse/shared/src/server";
-import { makeZodVerifiedAPICall } from "@/src/__tests__/test-utils";
+import {
+  makeZodVerifiedAPICall,
+  makeZodVerifiedAPICallSilent,
+} from "@/src/__tests__/test-utils";
 import {
   GetTracesV1Response,
   GetTraceV1Response,
@@ -257,5 +260,14 @@ describe("/api/public/traces API Endpoint", () => {
     expect(trace1.name).toBe("trace-name2");
     const trace2 = traces.body.data[1];
     expect(trace2.name).toBe("trace-name1");
+  });
+  it("should return 400 error when page=0", async () => {
+    const response = await makeZodVerifiedAPICallSilent(
+      GetTracesV1Response,
+      "GET",
+      "/api/public/traces?page=0&limit=10",
+    );
+
+    expect(response.status).toBe(400);
   });
 });

--- a/web/src/features/public-api/types/comments.ts
+++ b/web/src/features/public-api/types/comments.ts
@@ -1,7 +1,7 @@
 import {
   CommentObjectType,
   CreateCommentData,
-  paginationZod,
+  publicApiPaginationZod,
 } from "@langfuse/shared";
 import { z } from "zod";
 
@@ -38,7 +38,7 @@ export const GetCommentsV1Query = z
     objectType: z.nativeEnum(CommentObjectType).nullish(),
     objectId: z.string().nullish(),
     authorUserId: z.string().nullish(),
-    ...paginationZod,
+    ...publicApiPaginationZod,
   })
   .strict()
   .refine(

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -1,5 +1,6 @@
 import {
   jsonSchema,
+  publicApiPaginationZod,
   paginationZod,
   paginationMetaResponseZod,
   queryStringZod,
@@ -101,7 +102,7 @@ export const PostDatasetsV2Response = APIDataset.strict();
 
 // GET /v2/datasets
 export const GetDatasetsV2Query = z.object({
-  ...paginationZod,
+  ...publicApiPaginationZod,
 });
 export const GetDatasetsV2Response = z
   .object({
@@ -119,7 +120,7 @@ export const GetDatasetV2Response = APIDataset.strict();
 // GET /datasets/{name}/runs
 export const GetDatasetRunsV1Query = z.object({
   name: queryStringZod, // dataset name from URL, name as it is v1
-  ...paginationZod,
+  ...publicApiPaginationZod,
 });
 export const GetDatasetRunsV1Response = z
   .object({
@@ -155,7 +156,7 @@ export const GetDatasetItemsV1Query = z.object({
   datasetName: z.string().nullish(),
   sourceTraceId: z.string().nullish(),
   sourceObservationId: z.string().nullish(),
-  ...paginationZod,
+  ...publicApiPaginationZod,
 });
 export const GetDatasetItemsV1Response = z
   .object({

--- a/web/src/features/public-api/types/metrics.ts
+++ b/web/src/features/public-api/types/metrics.ts
@@ -1,4 +1,7 @@
-import { paginationMetaResponseZod, paginationZod } from "@langfuse/shared";
+import {
+  paginationMetaResponseZod,
+  publicApiPaginationZod,
+} from "@langfuse/shared";
 import { stringDateTime } from "@langfuse/shared/src/server";
 import { z } from "zod";
 
@@ -8,7 +11,7 @@ import { z } from "zod";
 
 // Get /metrics/daily
 export const GetMetricsDailyV1Query = z.object({
-  ...paginationZod,
+  ...publicApiPaginationZod,
   traceName: z.string().nullish(),
   userId: z.string().nullish(),
   tags: z.union([z.array(z.string()), z.string()]).nullish(),

--- a/web/src/features/public-api/types/models.ts
+++ b/web/src/features/public-api/types/models.ts
@@ -1,9 +1,9 @@
 import {
   type ModelUsageUnit as PrismaModelUsageUnit,
   paginationMetaResponseZod,
-  paginationZod,
   type Model as PrismaModel,
   jsonSchema,
+  publicApiPaginationZod,
 } from "@langfuse/shared";
 import { z } from "zod";
 
@@ -67,7 +67,7 @@ export function prismaToApiModelDefinition({
 
 // GET /models
 export const GetModelsV1Query = z.object({
-  ...paginationZod,
+  ...publicApiPaginationZod,
 });
 export const GetModelsV1Response = z
   .object({

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -1,7 +1,7 @@
 import {
   type ObservationView,
   paginationMetaResponseZod,
-  paginationZod,
+  publicApiPaginationZod,
 } from "@langfuse/shared";
 
 import { stringDateTime } from "@langfuse/shared/src/server";
@@ -115,7 +115,7 @@ export const transformDbToApiObservation = (
 
 // GET /observations
 export const GetObservationsV1Query = z.object({
-  ...paginationZod,
+  ...publicApiPaginationZod,
   type: ObservationType.nullish(),
   name: z.string().nullish(),
   userId: z.string().nullish(),

--- a/web/src/features/public-api/types/sessions.ts
+++ b/web/src/features/public-api/types/sessions.ts
@@ -1,5 +1,8 @@
 import { APITrace } from "@/src/features/public-api/types/traces";
-import { paginationMetaResponseZod, paginationZod } from "@langfuse/shared";
+import {
+  paginationMetaResponseZod,
+  publicApiPaginationZod,
+} from "@langfuse/shared";
 import { stringDateTime } from "@langfuse/shared/src/server";
 
 import { z } from "zod";
@@ -22,7 +25,7 @@ const APISession = z
 
 // GET /sessions
 export const GetSessionsV1Query = z.object({
-  ...paginationZod,
+  ...publicApiPaginationZod,
   fromTimestamp: stringDateTime,
   toTimestamp: stringDateTime,
 });

--- a/web/src/features/public-api/types/traces.ts
+++ b/web/src/features/public-api/types/traces.ts
@@ -1,9 +1,9 @@
 import { APIObservation } from "@/src/features/public-api/types/observations";
 import {
   APIScoreSchema,
-  paginationZod,
   paginationMetaResponseZod,
   orderBy,
+  publicApiPaginationZod,
 } from "@langfuse/shared";
 import { stringDateTime, TraceBody } from "@langfuse/shared/src/server";
 import { z } from "zod";
@@ -48,7 +48,7 @@ const APIExtendedTrace = APITrace.extend({
 
 // GET /api/public/traces
 export const GetTracesV1Query = z.object({
-  ...paginationZod,
+  ...publicApiPaginationZod,
   userId: z.string().nullish(),
   name: z.string().nullish(),
   tags: z.union([z.array(z.string()), z.string()]).nullish(),

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -11,7 +11,7 @@ import { Prisma } from "@langfuse/shared/src/db";
 import { processEventBatch } from "@langfuse/shared/src/server";
 import { tokenCount } from "@/src/features/ingest/usage";
 
-import { InvalidRequestError, type Trace } from "@langfuse/shared";
+import { type Trace } from "@langfuse/shared";
 import {
   eventTypes,
   logger,
@@ -206,8 +206,7 @@ export default withMiddlewares({
             },
           };
         },
-        clickhouseExecution: async () => {    
-
+        clickhouseExecution: async () => {
           const filterProps = {
             projectId: auth.scope.projectId,
             page: query.page ?? undefined,

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -11,7 +11,7 @@ import { Prisma } from "@langfuse/shared/src/db";
 import { processEventBatch } from "@langfuse/shared/src/server";
 import { tokenCount } from "@/src/features/ingest/usage";
 
-import { type Trace } from "@langfuse/shared";
+import { InvalidRequestError, type Trace } from "@langfuse/shared";
 import {
   eventTypes,
   logger,
@@ -207,6 +207,10 @@ export default withMiddlewares({
           };
         },
         clickhouseExecution: async () => {
+          if (query.page === 0) {
+            throw new InvalidRequestError("Page must be greater than 0");
+          }
+
           const filterProps = {
             projectId: auth.scope.projectId,
             page: query.page ?? undefined,

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -206,10 +206,7 @@ export default withMiddlewares({
             },
           };
         },
-        clickhouseExecution: async () => {
-          if (query.page === 0) {
-            throw new InvalidRequestError("Page must be greater than 0");
-          }
+        clickhouseExecution: async () => {    
 
           const filterProps = {
             projectId: auth.scope.projectId,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix pagination in public API by enforcing `page` > 0 and updating tests and schemas.
> 
>   - **Behavior**:
>     - Enforce `page` > 0 in `publicApiPaginationZod` in `zod.ts`.
>     - Add check for `page` > 0 in `clickhouseExecution` in `index.ts`.
>     - Return 400 error if `page` is 0 in `traces-api.servertest.ts`.
>   - **Tests**:
>     - Add test case in `traces-api.servertest.ts` to verify 400 error for `page=0`.
>   - **Refactoring**:
>     - Replace `paginationZod` with `publicApiPaginationZod` in `scoreConfigTypes.ts`, `scoreTypes.ts`, and `comments.ts` to enforce new pagination rules.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 80700011a2480bfdeae1fb5e7dec6ca78e64e487. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->