### PR TITLE
feat(llm-api-keys): allow for extra headers

### DIFF
--- a/packages/shared/prisma/generated/types.ts
+++ b/packages/shared/prisma/generated/types.ts
@@ -305,6 +305,7 @@ export type LlmApiKeys = {
     custom_models: Generated<string[]>;
     with_default_models: Generated<boolean>;
     extra_headers: string | null;
+    extra_header_keys: Generated<string[]>;
     config: unknown | null;
     project_id: string;
 };

--- a/packages/shared/prisma/generated/types.ts
+++ b/packages/shared/prisma/generated/types.ts
@@ -304,6 +304,7 @@ export type LlmApiKeys = {
     base_url: string | null;
     custom_models: Generated<string[]>;
     with_default_models: Generated<boolean>;
+    extra_headers: string | null;
     config: unknown | null;
     project_id: string;
 };

--- a/packages/shared/prisma/migrations/20250122152102_add_llm_api_keys_extra_headers/migration.sql
+++ b/packages/shared/prisma/migrations/20250122152102_add_llm_api_keys_extra_headers/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "llm_api_keys" ADD COLUMN "extra_headers" TEXT;

--- a/packages/shared/prisma/migrations/20250122152102_add_llm_api_keys_extra_headers/migration.sql
+++ b/packages/shared/prisma/migrations/20250122152102_add_llm_api_keys_extra_headers/migration.sql
@@ -1,1 +1,3 @@
-ALTER TABLE "llm_api_keys" ADD COLUMN "extra_headers" TEXT;
+ALTER TABLE "llm_api_keys"
+    ADD COLUMN "extra_headers" TEXT,
+    ADD COLUMN "extra_header_keys" TEXT[] NOT NULL DEFAULT '{}'::TEXT[];

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -193,6 +193,7 @@ model LlmApiKeys {
   customModels      String[] @default([]) @map("custom_models")
   withDefaultModels Boolean  @default(true) @map("with_default_models")
   extraHeaders      String?  @map("extra_headers")
+  extraHeaderKeys   String[] @default([]) @map("extra_header_keys")
   config            Json?
 
   projectId String  @map("project_id")

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -192,6 +192,7 @@ model LlmApiKeys {
   baseURL           String?  @map("base_url")
   customModels      String[] @default([]) @map("custom_models")
   withDefaultModels Boolean  @default(true) @map("with_default_models")
+  extraHeaders      String?  @map("extra_headers")
   config            Json?
 
   projectId String  @map("project_id")

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -8,6 +8,7 @@ export * from "./auth/apiKeys";
 export * from "./auth/customSsoProvider";
 export * from "./auth/gitHubEnterpriseProvider";
 export * from "./llm/fetchLLMCompletion";
+export * from "./llm/utils";
 export * from "./llm/types";
 export * from "./utils/DatabaseReadStream";
 export * from "./utils/transforms";

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -49,6 +49,7 @@ type LLMCompletionParams = {
   callbacks?: BaseCallbackHandler[];
   baseURL?: string;
   apiKey: string;
+  extraHeaders?: Record<string, string>;
   maxRetries?: number;
   config?: Record<string, string> | null;
   traceParams?: TraceParams;
@@ -100,6 +101,7 @@ export async function fetchLLMCompletion(
     maxRetries,
     config,
     traceParams,
+    extraHeaders,
   } = params;
 
   let finalCallbacks: BaseCallbackHandler[] | undefined = callbacks ?? [];
@@ -176,6 +178,7 @@ export async function fetchLLMCompletion(
       maxRetries,
       configuration: {
         baseURL,
+        defaultHeaders: extraHeaders,
       },
       timeout: 1000 * 60 * 2, // 2 minutes timeout
     });

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -148,6 +148,8 @@ export const LLMApiKeySchema = z
     provider: z.string(),
     displaySecretKey: z.string(),
     secretKey: z.string(),
+    extraHeaders: z.string(),
+    extraHeaderKeys: z.array(z.string()),
     baseURL: z.string().nullable(),
     customModels: z.array(z.string()),
     withDefaultModels: z.boolean(),

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -148,7 +148,7 @@ export const LLMApiKeySchema = z
     provider: z.string(),
     displaySecretKey: z.string(),
     secretKey: z.string(),
-    extraHeaders: z.string(),
+    extraHeaders: z.string().nullish(),
     extraHeaderKeys: z.array(z.string()),
     baseURL: z.string().nullable(),
     customModels: z.array(z.string()),

--- a/packages/shared/src/server/llm/utils.ts
+++ b/packages/shared/src/server/llm/utils.ts
@@ -4,7 +4,9 @@ import { decrypt } from "../../encryption";
 
 const ExtraHeaderSchema = z.record(z.string(), z.string());
 
-export function decryptAndParseExtraHeaders(extraHeaders: string | undefined) {
+export function decryptAndParseExtraHeaders(
+  extraHeaders: string | null | undefined,
+) {
   if (!extraHeaders) return;
 
   return ExtraHeaderSchema.parse(decrypt(extraHeaders));

--- a/packages/shared/src/server/llm/utils.ts
+++ b/packages/shared/src/server/llm/utils.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+import { decrypt } from "../../encryption";
+
+const ExtraHeaderSchema = z.record(z.string(), z.string());
+
+export function decryptAndParseExtraHeaders(extraHeaders: string | undefined) {
+  if (!extraHeaders) return;
+
+  return ExtraHeaderSchema.parse(decrypt(extraHeaders));
+}

--- a/web/src/ee/features/evals/server/router.ts
+++ b/web/src/ee/features/evals/server/router.ts
@@ -20,6 +20,7 @@ import {
 import { decrypt } from "@langfuse/shared/encryption";
 import { throwIfNoEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
 import {
+  decryptAndParseExtraHeaders,
   fetchLLMCompletion,
   getScoresByIds,
   LLMApiKeySchema,
@@ -536,6 +537,9 @@ export const evalRouter = createTRPCRouter({
           await fetchLLMCompletion({
             streaming: false,
             apiKey: decrypt(parsedKey.data.secretKey), // decrypt the secret key
+            extraHeaders: decryptAndParseExtraHeaders(
+              parsedKey.data.extraHeaders,
+            ),
             baseURL: parsedKey.data.baseURL ?? undefined,
             messages: [
               {

--- a/web/src/ee/features/playground/server/chatCompletionHandler.ts
+++ b/web/src/ee/features/playground/server/chatCompletionHandler.ts
@@ -17,6 +17,7 @@ import {
   LLMApiKeySchema,
   logger,
   fetchLLMCompletion,
+  decryptAndParseExtraHeaders,
 } from "@langfuse/shared/src/server";
 
 export default async function chatCompletionHandler(req: NextRequest) {
@@ -51,6 +52,7 @@ export default async function chatCompletionHandler(req: NextRequest) {
       streaming: true,
       callbacks: [new PosthogCallbackHandler("playground", body, userId)],
       apiKey: decrypt(parsedKey.data.secretKey),
+      extraHeaders: decryptAndParseExtraHeaders(parsedKey.data.extraHeaders),
       baseURL: parsedKey.data.baseURL || undefined,
       config: parsedKey.data.config,
     });

--- a/web/src/features/llm-api-key/server/router.ts
+++ b/web/src/features/llm-api-key/server/router.ts
@@ -41,6 +41,12 @@ export const llmApiKeyRouter = createTRPCRouter({
           data: {
             projectId: input.projectId,
             secretKey: encrypt(input.secretKey),
+            extraHeaders: input.extraHeaders
+              ? encrypt(JSON.stringify(input.extraHeaders))
+              : undefined,
+            extraHeaderKeys: input.extraHeaders
+              ? Object.keys(input.extraHeaders)
+              : undefined,
             adapter: input.adapter,
             displaySecretKey: getDisplaySecretKey(input.secretKey),
             provider: input.provider,

--- a/web/src/features/llm-api-key/server/router.ts
+++ b/web/src/features/llm-api-key/server/router.ts
@@ -110,10 +110,15 @@ export const llmApiKeyRouter = createTRPCRouter({
       });
 
       const apiKeys = z
-        .array(LLMApiKeySchema.extend({ secretKey: z.undefined() }))
+        .array(
+          LLMApiKeySchema.extend({
+            secretKey: z.undefined(),
+            extraHeaders: z.undefined(),
+          }),
+        )
         .parse(
           await ctx.prisma.llmApiKeys.findMany({
-            // we must not return the secret key via the API, hence not selected
+            // we must not return the secret key AND extra headers via the API, hence not selected
             select: {
               id: true,
               createdAt: true,
@@ -125,6 +130,7 @@ export const llmApiKeyRouter = createTRPCRouter({
               baseURL: true,
               customModels: true,
               withDefaultModels: true,
+              extraHeaderKeys: true,
             },
             where: {
               projectId: input.projectId,
@@ -175,6 +181,7 @@ export const llmApiKeyRouter = createTRPCRouter({
           },
           baseURL: input.baseURL,
           apiKey: input.secretKey,
+          extraHeaders: input.extraHeaders,
           messages: testMessages,
           streaming: false,
           maxRetries: 1,

--- a/web/src/features/llm-api-key/types.ts
+++ b/web/src/features/llm-api-key/types.ts
@@ -10,4 +10,5 @@ export const CreateLlmApiKey = z.object({
   withDefaultModels: z.boolean().optional(),
   customModels: z.array(z.string().min(1)).optional(),
   config: BedrockConfigSchema.optional(),
+  extraHeaders: z.record(z.string(), z.string()).optional(),
 });

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -409,53 +409,55 @@ export function CreateLLMApiKeyForm({
         )}
 
         {/* Extra Headers */}
-        <FormField
-          control={form.control}
-          name="extraHeaders"
-          render={() => (
-            <FormItem>
-              <FormLabel>Extra Headers</FormLabel>
-              <FormDescription>
-                Optional additional HTTP headers to include with requests
-                towards LLM provider. All header values stored encrypted on our
-                servers.
-              </FormDescription>
+        {currentAdapter === "openai" ? (
+          <FormField
+            control={form.control}
+            name="extraHeaders"
+            render={() => (
+              <FormItem>
+                <FormLabel>Extra Headers</FormLabel>
+                <FormDescription>
+                  Optional additional HTTP headers to include with requests
+                  towards LLM provider. All header values stored encrypted on
+                  our servers.
+                </FormDescription>
 
-              {headerFields.map((header, index) => (
-                <div key={header.id} className="flex flex-row space-x-2">
-                  <Input
-                    {...form.register(`extraHeaders.${index}.key`)}
-                    placeholder="Header name"
-                  />
-                  <Input
-                    {...form.register(`extraHeaders.${index}.value`)}
-                    placeholder="Header value"
-                  />
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    onClick={() => removeHeader(index)}
-                  >
-                    <TrashIcon className="h-4 w-4" />
-                  </Button>
-                </div>
-              ))}
+                {headerFields.map((header, index) => (
+                  <div key={header.id} className="flex flex-row space-x-2">
+                    <Input
+                      {...form.register(`extraHeaders.${index}.key`)}
+                      placeholder="Header name"
+                    />
+                    <Input
+                      {...form.register(`extraHeaders.${index}.value`)}
+                      placeholder="Header value"
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      onClick={() => removeHeader(index)}
+                    >
+                      <TrashIcon className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
 
-              <Button
-                type="button"
-                variant="ghost"
-                onClick={() => appendHeader({ key: "", value: "" })}
-                className="w-full"
-              >
-                <PlusIcon
-                  className="-ml-0.5 mr-1.5 h-5 w-5"
-                  aria-hidden="true"
-                />
-                Add Header
-              </Button>
-            </FormItem>
-          )}
-        />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => appendHeader({ key: "", value: "" })}
+                  className="w-full"
+                >
+                  <PlusIcon
+                    className="-ml-0.5 mr-1.5 h-5 w-5"
+                    aria-hidden="true"
+                  />
+                  Add Header
+                </Button>
+              </FormItem>
+            )}
+          />
+        ) : null}
 
         {/* With default models */}
         <FormField

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -44,6 +44,9 @@ const formSchema = z
     awsAccessKeyId: z.string().optional(),
     awsSecretAccessKey: z.string().optional(),
     awsRegion: z.string().optional(),
+    extraHeaders: z.array(
+      z.object({ key: z.string().min(1), value: z.string().min(1) }),
+    ),
   })
   .refine((data) => data.withDefaultModels || data.customModels.length > 0, {
     message:
@@ -115,6 +118,7 @@ export function CreateLLMApiKeyForm({
       baseURL: getCustomizedBaseURL(defaultAdapter),
       withDefaultModels: true,
       customModels: [],
+      extraHeaders: [],
     },
   });
 
@@ -123,6 +127,15 @@ export function CreateLLMApiKeyForm({
   const { fields, append, remove } = useFieldArray({
     control: form.control,
     name: "customModels",
+  });
+
+  const {
+    fields: headerFields,
+    append: appendHeader,
+    remove: removeHeader,
+  } = useFieldArray({
+    control: form.control,
+    name: "extraHeaders",
   });
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
@@ -155,6 +168,17 @@ export function CreateLLMApiKeyForm({
       };
     }
 
+    const extraHeaders =
+      values.extraHeaders.length > 0
+        ? values.extraHeaders.reduce(
+            (acc, header) => {
+              acc[header.key] = header.value;
+              return acc;
+            },
+            {} as Record<string, string>,
+          )
+        : undefined;
+
     const newKey = {
       projectId,
       secretKey: secretKey ?? "",
@@ -166,6 +190,7 @@ export function CreateLLMApiKeyForm({
       customModels: values.customModels
         .map((m) => m.value.trim())
         .filter(Boolean),
+      extraHeaders,
     };
 
     try {
@@ -382,6 +407,55 @@ export function CreateLLMApiKeyForm({
             )}
           />
         )}
+
+        {/* Extra Headers */}
+        <FormField
+          control={form.control}
+          name="extraHeaders"
+          render={() => (
+            <FormItem>
+              <FormLabel>Extra Headers</FormLabel>
+              <FormDescription>
+                Optional additional HTTP headers to include with requests
+                towards LLM provider. All header values stored encrypted on our
+                servers.
+              </FormDescription>
+
+              {headerFields.map((header, index) => (
+                <div key={header.id} className="flex flex-row space-x-2">
+                  <Input
+                    {...form.register(`extraHeaders.${index}.key`)}
+                    placeholder="Header name"
+                  />
+                  <Input
+                    {...form.register(`extraHeaders.${index}.value`)}
+                    placeholder="Header value"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => removeHeader(index)}
+                  >
+                    <TrashIcon className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => appendHeader({ key: "", value: "" })}
+                className="w-full"
+              >
+                <PlusIcon
+                  className="-ml-0.5 mr-1.5 h-5 w-5"
+                  aria-hidden="true"
+                />
+                Add Header
+              </Button>
+            </FormItem>
+          )}
+        />
 
         {/* With default models */}
         <FormField

--- a/web/src/features/public-api/components/LLMApiKeyList.tsx
+++ b/web/src/features/public-api/components/LLMApiKeyList.tsx
@@ -49,6 +49,10 @@ export function LlmApiKeyList(props: { projectId: string }) {
     },
   );
 
+  const hasExtraHeaderKeys = apiKeys.data?.data.some(
+    (key) => key.extraHeaderKeys.length > 0,
+  );
+
   if (!isAvailable) return null;
 
   if (!hasAccess) {
@@ -89,6 +93,9 @@ export function LlmApiKeyList(props: { projectId: string }) {
                 Base URL
               </TableHead>
               <TableHead className="text-primary">Secret Key</TableHead>
+              {hasExtraHeaderKeys ? (
+                <TableHead className="text-primary">Extra headers</TableHead>
+              ) : null}
               <TableHead />
             </TableRow>
           </TableHeader>
@@ -116,6 +123,9 @@ export function LlmApiKeyList(props: { projectId: string }) {
                   <TableCell className="font-mono">
                     {apiKey.displaySecretKey}
                   </TableCell>
+                  {hasExtraHeaderKeys ? (
+                    <TableCell> {apiKey.extraHeaderKeys.join(", ")} </TableCell>
+                  ) : null}
                   <TableCell>
                     <DeleteApiKeyButton
                       projectId={props.projectId}

--- a/worker/src/__tests__/experimentsService.test.ts
+++ b/worker/src/__tests__/experimentsService.test.ts
@@ -384,6 +384,7 @@ describe("create experiment job calls with langfuse server side tracing", async 
       secretKey: encrypt("test-key"),
       baseURL: null,
       customModels: [],
+      extraHeaderKeys: [],
       withDefaultModels: true,
       config: null,
     } as any);

--- a/worker/src/features/utilities.ts
+++ b/worker/src/features/utilities.ts
@@ -1,5 +1,6 @@
 import {
   ChatMessage,
+  decryptAndParseExtraHeaders,
   fetchLLMCompletion,
   logger,
   type TraceParams,
@@ -24,6 +25,7 @@ export async function callStructuredLLM<T extends ZodSchema>(
     const { completion, processTracedEvents } = await fetchLLMCompletion({
       streaming: false,
       apiKey: decrypt(llmApiKey.secretKey), // decrypt the secret key
+      extraHeaders: decryptAndParseExtraHeaders(llmApiKey.extraHeaders),
       baseURL: llmApiKey.baseURL || undefined,
       messages,
       modelParams: {
@@ -67,6 +69,7 @@ export async function callLLM(
     const { completion, processTracedEvents } = await fetchLLMCompletion({
       streaming: false,
       apiKey: decrypt(llmApiKey.secretKey), // decrypt the secret key
+      extraHeaders: decryptAndParseExtraHeaders(llmApiKey.extraHeaders),
       baseURL: llmApiKey.baseURL || undefined,
       messages,
       modelParams: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for extra headers in LLM API keys, updating database schema, API, and UI components to handle the new feature.
> 
>   - **Database Schema**:
>     - Add `extra_headers` and `extra_header_keys` to `LlmApiKeys` in `types.ts`, `schema.prisma`, and `migration.sql`.
>   - **API Changes**:
>     - Update `fetchLLMCompletion()` in `fetchLLMCompletion.ts` to accept `extraHeaders`.
>     - Add `decryptAndParseExtraHeaders()` in `utils.ts` to handle decryption and parsing of extra headers.
>     - Modify `LLMApiKeySchema` in `types.ts` to include `extraHeaders` and `extraHeaderKeys`.
>     - Update `evalRouter.ts`, `chatCompletionHandler.ts`, and `router.ts` to handle `extraHeaders` in API requests.
>   - **UI Changes**:
>     - Update `CreateLLMApiKeyForm.tsx` to allow users to input extra headers.
>     - Modify `LLMApiKeyList.tsx` to display extra header keys if present.
>   - **Tests**:
>     - Update `experimentsService.test.ts` to include `extraHeaderKeys` in mock data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5087782389d3f7db492bbd597ab32383ffb48920. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->