### PR TITLE
fix(cloud): remove unnecessary posthog events

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -48,7 +48,7 @@ const reportToHeader = {
 /** @type {import("next").NextConfig} */
 const nextConfig = {
   transpilePackages: ["@langfuse/shared"],
-  reactStrictMode: true,
+  reactStrictMode: false,
   experimental: {
     instrumentationHook: true,
     serverComponentsExternalPackages: [

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -48,7 +48,7 @@ const reportToHeader = {
 /** @type {import("next").NextConfig} */
 const nextConfig = {
   transpilePackages: ["@langfuse/shared"],
-  reactStrictMode: false,
+  reactStrictMode: true,
   experimental: {
     instrumentationHook: true,
     serverComponentsExternalPackages: [

--- a/web/src/features/setup/components/SetupTracingButton.tsx
+++ b/web/src/features/setup/components/SetupTracingButton.tsx
@@ -6,7 +6,7 @@ import { setupTracingRoute } from "@/src/features/setup/setupRoutes";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { LockIcon } from "lucide-react";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 const SetupTracingButton = () => {
@@ -27,10 +27,13 @@ const SetupTracingButton = () => {
     },
   );
 
+  // dedupe result via useRef, otherwise we'll capture the event multiple times on session refresh
+  const capturedEventAlready = useRef<boolean | undefined>(undefined);
   const capture = usePostHogClientCapture();
   useEffect(() => {
-    if (hasAnyTrace !== undefined) {
+    if (hasAnyTrace !== undefined && !capturedEventAlready.current) {
       capture("onboarding:tracing_check_active", { active: hasAnyTrace });
+      capturedEventAlready.current = true;
     }
   }, [hasAnyTrace, capture]);
 


### PR DESCRIPTION
- remove posthog heatmaps
- stop sending identify, groupidentify and onboarding:tracing_check_active events when auth session is refreshed
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Disable PostHog heatmaps and prevent certain events on session refresh with deduplication logic in `SetupTracingButton.tsx` and `_app.tsx`.
> 
>   - **Behavior**:
>     - Disable PostHog heatmaps in `_app.tsx`.
>     - Prevent `identify`, `groupidentify`, and `onboarding:tracing_check_active` events on session refresh in `SetupTracingButton.tsx` and `UserTracking()` in `_app.tsx`.
>   - **Code Changes**:
>     - Use `useRef` to deduplicate event captures in `SetupTracingButton.tsx` and `UserTracking()` in `_app.tsx`.
>     - Change `reactStrictMode` to `false` in `next.config.mjs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c76ea954d2f4b95435b9f43f7b8747f07eb16e02. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->