### PR TITLE
chore: skip re-builds for same tree hash

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -26,7 +26,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
         with:
-          do_not_skip: '["workflow_dispatch", "push"]'
+          do_not_skip: '["workflow_dispatch"]'
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -17,8 +17,20 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  pre-job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    timeout-minutes: 15
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+
   lint:
     runs-on: ubuntu-latest
+    needs:
+      - pre-job
+    if: needs.pre-job.outputs.should_skip != 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
@@ -41,6 +53,9 @@ jobs:
   test-docker-build:
     timeout-minutes: 20
     runs-on: ubuntu-latest
+    needs:
+      - pre-job
+    if: needs.pre-job.outputs.should_skip != 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -74,6 +89,9 @@ jobs:
   tests-web-sync:
     timeout-minutes: 20
     runs-on: ubuntu-latest
+    needs:
+      - pre-job
+    if: needs.pre-job.outputs.should_skip != 'true'
     name: tests-web-sync (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }})
     strategy:
       matrix:
@@ -147,6 +165,9 @@ jobs:
   tests-web-async:
     timeout-minutes: 20
     runs-on: ubuntu-latest
+    needs:
+      - pre-job
+    if: needs.pre-job.outputs.should_skip != 'true'
     name: tests-web-async (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }}, mode${{ matrix.blob-provider }})
     strategy:
       matrix:
@@ -219,6 +240,9 @@ jobs:
   tests-worker:
     timeout-minutes: 20
     runs-on: ubuntu-latest
+    needs:
+      - pre-job
+    if: needs.pre-job.outputs.should_skip != 'true'
     name: tests-worker (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }}, mode${{ matrix.blob-provider }})
     strategy:
       matrix:
@@ -284,6 +308,9 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-latest
+    needs:
+      - pre-job
+    if: needs.pre-job.outputs.should_skip != 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
@@ -325,6 +352,9 @@ jobs:
 
   e2e-server-tests:
     runs-on: ubuntu-latest
+    needs:
+      - pre-job
+    if: needs.pre-job.outputs.should_skip != 'true'
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
+        with:
+          do_not_skip: '["workflow_dispatch", "push"]'
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add pre-job to skip duplicate builds based on tree hash in GitHub Actions workflow.
> 
>   - **Behavior**:
>     - Adds `pre-job` to `.github/workflows/pipeline.yml` to check for duplicate builds using `fkirc/skip-duplicate-actions@v5`.
>     - Jobs `lint`, `test-docker-build`, `tests-web-sync`, `tests-web-async`, `tests-worker`, `e2e-tests`, and `e2e-server-tests` now depend on `pre-job` and are skipped if `pre-job` outputs `should_skip` as `true`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 013766dcfc84a2175907837ac9df1f32c95df847. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->