### PR TITLE
chore(media): increase rate-limit to use ingestion budget

### DIFF
--- a/web/src/pages/api/public/media/[mediaId].ts
+++ b/web/src/pages/api/public/media/[mediaId].ts
@@ -73,6 +73,7 @@ export default withMiddlewares({
     }),
     bodySchema: PatchMediaBodySchema,
     responseSchema: z.void(),
+    rateLimitResource: "ingestion",
     fn: async ({ query, body, auth }) => {
       if (auth.scope.accessLevel !== "all") throw new ForbiddenError();
 

--- a/web/src/pages/api/public/media/index.ts
+++ b/web/src/pages/api/public/media/index.ts
@@ -26,6 +26,7 @@ export default withMiddlewares({
     bodySchema: GetMediaUploadUrlQuerySchema,
     responseSchema: GetMediaUploadUrlResponseSchema,
     successStatusCode: 201,
+    rateLimitResource: "ingestion",
     fn: async ({ body, auth }) => {
       if (auth.scope.accessLevel !== "all") throw new ForbiddenError();
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase rate limit for media ingestion by adding `rateLimitResource: "ingestion"` to relevant API routes.
> 
>   - **Rate Limiting**:
>     - Adds `rateLimitResource: "ingestion"` to `PATCH` method in `[mediaId].ts`.
>     - Adds `rateLimitResource: "ingestion"` to `POST` method in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8f7ca57d2388e706e8d683d8af06cd4f5df6c226. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->