### PR TITLE
fix: build shared package when dev is run (#5118)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -20,7 +20,7 @@
     "dev": {
       "cache": false,
       "persistent": true,
-      "dependsOn": ["db:generate"]
+      "dependsOn": ["db:generate", "@langfuse/shared#build"]
     },
     "db:generate": {
       "cache": false,


### PR DESCRIPTION
@FlorianWoelki

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `@langfuse/shared#build` to `dev` pipeline dependencies in `turbo.json` to ensure shared package is built.
> 
>   - **Pipeline Configuration**:
>     - In `turbo.json`, add `@langfuse/shared#build` to `dependsOn` for `dev` pipeline.
>     - Ensures shared package is built when `dev` is run.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c971f593361598be3e24664345052148ac3ae636. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->