### PR TITLE
chore: increase rate limits

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -155,4 +155,3 @@ volumes:
     driver: local
   langfuse_minio_data:
     driver: local
-

--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -197,7 +197,7 @@ const getPlanBasedRateLimitConfig = (
         case "ingestion":
           return {
             resource: "ingestion",
-            points: 2000,
+            points: 4000,
             durationInSec: 60,
           };
         case "legacy-ingestion":
@@ -233,7 +233,7 @@ const getPlanBasedRateLimitConfig = (
         case "ingestion":
           return {
             resource: "ingestion",
-            points: 10000,
+            points: 20000,
             durationInSec: 60,
           };
         case "legacy-ingestion":


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase rate limits for `ingestion` resource in `RateLimitService.ts` for `cloud:hobby`, `cloud:pro`, and `cloud:team` plans.
> 
>   - **Rate Limits**:
>     - Increase `ingestion` rate limit from 2000 to 4000 points for `cloud:hobby` and `cloud:pro` plans in `getPlanBasedRateLimitConfig()`.
>     - Increase `ingestion` rate limit from 10000 to 20000 points for `cloud:team` plan in `getPlanBasedRateLimitConfig()`.
>   - **Misc**:
>     - Remove trailing newline in `docker-compose.build.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for faebe34da99350af1f7e66ab559bbdc36452f694. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->