### PR TITLE
fix(models): allow string tokenizer config

### DIFF
--- a/web/src/features/models/validation.ts
+++ b/web/src/features/models/validation.ts
@@ -17,9 +17,10 @@ export const GetModelResultSchema = z.object({
   projectId: z.string().nullable(),
   modelName: z.string(),
   matchPattern: z.string(),
-  tokenizerConfig: z
-    .record(z.union([z.string(), z.coerce.number()]))
-    .nullable(),
+  tokenizerConfig: z.union([
+    z.record(z.union([z.string(), z.coerce.number()])).nullable(),
+    z.string(),
+  ]),
   tokenizerId: TokenizerSchema,
   prices: PriceMapSchema,
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `tokenizerConfig` in `GetModelResultSchema` now accepts a string or a record of string/number in `validation.ts`.
> 
>   - **Schema Update**:
>     - In `validation.ts`, `tokenizerConfig` in `GetModelResultSchema` now accepts a `string` or a `record` of `string` or `number`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 273764c4490762d2ce05fa11bafd7decc6393163. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->