### PR TITLE
chore(ui): remove dateRangeFilter on prompt metrics table as no longer necessary on CH

### DIFF
--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -698,7 +698,6 @@ export const promptRouter = createTRPCRouter({
       z.object({
         projectId: z.string(),
         promptIds: z.array(z.string()),
-        filter: z.array(singleFilter).nullish(),
         queryClickhouse: z.boolean().default(false),
       }),
     )
@@ -715,11 +714,6 @@ export const promptRouter = createTRPCRouter({
         user: ctx.session.user,
         pgExecution: async () => {
           if (input.promptIds.length === 0) return [];
-          const filterCondition = tableColumnsToSqlFilterAndPrefix(
-            input.filter ?? [],
-            observationsTableCols,
-            "prompts",
-          );
           const [metrics, generationScores, traceScores] = await Promise.all([
             // metrics
             ctx.prisma.$queryRaw<
@@ -751,7 +745,6 @@ export const promptRouter = createTRPCRouter({
                 o.prompt_id = p.id
                 AND "type" = 'GENERATION'
                 AND "project_id" = ${input.projectId}
-                ${filterCondition}
             ) AS observation_metrics ON true
             WHERE "project_id" = ${input.projectId}
             AND p.id in (${Prisma.join(input.promptIds)})
@@ -785,7 +778,6 @@ export const promptRouter = createTRPCRouter({
                 AND o.project_id = ${input.projectId}
                 AND s.name IS NOT NULL
                 AND p.id IN (${Prisma.join(input.promptIds)})
-                ${filterCondition}
               ) s ON TRUE
           WHERE
             p.project_id = ${input.projectId}
@@ -820,7 +812,6 @@ export const promptRouter = createTRPCRouter({
                     AND o.type = 'GENERATION'
                     AND o.project_id = ${input.projectId}
                     AND o.prompt_id IN (${Prisma.join(input.promptIds)})
-                    ${filterCondition}
                 )
                 AND s.observation_id IS NULL
                 AND s.project_id = ${input.projectId}

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -12,7 +12,7 @@ import {
 } from "@/src/server/api/trpc";
 import { type Prompt, Prisma } from "@langfuse/shared/src/db";
 import { createPrompt } from "../actions/createPrompt";
-import { observationsTableCols, type ScoreSimplified } from "@langfuse/shared";
+import { type ScoreSimplified } from "@langfuse/shared";
 import { promptsTableCols } from "@/src/server/api/definitions/promptsTable";
 import { optionalPaginationZod, paginationZod } from "@langfuse/shared";
 import { orderBy, singleFilter } from "@langfuse/shared";

--- a/web/src/pages/project/[projectId]/prompts/[promptName]/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/[promptName]/metrics.tsx
@@ -16,8 +16,7 @@ import { formatIntervalSeconds } from "@/src/utils/dates";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { verifyAndPrefixScoreDataAgainstKeys } from "@/src/features/scores/components/ScoreDetailColumnHelpers";
-import { type ScoreAggregate, type FilterState } from "@langfuse/shared";
-import { useTableDateRange } from "@/src/hooks/useTableDateRange";
+import { type ScoreAggregate } from "@langfuse/shared";
 import { useIndividualScoreColumns } from "@/src/features/scores/hooks/useIndividualScoreColumns";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 import { FullScreenPage } from "@/src/components/layouts/full-screen-page";
@@ -92,19 +91,7 @@ export default function PromptVersionTable() {
     "promptVersion",
     "s",
   );
-  const { selectedOption, dateRange, setDateRangeAndOption } =
-    useTableDateRange(projectId);
 
-  const dateRangeFilter: FilterState | null = dateRange?.from
-    ? [
-        {
-          column: "Start Time",
-          type: "datetime",
-          operator: ">=",
-          value: dateRange.from,
-        },
-      ]
-    : null;
   const promptVersions = api.prompts.allVersions.useQuery(
     {
       projectId: projectId as string, // Typecast as query is enabled only when projectId is present
@@ -123,7 +110,6 @@ export default function PromptVersionTable() {
     {
       projectId: projectId as string, // Typecast as query is enabled only when projectId is present
       promptIds,
-      filter: dateRangeFilter,
       queryClickhouse: useClickhouse(),
     },
     {
@@ -145,7 +131,6 @@ export default function PromptVersionTable() {
     scoreColumnPrefix: "Trace",
     scoreColumnKey: "traceScores",
     showAggregateViewOnly: true,
-    selectedFilterOption: selectedOption,
   });
 
   const {
@@ -156,7 +141,6 @@ export default function PromptVersionTable() {
     scoreColumnPrefix: "Generation",
     scoreColumnKey: "generationScores",
     showAggregateViewOnly: true,
-    selectedFilterOption: selectedOption,
   });
 
   const columns: LangfuseColumnDef<PromptVersionTableRow>[] = [
@@ -435,8 +419,6 @@ export default function PromptVersionTable() {
           setRowHeight={setRowHeight}
           columnVisibility={columnVisibility}
           setColumnVisibility={setColumnVisibilityState}
-          selectedOption={selectedOption}
-          setDateRangeAndOption={setDateRangeAndOption}
           columnOrder={columnOrder}
           setColumnOrder={setColumnOrder}
         />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove date range filter from prompt metrics table in `promptRouter.ts` and `metrics.tsx`.
> 
>   - **Behavior**:
>     - Removed `filter` parameter from `versionMetrics` query in `promptRouter.ts`.
>     - Removed date range filter logic from `PromptVersionTable` in `metrics.tsx`.
>   - **UI**:
>     - Removed `useTableDateRange` and related date range filter logic from `metrics.tsx`.
>     - Removed `selectedOption` and `setDateRangeAndOption` from `PromptVersionTable` in `metrics.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bd9af2f63f58b2c034e6ddc9e0cbf1be17d6e839. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->