### PR TITLE
chore: correct data region

### DIFF
--- a/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
+++ b/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
@@ -127,7 +127,7 @@ const DataRegionInfo = () => (
         <p>Langfuse Cloud is available in two data regions:</p>
         <ul className="list-disc pl-5">
           <li>
-            US: Northern California (AWS us-west-1) & Virginia (AWS us-east-1)
+            US: Oregon (AWS us-west-2) & Virginia (AWS us-east-1)
           </li>
           <li>
             EU: Germany/Frankfurt (AWS eu-central-1) & Ireland (AWS eu-west-1)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Corrects US data region from "Northern California" to "Oregon" in `AuthCloudRegionSwitch.tsx`.
> 
>   - **Behavior**:
>     - Corrects the US data region from "Northern California (AWS us-west-1)" to "Oregon (AWS us-west-2)" in `DataRegionInfo` component in `AuthCloudRegionSwitch.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 806491002cb29f6efb14ac83514916c9dcabaadd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->