### PR TITLE
feat(ui): new experiment modal to highlight prompt and custom experiments

### DIFF
--- a/web/src/ee/features/experiments/components/CreateExperimentsForm.tsx
+++ b/web/src/ee/features/experiments/components/CreateExperimentsForm.tsx
@@ -41,6 +41,8 @@ import {
   Info,
   CircleCheck,
   Loader2,
+  Code2,
+  Wand2,
 } from "lucide-react";
 import { api } from "@/src/utils/api";
 import {
@@ -48,6 +50,8 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
+  CardContent,
+  CardFooter,
 } from "@/src/components/ui/card";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { useModelParams } from "@/src/ee/features/playground/page/hooks/useModelParams";
@@ -66,6 +70,13 @@ import { PromptType } from "@/src/features/prompts/server/utils/validation";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { Input } from "@/src/components/ui/input";
 import { EvaluatorStatus } from "@/src/ee/features/evals/types";
+import {
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/src/components/ui/dialog";
+import Link from "next/link";
+import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 
 const CreateExperimentData = z.object({
   name: z
@@ -111,6 +122,7 @@ export const CreateExperimentsForm = ({
   promptDefault,
   handleExperimentSettled,
   handleExperimentSuccess,
+  showSDKRunInfoPage = false,
 }: {
   projectId: string;
   setFormOpen: (open: boolean) => void;
@@ -131,8 +143,11 @@ export const CreateExperimentsForm = ({
     runId: string;
     runName: string;
   }) => Promise<void>;
+  showSDKRunInfoPage?: boolean;
 }) => {
   const [open, setOpen] = useState(false);
+  const hasPromptExperimentEntitlement =
+    useHasEntitlement("prompt-experiments");
   const [evaluatorOptions, setEvaluatorOptions] = useState<
     { key: string; value: string }[]
   >([]);
@@ -145,6 +160,7 @@ export const CreateExperimentsForm = ({
   const [selectedPromptVersion, setSelectedPromptVersion] = useState<
     number | null
   >(promptDefault?.version ?? null);
+  const [showPromptForm, setShowPromptForm] = useState(false);
 
   const {
     modelParams,
@@ -179,9 +195,14 @@ export const CreateExperimentsForm = ({
     scope: "evalJob:CUD",
   });
 
-  const promptMeta = api.prompts.allPromptMeta.useQuery({
-    projectId,
-  });
+  const promptMeta = api.prompts.allPromptMeta.useQuery(
+    {
+      projectId,
+    },
+    {
+      enabled: hasPromptExperimentEntitlement,
+    },
+  );
 
   const datasets = api.datasets.allDatasetMeta.useQuery(
     { projectId },
@@ -195,6 +216,7 @@ export const CreateExperimentsForm = ({
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
       staleTime: Infinity,
+      enabled: hasPromptExperimentEntitlement,
     },
   );
 
@@ -204,7 +226,8 @@ export const CreateExperimentsForm = ({
   const evaluators = api.evals.jobConfigsByTarget.useQuery(
     { projectId, targetObject: "dataset" },
     {
-      enabled: hasEvalReadAccess && !!datasetId,
+      enabled:
+        hasEvalReadAccess && !!datasetId && hasPromptExperimentEntitlement,
       trpc: {
         context: {
           skipBatch: true,
@@ -268,7 +291,7 @@ export const CreateExperimentsForm = ({
       datasetId: datasetId as string,
     },
     {
-      enabled: Boolean(promptId && datasetId),
+      enabled: Boolean(promptId && datasetId) && hasPromptExperimentEntitlement,
     },
   );
 
@@ -360,6 +383,96 @@ export const CreateExperimentsForm = ({
     return null;
   }
 
+  if (showSDKRunInfoPage && !showPromptForm) {
+    return (
+      <>
+        <DialogHeader>
+          <DialogTitle>Run Experiment on Dataset</DialogTitle>
+          <DialogDescription>
+            Experiments allow to test iterations of your application or prompt
+            on a dataset. Learn more about datasets and experiments{" "}
+            <Link
+              href="https://langfuse.com/docs/datasets/overview"
+              target="_blank"
+              className="underline"
+            >
+              here
+            </Link>
+            .
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-row gap-2">
+          {hasPromptExperimentEntitlement && (
+            <Card className="flex flex-1 flex-col">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-lg">
+                  <Wand2 className="size-4" />
+                  Prompt Experiment
+                </CardTitle>
+                <CardDescription>
+                  Test single prompts and model configurations via Langfuse UI
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ul className="list-disc space-y-2 pl-4 text-sm text-muted-foreground">
+                  <li>Compare prompt versions</li>
+                  <li>Compare model configurations</li>
+                  <li>No code required</li>
+                </ul>
+              </CardContent>
+              <CardFooter className="mt-auto flex flex-row gap-2">
+                <Button
+                  className="w-full"
+                  onClick={() => setShowPromptForm(true)}
+                >
+                  Create
+                </Button>
+                <Button variant="secondary" className="w-full" asChild>
+                  <Link href="https://langfuse.com/docs/datasets/prompt-experiments">
+                    View Docs
+                  </Link>
+                </Button>
+              </CardFooter>
+            </Card>
+          )}
+
+          <Card className="flex flex-1 flex-col">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <Code2 className="size-4" />
+                Custom Experiment
+              </CardTitle>
+              <CardDescription>
+                Run any experiment via the Langfuse SDKs
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="list-disc space-y-2 pl-4 text-sm text-muted-foreground">
+                <li>Full control over experiment execution</li>
+                <li>Custom evaluation logic</li>
+                <li>Integration with your codebase</li>
+              </ul>
+            </CardContent>
+            <CardFooter className="mt-auto">
+              <Button className="w-full" variant="secondary" asChild>
+                <Link
+                  href="https://langfuse.com/docs/datasets/get-started"
+                  target="_blank"
+                >
+                  View Docs
+                </Link>
+              </Button>
+            </CardFooter>
+          </Card>
+        </div>
+      </>
+    );
+  }
+
+  if (!hasPromptExperimentEntitlement) {
+    return null;
+  }
+
   if (
     !promptMeta.data ||
     !datasets.data ||
@@ -369,378 +482,411 @@ export const CreateExperimentsForm = ({
   }
 
   return (
-    <Form {...form}>
-      <form className="space-y-6" onSubmit={form.handleSubmit(onSubmit)}>
-        <FormField
-          control={form.control}
-          name="name"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Experiment name (optional)</FormLabel>
-              <FormControl>
-                <Input {...field} type="string" />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="description"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Description (optional)</FormLabel>
-              <FormControl>
-                <Textarea
-                  {...field}
-                  placeholder="Add description..."
-                  className="focus:outline-none focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0 active:ring-0"
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="promptId"
-          render={() => (
-            <FormItem>
-              <FormLabel>Prompt</FormLabel>
-              {/* FIX: I need the command list in the popover to be scrollable, currently it's not */}
-              <div className="mb-2 flex gap-2">
-                <Popover open={open} onOpenChange={setOpen}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="outline"
-                      role="combobox"
-                      aria-expanded={open}
-                      className="w-2/3 justify-between px-2 font-normal"
+    <>
+      <DialogHeader>
+        {showSDKRunInfoPage && (
+          <Button
+            variant="ghost"
+            onClick={() => setShowPromptForm(false)}
+            className="inline-block self-start"
+          >
+            ← Back
+          </Button>
+        )}
+        <DialogTitle>New Prompt Experiment</DialogTitle>
+        <DialogDescription>
+          Create an experiment to test a prompt version on a dataset. See{" "}
+          <Link
+            href="https://langfuse.com/docs/datasets/prompt-experiments"
+            target="_blank"
+            className="underline"
+          >
+            documentation
+          </Link>{" "}
+          to learn more.
+        </DialogDescription>
+      </DialogHeader>
+      <Form {...form}>
+        <form className="space-y-6" onSubmit={form.handleSubmit(onSubmit)}>
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Experiment name (optional)</FormLabel>
+                <FormControl>
+                  <Input {...field} type="string" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description (optional)</FormLabel>
+                <FormControl>
+                  <Textarea
+                    {...field}
+                    placeholder="Add description..."
+                    className="focus:outline-none focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0 active:ring-0"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="promptId"
+            render={() => (
+              <FormItem>
+                <FormLabel>Prompt</FormLabel>
+                {/* FIX: I need the command list in the popover to be scrollable, currently it's not */}
+                <div className="mb-2 flex gap-2">
+                  <Popover open={open} onOpenChange={setOpen}>
+                    <PopoverTrigger asChild>
+                      <Button
+                        variant="outline"
+                        role="combobox"
+                        aria-expanded={open}
+                        className="w-2/3 justify-between px-2 font-normal"
+                      >
+                        {selectedPromptName || "Select a prompt"}
+                        <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent
+                      className="w-[--radix-popover-trigger-width] overflow-auto p-0"
+                      align="start"
                     >
-                      {selectedPromptName || "Select a prompt"}
-                      <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent
-                    className="w-[--radix-popover-trigger-width] overflow-auto p-0"
-                    align="start"
-                  >
-                    <Command>
-                      <CommandInput
-                        placeholder="Search prompts..."
-                        className="h-9"
-                      />
-                      <CommandList>
-                        <CommandEmpty>No prompt found.</CommandEmpty>
-                        <CommandGroup>
-                          {promptsByName &&
-                            Object.entries(promptsByName).map(
-                              ([name, promptData]) => (
-                                <CommandItem
-                                  key={name}
-                                  onSelect={() => {
-                                    setSelectedPromptName(name);
-                                    const latestVersion = promptData[0];
-                                    setSelectedPromptVersion(
-                                      latestVersion.version,
-                                    );
-                                    form.setValue("promptId", latestVersion.id);
-                                    form.clearErrors("promptId");
-                                  }}
-                                >
-                                  {name}
-                                  <CheckIcon
-                                    className={cn(
-                                      "ml-auto h-4 w-4",
-                                      name === selectedPromptName
-                                        ? "opacity-100"
-                                        : "opacity-0",
-                                    )}
-                                  />
-                                </CommandItem>
-                              ),
-                            )}
-                        </CommandGroup>
-                      </CommandList>
-                    </Command>
-                  </PopoverContent>
-                </Popover>
+                      <Command>
+                        <CommandInput
+                          placeholder="Search prompts..."
+                          className="h-9"
+                        />
+                        <CommandList>
+                          <CommandEmpty>No prompt found.</CommandEmpty>
+                          <CommandGroup>
+                            {promptsByName &&
+                              Object.entries(promptsByName).map(
+                                ([name, promptData]) => (
+                                  <CommandItem
+                                    key={name}
+                                    onSelect={() => {
+                                      setSelectedPromptName(name);
+                                      const latestVersion = promptData[0];
+                                      setSelectedPromptVersion(
+                                        latestVersion.version,
+                                      );
+                                      form.setValue(
+                                        "promptId",
+                                        latestVersion.id,
+                                      );
+                                      form.clearErrors("promptId");
+                                    }}
+                                  >
+                                    {name}
+                                    <CheckIcon
+                                      className={cn(
+                                        "ml-auto h-4 w-4",
+                                        name === selectedPromptName
+                                          ? "opacity-100"
+                                          : "opacity-0",
+                                      )}
+                                    />
+                                  </CommandItem>
+                                ),
+                              )}
+                          </CommandGroup>
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
 
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <Button
-                      disabled={!selectedPromptName}
-                      variant="outline"
-                      role="combobox"
-                      className="w-1/3 justify-between px-2 font-normal"
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button
+                        disabled={!selectedPromptName}
+                        variant="outline"
+                        role="combobox"
+                        className="w-1/3 justify-between px-2 font-normal"
+                      >
+                        {selectedPromptVersion
+                          ? `Version ${selectedPromptVersion}`
+                          : "Version"}
+                        <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent
+                      className="w-[--radix-popover-trigger-width] p-0"
+                      align="start"
                     >
-                      {selectedPromptVersion
-                        ? `Version ${selectedPromptVersion}`
-                        : "Version"}
-                      <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent
-                    className="w-[--radix-popover-trigger-width] p-0"
-                    align="start"
-                  >
-                    <Command>
-                      <CommandList>
-                        <CommandEmpty>No version found.</CommandEmpty>
-                        <CommandGroup className="overflow-y-auto">
-                          {promptsByName &&
-                          selectedPromptName &&
-                          promptsByName[selectedPromptName] ? (
-                            promptsByName[selectedPromptName].map((prompt) => (
-                              <CommandItem
-                                key={prompt.id}
-                                onSelect={() => {
-                                  setSelectedPromptVersion(prompt.version);
-                                  form.setValue("promptId", prompt.id);
-                                  form.clearErrors("promptId");
-                                }}
-                              >
-                                Version {prompt.version}
-                                <CheckIcon
-                                  className={cn(
-                                    "ml-auto h-4 w-4",
-                                    prompt.version === selectedPromptVersion
-                                      ? "opacity-100"
-                                      : "opacity-0",
-                                  )}
-                                />
+                      <Command>
+                        <CommandList>
+                          <CommandEmpty>No version found.</CommandEmpty>
+                          <CommandGroup className="overflow-y-auto">
+                            {promptsByName &&
+                            selectedPromptName &&
+                            promptsByName[selectedPromptName] ? (
+                              promptsByName[selectedPromptName].map(
+                                (prompt) => (
+                                  <CommandItem
+                                    key={prompt.id}
+                                    onSelect={() => {
+                                      setSelectedPromptVersion(prompt.version);
+                                      form.setValue("promptId", prompt.id);
+                                      form.clearErrors("promptId");
+                                    }}
+                                  >
+                                    Version {prompt.version}
+                                    <CheckIcon
+                                      className={cn(
+                                        "ml-auto h-4 w-4",
+                                        prompt.version === selectedPromptVersion
+                                          ? "opacity-100"
+                                          : "opacity-0",
+                                      )}
+                                    />
+                                  </CommandItem>
+                                ),
+                              )
+                            ) : (
+                              <CommandItem disabled>
+                                No versions available
                               </CommandItem>
-                            ))
-                          ) : (
-                            <CommandItem disabled>
-                              No versions available
-                            </CommandItem>
-                          )}
-                        </CommandGroup>
-                      </CommandList>
-                    </Command>
-                  </PopoverContent>
-                </Popover>
-              </div>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+                            )}
+                          </CommandGroup>
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
+                </div>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-        <FormField
-          control={form.control}
-          name="modelConfig"
-          render={() => (
-            <FormItem>
-              <Card className="p-4">
-                <ModelParameters
-                  {...{
-                    modelParams,
-                    availableModels,
-                    availableProviders,
-                    updateModelParamValue: updateModelParamValue,
-                    setModelParamEnabled,
-                    modelParamsDescription:
-                      "Select a model which supports function calling.",
-                  }}
-                  evalModelsOnly
-                />
-              </Card>
-              {form.formState.errors.modelConfig && (
-                <p
-                  id="modelConfig"
-                  className={cn("text-sm font-medium text-destructive")}
+          <FormField
+            control={form.control}
+            name="modelConfig"
+            render={() => (
+              <FormItem>
+                <Card className="p-4">
+                  <ModelParameters
+                    {...{
+                      modelParams,
+                      availableModels,
+                      availableProviders,
+                      updateModelParamValue: updateModelParamValue,
+                      setModelParamEnabled,
+                      modelParamsDescription:
+                        "Select a model which supports function calling.",
+                    }}
+                    evalModelsOnly
+                  />
+                </Card>
+                {form.formState.errors.modelConfig && (
+                  <p
+                    id="modelConfig"
+                    className={cn("text-sm font-medium text-destructive")}
+                  >
+                    {[
+                      form.formState.errors.modelConfig?.model?.message,
+                      form.formState.errors.modelConfig?.provider?.message,
+                    ].join(", ")}
+                  </p>
+                )}
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="datasetId"
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex items-center gap-2">
+                  <FormLabel>Dataset</FormLabel>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <span className="cursor-pointer text-xs text-muted-foreground">
+                        (expected columns)
+                      </span>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-80">
+                      <div className="flex flex-col space-y-2">
+                        <h4 className="text-sm font-medium leading-none">
+                          Expected columns
+                        </h4>
+                        <span className="text-sm text-muted-foreground">
+                          {promptId ? (
+                            <div>
+                              <span>
+                                Given current prompt, dataset item input must
+                                contain at least one of these first-level JSON
+                                keys, mapped to a string value:
+                              </span>
+                              <ul className="my-2 ml-2 list-inside list-disc">
+                                {expectedColumns.map((col) => (
+                                  <li key={col}>{col}</li>
+                                ))}
+                              </ul>
+                              <span>
+                                These will be used as the input to your prompt.
+                              </span>
+                            </div>
+                          ) : (
+                            "Please select a prompt first"
+                          )}
+                        </span>
+                      </div>
+                    </PopoverContent>
+                  </Popover>
+                </div>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
                 >
-                  {[
-                    form.formState.errors.modelConfig?.model?.message,
-                    form.formState.errors.modelConfig?.provider?.message,
-                  ].join(", ")}
-                </p>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select a dataset" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {datasets.data?.map((dataset) => (
+                      <SelectItem value={dataset.id} key={dataset.id}>
+                        {dataset.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {evaluators.data && !!datasetId ? (
+            <FormItem>
+              <FormLabel>Evaluators</FormLabel>
+              <FormDescription>
+                Will run against your experiment results.
+              </FormDescription>
+              <MultiSelectKeyValues
+                key={datasetId}
+                placeholder="Value"
+                align="end"
+                className="grid grid-cols-[auto,1fr,auto,auto] gap-2"
+                disabled={!hasEvalWriteAccess}
+                onValueChange={handleOnValueChange}
+                options={evaluatorOptions}
+                values={
+                  selectedEvaluators as {
+                    value: string;
+                    key: string;
+                  }[]
+                }
+                hideClearButton
+                controlButtons={
+                  <CommandItem
+                    onSelect={() => {
+                      window.open(`/project/${projectId}/evals`, "_blank");
+                    }}
+                  >
+                    Manage evaluators
+                  </CommandItem>
+                }
+              />
+            </FormItem>
+          ) : (
+            <FormItem>
+              <FormLabel>Evaluators</FormLabel>
+              {hasEvalReadAccess ? (
+                <FormDescription>
+                  Select a dataset first to set up evaluators.
+                </FormDescription>
+              ) : (
+                <FormDescription>
+                  ⓘ You do not have access to view evaluators. Please contact
+                  your admin to upgrade your role.
+                </FormDescription>
               )}
             </FormItem>
           )}
-        />
 
-        <FormField
-          control={form.control}
-          name="datasetId"
-          render={({ field }) => (
-            <FormItem>
-              <div className="flex items-center gap-2">
-                <FormLabel>Dataset</FormLabel>
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <span className="cursor-pointer text-xs text-muted-foreground">
-                      (expected columns)
-                    </span>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-80">
-                    <div className="flex flex-col space-y-2">
-                      <h4 className="text-sm font-medium leading-none">
-                        Expected columns
-                      </h4>
-                      <span className="text-sm text-muted-foreground">
-                        {promptId ? (
-                          <div>
-                            <span>
-                              Given current prompt, dataset item input must
-                              contain at least one of these first-level JSON
-                              keys, mapped to a string value:
-                            </span>
-                            <ul className="my-2 ml-2 list-inside list-disc">
-                              {expectedColumns.map((col) => (
-                                <li key={col}>{col}</li>
-                              ))}
-                            </ul>
-                            <span>
-                              These will be used as the input to your prompt.
-                            </span>
-                          </div>
-                        ) : (
-                          "Please select a prompt first"
-                        )}
-                      </span>
-                    </div>
-                  </PopoverContent>
-                </Popover>
-              </div>
-              <Select onValueChange={field.onChange} defaultValue={field.value}>
-                <FormControl>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select a dataset" />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  {datasets.data?.map((dataset) => (
-                    <SelectItem value={dataset.id} key={dataset.id}>
-                      {dataset.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        {evaluators.data && !!datasetId ? (
-          <FormItem>
-            <FormLabel>Evaluators</FormLabel>
-            <FormDescription>
-              Will run against your experiment results.
-            </FormDescription>
-            <MultiSelectKeyValues
-              key={datasetId}
-              placeholder="Value"
-              align="end"
-              className="grid grid-cols-[auto,1fr,auto,auto] gap-2"
-              disabled={!hasEvalWriteAccess}
-              onValueChange={handleOnValueChange}
-              options={evaluatorOptions}
-              values={
-                selectedEvaluators as {
-                  value: string;
-                  key: string;
-                }[]
-              }
-              hideClearButton
-              controlButtons={
-                <CommandItem
-                  onSelect={() => {
-                    window.open(`/project/${projectId}/evals`, "_blank");
-                  }}
-                >
-                  Manage evaluators
-                </CommandItem>
-              }
-            />
-          </FormItem>
-        ) : (
-          <FormItem>
-            <FormLabel>Evaluators</FormLabel>
-            {hasEvalReadAccess ? (
-              <FormDescription>
-                Select a dataset first to set up evaluators.
-              </FormDescription>
-            ) : (
-              <FormDescription>
-                ⓘ You do not have access to view evaluators. Please contact your
-                admin to upgrade your role.
-              </FormDescription>
+          <div className="mt-4 flex flex-col gap-4">
+            {validationResult.isLoading && Boolean(promptId && datasetId) && (
+              <Card className="relative overflow-hidden rounded-md shadow-none group-data-[collapsible=icon]:hidden">
+                <CardHeader className="p-2">
+                  <CardTitle className="flex items-center justify-between text-sm">
+                    <span>Validating configuration...</span>
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  </CardTitle>
+                  <CardDescription className="text-foreground">
+                    Checking dataset items against prompt variables
+                  </CardDescription>
+                </CardHeader>
+              </Card>
             )}
-          </FormItem>
-        )}
+            {validationResult.data?.isValid === false && (
+              <Card className="relative overflow-hidden rounded-md border-dark-yellow bg-light-yellow shadow-none group-data-[collapsible=icon]:hidden">
+                <CardHeader className="p-2">
+                  <CardTitle className="flex items-center justify-between text-sm text-dark-yellow">
+                    <span>Invalid configuration</span>
+                    {/* TODO: add link to docs explaining error cases */}
+                    <Info className="h-4 w-4" />
+                  </CardTitle>
+                  <CardDescription className="text-foreground">
+                    {validationResult.data?.message}
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            )}
+            {validationResult.data?.isValid === true && (
+              <Card className="relative overflow-hidden rounded-md border-dark-green bg-light-green shadow-none group-data-[collapsible=icon]:hidden">
+                <CardHeader className="p-2">
+                  <CardTitle className="flex items-center justify-between text-sm text-dark-green">
+                    <span>Valid configuration</span>
+                    <CircleCheck className="h-4 w-4" />
+                  </CardTitle>
+                  <div className="text-sm">
+                    Matches between dataset items and prompt variables
+                    <ul className="my-2 ml-2 list-inside list-disc">
+                      {Object.entries(
+                        validationResult.data.variablesMap ?? {},
+                      ).map(([variable, count]) => (
+                        <li key={variable}>
+                          <strong>{variable}:</strong> {count} /{" "}
+                          {validationResult.data?.isValid
+                            ? validationResult.data.totalItems
+                            : "unknown"}
+                        </li>
+                      ))}
+                    </ul>
+                    Items missing all prompt variables will be excluded from the
+                    experiment.
+                  </div>
+                </CardHeader>
+              </Card>
+            )}
 
-        <div className="mt-4 flex flex-col gap-4">
-          {validationResult.isLoading && Boolean(promptId && datasetId) && (
-            <Card className="relative overflow-hidden rounded-md shadow-none group-data-[collapsible=icon]:hidden">
-              <CardHeader className="p-2">
-                <CardTitle className="flex items-center justify-between text-sm">
-                  <span>Validating configuration...</span>
-                  <Loader2 className="h-3 w-3 animate-spin" />
-                </CardTitle>
-                <CardDescription className="text-foreground">
-                  Checking dataset items against prompt variables
-                </CardDescription>
-              </CardHeader>
-            </Card>
-          )}
-          {validationResult.data?.isValid === false && (
-            <Card className="relative overflow-hidden rounded-md border-dark-yellow bg-light-yellow shadow-none group-data-[collapsible=icon]:hidden">
-              <CardHeader className="p-2">
-                <CardTitle className="flex items-center justify-between text-sm text-dark-yellow">
-                  <span>Invalid configuration</span>
-                  {/* TODO: add link to docs explaining error cases */}
-                  <Info className="h-4 w-4" />
-                </CardTitle>
-                <CardDescription className="text-foreground">
-                  {validationResult.data?.message}
-                </CardDescription>
-              </CardHeader>
-            </Card>
-          )}
-          {validationResult.data?.isValid === true && (
-            <Card className="relative overflow-hidden rounded-md border-dark-green bg-light-green shadow-none group-data-[collapsible=icon]:hidden">
-              <CardHeader className="p-2">
-                <CardTitle className="flex items-center justify-between text-sm text-dark-green">
-                  <span>Valid configuration</span>
-                  <CircleCheck className="h-4 w-4" />
-                </CardTitle>
-                <div className="text-sm">
-                  Matches between dataset items and prompt variables
-                  <ul className="my-2 ml-2 list-inside list-disc">
-                    {Object.entries(
-                      validationResult.data.variablesMap ?? {},
-                    ).map(([variable, count]) => (
-                      <li key={variable}>
-                        <strong>{variable}:</strong> {count} /{" "}
-                        {validationResult.data?.isValid
-                          ? validationResult.data.totalItems
-                          : "unknown"}
-                      </li>
-                    ))}
-                  </ul>
-                  Items missing all prompt variables will be excluded from the
-                  experiment.
-                </div>
-              </CardHeader>
-            </Card>
-          )}
-
-          <div className="flex justify-end">
-            <Button
-              type="submit"
-              disabled={
-                Boolean(promptId && datasetId) &&
-                !validationResult.data?.isValid
-              }
-              loading={form.formState.isSubmitting}
-            >
-              Create
-            </Button>
+            <div className="flex justify-end">
+              <Button
+                type="submit"
+                disabled={
+                  Boolean(promptId && datasetId) &&
+                  !validationResult.data?.isValid
+                }
+                loading={form.formState.isSubmitting}
+              >
+                Create
+              </Button>
+            </div>
           </div>
-        </div>
-      </form>
-    </Form>
+        </form>
+      </Form>
+    </>
   );
 };

--- a/web/src/ee/features/experiments/components/CreateExperimentsForm.tsx
+++ b/web/src/ee/features/experiments/components/CreateExperimentsForm.tsx
@@ -401,7 +401,7 @@ export const CreateExperimentsForm = ({
             .
           </DialogDescription>
         </DialogHeader>
-        <div className="flex flex-row gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row">
           {hasPromptExperimentEntitlement && (
             <Card className="flex flex-1 flex-col">
               <CardHeader>

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -179,21 +179,6 @@ export const PromptDetail = () => {
                       </Button>
                     </DialogTrigger>
                     <DialogContent className="max-h-[90vh] overflow-y-auto">
-                      <DialogHeader>
-                        <DialogTitle>Set up experiment</DialogTitle>
-                        <DialogDescription>
-                          Create an experiment to test a prompt version on a
-                          dataset. See{" "}
-                          <Link
-                            href="https://langfuse.com/docs/datasets/prompt-experiments"
-                            target="_blank"
-                            className="underline"
-                          >
-                            documentation
-                          </Link>{" "}
-                          to learn more.
-                        </DialogDescription>
-                      </DialogHeader>
                       <CreateExperimentsForm
                         key={`create-experiment-form-${prompt.id}`}
                         projectId={projectId as string}

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -33,9 +33,6 @@ import { ScrollScreenPage } from "@/src/components/layouts/scroll-screen-page";
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
   DialogTrigger,
 } from "@/src/components/ui/dialog";
 import { CreateExperimentsForm } from "@/src/ee/features/experiments/components/CreateExperimentsForm";

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
@@ -128,6 +128,7 @@ export default function DatasetCompare() {
                   datasetId,
                 }}
                 handleExperimentSettled={handleExperimentSettled}
+                showSDKRunInfoPage
               />
             </DialogContent>
           </Dialog>,

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
@@ -21,7 +21,6 @@ import {
 } from "@/src/components/ui/dialog";
 import { CreateExperimentsForm } from "@/src/ee/features/experiments/components/CreateExperimentsForm";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
-import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 
 export default function DatasetCompare() {
   const router = useRouter();
@@ -41,7 +40,6 @@ export default function DatasetCompare() {
     projectId,
     scope: "promptExperiments:CUD",
   });
-  const hasEntitlement = useHasEntitlement("prompt-experiments");
 
   const dataset = api.datasets.byId.useQuery({
     datasetId,

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
@@ -17,15 +17,11 @@ import { MarkdownOrJsonView } from "@/src/components/trace/IOPreview";
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
   DialogTrigger,
 } from "@/src/components/ui/dialog";
 import { CreateExperimentsForm } from "@/src/ee/features/experiments/components/CreateExperimentsForm";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
-import Link from "next/link";
 
 export default function DatasetCompare() {
   const router = useRouter();
@@ -112,49 +108,29 @@ export default function DatasetCompare() {
           description: "Compare your dataset runs side by side",
         }}
         actionButtons={[
-          hasEntitlement ? (
-            <Dialog
-              key="create-experiment-dialog"
-              open={isCreateExperimentDialogOpen}
-              onOpenChange={setIsCreateExperimentDialogOpen}
-            >
-              <DialogTrigger asChild disabled={!hasExperimentWriteAccess}>
-                <Button
-                  variant="secondary"
-                  disabled={!hasExperimentWriteAccess}
-                >
-                  <FlaskConical className="h-4 w-4" />
-                  <span className="ml-2">New experiment</span>
-                </Button>
-              </DialogTrigger>
-              <DialogContent className="max-h-[90vh] overflow-y-auto">
-                <DialogHeader>
-                  <DialogTitle>Set up experiment</DialogTitle>
-                  <DialogDescription>
-                    Create an experiment to test a prompt version on a dataset.
-                    See{" "}
-                    <Link
-                      href="https://langfuse.com/docs/datasets/prompt-experiments"
-                      target="_blank"
-                      className="underline"
-                    >
-                      documentation
-                    </Link>{" "}
-                    to learn more.
-                  </DialogDescription>
-                </DialogHeader>
-                <CreateExperimentsForm
-                  key={`create-experiment-form-${datasetId}`}
-                  projectId={projectId as string}
-                  setFormOpen={setIsCreateExperimentDialogOpen}
-                  defaultValues={{
-                    datasetId,
-                  }}
-                  handleExperimentSettled={handleExperimentSettled}
-                />
-              </DialogContent>
-            </Dialog>
-          ) : null,
+          <Dialog
+            key="create-experiment-dialog"
+            open={isCreateExperimentDialogOpen}
+            onOpenChange={setIsCreateExperimentDialogOpen}
+          >
+            <DialogTrigger asChild disabled={!hasExperimentWriteAccess}>
+              <Button variant="secondary" disabled={!hasExperimentWriteAccess}>
+                <FlaskConical className="h-4 w-4" />
+                <span className="ml-2">New experiment</span>
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="max-h-[90vh] overflow-y-auto">
+              <CreateExperimentsForm
+                key={`create-experiment-form-${datasetId}`}
+                projectId={projectId as string}
+                setFormOpen={setIsCreateExperimentDialogOpen}
+                defaultValues={{
+                  datasetId,
+                }}
+                handleExperimentSettled={handleExperimentSettled}
+              />
+            </DialogContent>
+          </Dialog>,
           <Popover key="show-dataset-details">
             <PopoverTrigger asChild>
               <Button variant="outline">

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
@@ -20,9 +20,6 @@ import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
   DialogTrigger,
 } from "@/src/components/ui/dialog";
 import { Button } from "@/src/components/ui/button";
@@ -35,7 +32,6 @@ export default function Dataset() {
   const datasetId = router.query.datasetId as string;
   const utils = api.useUtils();
   const hasEntitlement = useHasEntitlement("model-based-evaluations");
-  const hasExperimentEntitlement = useHasEntitlement("prompt-experiments");
   const [isCreateExperimentDialogOpen, setIsCreateExperimentDialogOpen] =
     useState(false);
 
@@ -109,48 +105,32 @@ export default function Dataset() {
         }
         actionButtons={
           <>
-            {hasExperimentEntitlement && (
-              <Dialog
-                open={isCreateExperimentDialogOpen}
-                onOpenChange={setIsCreateExperimentDialogOpen}
-              >
-                <DialogTrigger asChild disabled={!hasExperimentWriteAccess}>
-                  <Button
-                    variant="secondary"
-                    disabled={!hasExperimentWriteAccess}
-                  >
-                    <FlaskConical className="h-4 w-4" />
-                    <span className="ml-2">New experiment</span>
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className="max-h-[90vh] overflow-y-auto">
-                  <DialogHeader>
-                    <DialogTitle>Set up experiment</DialogTitle>
-                    <DialogDescription>
-                      Create an experiment to test a prompt version on a
-                      dataset. See{" "}
-                      <Link
-                        href="https://langfuse.com/docs/datasets/prompt-experiments"
-                        target="_blank"
-                        className="underline"
-                      >
-                        documentation
-                      </Link>{" "}
-                      to learn more.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <CreateExperimentsForm
-                    key={`create-experiment-form-${datasetId}`}
-                    projectId={projectId as string}
-                    setFormOpen={setIsCreateExperimentDialogOpen}
-                    defaultValues={{
-                      datasetId,
-                    }}
-                    handleExperimentSuccess={handleExperimentSuccess}
-                  />
-                </DialogContent>
-              </Dialog>
-            )}
+            <Dialog
+              open={isCreateExperimentDialogOpen}
+              onOpenChange={setIsCreateExperimentDialogOpen}
+            >
+              <DialogTrigger asChild disabled={!hasExperimentWriteAccess}>
+                <Button
+                  variant="secondary"
+                  disabled={!hasExperimentWriteAccess}
+                >
+                  <FlaskConical className="h-4 w-4" />
+                  <span className="ml-2">New experiment</span>
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="max-h-[90vh] overflow-y-auto">
+                <CreateExperimentsForm
+                  key={`create-experiment-form-${datasetId}`}
+                  projectId={projectId as string}
+                  setFormOpen={setIsCreateExperimentDialogOpen}
+                  defaultValues={{
+                    datasetId,
+                  }}
+                  handleExperimentSuccess={handleExperimentSuccess}
+                  showSDKRunInfoPage
+                />
+              </DialogContent>
+            </Dialog>
 
             {hasReadAccess && hasEntitlement && evaluators.isSuccess && (
               <MultiSelectKeyValues
@@ -236,14 +216,6 @@ export default function Dataset() {
           </Tabs>
         }
       />
-
-      <p className="mt-3 text-xs text-muted-foreground">
-        Add new runs via Python or JS/TS SDKs. See{" "}
-        <a href="https://langfuse.com/docs/datasets" className="underline">
-          documentation
-        </a>{" "}
-        for details.
-      </p>
     </FullScreenPage>
   );
 }


### PR DESCRIPTION

<img width="545" alt="image" src="https://github.com/user-attachments/assets/e985a1b8-0adb-4c30-bb8a-7600c6bc7a4a" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduce a new experiment creation modal in the UI, integrating it into prompt and dataset pages with entitlement checks and enhanced form handling.
> 
>   - **UI Enhancements**:
>     - Add new modal in `CreateExperimentsForm.tsx` for creating prompt and custom experiments.
>     - Update `prompt-detail.tsx` to use the new experiment modal.
>     - Modify dataset pages (`compare.tsx`, `index.tsx`) to integrate the new experiment modal.
>   - **Entitlement and Access Control**:
>     - Check for `prompt-experiments` entitlement in `CreateExperimentsForm.tsx` and related components.
>     - Ensure experiment creation is gated by `hasExperimentWriteAccess`.
>   - **Form Handling**:
>     - Add `showSDKRunInfoPage` prop to `CreateExperimentsForm` to toggle SDK run info.
>     - Update form submission logic to handle new experiment creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 36b314f2f4c5a90a55beb75c7e294afd2f0d75a8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->