### PR TITLE
chore: skip zod parse for json parsing

### DIFF
--- a/packages/shared/src/utils/json.ts
+++ b/packages/shared/src/utils/json.ts
@@ -52,7 +52,7 @@ export const mergeJson = (
 
 export const parseJsonPrioritised = (
   json: string,
-): z.infer<typeof jsonSchema> | string | undefined => {
+): JsonNested | string | undefined => {
   try {
     return JSON.parse(json);
   } catch (error) {

--- a/packages/shared/src/utils/json.ts
+++ b/packages/shared/src/utils/json.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { merge } from "lodash";
-import { JsonNested, jsonSchema, jsonSchemaNullable } from "./zod";
+import { JsonNested, jsonSchema } from "./zod";
 
 /**
  * Deeply parses a JSON string or object for nested stringified JSON
@@ -54,11 +54,9 @@ export const parseJsonPrioritised = (
   json: string,
 ): z.infer<typeof jsonSchema> | string | undefined => {
   try {
-    const parsedJson = JSON.parse(json);
-    return jsonSchema.parse(parsedJson);
+    return JSON.parse(json);
   } catch (error) {
-    const parsed = jsonSchema.safeParse(json);
-    return parsed.success ? parsed.data : json;
+    return json;
   }
 };
 

--- a/web/src/__tests__/zod.servertest.ts
+++ b/web/src/__tests__/zod.servertest.ts
@@ -37,7 +37,7 @@ describe("parseJsonPrioritised", () => {
     ["42", 42], // Number
     ["true", true], // Boolean true
     ["false", false], // Boolean false
-    ["null", "null"], // Null
+    ["null", null], // Null
     ["", ""], // Empty string
     ["invalid{json}", "invalid{json}"], // Invalid JSON string
     ['[null, 123, "abc"]', [null, 123, "abc"]], // Mixed array

--- a/web/src/__tests__/zod.servertest.ts
+++ b/web/src/__tests__/zod.servertest.ts
@@ -40,6 +40,7 @@ describe("parseJsonPrioritised", () => {
     ["null", null], // Null
     ["", ""], // Empty string
     ["invalid{json}", "invalid{json}"], // Invalid JSON string
+    ['{"hello": "world"', '{"hello": "world"'], // Invalid JSON string
     ['[null, 123, "abc"]', [null, 123, "abc"]], // Mixed array
     [
       '{"array": [1, 2], "nested": {"key": "value"}}',

--- a/web/src/features/public-api/server/observations.ts
+++ b/web/src/features/public-api/server/observations.ts
@@ -4,7 +4,6 @@ import {
   type ObservationRecordReadType,
   queryClickhouse,
   convertObservationToView,
-  queryClickhouseStream,
 } from "@langfuse/shared/src/server";
 
 type QueryType = {

--- a/web/src/features/public-api/server/observations.ts
+++ b/web/src/features/public-api/server/observations.ts
@@ -67,7 +67,7 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
       ${props.limit !== undefined && props.page !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
       `;
 
-  const asyncGenerator = queryClickhouseStream<ObservationRecordReadType>({
+  const result = await queryClickhouse<ObservationRecordReadType>({
     query,
     params: {
       ...appliedFilter.params,
@@ -78,10 +78,6 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
         : {}),
     },
   });
-  const result: Array<ObservationRecordReadType> = [];
-  for await (const row of asyncGenerator) {
-    result.push(row);
-  }
   return result.map(convertObservationToView);
 };
 

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -109,7 +109,7 @@ export const generateTracesForPublicApi = async (
     ${props.limit !== undefined && props.page !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
   `;
 
-  const asyncGenerator = queryClickhouseStream<
+  const result = await queryClickhouse<
     Trace & {
       observations: string[];
       scores: string[];
@@ -133,19 +133,6 @@ export const generateTracesForPublicApi = async (
         : {}),
     },
   });
-
-  const result: Array<
-    Trace & {
-      observations: string[];
-      scores: string[];
-      totalCost: number;
-      latency: number;
-      htmlPath: string;
-    }
-  > = [];
-  for await (const row of asyncGenerator) {
-    result.push(row);
-  }
 
   return result.map((trace) => ({
     ...trace,

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -6,7 +6,6 @@ import {
   orderByToClickhouseSql,
   type DateTimeFilter,
   parseClickhouseUTCDateTimeFormat,
-  queryClickhouseStream,
 } from "@langfuse/shared/src/server";
 import {
   convertRecordToJsonSchema,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Removed `zod` parsing for JSON in `parseJsonPrioritised()` and refactored server code to use synchronous query methods.
> 
>   - **JSON Parsing**:
>     - Removed `zod` parsing in `parseJsonPrioritised()` in `json.ts`, now directly uses `JSON.parse`.
>     - Updated test cases in `zod.servertest.ts` to reflect changes in JSON parsing behavior.
>   - **Server Code Refactoring**:
>     - Replaced `queryClickhouseStream` with `queryClickhouse` in `generateObservationsForPublicApi()` in `observations.ts`.
>     - Replaced `queryClickhouseStream` with `queryClickhouse` in `generateTracesForPublicApi()` in `traces.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8d490ac0930cf47359bfe2e1eadb406c9d1c04c4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->