### PR TITLE
fix: include time filter into user metrics query

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -680,10 +680,25 @@ export const getTotalUserCount = async (
   });
 };
 
-export const getUserMetrics = async (projectId: string, userIds: string[]) => {
+export const getUserMetrics = async (
+  projectId: string,
+  userIds: string[],
+  filter: FilterState,
+) => {
   if (userIds.length === 0) {
     return [];
   }
+
+  // filter state contains date range filter for traces so far.
+  const chFilter = new FilterList(
+    createFilterFromFilterState(filter, tracesTableUiColumnDefinitions),
+  );
+  const chFilterRes = chFilter.apply();
+
+  const timestampFilter = chFilter.find(
+    (f) => f.field === "timestamp" && f.operator === ">=",
+  );
+
   // this query uses window functions on observations + traces to always get only the first row and thereby remove deduplicates
   // we filter wherever possible by project id and user id
   const query = `
@@ -713,6 +728,7 @@ export const getUserMetrics = async (projectId: string, userIds: string[]) => {
                     observations o
                 WHERE
                     o.project_id = {projectId: String }
+                    ${timestampFilter ? `AND o.start_time >= {traceTimestamp: DateTime64(3)} - ${OBSERVATIONS_TO_TRACE_INTERVAL}` : ""}
                     AND o.trace_id in (
                         SELECT
                             distinct id
@@ -721,6 +737,7 @@ export const getUserMetrics = async (projectId: string, userIds: string[]) => {
                         where
                             user_id IN ({userIds: Array(String) })
                             AND project_id = {projectId: String }
+                            ${filter.length > 0 ? `AND ${chFilterRes.query}` : ""}
                     )
                     AND o.type = 'GENERATION'
             ) as o
@@ -740,6 +757,7 @@ export const getUserMetrics = async (projectId: string, userIds: string[]) => {
                 WHERE
                     t.user_id IN ({userIds: Array(String) })
                     AND t.project_id = {projectId: String }
+                    ${filter.length > 0 ? `AND ${chFilterRes.query}` : ""}
             ) as t on t.id = o.trace_id
             and t.project_id = o.project_id
         WHERE
@@ -762,6 +780,7 @@ export const getUserMetrics = async (projectId: string, userIds: string[]) => {
         stats
 
   `;
+  console.log(query);
 
   const rows = await queryClickhouse<{
     user_id: string;
@@ -778,8 +797,18 @@ export const getUserMetrics = async (projectId: string, userIds: string[]) => {
     params: {
       projectId,
       userIds,
+      ...chFilterRes.params,
+      ...(timestampFilter
+        ? {
+            traceTimestamp: convertDateToClickhouseDateTime(
+              (timestampFilter as DateTimeFilter).value,
+            ),
+          }
+        : {}),
     },
   });
+
+  console.log(rows);
   return rows.map((row) => ({
     userId: row.user_id,
     maxTimestamp: parseClickhouseUTCDateTimeFormat(row.max_timestamp),

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -780,7 +780,6 @@ export const getUserMetrics = async (
         stats
 
   `;
-  console.log(query);
 
   const rows = await queryClickhouse<{
     user_id: string;
@@ -808,7 +807,6 @@ export const getUserMetrics = async (
     },
   });
 
-  console.log(rows);
   return rows.map((row) => ({
     userId: row.user_id,
     maxTimestamp: parseClickhouseUTCDateTimeFormat(row.max_timestamp),

--- a/web/src/__tests__/async/users-ui-table.servertest.ts
+++ b/web/src/__tests__/async/users-ui-table.servertest.ts
@@ -52,7 +52,7 @@ describe("getUserMetrics function", () => {
 
     await createObservationsInClickhouse([observation1, observation2]);
 
-    const userMetrics = await getUserMetrics(projectId, [userId]);
+    const userMetrics = await getUserMetrics(projectId, [userId], []);
 
     expect(userMetrics.length).toBe(1);
     expect(userMetrics[0]).toMatchObject({

--- a/web/src/pages/project/[projectId]/users.tsx
+++ b/web/src/pages/project/[projectId]/users.tsx
@@ -89,6 +89,7 @@ export default function UsersPage() {
       projectId,
       userIds: users.data?.users.map((u) => u.userId) ?? [],
       queryClickhouse: useClickhouse(),
+      filter: filterState,
     },
     {
       enabled: users.isSuccess,

--- a/web/src/server/api/routers/users.ts
+++ b/web/src/server/api/routers/users.ts
@@ -121,6 +121,7 @@ export const userRouter = createTRPCRouter({
         projectId: z.string(),
         userIds: z.array(z.string().min(1)),
         queryClickhouse: z.boolean().default(false),
+        filter: z.array(singleFilter).nullable(),
       }),
     )
     .query(async ({ input, ctx }) => {
@@ -182,7 +183,11 @@ export const userRouter = createTRPCRouter({
           if (input.userIds.length === 0) {
             return [];
           }
-          const metrics = await getUserMetrics(input.projectId, input.userIds);
+          const metrics = await getUserMetrics(
+            input.projectId,
+            input.userIds,
+            input.filter ?? [],
+          );
 
           return metrics.map((metric) => ({
             userId: metric.userId,
@@ -262,7 +267,7 @@ export const userRouter = createTRPCRouter({
         },
         clickhouseExecution: async () => {
           const result = (
-            await getUserMetrics(input.projectId, [input.userId])
+            await getUserMetrics(input.projectId, [input.userId], [])
           ).shift();
 
           return {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add time filtering to user metrics queries in `traces.ts`, updating related API calls in `users.tsx` and `users.ts`.
> 
>   - **Behavior**:
>     - Add `filter` parameter to `getUserMetrics` in `traces.ts` for time filtering in user metrics queries.
>     - Update `getUserMetrics` query to apply `timestampFilter` and `chFilterRes.query` for filtering observations and traces.
>   - **API**:
>     - Update `users.tsx` to pass `filterState` to `api.users.metrics.useQuery` for time filtering.
>     - Modify `userRouter` in `users.ts` to include `filter` in `getUserMetrics` call for both `metrics` and `byId` procedures.
>   - **Misc**:
>     - Add `filter` parameter to `userRouter` input schema in `users.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ad0c3c29011c0fc85ad3c3346523af81df602564. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->