### PR TITLE
style(ui-tables): fix position of `No results.` text if table has no data

### DIFF
--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -206,7 +206,7 @@ export function DataTable<TData extends object, TValue>({
       >
         <div
           className={cn(
-            "relative w-full overflow-auto",
+            "w-full overflow-auto",
             isBorderless ? "" : "rounded-md border",
           )}
           style={{ ...columnSizeVars }}
@@ -422,20 +422,16 @@ function TableBodyComponent<TData>({
           </TableRow>
         ))
       ) : (
-        <>
-          <div className="sticky left-[50%]">
-            <TableRow className="hover:bg-transparent">
-              <TableCell colSpan={columns.length} className="h-24">
-                <div className="pointer-events-none absolute inset-0 flex w-24 items-center justify-center">
-                  No results.{" "}
-                  {help && (
-                    <DocPopup description={help.description} href={help.href} />
-                  )}
-                </div>
-              </TableCell>
-            </TableRow>
-          </div>
-        </>
+        <TableRow className="hover:bg-transparent">
+          <TableCell colSpan={columns.length} className="relative h-24">
+            <div className="pointer-events-none fixed left-[50%] flex -translate-y-1/2 items-center justify-center">
+              No results.{" "}
+              {help && (
+                <DocPopup description={help.description} href={help.href} />
+              )}
+            </div>
+          </TableCell>
+        </TableRow>
       )}
     </TableBody>
   );

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -206,7 +206,7 @@ export function DataTable<TData extends object, TValue>({
       >
         <div
           className={cn(
-            "w-full overflow-auto",
+            "relative w-full overflow-auto",
             isBorderless ? "" : "rounded-md border",
           )}
           style={{ ...columnSizeVars }}
@@ -422,16 +422,20 @@ function TableBodyComponent<TData>({
           </TableRow>
         ))
       ) : (
-        <TableRow>
-          <TableCell colSpan={columns.length} className="h-24 text-center">
-            <div>
-              No results.{" "}
-              {help && (
-                <DocPopup description={help.description} href={help.href} />
-              )}
-            </div>
-          </TableCell>
-        </TableRow>
+        <>
+          <div className="sticky left-[50%]">
+            <TableRow className="hover:bg-transparent">
+              <TableCell colSpan={columns.length} className="h-24">
+                <div className="pointer-events-none absolute inset-0 flex w-24 items-center justify-center">
+                  No results.{" "}
+                  {help && (
+                    <DocPopup description={help.description} href={help.href} />
+                  )}
+                </div>
+              </TableCell>
+            </TableRow>
+          </div>
+        </>
       )}
     </TableBody>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes the position of 'No results.' text in `TableBodyComponent` when the table has no data by adjusting CSS classes.
> 
>   - **Styling**:
>     - Adjusted `TableRow` and `TableCell` in `TableBodyComponent` to fix the position of 'No results.' text when no data is present.
>     - Added `hover:bg-transparent` to `TableRow` and `relative` to `TableCell`.
>     - Positioned 'No results.' text using `pointer-events-none fixed left-[50%] flex -translate-y-1/2 items-center justify-center` in the `div`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 937f5634af4c21e0ae00df9419971bdfb92eb4a6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->