### PR TITLE
fix: adjust clickhouse type mapping for session duration filter

### DIFF
--- a/packages/shared/src/tableDefinitions/mapSessionTable.ts
+++ b/packages/shared/src/tableDefinitions/mapSessionTable.ts
@@ -1,7 +1,7 @@
 import { UiColumnMapping } from ".";
 
 export const sessionCols: UiColumnMapping[] = [
-  // we do not access the traces scores in clichouse. We default back to the trace timestamps.
+  // we do not access the traces scores in ClickHouse. We default back to the trace timestamps.
 
   {
     uiTableName: "⭐️",
@@ -26,6 +26,8 @@ export const sessionCols: UiColumnMapping[] = [
     uiTableId: "sessionDuration",
     clickhouseTableName: "traces",
     clickhouseSelect: "duration",
+    // If we use the default of Decimal64(12), we cannot filter for more than ~40min due to an overflow
+    clickhouseTypeOverwrite: "Decimal64(3)",
   },
   {
     uiTableName: "Count Traces",
@@ -86,6 +88,8 @@ export const sessionCols: UiColumnMapping[] = [
     uiTableId: "sessionDuration",
     clickhouseTableName: "traces",
     clickhouseSelect: "duration",
+    // If we use the default of Decimal64(12), we cannot filter for more than ~40min due to an overflow
+    clickhouseTypeOverwrite: "Decimal64(3)",
   },
   {
     uiTableName: "Traces Count",


### PR DESCRIPTION
## What

Prevent a decimal overflow for sessions that are longer than 40min by changing the clickhouse type mapping.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adjusts ClickHouse type mapping for `sessionDuration` in `mapSessionTable.ts` to prevent overflow for sessions longer than 40 minutes.
> 
>   - **Behavior**:
>     - Adjusts ClickHouse type mapping for `sessionDuration` in `mapSessionTable.ts` to prevent overflow for sessions longer than 40 minutes.
>     - Changes `clickhouseTypeOverwrite` from `Decimal64(12)` to `Decimal64(3)` for `sessionDuration`.
>   - **Misc**:
>     - Fixes typo in comment in `mapSessionTable.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d8daf6bb7944dd58b6aefbdff76c64a0a36a8f4c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->