### PR TITLE
fix: fail open on redis errors in ratelimitservice

### DIFF
--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -100,9 +100,9 @@ export class RateLimitService {
           isFirstInDuration: err.isFirstInDuration,
         };
       } else {
-        // Some other error occurred, rethrow it
+        // Some other error occurred, return undefined to fail open
         logger.error("Internal Rate limit error", err);
-        throw err;
+        return undefined;
       }
     }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `RateLimitService` to fail open on non-`RateLimiterRes` errors by returning `undefined`.
> 
>   - **Behavior**:
>     - In `RateLimitService`, modify error handling to return `undefined` instead of throwing an error for non-`RateLimiterRes` errors, allowing the system to fail open on Redis errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 75fbe65336c6b295d349a2110996e98a52c8c19e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->