### PR TITLE
chore: add attributes to ingestion queue processing

### DIFF
--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -10,6 +10,7 @@ import {
   redis,
   clickhouseClient,
   getClickhouseEntityType,
+  getCurrentSpan,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 
@@ -37,6 +38,23 @@ export const ingestionQueueProcessor: Processor = async (
   job: Job<TQueueJobTypes[QueueName.IngestionQueue]>,
 ) => {
   try {
+    const span = getCurrentSpan();
+    if (span) {
+      span.setAttribute("messaging.bullmq.job.input.id", job.data.id);
+      span.setAttribute(
+        "messaging.bullmq.job.input.projectId",
+        job.data.payload.authCheck.scope.projectId,
+      );
+      span.setAttribute(
+        "messaging.bullmq.job.input.eventBodyId",
+        job.data.payload.data.eventBodyId,
+      );
+      span.setAttribute(
+        "messaging.bullmq.job.input.type",
+        job.data.payload.data.type,
+      );
+    }
+
     const s3Client = getS3StorageServiceClient(
       env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
     );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add tracing attributes to `ingestionQueueProcessor` for better job detail tracking.
> 
>   - **Tracing**:
>     - Adds `getCurrentSpan()` in `ingestionQueueProcessor` to retrieve the current span.
>     - Sets attributes `messaging.bullmq.job.input.id`, `messaging.bullmq.job.input.projectId`, `messaging.bullmq.job.input.eventBodyId`, and `messaging.bullmq.job.input.type` for tracing job details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8d1b09112065d89a5fe270bd88a8d6fd1d4ca638. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->