### PR TITLE
chore(ui): do not collapse chat messages on prompt view

### DIFF
--- a/web/src/components/trace/IOPreview.tsx
+++ b/web/src/components/trace/IOPreview.tsx
@@ -257,6 +257,7 @@ export const OpenAiMessageView: React.FC<{
   messages: z.infer<typeof ChatMlArraySchema>;
   title?: string;
   shouldRenderMarkdown?: boolean;
+  collapseLongHistory?: boolean;
   media?: MediaReturnType[];
   additionalInput?: Record<string, unknown>;
 }> = ({
@@ -264,11 +265,12 @@ export const OpenAiMessageView: React.FC<{
   messages,
   shouldRenderMarkdown = false,
   media,
+  collapseLongHistory = true,
   additionalInput,
 }) => {
   const COLLAPSE_THRESHOLD = 3;
   const [isCollapsed, setCollapsed] = useState(
-    messages.length > COLLAPSE_THRESHOLD ? true : null,
+    collapseLongHistory && messages.length > COLLAPSE_THRESHOLD ? true : null,
   );
 
   return (

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -262,7 +262,11 @@ export const PromptDetail = () => {
         </div>
         <div className="col-span-2 md:h-full">
           {prompt.type === PromptType.Chat && chatMessages ? (
-            <OpenAiMessageView title="Chat prompt" messages={chatMessages} />
+            <OpenAiMessageView
+              title="Chat prompt"
+              messages={chatMessages}
+              collapseLongHistory={false}
+            />
           ) : typeof prompt.prompt === "string" ? (
             <CodeView content={prompt.prompt} title="Text prompt" />
           ) : (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `collapseLongHistory` prop to `OpenAiMessageView` to prevent collapsing chat messages in prompt view.
> 
>   - **Behavior**:
>     - Add `collapseLongHistory` prop to `OpenAiMessageView` in `IOPreview.tsx` to control message collapsing.
>     - Set `collapseLongHistory` to `false` in `PromptDetail` in `prompt-detail.tsx` to prevent collapsing chat messages in prompt view.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for be345e00ca029a000fc36ead63afcbaa3d1173b1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->