### PR TITLE
feat: allow data retention configuration in project settings

### DIFF
--- a/packages/shared/prisma/generated/types.ts
+++ b/packages/shared/prisma/generated/types.ts
@@ -466,6 +466,7 @@ export type Project = {
     updated_at: Generated<Timestamp>;
     deleted_at: Timestamp | null;
     name: string;
+    retention_days: number | null;
 };
 export type ProjectMembership = {
     org_membership_id: string;

--- a/packages/shared/prisma/migrations/20250123103200_add_retention_days_to_projects/migration.sql
+++ b/packages/shared/prisma/migrations/20250123103200_add_retention_days_to_projects/migration.sql
@@ -1,3 +1,3 @@
 -- AlterTable
-ALTER TABLE postgres.public."projects"
+ALTER TABLE "projects"
     ADD COLUMN "retention_days" INTEGER;

--- a/packages/shared/prisma/migrations/20250123103200_add_retention_days_to_projects/migration.sql
+++ b/packages/shared/prisma/migrations/20250123103200_add_retention_days_to_projects/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE postgres.public."projects"
+    ADD COLUMN "retention_days" INTEGER;

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -115,6 +115,7 @@ model Project {
   updatedAt           DateTime               @default(now()) @updatedAt @map("updated_at")
   deletedAt           DateTime?              @map("deleted_at")
   name                String
+  retentionDays       Int?                   @map("retention_days")
   projectMembers      ProjectMembership[]
   organization        Organization           @relation(fields: [orgId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   traces              Trace[]

--- a/web/src/features/auth/lib/projectRetentionSchema.ts
+++ b/web/src/features/auth/lib/projectRetentionSchema.ts
@@ -1,0 +1,10 @@
+import * as z from "zod";
+
+export const projectRetentionSchema = z.object({
+  retention: z.coerce
+    .number()
+    .int("Must be an integer")
+    .refine((value) => value === 0 || value >= 7, {
+      message: "Value must be 0 or at least 7 days",
+    }),
+});

--- a/web/src/features/entitlements/constants/entitlements.ts
+++ b/web/src/features/entitlements/constants/entitlements.ts
@@ -14,6 +14,7 @@ const entitlements = [
   "prompt-experiments",
   "trace-deletion",
   "audit-logs",
+  "data-retention",
 ] as const;
 export type Entitlement = (typeof entitlements)[number];
 
@@ -76,6 +77,7 @@ export const entitlementAccess: Record<
       ...cloudAllPlansEntitlements,
       "rbac-project-roles",
       "audit-logs",
+      "data-retention",
     ],
     entitlementLimits: {
       "annotation-queue-count": false,

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -130,6 +130,7 @@ const events = {
   project_settings: [
     "project_delete",
     "rename_form_submit",
+    "retention_form_submit",
     "project_transfer",
     "api_key_delete",
     "api_key_create",

--- a/web/src/features/projects/components/ConfigureRetention.tsx
+++ b/web/src/features/projects/components/ConfigureRetention.tsx
@@ -108,11 +108,12 @@ export default function ConfigureRetention() {
                     <div className="relative">
                       <Input
                         type="number"
+                        step="1"
                         placeholder={project?.retentionDays?.toString() ?? ""}
                         {...field}
                         value={field.value ?? ""}
                         className="flex-1"
-                        disabled={!hasAccess}
+                        disabled={!hasAccess || !hasEntitlement}
                       />
                       {!hasAccess && (
                         <span title="No access">

--- a/web/src/features/projects/components/ConfigureRetention.tsx
+++ b/web/src/features/projects/components/ConfigureRetention.tsx
@@ -1,5 +1,4 @@
 import { Card } from "@/src/components/ui/card";
-import { Button } from "@/src/components/ui/button";
 import { Input } from "@/src/components/ui/input";
 import { api } from "@/src/utils/api";
 import type * as z from "zod";

--- a/web/src/features/projects/components/ConfigureRetention.tsx
+++ b/web/src/features/projects/components/ConfigureRetention.tsx
@@ -1,0 +1,145 @@
+import { Card } from "@/src/components/ui/card";
+import { Button } from "@/src/components/ui/button";
+import { Input } from "@/src/components/ui/input";
+import { api } from "@/src/utils/api";
+import type * as z from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@/src/components/ui/form";
+import Header from "@/src/components/layouts/header";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { LockIcon } from "lucide-react";
+import { useQueryProject } from "@/src/features/projects/hooks";
+import { useSession } from "next-auth/react";
+import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { projectRetentionSchema } from "@/src/features/auth/lib/projectRetentionSchema";
+import { ActionButton } from "@/src/components/ActionButton";
+import { useHasEntitlement } from "@/src/features/entitlements/hooks";
+
+export default function ConfigureRetention() {
+  const { update: updateSession } = useSession();
+  const { project } = useQueryProject();
+  const capture = usePostHogClientCapture();
+  const hasAccess = useHasProjectAccess({
+    projectId: project?.id,
+    scope: "project:update",
+  });
+  const hasEntitlement = useHasEntitlement("data-retention");
+
+  const form = useForm<z.infer<typeof projectRetentionSchema>>({
+    resolver: zodResolver(projectRetentionSchema),
+    defaultValues: {
+      retention: project?.retentionDays ?? 0,
+    },
+  });
+  const setRetention = api.projects.setRetention.useMutation({
+    onSuccess: (_) => {
+      void updateSession();
+    },
+    onError: (error) => form.setError("retention", { message: error.message }),
+  });
+
+  function onSubmit(values: z.infer<typeof projectRetentionSchema>) {
+    if (!hasAccess || !project) return;
+    capture("project_settings:retention_form_submit");
+    setRetention
+      .mutateAsync({
+        projectId: project.id,
+        retention: values.retention || null, // Fallback to null for indefinite retention
+      })
+      .then(() => {
+        form.reset();
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }
+
+  return (
+    <div>
+      <Header title="Data Retention (Beta)" level="h3" />
+      <Card className="mb-4 p-3">
+        <p className="mb-4 text-sm text-primary">
+          Data retention automatically deletes events older than the specified
+          number of days. The value must be an integer larger than 7. Set to 0
+          to retain data indefinitely. The deletion happens asynchronously, i.e.
+          event may be available for a while after they expired.
+        </p>
+        {Boolean(form.getValues().retention) &&
+        form.getValues().retention !== project?.retentionDays ? (
+          <p className="mb-4 text-sm text-primary">
+            Your Project&#39;s retention will be set from &quot;
+            {project?.retentionDays ?? "Indefinite"}
+            &quot; to &quot;
+            {Number(form.watch().retention) === 0
+              ? "Indefinite"
+              : form.watch().retention}
+            &quot; days.
+          </p>
+        ) : !Boolean(project?.retentionDays) ? (
+          <p className="mb-4 text-sm text-primary">
+            Your Project retains data indefinitely.
+          </p>
+        ) : (
+          <p className="mb-4 text-sm text-primary">
+            Your Project&#39;s current retention is &quot;
+            {project?.retentionDays ?? ""}
+            &quot; days.
+          </p>
+        )}
+        <Form {...form}>
+          <form
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="flex-1"
+            id="set-retention-project-form"
+          >
+            <FormField
+              control={form.control}
+              name="retention"
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <div className="relative">
+                      <Input
+                        type="number"
+                        placeholder={project?.retentionDays?.toString() ?? ""}
+                        {...field}
+                        value={field.value ?? ""}
+                        className="flex-1"
+                        disabled={!hasAccess}
+                      />
+                      {!hasAccess && (
+                        <span title="No access">
+                          <LockIcon className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-muted" />
+                        </span>
+                      )}
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <ActionButton
+              variant="secondary"
+              hasAccess={hasAccess}
+              hasEntitlement={hasEntitlement}
+              loading={setRetention.isLoading}
+              disabled={form.getValues().retention === null}
+              className="mt-4"
+              type="submit"
+            >
+              Save
+            </ActionButton>
+          </form>
+        </Form>
+      </Card>
+    </div>
+  );
+}

--- a/web/src/pages/project/[projectId]/settings/index.tsx
+++ b/web/src/pages/project/[projectId]/settings/index.tsx
@@ -24,11 +24,13 @@ import { BatchExportsSettingsPage } from "@/src/features/batch-exports/component
 import { AuditLogsSettingsPage } from "@/src/ee/features/audit-log-viewer/AuditLogsSettingsPage";
 import { ModelsSettings } from "@/src/features/models/components/ModelSettings";
 import ConfigureRetention from "@/src/features/projects/components/ConfigureRetention";
+import { env } from "@/src/env.mjs";
 
 export default function SettingsPage() {
   const { project, organization } = useQueryProject();
   const router = useRouter();
   const showBillingSettings = useHasEntitlement("cloud-billing");
+  const isLangfuseCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
   if (!project || !organization) return null;
   return (
     <div className="lg:container">
@@ -43,7 +45,7 @@ export default function SettingsPage() {
               <div className="flex flex-col gap-6">
                 <HostNameProject />
                 <RenameProject />
-                <ConfigureRetention />
+                {isLangfuseCloud && <ConfigureRetention />}
                 <div>
                   <Header title="Debug Information" level="h3" />
                   <JSONView

--- a/web/src/pages/project/[projectId]/settings/index.tsx
+++ b/web/src/pages/project/[projectId]/settings/index.tsx
@@ -23,6 +23,7 @@ import { ActionButton } from "@/src/components/ActionButton";
 import { BatchExportsSettingsPage } from "@/src/features/batch-exports/components/BatchExportsSettingsPage";
 import { AuditLogsSettingsPage } from "@/src/ee/features/audit-log-viewer/AuditLogsSettingsPage";
 import { ModelsSettings } from "@/src/features/models/components/ModelSettings";
+import ConfigureRetention from "@/src/features/projects/components/ConfigureRetention";
 
 export default function SettingsPage() {
   const { project, organization } = useQueryProject();
@@ -42,6 +43,7 @@ export default function SettingsPage() {
               <div className="flex flex-col gap-6">
                 <HostNameProject />
                 <RenameProject />
+                <ConfigureRetention />
                 <div>
                   <Header title="Debug Information" level="h3" />
                   <JSONView

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -469,6 +469,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                                 id: project.id,
                                 name: project.name,
                                 role: projectRole,
+                                retentionDays: project.retentionDays,
                                 deletedAt: project.deletedAt,
                               };
                             })

--- a/web/types/next-auth.d.ts
+++ b/web/types/next-auth.d.ts
@@ -45,6 +45,7 @@ declare module "next-auth" {
         id: PrismaProject["id"];
         name: PrismaProject["name"];
         deletedAt: PrismaProject["deletedAt"];
+        retentionDays: PrismaProject["retentionDays"];
         role: Role; // include only projects where user has a role
       }[];
     }[];


### PR DESCRIPTION

https://github.com/user-attachments/assets/357f4a82-8307-40bc-8772-ebffdfb042f7


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add data retention configuration feature to project settings with database, API, UI, and analytics support.
> 
>   - **Database**:
>     - Add `retention_days` column to `projects` table in `migration.sql`.
>     - Update `Project` type in `types.ts` and `schema.prisma` to include `retention_days`.
>   - **API**:
>     - Add `setRetention` mutation in `projectsRouter.ts` to update `retention_days`.
>   - **Validation**:
>     - Add `projectRetentionSchema` in `projectRetentionSchema.ts` to validate retention days (integer, 0 or >= 7).
>   - **UI**:
>     - Add `ConfigureRetention` component in `ConfigureRetention.tsx` for setting retention days in project settings.
>     - Update `SettingsPage` in `index.tsx` to include `ConfigureRetention` component.
>   - **Analytics**:
>     - Add `retention_form_submit` event in `usePostHogClientCapture.ts` for tracking form submissions.
>   - **Entitlements**:
>     - Add `data-retention` to entitlements in `entitlements.ts` and update access for `cloud:team` plan.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2aa2410f268279b386445288dcd14c7c559a1314. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->