### PR TITLE
feat(models): lastUsed column to full lookback

### DIFF
--- a/web/src/components/table/use-cases/models.tsx
+++ b/web/src/components/table/use-cases/models.tsx
@@ -52,8 +52,7 @@ const modelConfigDescriptions = {
     "Some tokenizers require additional configuration (e.g. openai tiktoken). See docs for details.",
   maintainer:
     "Maintainer of the model. Langfuse managed models can be cloned, user managed models can be edited and deleted. To supersede a Langfuse managed model, set the custom model name to the Langfuse model name.",
-  lastUsed:
-    "Start time of the latest generation using this model within last 30 days",
+  lastUsed: "Start time of the latest generation using this model",
 } as const;
 
 export default function ModelTable({ projectId }: { projectId: string }) {
@@ -204,7 +203,7 @@ export default function ModelTable({ projectId }: { projectId: string }) {
     {
       accessorKey: "lastUsed",
       id: "lastUsed",
-      header: "Last used (30d)",
+      header: "Last used",
       headerTooltip: {
         description: modelConfigDescriptions.lastUsed,
       },

--- a/web/src/server/api/routers/models.ts
+++ b/web/src/server/api/routers/models.ts
@@ -130,7 +130,6 @@ export const modelRouter = createTRPCRouter({
                 observations
             WHERE
                 project_id = {projectId: String}
-                AND start_time > now() - INTERVAL 30 DAY
                 AND internal_model_id IS NOT NULL
             GROUP BY
                 internal_model_id


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove 30-day restriction from `lastUsed` column in models table, updating both frontend and backend.
> 
>   - **Behavior**:
>     - Remove 30-day restriction from `lastUsed` column in `models.tsx` and `models.ts`.
>   - **Frontend**:
>     - Update `lastUsed` description and header in `models.tsx`.
>   - **Backend**:
>     - Remove 30-day filter from `lastUsed` query in `models.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0598ca2b213adbb7e0ecd410931d49efeb78d7eb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->