### PR TITLE
chore: reduce default write interval for CH queue to 1000

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -62,7 +62,7 @@ const EnvSchema = z.object({
   LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS: z.coerce
     .number()
     .positive()
-    .default(10000),
+    .default(1000),
   LANGFUSE_INGESTION_CLICKHOUSE_MAX_ATTEMPTS: z.coerce
     .number()
     .positive()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce default ClickHouse write interval from 10000ms to 1000ms in `worker/src/env.ts`.
> 
>   - **Behavior**:
>     - Reduce default `LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS` from 10000ms to 1000ms in `worker/src/env.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2d2c79bdedd86162f338805f092c7aef64d906fa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->