### PR TITLE
chore(ui): toggle json editor for text prompts

### DIFF
--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -48,6 +48,7 @@ import { PRODUCTION_LABEL } from "@/src/features/prompts/constants";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import usePlaygroundCache from "@/src/ee/features/playground/page/hooks/usePlaygroundCache";
 import { useQueryParam } from "use-query-params";
+import { Switch } from "@/src/components/ui/switch";
 
 type NewPromptFormProps = {
   initialPrompt?: Prompt | null;
@@ -61,6 +62,7 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
   const [formError, setFormError] = useState<string | null>(null);
   const { playgroundCache } = usePlaygroundCache();
   const [initialMessages, setInitialMessages] = useState<unknown>([]);
+  const [showJsonEditor, setShowJsonEditor] = useState(false);
 
   const utils = api.useUtils();
   const capture = usePostHogClientCapture();
@@ -250,7 +252,24 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
         {/* Prompt content field - text vs. chat */}
         <>
           <FormItem>
-            <FormLabel>Prompt</FormLabel>
+            <FormLabel className="flex flex-row items-center justify-between">
+              <div>Prompt</div>
+              {form.watch("type") === PromptType.Text ? (
+                <div className="flex flex-row items-center">
+                  <p className="mr-1 text-xs text-muted-foreground">
+                    JSON editor
+                  </p>
+
+                  <Switch
+                    checked={showJsonEditor}
+                    className={
+                      showJsonEditor ? "data-[state=checked]:bg-dark-green" : ""
+                    }
+                    onCheckedChange={setShowJsonEditor}
+                  />
+                </div>
+              ) : null}
+            </FormLabel>
             <Tabs
               value={form.watch("type")}
               onValueChange={(e) => {
@@ -288,10 +307,18 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
                   render={({ field }) => (
                     <>
                       <FormControl>
-                        <Textarea
-                          {...field}
-                          className="min-h-[200px] flex-1 font-mono text-xs"
-                        />
+                        {showJsonEditor ? (
+                          <JsonEditor
+                            defaultValue={field.value}
+                            onChange={field.onChange}
+                            editable
+                          />
+                        ) : (
+                          <Textarea
+                            {...field}
+                            className="min-h-[200px] flex-1 font-mono text-xs"
+                          />
+                        )}
                       </FormControl>
                       <FormMessage />
                     </>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a toggle switch to enable a JSON editor for text prompts in `NewPromptForm`.
> 
>   - **UI Enhancement**:
>     - Adds a `Switch` component to toggle JSON editor for text prompts in `NewPromptForm`.
>     - JSON editor is enabled only for `PromptType.Text`.
>   - **Behavior**:
>     - When `showJsonEditor` is true, `JsonEditor` is used instead of `Textarea` for text prompts.
>     - Toggle is not available for `PromptType.Chat`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 23fe5559129862a231873824e4f286acc364f626. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->