### PR TITLE
chore(cloud): run analytics jobs daily

### DIFF
--- a/packages/shared/src/server/redis/coreDataS3ExportQueue.ts
+++ b/packages/shared/src/server/redis/coreDataS3ExportQueue.ts
@@ -47,8 +47,7 @@ export class CoreDataS3ExportQueue {
           QueueJobs.CoreDataS3ExportJob,
           {},
           {
-            // repeat: { pattern: "30 4 * * *" }, // every day at 4:30am
-            repeat: { pattern: "30 * * * *" }, // tmp, every hour at 30 minutes
+            repeat: { pattern: "15 3 * * *" }, // every day at 3:15am
           },
         )
         .catch((err) => {

--- a/packages/shared/src/server/redis/meteringDataPostgresExportQueue.ts
+++ b/packages/shared/src/server/redis/meteringDataPostgresExportQueue.ts
@@ -47,8 +47,7 @@ export class MeteringDataPostgresExportQueue {
           QueueJobs.MeteringDataPostgresExportJob,
           {},
           {
-            // repeat: { pattern: "30 3 * * *" }, // every day at 3:30am UTC
-            repeat: { pattern: "0 * * * *" }, // initially, run every hour
+            repeat: { pattern: "30 2 * * *" }, // every day at 2:30am UTC
           },
         )
         .catch((err) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update analytics job schedules to run daily at specific times in `CoreDataS3ExportQueue` and `MeteringDataPostgresExportQueue`.
> 
>   - **Behavior**:
>     - Update `CoreDataS3ExportQueue` to schedule jobs daily at 3:15am instead of hourly.
>     - Update `MeteringDataPostgresExportQueue` to schedule jobs daily at 2:30am UTC instead of hourly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 57201b81e93e9433c165d399ffcc0914a779ff39. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->