### PR TITLE
fix: correctly upgrade katex

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -195,7 +195,7 @@
     "overrides": {
       "jsonpath-plus": "10.0.7",
       "nanoid": "^3.3.8",
-      "^katex": "0.16.21"
+      "katex": "0.16.21"
     }
   }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `katex` version in `package.json` by removing caret to lock version to `0.16.21`.
> 
>   - **Dependencies**:
>     - Fix `katex` version in `package.json` by removing caret (^) to lock version to `0.16.21`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7f1e79558efc99f1d9f1d65a98263c534b92e1fc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->