### PR TITLE
fix(ui-tables): populate filter operator by default

### DIFF
--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -227,6 +227,14 @@ export function InlineFilterBuilder({
   );
 }
 
+const getOperator = (
+  type: NonNullable<WipFilterCondition["type"]>,
+): WipFilterCondition["operator"] => {
+  return filterOperators[type]?.length > 0
+    ? filterOperators[type][0]
+    : undefined;
+};
+
 function FilterBuilderForm({
   columns,
   filterState,
@@ -312,19 +320,18 @@ function FilterBuilderForm({
                                   const col = columns.find(
                                     (c) => c.id === value,
                                   );
+                                  const defaultOperator = col?.type
+                                    ? getOperator(col.type)
+                                    : undefined;
+
                                   handleFilterChange(
                                     {
                                       column: col?.name,
                                       type: col?.type,
-                                      operator:
-                                        // does not work as expected on eval-template form when embedded into form via InlineFilterBuilder
-                                        // col?.type !== undefined &&
-                                        // filterOperators[col.type]?.length > 0
-                                        //   ? (filterOperators[col.type][0] as any) // operator matches type
-                                        undefined,
+                                      operator: defaultOperator,
                                       value: undefined,
                                       key: undefined,
-                                    },
+                                    } as WipFilterCondition,
                                     i,
                                   );
                                 }}
@@ -391,6 +398,8 @@ function FilterBuilderForm({
                   <Select
                     disabled={!filter.column || disabled}
                     onValueChange={(value) => {
+                      // protect against invalid empty operator values
+                      if (value === "") return;
                       handleFilterChange(
                         {
                           ...filter,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Default filter operator is set based on column type in `FilterBuilderForm`, with safeguards against empty operator values.
> 
>   - **Behavior**:
>     - Default filter operator is now set based on column type in `FilterBuilderForm`.
>     - Prevents setting empty operator values in `FilterBuilderForm`.
>   - **Functions**:
>     - Adds `getOperator()` to determine default operator based on column type.
>     - Updates `handleFilterChange()` in `FilterBuilderForm` to use `getOperator()`.
>   - **Misc**:
>     - Minor comment added to explain prevention of empty operator values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2bf3c02772358f99f2e94ec7296e3fff461998e9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->