### PR TITLE
fix: quickly recover from metering queue errors

### DIFF
--- a/worker/src/queues/cloudUsageMeteringQueue.ts
+++ b/worker/src/queues/cloudUsageMeteringQueue.ts
@@ -5,6 +5,9 @@ import {
   QueueJobs,
 } from "@langfuse/shared/src/server";
 import { handleCloudUsageMeteringJob } from "../ee/cloudUsageMetering/handleCloudUsageMeteringJob";
+import { cloudUsageMeteringDbCronJobName } from "../ee/cloudUsageMetering/constants";
+import { CloudUsageMeteringDbCronJobStates } from "../ee/cloudUsageMetering/constants";
+import { prisma } from "@langfuse/shared/src/db";
 
 export const cloudUsageMeteringQueueProcessor: Processor = async (job) => {
   if (job.name === QueueJobs.CloudUsageMeteringJob) {
@@ -14,6 +17,15 @@ export const cloudUsageMeteringQueueProcessor: Processor = async (job) => {
     } catch (error) {
       logger.error("Error executing Cloud Usage Metering Job", error);
       // adding another job to the queue to process again.
+      await prisma.cronJobs.update({
+        where: {
+          name: cloudUsageMeteringDbCronJobName,
+        },
+        data: {
+          state: CloudUsageMeteringDbCronJobStates.Queued,
+          jobStartedAt: null,
+        },
+      });
       await CloudUsageMeteringQueue.getInstance()?.add(
         QueueJobs.CloudUsageMeteringJob,
         {},


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance error recovery in `cloudUsageMeteringQueueProcessor` by updating cron job state in the database on errors.
> 
>   - **Error Handling**:
>     - In `cloudUsageMeteringQueueProcessor`, update cron job state to `Queued` in `prisma.cronJobs` on error.
>     - Reset `jobStartedAt` to `null` to allow reprocessing.
>   - **Imports**:
>     - Add imports for `cloudUsageMeteringDbCronJobName` and `CloudUsageMeteringDbCronJobStates` from `constants`.
>     - Add import for `prisma` from `@langfuse/shared/src/db`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for de5ec0c4b8c29f81d4c7f1e2e1ea42938737c847. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->