### PR TITLE
perf: add timestamp filter to observations join in eval queue

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -73,7 +73,7 @@ export const checkTraceExists = async (
         FROM observations o FINAL 
         WHERE o.project_id = {projectId: String}
         ${timeStampFilter ? `AND o.start_time >= {traceTimestamp: DateTime64(3)} - ${OBSERVATIONS_TO_TRACE_INTERVAL}` : ""}
-        ${timestamp ? `AND o.start_time >= {timestamp: DateTime64(3)} - ${OBSERVATIONS_TO_TRACE_INTERVAL}` : ""}
+        AND o.start_time >= {timestamp: DateTime64(3)} - ${OBSERVATIONS_TO_TRACE_INTERVAL}
         GROUP BY trace_id, project_id
       )
     SELECT 
@@ -83,7 +83,7 @@ export const checkTraceExists = async (
     ${observationFilterRes ? `INNER JOIN observations_agg o ON t.id = o.trace_id AND t.project_id = o.project_id` : ""}
     WHERE ${tracesFilterRes.query}
     AND t.project_id = {projectId: String}
-    ${timestamp ? `AND timestamp >= {timestamp: DateTime64(3)} - ${TRACE_TO_OBSERVATIONS_INTERVAL}` : ""}
+    AND timestamp >= {timestamp: DateTime64(3)} - ${TRACE_TO_OBSERVATIONS_INTERVAL}
     GROUP BY t.id, t.project_id
   `;
 

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -30,7 +30,7 @@ import { env } from "../../env";
 export const checkTraceExists = async (
   projectId: string,
   traceId: string,
-  timestamp: Date | undefined,
+  timestamp: Date,
   filter: FilterState,
 ): Promise<boolean> => {
   const { tracesFilter } = getProjectIdDefaultFilter(projectId, {
@@ -73,6 +73,7 @@ export const checkTraceExists = async (
         FROM observations o FINAL 
         WHERE o.project_id = {projectId: String}
         ${timeStampFilter ? `AND o.start_time >= {traceTimestamp: DateTime64(3)} - ${OBSERVATIONS_TO_TRACE_INTERVAL}` : ""}
+        ${timestamp ? `AND o.start_time >= {timestamp: DateTime64(3)} - ${OBSERVATIONS_TO_TRACE_INTERVAL}` : ""}
         GROUP BY trace_id, project_id
       )
     SELECT 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enforces timestamp filtering in `checkTraceExists` in `traces.ts` for improved query performance.
> 
>   - **Behavior**:
>     - Enforces timestamp filter in `checkTraceExists` in `traces.ts` by making `timestamp` a required parameter.
>     - Adds timestamp filter to SQL query in `checkTraceExists` to ensure observations are filtered by start time.
>   - **Misc**:
>     - Removes conditional check for `timestamp` in SQL query, making it mandatory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 692fd7111585ec293aafa0b578650f0fab56b06a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->