### PR TITLE
chore(cloud): region details

### DIFF
--- a/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
+++ b/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
@@ -127,10 +127,10 @@ const DataRegionInfo = () => (
         <p>Langfuse Cloud is available in two data regions:</p>
         <ul className="list-disc pl-5">
           <li>
-            US: Oregon (AWS us-west-2) & Virginia (AWS us-east-1)
+            US: Oregon (AWS us-west-2)
           </li>
           <li>
-            EU: Germany/Frankfurt (AWS eu-central-1) & Ireland (AWS eu-west-1)
+            EU: Ireland (AWS eu-west-1)
           </li>
         </ul>
         <p>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `DataRegionInfo` in `AuthCloudRegionSwitch.tsx` to reflect changes in available Langfuse Cloud data regions.
> 
>   - **Behavior**:
>     - Update `DataRegionInfo` in `AuthCloudRegionSwitch.tsx` to remove Virginia (AWS us-east-1) and Germany/Frankfurt (AWS eu-central-1) from the list of available data regions.
>     - Now only lists US: Oregon (AWS us-west-2) and EU: Ireland (AWS eu-west-1) as available regions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7d9ea542e32fbc97440a8d0f0e984cc98f99f929. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->