### PR TITLE
chore: skip existence check for score deletion

### DIFF
--- a/web/src/pages/api/public/scores/[scoreId].ts
+++ b/web/src/pages/api/public/scores/[scoreId].ts
@@ -65,32 +65,15 @@ export default withMiddlewares({
     fn: async ({ query, auth }) => {
       const { scoreId } = query;
 
-      const score = await prisma.score.findUnique({
-        select: {
-          id: true,
-        },
-        where: {
-          id: scoreId,
-          projectId: auth.scope.projectId,
-        },
-      });
-
-      if (!score) {
-        throw new LangfuseNotFoundError(
-          "Score not found within authorized project",
-        );
-      }
-
-      if (env.CLICKHOUSE_URL) {
-        await deleteScore(auth.scope.projectId, scoreId);
-      }
-
-      await prisma.score.delete({
-        where: {
-          id: scoreId,
-          projectId: auth.scope.projectId,
-        },
-      });
+      await Promise.all([
+        prisma.score.deleteMany({
+          where: {
+            id: scoreId,
+            projectId: auth.scope.projectId,
+          },
+        }),
+        deleteScore(auth.scope.projectId, scoreId),
+      ]);
 
       return { message: "Score deleted successfully" };
     },

--- a/web/src/pages/api/public/scores/[scoreId].ts
+++ b/web/src/pages/api/public/scores/[scoreId].ts
@@ -1,4 +1,3 @@
-import { env } from "@/src/env.mjs";
 import { createAuthedAPIRoute } from "@/src/features/public-api/server/createAuthedAPIRoute";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { measureAndReturnApi } from "@/src/server/utils/checkClickhouseAccess";


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/4828
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove existence check before score deletion, using `Promise.all` for concurrent deletion in `web/src/pages/api/public/scores/[scoreId].ts`.
> 
>   - **Behavior**:
>     - Removed existence check before score deletion in `DELETE` route of `web/src/pages/api/public/scores/[scoreId].ts`.
>     - Uses `Promise.all` to concurrently delete score from database and Clickhouse.
>   - **Error Handling**:
>     - Relies on error handling for non-existent scores instead of pre-checking existence.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 67dd89aa077d472f2edb7e02a2d283c10c5b595f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->