### PR TITLE
feat(onboarding): add GitHub star prompt with badge

### DIFF
--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -111,7 +111,11 @@ const events = {
     "modal_open",
     "create_new_button_click",
   ],
-  onboarding: ["code_example_tab_switch", "tracing_check_active"],
+  onboarding: [
+    "code_example_tab_switch",
+    "tracing_check_active",
+    "click_github_star_cta",
+  ],
   user_settings: ["theme_changed"],
   project_settings: [
     "project_delete",

--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -18,6 +18,7 @@ import { useRouter } from "next/router";
 import { LangfuseIcon } from "@/src/components/LangfuseLogo";
 import { Textarea } from "@/src/components/ui/textarea";
 import Image from "next/image";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 const referralSourceSchema = z.object({
   referralSource: z.string().optional(),
@@ -25,6 +26,7 @@ const referralSourceSchema = z.object({
 
 export default function ReferralSource() {
   const posthog = usePostHog();
+  const capture = usePostHogClientCapture();
   const router = useRouter();
   const form = useForm<z.infer<typeof referralSourceSchema>>({
     resolver: zodResolver(referralSourceSchema),
@@ -65,7 +67,7 @@ export default function ReferralSource() {
           rel="noopener noreferrer"
           className="flex-shrink-0"
           onClick={() => {
-            posthog.capture("github star clicked");
+            capture("onboarding:click_github_star_cta");
           }}
         >
           <Image

--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -17,6 +17,7 @@ import { usePostHog } from "posthog-js/react";
 import { useRouter } from "next/router";
 import { LangfuseIcon } from "@/src/components/LangfuseLogo";
 import { Textarea } from "@/src/components/ui/textarea";
+import Image from "next/image";
 
 const referralSourceSchema = z.object({
   referralSource: z.string().optional(),
@@ -51,19 +52,32 @@ export default function ReferralSource() {
           Welcome to Langfuse
         </h2>
       </div>
-      <div className="mt-4 bg-background px-6 py-10 shadow sm:mx-auto sm:w-full sm:max-w-[480px] sm:rounded-lg sm:px-12">
-        <p className="text-sm">
-          Star Langfuse on GitHub: See the latest releases and help grow the community.
-        </p>
-        <a href="https://github.com/langfuse/langfuse" target="_blank" rel="noopener noreferrer" className="flex justify-center">
-          <img
+      <div className="mt-4 flex w-full flex-col items-start gap-3 bg-background px-6 py-8 shadow sm:mx-auto sm:max-w-[480px] sm:rounded-lg sm:px-12">
+        <div>
+          <p className="text-sm font-medium">Star Langfuse on GitHub</p>
+          <div className="text-sm text-muted-foreground">
+            See the latest releases and help grow the community.
+          </div>
+        </div>
+        <a
+          href="https://github.com/langfuse/langfuse"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex-shrink-0"
+          onClick={() => {
+            posthog.capture("github star clicked");
+          }}
+        >
+          <Image
             alt="Langfuse Github stars"
             src="https://img.shields.io/github/stars/langfuse/langfuse?label=langfuse&amp;style=social"
-            className="mt-4"
+            width={112}
+            height={20}
+            unoptimized
           />
         </a>
       </div>
-      <div className="mt-4 bg-background px-6 py-10 shadow sm:mx-auto sm:w-full sm:max-w-[480px] sm:rounded-lg sm:px-12">
+      <div className="mt-4 bg-background px-6 py-8 shadow sm:mx-auto sm:w-full sm:max-w-[480px] sm:rounded-lg sm:px-12">
         <Form {...form}>
           <form
             className="space-y-6"

--- a/web/src/pages/onboarding.tsx
+++ b/web/src/pages/onboarding.tsx
@@ -51,7 +51,19 @@ export default function ReferralSource() {
           Welcome to Langfuse
         </h2>
       </div>
-      <div className="mt-14 bg-background px-6 py-10 shadow sm:mx-auto sm:w-full sm:max-w-[480px] sm:rounded-lg sm:px-12">
+      <div className="mt-4 bg-background px-6 py-10 shadow sm:mx-auto sm:w-full sm:max-w-[480px] sm:rounded-lg sm:px-12">
+        <p className="text-sm">
+          Star Langfuse on GitHub: See the latest releases and help grow the community.
+        </p>
+        <a href="https://github.com/langfuse/langfuse" target="_blank" rel="noopener noreferrer" className="flex justify-center">
+          <img
+            alt="Langfuse Github stars"
+            src="https://img.shields.io/github/stars/langfuse/langfuse?label=langfuse&amp;style=social"
+            className="mt-4"
+          />
+        </a>
+      </div>
+      <div className="mt-4 bg-background px-6 py-10 shadow sm:mx-auto sm:w-full sm:max-w-[480px] sm:rounded-lg sm:px-12">
         <Form {...form}>
           <form
             className="space-y-6"


### PR DESCRIPTION
## What does this PR do?

add GitHub star count with badge to onboarding page

![CleanShot 2025-01-20 at 19 27 19](https://github.com/user-attachments/assets/89a7d5ed-91e7-49c9-918b-612e5862c436)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add GitHub star prompt with badge to onboarding page in `onboarding.tsx`.
> 
>   - **UI Changes**:
>     - Adds a prompt to star Langfuse on GitHub with a badge displaying star count in `onboarding.tsx`.
>     - Includes a link to the GitHub repository and a badge image from shields.io.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e4ac40b8fc34af3c5c3c5fb081dbc575b0e8e803. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->