### PR TITLE
fix: flaky session export test

### DIFF
--- a/worker/src/__tests__/batch-export.test.ts
+++ b/worker/src/__tests__/batch-export.test.ts
@@ -413,13 +413,13 @@ describe("batch export test suite", () => {
       expect.arrayContaining([
         expect.objectContaining({
           id: traces[0].id,
-          latency: 1,
+          latency: expect.closeTo(1.0, 0.1), // allows deviation of ±0.1
           test: [score.value],
           qualitative_test: ["This is some qualitative text"],
         }),
         expect.objectContaining({
           id: traces[1].id,
-          latency: 2.123,
+          latency: expect.closeTo(2.123, 0.1), // allows deviation of ±0.1
           test: null,
           qualitative_test: null,
         }),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Allow small deviation in latency expectation in `batch-export.test.ts` to reduce test flakiness.
> 
>   - **Tests**:
>     - In `batch-export.test.ts`, change latency expectation to `expect.closeTo` with a deviation of ±0.1 for traces to reduce flakiness.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 95a8c55fae790762c4aecfb74d739168476cd6f8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->