### PR TITLE
feat: retry 429 errors for eval executions for up to 24h

### DIFF
--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -114,6 +114,7 @@ export const evalJobExecutorQueueProcessor = async (
     if (
       (e instanceof BaseError && e.message.includes("API key for provider")) || // api key not provided
       (e instanceof ApiError && e.httpCode >= 400 && e.httpCode < 500) || // do not error and retry on 4xx errors. They are visible to the user in the UI but do not alert us.
+      (e instanceof ApiError && e.message.includes("TypeError")) || // Zod parsing the response failed. User should update prompt to consistently return expected output structure.
       (e instanceof BaseError &&
         e.message.includes(
           "Please ensure the mapped data exists and consider extending the job delay.",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds retry mechanism for 429 errors in `evalJobExecutorQueueProcessor`, retrying jobs with delay if not older than 24 hours.
> 
>   - **Behavior**:
>     - Adds retry logic for 429 errors in `evalJobExecutorQueueProcessor` in `evalQueue.ts`.
>     - Retries jobs with a random delay (1-10 minutes) if not older than 24 hours.
>     - Stops retrying if job execution is older than 24 hours.
>   - **Error Handling**:
>     - Logs error and continues processing if retry handling fails.
>     - Updates job status to 'ERROR' in database on failure.
>     - Skips logging for expected errors like missing API keys or 4xx errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4989369d2dfddc67e9d87a00657665c4ba69e11c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->