### PR TITLE
feat(cloud): improve open/close state of support chat

### DIFF
--- a/web/src/features/setup/components/SetupPage.tsx
+++ b/web/src/features/setup/components/SetupPage.tsx
@@ -22,6 +22,7 @@ import {
   inviteMembersRoute,
   setupTracingRoute,
 } from "@/src/features/setup/setupRoutes";
+import { showChat } from "@/src/features/support-chat/chat";
 import { api } from "@/src/utils/api";
 import { cn } from "@/src/utils/tailwind";
 import { type RouterOutput } from "@/src/utils/types";
@@ -226,7 +227,10 @@ const TracingSetup = ({
   >(null);
   const utils = api.useUtils();
   const mutCreateApiKey = api.apiKeys.create.useMutation({
-    onSuccess: () => utils.apiKeys.invalidate(),
+    onSuccess: () => {
+      utils.apiKeys.invalidate();
+      showChat();
+    },
   });
   const isLoadingRef = useRef(false);
 


### PR DESCRIPTION
- hide chat by default
- show when opened manually or on incoming/unread messages
- persist in session storage for current session
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves support chat visibility by hiding it by default, showing it on specific triggers, and persisting its state in session storage.
> 
>   - **Behavior**:
>     - Chat is hidden by default and shown when manually opened or on incoming/unread messages in `chat.tsx`.
>     - Chat visibility state is persisted in session storage for the current session in `chat.tsx`.
>   - **Functions**:
>     - Introduces `showChat()` and `hideChat()` in `chat.tsx` to manage chat visibility.
>     - Calls `showChat()` on message receipt and after project creation in `chat.tsx` and `SetupPage.tsx`.
>   - **Misc**:
>     - Adds `showChat()` call in `mutCreateApiKey.onSuccess` in `SetupPage.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b744ac35e247fcf570220e9737bd09f6c46c9413. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->