### PR TITLE
fix(comments-api): increase comment character limit to 3,000

### DIFF
--- a/web/src/features/public-api/types/comments.ts
+++ b/web/src/features/public-api/types/comments.ts
@@ -17,7 +17,7 @@ const APIComment = z
     updatedAt: z.coerce.date(),
     objectType: z.nativeEnum(CommentObjectType),
     objectId: z.string(),
-    content: z.string().min(1).max(500),
+    content: z.string().min(1).max(3000),
     authorUserId: z.string().nullish(),
   })
   .strict();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase comment `content` character limit from 500 to 3000 in `APIComment` schema in `comments.ts`.
> 
>   - **Behavior**:
>     - Increase comment `content` character limit from 500 to 3000 in `APIComment` schema in `comments.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 81deafff3824e9ceac95f46b2bd1106202714dce. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->