### PR TITLE
fix(ui): clarify what applying producation label to a new prompt does

### DIFF
--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -373,21 +373,25 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
           control={form.control}
           name="isActive"
           render={({ field }) => (
-            <FormItem className="flex flex-row items-center space-x-3 space-y-0 rounded-md border p-3">
-              <FormControl>
-                <Checkbox
-                  checked={field.value}
-                  onCheckedChange={field.onChange}
-                />
-              </FormControl>
-              <div className="space-y-1 leading-none">
-                <FormLabel>Serve prompt as default to SDKs</FormLabel>
-              </div>
-              {currentIsActive ? (
-                <div className="text-xs text-muted-foreground">
-                  This makes the prompt available to the SDKs immediately.
+            <FormItem>
+              <FormLabel>Labels</FormLabel>
+              <div className="flex flex-row items-center space-x-3 space-y-0 rounded-md border p-3">
+                <FormControl>
+                  <Checkbox
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                  />
+                </FormControl>
+                <div className="space-y-1 leading-none">
+                  <FormLabel>
+                    Apply the production label to this prompt immediately
+                  </FormLabel>
                 </div>
-              ) : null}
+              </div>
+              <FormDescription>
+                By setting the production label, the prompt will be available to
+                the SDKs immediately. You can update labels later.
+              </FormDescription>
             </FormItem>
           )}
         />

--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -89,7 +89,7 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
         : "",
     name: initialPrompt?.name ?? "",
     config: JSON.stringify(initialPrompt?.config?.valueOf(), null, 2) || "{}",
-    isActive: false,
+    isActive: !Boolean(initialPrompt),
   };
 
   const form = useForm<NewPromptFormSchemaType>({
@@ -99,7 +99,6 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
 
   const currentName = form.watch("name");
   const currentType = form.watch("type");
-  const currentIsActive = form.watch("isActive");
   const currentExtractedVariables = extractVariables(
     currentType === PromptType.Text
       ? form.watch("textPrompt")
@@ -383,14 +382,12 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
                   />
                 </FormControl>
                 <div className="space-y-1 leading-none">
-                  <FormLabel>
-                    Apply the production label to this prompt immediately
-                  </FormLabel>
+                  <FormLabel>Set the &quot;production&quot; label</FormLabel>
                 </div>
               </div>
               <FormDescription>
-                By setting the production label, the prompt will be available to
-                the SDKs immediately. You can update labels later.
+                This version will be labeled as the version to be used in
+                production for this prompt. Can be updated later.
               </FormDescription>
             </FormItem>
           )}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `NewPromptForm` to clarify `isActive` checkbox functionality with new label and description.
> 
>   - **UI Changes**:
>     - In `NewPromptForm`, update `isActive` checkbox label to "Set the 'production' label".
>     - Add `FormDescription` to clarify that the production label makes the prompt available to SDKs immediately and can be updated later.
>   - **Behavior**:
>     - Default `isActive` to `true` if `initialPrompt` is not provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 26ff431092353e42fad9d4263fcc9dcd524caf1a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->