### PR TITLE
feat(trace-detail-ui): filter by minObservationlvl

### DIFF
--- a/web/src/components/trace/ObservationTree.tsx
+++ b/web/src/components/trace/ObservationTree.tsx
@@ -4,7 +4,7 @@ import {
   type APIScore,
   type Trace,
   type $Enums,
-  ObservationLevel,
+  type ObservationLevel,
 } from "@langfuse/shared";
 import { GroupedScoreBadges } from "@/src/components/grouped-score-badge";
 import { Fragment, useMemo } from "react";

--- a/web/src/components/trace/ObservationTree.tsx
+++ b/web/src/components/trace/ObservationTree.tsx
@@ -1,6 +1,11 @@
 import { type NestedObservation } from "@/src/utils/types";
 import { cn } from "@/src/utils/tailwind";
-import { type APIScore, type Trace, type $Enums } from "@langfuse/shared";
+import {
+  type APIScore,
+  type Trace,
+  type $Enums,
+  ObservationLevel,
+} from "@langfuse/shared";
 import { GroupedScoreBadges } from "@/src/components/grouped-score-badge";
 import { Fragment, useMemo } from "react";
 import { type ObservationReturnType } from "@/src/server/api/routers/traces";
@@ -39,10 +44,11 @@ export const ObservationTree = ({
   traceCommentCounts?: Map<string, number>;
   className?: string;
   showExpandControls?: boolean;
+  minLevel?: ObservationLevel;
 }) => {
   const nestedObservations = useMemo(
-    () => nestObservations(props.observations),
-    [props.observations],
+    () => nestObservations(props.observations, props.minLevel),
+    [props.observations, props.minLevel],
   );
   const totalCost = useMemo(() => {
     return calculateDisplayTotalCost({

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -258,7 +258,9 @@ export function Trace(props: {
                   Min. Level
                 </SelectLabel>
                 {Object.values(ObservationLevel).map((level) => (
-                  <SelectItem value={level}>{level}</SelectItem>
+                  <SelectItem value={level} key={level}>
+                    {level}
+                  </SelectItem>
                 ))}
               </SelectGroup>
             </SelectContent>

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -5,6 +5,14 @@ import { TracePreview } from "./TracePreview";
 
 import Header from "@/src/components/layouts/header";
 import { Badge } from "@/src/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectLabel,
+  SelectGroup,
+} from "@/src/components/ui/select";
 import { AggUsageBadge } from "@/src/components/token-usage-badge";
 import { StringParam, useQueryParam, withDefault } from "use-query-params";
 import { PublishTraceSwitch } from "@/src/components/publish-object-switch";
@@ -22,6 +30,7 @@ import {
   Award,
   ChevronsDownUp,
   ChevronsUpDown,
+  FilterIcon,
   ListTree,
   Network,
   Percent,
@@ -31,7 +40,7 @@ import { useCallback, useState } from "react";
 import { DeleteButton } from "@/src/components/deleteButton";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { TraceTimelineView } from "@/src/components/trace/TraceTimelineView";
-import { type APIScore } from "@langfuse/shared";
+import { type APIScore, ObservationLevel } from "@langfuse/shared";
 import { FullScreenPage } from "@/src/components/layouts/full-screen-page";
 import { calculateDisplayTotalCost } from "@/src/components/trace/lib/helpers";
 import { useIsAuthenticatedAndProjectMember } from "@/src/features/auth/hooks";
@@ -73,6 +82,9 @@ export function Trace(props: {
   const [collapsedObservations, setCollapsedObservations] = useState<string[]>(
     [],
   );
+
+  const [minObservationLevel, setMinObservationLevel] =
+    useState<ObservationLevel>(ObservationLevel.DEFAULT);
 
   const isAuthenticatedAndProjectMember = useIsAuthenticatedAndProjectMember(
     props.projectId,
@@ -223,6 +235,34 @@ export function Trace(props: {
           >
             <Percent className="h-4 w-4" />
           </Toggle>
+          <Select
+            onValueChange={(v: ObservationLevel) => setMinObservationLevel(v)}
+            defaultValue={ObservationLevel.DEFAULT}
+          >
+            <SelectTrigger
+              hideDownIcon
+              className="focus:ring-none h-auto w-auto border-none px-0 py-0 text-sm focus:outline-none focus:ring-0 focus:ring-offset-0"
+            >
+              <Toggle
+                pressed={colorCodeMetricsOnObservationTree}
+                onPressedChange={(e) => setColorCodeMetricsOnObservationTree(e)}
+                size="xs"
+                title="Color code metrics (>50% yellow, >75% red)"
+              >
+                <FilterIcon className="h-4 w-4" />
+              </Toggle>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectLabel className="py-1 text-sm font-semibold">
+                  Min. Level
+                </SelectLabel>
+                {Object.values(ObservationLevel).map((level) => (
+                  <SelectItem value={level}>{level}</SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
         </div>
 
         <ObservationTree
@@ -240,6 +280,7 @@ export function Trace(props: {
           colorCodeMetrics={colorCodeMetricsOnObservationTree}
           observationCommentCounts={observationCommentCounts.data}
           traceCommentCounts={traceCommentCounts.data}
+          minLevel={minObservationLevel}
           className="flex w-full flex-col overflow-y-auto"
         />
       </div>

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -14,7 +14,9 @@ const SelectValue = SelectPrimitive.Value;
 
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & {
+    hideDownIcon?: boolean;
+  }
 >(({ className, children, ...props }, ref) => (
   <SelectPrimitive.Trigger
     ref={ref}
@@ -25,9 +27,11 @@ const SelectTrigger = React.forwardRef<
     {...props}
   >
     {children}
-    <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
-    </SelectPrimitive.Icon>
+    {props.hideDownIcon ? null : (
+      <SelectPrimitive.Icon asChild>
+        <ChevronDown className="h-4 w-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    )}
   </SelectPrimitive.Trigger>
 ));
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add filtering by minimum observation level to trace detail UI with a new select dropdown for level selection.
> 
>   - **Behavior**:
>     - Add `minLevel` prop to `ObservationTree` in `ObservationTree.tsx` to filter observations by minimum level.
>     - Add `Select` component in `index.tsx` to allow users to select minimum observation level.
>     - Update `nestObservations()` in `helpers.ts` to filter observations based on `minLevel`.
>   - **UI Components**:
>     - Modify `SelectTrigger` in `select.tsx` to optionally hide the dropdown icon.
>   - **Misc**:
>     - Add `minObservationLevel` state in `Trace` component in `index.tsx` to manage selected level.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ebf5e952f95dcb298269b9c6a49c9b355e5f41c4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->