### PR TITLE
fix(llm-api-keys): improve form dialog for bedrock

### DIFF
--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -398,14 +398,16 @@ export function CreateLLMApiKeyForm({
                   </FormDescription>
                   {currentAdapter === LLMAdapter.Azure && (
                     <FormDescription className="text-dark-yellow">
-                      Azure LLM adapter does not support default models. Please
-                      add a custom model with your deployment name.
+                      Azure LLM adapter does not support default model names
+                      maintained by Langfuse. Instead, please add a custom model
+                      below that is the same as your deployment name.
                     </FormDescription>
                   )}
                   {currentAdapter === LLMAdapter.Bedrock && (
                     <FormDescription className="text-dark-yellow">
-                      Bedrock LLM adapter does not support default models.
-                      Please add your enabled Bedrock model IDs.
+                      Bedrock LLM adapter does not support default model names
+                      maintained by Langfuse. Instead, please add the Bedrock
+                      model IDs you have enabled in the AWS console.
                     </FormDescription>
                   )}
                 </span>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `CreateLLMApiKeyForm` to clarify Bedrock model ID instructions and unsupported default model names.
> 
>   - **Behavior**:
>     - Update form description for Bedrock in `CreateLLMApiKeyForm` to clarify that users should add Bedrock model IDs enabled in the AWS console.
>     - Clarifies that default model names maintained by Langfuse are not supported for Bedrock.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bb4cac3ee397c05529f6285319d70acfc97e56a0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->