### PR TITLE
Fix: in telemetry, prisma invalid input syntax for type interval: "24 * 60 minute"

### DIFF
--- a/web/src/features/telemetry/index.ts
+++ b/web/src/features/telemetry/index.ts
@@ -11,10 +11,10 @@ import {
 import { env } from "@/src/env.mjs";
 
 // Interval between jobs in minutes
-const JOB_INTERVAL_MINUTES = Prisma.raw("24 * 60"); // 24 hours
+const JOB_INTERVAL_MINUTES = Prisma.raw(24 * 60); // 24 hours
 
 // Timeout for job in minutes, if job is not finished in this time, it will be retried
-const JOB_TIMEOUT_MINUTES = Prisma.raw("10"); // 10 minutes
+const JOB_TIMEOUT_MINUTES = Prisma.raw(10); // 10 minutes
 
 export async function telemetry() {
   try {


### PR DESCRIPTION
## What does this PR do?

It fixes a bug in telemetry related code. Without this fix, when the instructions given at [Self Hosting > Kubernetes (Helm)](https://langfuse.com/self-hosting/kubernetes-helm) are followed, the langfuse-web pod keeps printing the following error:-

> 2025-01-12T02:52:28.885Z error  prisma:error 
Invalid `prisma.$queryRaw()` invocation:
Raw query failed. Code: `22007`. Message: `ERROR: invalid input syntax for type interval: "24 * 60 minute"`
2025-01-12T02:52:28.896Z error  Telemetry, unexpected error: 
Invalid `prisma.$queryRaw()` invocation:
Raw query failed. Code: `22007`. Message: `ERROR: invalid input syntax for type interval: "24 * 60 minute"`
PrismaClientKnownRequestError: 
Invalid `prisma.$queryRaw()` invocation:
Raw query failed. Code: `22007`. Message: `ERROR: invalid input syntax for type interval: "24 * 60 minute"`
    at $n.handleRequestError (/app/node_modules/.pnpm/@prisma+client@5.22.0_prisma@5.22.0/node_modules/@prisma/client/runtime/library.js:121:7315)
    at $n.handleAndLogRequestError (/app/node_modules/.pnpm/@prisma+client@5.22.0_prisma@5.22.0/node_modules/@prisma/client/runtime/library.js:121:6623)
    at $n.request (/app/node_modules/.pnpm/@prisma+client@5.22.0_prisma@5.22.0/node_modules/@prisma/client/runtime/library.js:121:6307)
    at async l (/app/node_modules/.pnpm/@prisma+client@5.22.0_prisma@5.22.0/node_modules/@prisma/client/runtime/library.js:130:9633)
    at async d (/app/web/.next/server/pages/api/public/health.js:13:2698)
    at async p (/app/web/.next/server/pages/api/public/health.js:13:2385)
    at async p (/app/web/.next/server/pages/api/public/health.js:1:4387)
    at async /app/node_modules/.pnpm/@sentry+nextjs@8.39.0_@opentelemetry+core@1.26.0_@opentelemetry+api@1.9.0__@opentelemetry+ins_2ujtc3rfcmw2mam2weoibjylcq/node_modules/@sentry/nextjs/build/cjs/common/pages-router-instrumentation/wrapApiHandlerWithSentry.js:83:28
    at async K (/app/node_modules/.pnpm/next@14.2.21_@babel+core@7.24.3_@opentelemetry+api@1.9.0_@playwright+test@1.47.2_babel-plugin_yqlzwwxnhgfuesbfmfmtmhekse/node_modules/next/dist/compiled/next-server/pages-api.runtime.prod.js:20:16881)
    at async U.render (/app/node_modules/.pnpm/next@14.2.21_@babel+core@7.24.3_@opentelemetry+api@1.9.0_@playwright+test@1.47.2_babel-plugin_yqlzwwxnhgfuesbfmfmtmhekse/node_modules/next/dist/compiled/next-server/pages-api.runtime.prod.js:20:17520)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes interval syntax in telemetry code to prevent Prisma query errors.
> 
>   - **Bug Fix**:
>     - Corrects interval syntax in `JOB_INTERVAL_MINUTES` and `JOB_TIMEOUT_MINUTES` in `index.ts` from string to numeric expression to fix Prisma query error.
>   - **Behavior**:
>     - Prevents `invalid input syntax for type interval` error in telemetry when running on Kubernetes with Helm.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 895a9c235f46aabfb84f3af9f7261fdcf163a770. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->