### PR TITLE
fix: retry stripe in metering logic and meter again if error ocurred

### DIFF
--- a/worker/src/queues/cloudUsageMeteringQueue.ts
+++ b/worker/src/queues/cloudUsageMeteringQueue.ts
@@ -1,5 +1,9 @@
 import { Processor } from "bullmq";
-import { logger, QueueJobs } from "@langfuse/shared/src/server";
+import {
+  CloudUsageMeteringQueue,
+  logger,
+  QueueJobs,
+} from "@langfuse/shared/src/server";
 import { handleCloudUsageMeteringJob } from "../ee/cloudUsageMetering/handleCloudUsageMeteringJob";
 
 export const cloudUsageMeteringQueueProcessor: Processor = async (job) => {
@@ -9,6 +13,11 @@ export const cloudUsageMeteringQueueProcessor: Processor = async (job) => {
       return await handleCloudUsageMeteringJob(job);
     } catch (error) {
       logger.error("Error executing Cloud Usage Metering Job", error);
+      // adding another job to the queue to process again.
+      await CloudUsageMeteringQueue.getInstance()?.add(
+        QueueJobs.CloudUsageMeteringJob,
+        {},
+      );
       throw error;
     }
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add retry logic for Stripe API calls and re-queue failed jobs in cloud usage metering.
> 
>   - **Error Handling and Retry Logic**:
>     - In `handleCloudUsageMeteringJob.ts`, added `backOff` from `exponential-backoff` to retry Stripe API calls on HTTP errors, with up to 2 attempts.
>     - In `cloudUsageMeteringQueue.ts`, modified the processor to re-add failed jobs to the queue for retry.
>   - **Misc**:
>     - Import `CloudUsageMeteringQueue` in `cloudUsageMeteringQueue.ts` for re-queuing jobs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6b9eec79b2f1c3676941089dd5cacc106c60a4ea. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->