### PR TITLE
chore: add additional metrics into ingestion pipeline

### DIFF
--- a/web/src/ee/features/evals/components/evaluator-form.tsx
+++ b/web/src/ee/features/evals/components/evaluator-form.tsx
@@ -69,7 +69,7 @@ import { showSuccessToast } from "@/src/features/notifications/showSuccessToast"
 const formSchema = z.object({
   scoreName: z.string(),
   target: z.string(),
-  filter: z.array(singleFilter).nullable(), // re-using the filter type from the tables
+  filter: z.array(singleFilter).nullable(), // reusing the filter type from the tables
   mapping: z.array(wipVariableMapping),
   sampling: z.coerce.number().gt(0).lte(1),
   delay: z.coerce.number().optional().default(10),

--- a/web/src/ee/features/evals/server/router.ts
+++ b/web/src/ee/features/evals/server/router.ts
@@ -37,7 +37,7 @@ const APIEvaluatorSchema = z.object({
   evalTemplateId: z.string(),
   scoreName: z.string(),
   targetObject: z.string(),
-  filter: z.array(singleFilter).nullable(), // re-using the filter type from the tables
+  filter: z.array(singleFilter).nullable(), // reusing the filter type from the tables
   variableMapping: z.array(variableMapping),
   sampling: z.instanceof(Prisma.Decimal),
   delay: z.number(),
@@ -93,7 +93,7 @@ const CreateEvalJobSchema = z.object({
   evalTemplateId: z.string(),
   scoreName: z.string().min(1),
   target: z.string(),
-  filter: z.array(singleFilter).nullable(), // re-using the filter type from the tables
+  filter: z.array(singleFilter).nullable(), // reusing the filter type from the tables
   mapping: z.array(variableMapping),
   sampling: z.number().gt(0).lte(1),
   delay: z.number().gte(0).default(DEFAULT_TRACE_JOB_DELAY), // 10 seconds default

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -12,6 +12,7 @@ import {
   getClickhouseEntityType,
   getCurrentSpan,
   getQueue,
+  recordHistogram,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 
@@ -93,9 +94,20 @@ export const ingestionQueueProcessorBuilder = (
       );
 
       // Download all events from folder into a local array
-      const eventFiles = await s3Client.listFiles(
-        `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${getClickhouseEntityType(job.data.payload.data.type)}/${job.data.payload.data.eventBodyId}/`,
+      const clickhouseEntityType = getClickhouseEntityType(
+        job.data.payload.data.type,
       );
+      const eventFiles = await s3Client.listFiles(
+        `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${clickhouseEntityType}/${job.data.payload.data.eventBodyId}/`,
+      );
+      recordHistogram("langfuse.ingestion.count_files", eventFiles.length, {
+        kind: clickhouseEntityType,
+      });
+      span?.setAttribute(
+        "langfuse.ingestion.event.count_files",
+        eventFiles.length,
+      );
+      span?.setAttribute("langfuse.ingestion.event.kind", clickhouseEntityType);
 
       const firstS3WriteTime =
         eventFiles

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -816,8 +816,16 @@ export class IngestionService {
     };
   }) {
     if (await this.shouldSkipClickHouseRead(params.projectId)) {
+      recordIncrement("langfuse.ingestion.clickhouse_read_for_update", 1, {
+        skipped: "true",
+        table: params.table,
+      });
       return null;
     }
+    recordIncrement("langfuse.ingestion.clickhouse_read_for_update", 1, {
+      skipped: "false",
+      table: params.table,
+    });
 
     const recordParser = {
       traces: traceRecordReadSchema,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> This pull request adds metrics for file counts and Clickhouse read operations in the ingestion pipeline and fixes typos in comments.
> 
>   - **Metrics**:
>     - Add `recordHistogram` for file count in `ingestionQueue.ts`.
>     - Add `recordIncrement` for Clickhouse read operations in `IngestionService/index.ts`.
>   - **Typo Fixes**:
>     - Fix comment typos in `evaluator-form.tsx` and `router.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1dbfe532615faa356e8ac7ca15643e529052b4aa. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->