### PR TITLE
fix: use database upserts correctly

### DIFF
--- a/web/src/__tests__/async/datasets-api.servertest.ts
+++ b/web/src/__tests__/async/datasets-api.servertest.ts
@@ -263,6 +263,46 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     });
   });
 
+  it("should return 404 when trying to update dataset item that exists in different dataset of the same project", async () => {
+    const datasetItemId = v4();
+
+    const dataset = await prisma.dataset.create({
+      data: {
+        name: "dataset-name-1",
+        projectId: projectId,
+      },
+    });
+
+    await prisma.dataset.create({
+      data: {
+        name: "dataset-name-2",
+        projectId: projectId,
+      },
+    });
+
+    await prisma.datasetItem.create({
+      data: {
+        id: datasetItemId,
+        datasetId: dataset.id,
+        projectId: projectId,
+      },
+    });
+
+    const response = await makeAPICall(
+      "POST",
+      "/api/public/dataset-items",
+      {
+        datasetName: "dataset-name-2",
+        id: datasetItemId,
+        input: { key: "new-value" },
+        expectedOutput: { key: "new-value" },
+      },
+      auth,
+    );
+
+    expect(response.status).toBe(404);
+  });
+
   it("GET datasets (v1 & v2)", async () => {
     // v1 post
     await makeZodVerifiedAPICall(

--- a/web/src/__tests__/async/datasets-api.servertest.ts
+++ b/web/src/__tests__/async/datasets-api.servertest.ts
@@ -215,6 +215,54 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     expect(getDataset.body.items[0].id).toEqual("active-item-id");
   });
 
+  it("should correctly update dataset items", async () => {
+    const datasetItemId = v4();
+
+    await makeZodVerifiedAPICall(
+      PostDatasetItemsV1Response,
+      "POST",
+      "/api/public/dataset-items",
+      {
+        datasetName: "dataset-name-1",
+        id: datasetItemId,
+        input: { key: "value" },
+        expectedOutput: { key: "value" },
+        metadata: null,
+        sourceTraceId: null,
+        sourceObservationId: null,
+        status: null,
+      },
+      auth,
+    );
+
+    await makeZodVerifiedAPICall(
+      PostDatasetItemsV1Response,
+      "POST",
+      "/api/public/dataset-items",
+      {
+        datasetName: "dataset-name-1",
+        id: datasetItemId,
+        input: { john: "doe" },
+        expectedOutput: { john: "doe" },
+        metadata: null,
+        sourceTraceId: null,
+        sourceObservationId: null,
+        status: null,
+      },
+      auth,
+    );
+
+    const databaseDatasetItem = await prisma.datasetItem.findFirst({
+      where: {
+        id: datasetItemId,
+      },
+    });
+    expect(databaseDatasetItem).toMatchObject({
+      input: { john: "doe" },
+      expectedOutput: { john: "doe" },
+    });
+  });
+
   it("GET datasets (v1 & v2)", async () => {
     // v1 post
     await makeZodVerifiedAPICall(

--- a/web/src/__tests__/async/datasets-api.servertest.ts
+++ b/web/src/__tests__/async/datasets-api.servertest.ts
@@ -217,13 +217,21 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
 
   it("should correctly update dataset items", async () => {
     const datasetItemId = v4();
+    const datasetName = v4();
+
+    await prisma.dataset.create({
+      data: {
+        name: datasetName,
+        projectId: projectId,
+      },
+    });
 
     await makeZodVerifiedAPICall(
       PostDatasetItemsV1Response,
       "POST",
       "/api/public/dataset-items",
       {
-        datasetName: "dataset-name-1",
+        datasetName: datasetName,
         id: datasetItemId,
         input: { key: "value" },
         expectedOutput: { key: "value" },
@@ -240,7 +248,7 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
       "POST",
       "/api/public/dataset-items",
       {
-        datasetName: "dataset-name-1",
+        datasetName: datasetName,
         id: datasetItemId,
         input: { john: "doe" },
         expectedOutput: { john: "doe" },

--- a/web/src/pages/api/public/dataset-items/index.ts
+++ b/web/src/pages/api/public/dataset-items/index.ts
@@ -81,7 +81,7 @@ export default withMiddlewares({
           e.code === "P2025"
         ) {
           // this case happens when a dataset item was created for a different dataset.
-          // In the databse, the uniqueness constraint is on (id, projectId) only.
+          // In the database, the uniqueness constraint is on (id, projectId) only.
           // When this constraint is violated, the database will upsert based on (id, projectId, datasetId).
           // If this record does not exist, the database will throw an error.
           logger.warn(

--- a/web/src/pages/api/public/dataset-items/index.ts
+++ b/web/src/pages/api/public/dataset-items/index.ts
@@ -87,7 +87,9 @@ export default withMiddlewares({
           logger.warn(
             `Failed to upsert dataset item. Dataset item ${itemId} in project ${auth.scope.projectId} already exists for a different dataset than ${dataset.id}`,
           );
-          throw new LangfuseNotFoundError("Dataset item not found");
+          throw new LangfuseNotFoundError(
+            `The dataset item with id ${itemId} was not found in the dataset ${dataset.name}`,
+          );
         }
         throw e;
       }

--- a/web/src/pages/api/public/dataset-items/index.ts
+++ b/web/src/pages/api/public/dataset-items/index.ts
@@ -9,7 +9,7 @@ import {
   PostDatasetItemsV1Response,
   transformDbDatasetItemToAPIDatasetItem,
 } from "@/src/features/public-api/types/datasets";
-import { LangfuseNotFoundError } from "@langfuse/shared";
+import { type DatasetItem, LangfuseNotFoundError } from "@langfuse/shared";
 
 export default withMiddlewares({
   POST: createAuthedAPIRoute({
@@ -40,37 +40,54 @@ export default withMiddlewares({
 
       const itemId = id ?? uuidv4();
 
-      const item = await prisma.datasetItem.upsert({
-        where: {
-          datasetId: dataset.id,
-          id_projectId: {
-            projectId: auth.scope.projectId,
-            id: itemId,
-          },
-        },
-        create: {
-          id: itemId,
-          input: input ?? undefined,
-          expectedOutput: expectedOutput ?? undefined,
-          datasetId: dataset.id,
-          metadata: metadata ?? undefined,
-          sourceTraceId: sourceTraceId ?? undefined,
-          sourceObservationId: sourceObservationId ?? undefined,
-          status: status ?? undefined,
-          projectId: auth.scope.projectId,
-        },
-        update: {
-          input: input ?? undefined,
-          expectedOutput: expectedOutput ?? undefined,
-          metadata: metadata ?? undefined,
-          sourceTraceId: sourceTraceId ?? undefined,
-          sourceObservationId: sourceObservationId ?? undefined,
-          status: status ?? undefined,
-        },
-      });
+      // SQL injection is handled by Prisma's $queryRaw tagged template literal
+      // Values are automatically escaped and parameterized by Prisma
+      // The template literal syntax ${value} safely interpolates values
+      const items = await prisma.$queryRaw<Array<DatasetItem>>`
+        INSERT INTO "public"."dataset_items" (
+          "id",
+          "project_id", 
+          "status",
+          "input",
+          "expected_output",
+          "dataset_id",
+          "created_at",
+          "updated_at",
+          "metadata",
+          "source_trace_id",
+          "source_observation_id"
+        )
+        VALUES (
+          ${itemId},
+          ${auth.scope.projectId},
+          ${status ?? null}::public."DatasetStatus",
+          ${input ?? null},
+          ${expectedOutput ?? null}, 
+          ${dataset.id},
+          NOW(),
+          NOW(),
+          ${metadata ?? null},
+          ${sourceTraceId ?? null},
+          ${sourceObservationId ?? null}
+        )
+        ON CONFLICT ("id", "project_id", "dataset_id")
+        DO UPDATE SET
+          "input" = ${input ?? null},
+          "expected_output" = ${expectedOutput ?? null},
+          "metadata" = ${metadata ?? null},
+          "source_trace_id" = ${sourceTraceId ?? null},
+          "source_observation_id" = ${sourceObservationId ?? null},
+          "status" = ${status ?? null}::public."DatasetStatus",
+          "updated_at" = NOW()
+        RETURNING *;
+      `;
+
+      if (items.length === 0) {
+        throw new LangfuseNotFoundError("Dataset item not found");
+      }
 
       return transformDbDatasetItemToAPIDatasetItem({
-        ...item,
+        ...items[0],
         datasetName: dataset.name,
       });
     },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improve dataset item upsert logic using `prisma.$queryRaw` for better SQL handling and add a test case for verification.
> 
>   - **Behavior**:
>     - Replace `prisma.upsert` with `prisma.$queryRaw` in `index.ts` for dataset item upsert logic.
>     - Ensure SQL injection protection using Prisma's tagged template literals.
>     - Throw `LangfuseNotFoundError` if upsert returns no items in `index.ts`.
>   - **Testing**:
>     - Add test case in `datasets-api.servertest.ts` to verify correct dataset item updates using the new upsert logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d591693f9ec0909fe4e6117e04b29550feb4810d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->