### PR TITLE
feat(annotation-queue): show "add to dataset" button on trace preview

### DIFF
--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -290,55 +290,58 @@ export const ObservationPreview = ({
               </div>
             )}
           </div>
-          {viewType === "detailed" && (
-            <div className="flex flex-wrap gap-2">
-              <CommentDrawerButton
-                projectId={preloadedObservation.projectId}
-                objectId={preloadedObservation.id}
-                objectType="OBSERVATION"
-                count={commentCounts?.get(preloadedObservation.id)}
-              />
-              <div className="flex items-start">
-                <AnnotateDrawer
-                  key={"annotation-drawer" + preloadedObservation.id}
-                  projectId={projectId}
-                  traceId={traceId}
-                  observationId={preloadedObservation.id}
-                  scores={scores}
-                  emptySelectedConfigIds={emptySelectedConfigIds}
-                  setEmptySelectedConfigIds={setEmptySelectedConfigIds}
-                  type="observation"
-                  hasGroupedButton={hasEntitlement}
+
+          <div className="flex flex-wrap gap-2">
+            {viewType === "detailed" && (
+              <>
+                <CommentDrawerButton
+                  projectId={preloadedObservation.projectId}
+                  objectId={preloadedObservation.id}
+                  objectType="OBSERVATION"
+                  count={commentCounts?.get(preloadedObservation.id)}
                 />
-                {hasEntitlement && (
-                  <CreateNewAnnotationQueueItem
+                <div className="flex items-start">
+                  <AnnotateDrawer
+                    key={"annotation-drawer" + preloadedObservation.id}
                     projectId={projectId}
-                    objectId={preloadedObservation.id}
-                    objectType={AnnotationQueueObjectType.OBSERVATION}
+                    traceId={traceId}
+                    observationId={preloadedObservation.id}
+                    scores={scores}
+                    emptySelectedConfigIds={emptySelectedConfigIds}
+                    setEmptySelectedConfigIds={setEmptySelectedConfigIds}
+                    type="observation"
+                    hasGroupedButton={hasEntitlement}
+                  />
+                  {hasEntitlement && (
+                    <CreateNewAnnotationQueueItem
+                      projectId={projectId}
+                      objectId={preloadedObservation.id}
+                      objectType={AnnotationQueueObjectType.OBSERVATION}
+                    />
+                  )}
+                </div>
+
+                {observationWithInputAndOutput.data?.type === "GENERATION" && (
+                  <JumpToPlaygroundButton
+                    source="generation"
+                    generation={observationWithInputAndOutput.data}
+                    analyticsEventName="trace_detail:test_in_playground_button_click"
                   />
                 )}
-              </div>
-
-              {observationWithInputAndOutput.data?.type === "GENERATION" && (
-                <JumpToPlaygroundButton
-                  source="generation"
-                  generation={observationWithInputAndOutput.data}
-                  analyticsEventName="trace_detail:test_in_playground_button_click"
-                />
-              )}
-              {observationWithInputAndOutput.data ? (
-                <NewDatasetItemFromTrace
-                  traceId={preloadedObservation.traceId}
-                  observationId={preloadedObservation.id}
-                  projectId={projectId}
-                  input={observationWithInputAndOutput.data.input}
-                  output={observationWithInputAndOutput.data.output}
-                  metadata={observationWithInputAndOutput.data.metadata}
-                  key={preloadedObservation.id}
-                />
-              ) : null}
-            </div>
-          )}
+              </>
+            )}
+            {observationWithInputAndOutput.data ? (
+              <NewDatasetItemFromTrace
+                traceId={preloadedObservation.traceId}
+                observationId={preloadedObservation.id}
+                projectId={projectId}
+                input={observationWithInputAndOutput.data.input}
+                output={observationWithInputAndOutput.data.output}
+                metadata={observationWithInputAndOutput.data.metadata}
+                key={preloadedObservation.id}
+              />
+            ) : null}
+          </div>
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
           {selectedTab === "preview" && (

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -169,42 +169,45 @@ export const TracePreview = ({
               </div>
             )}
           </div>
-          {viewType === "detailed" && (
-            <div className="flex flex-wrap gap-2">
-              <CommentDrawerButton
-                projectId={trace.projectId}
-                objectId={trace.id}
-                objectType="TRACE"
-                count={commentCounts?.get(trace.id)}
-              />
-              <div className="flex items-start">
-                <AnnotateDrawer
-                  key={"annotation-drawer" + trace.id}
+
+          <div className="flex flex-wrap gap-2">
+            {viewType === "detailed" && (
+              <>
+                <CommentDrawerButton
                   projectId={trace.projectId}
-                  traceId={trace.id}
-                  scores={scores}
-                  emptySelectedConfigIds={emptySelectedConfigIds}
-                  setEmptySelectedConfigIds={setEmptySelectedConfigIds}
-                  hasGroupedButton={hasEntitlement}
+                  objectId={trace.id}
+                  objectType="TRACE"
+                  count={commentCounts?.get(trace.id)}
                 />
-                {hasEntitlement && (
-                  <CreateNewAnnotationQueueItem
+                <div className="flex items-start">
+                  <AnnotateDrawer
+                    key={"annotation-drawer" + trace.id}
                     projectId={trace.projectId}
-                    objectId={trace.id}
-                    objectType={AnnotationQueueObjectType.TRACE}
+                    traceId={trace.id}
+                    scores={scores}
+                    emptySelectedConfigIds={emptySelectedConfigIds}
+                    setEmptySelectedConfigIds={setEmptySelectedConfigIds}
+                    hasGroupedButton={hasEntitlement}
                   />
-                )}
-              </div>
-              <NewDatasetItemFromTrace
-                traceId={trace.id}
-                projectId={trace.projectId}
-                input={trace.input}
-                output={trace.output}
-                metadata={trace.metadata}
-                key={trace.id}
-              />
-            </div>
-          )}
+                  {hasEntitlement && (
+                    <CreateNewAnnotationQueueItem
+                      projectId={trace.projectId}
+                      objectId={trace.id}
+                      objectType={AnnotationQueueObjectType.TRACE}
+                    />
+                  )}
+                </div>
+              </>
+            )}
+            <NewDatasetItemFromTrace
+              traceId={trace.id}
+              projectId={trace.projectId}
+              input={trace.input}
+              output={trace.output}
+              metadata={trace.metadata}
+              key={trace.id}
+            />
+          </div>
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
           {selectedTab === "preview" && (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add "NewDatasetItemFromTrace" button to `ObservationPreview.tsx` and `TracePreview.tsx` for dataset integration.
> 
>   - **UI Enhancements**:
>     - Add `NewDatasetItemFromTrace` button to `ObservationPreview.tsx` and `TracePreview.tsx` for adding items to datasets.
>     - Button is displayed outside the `viewType === "detailed"` condition, ensuring visibility in all view types.
>   - **Behavior**:
>     - Button is conditionally rendered based on the availability of `observationWithInputAndOutput.data` in `ObservationPreview.tsx`.
>     - In `TracePreview.tsx`, the button is always rendered, using `trace.input`, `trace.output`, and `trace.metadata`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 67f50b3e06553f8e628064a91bf6b7c6132fb55d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->