### PR TITLE
chore: accept projectId list which skips clickhouse reads during ingestion

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -110,6 +110,11 @@ const EnvSchema = z.object({
   // TODO: Remove for go-live
   LANGFUSE_RETURN_FROM_CLICKHOUSE: z.enum(["true", "false"]).default("true"),
 
+  // Skip the read from ClickHouse within the Ingestion pipeline for the given
+  // project ids. Applicable for projects that were created after the S3 write
+  // was activated and which don't rely on historic updates.
+  LANGFUSE_SKIP_INGESTION_CLICKHOUSE_READ_PROJECT_IDS: z.string().default(""),
+
   // Otel
   OTEL_EXPORTER_OTLP_ENDPOINT: z.string().default("http://localhost:4318"),
   OTEL_SERVICE_NAME: z.string().default("worker"),

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -39,6 +39,7 @@ import { tokenCount } from "../../features/tokenisation/usage";
 import { ClickhouseWriter, TableName } from "../ClickhouseWriter";
 import { convertJsonSchemaToRecord, overwriteObject } from "./utils";
 import { randomUUID } from "crypto";
+import { env } from "../../env";
 
 type InsertRecord =
   | TraceRecordInsertType
@@ -742,6 +743,15 @@ export class IngestionService {
       params: Record<string, unknown>;
     };
   }) {
+    if (
+      env.LANGFUSE_SKIP_INGESTION_CLICKHOUSE_READ_PROJECT_IDS &&
+      env.LANGFUSE_SKIP_INGESTION_CLICKHOUSE_READ_PROJECT_IDS.split(
+        ",",
+      ).includes(params.projectId)
+    ) {
+      return null;
+    }
+
     const recordParser = {
       traces: traceRecordReadSchema,
       scores: scoreRecordReadSchema,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add environment variable to skip ClickHouse reads for specified project IDs during ingestion in `IngestionService`.
> 
>   - **Environment**:
>     - Add `LANGFUSE_SKIP_INGESTION_CLICKHOUSE_READ_PROJECT_IDS` to `env.ts` to specify project IDs that skip ClickHouse reads during ingestion.
>   - **IngestionService**:
>     - Modify `getClickhouseRecord()` in `index.ts` to return `null` if project ID is in `LANGFUSE_SKIP_INGESTION_CLICKHOUSE_READ_PROJECT_IDS`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d9e95bcd91e8fe122cedd7fde8a1afae28cebef7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->