### PR TITLE
fix: process status codes on eval execution errors

### DIFF
--- a/packages/shared/src/errors/ApiError.ts
+++ b/packages/shared/src/errors/ApiError.ts
@@ -1,7 +1,7 @@
 import { BaseError } from "./BaseError";
 
 export class ApiError extends BaseError {
-  constructor(description = "Api call failed") {
-    super("ApiError", 500, description, true);
+  constructor(description = "Api call failed", status = 500) {
+    super("ApiError", status, description, true);
   }
 }

--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -20,6 +20,7 @@ import {
   LLMAdapter,
   LangfuseNotFoundError,
   variableMappingList,
+  ApiError,
 } from "@langfuse/shared";
 import { encrypt } from "@langfuse/shared/encryption";
 import { OpenAIServer } from "./network";
@@ -939,6 +940,100 @@ describe("eval service tests", () => {
         new LangfuseNotFoundError(
           "API key for provider openai and project 7a88fb47-b4e2-43b8-a06c-a5ce950dc53a not found.",
         ),
+      );
+
+      const jobs = await kyselyPrisma.$kysely
+        .selectFrom("job_executions")
+        .selectAll()
+        .where("project_id", "=", "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a")
+        .execute();
+
+      expect(jobs.length).toBe(1);
+      expect(jobs[0].project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
+      expect(jobs[0].job_input_trace_id).toBe(traceId);
+      // the job will be failed when the exception is caught in the worker consumer
+      expect(jobs[0].status.toString()).toBe("PENDING");
+    }, 10_000);
+
+    test("fails to eval on openai error", async () => {
+      openAIServer.respondWithError(401, "Not authorized");
+
+      const traceId = randomUUID();
+
+      await kyselyPrisma.$kysely
+        .insertInto("traces")
+        .values({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          user_id: "a",
+          input: { input: "This is a great prompt" },
+          output: { output: "This is a great response" },
+        })
+        .execute();
+
+      const templateId = randomUUID();
+      await kyselyPrisma.$kysely
+        .insertInto("eval_templates")
+        .values({
+          id: templateId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          name: "test-template",
+          version: 1,
+          prompt: "Please evaluate toxicity {{input}} {{output}}",
+          model: "gpt-3.5-turbo",
+          provider: "openai",
+          model_params: {},
+          output_schema: {
+            reasoning: "Please explain your reasoning",
+            score: "Please provide a score between 0 and 1",
+          },
+        })
+        .executeTakeFirst();
+
+      const jobConfiguration = await prisma.jobConfiguration.create({
+        data: {
+          id: randomUUID(),
+          projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          filter: [
+            {
+              type: "string",
+              value: "a",
+              column: "User ID",
+              operator: "contains",
+            },
+          ],
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: "trace",
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+          evalTemplateId: templateId,
+        },
+      });
+
+      const jobExecutionId = randomUUID();
+
+      await kyselyPrisma.$kysely
+        .insertInto("job_executions")
+        .values({
+          id: jobExecutionId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          job_configuration_id: jobConfiguration.id,
+          status: sql`'PENDING'::"JobExecutionStatus"`,
+          start_time: new Date(),
+          job_input_trace_id: traceId,
+        })
+        .execute();
+
+      const payload = {
+        projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+        jobExecutionId: jobExecutionId,
+        delay: 1000,
+      };
+
+      await expect(evaluate({ event: payload })).rejects.toThrowError(
+        new ApiError("Not authorized", 401),
       );
 
       const jobs = await kyselyPrisma.$kysely

--- a/worker/src/features/utilities.ts
+++ b/worker/src/features/utilities.ts
@@ -46,8 +46,11 @@ export async function callStructuredLLM<T extends ZodSchema>(
 
     return structuredOutputSchema.parse(completion);
   } catch (e) {
-    logger.error(`Job ${jeId} failed to call LLM. Eval will fail. ${e}`);
-    throw new ApiError(`Failed to call LLM: ${e}`);
+    logger.error(`Job ${jeId} failed to call LLM. Eval will fail.`, e);
+    throw new ApiError(
+      `Failed to call LLM: ${e}`,
+      (e as any)?.response?.status,
+    );
   }
 }
 
@@ -85,8 +88,11 @@ export async function callLLM(
 
     return completion;
   } catch (e) {
-    logger.error(`Job ${jeId} failed to call LLM. Eval will fail. ${e}`);
-    throw new ApiError(`Failed to call LLM: ${e}`);
+    logger.error(`Job ${jeId} failed to call LLM. Eval will fail.`, e);
+    throw new ApiError(
+      `Failed to call LLM: ${e}`,
+      (e as any)?.response?.status,
+    );
   }
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `ApiError` to handle HTTP status codes and update LLM call functions and tests accordingly.
> 
>   - **Error Handling**:
>     - `ApiError` constructor in `ApiError.ts` now accepts a `status` parameter to handle HTTP status codes.
>     - `callStructuredLLM()` and `callLLM()` in `utilities.ts` updated to throw `ApiError` with status code from error response.
>   - **Testing**:
>     - Added test `fails to eval on openai error` in `evalService.test.ts` to verify handling of 401 error with `ApiError`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8995d3aec217a48b2ab6b69ace21c6db13ea9961. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->