### PR TITLE
fix: do not error on 403 by model provider for eval executions

### DIFF
--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -65,7 +65,7 @@ export const evalJobExecutorQueueProcessor = async (
     // do not log expected errors (api failures + missing api keys not provided by the user)
     if (
       (e instanceof BaseError && e.message.includes("API key for provider")) || // api key not provided
-      (e instanceof ApiError && e.httpCode === 403) || // user has no access to the requested model
+      (e instanceof ApiError && e.httpCode >= 400 && e.httpCode < 500) || // do not error and retry on 4xx errors. They are visible to the user in the UI but do not alert us.
       (e instanceof BaseError &&
         e.message.includes(
           "Please ensure the mapped data exists and consider extending the job delay.",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `evalJobExecutorQueueProcessor` in `evalQueue.ts` to prevent logging and throwing errors for expected cases like 403 errors and missing API keys.
> 
>   - **Error Handling**:
>     - In `evalJobExecutorQueueProcessor` in `evalQueue.ts`, do not log or throw errors for `ApiError` with 403 status or `BaseError` with specific messages (missing API key, trace not found).
>     - Refactor error handling logic to return early for expected errors, reducing unnecessary logging and exception tracing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6768b4e373db1506a501b4bb1406f453d415b7fd. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->