### PR TITLE
fix: align input/output and metadata parsing between GET /traces and /traces/:id

### DIFF
--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -5,13 +5,11 @@ import {
   TRACE_TO_OBSERVATIONS_INTERVAL,
   orderByToClickhouseSql,
   type DateTimeFilter,
-  parseClickhouseUTCDateTimeFormat,
   convertClickhouseToDomain,
   TraceRecordReadType,
 } from "@langfuse/shared/src/server";
-import { convertRecordToJsonSchema, type OrderByState } from "@langfuse/shared";
+import { type OrderByState } from "@langfuse/shared";
 import { snakeCase } from "lodash";
-import { type JsonValue } from "@prisma/client/runtime/binary";
 
 type QueryType = {
   page: number;

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -6,7 +6,7 @@ import {
   orderByToClickhouseSql,
   type DateTimeFilter,
   convertClickhouseToDomain,
-  TraceRecordReadType,
+  type TraceRecordReadType,
 } from "@langfuse/shared/src/server";
 import { type OrderByState } from "@langfuse/shared";
 import { snakeCase } from "lodash";

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -6,12 +6,10 @@ import {
   orderByToClickhouseSql,
   type DateTimeFilter,
   parseClickhouseUTCDateTimeFormat,
+  convertClickhouseToDomain,
+  TraceRecordReadType,
 } from "@langfuse/shared/src/server";
-import {
-  convertRecordToJsonSchema,
-  type OrderByState,
-  type Trace,
-} from "@langfuse/shared";
+import { convertRecordToJsonSchema, type OrderByState } from "@langfuse/shared";
 import { snakeCase } from "lodash";
 import { type JsonValue } from "@prisma/client/runtime/binary";
 
@@ -82,22 +80,21 @@ export const generateTracesForPublicApi = async (
     SELECT
       t.id as id,
       CONCAT('/project/', t.project_id, '/traces/', t.id) as "htmlPath",
-      t.project_id as projectId,
+      t.project_id as project_id,
       t.timestamp as timestamp,
       t.name as name,
       t.input as input,
       t.output as output,
-      null as externalId,
-      t.session_id as sessionId,
+      t.session_id as session_id,
       t.metadata as metadata,
-      t.user_id as userId,
+      t.user_id as user_id,
       t.release as release,
       t.version as version,
       t.bookmarked as bookmarked,
       t.public as public,
       t.tags as tags,
-      t.created_at as createdAt,
-      t.updated_at as updatedAt,
+      t.created_at as created_at,
+      t.updated_at as updated_at,
       s.score_ids as scores,
       o.observation_ids as observations,
       COALESCE(o.latency_milliseconds / 1000, 0) as latency,
@@ -113,7 +110,7 @@ export const generateTracesForPublicApi = async (
   `;
 
   const result = await queryClickhouse<
-    Trace & {
+    TraceRecordReadType & {
       observations: string[];
       scores: string[];
       totalCost: number;
@@ -138,14 +135,12 @@ export const generateTracesForPublicApi = async (
   });
 
   return result.map((trace) => ({
-    ...trace,
-    timestamp: parseClickhouseUTCDateTimeFormat(trace.timestamp.toString()),
-    createdAt: parseClickhouseUTCDateTimeFormat(trace.createdAt.toString()),
-    updatedAt: parseClickhouseUTCDateTimeFormat(trace.updatedAt.toString()),
-    // Parse metadata values to JSON and make TypeScript happy
-    metadata: convertRecordToJsonSchema(
-      (trace.metadata as Record<string, string>) || {},
-    ) as JsonValue,
+    ...convertClickhouseToDomain(trace),
+    observations: trace.observations,
+    scores: trace.scores,
+    totalCost: trace.totalCost,
+    latency: trace.latency,
+    htmlPath: trace.htmlPath,
   }));
 };
 

--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -6,7 +6,6 @@ import {
   BatchExportStatus,
   exportOptions,
   FilterCondition,
-  Prisma,
   Score,
   TimeFilter,
 } from "@langfuse/shared";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Aligns metadata parsing and field naming between `GET /traces` and `/traces/:id` endpoints, with updated tests and query logic.
> 
>   - **Behavior**:
>     - Aligns metadata parsing between `GET /traces` and `/traces/:id` endpoints in `traces.ts`.
>     - Ensures metadata is unescaped and correctly parsed in both endpoints.
>   - **Tests**:
>     - Adds test cases in `traces-api.servertest.ts` to verify unescaped metadata handling for both endpoints.
>     - Tests fetching a single trace and traces list with unescaped metadata.
>   - **Query Logic**:
>     - Uses `convertClickhouseToDomain` in `generateTracesForPublicApi` to standardize field names.
>     - Updates SQL query to ensure consistent field naming and data handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7a82aa42cea0b330d6b285e77a8f8b94260bb758. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->