### PR TITLE
chore(ui): improve button labels for playground and experiments on prompt view

### DIFF
--- a/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -62,16 +62,15 @@ export const JumpToPlaygroundButton: React.FC<JumpToPlaygroundButtonProps> = (
   return (
     <Button
       variant={props.variant ?? "secondary"}
-      size={props.source === "prompt" ? "icon" : "default"}
       title="Test in LLM playground"
       onClick={handleClick}
       asChild
     >
       <Link href={`/project/${projectId}/playground`}>
         <Terminal className="h-4 w-4" />
-        {props.source === "generation" && (
-          <span className="ml-2">Test in playground</span>
-        )}
+        <span className="ml-2">
+          {props.source === "generation" ? "Test in playground" : "Playground"}
+        </span>
       </Link>
     </Button>
   );

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -159,6 +159,12 @@ export const PromptDetail = () => {
         ]}
         actionButtons={
           <>
+            <JumpToPlaygroundButton
+              source="prompt"
+              prompt={prompt}
+              analyticsEventName="prompt_detail:test_in_playground_button_click"
+              variant="outline"
+            />
             {hasAccess ? (
               <>
                 {hasEntitlement && (
@@ -168,11 +174,11 @@ export const PromptDetail = () => {
                   >
                     <DialogTrigger asChild disabled={!hasExperimentWriteAccess}>
                       <Button
-                        variant="secondary"
+                        variant="outline"
                         disabled={!hasExperimentWriteAccess}
                       >
                         <FlaskConical className="h-4 w-4" />
-                        <span className="ml-2">New experiment</span>
+                        <span className="ml-2">Experiment</span>
                       </Button>
                     </DialogTrigger>
                     <DialogContent className="max-h-[90vh] overflow-y-auto">
@@ -194,7 +200,7 @@ export const PromptDetail = () => {
                 )}
 
                 <Button
-                  variant="secondary"
+                  variant="default"
                   onClick={() => {
                     capture("prompts:update_form_open");
                   }}
@@ -217,12 +223,6 @@ export const PromptDetail = () => {
                 </div>
               </Button>
             )}
-            <JumpToPlaygroundButton
-              source="prompt"
-              prompt={prompt}
-              analyticsEventName="prompt_detail:test_in_playground_button_click"
-              variant="outline"
-            />
             <DetailPageNav
               key="nav"
               currentId={promptName}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improved button labels and variants in `JumpToPlaygroundButton.tsx` and `prompt-detail.tsx` for better UI consistency.
> 
>   - **UI Improvements**:
>     - In `JumpToPlaygroundButton.tsx`, updated button label to "Playground" for `source="prompt"` and retained "Test in playground" for `source="generation"`.
>     - In `prompt-detail.tsx`, changed button label from "New experiment" to "Experiment".
>     - Adjusted button variants from `secondary` to `outline` and `default` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d3c31089c23731258ef65f9d4a90ee72bf57c8c4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->