### PR TITLE
feat(trace-timeline): add time to first token

### DIFF
--- a/web/src/components/trace/TraceTimelineView.tsx
+++ b/web/src/components/trace/TraceTimelineView.tsx
@@ -76,6 +76,7 @@ function TreeItemInner({
   totalScaleSpan,
   type,
   startOffset = 0,
+  firstTokenTimeOffset,
   name,
   children,
   setBackgroundColor,
@@ -86,6 +87,7 @@ function TreeItemInner({
   totalScaleSpan: number;
   type: TreeItemType;
   startOffset?: number;
+  firstTokenTimeOffset?: number;
   name?: string | null;
   children?: React.ReactNode;
   setBackgroundColor: (color: string) => void;
@@ -147,31 +149,75 @@ function TreeItemInner({
       <div className="flex items-center" style={{ width: `${SCALE_WIDTH}px` }}>
         <div className={`relative w-[${SCALE_WIDTH}px]`}>
           <div className="ml-4 mr-4 h-full border-r-2"></div>
-          <div
-            className={cn(
-              "flex h-5 items-center justify-end rounded-sm",
-              itemWidth
-                ? treeItemColors.get(type)
-                : "border border-dashed bg-muted",
-            )}
-            style={{
-              width: `${itemWidth || 10}px`,
-              marginLeft: `${startOffset}px`,
-            }}
-          >
-            <span
+          {firstTokenTimeOffset ? (
+            <div className="flex" style={{ marginLeft: `${startOffset}px` }}>
+              <div
+                className={cn(
+                  "flex h-5 items-center justify-end rounded-l-sm border-r border-gray-400 opacity-60",
+                  itemWidth
+                    ? treeItemColors.get(type)
+                    : "border border-dashed bg-muted",
+                )}
+                style={{
+                  width: `${firstTokenTimeOffset - startOffset}px`,
+                }}
+              >
+                <span className="text mr-2 text-xs font-light italic text-foreground group-hover:block">
+                  First token
+                </span>
+              </div>
+              <div
+                className={cn(
+                  "flex h-5 items-center justify-end rounded-r-sm",
+                  itemWidth
+                    ? treeItemColors.get(type)
+                    : "border border-dashed bg-muted",
+                )}
+                style={{
+                  width: `${itemWidth - (firstTokenTimeOffset - startOffset)}px`,
+                }}
+              >
+                <span
+                  className={cn(
+                    "hidden justify-end text-xs text-muted-foreground group-hover:block",
+                    itemOffsetLabelWidth > SCALE_WIDTH
+                      ? "mr-1"
+                      : isPresent(latency)
+                        ? `-mr-9`
+                        : "-mr-6",
+                  )}
+                >
+                  {isPresent(latency) ? `${latency.toFixed(2)}s` : "n/a"}
+                </span>
+              </div>
+            </div>
+          ) : (
+            <div
               className={cn(
-                "hidden justify-end text-xs text-muted-foreground group-hover:block",
-                itemOffsetLabelWidth > SCALE_WIDTH
-                  ? "mr-1"
-                  : isPresent(latency)
-                    ? `-mr-9`
-                    : "-mr-6",
+                "flex h-5 items-center justify-end rounded-sm",
+                itemWidth
+                  ? treeItemColors.get(type)
+                  : "border border-dashed bg-muted",
               )}
+              style={{
+                width: `${itemWidth || 10}px`,
+                marginLeft: `${startOffset}px`,
+              }}
             >
-              {isPresent(latency) ? `${latency.toFixed(2)}s` : "n/a"}
-            </span>
-          </div>
+              <span
+                className={cn(
+                  "hidden justify-end text-xs text-muted-foreground group-hover:block",
+                  itemOffsetLabelWidth > SCALE_WIDTH
+                    ? "mr-1"
+                    : isPresent(latency)
+                      ? `-mr-9`
+                      : "-mr-6",
+                )}
+              >
+                {isPresent(latency) ? `${latency.toFixed(2)}s` : "n/a"}
+              </span>
+            </div>
+          )}
         </div>
       </div>
     </div>
@@ -199,7 +245,7 @@ function TraceTreeItem({
   cardWidth: number;
   commentCounts?: Map<string, number>;
 }) {
-  const { startTime, endTime } = observation || {};
+  const { startTime, completionStartTime, endTime } = observation || {};
   const [backgroundColor, setBackgroundColor] = useState("");
 
   const latency = endTime
@@ -208,6 +254,12 @@ function TraceTreeItem({
   const startOffset =
     ((startTime.getTime() - traceStartTime.getTime()) / totalScaleSpan / 1000) *
     SCALE_WIDTH;
+  const firstTokenTimeOffset = completionStartTime
+    ? ((completionStartTime.getTime() - traceStartTime.getTime()) /
+        totalScaleSpan /
+        1000) *
+      SCALE_WIDTH
+    : undefined;
 
   return (
     <TreeItem
@@ -224,6 +276,7 @@ function TraceTreeItem({
           type={observation.type}
           name={observation.name}
           startOffset={startOffset}
+          firstTokenTimeOffset={firstTokenTimeOffset}
           totalScaleSpan={totalScaleSpan}
           setBackgroundColor={setBackgroundColor}
           level={level}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`npm run prettier`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add visualization for time to first token in `TraceTimelineView` component by introducing `firstTokenTimeOffset`.
> 
>   - **Behavior**:
>     - Add `firstTokenTimeOffset` to `TreeItemInner` and `TraceTreeItem` in `TraceTimelineView.tsx` to display time to first token.
>     - Visualizes the time to first token with a distinct segment in the timeline.
>   - **Functions**:
>     - Modify `TreeItemInner` to accept and use `firstTokenTimeOffset` for rendering timeline segments.
>     - Update `TraceTreeItem` to calculate `firstTokenTimeOffset` from `completionStartTime`.
>   - **Misc**:
>     - Adjust timeline rendering logic to accommodate new visual segment for first token time.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d57499da0bbf53bed3080edec7e136d6716e5c8b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->