### PR TITLE
chore: use a distribution metric for langfuse.ingestion.count_files

### DIFF
--- a/packages/shared/src/server/instrumentation/index.ts
+++ b/packages/shared/src/server/instrumentation/index.ts
@@ -226,6 +226,14 @@ export const recordHistogram = (
   dd.dogstatsd.histogram(stat, value, tags);
 };
 
+export const recordDistribution = (
+  stat: string,
+  value?: number | undefined,
+  tags?: { [tag: string]: string | number } | undefined,
+) => {
+  dd.dogstatsd.distribution(stat, value, tags);
+};
+
 /**
  * Converts a queue name to the matching datadog metric name.
  * Consumer only needs to append the relevant suffix.

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -12,7 +12,6 @@ import {
   getClickhouseEntityType,
   getCurrentSpan,
   getQueue,
-  recordHistogram,
   recordDistribution,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -13,6 +13,7 @@ import {
   getCurrentSpan,
   getQueue,
   recordHistogram,
+  recordDistribution,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 
@@ -100,7 +101,7 @@ export const ingestionQueueProcessorBuilder = (
       const eventFiles = await s3Client.listFiles(
         `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${clickhouseEntityType}/${job.data.payload.data.eventBodyId}/`,
       );
-      recordHistogram("langfuse.ingestion.count_files", eventFiles.length, {
+      recordDistribution("langfuse.ingestion.count_files", eventFiles.length, {
         kind: clickhouseEntityType,
       });
       span?.setAttribute(

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -105,7 +105,7 @@ export const ingestionQueueProcessorBuilder = (
         kind: clickhouseEntityType,
       });
       span?.setAttribute(
-        "langfuse.ingestion.event.count_files",
+        "langfuse.ingestion.event.count_files.distribution",
         eventFiles.length,
       );
       span?.setAttribute("langfuse.ingestion.event.kind", clickhouseEntityType);

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -101,11 +101,15 @@ export const ingestionQueueProcessorBuilder = (
       const eventFiles = await s3Client.listFiles(
         `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${clickhouseEntityType}/${job.data.payload.data.eventBodyId}/`,
       );
-      recordDistribution("langfuse.ingestion.count_files", eventFiles.length, {
-        kind: clickhouseEntityType,
-      });
+      recordDistribution(
+        "langfuse.ingestion.count_files_distribution",
+        eventFiles.length,
+        {
+          kind: clickhouseEntityType,
+        },
+      );
       span?.setAttribute(
-        "langfuse.ingestion.event.count_files.distribution",
+        "langfuse.ingestion.event.count_files",
         eventFiles.length,
       );
       span?.setAttribute("langfuse.ingestion.event.kind", clickhouseEntityType);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change metric type from histogram to distribution for `langfuse.ingestion.count_files` in `ingestionQueue.ts`.
> 
>   - **Metrics**:
>     - Add `recordDistribution` function in `index.ts` to send distribution metrics using `dd.dogstatsd.distribution`.
>     - Replace `recordHistogram` with `recordDistribution` for `langfuse.ingestion.count_files` in `ingestionQueue.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 86b39aa30cdd43d8b6147634634ca778914aed91. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->