### PR TITLE
fix: sessions table id filter

### DIFF
--- a/packages/shared/src/server/services/sessions-ui-table-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-service.ts
@@ -166,16 +166,28 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
       (f.operator === ">=" || f.operator === ">"),
   ) as DateTimeFilter | undefined;
 
-  const singleTraceFilter = traceTimestampFilter
-    ? new FilterList([
-        new DateTimeFilter({
-          clickhouseTable: "traces",
-          field: "timestamp",
-          operator: traceTimestampFilter.operator,
-          value: traceTimestampFilter.value,
-        }),
-      ]).apply()
-    : undefined;
+  const filters = [];
+  if (traceTimestampFilter) {
+    filters.push(
+      new DateTimeFilter({
+        clickhouseTable: "traces",
+        field: "timestamp",
+        operator: traceTimestampFilter.operator,
+        value: traceTimestampFilter.value,
+      }),
+    );
+  }
+
+  const additionalSingleTraceFilter = tracesFilter.find(
+    (f) => f.field === "bookmarked" || f.field === "session_id",
+  );
+
+  if (additionalSingleTraceFilter) {
+    filters.push(additionalSingleTraceFilter);
+  }
+
+  const singleTraceFilter =
+    filters.length > 0 ? new FilterList(filters).apply() : undefined;
 
   const hasMetricsFilter = tracesFilter.find((f) =>
     [


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor filtering logic in `getSessionsTableGeneric` to include `bookmarked` and `session_id` filters.
> 
>   - **Filtering Logic**:
>     - In `getSessionsTableGeneric`, refactor filter construction to handle `bookmarked` and `session_id` fields.
>     - Use `filters` array to collect applicable filters and apply them using `FilterList`.
>   - **Behavior**:
>     - Ensures `singleTraceFilter` includes `bookmarked` and `session_id` filters if present.
>     - Adjusts query construction to incorporate new filter logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 39696444ecd9278fa3ad3bde0ca7614593228600. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->