### PR TITLE
feat: redirect ingestion traffic for specific projects to secondary queue

### DIFF
--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -112,6 +112,7 @@ export enum QueueName {
   DatasetRunItemUpsert = "dataset-run-item-upsert-queue",
   BatchExport = "batch-export-queue",
   IngestionQueue = "ingestion-queue", // Process single events with S3-merge
+  IngestionSecondaryQueue = "secondary-ingestion-queue", // Separates high priority + high throughput projects from other projects.
   LegacyIngestionQueue = "legacy-ingestion-queue", // Used for batch processing of Ingestion
   CloudUsageMeteringQueue = "cloud-usage-metering-queue",
   ExperimentCreate = "experiment-create-queue",
@@ -129,6 +130,7 @@ export enum QueueJobs {
   LegacyIngestionJob = "legacy-ingestion-job",
   CloudUsageMeteringJob = "cloud-usage-metering-job",
   IngestionJob = "ingestion-job",
+  IngestionSecondaryJob = "secondary-ingestion-job",
   ExperimentCreateJob = "experiment-create-job",
   PostHogIntegrationJob = "posthog-integration-job",
   PostHogIntegrationProcessingJob = "posthog-integration-processing-job",
@@ -178,6 +180,12 @@ export type TQueueJobTypes = {
     name: QueueJobs.LegacyIngestionJob;
   };
   [QueueName.IngestionQueue]: {
+    timestamp: Date;
+    id: string;
+    payload: IngestionEventQueueType;
+    name: QueueJobs.IngestionJob;
+  };
+  [QueueName.IngestionSecondaryQueue]: {
     timestamp: Date;
     id: string;
     payload: IngestionEventQueueType;

--- a/packages/shared/src/server/redis/getQueue.ts
+++ b/packages/shared/src/server/redis/getQueue.ts
@@ -5,7 +5,7 @@ import { CloudUsageMeteringQueue } from "./cloudUsageMeteringQueue";
 import { DatasetRunItemUpsertQueue } from "./datasetRunItemUpsert";
 import { EvalExecutionQueue } from "./evalExecutionQueue";
 import { ExperimentCreateQueue } from "./experimentCreateQueue";
-import { IngestionQueue } from "./ingestionQueue";
+import { IngestionQueue, SecondaryIngestionQueue } from "./ingestionQueue";
 import { LegacyIngestionQueue } from "./legacyIngestion";
 import { TraceUpsertQueue } from "./traceUpsert";
 import { TraceDeleteQueue } from "./traceDelete";
@@ -39,6 +39,8 @@ export function getQueue(queueName: QueueName): Queue | null {
       return PostHogIntegrationQueue.getInstance();
     case QueueName.PostHogIntegrationProcessingQueue:
       return PostHogIntegrationProcessingQueue.getInstance();
+    case QueueName.IngestionSecondaryQueue:
+      return SecondaryIngestionQueue.getInstance();
     default:
       const exhaustiveCheckDefault: never = queueName;
       throw new Error(`Queue ${queueName} not found`);

--- a/packages/shared/src/server/redis/ingestionQueue.ts
+++ b/packages/shared/src/server/redis/ingestionQueue.ts
@@ -43,3 +43,45 @@ export class IngestionQueue {
     return IngestionQueue.instance;
   }
 }
+
+export class SecondaryIngestionQueue {
+  private static instance: Queue<
+    TQueueJobTypes[QueueName.IngestionSecondaryQueue]
+  > | null = null;
+
+  public static getInstance(): Queue<
+    TQueueJobTypes[QueueName.IngestionSecondaryQueue]
+  > | null {
+    if (SecondaryIngestionQueue.instance)
+      return SecondaryIngestionQueue.instance;
+
+    const newRedis = createNewRedisInstance({
+      enableOfflineQueue: false,
+      ...redisQueueRetryOptions,
+    });
+
+    SecondaryIngestionQueue.instance = newRedis
+      ? new Queue<TQueueJobTypes[QueueName.IngestionSecondaryQueue]>(
+          QueueName.IngestionSecondaryQueue,
+          {
+            connection: newRedis,
+            defaultJobOptions: {
+              removeOnComplete: true,
+              removeOnFail: 100_000,
+              attempts: 5,
+              backoff: {
+                type: "exponential",
+                delay: 5000,
+              },
+            },
+          },
+        )
+      : null;
+
+    SecondaryIngestionQueue.instance?.on("error", (err) => {
+      logger.error("SecondaryIngestionQueue error", err);
+    });
+
+    return SecondaryIngestionQueue.instance;
+  }
+}

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -128,6 +128,17 @@ if (env.QUEUE_CONSUMER_INGESTION_QUEUE_IS_ENABLED === "true") {
   });
 }
 
+if (env.QUEUE_CONSUMER_INGESTION_SECONDARY_QUEUE_IS_ENABLED === "true") {
+  WorkerManager.register(
+    QueueName.IngestionSecondaryQueue,
+    ingestionQueueProcessor,
+    {
+      concurrency:
+        env.LANGFUSE_INGESTION_SECONDARY_QUEUE_PROCESSING_CONCURRENCY,
+    },
+  );
+}
+
 if (
   env.QUEUE_CONSUMER_CLOUD_USAGE_METERING_QUEUE_IS_ENABLED === "true" &&
   env.STRIPE_SECRET_KEY

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -132,7 +132,7 @@ if (env.QUEUE_CONSUMER_INGESTION_QUEUE_IS_ENABLED === "true") {
   );
 }
 
-if (env.QUEUE_CONSUMER_INGESTION_SECONDARY_QUEUE_IS_ENABLED === "true") {
+if (env.QUEUE_CONSUMER_INGESTION_QUEUE_IS_ENABLED === "true") {
   WorkerManager.register(
     QueueName.IngestionSecondaryQueue,
     ingestionQueueProcessorBuilder(false),

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -26,7 +26,7 @@ import {
   PostHogIntegrationQueue,
 } from "@langfuse/shared/src/server";
 import { env } from "./env";
-import { ingestionQueueProcessor } from "./queues/ingestionQueue";
+import { ingestionQueueProcessorBuilder } from "./queues/ingestionQueue";
 import { BackgroundMigrationManager } from "./backgroundMigrations/backgroundMigrationManager";
 import { experimentCreateQueueProcessor } from "./queues/experimentQueue";
 import { traceDeleteProcessor } from "./queues/traceDelete";
@@ -123,15 +123,19 @@ if (env.QUEUE_CONSUMER_BATCH_EXPORT_QUEUE_IS_ENABLED === "true") {
 }
 
 if (env.QUEUE_CONSUMER_INGESTION_QUEUE_IS_ENABLED === "true") {
-  WorkerManager.register(QueueName.IngestionQueue, ingestionQueueProcessor, {
-    concurrency: env.LANGFUSE_INGESTION_QUEUE_PROCESSING_CONCURRENCY,
-  });
+  WorkerManager.register(
+    QueueName.IngestionQueue,
+    ingestionQueueProcessorBuilder(true), // this might redirect to secondary queue
+    {
+      concurrency: env.LANGFUSE_INGESTION_QUEUE_PROCESSING_CONCURRENCY,
+    },
+  );
 }
 
 if (env.QUEUE_CONSUMER_INGESTION_SECONDARY_QUEUE_IS_ENABLED === "true") {
   WorkerManager.register(
     QueueName.IngestionSecondaryQueue,
-    ingestionQueueProcessor,
+    ingestionQueueProcessorBuilder(false),
     {
       concurrency:
         env.LANGFUSE_INGESTION_SECONDARY_QUEUE_PROCESSING_CONCURRENCY,

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -49,6 +49,11 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(20),
+  LANGFUSE_INGESTION_SECONDARY_QUEUE_PROCESSING_CONCURRENCY: z.coerce
+    .number()
+    .positive()
+    .default(20),
+  LANGFUSE_SECONDARY_INGESTION_QUEUE_ENABLED_PROJECT_IDS: z.string().optional(),
   LANGFUSE_INGESTION_CLICKHOUSE_WRITE_BATCH_SIZE: z.coerce
     .number()
     .positive()
@@ -142,6 +147,9 @@ const EnvSchema = z.object({
     .enum(["true", "false"])
     .default("true"),
   QUEUE_CONSUMER_POSTHOG_INTEGRATION_QUEUE_IS_ENABLED: z
+    .enum(["true", "false"])
+    .default("true"),
+  QUEUE_CONSUMER_INGESTION_SECONDARY_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])
     .default("true"),
   LANGFUSE_POSTGRES_INGESTION_ENABLED: z

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -52,7 +52,7 @@ const EnvSchema = z.object({
   LANGFUSE_INGESTION_SECONDARY_QUEUE_PROCESSING_CONCURRENCY: z.coerce
     .number()
     .positive()
-    .default(20),
+    .default(5),
   LANGFUSE_SECONDARY_INGESTION_QUEUE_ENABLED_PROJECT_IDS: z.string().optional(),
   LANGFUSE_INGESTION_CLICKHOUSE_WRITE_BATCH_SIZE: z.coerce
     .number()
@@ -147,9 +147,6 @@ const EnvSchema = z.object({
     .enum(["true", "false"])
     .default("true"),
   QUEUE_CONSUMER_POSTHOG_INTEGRATION_QUEUE_IS_ENABLED: z
-    .enum(["true", "false"])
-    .default("true"),
-  QUEUE_CONSUMER_INGESTION_SECONDARY_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])
     .default("true"),
   LANGFUSE_POSTGRES_INGESTION_ENABLED: z

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -11,6 +11,7 @@ import {
   clickhouseClient,
   getClickhouseEntityType,
   getCurrentSpan,
+  getQueue,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 
@@ -34,78 +35,101 @@ const getS3StorageServiceClient = (bucketName: string): StorageService => {
   return s3StorageServiceClient;
 };
 
-export const ingestionQueueProcessor: Processor = async (
-  job: Job<TQueueJobTypes[QueueName.IngestionQueue]>,
-) => {
-  try {
-    const span = getCurrentSpan();
-    if (span) {
-      span.setAttribute("messaging.bullmq.job.input.id", job.data.id);
-      span.setAttribute(
-        "messaging.bullmq.job.input.projectId",
+export const ingestionQueueProcessorBuilder = (
+  enableRedirectToSecondaryQueue: boolean,
+): Processor => {
+  const projectIdsToRedirectToSecondaryQueue =
+    env.LANGFUSE_SECONDARY_INGESTION_QUEUE_ENABLED_PROJECT_IDS?.split(",") ??
+    [];
+
+  return async (job: Job<TQueueJobTypes[QueueName.IngestionQueue]>) => {
+    try {
+      const span = getCurrentSpan();
+      if (span) {
+        span.setAttribute("messaging.bullmq.job.input.id", job.data.id);
+        span.setAttribute(
+          "messaging.bullmq.job.input.projectId",
+          job.data.payload.authCheck.scope.projectId,
+        );
+        span.setAttribute(
+          "messaging.bullmq.job.input.eventBodyId",
+          job.data.payload.data.eventBodyId,
+        );
+        span.setAttribute(
+          "messaging.bullmq.job.input.type",
+          job.data.payload.data.type,
+        );
+      }
+
+      if (
+        enableRedirectToSecondaryQueue &&
+        projectIdsToRedirectToSecondaryQueue.includes(
+          job.data.payload.authCheck.scope.projectId,
+        )
+      ) {
+        logger.debug(
+          `Redirecting ingestion event to secondary queue for project ${job.data.payload.authCheck.scope.projectId}`,
+        );
+        const secondaryQueue = getQueue(QueueName.IngestionSecondaryQueue);
+        if (secondaryQueue) {
+          await secondaryQueue.add(QueueName.IngestionSecondaryQueue, job.data);
+        }
+        return;
+        // If we don't redirect, we continue with the ingestion. Otherwise, we finish here.
+      }
+
+      const s3Client = getS3StorageServiceClient(
+        env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+      );
+
+      logger.info("Processing ingestion event", {
+        projectId: job.data.payload.authCheck.scope.projectId,
+        payload: job.data.payload.data,
+      });
+
+      // Download all events from folder into a local array
+      const eventFiles = await s3Client.listFiles(
+        `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${getClickhouseEntityType(job.data.payload.data.type)}/${job.data.payload.data.eventBodyId}/`,
+      );
+
+      const events: IngestionEventType[] = (
+        await Promise.all(
+          eventFiles.map(async (key) => {
+            const file = await s3Client.download(key);
+            const parsedFile = JSON.parse(file);
+            return Array.isArray(parsedFile) ? parsedFile : [parsedFile];
+          }),
+        )
+      ).flat();
+
+      if (events.length === 0) {
+        logger.warn(
+          `No events found for project ${job.data.payload.authCheck.scope.projectId} and event ${job.data.payload.data.eventBodyId}`,
+        );
+        return;
+      }
+
+      // Perform merge of those events
+      if (!redis) throw new Error("Redis not available");
+      if (!prisma) throw new Error("Prisma not available");
+      await new IngestionService(
+        redis,
+        prisma,
+        ClickhouseWriter.getInstance(),
+        clickhouseClient(),
+      ).mergeAndWrite(
+        getClickhouseEntityType(events[0].type),
         job.data.payload.authCheck.scope.projectId,
-      );
-      span.setAttribute(
-        "messaging.bullmq.job.input.eventBodyId",
         job.data.payload.data.eventBodyId,
+        events,
       );
-      span.setAttribute(
-        "messaging.bullmq.job.input.type",
-        job.data.payload.data.type,
+    } catch (e) {
+      logger.error(
+        `Failed job ingestion processing for ${job.data.payload.authCheck.scope.projectId}`,
+        e,
       );
+      traceException(e);
+      throw e;
     }
-
-    const s3Client = getS3StorageServiceClient(
-      env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
-    );
-
-    logger.info("Processing ingestion event", {
-      projectId: job.data.payload.authCheck.scope.projectId,
-      payload: job.data.payload.data,
-    });
-
-    // Download all events from folder into a local array
-    const eventFiles = await s3Client.listFiles(
-      `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${getClickhouseEntityType(job.data.payload.data.type)}/${job.data.payload.data.eventBodyId}/`,
-    );
-
-    const events: IngestionEventType[] = (
-      await Promise.all(
-        eventFiles.map(async (key) => {
-          const file = await s3Client.download(key);
-          const parsedFile = JSON.parse(file);
-          return Array.isArray(parsedFile) ? parsedFile : [parsedFile];
-        }),
-      )
-    ).flat();
-
-    if (events.length === 0) {
-      logger.warn(
-        `No events found for project ${job.data.payload.authCheck.scope.projectId} and event ${job.data.payload.data.eventBodyId}`,
-      );
-      return;
-    }
-
-    // Perform merge of those events
-    if (!redis) throw new Error("Redis not available");
-    if (!prisma) throw new Error("Prisma not available");
-    await new IngestionService(
-      redis,
-      prisma,
-      ClickhouseWriter.getInstance(),
-      clickhouseClient(),
-    ).mergeAndWrite(
-      getClickhouseEntityType(events[0].type),
-      job.data.payload.authCheck.scope.projectId,
-      job.data.payload.data.eventBodyId,
-      events,
-    );
-  } catch (e) {
-    logger.error(
-      `Failed job ingestion processing for ${job.data.payload.authCheck.scope.projectId}`,
-      e,
-    );
-    traceException(e);
-    throw e;
-  }
+  };
 };

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -84,7 +84,7 @@ export const ingestionQueueProcessorBuilder = (
 
       logger.info(
         `Processing ingestion event ${
-          enableRedirectToSecondaryQueue === true ? "" : "secondary"
+          enableRedirectToSecondaryQueue ? "" : "secondary"
         }`,
         {
           projectId: job.data.payload.authCheck.scope.projectId,

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -82,10 +82,15 @@ export const ingestionQueueProcessorBuilder = (
         env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
       );
 
-      logger.info("Processing ingestion event", {
-        projectId: job.data.payload.authCheck.scope.projectId,
-        payload: job.data.payload.data,
-      });
+      logger.info(
+        `Processing ingestion event ${
+          enableRedirectToSecondaryQueue === true ? "" : "secondary"
+        }`,
+        {
+          projectId: job.data.payload.authCheck.scope.projectId,
+          payload: job.data.payload.data,
+        },
+      );
 
       // Download all events from folder into a local array
       const eventFiles = await s3Client.listFiles(

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -73,9 +73,9 @@ export const ingestionQueueProcessorBuilder = (
         const secondaryQueue = getQueue(QueueName.IngestionSecondaryQueue);
         if (secondaryQueue) {
           await secondaryQueue.add(QueueName.IngestionSecondaryQueue, job.data);
+          // If we don't redirect, we continue with the ingestion. Otherwise, we finish here.
+          return;
         }
-        return;
-        // If we don't redirect, we continue with the ingestion. Otherwise, we finish here.
       }
 
       const s3Client = getS3StorageServiceClient(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduce a secondary ingestion queue to handle specific high-priority projects separately, with updates to queue management, ingestion processing, and environment configurations.
> 
>   - **Queues**:
>     - Add `IngestionSecondaryQueue` to `QueueName` and `QueueJobs` enums in `queues.ts`.
>     - Implement `SecondaryIngestionQueue` class in `ingestionQueue.ts`.
>     - Update `getQueue()` in `getQueue.ts` to handle `IngestionSecondaryQueue`.
>   - **Ingestion Processing**:
>     - Modify `ingestionQueueProcessorBuilder()` in `ingestionQueue.ts` to optionally redirect jobs to `IngestionSecondaryQueue` based on project ID.
>     - Add logic to handle ingestion events in `ingestionQueue.ts`, including S3 file processing and event merging.
>   - **Environment**:
>     - Add `LANGFUSE_INGESTION_SECONDARY_QUEUE_PROCESSING_CONCURRENCY` and `LANGFUSE_SECONDARY_INGESTION_QUEUE_ENABLED_PROJECT_IDS` to `env.ts`.
>     - Add `QUEUE_CONSUMER_INGESTION_SECONDARY_QUEUE_IS_ENABLED` to `env.ts`.
>   - **Worker Management**:
>     - Register `IngestionSecondaryQueue` in `app.ts` with concurrency settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7c6722ac252b81a3056e0430b454152fba9f4602. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->