### PR TITLE
fix: ensure idemptence of project deletion queue

### DIFF
--- a/worker/src/queues/projectDelete.ts
+++ b/worker/src/queues/projectDelete.ts
@@ -46,6 +46,18 @@ export const projectDeleteProcessor: Processor = async (
   // Finally, delete the project itself which should delete all related
   // resources due to the referential actions defined via Prisma
   try {
+    const existingProject = await prisma.project.findUnique({
+      where: {
+        id: projectId,
+        orgId,
+      },
+    });
+    if (!existingProject) {
+      logger.info(
+        `Tried to delete project ${projectId} from PG, but it does not exist anymore.`,
+      );
+      return;
+    }
     await prisma.project.delete({
       where: {
         id: projectId,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure idempotence in `projectDeleteProcessor` by checking project existence before deletion.
> 
>   - **Behavior**:
>     - Adds a check in `projectDeleteProcessor` in `projectDelete.ts` to verify if a project exists before attempting deletion.
>     - Logs an info message if the project does not exist, preventing unnecessary deletion attempts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for eca3151cb6bed75eea0efcfe0f6f9eb39aa39fab. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->