### PR TITLE
fix: fix time to first token in trace detail view

### DIFF
--- a/packages/shared/src/server/repositories/observations_converters.ts
+++ b/packages/shared/src/server/repositories/observations_converters.ts
@@ -126,10 +126,11 @@ export const convertObservation = (
         parseClickhouseUTCDateTimeFormat(record.start_time).getTime()
       : null,
     timeToFirstToken: record.completion_start_time
-      ? parseClickhouseUTCDateTimeFormat(
+      ? (parseClickhouseUTCDateTimeFormat(
           record.completion_start_time,
         ).getTime() -
-        parseClickhouseUTCDateTimeFormat(record.start_time).getTime()
+          parseClickhouseUTCDateTimeFormat(record.start_time).getTime()) /
+        1000
       : null,
   };
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `timeToFirstToken` calculation in `convertObservation` to convert milliseconds to seconds.
> 
>   - **Behavior**:
>     - Fix `timeToFirstToken` calculation in `convertObservation` in `observations_converters.ts` to convert milliseconds to seconds by dividing by 1000.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f50942a3cf3c34a86ae82961a6bbe7c6ef91bd27. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->