### PR TITLE
chore: stream clickhouse results to posthog to reduce memory consumption

### DIFF
--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -109,43 +109,47 @@ export async function* queryClickhouseStream<T>(opts: {
   const tracer = getTracer("clickhouse-query-stream");
   const span = tracer.startSpan("clickhouse-query-stream");
 
-  // https://opentelemetry.io/docs/specs/semconv/database/database-spans/
-  span.setAttribute("ch.query.text", opts.query);
+  try {
+    // https://opentelemetry.io/docs/specs/semconv/database/database-spans/
+    span.setAttribute("ch.query.text", opts.query);
 
-  const res = await clickhouseClient(opts.clickhouseConfigs).query({
-    query: opts.query,
-    format: "JSONEachRow",
-    query_params: opts.params,
-  });
-  // same logic as for prisma. we want to see queries in development
-  if (env.NODE_ENV === "development") {
-    logger.info(`clickhouse:query ${res.query_id} ${opts.query}`);
-  }
+    const res = await clickhouseClient(opts.clickhouseConfigs).query({
+      query: opts.query,
+      format: "JSONEachRow",
+      query_params: opts.params,
+    });
+    // same logic as for prisma. we want to see queries in development
+    if (env.NODE_ENV === "development") {
+      logger.info(`clickhouse:query ${res.query_id} ${opts.query}`);
+    }
 
-  span.setAttribute("ch.queryId", res.query_id);
+    span.setAttribute("ch.queryId", res.query_id);
 
-  // add summary headers to the span. Helps to tune performance
-  const summaryHeader = res.response_headers["x-clickhouse-summary"];
-  if (summaryHeader) {
-    try {
-      const summary = Array.isArray(summaryHeader)
-        ? JSON.parse(summaryHeader[0])
-        : JSON.parse(summaryHeader);
-      for (const key in summary) {
-        span.setAttribute(`ch.${key}`, summary[key]);
+    // add summary headers to the span. Helps to tune performance
+    const summaryHeader = res.response_headers["x-clickhouse-summary"];
+    if (summaryHeader) {
+      try {
+        const summary = Array.isArray(summaryHeader)
+          ? JSON.parse(summaryHeader[0])
+          : JSON.parse(summaryHeader);
+        for (const key in summary) {
+          span.setAttribute(`ch.${key}`, summary[key]);
+        }
+      } catch (error) {
+        logger.debug(
+          `Failed to parse clickhouse summary header ${summaryHeader}`,
+          error,
+        );
       }
-    } catch (error) {
-      logger.debug(
-        `Failed to parse clickhouse summary header ${summaryHeader}`,
-        error,
-      );
     }
-  }
 
-  for await (const rows of res.stream<T>()) {
-    for (const row of rows) {
-      yield row.json();
+    for await (const rows of res.stream<T>()) {
+      for (const row of rows) {
+        yield row.json();
+      }
     }
+  } finally {
+    span.end();
   }
 }
 

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -12,6 +12,7 @@ import {
 import { randomUUID } from "crypto";
 import { getClickhouseEntityType } from "../clickhouse/schemaUtils";
 import { NodeClickHouseClientConfigOptions } from "@clickhouse/client/dist/config";
+import { context, trace } from "@opentelemetry/api";
 
 let s3StorageServiceClient: StorageService;
 
@@ -110,38 +111,44 @@ export async function* queryClickhouseStream<T>(opts: {
   const span = tracer.startSpan("clickhouse-query-stream");
 
   try {
-    // https://opentelemetry.io/docs/specs/semconv/database/database-spans/
-    span.setAttribute("ch.query.text", opts.query);
+    const res = await context.with(
+      trace.setSpan(context.active(), span),
+      async () => {
+        // https://opentelemetry.io/docs/specs/semconv/database/database-spans/
+        span.setAttribute("ch.query.text", opts.query);
 
-    const res = await clickhouseClient(opts.clickhouseConfigs).query({
-      query: opts.query,
-      format: "JSONEachRow",
-      query_params: opts.params,
-    });
-    // same logic as for prisma. we want to see queries in development
-    if (env.NODE_ENV === "development") {
-      logger.info(`clickhouse:query ${res.query_id} ${opts.query}`);
-    }
-
-    span.setAttribute("ch.queryId", res.query_id);
-
-    // add summary headers to the span. Helps to tune performance
-    const summaryHeader = res.response_headers["x-clickhouse-summary"];
-    if (summaryHeader) {
-      try {
-        const summary = Array.isArray(summaryHeader)
-          ? JSON.parse(summaryHeader[0])
-          : JSON.parse(summaryHeader);
-        for (const key in summary) {
-          span.setAttribute(`ch.${key}`, summary[key]);
+        const res = await clickhouseClient(opts.clickhouseConfigs).query({
+          query: opts.query,
+          format: "JSONEachRow",
+          query_params: opts.params,
+        });
+        // same logic as for prisma. we want to see queries in development
+        if (env.NODE_ENV === "development") {
+          logger.info(`clickhouse:query ${res.query_id} ${opts.query}`);
         }
-      } catch (error) {
-        logger.debug(
-          `Failed to parse clickhouse summary header ${summaryHeader}`,
-          error,
-        );
-      }
-    }
+
+        span.setAttribute("ch.queryId", res.query_id);
+
+        // add summary headers to the span. Helps to tune performance
+        const summaryHeader = res.response_headers["x-clickhouse-summary"];
+        if (summaryHeader) {
+          try {
+            const summary = Array.isArray(summaryHeader)
+              ? JSON.parse(summaryHeader[0])
+              : JSON.parse(summaryHeader);
+            for (const key in summary) {
+              span.setAttribute(`ch.${key}`, summary[key]);
+            }
+          } catch (error) {
+            logger.debug(
+              `Failed to parse clickhouse summary header ${summaryHeader}`,
+              error,
+            );
+          }
+        }
+        return res;
+      },
+    );
 
     for await (const rows of res.stream<T>()) {
       for (const row of rows) {

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -4,7 +4,7 @@ import {
   convertDateToClickhouseDateTime,
 } from "../clickhouse/client";
 import { logger } from "../logger";
-import { instrumentAsync } from "../instrumentation";
+import { getTracer, instrumentAsync } from "../instrumentation";
 import {
   StorageService,
   StorageServiceFactory,
@@ -99,6 +99,54 @@ export async function upsertClickhouse<
       }
     }
   });
+}
+
+export async function* queryClickhouseStream<T>(opts: {
+  query: string;
+  params?: Record<string, unknown> | undefined;
+  clickhouseConfigs?: NodeClickHouseClientConfigOptions;
+}): AsyncGenerator<T> {
+  const tracer = getTracer("clickhouse-query-stream");
+  const span = tracer.startSpan("clickhouse-query-stream");
+
+  // https://opentelemetry.io/docs/specs/semconv/database/database-spans/
+  span.setAttribute("ch.query.text", opts.query);
+
+  const res = await clickhouseClient(opts.clickhouseConfigs).query({
+    query: opts.query,
+    format: "JSONEachRow",
+    query_params: opts.params,
+  });
+  // same logic as for prisma. we want to see queries in development
+  if (env.NODE_ENV === "development") {
+    logger.info(`clickhouse:query ${res.query_id} ${opts.query}`);
+  }
+
+  span.setAttribute("ch.queryId", res.query_id);
+
+  // add summary headers to the span. Helps to tune performance
+  const summaryHeader = res.response_headers["x-clickhouse-summary"];
+  if (summaryHeader) {
+    try {
+      const summary = Array.isArray(summaryHeader)
+        ? JSON.parse(summaryHeader[0])
+        : JSON.parse(summaryHeader);
+      for (const key in summary) {
+        span.setAttribute(`ch.${key}`, summary[key]);
+      }
+    } catch (error) {
+      logger.debug(
+        `Failed to parse clickhouse summary header ${summaryHeader}`,
+        error,
+      );
+    }
+  }
+
+  for await (const rows of res.stream<T>()) {
+    for (const row of rows) {
+      yield row.json();
+    }
+  }
 }
 
 export async function queryClickhouse<T>(opts: {

--- a/worker/src/ee/integrations/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/ee/integrations/posthog/handlePostHogIntegrationProjectJob.ts
@@ -23,22 +23,22 @@ type PostHogExecutionConfig = {
 const POSTHOG_UUID_NAMESPACE = "0f6c91df-d035-4813-b838-9741ba38ef0b";
 
 const processPostHogTraces = async (config: PostHogExecutionConfig) => {
-  const postHogTraces = await getTracesForPostHog(
+  const postHogTraces = getTracesForPostHog(
     config.projectId,
     config.minTimestamp,
     config.maxTimestamp,
   );
 
-  logger.info(
-    `Found ${postHogTraces.length} traces for project ${config.projectId} to send to PostHog`,
-  );
+  logger.info(`Sending traces for project ${config.projectId} to PostHog`);
 
   // Send each via PostHog SDK
   const posthog = new PostHog(config.decryptedPostHogApiKey, {
     host: config.postHogHost,
   });
 
-  for (const trace of postHogTraces) {
+  let count = 0;
+  for await (const trace of postHogTraces) {
+    count++;
     posthog.capture({
       distinctId: trace.langfuse_user_id as string,
       event: "langfuse trace",
@@ -49,27 +49,36 @@ const processPostHogTraces = async (config: PostHogExecutionConfig) => {
         POSTHOG_UUID_NAMESPACE,
       ),
     });
+    if (count % 10000 === 0) {
+      await posthog.flush();
+      logger.info(
+        `Sent ${count} traces to PostHog for project ${config.projectId}`,
+      );
+    }
   }
   await posthog.flush();
+  logger.info(
+    `Sent ${count} traces to PostHog for project ${config.projectId}`,
+  );
 };
 
 const processPostHogGenerations = async (config: PostHogExecutionConfig) => {
-  const postHogGenerations = await getGenerationsForPostHog(
+  const postHogGenerations = getGenerationsForPostHog(
     config.projectId,
     config.minTimestamp,
     config.maxTimestamp,
   );
 
-  logger.info(
-    `Found ${postHogGenerations.length} generations for project ${config.projectId} to send to PostHog`,
-  );
+  logger.info(`Sending generations for project ${config.projectId} to PostHog`);
 
   // Send each via PostHog SDK
   const posthog = new PostHog(config.decryptedPostHogApiKey, {
     host: config.postHogHost,
   });
 
-  for (const generation of postHogGenerations) {
+  let count = 0;
+  for await (const generation of postHogGenerations) {
+    count++;
     posthog.capture({
       distinctId: generation.langfuse_user_id as string,
       event: "langfuse generation",
@@ -80,27 +89,36 @@ const processPostHogGenerations = async (config: PostHogExecutionConfig) => {
         POSTHOG_UUID_NAMESPACE,
       ),
     });
+    if (count % 10000 === 0) {
+      await posthog.flush();
+      logger.info(
+        `Sent ${count} generations to PostHog for project ${config.projectId}`,
+      );
+    }
   }
   await posthog.flush();
+  logger.info(
+    `Sent ${count} generations to PostHog for project ${config.projectId}`,
+  );
 };
 
 const processPostHogScores = async (config: PostHogExecutionConfig) => {
-  const postHogScores = await getScoresForPostHog(
+  const postHogScores = getScoresForPostHog(
     config.projectId,
     config.minTimestamp,
     config.maxTimestamp,
   );
 
-  logger.info(
-    `Found ${postHogScores.length} scores for project ${config.projectId} to send to PostHog`,
-  );
+  logger.info(`Sending scores for project ${config.projectId} to PostHog`);
 
   // Send each via PostHog SDK
   const posthog = new PostHog(config.decryptedPostHogApiKey, {
     host: config.postHogHost,
   });
 
-  for (const score of postHogScores) {
+  let count = 0;
+  for await (const score of postHogScores) {
+    count++;
     posthog.capture({
       distinctId: score.langfuse_user_id as string,
       event: "langfuse score",
@@ -111,8 +129,17 @@ const processPostHogScores = async (config: PostHogExecutionConfig) => {
         POSTHOG_UUID_NAMESPACE,
       ),
     });
+    if (count % 10000 === 0) {
+      await posthog.flush();
+      logger.info(
+        `Sent ${count} scores to PostHog for project ${config.projectId}`,
+      );
+    }
   }
   await posthog.flush();
+  logger.info(
+    `Sent ${count} scores to PostHog for project ${config.projectId}`,
+  );
 };
 
 export const handlePostHogIntegrationProjectJob = async (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Stream Clickhouse query results to PostHog to reduce memory usage by using async generators and updating PostHog integration logic.
> 
>   - **Behavior**:
>     - Introduces `queryClickhouseStream` in `clickhouse.ts` for streaming Clickhouse query results.
>     - Updates `getGenerationsForPostHog`, `getScoresForPostHog`, and `getTracesForPostHog` in `observations.ts`, `scores.ts`, and `traces.ts` to use `queryClickhouseStream`.
>     - Modifies `processPostHogTraces`, `processPostHogGenerations`, and `processPostHogScores` in `handlePostHogIntegrationProjectJob.ts` to handle streamed data.
>   - **Functions**:
>     - Converts `getGenerationsForPostHog`, `getScoresForPostHog`, and `getTracesForPostHog` to async generators.
>     - Adds logging and periodic flushing in `processPostHogTraces`, `processPostHogGenerations`, and `processPostHogScores` to manage large data volumes.
>   - **Misc**:
>     - Adds OpenTelemetry tracing to `queryClickhouseStream` for performance monitoring.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1163f7859a4e9c7498f37e6d356608f218a12654. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->