### PR TITLE
fix(trace-view): show disabled jump to playground instead of hiding

### DIFF
--- a/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -1,6 +1,6 @@
 import { Terminal } from "lucide-react";
-import Link from "next/link";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
 import { z } from "zod";
 
 import { createEmptyMessage } from "@/src/components/ChatMessages/utils/createEmptyMessage";
@@ -38,6 +38,7 @@ type JumpToPlaygroundButtonProps = (
 export const JumpToPlaygroundButton: React.FC<JumpToPlaygroundButtonProps> = (
   props,
 ) => {
+  const router = useRouter();
   const capture = usePostHogClientCapture();
   const projectId = useProjectIdFromURL();
   const { setPlaygroundCache } = usePlaygroundCache();
@@ -64,23 +65,31 @@ export const JumpToPlaygroundButton: React.FC<JumpToPlaygroundButtonProps> = (
   const handleClick = () => {
     capture(props.analyticsEventName);
     setPlaygroundCache(capturedState);
-  };
 
-  if (!isAvailable) return null;
+    router.push(`/project/${projectId}/playground`);
+  };
 
   return (
     <Button
       variant={props.variant ?? "secondary"}
-      title="Test in LLM playground"
+      disabled={!isAvailable}
+      title={
+        isAvailable
+          ? "Test in LLM playground"
+          : "Test in LLM playground is not available since messages are not in valid ChatML format or tool calls have been used. If you think this is not correct, please open a Github issue."
+      }
       onClick={handleClick}
       asChild
+      className={
+        !isAvailable ? "cursor-not-allowed opacity-50" : "cursor-pointer"
+      }
     >
-      <Link href={`/project/${projectId}/playground`}>
+      <span>
         <Terminal className="h-4 w-4" />
         <span className="ml-2">
           {props.source === "generation" ? "Test in playground" : "Playground"}
         </span>
-      </Link>
+      </span>
     </Button>
   );
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `JumpToPlaygroundButton` now shows a disabled button with a tooltip instead of hiding it when unavailable, using `useRouter` for navigation.
> 
>   - **Behavior**:
>     - `JumpToPlaygroundButton` now shows a disabled button instead of hiding it when `isAvailable` is false.
>     - Adds a tooltip explaining why the button is disabled when `isAvailable` is false.
>     - Button's `className` changes to `cursor-not-allowed opacity-50` when disabled.
>   - **Routing**:
>     - Uses `useRouter` from `next/router` to navigate to the playground on button click.
>   - **Imports**:
>     - Removes unused `Link` import from `JumpToPlaygroundButton.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d5a834fda1bd529dd6b8d39ced932368d3ba5517. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->