### PR TITLE
chore: do not add latest, major, and major.minor tags to docker images of `-rc` versions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -459,9 +459,9 @@ jobs:
             type=ref,event=pr
             type=sha
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v3') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-rc') }}
+            type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-rc') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v3') && !contains(github.ref, '-rc') }}
       - name: Build and push Docker image (web)
         uses: docker/build-push-action@v4
         with:
@@ -487,9 +487,9 @@ jobs:
             type=ref,event=pr
             type=sha
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v3') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-rc') }}
+            type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-rc') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v3') && !contains(github.ref, '-rc') }}
       - name: Build and push Docker image (worker)
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
Goal: be able to release `-rc` versions from branches without pushing latest or version tags

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevent `latest`, `major`, and `major.minor` Docker tags for `-rc` versions in `pipeline.yml`.
> 
>   - **Docker Image Tagging**:
>     - Modify `pipeline.yml` to prevent `latest`, `major`, and `major.minor` tags from being added to Docker images for `-rc` (release candidate) versions.
>     - Changes applied to both `meta-web` and `meta-worker` steps in `pipeline.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5600f40d985dd68979d4a9c328a78ca0c20f48ea. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->