### PR TITLE
chore: enable clickhouse cluster mode by default

### DIFF
--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -155,7 +155,7 @@ export const env = createEnv({
     CLICKHOUSE_DB: z.string().default("default"),
     CLICKHOUSE_USER: z.string(),
     CLICKHOUSE_PASSWORD: z.string(),
-    CLICKHOUSE_CLUSTER_ENABLED: z.enum(["true", "false"]).default("false"),
+    CLICKHOUSE_CLUSTER_ENABLED: z.enum(["true", "false"]).default("true"),
 
     // EE ui customization
     LANGFUSE_UI_API_HOST: z.string().optional(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default `CLICKHOUSE_CLUSTER_ENABLED` to `true` in `web/src/env.mjs`, enabling ClickHouse cluster mode by default.
> 
>   - **Behavior**:
>     - Change default value of `CLICKHOUSE_CLUSTER_ENABLED` from `false` to `true` in `web/src/env.mjs`. This enables ClickHouse cluster mode by default.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4ea5dbbd919519891abba65c1f48b461fb9113c5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->