### PR TITLE
fix(trace-timeline): first token label

### DIFF
--- a/web/src/components/trace/TraceTimelineView.tsx
+++ b/web/src/components/trace/TraceTimelineView.tsx
@@ -162,7 +162,12 @@ function TreeItemInner({
                   width: `${firstTokenTimeOffset - startOffset}px`,
                 }}
               >
-                <span className="text mr-2 text-xs font-light italic text-foreground group-hover:block">
+                <span
+                  className={cn(
+                    "text text-xs font-light italic text-foreground group-hover:block",
+                    firstTokenTimeOffset - startOffset < 30 ? "-mr-14" : "mr-2",
+                  )}
+                >
                   First token
                 </span>
               </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjusts margin-right of 'First token' label in `TreeItemInner` of `TraceTimelineView.tsx` based on width condition.
> 
>   - **UI Adjustment**:
>     - In `TraceTimelineView.tsx`, `TreeItemInner` function adjusts the margin-right of the 'First token' label based on the width between `firstTokenTimeOffset` and `startOffset`. If the width is less than 30px, applies `-mr-14`; otherwise, `mr-2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for dd4c3eeb3807df2063096f852c75f8726ad417be. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->