### PR TITLE
chore: add cloud meter event trigger

### DIFF
--- a/packages/shared/src/server/redis/cloudUsageMeteringQueue.ts
+++ b/packages/shared/src/server/redis/cloudUsageMeteringQueue.ts
@@ -45,6 +45,7 @@ export class CloudUsageMeteringQueue {
         QueueJobs.CloudUsageMeteringJob,
         {},
         {
+          // Run at minute 5 of every hour (e.g. 1:05, 2:05, 3:05, etc)
           repeat: { pattern: "5 * * * *" },
         },
       );

--- a/worker/package.json
+++ b/worker/package.json
@@ -15,7 +15,8 @@
     "dev": "dotenv -e ../.env -- nodemon src/index.ts",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
-    "refill-ingestion-events": "dotenv -e ../.env -- tsx src/scripts/refill-ingestion-events.ts"
+    "refill-ingestion-events": "dotenv -e ../.env -- tsx src/scripts/refill-ingestion-events.ts",
+    "refill-billing-event": "dotenv -e ../.env -- tsx src/scripts/refill-billing-event.ts"
   },
   "author": "engineering@langfuse.com",
   "dependencies": {

--- a/worker/src/scripts/refill-billing-event.ts
+++ b/worker/src/scripts/refill-billing-event.ts
@@ -8,9 +8,6 @@ import { logger } from "@langfuse/shared/src/server";
 import { redis } from "@langfuse/shared/src/server";
 
 const main = async () => {
-  // Read and parse CSV file
-  // Find events.csv in root directory
-
   // Create queue connection
   const billingQueue = CloudUsageMeteringQueue.getInstance();
 

--- a/worker/src/scripts/refill-billing-event.ts
+++ b/worker/src/scripts/refill-billing-event.ts
@@ -1,0 +1,33 @@
+// This script can be used to manually refill ingestion events.
+// Execute with caution in production.
+import {
+  QueueJobs,
+  CloudUsageMeteringQueue,
+} from "@langfuse/shared/src/server";
+import { logger } from "@langfuse/shared/src/server";
+import { redis } from "@langfuse/shared/src/server";
+
+const main = async () => {
+  // Read and parse CSV file
+  // Find events.csv in root directory
+
+  // Create queue connection
+  const billingQueue = CloudUsageMeteringQueue.getInstance();
+
+  await billingQueue?.add(QueueJobs.CloudUsageMeteringJob, {
+    name: QueueJobs.CloudUsageMeteringJob as const,
+  });
+
+  logger.info("Done triggering billing event");
+};
+
+if (require.main === module) {
+  main()
+    .catch((err) => {
+      console.error("Error running script:", err);
+    })
+    .finally(() => {
+      redis?.disconnect();
+      process.exit(0);
+    });
+}

--- a/worker/src/scripts/refill-billing-event.ts
+++ b/worker/src/scripts/refill-billing-event.ts
@@ -1,4 +1,4 @@
-// This script can be used to manually refill ingestion events.
+// This script can be used to manually retrigger the metering job.
 // Execute with caution in production.
 import {
   QueueJobs,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add script and npm command to manually trigger billing events and update metering job schedule.
> 
>   - **Scripts**:
>     - Add `refill-billing-event.ts` to manually retrigger the metering job.
>     - Add npm script `refill-billing-event` in `package.json` to execute the new script.
>   - **Scheduling**:
>     - Update `cloudUsageMeteringQueue.ts` to schedule the metering job at the 5th minute of every hour.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c5c3ebd56e787e27b9b6111d77b981a67b1aa734. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->