### PR TITLE
fix(ui): redirect after org/project deletion when using custom base path

### DIFF
--- a/web/src/features/organizations/components/DeleteOrganizationButton.tsx
+++ b/web/src/features/organizations/components/DeleteOrganizationButton.tsx
@@ -23,6 +23,7 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import { useQueryOrganization } from "@/src/features/organizations/hooks";
 import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast"; // Import success toast function
+import { env } from "@/src/env.mjs";
 
 export function DeleteOrganizationButton() {
   const capture = usePostHogClientCapture();
@@ -64,7 +65,7 @@ export function DeleteOrganizationButton() {
         description: "The organization has been successfully deleted.",
       });
       await new Promise((resolve) => setTimeout(resolve, 5000)); // Delay for 5 seconds
-      window.location.href = "/"; // Browser reload to refresh jwt
+      window.location.href = env.NEXT_PUBLIC_BASE_PATH ?? "/"; // Browser reload to refresh jwt
     } catch (error) {
       console.error(error);
     }

--- a/web/src/features/projects/components/DeleteProjectButton.tsx
+++ b/web/src/features/projects/components/DeleteProjectButton.tsx
@@ -22,6 +22,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useQueryProject } from "@/src/features/projects/hooks";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { env } from "@/src/env.mjs";
 
 export function DeleteProjectButton() {
   const capture = usePostHogClientCapture();
@@ -61,7 +62,7 @@ export function DeleteProjectButton() {
         projectId: project.id,
       })
       .then(() => {
-        window.location.href = "/"; // browser reload to refresh jwt
+        window.location.href = env.NEXT_PUBLIC_BASE_PATH ?? "/"; // browser reload to refresh jwt
       })
       .catch((error) => {
         console.error(error);
@@ -77,7 +78,7 @@ export function DeleteProjectButton() {
       </DialogTrigger>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
-          <DialogTitle className="text-lg font-semibold  ">
+          <DialogTitle className="text-lg font-semibold">
             Delete Project
           </DialogTitle>
           <DialogDescription className=" ">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update redirection in `DeleteOrganizationButton` and `DeleteProjectButton` to use custom base path after deletion.
> 
>   - **Behavior**:
>     - Update redirection in `DeleteOrganizationButton` and `DeleteProjectButton` to use `env.NEXT_PUBLIC_BASE_PATH` or fallback to `/` after deletion.
>   - **Misc**:
>     - Remove extra space in `DialogTitle` in `DeleteProjectButton.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 10674dcf40f5987bd0aa817a63527c7a888c8978. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->