### PR TITLE
fix(media): reduce tx level to RepeateableRead

### DIFF
--- a/web/src/pages/api/public/media/index.ts
+++ b/web/src/pages/api/public/media/index.ts
@@ -179,7 +179,8 @@ export default withMiddlewares({
                   };
                 },
                 {
-                  isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+                  isolationLevel:
+                    Prisma.TransactionIsolationLevel.RepeatableRead,
                   maxWait: 5000,
                 },
               );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce transaction isolation level to `RepeatableRead` in media upload API endpoint.
> 
>   - **Behavior**:
>     - Change transaction isolation level from `Serializable` to `RepeatableRead` in `web/src/pages/api/public/media/index.ts` for media upload URL generation.
>     - Affects the transaction handling in the `POST` method of the API route.
>   - **Misc**:
>     - No other changes or refactoring in the file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8e1f98c02d959cbf44823baa999b61dfa9c3f7e3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->