### PR TITLE
feat(ui-tabels): Count of group selection on column visibility

### DIFF
--- a/web/src/components/table/data-table-column-visibility-filter.tsx
+++ b/web/src/components/table/data-table-column-visibility-filter.tsx
@@ -160,8 +160,12 @@ function ColumnVisibilityDropdownItem<TData, TValue>({
 
 function GroupVisibilityDropdownHeader<TData, TValue>({
   column,
+  groupTotalCount,
+  groupVisibleCount,
 }: {
   column: LangfuseColumnDef<TData, TValue>;
+  groupTotalCount: number;
+  groupVisibleCount: number;
 }) {
   const { attributes, isDragging, listeners, setNodeRef, transform } =
     useSortable({
@@ -188,6 +192,9 @@ function GroupVisibilityDropdownHeader<TData, TValue>({
           {column.header && typeof column.header === "string"
             ? column.header
             : column.accessorKey}
+        </span>
+        <span className="ml-1.5 text-xs text-muted-foreground">
+          ({groupVisibleCount}/{groupTotalCount})
         </span>
       </div>
       <div className="flex items-center">
@@ -352,7 +359,11 @@ export function DataTableColumnVisibilityFilter<TData, TValue>({
                   return (
                     <DropdownMenuSub key={index}>
                       {isColumnOrderingEnabled ? (
-                        <GroupVisibilityDropdownHeader column={column} />
+                        <GroupVisibilityDropdownHeader
+                          column={column}
+                          groupTotalCount={groupTotalCount}
+                          groupVisibleCount={groupVisibleCount}
+                        />
                       ) : (
                         <DropdownMenuSubTrigger hasCustomIcon>
                           <Component className="mr-2 h-4 w-4 opacity-50" />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds visible/total column count display to `GroupVisibilityDropdownHeader` in `data-table-column-visibility-filter.tsx`.
> 
>   - **Behavior**:
>     - Displays count of visible columns over total columns in `GroupVisibilityDropdownHeader`.
>     - Updates `GroupVisibilityDropdownHeader` to accept `groupTotalCount` and `groupVisibleCount`.
>   - **Components**:
>     - `GroupVisibilityDropdownHeader` in `data-table-column-visibility-filter.tsx` now shows "(visible/total)" count.
>     - `DataTableColumnVisibilityFilter` passes `groupTotalCount` and `groupVisibleCount` to `GroupVisibilityDropdownHeader`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ae419fec92b6eac6cebfeba99823e75bceb52a38. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->