### PR TITLE
fix(ingestion): overwriting of observation level

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -360,6 +360,7 @@ export class IngestionService {
     });
     finalObservationRecord.created_at =
       clickhouseObservationRecord?.created_at ?? createdAtTimestamp.getTime();
+    finalObservationRecord.level = finalObservationRecord.level ?? "DEFAULT";
 
     // Backward compat: create wrapper trace for SDK < 2.0.0 events that do not have a traceId
     if (!finalObservationRecord.trace_id) {
@@ -976,7 +977,7 @@ export class IngestionService {
         provided_cost_details,
         usage_details: provided_usage_details,
         cost_details: provided_cost_details,
-        level: obs.body.level ?? "DEFAULT",
+        level: obs.body.level,
         status_message: obs.body.statusMessage ?? undefined,
         parent_observation_id: obs.body.parentObservationId ?? undefined,
         version: obs.body.version ?? undefined,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes overwriting of `level` attribute in `IngestionService` by ensuring it defaults to 'DEFAULT' only when not set.
> 
>   - **Behavior**:
>     - In `IngestionService`, `finalObservationRecord.level` is set to 'DEFAULT' only if not already defined in `processObservationEventList()`.
>     - Removed default assignment of `level` to 'DEFAULT' in `mapObservationEventsToRecords()`.
>   - **Misc**:
>     - Minor refactoring to ensure `level` is not redundantly set to 'DEFAULT'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 22f555244837d4fd3190f0867270d3ce6604c179. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->