### PR TITLE
fix: adjust deletion order for apikey invalidation on project delete

### DIFF
--- a/web/src/features/projects/server/projectsRouter.ts
+++ b/web/src/features/projects/server/projectsRouter.ts
@@ -132,17 +132,17 @@ export const projectsRouter = createTRPCRouter({
         action: "delete",
       });
 
-      // Delete API keys from DB first
+      // API keys need to be deleted from cache. Otherwise, they will still be valid.
+      await new ApiAuthService(ctx.prisma, redis).invalidateProjectApiKeys(
+        input.projectId,
+      );
+
+      // Delete API keys from DB
       await ctx.prisma.apiKey.deleteMany({
         where: {
           projectId: input.projectId,
         },
       });
-
-      // API keys need to be deleted from cache. Otherwise, they will still be valid.
-      await new ApiAuthService(ctx.prisma, redis).invalidateProjectApiKeys(
-        input.projectId,
-      );
 
       await ctx.prisma.project.update({
         where: {


### PR DESCRIPTION
## Why

Otherwise, we delete the keys first and then don't receive anything when we fetch the keys that are to be invalidated. Race condition of someone creating a key just within this second is accepted.