### PR TITLE
feat(trace-tree-ui): add hint for hidden obs

### DIFF
--- a/web/src/components/trace/ObservationTree.tsx
+++ b/web/src/components/trace/ObservationTree.tsx
@@ -51,7 +51,7 @@ export const ObservationTree = ({
   className?: string;
   showExpandControls?: boolean;
   minLevel?: ObservationLevel;
-  setMinLevel: React.Dispatch<React.SetStateAction<ObservationLevel>>;
+  setMinLevel?: React.Dispatch<React.SetStateAction<ObservationLevel>>;
 }) => {
   const { nestedObservations, hiddenObservationsCount } = useMemo(
     () => nestObservations(props.observations, props.minLevel),
@@ -105,7 +105,7 @@ export const ObservationTree = ({
             </p>
             <p
               className="cursor-pointer underline"
-              onClick={() => props.setMinLevel(ObservationLevel.DEBUG)}
+              onClick={() => props.setMinLevel?.(ObservationLevel.DEBUG)}
             >
               Show all
             </p>

--- a/web/src/components/trace/ObservationTree.tsx
+++ b/web/src/components/trace/ObservationTree.tsx
@@ -4,14 +4,20 @@ import {
   type APIScore,
   type Trace,
   type $Enums,
-  type ObservationLevel,
+  ObservationLevel,
 } from "@langfuse/shared";
 import { GroupedScoreBadges } from "@/src/components/grouped-score-badge";
 import { Fragment, useMemo } from "react";
 import { type ObservationReturnType } from "@/src/server/api/routers/traces";
 import { LevelColors } from "@/src/components/level-colors";
 import { formatIntervalSeconds } from "@/src/utils/dates";
-import { MinusCircle, MinusIcon, PlusCircleIcon, PlusIcon } from "lucide-react";
+import {
+  InfoIcon,
+  MinusCircle,
+  MinusIcon,
+  PlusCircleIcon,
+  PlusIcon,
+} from "lucide-react";
 import { Toggle } from "@/src/components/ui/toggle";
 import { Button } from "@/src/components/ui/button";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
@@ -45,8 +51,9 @@ export const ObservationTree = ({
   className?: string;
   showExpandControls?: boolean;
   minLevel?: ObservationLevel;
+  setMinLevel: React.Dispatch<React.SetStateAction<ObservationLevel>>;
 }) => {
-  const nestedObservations = useMemo(
+  const { nestedObservations, hiddenObservationsCount } = useMemo(
     () => nestObservations(props.observations, props.minLevel),
     [props.observations, props.minLevel],
   );
@@ -88,6 +95,23 @@ export const ObservationTree = ({
           props.trace.latency ? props.trace.latency * 1000 : undefined
         }
       />
+      {props.minLevel && hiddenObservationsCount > 0 ? (
+        <span className="flex items-center gap-1 p-2 py-4">
+          <InfoIcon className="h-4 w-4 text-muted-foreground" />
+          <span className="flex flex-row gap-1 text-sm text-muted-foreground">
+            <p>
+              {hiddenObservationsCount} observations below {props.minLevel}{" "}
+              level are hidden.
+            </p>
+            <p
+              className="cursor-pointer underline"
+              onClick={() => props.setMinLevel(ObservationLevel.DEBUG)}
+            >
+              Show all
+            </p>
+          </span>
+        </span>
+      ) : null}
     </div>
   );
 };

--- a/web/src/components/trace/TraceTimelineView.tsx
+++ b/web/src/components/trace/TraceTimelineView.tsx
@@ -304,7 +304,7 @@ export function TraceTimelineView({
     };
   }, [parentRef]);
 
-  const nestedObservations = useMemo(
+  const { nestedObservations } = useMemo(
     () => nestObservations(observations),
     [observations],
   );

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -237,7 +237,7 @@ export function Trace(props: {
           </Toggle>
           <Select
             onValueChange={(v: ObservationLevel) => setMinObservationLevel(v)}
-            defaultValue={ObservationLevel.DEFAULT}
+            value={minObservationLevel}
           >
             <SelectTrigger
               hideDownIcon
@@ -283,6 +283,7 @@ export function Trace(props: {
           observationCommentCounts={observationCommentCounts.data}
           traceCommentCounts={traceCommentCounts.data}
           minLevel={minObservationLevel}
+          setMinLevel={setMinObservationLevel}
           className="flex w-full flex-col overflow-y-auto"
         />
       </div>

--- a/web/src/components/trace/lib/helpers.ts
+++ b/web/src/components/trace/lib/helpers.ts
@@ -15,8 +15,12 @@ export const treeItemColors: Map<TreeItemType, string> = new Map([
 export function nestObservations(
   list: ObservationReturnType[],
   minLevel?: ObservationLevel,
-): NestedObservation[] {
-  if (list.length === 0) return [];
+): {
+  nestedObservations: NestedObservation[];
+  hiddenObservationsCount: number;
+} {
+  if (list.length === 0)
+    return { nestedObservations: [], hiddenObservationsCount: 0 };
 
   // Data prep:
   // - Filter for observations with minimum level
@@ -24,6 +28,7 @@ export function nestObservations(
   const mutableList = list.filter((o) =>
     getObservationLevels(minLevel).includes(o.level),
   );
+  const hiddenObservationsCount = list.length - mutableList.length;
 
   mutableList.forEach((observation) => {
     if (
@@ -67,7 +72,10 @@ export function nestObservations(
   }
 
   // Step 5: Return the roots.
-  return Array.from(roots.values());
+  return {
+    nestedObservations: Array.from(roots.values()),
+    hiddenObservationsCount,
+  };
 }
 
 export function calculateDisplayTotalCost(p: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a hint in `ObservationTree` to indicate hidden observations due to `minLevel` filtering, with an option to show all.
> 
>   - **Behavior**:
>     - Adds a hint in `ObservationTree` to show the count of hidden observations below the `minLevel`.
>     - Clicking the hint sets `minLevel` to `DEBUG` to show all observations.
>   - **Functions**:
>     - Updates `nestObservations` in `helpers.ts` to return `hiddenObservationsCount`.
>   - **Components**:
>     - Passes `setMinLevel` to `ObservationTree` in `Trace` component.
>     - Updates `TraceTimelineView` to use destructured `nestedObservations`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2c3950b35e5c57c7391cde2ecff8a9424e341a65. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->