### PR TITLE
fix(prompt-diff-dialog): keep open on cursor leaving window

### DIFF
--- a/web/src/features/prompts/components/PromptVersionDiffDialog.tsx
+++ b/web/src/features/prompts/components/PromptVersionDiffDialog.tsx
@@ -14,23 +14,22 @@ import DiffViewer from "@/src/components/DiffViewer";
 import { FileDiffIcon } from "lucide-react";
 
 type PromptVersionDiffDialogProps = {
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
   leftPrompt: Prompt;
   rightPrompt: Prompt;
-  onClose: () => void;
 };
 
 export const PromptVersionDiffDialog: React.FC<PromptVersionDiffDialogProps> = (
   props,
 ) => {
-  const { leftPrompt, rightPrompt, onClose } = props;
-  const [open, setOpen] = React.useState<boolean>(false);
+  const { leftPrompt, rightPrompt, isOpen, setIsOpen } = props;
 
   return (
     <Dialog
-      open={open}
+      open={isOpen}
       onOpenChange={(open) => {
-        setOpen(open);
-        if (!open) onClose();
+        setIsOpen(open);
       }}
     >
       <DialogTrigger asChild>
@@ -98,8 +97,7 @@ export const PromptVersionDiffDialog: React.FC<PromptVersionDiffDialogProps> = (
         <DialogFooter className="flex flex-row">
           <Button
             onClick={() => {
-              setOpen(false);
-              onClose();
+              setIsOpen(false);
             }}
             className="w-full"
           >

--- a/web/src/features/prompts/components/prompt-history.tsx
+++ b/web/src/features/prompts/components/prompt-history.tsx
@@ -19,6 +19,7 @@ const PromptHistoryTraceNode = (props: {
 }) => {
   const [isHovered, setIsHovered] = useState(false);
   const [isLabelPopoverOpen, setIsLabelPopoverOpen] = useState(false);
+  const [isPromptDiffOpen, setIsPromptDiffOpen] = useState(false);
   const { prompt } = props;
   let badges: JSX.Element[] = prompt.labels
     .sort((a, b) =>
@@ -72,14 +73,20 @@ const PromptHistoryTraceNode = (props: {
             </span>
           </div>
         </div>
-        {(isHovered || props.currentPromptVersion === prompt.version) && (
+        {(isHovered ||
+          props.currentPromptVersion === prompt.version ||
+          isPromptDiffOpen) && (
           <div className="flex flex-row justify-end space-x-1">
             {props.currentPrompt &&
             props.currentPromptVersion !== prompt.version ? (
               <PromptVersionDiffDialog
+                isOpen={isPromptDiffOpen}
+                setIsOpen={(open) => {
+                  setIsPromptDiffOpen(open);
+                  if (!open) setIsHovered(false);
+                }}
                 leftPrompt={prompt}
                 rightPrompt={props.currentPrompt}
-                onClose={() => setIsHovered(false)}
               />
             ) : null}
             <SetPromptVersionLabels


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `PromptVersionDiffDialog` now stays open when the cursor leaves the window, with updated state management for dialog visibility.
> 
>   - **Behavior**:
>     - `PromptVersionDiffDialog` now remains open when the cursor leaves the window.
>     - Replaces `onClose` prop with `isOpen` and `setIsOpen` in `PromptVersionDiffDialog`.
>   - **State Management**:
>     - Adds `isPromptDiffOpen` state in `prompt-history.tsx` to control dialog visibility.
>     - Updates `onOpenChange` in `PromptVersionDiffDialog` to use `setIsOpen`.
>   - **Code Cleanup**:
>     - Removes `onClose` prop from `PromptVersionDiffDialog`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b2b625a4e62f2e27701eb2e96904829839b4a843. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->