### PR TITLE
chore: move sessions, traces, comments router logs to logger

### DIFF
--- a/web/src/server/api/routers/comments.ts
+++ b/web/src/server/api/routers/comments.ts
@@ -11,7 +11,10 @@ import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { TRPCError } from "@trpc/server";
 import { validateCommentReferenceObject } from "@/src/features/comments/validateCommentReferenceObject";
 import { measureAndReturnApi } from "@/src/server/utils/checkClickhouseAccess";
-import { getTracesIdentifierForSession } from "@langfuse/shared/src/server";
+import {
+  getTracesIdentifierForSession,
+  logger,
+} from "@langfuse/shared/src/server";
 
 export const commentsRouter = createTRPCRouter({
   create: protectedProjectProcedure
@@ -56,7 +59,7 @@ export const commentsRouter = createTRPCRouter({
 
         return comment;
       } catch (error) {
-        console.error(error);
+        logger.error("Failed to call comments.create", error);
         if (error instanceof TRPCError) {
           throw error;
         }
@@ -115,7 +118,7 @@ export const commentsRouter = createTRPCRouter({
           before: comment,
         });
       } catch (error) {
-        console.error(error);
+        logger.error("Failed to call comments.delete", error);
         if (error instanceof TRPCError) {
           throw error;
         }
@@ -172,7 +175,7 @@ export const commentsRouter = createTRPCRouter({
 
         return comments;
       } catch (error) {
-        console.error(error);
+        logger.error("Failed to call comments.getByObjectId", error);
         if (error instanceof TRPCError) {
           throw error;
         }
@@ -207,7 +210,7 @@ export const commentsRouter = createTRPCRouter({
         });
         return new Map([[input.objectId, commentCount]]);
       } catch (error) {
-        console.error(error);
+        logger.error("Failed to call comments.getCountByObjectId", error);
         if (error instanceof TRPCError) {
           throw error;
         }
@@ -251,7 +254,7 @@ export const commentsRouter = createTRPCRouter({
           ]),
         );
       } catch (error) {
-        console.error(error);
+        logger.error("Failed to call comments.getCountByObjectType", error);
         if (error instanceof TRPCError) {
           throw error;
         }
@@ -339,8 +342,11 @@ export const commentsRouter = createTRPCRouter({
             );
           },
         });
-      } catch (e) {
-        console.error(e);
+      } catch (error) {
+        logger.error(
+          "Failed to call comments.getTraceCommentCountBySessionId",
+          error,
+        );
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: "Unable to get trace comment counts by session id",

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -32,6 +32,7 @@ import {
   getCostForTraces,
   getTracesGroupedByUsers,
   getPublicSessionsFilter,
+  logger,
 } from "@langfuse/shared/src/server";
 
 const SessionFilterOptions = z.object({
@@ -129,7 +130,7 @@ export const sessionRouter = createTRPCRouter({
           },
         });
       } catch (e) {
-        console.error(e);
+        logger.error("Unable to call sessions.all", e);
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: "unable to get sessions",
@@ -196,7 +197,7 @@ export const sessionRouter = createTRPCRouter({
           },
         });
       } catch (e) {
-        console.error(e);
+        logger.error("Error in sessions.countAll", e);
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: "unable to get session count",
@@ -277,7 +278,7 @@ export const sessionRouter = createTRPCRouter({
           },
         });
       } catch (e) {
-        console.error(e);
+        logger.error("Error in sessions.metrics", e);
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: "unable to get session metrics",
@@ -391,7 +392,7 @@ export const sessionRouter = createTRPCRouter({
           },
         });
       } catch (e) {
-        console.error(e);
+        logger.error("Unable to get sessions.filterOptions", e);
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: "unable to get session filter options",
@@ -549,7 +550,7 @@ export const sessionRouter = createTRPCRouter({
           },
         });
       } catch (e) {
-        console.error(e);
+        logger.error("Unable to get sessions.byId", e);
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: "unable to get session",
@@ -593,7 +594,7 @@ export const sessionRouter = createTRPCRouter({
         });
         return session;
       } catch (error) {
-        console.error(error);
+        logger.error("Unable to call sessions.bookmark", error);
         if (
           error instanceof Prisma.PrismaClientKnownRequestError &&
           error.code === "P2025" // Record to update not found
@@ -643,7 +644,7 @@ export const sessionRouter = createTRPCRouter({
           },
         });
       } catch (e) {
-        console.error(e);
+        logger.error("Unable to call sessions.publish", e);
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: "unable to publish session",

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -769,7 +769,7 @@ export const traceRouter = createTRPCRouter({
 
         return trace;
       } catch (error) {
-        console.error(error);
+        logger.error("Failed to call traces.bookmark", error);
         if (
           error instanceof Prisma.PrismaClientKnownRequestError &&
           error.code === "P2025" // Record to update not found
@@ -839,7 +839,7 @@ export const traceRouter = createTRPCRouter({
           return clickhouseTrace;
         }
       } catch (error) {
-        console.error(error);
+        logger.error("Failed to call traces.publish", error);
         if (
           error instanceof Prisma.PrismaClientKnownRequestError &&
           error.code === "P2025" // Record to update not found
@@ -907,7 +907,7 @@ export const traceRouter = createTRPCRouter({
           await upsertTrace(convertTraceDomainToClickhouse(clickhouseTrace));
         }
       } catch (error) {
-        console.error(error);
+        logger.error("Failed to call traces.updateTags", error);
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
         });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replace `console.error` with `logger.error` in `commentsRouter`, `sessionRouter`, and `traceRouter` for improved logging.
> 
>   - **Logging**:
>     - Replace `console.error` with `logger.error` in `commentsRouter` methods: `create`, `delete`, `getByObjectId`, `getCountByObjectId`, `getCountByObjectType`, and `getTraceCommentCountsBySessionId`.
>     - Replace `console.error` with `logger.error` in `sessionRouter` methods: `all`, `countAll`, `metrics`, `filterOptions`, `byId`, `bookmark`, and `publish`.
>     - Replace `console.error` with `logger.error` in `traceRouter` methods: `bookmark`, `publish`, and `updateTags`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3b546b4263bbb9619bf2fcf54ee5b5625ca2d4a8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->