### PR TITLE
fix(fern-models): unit to optional commons.model

### DIFF
--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -381,7 +381,7 @@ types:
         type: optional<datetime>
       unit:
         docs: Unit used by this model.
-        type: ModelUsageUnit
+        type: optional<ModelUsageUnit>
       inputPrice:
         docs: Price (USD) per input unit
         type: optional<double>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `unit` property in `Model` type to optional in `commons.yml`.
> 
>   - **Behavior**:
>     - Change `unit` property in `Model` type from `ModelUsageUnit` to `optional<ModelUsageUnit>` in `commons.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 41f31c5ebb25bbecd8364151e2a8cf2ad1e6bb14. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->