### PR TITLE
fix: fix session table sorting

### DIFF
--- a/packages/shared/src/server/services/sessions-ui-table-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-service.ts
@@ -189,17 +189,28 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
   const singleTraceFilter =
     filters.length > 0 ? new FilterList(filters).apply() : undefined;
 
-  const hasMetricsFilter = tracesFilter.find((f) =>
-    [
-      "session_total_cost",
-      "session_input_cost",
-      "session_output_cost",
-      "duration",
-      "session_total_usage",
-      "session_output_usage",
-      "session_input_usage",
-    ].includes(f.field),
-  );
+  const hasMetricsFilter =
+    tracesFilter.find((f) =>
+      [
+        "session_total_cost",
+        "session_input_cost",
+        "session_output_cost",
+        "duration",
+        "session_total_usage",
+        "session_output_usage",
+        "session_input_usage",
+      ].includes(f.field),
+    ) ||
+    (orderBy &&
+      [
+        "totalCost",
+        "inputCost",
+        "outputCost",
+        "duration",
+        "totalUsage",
+        "outputUsage",
+        "inputUsage",
+      ].includes(orderBy?.column));
 
   const selectMetrics = select === "metrics" || hasMetricsFilter;
 

--- a/web/src/__tests__/async/sessions-ui-table.servertest.ts
+++ b/web/src/__tests__/async/sessions-ui-table.servertest.ts
@@ -92,6 +92,79 @@ describe("trpc.sessions", () => {
     expect(uiSessions[0].user_ids).toEqual(["user1"]);
   });
 
+  it.only("should GET sessions ordered by total cost", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const sessionId1 = v4();
+    const sessionId2 = v4();
+
+    await prisma.traceSession.createMany({
+      data: [
+        {
+          id: sessionId1,
+          projectId: projectId,
+        },
+        {
+          id: sessionId2,
+          projectId: projectId,
+        },
+      ],
+    });
+
+    const traces = [
+      createTrace({
+        session_id: sessionId1,
+        project_id: projectId,
+      }),
+      createTrace({
+        session_id: sessionId2,
+        project_id: projectId,
+      }),
+    ];
+
+    const observations = [
+      createObservation({
+        trace_id: traces[0].id,
+        project_id: projectId,
+        cost_details: {
+          input: 0.1,
+          output: 0.2,
+          total: 0.3,
+        },
+        total_cost: 0.3,
+      }),
+      createObservation({
+        trace_id: traces[1].id,
+        project_id: projectId,
+        cost_details: {
+          input: 0.3,
+          output: 0.4,
+          total: 0.7,
+        },
+        total_cost: 0.7,
+      }),
+    ];
+
+    await createTracesCh(traces);
+    await createObservationsCh(observations);
+
+    const uiSessions = await getSessionsTable({
+      projectId: projectId,
+      filter: [],
+      orderBy: {
+        column: "totalCost",
+        order: "DESC" as const,
+      },
+      limit: 10000,
+      page: 0,
+    });
+
+    expect(uiSessions.length).toBe(2);
+    expect(uiSessions[0].session_id).toBe(sessionId2);
+    expect(uiSessions[1].session_id).toBe(sessionId1);
+    expect(uiSessions[0].session_id).toBe(sessionId2); // session with higher cost
+    expect(uiSessions[1].session_id).toBe(sessionId1); // session with lower cost
+  });
+
   it("should GET metrics for a list of sessions", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
     const sessionId1 = v4();

--- a/web/src/__tests__/async/sessions-ui-table.servertest.ts
+++ b/web/src/__tests__/async/sessions-ui-table.servertest.ts
@@ -92,7 +92,7 @@ describe("trpc.sessions", () => {
     expect(uiSessions[0].user_ids).toEqual(["user1"]);
   });
 
-  it.only("should GET sessions ordered by total cost", async () => {
+  it("should GET sessions ordered by total cost", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
     const sessionId1 = v4();
     const sessionId2 = v4();
@@ -161,8 +161,6 @@ describe("trpc.sessions", () => {
     expect(uiSessions.length).toBe(2);
     expect(uiSessions[0].session_id).toBe(sessionId2);
     expect(uiSessions[1].session_id).toBe(sessionId1);
-    expect(uiSessions[0].session_id).toBe(sessionId2); // session with higher cost
-    expect(uiSessions[1].session_id).toBe(sessionId1); // session with lower cost
   });
 
   it("should GET metrics for a list of sessions", async () => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes session table sorting by updating `hasMetricsFilter` to include `orderBy` conditions and adds a test for ordering by `totalCost`.
> 
>   - **Behavior**:
>     - Fixes session table sorting by updating `hasMetricsFilter` in `getSessionsTableGeneric()` in `sessions-ui-table-service.ts` to include `orderBy` conditions for metrics like `totalCost`, `inputCost`, etc.
>   - **Tests**:
>     - Adds test case in `sessions-ui-table.servertest.ts` to verify sessions are ordered by `totalCost` correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b57a0ed2057a8c8f240366c63ece22bde3c9bf82. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->