### PR TITLE
fix: telemetry error "invalid input syntax for type interval"

### DIFF
--- a/web/src/features/telemetry/index.ts
+++ b/web/src/features/telemetry/index.ts
@@ -11,7 +11,7 @@ import {
 import { env } from "@/src/env.mjs";
 
 // Interval between jobs in minutes
-const JOB_INTERVAL_MINUTES = Prisma.raw("24 * 60"); // 24 hours
+const JOB_INTERVAL_MINUTES = Prisma.raw("720"); // 12 hours
 
 // Timeout for job in minutes, if job is not finished in this time, it will be retried
 const JOB_TIMEOUT_MINUTES = Prisma.raw("10"); // 10 minutes


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce telemetry job interval from 24 hours to 12 hours in `index.ts`.
> 
>   - **Behavior**:
>     - Change `JOB_INTERVAL_MINUTES` in `index.ts` from 1440 (24 hours) to 720 (12 hours) to schedule telemetry jobs more frequently.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d5c85e79960f889849be83522967f00783cc12eb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->