### PR TITLE
chore(ui): move dataset details into popover on runs table

### DIFF
--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
@@ -7,7 +7,6 @@ import Link from "next/link";
 import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 import { DatasetActionButton } from "@/src/features/datasets/components/DatasetActionButton";
 import { DeleteButton } from "@/src/components/deleteButton";
-import { JSONView } from "@/src/components/ui/CodeJsonViewer";
 import { FullScreenPage } from "@/src/components/layouts/full-screen-page";
 import { DuplicateDatasetButton } from "@/src/features/datasets/components/DuplicateDatasetButton";
 import { useState } from "react";

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
@@ -12,7 +12,7 @@ import { FullScreenPage } from "@/src/components/layouts/full-screen-page";
 import { DuplicateDatasetButton } from "@/src/features/datasets/components/DuplicateDatasetButton";
 import { useState } from "react";
 import { MultiSelectKeyValues } from "@/src/features/scores/components/multi-select-key-values";
-import { ExternalLink, FlaskConical } from "lucide-react";
+import { ExternalLink, FlaskConical, FolderKanban } from "lucide-react";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { useMemo } from "react";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
@@ -27,6 +27,12 @@ import { showSuccessToast } from "@/src/features/notifications/showSuccessToast"
 import { DropdownMenuItem } from "@/src/components/ui/dropdown-menu";
 import { DatasetAnalytics } from "@/src/features/datasets/components/DatasetAnalytics";
 import { RESOURCE_METRICS } from "@/src/features/dashboard/lib/score-analytics-utils";
+import { MarkdownOrJsonView } from "@/src/components/trace/IOPreview";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/src/components/ui/popover";
 
 export default function Dataset() {
   const router = useRouter();
@@ -178,6 +184,30 @@ export default function Dataset() {
                 }
               />
             )}
+            <Popover key="show-dataset-details">
+              <PopoverTrigger asChild>
+                <Button variant="outline">
+                  <FolderKanban className="mr-2 h-4 w-4" />
+                  Dataset details
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="mx-2 max-h-[50vh] w-[50vw] overflow-y-auto md:w-[25vw]">
+                <div className="space-y-4">
+                  <div>
+                    <h4 className="mb-1 font-medium">Description</h4>
+                    <span className="text-sm text-muted-foreground">
+                      {dataset.data?.description ?? "No description"}
+                    </span>
+                  </div>
+                  <div>
+                    <h4 className="mb-1 font-medium">Metadata</h4>
+                    <MarkdownOrJsonView
+                      content={dataset.data?.metadata ?? null}
+                    />
+                  </div>
+                </div>
+              </PopoverContent>
+            </Popover>
             <DetailPageNav
               currentId={datasetId}
               path={(entry) => `/project/${projectId}/datasets/${entry.id}`}
@@ -209,13 +239,6 @@ export default function Dataset() {
           </>
         }
       />
-      {!!dataset.data?.metadata && (
-        <JSONView
-          json={dataset?.data.metadata}
-          title="Metadata"
-          className="max-h-[25vh] overflow-y-auto"
-        />
-      )}
 
       <DatasetRunsTable
         projectId={projectId}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Move dataset details into a popover on the runs table page, replacing the inline JSON view with a popover display in `index.tsx`.
> 
>   - **UI Changes**:
>     - Added `Popover` for dataset details in `index.tsx`.
>     - Displays dataset description and metadata using `PopoverContent`.
>     - Removed inline `JSONView` for metadata display.
>   - **Imports**:
>     - Added `FolderKanban` icon from `lucide-react`.
>     - Added `Popover`, `PopoverContent`, `PopoverTrigger` from `ui/popover`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8e827991b2a6849f2b5ddece38c90fbe1fbb19bb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->