### PR TITLE
chore: add BUILD_ID to otel setup and exclude health from tracing

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -95,6 +95,9 @@ ARG BUILDPLATFORM
 
 WORKDIR /app
 
+ARG NEXT_PUBLIC_BUILD_ID
+ENV BUILD_ID=$NEXT_PUBLIC_BUILD_ID
+
 ENV NODE_ENV production
 # Uncomment the following line in case you want to disable telemetry during runtime.
 ENV NEXT_TELEMETRY_DISABLED 1

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -9,6 +9,7 @@ export const env = createEnv({
   server: {
     DATABASE_URL: z.string().url(),
     NODE_ENV: z.enum(["development", "test", "production"]),
+    BUILD_ID: z.string().optional(),
     NEXTAUTH_SECRET:
       process.env.NODE_ENV === "production"
         ? z.string().min(1)
@@ -303,6 +304,7 @@ export const env = createEnv({
     NEXT_PUBLIC_DEMO_ORG_ID: process.env.NEXT_PUBLIC_DEMO_ORG_ID,
     DATABASE_URL: process.env.DATABASE_URL,
     NODE_ENV: process.env.NODE_ENV,
+    BUILD_ID: process.env.BUILD_ID,
     NEXT_PUBLIC_BUILD_ID: process.env.NEXT_PUBLIC_BUILD_ID,
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
     NEXTAUTH_COOKIE_DOMAIN: process.env.NEXTAUTH_COOKIE_DOMAIN,

--- a/web/src/observability.config.ts
+++ b/web/src/observability.config.ts
@@ -47,7 +47,6 @@ if (!process.env.VERCEL && process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
           return req.host === "127.0.0.1";
         },
         requestHook: (span, req: any) => {
-          // TODO: Ignore health checks
           const url = "path" in req ? req?.path : req?.url;
           let path = new URL(url, `http://${req?.host ?? "localhost"}`)
             .pathname;

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -54,6 +54,9 @@ RUN apk add --no-cache dumb-init
 
 WORKDIR /app
 
+ARG NEXT_PUBLIC_BUILD_ID
+ENV BUILD_ID=$NEXT_PUBLIC_BUILD_ID
+
 ENV NODE_ENV production
 ENV DOCKER_BUILD 0
 

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -2,6 +2,7 @@ import { removeEmptyEnvVariables } from "@langfuse/shared";
 import { z } from "zod";
 
 const EnvSchema = z.object({
+  BUILD_ID: z.string().optional(),
   NODE_ENV: z
     .enum(["development", "test", "production"])
     .default("development"),

--- a/worker/src/instrumentation.ts
+++ b/worker/src/instrumentation.ts
@@ -25,6 +25,7 @@ dd.init({
 const sdk = new NodeSDK({
   resource: new Resource({
     "service.name": env.OTEL_SERVICE_NAME,
+    "service.version": env.BUILD_ID,
   }),
   traceExporter: new OTLPTraceExporter({
     url: `${env.OTEL_EXPORTER_OTLP_ENDPOINT}/v1/traces`,
@@ -33,6 +34,12 @@ const sdk = new NodeSDK({
     new IORedisInstrumentation(),
     new HttpInstrumentation({
       requireParentforOutgoingSpans: true,
+      ignoreIncomingRequestHook: (req) => {
+        // Ignore health checks
+        return ["/api/public/health", "/api/public/ready", "/api/health"].some(
+          (path) => req.url?.includes(path),
+        );
+      },
       ignoreOutgoingRequestHook: (req) => {
         return req.host === "127.0.0.1";
       },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `BUILD_ID` environment variable and exclude health check endpoints from OpenTelemetry tracing in web and worker components.
> 
>   - **Environment Variables**:
>     - Add `BUILD_ID` as an optional environment variable in `web/src/env.mjs` and `worker/src/env.ts`.
>     - Pass `NEXT_PUBLIC_BUILD_ID` as `BUILD_ID` in `web/Dockerfile` and `worker/Dockerfile`.
>   - **OpenTelemetry Configuration**:
>     - Set `service.version` to `BUILD_ID` in `web/src/observability.config.ts` and `worker/src/instrumentation.ts`.
>     - Exclude health check endpoints from tracing in `HttpInstrumentation` in both `web/src/observability.config.ts` and `worker/src/instrumentation.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 896fddf72342e67bc2eede223fb01f85fc49945a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->