### PR TITLE
fix: build shared package when dev is run

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -23,7 +23,7 @@
     "dev": {
       "cache": false,
       "persistent": true,
-      "dependsOn": ["db:generate"]
+      "dependsOn": ["db:generate", "@langfuse/shared#build"]
     },
     "db:generate": {
       "cache": false,


### PR DESCRIPTION
## What does this PR do?

This PR fixes the following issues:
- Initial setup and run (`pnpm dev`) does not build the `shared` package
- Changes for the `shared` package will be build while running `pnpm dev`

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `shared` package build issue during `pnpm dev` by updating `turbo.json`.
> 
>   - **Behavior**:
>     - Fixes issue where `shared` package was not built on initial `pnpm dev` run.
>     - Ensures `shared` package is rebuilt on changes during `pnpm dev`.
>   - **Configuration**:
>     - Adds `@langfuse/shared#build` to `dependsOn` in `dev` pipeline in `turbo.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a8b26c5de4c6b22ae3266f58540f856daecd14a4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->