### PR TITLE
fix(openapi-models): modelusageunit to optional

### DIFF
--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3191,6 +3191,7 @@ components:
           description: Apply only to generations which are newer than this ISO date.
         unit:
           $ref: '#/components/schemas/ModelUsageUnit'
+          nullable: true
           description: Unit used by this model.
         inputPrice:
           type: number
@@ -3226,7 +3227,6 @@ components:
         - id
         - modelName
         - matchPattern
-        - unit
         - isLangfuseManaged
     ModelUsageUnit:
       title: ModelUsageUnit


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> The `unit` field in the `Model` schema in `openapi.yml` is now optional, allowing it to be nullable and removing it from the required fields.
> 
>   - **Behavior**:
>     - `unit` in `Model` schema in `openapi.yml` is now optional (nullable).
>     - Removed `unit` from required fields in `Model` schema.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fe3789b618a398555f906af04abda640a2fd0560. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->