### PR TITLE
chore(cloud): add login issue banner, allow to open support chat

### DIFF
--- a/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
+++ b/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
@@ -10,6 +10,7 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -123,15 +124,11 @@ const DataRegionInfo = () => (
       <DialogHeader>
         <DialogTitle>Data Regions</DialogTitle>
       </DialogHeader>
-      <div className="flex flex-col gap-2">
+      <DialogDescription className="flex flex-col gap-2">
         <p>Langfuse Cloud is available in two data regions:</p>
         <ul className="list-disc pl-5">
-          <li>
-            US: Oregon (AWS us-west-2)
-          </li>
-          <li>
-            EU: Ireland (AWS eu-west-1)
-          </li>
+          <li>US: Oregon (AWS us-west-2)</li>
+          <li>EU: Ireland (AWS eu-west-1)</li>
         </ul>
         <p>
           Regions are strictly separated, and no data is shared across regions.
@@ -154,7 +151,7 @@ const DataRegionInfo = () => (
           </a>
           .
         </p>
-      </div>
+      </DialogDescription>
     </DialogContent>
   </Dialog>
 );

--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -32,6 +32,7 @@ import { Shield } from "lucide-react";
 import { useRouter } from "next/router";
 import { captureException } from "@sentry/nextjs";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { openChat } from "@/src/features/support-chat/chat";
 
 const credentialAuthForm = z.object({
   email: z.string().email(),
@@ -434,6 +435,20 @@ export default function SignIn({
             Sign in to your account
           </h2>
         </div>
+
+        {env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== undefined && (
+          <div className="-mb-4 mt-4 rounded-lg bg-card p-3 text-center text-sm sm:mx-auto sm:w-full sm:max-w-[480px] sm:rounded-lg sm:px-6">
+            If you are experiencing issues signing in, please force refresh this
+            page (CMD + SHIFT + R) or clear your browser cache. We are working
+            on a solution.{" "}
+            <span
+              className="cursor-pointer whitespace-nowrap text-xs font-medium text-primary-accent hover:text-hover-primary-accent"
+              onClick={openChat}
+            >
+              (contact us)
+            </span>
+          </div>
+        )}
 
         <CloudRegionSwitch />
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add login issue banner and support chat link to `sign-in.tsx`, and refactor `AuthCloudRegionSwitch.tsx` for better structure.
> 
>   - **UI Enhancements**:
>     - Add login issue banner to `sign-in.tsx` with instructions to refresh or clear cache and a link to open support chat.
>     - Update `AuthCloudRegionSwitch.tsx` to use `DialogDescription` for better semantic structure.
>   - **Support**:
>     - Import and use `openChat` from `support-chat/chat` in `sign-in.tsx` to allow users to contact support.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 76e9db4ac245b5d34c498a500b24d20e18dd9e86. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->