### PR TITLE
fix: add latencies to trace exports

### DIFF
--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -244,7 +244,7 @@ describe("Fetch datasets for UI presentation", () => {
     expect(JSON.stringify(secondRun.scores)).toEqual(JSON.stringify({}));
   });
 
-  it.only("should test that dataset runs can link to the same traces", async () => {
+  it("should test that dataset runs can link to the same traces", async () => {
     const datasetId = v4();
 
     await prisma.dataset.create({

--- a/worker/src/__tests__/batch-export.test.ts
+++ b/worker/src/__tests__/batch-export.test.ts
@@ -332,7 +332,7 @@ describe("batch export test suite", () => {
     );
   });
 
-  it.only("should export traces", async () => {
+  it("should export traces", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
 
     const traces = [

--- a/worker/src/__tests__/batch-export.test.ts
+++ b/worker/src/__tests__/batch-export.test.ts
@@ -332,7 +332,7 @@ describe("batch export test suite", () => {
     );
   });
 
-  it("should export traces", async () => {
+  it.only("should export traces", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
 
     const traces = [
@@ -353,16 +353,22 @@ describe("batch export test suite", () => {
         project_id: projectId,
         trace_id: traces[0].id,
         type: "GENERATION",
+        start_time: new Date().getTime() - 1000,
+        end_time: new Date().getTime(),
       }),
       createObservation({
         project_id: projectId,
         trace_id: traces[1].id,
         type: "GENERATION",
+        start_time: new Date().getTime() - 2000,
+        end_time: new Date().getTime(),
       }),
       createObservation({
         project_id: projectId,
         trace_id: traces[1].id,
         type: "GENERATION",
+        start_time: new Date().getTime() - 2123,
+        end_time: new Date().getTime(),
       }),
     ];
 
@@ -397,10 +403,12 @@ describe("batch export test suite", () => {
       expect.arrayContaining([
         expect.objectContaining({
           id: traces[0].id,
+          latency: 1,
           test: [score.value],
         }),
         expect.objectContaining({
           id: traces[1].id,
+          latency: 2.123,
         }),
       ]),
     );

--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -401,6 +401,7 @@ export const getDatabaseReadStream = async ({
                 input: fullTrace?.input,
                 output: fullTrace?.output,
                 metadata: fullTrace?.metadata,
+                latency: metric?.latency,
                 name: t.name ?? "",
                 usage: {
                   promptTokens: metric?.promptTokens,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds latency calculation to trace exports and updates tests to verify latency values in `handleBatchExportJob.ts` and `batch-export.test.ts`.
> 
>   - **Behavior**:
>     - Adds latency calculation to trace exports in `getDatabaseReadStream` in `handleBatchExportJob.ts`.
>     - Updates test `should export traces` in `batch-export.test.ts` to check for latency values.
>   - **Tests**:
>     - Modifies `should export traces` test to include `start_time` and `end_time` for latency calculation.
>     - Removes `it.only` from a test in `dataset-service.servertest.ts`.
>   - **Misc**:
>     - Adds `latency` field to the trace export data structure in `handleBatchExportJob.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d1c0022e97182f2f33ee38f7a1d268af26d7058a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->