### PR TITLE
feat(cloud): switch between available plans

### DIFF
--- a/web/src/ee/features/billing/server/cloudBillingRouter.ts
+++ b/web/src/ee/features/billing/server/cloudBillingRouter.ts
@@ -223,7 +223,8 @@ export const cloudBillingRouter = createTRPCRouter({
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message:
-            "Subscription is not active, currently in " + subscription.status,
+            "Subscription is not active, current status: " +
+            subscription.status,
         });
 
       if (subscription.items.data.length !== 1)

--- a/web/src/ee/features/billing/server/cloudBillingRouter.ts
+++ b/web/src/ee/features/billing/server/cloudBillingRouter.ts
@@ -192,7 +192,6 @@ export const cloudBillingRouter = createTRPCRouter({
           message: "Cannot change plan for orgs that have a manual/legacy plan",
         });
 
-      const stripeCustomerId = parsedOrg.cloudConfig?.stripe?.customerId;
       const stripeSubscriptionId =
         parsedOrg.cloudConfig?.stripe?.activeSubscriptionId;
 
@@ -250,8 +249,8 @@ export const cloudBillingRouter = createTRPCRouter({
         });
 
       // remove current product from subscription
-      // reset billing cycle and invoice immediately
       // add new product to subscription
+      // reset billing cycle which causes immediate invoice for existing plan
       await stripeClient.subscriptions.update(stripeSubscriptionId, {
         items: [
           {

--- a/web/src/ee/features/billing/server/cloudBillingRouter.ts
+++ b/web/src/ee/features/billing/server/cloudBillingRouter.ts
@@ -248,19 +248,19 @@ export const cloudBillingRouter = createTRPCRouter({
           message: "New product does not have a default price in Stripe",
         });
 
-      // remove current product from subscription
-      // add new product to subscription
-      // reset billing cycle which causes immediate invoice for existing plan
       await stripeClient.subscriptions.update(stripeSubscriptionId, {
         items: [
+          // remove current product from subscription
           {
             id: item.id,
             deleted: true,
           },
+          // add new product to subscription
           {
             price: newProduct.default_price as string,
           },
         ],
+        // reset billing cycle which causes immediate invoice for existing plan
         billing_cycle_anchor: "now",
         proration_behavior: "none",
       });

--- a/web/src/ee/features/billing/server/cloudBillingRouter.ts
+++ b/web/src/ee/features/billing/server/cloudBillingRouter.ts
@@ -147,6 +147,125 @@ export const cloudBillingRouter = createTRPCRouter({
 
       return session.url;
     }),
+  changeStripeSubscriptionProduct: protectedOrganizationProcedure
+    .input(
+      z.object({
+        orgId: z.string(),
+        stripeProductId: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      throwIfNoOrganizationAccess({
+        organizationId: input.orgId,
+        scope: "langfuseCloudBilling:CRUD",
+        session: ctx.session,
+      });
+
+      // check that product is valid
+      if (
+        !stripeProducts
+          .filter((i) => Boolean(i.checkout))
+          .map((i) => i.stripeProductId)
+          .includes(input.stripeProductId)
+      )
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Invalid stripe product id, product not available",
+        });
+
+      const org = await ctx.prisma.organization.findUnique({
+        where: {
+          id: input.orgId,
+        },
+      });
+      if (!org) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Organization not found",
+        });
+      }
+
+      const parsedOrg = parseDbOrg(org);
+      if (parsedOrg.cloudConfig?.plan)
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Cannot change plan for orgs that have a manual/legacy plan",
+        });
+
+      const stripeCustomerId = parsedOrg.cloudConfig?.stripe?.customerId;
+      const stripeSubscriptionId =
+        parsedOrg.cloudConfig?.stripe?.activeSubscriptionId;
+
+      if (!stripeSubscriptionId)
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Organization does not have an active subscription",
+        });
+
+      if (!stripeClient)
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Stripe client not initialized",
+        });
+
+      const subscription =
+        await stripeClient.subscriptions.retrieve(stripeSubscriptionId);
+
+      if (
+        ["canceled", "paused", "incomplete", "incomplete_expired"].includes(
+          subscription.status,
+        )
+      )
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message:
+            "Subscription is not active, currently in " + subscription.status,
+        });
+
+      if (subscription.items.data.length !== 1)
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Subscription has multiple items",
+        });
+
+      const item = subscription.items.data[0];
+
+      if (
+        !stripeProducts
+          .map((i) => i.stripeProductId)
+          .includes(item.price.product as string)
+      )
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Current subscription product is not a valid product",
+        });
+
+      const newProduct = await stripeClient.products.retrieve(
+        input.stripeProductId,
+      );
+      if (!newProduct.default_price)
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "New product does not have a default price in Stripe",
+        });
+
+      // remove current product from subscription
+      // reset billing cycle and invoice immediately
+      // add new product to subscription
+      await stripeClient.subscriptions.update(stripeSubscriptionId, {
+        items: [
+          {
+            id: item.id,
+            deleted: true,
+          },
+          {
+            price: newProduct.default_price as string,
+          },
+        ],
+        billing_cycle_anchor: "now",
+        proration_behavior: "none",
+      });
+    }),
   getStripeCustomerPortalUrl: protectedOrganizationProcedure
     .input(
       z.object({

--- a/web/src/ee/features/billing/server/cloudBillingRouter.ts
+++ b/web/src/ee/features/billing/server/cloudBillingRouter.ts
@@ -160,6 +160,11 @@ export const cloudBillingRouter = createTRPCRouter({
         scope: "langfuseCloudBilling:CRUD",
         session: ctx.session,
       });
+      throwIfNoEntitlement({
+        entitlement: "cloud-billing",
+        sessionUser: ctx.session.user,
+        orgId: input.orgId,
+      });
 
       // check that product is valid
       if (

--- a/web/src/ee/features/billing/utils/stripeProducts.ts
+++ b/web/src/ee/features/billing/utils/stripeProducts.ts
@@ -2,7 +2,6 @@ import { env } from "@/src/env.mjs";
 import { type Plan } from "@langfuse/shared";
 
 type StripeProduct = {
-  id: number;
   stripeProductId: string;
   mappedPlan: Plan;
   // include checkout if product can be subscribed to by new users
@@ -16,7 +15,6 @@ type StripeProduct = {
 // map of planid to plan name
 export const stripeProducts: StripeProduct[] = [
   {
-    id: 1,
     stripeProductId:
       env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "DEV" ||
       env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "STAGING"
@@ -31,7 +29,6 @@ export const stripeProducts: StripeProduct[] = [
     },
   },
   {
-    id: 2,
     stripeProductId:
       env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "DEV" ||
       env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "STAGING"

--- a/web/src/ee/features/billing/utils/stripeProducts.ts
+++ b/web/src/ee/features/billing/utils/stripeProducts.ts
@@ -2,6 +2,7 @@ import { env } from "@/src/env.mjs";
 import { type Plan } from "@langfuse/shared";
 
 type StripeProduct = {
+  id: number;
   stripeProductId: string;
   mappedPlan: Plan;
   // include checkout if product can be subscribed to by new users
@@ -15,6 +16,7 @@ type StripeProduct = {
 // map of planid to plan name
 export const stripeProducts: StripeProduct[] = [
   {
+    id: 1,
     stripeProductId:
       env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "DEV" ||
       env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "STAGING"
@@ -29,6 +31,7 @@ export const stripeProducts: StripeProduct[] = [
     },
   },
   {
+    id: 2,
     stripeProductId:
       env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "DEV" ||
       env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "STAGING"

--- a/web/src/ee/features/evals/components/evaluator-form.tsx
+++ b/web/src/ee/features/evals/components/evaluator-form.tsx
@@ -69,7 +69,7 @@ import { showSuccessToast } from "@/src/features/notifications/showSuccessToast"
 const formSchema = z.object({
   scoreName: z.string(),
   target: z.string(),
-  filter: z.array(singleFilter).nullable(), // re-using the filter type from the tables
+  filter: z.array(singleFilter).nullable(), // reusing the filter type from the tables
   mapping: z.array(wipVariableMapping),
   sampling: z.coerce.number().gt(0).lte(1),
   delay: z.coerce.number().optional().default(10),

--- a/web/src/ee/features/evals/server/router.ts
+++ b/web/src/ee/features/evals/server/router.ts
@@ -37,7 +37,7 @@ const APIEvaluatorSchema = z.object({
   evalTemplateId: z.string(),
   scoreName: z.string(),
   targetObject: z.string(),
-  filter: z.array(singleFilter).nullable(), // re-using the filter type from the tables
+  filter: z.array(singleFilter).nullable(), // reusing the filter type from the tables
   variableMapping: z.array(variableMapping),
   sampling: z.instanceof(Prisma.Decimal),
   delay: z.number(),
@@ -93,7 +93,7 @@ const CreateEvalJobSchema = z.object({
   evalTemplateId: z.string(),
   scoreName: z.string().min(1),
   target: z.string(),
-  filter: z.array(singleFilter).nullable(), // re-using the filter type from the tables
+  filter: z.array(singleFilter).nullable(), // reusing the filter type from the tables
   mapping: z.array(variableMapping),
   sampling: z.number().gt(0).lte(1),
   delay: z.number().gte(0).default(DEFAULT_TRACE_JOB_DELAY), // 10 seconds default


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add functionality to switch between available cloud billing plans with UI updates and backend support for Stripe subscription changes.
> 
>   - **Behavior**:
>     - Add `changeStripeSubscriptionProduct` mutation in `cloudBillingRouter.ts` to handle plan changes.
>     - Update `BillingSettings.tsx` to include UI for switching plans, with confirmation dialog and success toast.
>   - **UI Components**:
>     - Add `Dialog`, `DialogTrigger`, `DialogContent`, `DialogFooter`, `DialogDescription`, `DialogHeader`, `DialogTitle`, `DialogClose` to `BillingSettings.tsx` for plan change confirmation.
>     - Use `ActionButton` for plan selection and change actions.
>   - **Validation**:
>     - Validate Stripe product ID and subscription status in `cloudBillingRouter.ts`.
>   - **Misc**:
>     - Fix typo in `evaluator-form.tsx` and `router.ts` ("re-using" to "reusing").
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for dbef6374945ae3d560dcc997f8969fe6d8f4307b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->