### PR TITLE
fix: route all links to new observations table

### DIFF
--- a/web/src/components/layouts/routes.tsx
+++ b/web/src/components/layouts/routes.tsx
@@ -71,8 +71,8 @@ export const ROUTES: Route[] = [
         pathname: `/project/[projectId]/sessions`,
       },
       {
-        title: "Generations",
-        pathname: `/project/[projectId]/generations`,
+        title: "Observations",
+        pathname: `/project/[projectId]/observations`,
       },
       {
         title: "Scores",

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -187,7 +187,7 @@ export function PromptTable() {
       },
     }),
     columnHelper.accessor("numberOfObservations", {
-      header: "Number of Generations",
+      header: "Number of Observations",
       size: 170,
       cell: (row) => {
         const numberOfObservations = row.getValue();
@@ -200,7 +200,7 @@ export function PromptTable() {
         }
         return (
           <TableLink
-            path={`/project/${projectId}/generations?filter=${numberOfObservations ? filter : ""}`}
+            path={`/project/${projectId}/observations?filter=${numberOfObservations ? filter : ""}`}
             value={numberOfObservations.toLocaleString()}
           />
         );

--- a/web/src/pages/project/[projectId]/models/[modelId].tsx
+++ b/web/src/pages/project/[projectId]/models/[modelId].tsx
@@ -180,10 +180,10 @@ export default function ModelDetailPage() {
         <Card className="col-span-2">
           <CardHeader>
             <CardTitle className="flex items-center justify-between">
-              <span>Model generations</span>
+              <span>Model observations</span>
               <Button variant="ghost" asChild>
                 <Link
-                  href={`/project/${projectId}/generations`}
+                  href={`/project/${projectId}/observations`}
                   className="flex items-center gap-1"
                 >
                   <span className="text-sm">View all</span>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update all references from 'Generations' to 'Observations' in routes, paths, and UI components.
> 
>   - **Behavior**:
>     - Update route title from "Generations" to "Observations" in `routes.tsx`.
>     - Change path from `/generations` to `/observations` in `routes.tsx` and `prompts-table.tsx`.
>     - Update link text from "Model generations" to "Model observations" in `models/[modelId].tsx`.
>   - **UI Components**:
>     - Change column header from "Number of Generations" to "Number of Observations" in `prompts-table.tsx`.
>     - Update `TableLink` path to use `/observations` in `prompts-table.tsx`.
>     - Modify `CardTitle` text to "Model observations" in `models/[modelId].tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d41fe3801d5a13933ac7e43ac4ae3dc8e6387793. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->