### PR TITLE
fix: correctly order sessions by time

### DIFF
--- a/packages/shared/src/server/services/sessions-ui-table-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-service.ts
@@ -206,7 +206,7 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
         "totalCost",
         "inputCost",
         "outputCost",
-        "duration",
+        "sessionDuration",
         "totalUsage",
         "outputUsage",
         "inputUsage",

--- a/web/src/__tests__/async/sessions-ui-table.servertest.ts
+++ b/web/src/__tests__/async/sessions-ui-table.servertest.ts
@@ -191,19 +191,18 @@ describe("trpc.sessions", () => {
         project_id: projectId,
       }),
     ];
-
     const observations = [
       createObservation({
         trace_id: traces[0].id,
         project_id: projectId,
         start_time: new Date("2024-01-01T00:00:00Z").getTime(),
-        end_time: new Date("2024-01-01T00:00:01Z").getTime(),
+        end_time: new Date("2024-01-01T00:00:10Z").getTime(), // 10 second duration
       }),
       createObservation({
         trace_id: traces[1].id,
         project_id: projectId,
         start_time: new Date("2024-01-01T00:00:00Z").getTime(),
-        end_time: new Date("2024-01-01T00:00:01Z").getTime(),
+        end_time: new Date("2024-01-01T00:00:20Z").getTime(), // 20 second duration
       }),
     ];
 

--- a/web/src/__tests__/async/sessions-ui-table.servertest.ts
+++ b/web/src/__tests__/async/sessions-ui-table.servertest.ts
@@ -163,6 +163,69 @@ describe("trpc.sessions", () => {
     expect(uiSessions[1].session_id).toBe(sessionId1);
   });
 
+  it("should GET sessions ordered by duration", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const sessionId1 = v4();
+    const sessionId2 = v4();
+
+    await prisma.traceSession.createMany({
+      data: [
+        {
+          id: sessionId1,
+          projectId: projectId,
+        },
+        {
+          id: sessionId2,
+          projectId: projectId,
+        },
+      ],
+    });
+
+    const traces = [
+      createTrace({
+        session_id: sessionId1,
+        project_id: projectId,
+      }),
+      createTrace({
+        session_id: sessionId2,
+        project_id: projectId,
+      }),
+    ];
+
+    const observations = [
+      createObservation({
+        trace_id: traces[0].id,
+        project_id: projectId,
+        start_time: new Date("2024-01-01T00:00:00Z").getTime(),
+        end_time: new Date("2024-01-01T00:00:01Z").getTime(),
+      }),
+      createObservation({
+        trace_id: traces[1].id,
+        project_id: projectId,
+        start_time: new Date("2024-01-01T00:00:00Z").getTime(),
+        end_time: new Date("2024-01-01T00:00:01Z").getTime(),
+      }),
+    ];
+
+    await createTracesCh(traces);
+    await createObservationsCh(observations);
+
+    const uiSessions = await getSessionsTable({
+      projectId: projectId,
+      filter: [],
+      orderBy: {
+        column: "duration",
+        order: "DESC" as const,
+      },
+      limit: 10000,
+      page: 0,
+    });
+
+    expect(uiSessions.length).toBe(2);
+    expect(uiSessions[0].session_id).toBe(sessionId2);
+    expect(uiSessions[1].session_id).toBe(sessionId1);
+  });
+
   it("should GET metrics for a list of sessions", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
     const sessionId1 = v4();

--- a/web/src/__tests__/async/sessions-ui-table.servertest.ts
+++ b/web/src/__tests__/async/sessions-ui-table.servertest.ts
@@ -214,7 +214,7 @@ describe("trpc.sessions", () => {
       projectId: projectId,
       filter: [],
       orderBy: {
-        column: "duration",
+        column: "sessionDuration",
         order: "DESC" as const,
       },
       limit: 10000,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes session ordering by duration in `getSessionsTableGeneric` and adds a test case for it.
> 
>   - **Behavior**:
>     - Fixes ordering of sessions by `sessionDuration` in `getSessionsTableGeneric` in `sessions-ui-table-service.ts`.
>     - Adds test case in `sessions-ui-table.servertest.ts` to verify sessions are ordered by duration.
>   - **Misc**:
>     - Renames `duration` to `sessionDuration` in `getSessionsTableGeneric` in `sessions-ui-table-service.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cc0bea5c5d275c21b9d88ba947b0c5be3215b7c5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->