### PR TITLE
chore: export core information tables to S3 daily

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -66,6 +66,10 @@ const EnvSchema = z.object({
     .default("false"),
   LANGFUSE_USE_AZURE_BLOB: z.enum(["true", "false"]).default("false"),
   STRIPE_SECRET_KEY: z.string().optional(),
+
+  LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED: z
+    .enum(["true", "false"])
+    .default("false"),
 });
 
 export const env: z.infer<typeof EnvSchema> =

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -32,6 +32,7 @@ export * from "./redis/legacyIngestion";
 export * from "./redis/ingestionQueue";
 export * from "./redis/postHogIntegrationQueue";
 export * from "./redis/postHogIntegrationProcessingQueue";
+export * from "./redis/coreDataS3ExportQueue";
 export * from "./redis/experimentCreateQueue";
 export * from "./auth/types";
 export * from "./ingestion/legacy/index";

--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -118,6 +118,7 @@ export enum QueueName {
   ExperimentCreate = "experiment-create-queue",
   PostHogIntegrationQueue = "posthog-integration-queue",
   PostHogIntegrationProcessingQueue = "posthog-integration-processing-queue",
+  CoreDataS3ExportQueue = "core-data-s3-export-queue",
 }
 
 export enum QueueJobs {
@@ -134,6 +135,7 @@ export enum QueueJobs {
   ExperimentCreateJob = "experiment-create-job",
   PostHogIntegrationJob = "posthog-integration-job",
   PostHogIntegrationProcessingJob = "posthog-integration-processing-job",
+  CoreDataS3ExportJob = "core-data-s3-export-job",
 }
 
 export type TQueueJobTypes = {

--- a/packages/shared/src/server/redis/coreDataS3ExportQueue.ts
+++ b/packages/shared/src/server/redis/coreDataS3ExportQueue.ts
@@ -1,0 +1,60 @@
+import { Queue } from "bullmq";
+import { QueueName, QueueJobs } from "../queues";
+import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import { logger } from "../logger";
+import { env } from "../../env";
+
+export class CoreDataS3ExportQueue {
+  private static instance: Queue | null = null;
+
+  public static getInstance(): Queue | null {
+    if (env.LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED !== "true") {
+      return null;
+    }
+
+    if (CoreDataS3ExportQueue.instance) {
+      return CoreDataS3ExportQueue.instance;
+    }
+
+    const newRedis = createNewRedisInstance({
+      enableOfflineQueue: false,
+      ...redisQueueRetryOptions,
+    });
+
+    CoreDataS3ExportQueue.instance = newRedis
+      ? new Queue(QueueName.CoreDataS3ExportQueue, {
+          connection: newRedis,
+          defaultJobOptions: {
+            removeOnComplete: true,
+            removeOnFail: 100,
+            attempts: 5,
+            backoff: {
+              type: "exponential",
+              delay: 5000,
+            },
+          },
+        })
+      : null;
+
+    CoreDataS3ExportQueue.instance?.on("error", (err) => {
+      logger.error("CoreDataS3ExportQueue error", err);
+    });
+
+    if (CoreDataS3ExportQueue.instance) {
+      logger.debug("Scheduling jobs for CoreDataS3ExportQueue");
+      CoreDataS3ExportQueue.instance
+        .add(
+          QueueJobs.CoreDataS3ExportJob,
+          {},
+          {
+            repeat: { pattern: "30 4 * * *" }, // every day at 4:30am
+          },
+        )
+        .catch((err) => {
+          logger.error("Error adding CoreDataS3ExportJob schedule", err);
+        });
+    }
+
+    return CoreDataS3ExportQueue.instance;
+  }
+}

--- a/packages/shared/src/server/redis/getQueue.ts
+++ b/packages/shared/src/server/redis/getQueue.ts
@@ -12,6 +12,7 @@ import { TraceDeleteQueue } from "./traceDelete";
 import { ProjectDeleteQueue } from "./projectDelete";
 import { PostHogIntegrationQueue } from "./postHogIntegrationQueue";
 import { PostHogIntegrationProcessingQueue } from "./postHogIntegrationProcessingQueue";
+import { CoreDataS3ExportQueue } from "./coreDataS3ExportQueue";
 
 export function getQueue(queueName: QueueName): Queue | null {
   switch (queueName) {
@@ -41,6 +42,8 @@ export function getQueue(queueName: QueueName): Queue | null {
       return PostHogIntegrationProcessingQueue.getInstance();
     case QueueName.IngestionSecondaryQueue:
       return SecondaryIngestionQueue.getInstance();
+    case QueueName.CoreDataS3ExportQueue:
+      return CoreDataS3ExportQueue.getInstance();
     default:
       const exhaustiveCheckDefault: never = queueName;
       throw new Error(`Queue ${queueName} not found`);

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -24,6 +24,7 @@ import {
   QueueName,
   logger,
   PostHogIntegrationQueue,
+  CoreDataS3ExportQueue,
 } from "@langfuse/shared/src/server";
 import { env } from "./env";
 import { ingestionQueueProcessorBuilder } from "./queues/ingestionQueue";
@@ -35,6 +36,7 @@ import {
   postHogIntegrationProcessingProcessor,
   postHogIntegrationProcessor,
 } from "./queues/postHogIntegrationQueue";
+import { coreDataS3ExportProcessor } from "./queues/coreDataS3ExportQueue";
 
 const app = express();
 
@@ -66,6 +68,15 @@ if (env.QUEUE_CONSUMER_TRACE_UPSERT_QUEUE_IS_ENABLED === "true") {
     {
       concurrency: env.LANGFUSE_EVAL_CREATOR_WORKER_CONCURRENCY,
     },
+  );
+}
+
+if (env.LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED === "true") {
+  // Instantiate the queue to trigger scheduled jobs
+  CoreDataS3ExportQueue.getInstance();
+  WorkerManager.register(
+    QueueName.CoreDataS3ExportQueue,
+    coreDataS3ExportProcessor,
   );
 }
 

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -152,6 +152,20 @@ const EnvSchema = z.object({
   LANGFUSE_POSTGRES_INGESTION_ENABLED: z
     .enum(["true", "false"])
     .default("false"),
+
+  // Core data S3 upload - only used internally
+  LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED: z
+    .enum(["true", "false"])
+    .default("false"),
+  LANGFUSE_S3_CORE_DATA_UPLOAD_BUCKET: z.string().optional(),
+  LANGFUSE_S3_CORE_DATA_UPLOAD_PREFIX: z.string().default(""),
+  LANGFUSE_S3_CORE_DATA_UPLOAD_REGION: z.string().optional(),
+  LANGFUSE_S3_CORE_DATA_UPLOAD_ENDPOINT: z.string().optional(),
+  LANGFUSE_S3_CORE_DATA_UPLOAD_ACCESS_KEY_ID: z.string().optional(),
+  LANGFUSE_S3_CORE_DATA_UPLOAD_SECRET_ACCESS_KEY: z.string().optional(),
+  LANGFUSE_S3_CORE_DATA_UPLOAD_FORCE_PATH_STYLE: z
+    .enum(["true", "false"])
+    .default("false"),
 });
 
 export const env: z.infer<typeof EnvSchema> =

--- a/worker/src/queues/coreDataS3ExportQueue.ts
+++ b/worker/src/queues/coreDataS3ExportQueue.ts
@@ -1,0 +1,131 @@
+import { Job, Processor } from "bullmq";
+import {
+  logger,
+  StorageService,
+  StorageServiceFactory,
+} from "@langfuse/shared/src/server";
+import { prisma } from "@langfuse/shared/src/db";
+import { env } from "../env";
+
+let s3StorageServiceClient: StorageService;
+
+const getS3StorageServiceClient = (bucketName: string): StorageService => {
+  if (!s3StorageServiceClient) {
+    s3StorageServiceClient = StorageServiceFactory.getInstance({
+      bucketName,
+      accessKeyId: env.LANGFUSE_S3_CORE_DATA_UPLOAD_ACCESS_KEY_ID,
+      secretAccessKey: env.LANGFUSE_S3_CORE_DATA_UPLOAD_SECRET_ACCESS_KEY,
+      endpoint: env.LANGFUSE_S3_CORE_DATA_UPLOAD_ENDPOINT,
+      region: env.LANGFUSE_S3_CORE_DATA_UPLOAD_REGION,
+      forcePathStyle:
+        env.LANGFUSE_S3_CORE_DATA_UPLOAD_FORCE_PATH_STYLE === "true",
+    });
+  }
+  return s3StorageServiceClient;
+};
+
+export const coreDataS3ExportProcessor: Processor = async (
+  job: Job,
+): Promise<void> => {
+  if (!env.LANGFUSE_S3_CORE_DATA_UPLOAD_BUCKET) {
+    logger.error("No bucket name provided for core data S3 export");
+    throw new Error(
+      "Must provide LANGFUSE_S3_CORE_DATA_UPLOAD_BUCKET to use core data S3 exports",
+    );
+  }
+
+  logger.info("Starting core data S3 export");
+
+  const s3Client = getS3StorageServiceClient(
+    env.LANGFUSE_S3_CORE_DATA_UPLOAD_BUCKET,
+  );
+
+  // Fetch table data
+  const [
+    projects,
+    users,
+    organizations,
+    orgMemberships,
+    projectMemberships,
+    prompts,
+  ] = await Promise.all([
+    prisma.project.findMany({
+      select: {
+        id: true,
+        name: true,
+        orgId: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    }),
+    prisma.user.findMany({
+      select: {
+        id: true,
+        name: true,
+        admin: true,
+        email: true,
+        featureFlags: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    }),
+    prisma.organization.findMany({
+      select: {
+        id: true,
+        name: true,
+        cloudConfig: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    }),
+    prisma.organizationMembership.findMany({
+      select: {
+        id: true,
+        role: true,
+        orgId: true,
+        userId: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    }),
+    prisma.projectMembership.findMany({
+      select: {
+        role: true,
+        projectId: true,
+        userId: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    }),
+    prisma.prompt.findMany({
+      select: {
+        id: true,
+        name: true,
+        projectId: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    }),
+  ]);
+
+  // Iterate through the tables and upload them to S3 as JSONLs
+  await Promise.all(
+    Object.entries({
+      projects,
+      users,
+      organizations,
+      orgMemberships,
+      projectMemberships,
+      prompts,
+    }).map(async ([key, value]) =>
+      s3Client.uploadFile({
+        fileName: `${env.LANGFUSE_S3_CORE_DATA_UPLOAD_PREFIX}${key}.jsonl`,
+        fileType: "application/x-ndjson",
+        data: value.map((item) => JSON.stringify(item)).join("\n"),
+        expiresInSeconds: 1, // not used as we only upload
+      }),
+    ),
+  );
+
+  logger.info("Finished core data S3 export");
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add daily S3 export of core data via new `CoreDataS3ExportQueue` and processor, controlled by environment variables.
> 
>   - **Behavior**:
>     - Adds `CoreDataS3ExportQueue` in `coreDataS3ExportQueue.ts` to export core data to S3 daily at 4:30 AM.
>     - Introduces `coreDataS3ExportProcessor` in `coreDataS3ExportQueue.ts` to handle data fetching and uploading to S3.
>     - Controlled by `LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED` environment variable.
>   - **Environment**:
>     - Adds `LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED` and related S3 configuration variables to `env.ts` in both `shared` and `worker`.
>   - **Queue Management**:
>     - Registers `CoreDataS3ExportQueue` in `getQueue.ts` and `app.ts`.
>     - Updates `QueueName` and `QueueJobs` enums in `queues.ts` to include `CoreDataS3ExportQueue` and `CoreDataS3ExportJob`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 61517b18d0d47bec65d464e357dafab8c0db790f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->