### PR TITLE
style(ui): improve observation type label colors for readbility, accessibility

### DIFF
--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -152,8 +152,8 @@ export const ObservationPreview = ({
       <div className="flex w-full flex-col overflow-y-auto">
         <CardHeader className="flex flex-row flex-wrap justify-between gap-2">
           <div className="flex flex-col gap-1">
-            <CardTitle>
-              <span className="mr-2 rounded-sm bg-input p-1 text-xs">
+            <CardTitle className="flex flex-row items-center gap-2">
+              <span className="rounded-sm bg-input p-1 text-xs">
                 {preloadedObservation.type}
               </span>
               <span>{preloadedObservation.name}</span>

--- a/web/src/components/trace/ObservationTree.tsx
+++ b/web/src/components/trace/ObservationTree.tsx
@@ -253,6 +253,7 @@ const ObservationTreeNode = (props: {
                       {props.comments ? (
                         <CommentCountIcon
                           count={props.comments.get(observation.id)}
+                          className={treeItemColors.get(observation.type)}
                         />
                       ) : null}
                     </div>

--- a/web/src/components/trace/lib/helpers.ts
+++ b/web/src/components/trace/lib/helpers.ts
@@ -7,7 +7,7 @@ export type TreeItemType = ObservationType | "TRACE";
 
 export const treeItemColors: Map<TreeItemType, string> = new Map([
   [ObservationType.SPAN, "bg-muted-blue"],
-  [ObservationType.GENERATION, "bg-muted-orange"],
+  [ObservationType.GENERATION, "bg-muted-magenta"],
   [ObservationType.EVENT, "bg-muted-green"],
   ["TRACE", "bg-input"],
 ]);

--- a/web/src/features/comments/CommentCountIcon.tsx
+++ b/web/src/features/comments/CommentCountIcon.tsx
@@ -1,12 +1,24 @@
+import { cn } from "@/src/utils/tailwind";
 import { MessageCircleMore } from "lucide-react";
 
-export function CommentCountIcon({ count }: { count?: number }) {
+export function CommentCountIcon({
+  count,
+  className,
+}: {
+  count?: number;
+  className?: string;
+}) {
   if (!count) return null;
 
   return (
     <span className="relative mr-1 text-xs">
       <MessageCircleMore className="h-4 w-4" />
-      <span className="absolute -top-0.5 left-2.5 flex max-h-[0.8rem] min-w-[0.8rem] items-center justify-center rounded-full border border-muted-foreground bg-accent-light-blue px-[0.2rem] text-[8px]">
+      <span
+        className={cn(
+          "absolute -top-0.5 left-2.5 flex max-h-[0.8rem] min-w-[0.8rem] items-center justify-center rounded-full border border-muted-foreground bg-accent-light-blue px-[0.2rem] text-[8px]",
+          className,
+        )}
+      >
         {count > 99 ? "99+" : count}
       </span>
     </span>

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -36,9 +36,9 @@
     --primary-accent: 243 75.4% 58.6%;
     --hover-primary-accent: 239 83.5% 66.7%;
 
-    --muted-green: 141 84.2% 92.5%;
-    --muted-orange: 34 100% 91.8%;
-    --muted-blue: 214 94.6% 92.7%;
+    --muted-green: 190, 80%, 90%;
+    --muted-magenta: 350, 70%, 95%;
+    --muted-blue: 215, 70%, 85%;
     --muted-gray: 210 50% 91.1%;
 
     --accent-light-green: 138 76.5% 96.7%;
@@ -102,9 +102,9 @@
     --primary-accent: 246 55% 70%;
     --muted-primary-accent: 239 83.5% 66.7%;
 
-    --muted-blue: 226 60.7% 30.2%;
-    --muted-green: 143 64.2% 24.1%;
-    --muted-orange: 23 79.1% 33.7%;
+    --muted-blue: 220, 70%, 25%;
+    --muted-green: 190, 70%, 25%;
+    --muted-magenta: 325, 70%, 25%;
     --muted-gray: 210 50% 25%;
 
     --light-red: 0 62.8% 30.6%;
@@ -153,13 +153,12 @@
   html,
   body,
   div#__next,
-  div#__next>div {
+  div#__next > div {
     height: 100%;
   }
 }
 
 @layer base {
-
   input[type="number"].appearance-none::-webkit-inner-spin-button,
   input[type="number"].appearance-none::-webkit-outer-spin-button {
     -webkit-appearance: none;

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -153,7 +153,7 @@
   html,
   body,
   div#__next,
-  div#__next > div {
+  div#__next>div {
     height: 100%;
   }
 }

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -24,7 +24,7 @@ module.exports = {
       colors: {
         "primary-accent": "hsl(var(--primary-accent))",
         "hover-primary-accent": "hsl(var(--hover-primary-accent))",
-        "muted-orange": "hsl(var(--muted-orange))",
+        "muted-magenta": "hsl(var(--muted-magenta))",
         "muted-blue": "hsl(var(--muted-blue))",
         "muted-green": "hsl(var(--muted-green))",
         "muted-gray": "hsl(var(--muted-gray))",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adjust muted colors for improved readability and accessibility, replacing `muted-orange` with `muted-magenta` and updating component styles accordingly.
> 
>   - **Color Adjustments**:
>     - Replace `muted-orange` with `muted-magenta` in `globals.css` and `tailwind.config.ts`.
>     - Update `muted-green` and `muted-blue` color values in `globals.css` for both light and dark themes.
>   - **Component Updates**:
>     - Modify `ObservationPreview.tsx` to adjust `CardTitle` layout.
>     - Add `className` prop to `CommentCountIcon` in `ObservationTree.tsx`.
>   - **Helpers**:
>     - Update `treeItemColors` in `helpers.ts` to use `bg-muted-magenta` for `ObservationType.GENERATION`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 04e59841ee6ac21c27d89d3a70795778a9d2c730. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->