### PR TITLE
feat(prompts): support in UI prompt duplication

### DIFF
--- a/web/src/components/ActionButton.tsx
+++ b/web/src/components/ActionButton.tsx
@@ -23,7 +23,7 @@ interface ActionButtonProps extends ButtonProps {
   hasEntitlement?: boolean;
   limitValue?: number;
   limit?: number | false;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   className?: string;
   href?: string;
 }
@@ -75,7 +75,7 @@ export function ActionButton({
       buttonProps={buttonProps}
       href={href}
     >
-      {children}
+      {children && children}
     </ButtonContent>
   );
 

--- a/web/src/components/ActionButton.tsx
+++ b/web/src/components/ActionButton.tsx
@@ -23,7 +23,7 @@ interface ActionButtonProps extends ButtonProps {
   hasEntitlement?: boolean;
   limitValue?: number;
   limit?: number | false;
-  children?: React.ReactNode;
+  children: React.ReactNode;
   className?: string;
   href?: string;
 }
@@ -75,7 +75,7 @@ export function ActionButton({
       buttonProps={buttonProps}
       href={href}
     >
-      {children && children}
+      {children}
     </ButtonContent>
   );
 

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -57,6 +57,8 @@ const events = {
     "apply_labels",
     "version_delete_open",
     "version_delete_submit",
+    "duplicate_button_click",
+    "duplicate_form_submit",
   ],
   session_detail: ["publish_button_click"],
   eval_config: [

--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -49,6 +49,7 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import usePlaygroundCache from "@/src/ee/features/playground/page/hooks/usePlaygroundCache";
 import { useQueryParam } from "use-query-params";
 import { Switch } from "@/src/components/ui/switch";
+import { usePromptNameValidation } from "@/src/features/prompts/hooks/usePromptNameValidation";
 
 type NewPromptFormProps = {
   initialPrompt?: Prompt | null;
@@ -184,24 +185,11 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
     }
   }, [playgroundCache, initialPrompt, form, shouldLoadPlaygroundCache]);
 
-  useEffect(() => {
-    const isNewPrompt = !allPrompts
-      ?.map((prompt) => prompt.value)
-      .includes(currentName);
-
-    if (!isNewPrompt) {
-      form.setError("name", { message: "Prompt name already exist." });
-    } else if (currentName === "new") {
-      form.setError("name", { message: "Prompt name cannot be 'new'" });
-    } else if (currentName && !/^[a-zA-Z0-9_\-.]+$/.test(currentName)) {
-      form.setError("name", {
-        message:
-          "Name must be alphanumeric with optional underscores, hyphens, or periods",
-      });
-    } else {
-      form.clearErrors("name");
-    }
-  }, [currentName, allPrompts, form]);
+  usePromptNameValidation({
+    currentName,
+    allPrompts,
+    form,
+  });
 
   return (
     <Form {...form}>

--- a/web/src/features/prompts/components/duplicate-prompt.tsx
+++ b/web/src/features/prompts/components/duplicate-prompt.tsx
@@ -187,7 +187,7 @@ export const DuplicatePromptButton: React.FC<{
   const promptLimit = useEntitlementLimit("prompt-management-count-prompts");
   const capture = usePostHogClientCapture();
 
-  const totalPromptCount = api.prompts.count.useQuery(
+  const allPromptNames = api.prompts.allNames.useQuery(
     {
       projectId,
     },
@@ -208,7 +208,7 @@ export const DuplicatePromptButton: React.FC<{
           variant="secondary"
           limit={promptLimit}
           title="Duplicate prompt"
-          limitValue={totalPromptCount.data ?? undefined}
+          limitValue={allPromptNames.data?.length ?? undefined}
           onClick={() => {
             capture("prompt_detail:duplicate_button_click");
           }}

--- a/web/src/features/prompts/components/duplicate-prompt.tsx
+++ b/web/src/features/prompts/components/duplicate-prompt.tsx
@@ -203,8 +203,7 @@ export const DuplicatePromptButton: React.FC<{
     <Dialog open={hasAccess && open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <ActionButton
-          size="icon"
-          icon={<Copy className="-mr-1 h-4 w-4" aria-hidden="true" />}
+          icon={<Copy className="mr-1 h-4 w-4" aria-hidden="true" />}
           hasAccess={hasAccess}
           variant="secondary"
           limit={promptLimit}
@@ -213,7 +212,9 @@ export const DuplicatePromptButton: React.FC<{
           onClick={() => {
             capture("prompt_detail:duplicate_button_click");
           }}
-        ></ActionButton>
+        >
+          Duplicate
+        </ActionButton>
       </DialogTrigger>
       <DialogContent className="max-h-[90vh] min-h-0">
         <DialogHeader>

--- a/web/src/features/prompts/components/duplicate-prompt.tsx
+++ b/web/src/features/prompts/components/duplicate-prompt.tsx
@@ -27,13 +27,13 @@ import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Input } from "@/src/components/ui/input";
 import { RadioGroup, RadioGroupItem } from "@/src/components/ui/radio-group";
+import { usePromptNameValidation } from "@/src/features/prompts/hooks/usePromptNameValidation";
 
 enum CopySettings {
   SINGLE_VERSION = "single_version",
   ALL_VERSIONS = "all_versions",
 }
 
-// fix name validation
 const formSchema = z.object({
   name: z.string().min(1, "Name is required"),
   isCopySingleVersion: z.nativeEnum(CopySettings),
@@ -55,6 +55,8 @@ const DuplicatePromptForm: React.FC<{
       isCopySingleVersion: CopySettings.SINGLE_VERSION,
     },
   });
+
+  const currentName = form.watch("name");
 
   const utils = api.useUtils();
   const duplicatePrompt = api.prompts.duplicatePrompt.useMutation({
@@ -84,6 +86,24 @@ const DuplicatePromptForm: React.FC<{
         console.error(error);
       });
   }
+
+  const allPrompts = api.prompts.filterOptions.useQuery(
+    {
+      projectId: projectId,
+    },
+    {
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: Infinity,
+    },
+  ).data?.name;
+
+  usePromptNameValidation({
+    currentName,
+    allPrompts,
+    form,
+  });
 
   return (
     <Form {...form}>

--- a/web/src/features/prompts/components/duplicate-prompt.tsx
+++ b/web/src/features/prompts/components/duplicate-prompt.tsx
@@ -1,0 +1,201 @@
+import { useRouter } from "next/router";
+import { Button } from "@/src/components/ui/button";
+import { api } from "@/src/utils/api";
+import { Copy } from "lucide-react";
+import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/src/components/ui/dialog";
+import { ActionButton } from "@/src/components/ActionButton";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { useEntitlementLimit } from "@/src/features/entitlements/hooks";
+import { useState } from "react";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/src/components/ui/form";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Input } from "@/src/components/ui/input";
+import { RadioGroup, RadioGroupItem } from "@/src/components/ui/radio-group";
+
+enum CopySettings {
+  SINGLE_VERSION = "single_version",
+  ALL_VERSIONS = "all_versions",
+}
+
+// fix name validation
+const formSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  isCopySingleVersion: z.nativeEnum(CopySettings),
+});
+
+const DuplicatePromptForm: React.FC<{
+  projectId: string;
+  promptId: string;
+  promptName: string;
+  promptVersion: number;
+  onFormSuccess: () => void;
+}> = ({ projectId, promptId, promptName, promptVersion, onFormSuccess }) => {
+  const capture = usePostHogClientCapture();
+  const router = useRouter();
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: promptName,
+      isCopySingleVersion: CopySettings.SINGLE_VERSION,
+    },
+  });
+
+  const utils = api.useUtils();
+  const duplicatePrompt = api.prompts.duplicatePrompt.useMutation({
+    onSuccess: ({ name }) => {
+      utils.prompts.invalidate();
+      void router.push(
+        `/project/${projectId}/prompts/${encodeURIComponent(name)}`,
+      );
+    },
+  });
+
+  function onSubmit(values: z.infer<typeof formSchema>) {
+    capture("prompt_detail:duplicate_form_submit");
+    duplicatePrompt
+      .mutateAsync({
+        ...values,
+        projectId: projectId,
+        promptId: promptId,
+        isSingleVersion:
+          values.isCopySingleVersion === CopySettings.SINGLE_VERSION,
+      })
+      .then(() => {
+        onFormSuccess();
+        form.reset();
+      })
+      .catch((error: Error) => {
+        console.error(error);
+      });
+  }
+
+  return (
+    <Form {...form}>
+      <form
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="mt-4 flex h-full flex-1 flex-col gap-4"
+      >
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem className="flex flex-col gap-2">
+              <FormLabel>Name</FormLabel>
+              <FormControl>
+                <Input {...field} type="text" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="isCopySingleVersion"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Settings</FormLabel>
+              <FormControl>
+                <RadioGroup
+                  {...field}
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
+                  className="flex flex-col space-y-1"
+                >
+                  <FormItem className="flex items-center space-x-3 space-y-0">
+                    <FormControl>
+                      <RadioGroupItem value={CopySettings.SINGLE_VERSION} />
+                    </FormControl>
+                    <FormLabel className="font-normal">
+                      Copy only version {promptVersion}
+                    </FormLabel>
+                  </FormItem>
+                  <FormItem className="flex items-center space-x-3 space-y-0">
+                    <FormControl>
+                      <RadioGroupItem value={CopySettings.ALL_VERSIONS} />
+                    </FormControl>
+                    <FormLabel className="font-normal">
+                      Copy all prompt versions and labels
+                    </FormLabel>
+                  </FormItem>
+                </RadioGroup>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button
+          type="submit"
+          loading={duplicatePrompt.isLoading}
+          className="mb-4 mt-auto w-full"
+        >
+          Submit
+        </Button>
+      </form>
+    </Form>
+  );
+};
+
+export const DuplicatePromptButton: React.FC<{
+  projectId: string;
+  promptId: string;
+  promptName: string;
+  promptVersion: number;
+  totalPromptCount: number;
+}> = ({ projectId, promptId, promptName, promptVersion, totalPromptCount }) => {
+  const [open, setOpen] = useState(false);
+  const hasAccess = useHasProjectAccess({
+    projectId,
+    scope: "prompts:CUD",
+  });
+  const promptLimit = useEntitlementLimit("prompt-management-count-prompts");
+  const capture = usePostHogClientCapture();
+
+  return (
+    <Dialog open={hasAccess && open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <ActionButton
+          size="icon"
+          icon={<Copy className="-mr-1 h-4 w-4" aria-hidden="true" />}
+          hasAccess={hasAccess}
+          variant="secondary"
+          limit={promptLimit}
+          title="Duplicate prompt"
+          limitValue={totalPromptCount}
+          onClick={() => {
+            capture("prompt_detail:duplicate_button_click");
+          }}
+        ></ActionButton>
+      </DialogTrigger>
+      <DialogContent className="max-h-[90vh] min-h-0">
+        <DialogHeader>
+          <DialogTitle>Duplicate prompt</DialogTitle>
+        </DialogHeader>
+        <DuplicatePromptForm
+          projectId={projectId}
+          promptId={promptId}
+          promptName={promptName}
+          promptVersion={promptVersion}
+          onFormSuccess={() => setOpen(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/web/src/features/prompts/components/duplicate-prompt.tsx
+++ b/web/src/features/prompts/components/duplicate-prompt.tsx
@@ -178,8 +178,7 @@ export const DuplicatePromptButton: React.FC<{
   promptId: string;
   promptName: string;
   promptVersion: number;
-  totalPromptCount: number;
-}> = ({ projectId, promptId, promptName, promptVersion, totalPromptCount }) => {
+}> = ({ projectId, promptId, promptName, promptVersion }) => {
   const [open, setOpen] = useState(false);
   const hasAccess = useHasProjectAccess({
     projectId,
@@ -187,6 +186,18 @@ export const DuplicatePromptButton: React.FC<{
   });
   const promptLimit = useEntitlementLimit("prompt-management-count-prompts");
   const capture = usePostHogClientCapture();
+
+  const totalPromptCount = api.prompts.count.useQuery(
+    {
+      projectId,
+    },
+    {
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      enabled: hasAccess,
+    },
+  );
 
   return (
     <Dialog open={hasAccess && open} onOpenChange={setOpen}>
@@ -198,7 +209,7 @@ export const DuplicatePromptButton: React.FC<{
           variant="secondary"
           limit={promptLimit}
           title="Duplicate prompt"
-          limitValue={totalPromptCount}
+          limitValue={totalPromptCount.data ?? undefined}
           onClick={() => {
             capture("prompt_detail:duplicate_button_click");
           }}

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -39,6 +39,7 @@ import { CreateExperimentsForm } from "@/src/ee/features/experiments/components/
 import { useState } from "react";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
+import { DuplicatePromptButton } from "@/src/features/prompts/components/duplicate-prompt";
 
 export const PromptDetail = () => {
   const projectId = useProjectIdFromURL();
@@ -222,6 +223,15 @@ export const PromptDetail = () => {
                   <span className="ml-2">New version</span>
                 </div>
               </Button>
+            )}
+            {projectId && (
+              <DuplicatePromptButton
+                promptId={prompt.id}
+                projectId={projectId}
+                promptName={prompt.name}
+                promptVersion={prompt.version}
+                totalPromptCount={promptHistory.data.totalCount}
+              />
             )}
             <DetailPageNav
               key="nav"

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -230,7 +230,6 @@ export const PromptDetail = () => {
                 projectId={projectId}
                 promptName={prompt.name}
                 promptVersion={prompt.version}
-                totalPromptCount={promptHistory.data.totalCount}
               />
             )}
             <DetailPageNav

--- a/web/src/features/prompts/hooks/usePromptNameValidation.tsx
+++ b/web/src/features/prompts/hooks/usePromptNameValidation.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { UseFormReturn } from "react-hook-form";
+import { type UseFormReturn } from "react-hook-form";
 
 interface UsePromptNameValidationProps {
   currentName: string | undefined;

--- a/web/src/features/prompts/hooks/usePromptNameValidation.tsx
+++ b/web/src/features/prompts/hooks/usePromptNameValidation.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+import { UseFormReturn } from "react-hook-form";
+
+interface UsePromptNameValidationProps {
+  currentName: string | undefined;
+  allPrompts: { value: string }[] | undefined;
+  form: UseFormReturn<any>;
+}
+
+export const usePromptNameValidation = ({
+  currentName,
+  allPrompts,
+  form,
+}: UsePromptNameValidationProps) => {
+  useEffect(() => {
+    if (!currentName) return;
+
+    const isNewPrompt = !allPrompts
+      ?.map((prompt) => prompt.value)
+      .includes(currentName);
+
+    if (!isNewPrompt) {
+      form.setError("name", { message: "Prompt name already exist." });
+    } else if (currentName === "new") {
+      form.setError("name", { message: "Prompt name cannot be 'new'" });
+    } else if (!/^[a-zA-Z0-9_\-.]+$/.test(currentName)) {
+      form.setError("name", {
+        message:
+          "Name must be alphanumeric with optional underscores, hyphens, or periods",
+      });
+    } else {
+      form.clearErrors("name");
+    }
+  }, [currentName, allPrompts, form]);
+};

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -97,16 +97,6 @@ export const promptRouter = createTRPCRouter({
           promptCount.length > 0 ? Number(promptCount[0]?.totalCount) : 0,
       };
     }),
-  count: protectedProjectProcedure
-    .input(z.object({ projectId: z.string() }))
-    .query(async ({ input, ctx }) => {
-      throwIfNoProjectAccess({
-        session: ctx.session,
-        projectId: input.projectId,
-        scope: "prompts:read",
-      });
-      return ctx.prisma.prompt.count({ where: { projectId: input.projectId } });
-    }),
   metrics: protectedProjectProcedure
     .input(
       z.object({

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -97,6 +97,16 @@ export const promptRouter = createTRPCRouter({
           promptCount.length > 0 ? Number(promptCount[0]?.totalCount) : 0,
       };
     }),
+  count: protectedProjectProcedure
+    .input(z.object({ projectId: z.string() }))
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "prompts:read",
+      });
+      return ctx.prisma.prompt.count({ where: { projectId: input.projectId } });
+    }),
   metrics: protectedProjectProcedure
     .input(
       z.object({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add UI and backend support for duplicating prompts, including single and all versions, with reusable prompt name validation.
> 
>   - **Feature**:
>     - Add `DuplicatePromptButton` and `DuplicatePromptForm` components in `duplicate-prompt.tsx` to support prompt duplication in the UI.
>     - Support duplicating a single version or all versions of a prompt.
>   - **Backend**:
>     - Add `duplicatePrompt` function in `createPrompt.ts` to handle prompt duplication logic.
>     - Update `promptRouter.ts` to include `duplicatePrompt` mutation for handling duplication requests.
>   - **Validation**:
>     - Extract prompt name validation logic to `usePromptNameValidation` hook for reuse in `NewPromptForm` and `DuplicatePromptForm`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b3083108bf6a99ae118e4a6a1f6a556be959d3a2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->