### PR TITLE
perf: enable api key and prompt caches by default

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -26,7 +26,7 @@ const EnvSchema = z.object({
       "ENCRYPTION_KEY must be 256 bits, 64 string characters in hex format, generate via: openssl rand -hex 32",
     )
     .optional(),
-  LANGFUSE_CACHE_PROMPT_ENABLED: z.enum(["true", "false"]).default("false"),
+  LANGFUSE_CACHE_PROMPT_ENABLED: z.enum(["true", "false"]).default("true"),
   LANGFUSE_CACHE_PROMPT_TTL_SECONDS: z.coerce.number().default(60 * 60),
   CLICKHOUSE_URL: z.string().url(),
   CLICKHOUSE_CLUSTER_NAME: z.string().default("default"),

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -197,7 +197,7 @@ export const env = createEnv({
     REDIS_ENABLE_AUTO_PIPELINING: z.enum(["true", "false"]).default("true"),
 
     // langfuse caching
-    LANGFUSE_CACHE_API_KEY_ENABLED: z.enum(["true", "false"]).default("false"),
+    LANGFUSE_CACHE_API_KEY_ENABLED: z.enum(["true", "false"]).default("true"),
     LANGFUSE_CACHE_API_KEY_TTL_SECONDS: z.coerce.number().default(120),
 
     // Multimodal media upload to S3


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable caching for API keys and prompts by default in `env.ts` and `env.mjs`.
> 
>   - **Behavior**:
>     - Enable `LANGFUSE_CACHE_PROMPT_ENABLED` by default in `env.ts`.
>     - Enable `LANGFUSE_CACHE_API_KEY_ENABLED` by default in `env.mjs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 355686f56660cb7e1eee5db27c8406018e288dd6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->