### PR TITLE
chore(models): update fern types startDate unit

### DIFF
--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -378,7 +378,7 @@ types:
         type: string
       startDate:
         docs: Apply only to generations which are newer than this ISO date.
-        type: optional<date>
+        type: optional<datetime>
       unit:
         docs: Unit used by this model.
         type: ModelUsageUnit

--- a/fern/apis/server/definition/models.yml
+++ b/fern/apis/server/definition/models.yml
@@ -58,7 +58,7 @@ types:
         type: optional<datetime>
       unit:
         docs: Unit used by this model.
-        type: commons.ModelUsageUnit
+        type: optional<commons.ModelUsageUnit>
       inputPrice:
         docs: Price (USD) per input unit
         type: optional<double>

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,5 @@
 {
-  "organization": "finto",
+  "organization": "langfuse",
   "version": "0.43.7"
 }
+

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3186,7 +3186,7 @@ components:
             to exact match, use `(?i)^modelname$`
         startDate:
           type: string
-          format: date
+          format: date-time
           nullable: true
           description: Apply only to generations which are newer than this ISO date.
         unit:
@@ -4279,6 +4279,7 @@ components:
           description: Apply only to generations which are newer than this ISO date.
         unit:
           $ref: '#/components/schemas/ModelUsageUnit'
+          nullable: true
           description: Unit used by this model.
         inputPrice:
           type: number
@@ -4311,7 +4312,6 @@ components:
       required:
         - modelName
         - matchPattern
-        - unit
     Observations:
       title: Observations
       type: object


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `startDate` to `datetime` and make `unit` optional in model definitions across `commons.yml`, `models.yml`, and `openapi.yml`.
> 
>   - **Behavior**:
>     - Update `startDate` type from `optional<date>` to `optional<datetime>` in `commons.yml` and `openapi.yml` to include time information.
>     - Change `unit` type from `commons.ModelUsageUnit` to `optional<commons.ModelUsageUnit>` in `models.yml` and `openapi.yml`, making it optional.
>   - **API Schema**:
>     - Remove `unit` from required fields in `openapi.yml` for model components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b6e43afb8c02e15d9ccbdffd525a9312c734c728. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->