### PR TITLE
fix: correctly export categorical scores for trace exports

### DIFF
--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -135,13 +135,16 @@ export const upsertScore = async (score: Partial<ScoreRecordReadType>) => {
   });
 };
 
-export const getScoresForTraces = async (
-  projectId: string,
-  traceIds: string[],
-  timestamp?: Date,
-  limit?: number,
-  offset?: number,
-) => {
+export type GetScoresForTracesProps = {
+  projectId: string;
+  traceIds: string[];
+  timestamp?: Date;
+  limit?: number;
+  offset?: number;
+};
+
+export const getScoresForTraces = async (props: GetScoresForTracesProps) => {
+  const { projectId, traceIds, timestamp, limit, offset } = props;
   const query = `
       select 
         *

--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -531,10 +531,10 @@ export const getRunItemsByRunIdOrItemId = async (
 ) => {
   const [traceScores, observationAggregates, traceAggregate] =
     await Promise.all([
-      getScoresForTraces(
+      getScoresForTraces({
         projectId,
-        runItems.map((ri) => ri.traceId),
-      ),
+        traceIds: runItems.map((ri) => ri.traceId),
+      }),
       getLatencyAndTotalCostForObservations(
         projectId,
         runItems

--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -91,11 +91,11 @@ export default withMiddlewares({
               trace?.timestamp,
               true,
             ),
-            getScoresForTraces(
-              auth.scope.projectId,
-              [traceId],
-              trace?.timestamp,
-            ),
+            getScoresForTraces({
+              projectId: auth.scope.projectId,
+              traceIds: [traceId],
+              timestamp: trace?.timestamp,
+            }),
           ]);
 
           const uniqueModels: string[] = Array.from(

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -515,7 +515,10 @@ export const sessionRouter = createTRPCRouter({
             const [scores, costs] = await Promise.all([
               Promise.all(
                 chunks.map((chunk) =>
-                  getScoresForTraces(input.projectId, chunk),
+                  getScoresForTraces({
+                    projectId: input.projectId,
+                    traceIds: chunk,
+                  }),
                 ),
               ).then((results) => results.flat()),
               Promise.all(

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -291,13 +291,12 @@ export const traceRouter = createTRPCRouter({
             ],
           });
 
-          const scores = await getScoresForTraces(
-            ctx.session.projectId,
-            res.map((r) => r.id),
-            undefined,
-            1000,
-            0,
-          );
+          const scores = await getScoresForTraces({
+            projectId: ctx.session.projectId,
+            traceIds: res.map((r) => r.id),
+            limit: 1000,
+            offset: 0,
+          });
 
           const validatedScores = filterAndValidateDbScoreList(
             scores,
@@ -576,13 +575,11 @@ export const traceRouter = createTRPCRouter({
               input.projectId,
               input.timestamp ?? undefined,
             ),
-            getScoresForTraces(
-              input.projectId,
-              [input.traceId],
-              input.timestamp ?? undefined,
-              undefined,
-              undefined,
-            ),
+            getScoresForTraces({
+              projectId: input.projectId,
+              traceIds: [input.traceId],
+              timestamp: input.timestamp ?? undefined,
+            }),
           ]);
 
           if (!trace) {

--- a/worker/src/__tests__/batch-export.test.ts
+++ b/worker/src/__tests__/batch-export.test.ts
@@ -380,7 +380,17 @@ describe("batch export test suite", () => {
       value: 123,
     });
 
-    await createScoresCh([score]);
+    const qualitativeScore = createScore({
+      project_id: projectId,
+      trace_id: traces[0].id,
+      observation_id: generations[0].id,
+      name: "qualitative_test",
+      value: undefined,
+      string_value: "This is some qualitative text",
+      data_type: "CATEGORICAL",
+    });
+
+    await createScoresCh([score, qualitativeScore]);
     await createObservationsCh(generations);
 
     const stream = await getDatabaseReadStream({
@@ -405,10 +415,13 @@ describe("batch export test suite", () => {
           id: traces[0].id,
           latency: 1,
           test: [score.value],
+          qualitative_test: ["This is some qualitative text"],
         }),
         expect.objectContaining({
           id: traces[1].id,
           latency: 2.123,
+          test: null,
+          qualitative_test: null,
         }),
       ]),
     );

--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -387,7 +387,6 @@ export const getDatabaseReadStream = async ({
               traceIds: traces.map((t) => t.id),
             });
 
-            console.log(scores);
             chunk = traces.map((t) => {
               const metric = metrics.find((m) => m.id === t.id);
               const filteredScores = scores.filter((s) => s.traceId === t.id);

--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -382,10 +382,12 @@ export const getDatabaseReadStream = async ({
               ),
             ]);
 
-            const scores = await getScoresForTraces(
+            const scores = await getScoresForTraces({
               projectId,
-              traces.map((t) => t.id),
-            );
+              traceIds: traces.map((t) => t.id),
+            });
+
+            console.log(scores);
             chunk = traces.map((t) => {
               const metric = metrics.find((m) => m.id === t.id);
               const filteredScores = scores.filter((s) => s.traceId === t.id);
@@ -604,7 +606,8 @@ function prepareScoresForOutput(
     (acc, score) => {
       // If this score name already exists in acc, use its existing type
       const existingValues = acc[score.name];
-      const newValue = score.value ?? score.stringValue;
+      const newValue =
+        score.dataType === "NUMERIC" ? score.value : score.stringValue;
       if (!newValue) return acc;
 
       if (!existingValues) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `getScoresForTraces` to use a props object and update its usage across the codebase, with a test for categorical score export.
> 
>   - **Function Signature Change**:
>     - `getScoresForTraces` now accepts a single `props` object instead of multiple parameters in `scores.ts`.
>     - Updates calls to `getScoresForTraces` in `service.ts`, `[traceId].ts`, `sessions.ts`, and `traces.ts` to use the new `props` object.
>   - **Testing**:
>     - Adds a qualitative score test case in `batch-export.test.ts` to verify categorical score export.
>   - **Misc**:
>     - Adds `GetScoresForTracesProps` type in `scores.ts` for the new function signature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f311ff1a75421e77260960a64383b75dfd84eb82. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->