### PR TITLE
fix: add race condition check to billing queue

### DIFF
--- a/worker/src/ee/cloudUsageMetering/handleCloudUsageMeteringJob.ts
+++ b/worker/src/ee/cloudUsageMetering/handleCloudUsageMeteringJob.ts
@@ -77,8 +77,8 @@ export const handleCloudUsageMeteringJob = async (job: Job) => {
         state: CloudUsageMeteringDbCronJobStates.Queued,
       },
       data: {
-        state: CloudUsageMeteringDbCronJobStates.Processing,
-        jobStartedAt: new Date(),
+        state: cron.state,
+        jobStartedAt: cron.jobStartedAt,
       },
     });
   } catch (e) {

--- a/worker/src/ee/cloudUsageMetering/handleCloudUsageMeteringJob.ts
+++ b/worker/src/ee/cloudUsageMetering/handleCloudUsageMeteringJob.ts
@@ -74,11 +74,12 @@ export const handleCloudUsageMeteringJob = async (job: Job) => {
     await prisma.cronJobs.update({
       where: {
         name: cloudUsageMeteringDbCronJobName,
-        state: CloudUsageMeteringDbCronJobStates.Queued,
-      },
-      data: {
         state: cron.state,
         jobStartedAt: cron.jobStartedAt,
+      },
+      data: {
+        state: CloudUsageMeteringDbCronJobStates.Processing,
+        jobStartedAt: new Date(),
       },
     });
   } catch (e) {

--- a/worker/src/ee/cloudUsageMetering/handleCloudUsageMeteringJob.ts
+++ b/worker/src/ee/cloudUsageMetering/handleCloudUsageMeteringJob.ts
@@ -70,15 +70,26 @@ export const handleCloudUsageMeteringJob = async (job: Job) => {
     }
   }
 
-  await prisma.cronJobs.update({
-    where: {
-      name: cloudUsageMeteringDbCronJobName,
-    },
-    data: {
-      state: CloudUsageMeteringDbCronJobStates.Processing,
-      jobStartedAt: new Date(),
-    },
-  });
+  try {
+    await prisma.cronJobs.update({
+      where: {
+        name: cloudUsageMeteringDbCronJobName,
+        state: CloudUsageMeteringDbCronJobStates.Queued,
+      },
+      data: {
+        state: CloudUsageMeteringDbCronJobStates.Processing,
+        jobStartedAt: new Date(),
+      },
+    });
+  } catch (e) {
+    logger.warn(
+      "[CLOUD USAGE METERING] Failed to update cron job state, potential race condition, exiting",
+      {
+        e,
+      },
+    );
+    return;
+  }
 
   // timing
   const meterIntervalStart = cron.lastRun;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds race condition check in `handleCloudUsageMeteringJob` to log a warning and exit if `prisma.cronJobs.update` fails.
> 
>   - **Behavior**:
>     - Adds race condition check in `handleCloudUsageMeteringJob` in `handleCloudUsageMeteringJob.ts` by wrapping `prisma.cronJobs.update` in a try-catch block.
>     - Logs a warning and exits if the update fails, indicating a potential race condition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a355eb7da2ad813342426183aae8b5e62c6aaf66. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->