### PR TITLE
fix(ui): docs menu item should open in new tab

### DIFF
--- a/web/src/components/nav-main.tsx
+++ b/web/src/components/nav-main.tsx
@@ -115,7 +115,7 @@ export function NavMain({
                         >
                           <Link
                             href={subItem.url}
-                            target={subItem.newTab ? "blank" : undefined}
+                            target={subItem.newTab ? "_blank" : undefined}
                           >
                             <span>{subItem.title}</span>
                           </Link>

--- a/web/src/components/nav-main.tsx
+++ b/web/src/components/nav-main.tsx
@@ -28,10 +28,12 @@ export type NavMainItem = {
   icon?: LucideIcon;
   isActive?: boolean;
   label?: string | ReactNode;
+  newTab?: boolean;
   items?: {
     title: string;
     url: string;
     isActive?: boolean;
+    newTab?: boolean;
   }[];
 };
 
@@ -111,7 +113,10 @@ export function NavMain({
                           asChild
                           isActive={subItem.isActive}
                         >
-                          <Link href={subItem.url}>
+                          <Link
+                            href={subItem.url}
+                            target={subItem.newTab ? "blank" : undefined}
+                          >
                             <span>{subItem.title}</span>
                           </Link>
                         </SidebarMenuSubButton>
@@ -128,7 +133,10 @@ export function NavMain({
                 tooltip={item.title}
                 isActive={item.isActive}
               >
-                <Link href={item.url}>
+                <Link
+                  href={item.url}
+                  target={item.newTab ? "blank" : undefined}
+                >
                   <NavItemContent item={item} />
                 </Link>
               </SidebarMenuButton>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `newTab` property to `NavMainItem` and updates `NavMain` to open links in a new tab if specified.
> 
>   - **Behavior**:
>     - Adds `newTab` property to `NavMainItem` type to specify if a link should open in a new tab.
>     - Updates `NavMain` component to use `newTab` property for `Link` components, setting `target` to `"blank"` if `newTab` is true.
>   - **Components**:
>     - Modifies `NavMain` to handle `newTab` for both main items and sub-items.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f7a0845f299c184de008ade27339d98dc03065fe. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->