### PR TITLE
fix: allow field overwrites with `null` in ingestion api

### DIFF
--- a/web/src/__tests__/async/scores-api.servertest.ts
+++ b/web/src/__tests__/async/scores-api.servertest.ts
@@ -107,6 +107,7 @@ describe("/api/public/scores API Endpoint", () => {
     expect(fetchedScore.body?.source).toBe("API");
     expect(fetchedScore.body?.projectId).toBe(projectId);
   });
+
   it("should GET score with minimal score data and minimal trace data", async () => {
     const { projectId, auth } = await createOrgProjectAndApiKey();
 
@@ -142,6 +143,7 @@ describe("/api/public/scores API Endpoint", () => {
 
     expect(fetchedScore.status).toBe(200);
   });
+
   describe("should Filter scores", () => {
     let configId = "";
     const userId = "user-name";
@@ -450,235 +452,243 @@ describe("/api/public/scores API Endpoint", () => {
       });
     });
 
-    it("test only operator", async () => {
-      const getScore = await makeZodVerifiedAPICall(
-        GetScoresResponse,
-        "GET",
-        `/api/public/scores?${queryUserName}&operator=<`,
-        undefined,
-        authentication,
-      );
-      expect(getScore.status).toBe(200);
-      expect(getScore.body.meta).toMatchObject({
-        page: 1,
-        limit: 50,
-        totalItems: 3,
-        totalPages: 1,
-      });
-    });
-
-    it("test only value", async () => {
-      const getScore = await makeZodVerifiedAPICall(
-        GetScoresResponse,
-        "GET",
-        `/api/public/scores?${queryUserName}&value=0.8`,
-        undefined,
-        authentication,
-      );
-      expect(getScore.status).toBe(200);
-      expect(getScore.body.meta).toMatchObject({
-        page: 1,
-        limit: 50,
-        totalItems: 3,
-        totalPages: 1,
-      });
-    });
-
-    it("test operator <", async () => {
-      const getScore = await makeZodVerifiedAPICall(
-        GetScoresResponse,
-        "GET",
-        `/api/public/scores?${queryUserName}&operator=<&value=50`,
-        undefined,
-        authentication,
-      );
-      expect(getScore.status).toBe(200);
-      expect(getScore.body.meta).toMatchObject({
-        page: 1,
-        limit: 50,
-        totalItems: 1,
-        totalPages: 1,
-      });
-      expect(getScore.body.data).toMatchObject([
-        {
-          id: scoreId_1,
-          name: scoreName,
-          value: 10.5,
-        },
-      ]);
-    });
-    it("test operator >", async () => {
-      const getScore = await makeZodVerifiedAPICall(
-        GetScoresResponse,
-        "GET",
-        `/api/public/scores?${queryUserName}&operator=>&value=100`,
-        undefined,
-        authentication,
-      );
-      expect(getScore.status).toBe(200);
-      expect(getScore.body.meta).toMatchObject({
-        page: 1,
-        limit: 50,
-        totalItems: 1,
-        totalPages: 1,
-      });
-      expect(getScore.body.data).toMatchObject([
-        {
-          id: scoreId_3,
-          name: scoreName,
-          value: 100.8,
-        },
-      ]);
-    });
-    it("test operator <=", async () => {
-      const getScore = await makeZodVerifiedAPICall(
-        GetScoresResponse,
-        "GET",
-        `/api/public/scores?${queryUserName}&operator=<=&value=50.5`,
-        undefined,
-        authentication,
-      );
-      expect(getScore.status).toBe(200);
-      expect(getScore.body.meta).toMatchObject({
-        page: 1,
-        limit: 50,
-        totalItems: 2,
-        totalPages: 1,
-      });
-      expect(getScore.body.data).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            id: scoreId_2,
-            name: scoreName,
-            value: 50.5,
-          }),
-          expect.objectContaining({
-            id: scoreId_1,
-            name: scoreName,
-            value: 10.5,
-          }),
-        ]),
-      );
-    });
-    it("test operator >=", async () => {
-      const getScore = await makeZodVerifiedAPICall(
-        GetScoresResponse,
-        "GET",
-        `/api/public/scores?${queryUserName}&operator=>=&value=50.5`,
-        undefined,
-        authentication,
-      );
-      expect(getScore.status).toBe(200);
-      expect(getScore.body.meta).toMatchObject({
-        page: 1,
-        limit: 50,
-        totalItems: 2,
-        totalPages: 1,
-      });
-      expect(getScore.body.data).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            id: scoreId_3,
-            name: scoreName,
-            value: 100.8,
-          }),
-          expect.objectContaining({
-            id: scoreId_2,
-            name: scoreName,
-            value: 50.5,
-          }),
-        ]),
-      );
-    });
-    it("test operator !=", async () => {
-      const getScore = await makeZodVerifiedAPICall(
-        GetScoresResponse,
-        "GET",
-        `/api/public/scores?${queryUserName}&operator=!=&value=50.5`,
-        undefined,
-        authentication,
-      );
-      expect(getScore.status).toBe(200);
-      expect(getScore.body.meta).toMatchObject({
-        page: 1,
-        limit: 50,
-        totalItems: 2,
-        totalPages: 1,
-      });
-      expect(getScore.body.data).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            id: scoreId_3,
-            name: scoreName,
-            value: 100.8,
-          }),
-          expect.objectContaining({
-            id: scoreId_1,
-            name: scoreName,
-            value: 10.5,
-          }),
-        ]),
-      );
-    });
-    it("test operator =", async () => {
-      const getScore = await makeZodVerifiedAPICall(
-        GetScoresResponse,
-        "GET",
-        `/api/public/scores?${queryUserName}&operator==&value=50.5`,
-        undefined,
-        authentication,
-      );
-      expect(getScore.status).toBe(200);
-      expect(getScore.body.meta).toMatchObject({
-        page: 1,
-        limit: 50,
-        totalItems: 1,
-        totalPages: 1,
-      });
-      expect(getScore.body.data).toMatchObject([
-        {
-          id: scoreId_2,
-          name: scoreName,
-          value: 50.5,
-        },
-      ]);
-    });
-
-    it("test invalid operator", async () => {
-      try {
-        await makeZodVerifiedAPICall(
-          z.object({
-            message: z.string(),
-            error: z.array(z.object({})),
-          }),
+    describe("should use score operators correctly", () => {
+      it("test only operator", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponse,
           "GET",
-          `/api/public/scores?${queryUserName}&operator=op&value=50.5`,
+          `/api/public/scores?${queryUserName}&operator=<`,
           undefined,
           authentication,
         );
-      } catch (error) {
-        expect((error as Error).message).toBe(
-          `API call did not return 200, returned status 400, body {\"message\":\"Invalid request data\",\"error\":[{\"received\":\"op\",\"code\":\"invalid_enum_value\",\"options\":[\"<\",\">\",\"<=\",\">=\",\"!=\",\"=\"],\"path\":[\"operator\"],\"message\":\"Invalid enum value. Expected '<' | '>' | '<=' | '>=' | '!=' | '=', received 'op'\"}]}`,
-        );
-      }
-    });
-    it("test invalid value", async () => {
-      try {
-        await makeZodVerifiedAPICall(
-          z.object({
-            message: z.string(),
-            error: z.array(z.object({})),
-          }),
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({
+          page: 1,
+          limit: 50,
+          totalItems: 3,
+          totalPages: 1,
+        });
+      });
+
+      it("test only value", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponse,
           "GET",
-          `/api/public/scores?${queryUserName}&operator=<&value=myvalue`,
+          `/api/public/scores?${queryUserName}&value=0.8`,
           undefined,
           authentication,
         );
-      } catch (error) {
-        expect((error as Error).message).toBe(
-          'API call did not return 200, returned status 400, body {"message":"Invalid request data","error":[{"code":"invalid_type","expected":"number","received":"nan","path":["value"],"message":"Expected number, received nan"}]}',
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({
+          page: 1,
+          limit: 50,
+          totalItems: 3,
+          totalPages: 1,
+        });
+      });
+
+      it("test operator <", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponse,
+          "GET",
+          `/api/public/scores?${queryUserName}&operator=<&value=50`,
+          undefined,
+          authentication,
         );
-      }
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({
+          page: 1,
+          limit: 50,
+          totalItems: 1,
+          totalPages: 1,
+        });
+        expect(getScore.body.data).toMatchObject([
+          {
+            id: scoreId_1,
+            name: scoreName,
+            value: 10.5,
+          },
+        ]);
+      });
+
+      it("test operator >", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponse,
+          "GET",
+          `/api/public/scores?${queryUserName}&operator=>&value=100`,
+          undefined,
+          authentication,
+        );
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({
+          page: 1,
+          limit: 50,
+          totalItems: 1,
+          totalPages: 1,
+        });
+        expect(getScore.body.data).toMatchObject([
+          {
+            id: scoreId_3,
+            name: scoreName,
+            value: 100.8,
+          },
+        ]);
+      });
+
+      it("test operator <=", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponse,
+          "GET",
+          `/api/public/scores?${queryUserName}&operator=<=&value=50.5`,
+          undefined,
+          authentication,
+        );
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({
+          page: 1,
+          limit: 50,
+          totalItems: 2,
+          totalPages: 1,
+        });
+        expect(getScore.body.data).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: scoreId_2,
+              name: scoreName,
+              value: 50.5,
+            }),
+            expect.objectContaining({
+              id: scoreId_1,
+              name: scoreName,
+              value: 10.5,
+            }),
+          ]),
+        );
+      });
+
+      it("test operator >=", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponse,
+          "GET",
+          `/api/public/scores?${queryUserName}&operator=>=&value=50.5`,
+          undefined,
+          authentication,
+        );
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({
+          page: 1,
+          limit: 50,
+          totalItems: 2,
+          totalPages: 1,
+        });
+        expect(getScore.body.data).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: scoreId_3,
+              name: scoreName,
+              value: 100.8,
+            }),
+            expect.objectContaining({
+              id: scoreId_2,
+              name: scoreName,
+              value: 50.5,
+            }),
+          ]),
+        );
+      });
+
+      it("test operator !=", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponse,
+          "GET",
+          `/api/public/scores?${queryUserName}&operator=!=&value=50.5`,
+          undefined,
+          authentication,
+        );
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({
+          page: 1,
+          limit: 50,
+          totalItems: 2,
+          totalPages: 1,
+        });
+        expect(getScore.body.data).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: scoreId_3,
+              name: scoreName,
+              value: 100.8,
+            }),
+            expect.objectContaining({
+              id: scoreId_1,
+              name: scoreName,
+              value: 10.5,
+            }),
+          ]),
+        );
+      });
+
+      it("test operator =", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponse,
+          "GET",
+          `/api/public/scores?${queryUserName}&operator==&value=50.5`,
+          undefined,
+          authentication,
+        );
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({
+          page: 1,
+          limit: 50,
+          totalItems: 1,
+          totalPages: 1,
+        });
+        expect(getScore.body.data).toMatchObject([
+          {
+            id: scoreId_2,
+            name: scoreName,
+            value: 50.5,
+          },
+        ]);
+      });
+
+      it("test invalid operator", async () => {
+        try {
+          await makeZodVerifiedAPICall(
+            z.object({
+              message: z.string(),
+              error: z.array(z.object({})),
+            }),
+            "GET",
+            `/api/public/scores?${queryUserName}&operator=op&value=50.5`,
+            undefined,
+            authentication,
+          );
+        } catch (error) {
+          expect((error as Error).message).toBe(
+            `API call did not return 200, returned status 400, body {\"message\":\"Invalid request data\",\"error\":[{\"received\":\"op\",\"code\":\"invalid_enum_value\",\"options\":[\"<\",\">\",\"<=\",\">=\",\"!=\",\"=\"],\"path\":[\"operator\"],\"message\":\"Invalid enum value. Expected '<' | '>' | '<=' | '>=' | '!=' | '=', received 'op'\"}]}`,
+          );
+        }
+      });
+
+      it("test invalid value", async () => {
+        try {
+          await makeZodVerifiedAPICall(
+            z.object({
+              message: z.string(),
+              error: z.array(z.object({})),
+            }),
+            "GET",
+            `/api/public/scores?${queryUserName}&operator=<&value=myvalue`,
+            undefined,
+            authentication,
+          );
+        } catch (error) {
+          expect((error as Error).message).toBe(
+            'API call did not return 200, returned status 400, body {"message":"Invalid request data","error":[{"code":"invalid_type","expected":"number","received":"nan","path":["value"],"message":"Expected number, received nan"}]}',
+          );
+        }
+      });
     });
 
     it("should filter scores by score IDs", async () => {

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -1875,7 +1875,7 @@ describe("Ingestion end-to-end tests", () => {
     expect(observation?.usage_details.output).toEqual(11);
   });
 
-  it("null does not override set values", async () => {
+  it("null does override set values, undefined doesn't", async () => {
     const traceId = randomUUID();
     const timestamp = Date.now();
 
@@ -1904,7 +1904,7 @@ describe("Ingestion end-to-end tests", () => {
           userId: "user-1",
           metadata: { key: "value" },
           release: null,
-          version: null,
+          version: undefined,
         },
       },
     ];
@@ -1921,7 +1921,7 @@ describe("Ingestion end-to-end tests", () => {
     const trace = await getClickhouseRecord(TableName.Traces, traceId);
 
     expect(trace.release).toBe(null);
-    expect(trace.version).toBe(null);
+    expect(trace.version).toBe("2.0.0");
   });
 
   [

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -1163,62 +1163,6 @@ describe("Ingestion end-to-end tests", () => {
     expect(trace.project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
   });
 
-  it("should merge scores from postgres and event list", async () => {
-    const traceId = randomUUID();
-    const scoreId = randomUUID();
-    const observationId = randomUUID();
-
-    const latestEvent = new Date();
-    const oldEvent = new Date(latestEvent).setSeconds(
-      latestEvent.getSeconds() - 1,
-    );
-
-    await prisma.score.create({
-      data: {
-        id: scoreId,
-        name: "score-name",
-        value: 100.5,
-        observationId,
-        traceId,
-        projectId,
-        source: ScoreSource.API,
-        timestamp: new Date(oldEvent),
-      },
-    });
-
-    const scoreEventList: ScoreEventType[] = [
-      {
-        id: randomUUID(),
-        type: "score-create",
-        timestamp: new Date().toISOString(),
-        body: {
-          id: scoreId,
-          dataType: "NUMERIC",
-          source: ScoreSource.API,
-          name: "score-name",
-          traceId: traceId,
-          value: 100.5,
-          observationId,
-        },
-      },
-    ];
-
-    await ingestionService.processScoreEventList({
-      projectId,
-      entityId: scoreId,
-      createdAtTimestamp: new Date(),
-      scoreEventList,
-    });
-
-    await clickhouseWriter.flushAll(true);
-
-    const score = await getClickhouseRecord(TableName.Scores, scoreId);
-
-    expect(score.name).toBe("score-name");
-    expect(score.value).toBe(100.5);
-    expect(score.project_id).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-  });
-
   it("should merge observations and set negative tokens and cost to null", async () => {
     await prisma.model.create({
       data: {
@@ -1976,8 +1920,8 @@ describe("Ingestion end-to-end tests", () => {
 
     const trace = await getClickhouseRecord(TableName.Traces, traceId);
 
-    expect(trace.release).toBe("1.0.0");
-    expect(trace.version).toBe("2.0.0");
+    expect(trace.release).toBe(null);
+    expect(trace.version).toBe(null);
   });
 
   [

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -1901,8 +1901,8 @@ describe("Ingestion end-to-end tests", () => {
         body: {
           id: traceId,
           name: "trace-name",
-          userId: "user-1",
           metadata: { key: "value" },
+          // Do not set user_id here to validate behaviour for missing fields
           release: null,
           version: undefined,
         },
@@ -1922,6 +1922,7 @@ describe("Ingestion end-to-end tests", () => {
 
     expect(trace.release).toBe(null);
     expect(trace.version).toBe("2.0.0");
+    expect(trace.user_id).toBe("user-1");
   });
 
   [

--- a/worker/src/services/IngestionService/utils.ts
+++ b/worker/src/services/IngestionService/utils.ts
@@ -60,6 +60,7 @@ export function overwriteObject(
   const result = mergeWith({}, a, b, (objValue, srcValue, key) => {
     if (
       nonOverwritableKeys.includes(key) ||
+      srcValue === undefined ||
       (typeof srcValue === "object" &&
         srcValue !== null &&
         Object.keys(srcValue).length === 0) // empty object check for cost / usage details

--- a/worker/src/services/IngestionService/utils.ts
+++ b/worker/src/services/IngestionService/utils.ts
@@ -4,6 +4,7 @@ import {
   mergeJson,
 } from "@langfuse/shared";
 import { mergeWith } from "lodash";
+import { logger } from "@langfuse/shared/src/server";
 
 export const convertJsonSchemaToRecord = (
   jsonSchema: JsonNested,
@@ -59,8 +60,9 @@ export function overwriteObject(
   const result = mergeWith({}, a, b, (objValue, srcValue, key) => {
     if (
       nonOverwritableKeys.includes(key) ||
-      srcValue == null ||
-      (typeof srcValue === "object" && Object.keys(srcValue).length === 0) // empty object check for cost / usage details
+      (typeof srcValue === "object" &&
+        srcValue !== null &&
+        Object.keys(srcValue).length === 0) // empty object check for cost / usage details
     ) {
       return objValue;
     } else {


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/4900
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix ingestion API to allow `null` values to overwrite fields, updating tests to verify behavior.
> 
>   - **Behavior**:
>     - Allow `null` values to overwrite existing fields in the ingestion API, while `undefined` does not.
>     - Update `overwriteObject` function in `utils.ts` to handle `null` and `undefined` values correctly.
>   - **Tests**:
>     - Add test case in `ingestion-api.servertest.ts` to verify clearing of score comment with `null`.
>     - Update `scores-api.servertest.ts` to include tests for operator handling and value filtering.
>     - Modify `IngestionService.integration.test.ts` to test `null` and `undefined` behavior in trace and observation events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a4e03645670121308c8db79c672703bd67d5dd79. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->