### PR TITLE
fix(ui-annoation): bug when re-submitting score comments on categorical scores

### DIFF
--- a/web/src/features/scores/components/AnnotateDrawerContent.tsx
+++ b/web/src/features/scores/components/AnnotateDrawerContent.tsx
@@ -481,6 +481,7 @@ export function AnnotateDrawerContent({
             ...score,
             scoreId: createdScore.id,
             value: createdScore.value,
+            stringValue: createdScore.stringValue ?? undefined,
           });
         }
       }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes handling of `stringValue` in `AnnotateDrawerContent.tsx` to set it to `undefined` if `null` when creating scores.
> 
>   - **Bug Fix**:
>     - In `AnnotateDrawerContent.tsx`, ensure `stringValue` is set to `undefined` if `null` when creating a new score in `handleScoreChange()` and `onSettledUpsert()` functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3d4de583814fe544ec942d5d0392b8ec1f37900e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->