### PR TITLE
fix: fix session ui table ordering

### DIFF
--- a/packages/shared/src/server/services/sessions-ui-table-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-service.ts
@@ -207,9 +207,10 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
         "inputCost",
         "outputCost",
         "sessionDuration",
-        "totalUsage",
-        "outputUsage",
-        "inputUsage",
+        "totalTokens",
+        "outputTokens",
+        "inputTokens",
+        "usage",
       ].includes(orderBy?.column));
 
   const selectMetrics = select === "metrics" || hasMetricsFilter;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update column names for ordering in `getSessionsTableGeneric` to reflect new token-based metrics.
> 
>   - **Behavior**:
>     - Update column names for ordering in `getSessionsTableGeneric` in `sessions-ui-table-service.ts`.
>     - Replaces `totalUsage`, `outputUsage`, `inputUsage` with `totalTokens`, `outputTokens`, `inputTokens`, and adds `usage`.
>   - **Misc**:
>     - No changes to logic or additional functionality added.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6a18f1861673caf39fcc887b602662d1aff5917d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->