### PR TITLE
chore(ui-dashboard): save selected score graphs in the dashboard to `localStorage` (project-bound)

### DIFF
--- a/web/src/components/table/use-cases/score-configs.tsx
+++ b/web/src/components/table/use-cases/score-configs.tsx
@@ -249,7 +249,7 @@ export function ScoreConfigsTable({ projectId }: { projectId: string }) {
         rowHeight={rowHeight}
         setRowHeight={setRowHeight}
       />
-      <Card className="mb-4 flex max-h-[calc(100dvh-30rem)] flex-col overflow-hidden">
+      <Card className="mb-4 flex max-h-[60dvh] flex-col overflow-hidden">
         <DataTable
           columns={columns}
           data={

--- a/web/src/features/dashboard/components/score-analytics/ScoreAnalytics.tsx
+++ b/web/src/features/dashboard/components/score-analytics/ScoreAnalytics.tsx
@@ -4,7 +4,7 @@ import { DashboardCard } from "@/src/features/dashboard/components/cards/Dashboa
 import { type FilterState } from "@langfuse/shared";
 import { type DashboardDateRangeAggregationOption } from "@/src/utils/date-range-utils";
 import { MultiSelectKeyValues } from "@/src/features/scores/components/multi-select-key-values";
-import React, { useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import { Separator } from "@/src/components/ui/separator";
 import {
   isBooleanDataType,
@@ -20,6 +20,7 @@ import DocPopup from "@/src/components/layouts/doc-popup";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 import { Flex, Text } from "@tremor/react";
 import { useClickhouse } from "@/src/components/layouts/ClickhouseAdminToggle";
+import useLocalStorage from "@/src/components/useLocalStorage";
 
 export function ScoreAnalytics(props: {
   className?: string;
@@ -27,9 +28,11 @@ export function ScoreAnalytics(props: {
   globalFilterState: FilterState;
   projectId: string;
 }) {
-  const [selectedDashboardScoreKeys, setSelectedDashboardScoreKeys] = useState<
-    string[]
-  >([]);
+  const [selectedDashboardScoreKeys, setSelectedDashboardScoreKeys] =
+    useLocalStorage<string[]>(
+      `selectedDashboardScoreKeys-${props.projectId}`,
+      [],
+    );
 
   const scoreKeysAndProps = api.scores.getScoreKeysAndProps.useQuery(
     {

--- a/web/src/features/dashboard/components/score-analytics/ScoreAnalytics.tsx
+++ b/web/src/features/dashboard/components/score-analytics/ScoreAnalytics.tsx
@@ -28,7 +28,7 @@ export function ScoreAnalytics(props: {
   globalFilterState: FilterState;
   projectId: string;
 }) {
-  // Possibly stale score selections persist in localStorage but are filtered during render
+  // Stale score selections in localStorage are ignored as we only show scores that exist in scoreAnalyticsOptions
   const [selectedDashboardScoreKeys, setSelectedDashboardScoreKeys] =
     useLocalStorage<string[]>(
       `selectedDashboardScoreKeys-${props.projectId}`,

--- a/web/src/features/dashboard/components/score-analytics/ScoreAnalytics.tsx
+++ b/web/src/features/dashboard/components/score-analytics/ScoreAnalytics.tsx
@@ -28,6 +28,7 @@ export function ScoreAnalytics(props: {
   globalFilterState: FilterState;
   projectId: string;
 }) {
+  // Possibly stale score selections persist in localStorage but are filtered during render
   const [selectedDashboardScoreKeys, setSelectedDashboardScoreKeys] =
     useLocalStorage<string[]>(
       `selectedDashboardScoreKeys-${props.projectId}`,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Persist selected score graphs in the dashboard using `localStorage`, scoped by project, and adjust UI in `score-configs.tsx`.
> 
>   - **Behavior**:
>     - Persist selected score graphs in `ScoreAnalytics.tsx` using `localStorage`, scoped by `projectId`.
>     - Ignores stale selections not present in `scoreAnalyticsOptions`.
>   - **UI Changes**:
>     - Adjust `Card` max height to `60dvh` in `score-configs.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for faf81cddcbd318c855dfb951ad56646c31a9669e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->