### PR TITLE
feat: backup redis queues to postgres

### DIFF
--- a/packages/shared/prisma/generated/types.ts
+++ b/packages/shared/prisma/generated/types.ts
@@ -479,6 +479,13 @@ export type Prompt = {
     tags: Generated<string[]>;
     labels: Generated<string[]>;
 };
+export type QueueBackUp = {
+    id: string;
+    project_id: string | null;
+    queue_name: string;
+    content: unknown;
+    created_at: Generated<Timestamp>;
+};
 export type Score = {
     id: string;
     timestamp: Generated<Timestamp>;
@@ -628,6 +635,7 @@ export type DB = {
     project_memberships: ProjectMembership;
     projects: Project;
     prompts: Prompt;
+    queue_backups: QueueBackUp;
     score_configs: ScoreConfig;
     scores: Score;
     Session: Session;

--- a/packages/shared/prisma/migrations/20250108220721_add_queue_backup_table/migration.sql
+++ b/packages/shared/prisma/migrations/20250108220721_add_queue_backup_table/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "queue_backups" (
+    "id" TEXT NOT NULL,
+    "project_id" TEXT,
+    "queue_name" TEXT NOT NULL,
+    "content" JSONB NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "queue_backups_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "traces" ADD CONSTRAINT "traces_session_id_project_id_fkey" FOREIGN KEY ("session_id", "project_id") REFERENCES "trace_sessions"("id", "project_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -1017,3 +1017,14 @@ model ObservationMedia {
   @@index([projectId, observationId])
   @@map("observation_media")
 }
+
+model QueueBackUp {
+  id        String  @id @default(cuid())
+  projectId String? @map("project_id")
+  queueName String  @map("queue_name")
+  content   Json
+
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@map("queue_backups")
+}

--- a/web/src/pages/api/admin/bullmq/index.ts
+++ b/web/src/pages/api/admin/bullmq/index.ts
@@ -2,10 +2,21 @@ import { type NextApiRequest, type NextApiResponse } from "next";
 import { z } from "zod";
 import { logger, QueueName, getQueue } from "@langfuse/shared/src/server";
 import { env } from "@/src/env.mjs";
+import { prisma } from "@langfuse/shared/src/db";
 
 /* 
 This API route is used by Langfuse Cloud to retry failed bullmq jobs.
 */
+
+const BullStatus = z.enum([
+  "completed",
+  "failed",
+  "active",
+  "delayed",
+  "prioritized",
+  "paused",
+  "wait",
+]);
 
 const ManageBullBody = z.discriminatedUnion("action", [
   z.object({
@@ -15,15 +26,18 @@ const ManageBullBody = z.discriminatedUnion("action", [
   z.object({
     action: z.literal("remove"),
     queueNames: z.array(z.string()),
-    bullStatus: z.enum([
-      "completed",
-      "failed",
-      "active",
-      "delayed",
-      "prioritized",
-      "paused",
-      "wait",
-    ]),
+    bullStatus: BullStatus,
+  }),
+  z.object({
+    action: z.literal("backup"),
+    queueName: z.string(),
+    bullStatus: BullStatus,
+    numberOfEvents: z.number(),
+  }),
+  z.object({
+    action: z.literal("restore"),
+    queueName: z.string(),
+    numberOfEvents: z.number(),
   }),
 ]);
 
@@ -162,6 +176,21 @@ export default async function handler(
       return res.status(200).json({ message: "Retried all jobs" });
     }
 
+    if (req.method === "POST" && body.data.action === "backup") {
+      await backUpEvents(
+        body.data.queueName as QueueName,
+        body.data.numberOfEvents,
+        body.data.bullStatus,
+      );
+    }
+
+    if (req.method === "POST" && body.data.action === "restore") {
+      await restoreEvents(
+        body.data.queueName as QueueName,
+        body.data.numberOfEvents,
+      );
+    }
+
     // return not implemented error
     res.status(404).json({ error: "Action does not exist" });
   } catch (e) {
@@ -169,3 +198,69 @@ export default async function handler(
     res.status(500).json({ error: e });
   }
 }
+
+const backUpEvents = async (
+  queueName: QueueName,
+  numberOfEvents: number,
+  bullStatus: z.infer<typeof BullStatus>,
+) => {
+  const queue = getQueue(queueName);
+  let processedEvents = 0;
+  const batchSize = 1000;
+
+  while (processedEvents < numberOfEvents) {
+    const remainingEvents = numberOfEvents - processedEvents;
+    const currentBatchSize = Math.min(batchSize, remainingEvents);
+
+    const events = await queue?.getJobs(
+      [bullStatus],
+      0,
+      currentBatchSize,
+      true,
+    );
+
+    if (!events || events.length === 0) {
+      break;
+    }
+
+    await prisma.queueBackUp.createMany({
+      data: events.map((event) => ({
+        queueName,
+        content: event,
+        projectId: event.data.projectId ?? undefined,
+        createdAt: new Date(),
+      })),
+    });
+
+    // remove events from the queue but might throw in case if the job is already processing
+    await Promise.all(
+      events.map(async (event) => {
+        try {
+          await event.remove();
+        } catch (error) {
+          logger.error(`Failed to remove event ${event.id}:`, error);
+        }
+      }),
+    );
+
+    processedEvents += events.length;
+  }
+};
+
+const restoreEvents = async (queueName: QueueName, numberOfEvents: number) => {
+  const queue = getQueue(queueName);
+
+  const queueBackUp = await prisma.queueBackUp.findMany({
+    where: {
+      queueName,
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+    take: numberOfEvents,
+  });
+
+  await queue?.addBulk(
+    queueBackUp.map((event) => ({ name: queueName, data: event.content })),
+  );
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds functionality to backup and restore Redis queues to/from Postgres, including new API actions and database schema changes.
> 
>   - **Behavior**:
>     - Adds `backup` and `restore` actions to the API in `index.ts` for managing BullMQ jobs.
>     - `backup` action stores specified number of events from a queue to Postgres.
>     - `restore` action retrieves events from Postgres and adds them back to the queue.
>   - **Database**:
>     - Adds `QueueBackUp` model to `schema.prisma` and `types.ts` for storing queue data.
>     - Creates `queue_backups` table in `migration.sql` with fields for `id`, `project_id`, `queue_name`, `content`, and `created_at`.
>   - **Functions**:
>     - Implements `backUpEvents()` in `index.ts` to handle event backup.
>     - Implements `restoreEvents()` in `index.ts` to handle event restoration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c1652b2ac3104fd70987e0d4d34f2725730258fa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->