### PR TITLE
chore: measure lookup hits in ingestion pipeline

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -35,6 +35,7 @@ import {
   convertDateToClickhouseDateTime,
   TraceUpsertQueue,
   QueueJobs,
+  recordIncrement,
 } from "@langfuse/shared/src/server";
 
 import { tokenCount } from "../../features/tokenisation/usage";
@@ -181,6 +182,19 @@ export class IngestionService {
         ),
       ]);
 
+    if (postgresScoreRecord) {
+      recordIncrement("langfuse.ingestion.lookup.hit", 1, {
+        store: "postgres",
+        object: "score",
+      });
+    }
+    if (clickhouseScoreRecord) {
+      recordIncrement("langfuse.ingestion.lookup.hit", 1, {
+        store: "clickhouse",
+        object: "score",
+      });
+    }
+
     const finalScoreRecord: ScoreRecordInsertType =
       await this.mergeScoreRecords({
         clickhouseScoreRecord,
@@ -235,6 +249,19 @@ export class IngestionService {
         },
       }),
     ]);
+
+    if (postgresTraceRecord) {
+      recordIncrement("langfuse.ingestion.lookup.hit", 1, {
+        store: "postgres",
+        object: "trace",
+      });
+    }
+    if (clickhouseTraceRecord) {
+      recordIncrement("langfuse.ingestion.lookup.hit", 1, {
+        store: "clickhouse",
+        object: "trace",
+      });
+    }
 
     const finalTraceRecord = await this.mergeTraceRecords({
       clickhouseTraceRecord,
@@ -334,6 +361,19 @@ export class IngestionService {
         }),
         this.getPrompt(projectId, observationEventList),
       ]);
+
+    if (postgresObservationRecord) {
+      recordIncrement("langfuse.ingestion.lookup.hit", 1, {
+        store: "postgres",
+        object: "observation",
+      });
+    }
+    if (clickhouseObservationRecord) {
+      recordIncrement("langfuse.ingestion.lookup.hit", 1, {
+        store: "clickhouse",
+        object: "observation",
+      });
+    }
 
     const observationRecords = this.mapObservationEventsToRecords({
       observationEventList: timeSortedEvents,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds functionality to measure lookup hits in the ingestion pipeline by logging increments for successful lookups in Postgres and Clickhouse for scores, traces, and observations.
> 
>   - **Behavior**:
>     - Adds `recordIncrement` calls in `IngestionService` to measure lookup hits for `postgres` and `clickhouse` stores.
>     - Tracks hits for `score`, `trace`, and `observation` objects.
>   - **Functions**:
>     - `processScoreEventList()`, `processTraceEventList()`, and `processObservationEventList()` now include `recordIncrement` to log lookup hits.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 088a3a9673003b160fb4ca7c7f33c2ccf1b3b9de. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->