### PR TITLE
fix(ingestion): allow nullish tokens_details in openai usage schema

### DIFF
--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -66,8 +66,12 @@ const OpenAIUsageSchema = z
     prompt_tokens: z.number().nonnegative(),
     completion_tokens: z.number().nonnegative(),
     total_tokens: z.number().nonnegative(),
-    prompt_tokens_details: z.record(z.string(), z.number().nonnegative()),
-    completion_tokens_details: z.record(z.string(), z.number().nonnegative()),
+    prompt_tokens_details: z
+      .record(z.string(), z.number().nonnegative())
+      .nullish(),
+    completion_tokens_details: z
+      .record(z.string(), z.number().nonnegative())
+      .nullish(),
   })
   .strict()
   .transform((v) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Allow `prompt_tokens_details` and `completion_tokens_details` to be nullish in `OpenAIUsageSchema`.
> 
>   - **Schema Adjustment**:
>     - In `OpenAIUsageSchema`, `prompt_tokens_details` and `completion_tokens_details` are now allowed to be `nullish`. This change accommodates cases where these details are not provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d3ce3022c0fc21588b1dd8098b0a81c936338b99. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->