### PR TITLE
fix(openapi): upgrade openapi spec generator to correctly specify /ingestion 207 status code

### DIFF
--- a/fern/apis/client/generators.yml
+++ b/fern/apis/client/generators.yml
@@ -12,7 +12,7 @@ groups:
       #     namespaceExport: Langfuse
       #     allowCustomFetcher: true
       - name: fernapi/fern-openapi
-        version: 0.0.26
+        version: 0.1.7
         output:
           location: local-file-system
           path: ../../../web/public/generated/api-client

--- a/fern/apis/server/definition/ingestion.yml
+++ b/fern/apis/server/definition/ingestion.yml
@@ -128,7 +128,7 @@ types:
       modelParameters: optional<map<string, commons.MapValue>>
       usage: optional<IngestionUsage>
       usageDetails: optional<UsageDetails>
-      costDetails: optional<map<string, float>>
+      costDetails: optional<map<string, double>>
       promptName: optional<string>
       promptVersion: optional<integer>
 
@@ -141,7 +141,7 @@ types:
       usage: optional<IngestionUsage>
       promptName: optional<string>
       usageDetails: optional<UsageDetails>
-      costDetails: optional<map<string, float>>
+      costDetails: optional<map<string, double>>
       promptVersion: optional<integer>
 
   ObservationBody:

--- a/fern/apis/server/definition/score.yml
+++ b/fern/apis/server/definition/score.yml
@@ -59,7 +59,7 @@ service:
             type: optional<commons.ScoreDataType>
             docs: Retrieve only scores with a specific dataType.
           traceTags:
-            type: optional<list<string>>
+            type: optional<string>
             allow-multiple: true
             docs: Only scores linked to traces that include all of these tags will be returned.
       response: GetScoresResponse

--- a/fern/apis/server/generators.yml
+++ b/fern/apis/server/generators.yml
@@ -3,7 +3,7 @@ groups:
   local:
     generators:
       - name: fernapi/fern-openapi
-        version: 0.0.31
+        version: 0.1.7
         output:
           location: local-file-system
           path: ../../../web/public/generated/api

--- a/web/public/generated/api-client/openapi.yml
+++ b/web/public/generated/api-client/openapi.yml
@@ -53,6 +53,7 @@ components:
       properties:
         id:
           type: string
+          nullable: true
         traceId:
           type: string
           example: cdef-1234-5678-90ab
@@ -67,15 +68,19 @@ components:
             values must equal either 1 or 0 (true or false)
         observationId:
           type: string
+          nullable: true
         comment:
           type: string
+          nullable: true
         dataType:
           $ref: '#/components/schemas/ScoreDataType'
+          nullable: true
           description: >-
             When set, must match the score value's type. If not set, will be
             inferred from the score value or config
         configId:
           type: string
+          nullable: true
           description: >-
             Reference a score config on a score. When set, the score name must
             equal the config name and scores must comply with the config's range
@@ -100,6 +105,7 @@ components:
           $ref: '#/components/schemas/ScoreSource'
         observationId:
           type: string
+          nullable: true
         timestamp:
           type: string
           format: date-time
@@ -111,10 +117,13 @@ components:
           format: date-time
         authorUserId:
           type: string
+          nullable: true
         comment:
           type: string
+          nullable: true
         configId:
           type: string
+          nullable: true
           description: >-
             Reference a score config on a score. When set, config and score name
             must be equal and value must comply to optionally defined numerical
@@ -166,6 +175,7 @@ components:
         value:
           type: number
           format: double
+          nullable: true
           description: >-
             Only defined if a config is linked. Represents the numeric category
             mapping of the stringValue

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -737,7 +737,7 @@ paths:
         - Ingestion
       parameters: []
       responses:
-        '200':
+        '207':
           description: ''
           content:
             application/json:
@@ -2012,7 +2012,9 @@ paths:
           schema:
             type: array
             items:
-              type: string
+              type: array
+              items:
+                type: string
               nullable: true
       responses:
         '200':
@@ -3716,8 +3718,8 @@ components:
         costDetails:
           type: object
           additionalProperties:
-            type: number
-            format: double
+            type: integer
+            format: float
           nullable: true
         promptName:
           type: string
@@ -3755,8 +3757,8 @@ components:
         costDetails:
           type: object
           additionalProperties:
-            type: number
-            format: double
+            type: integer
+            format: float
           nullable: true
         promptVersion:
           type: integer

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -2012,9 +2012,7 @@ paths:
           schema:
             type: array
             items:
-              type: array
-              items:
-                type: string
+              type: string
               nullable: true
       responses:
         '200':

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3716,8 +3716,8 @@ components:
         costDetails:
           type: object
           additionalProperties:
-            type: integer
-            format: float
+            type: number
+            format: double
           nullable: true
         promptName:
           type: string
@@ -3755,8 +3755,8 @@ components:
         costDetails:
           type: object
           additionalProperties:
-            type: integer
-            format: float
+            type: number
+            format: double
           nullable: true
         promptVersion:
           type: integer


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Upgraded OpenAPI spec generator and updated `/ingestion` endpoint to return a 207 status code, with schema adjustments for improved compatibility.
> 
>   - **OpenAPI Spec Generator**:
>     - Upgraded `fernapi/fern-openapi` version from `0.0.26` to `0.1.7` in `client/generators.yml` and `server/generators.yml`.
>   - **API Specification**:
>     - Changed `/ingestion` endpoint response status code from `200` to `207` in `api/openapi.yml`.
>   - **Schema Changes**:
>     - Updated `costDetails` type from `float` to `double` in `ingestion.yml`.
>     - Changed `traceTags` type from `list<string>` to `string` in `score.yml`.
>     - Added `nullable: true` to several properties in `api-client/openapi.yml` and `api/openapi.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6af8c095d08df9ead8cb3489d46b5df0eb447b31. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->