### PR TITLE
perf: use streaming for observation and trace list endpoints

### DIFF
--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -6,6 +6,7 @@ import {
   orderByToClickhouseSql,
   type DateTimeFilter,
   parseClickhouseUTCDateTimeFormat,
+  queryClickhouseStream,
 } from "@langfuse/shared/src/server";
 import {
   convertRecordToJsonSchema,
@@ -108,7 +109,7 @@ export const generateTracesForPublicApi = async (
     ${props.limit !== undefined && props.page !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
   `;
 
-  const result = await queryClickhouse<
+  const asyncGenerator = queryClickhouseStream<
     Trace & {
       observations: string[];
       scores: string[];
@@ -132,6 +133,19 @@ export const generateTracesForPublicApi = async (
         : {}),
     },
   });
+
+  const result: Array<
+    Trace & {
+      observations: string[];
+      scores: string[];
+      totalCost: number;
+      latency: number;
+      htmlPath: string;
+    }
+  > = [];
+  for await (const row of asyncGenerator) {
+    result.push(row);
+  }
 
   return result.map((trace) => ({
     ...trace,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switches observation and trace list endpoints to use streaming for improved performance in data retrieval.
> 
>   - **Performance**:
>     - Switch from `queryClickhouse` to `queryClickhouseStream` in `generateObservationsForPublicApi` in `observations.ts` and `generateTracesForPublicApi` in `traces.ts` for streaming data retrieval.
>     - Process data using `for await` loop to handle streaming results in both functions.
>   - **Behavior**:
>     - No change in the API response structure; the change is internal to improve performance.
>     - Handles large datasets more efficiently by processing data as it streams in.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8d294cbbee885b853b0025c7cc1b0d5ab9d04e18. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->