### PR TITLE
fix: rate limit deletions globally to 1 per 3s

### DIFF
--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -64,12 +64,22 @@ if (env.QUEUE_CONSUMER_TRACE_UPSERT_QUEUE_IS_ENABLED === "true") {
 if (env.QUEUE_CONSUMER_TRACE_DELETE_QUEUE_IS_ENABLED === "true") {
   WorkerManager.register(QueueName.TraceDelete, traceDeleteProcessor, {
     concurrency: env.LANGFUSE_TRACE_DELETE_CONCURRENCY,
+    limiter: {
+      // Process at most `max` delete jobs per 3 seconds
+      max: env.LANGFUSE_TRACE_DELETE_CONCURRENCY,
+      duration: 3_000,
+    },
   });
 }
 
 if (env.QUEUE_CONSUMER_PROJECT_DELETE_QUEUE_IS_ENABLED === "true") {
   WorkerManager.register(QueueName.ProjectDelete, projectDeleteProcessor, {
     concurrency: env.LANGFUSE_PROJECT_DELETE_CONCURRENCY,
+    limiter: {
+      // Process at most `max` delete jobs per 3 seconds
+      max: env.LANGFUSE_PROJECT_DELETE_CONCURRENCY,
+      duration: 3_000,
+    },
   });
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a global rate limit for deletion operations in `worker/src/app.ts`, processing at most `max` delete jobs per 3 seconds for `TraceDelete` and `ProjectDelete` queues.
> 
>   - **Rate Limiting**:
>     - Adds a global rate limit for deletions in `worker/src/app.ts`.
>     - Configures `WorkerManager.register` for `TraceDelete` and `ProjectDelete` queues with a limiter to process at most `max` delete jobs per 3 seconds.
>     - Uses `env.LANGFUSE_TRACE_DELETE_CONCURRENCY` and `env.LANGFUSE_PROJECT_DELETE_CONCURRENCY` for `max` value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 12818b7635087dbc69c144b01b9360cc283a4fea. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->