### PR TITLE
fix(jump-to-playground): hide button if message parsing will fail

### DIFF
--- a/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -42,7 +42,8 @@ export const JumpToPlaygroundButton: React.FC<JumpToPlaygroundButtonProps> = (
   const projectId = useProjectIdFromURL();
   const { setPlaygroundCache } = usePlaygroundCache();
   const [capturedState, setCapturedState] = useState<PlaygroundCache>(null);
-  const available = useHasEntitlement("playground");
+  const [isAvailable, setIsAvailable] = useState<boolean>(false);
+  const isEntitled = useHasEntitlement("playground");
 
   useEffect(() => {
     if (props.source === "prompt") {
@@ -52,12 +53,20 @@ export const JumpToPlaygroundButton: React.FC<JumpToPlaygroundButtonProps> = (
     }
   }, [props]);
 
+  useEffect(() => {
+    if (capturedState && isEntitled) {
+      setIsAvailable(true);
+    } else {
+      setIsAvailable(false);
+    }
+  }, [capturedState, isEntitled, setIsAvailable]);
+
   const handleClick = () => {
     capture(props.analyticsEventName);
     setPlaygroundCache(capturedState);
   };
 
-  if (!available) return null;
+  if (!isAvailable) return null;
 
   return (
     <Button


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `JumpToPlaygroundButton` now conditionally renders based on `capturedState` and `isEntitled` to prevent message parsing errors.
> 
>   - **Behavior**:
>     - `JumpToPlaygroundButton` now checks both `capturedState` and `isEntitled` before rendering.
>     - Introduces `isAvailable` state to manage button visibility.
>   - **State Management**:
>     - Adds `isAvailable` state variable in `JumpToPlaygroundButton.tsx`.
>     - Adds `useEffect` to update `isAvailable` based on `capturedState` and `isEntitled`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7e8aafef80492defd81a91b05e545ef49c3310de. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->