### PR TITLE
perf: use final for traces and observations api if no skip indexes are filtered

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -383,6 +383,10 @@ export class FilterList {
     return this.filters.find(predicate);
   }
 
+  some(predicate: (filter: Filter) => boolean) {
+    return this.filters.some(predicate);
+  }
+
   length() {
     return this.filters.length;
   }

--- a/web/src/features/public-api/server/observations.ts
+++ b/web/src/features/public-api/server/observations.ts
@@ -25,6 +25,14 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
   const appliedFilter = chFilter.apply();
   const traceFilter = chFilter.find((f) => f.clickhouseTable === "traces");
 
+  // This _must_ be updated if we add a new skip index column to the observations table.
+  // Otherwise, we will ignore it in most cases due to `FINAL`.
+  const shouldUseSkipIndexes = chFilter.some(
+    (f) =>
+      f.clickhouseTable === "observations" &&
+      ["trace_id"].some((skipIndexCol) => f.field.includes(skipIndexCol)),
+  );
+
   const query = `
         SELECT
         id,
@@ -56,13 +64,12 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
         created_at,
         updated_at,
         event_ts
-      FROM observations o
+      FROM observations o ${shouldUseSkipIndexes ? "" : "FINAL"}
       ${traceFilter ? `LEFT JOIN traces t ON o.trace_id = t.id AND t.project_id = o.project_id` : ""}
       WHERE o.project_id = {projectId: String}
       ${traceFilter ? `AND t.project_id = {projectId: String}` : ""}
       AND ${appliedFilter.query}
-      ORDER BY event_ts desc
-      LIMIT 1 by id, project_id
+      ${shouldUseSkipIndexes ? "ORDER BY start_time desc, event_ts desc LIMIT 1 by id, project_id" : "ORDER BY start_time DESC"}
       ${props.limit !== undefined && props.page !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
       `;
 

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -61,9 +61,8 @@ export const generateTracesForPublicApi = async (
   // applies only to a stale value.
   const chOrderBy =
     (orderByToClickhouseSql(orderBy || [], orderByColumns) ||
-      "ORDER BY t.timestamp desc") + shouldUseSkipIndexes
-      ? ", t.event_ts desc"
-      : "";
+      "ORDER BY t.timestamp desc") +
+    (shouldUseSkipIndexes ? ", t.event_ts desc" : "");
 
   const query = `
     WITH observation_stats AS (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimize query performance by conditionally using `FINAL` in `generateObservationsForPublicApi` and `generateTracesForPublicApi` based on skip index columns in filters.
> 
>   - **Behavior**:
>     - In `observations.ts`, `generateObservationsForPublicApi` now conditionally uses `FINAL` based on `shouldUseSkipIndexes`, which checks for `trace_id` in filters.
>     - In `traces.ts`, `generateTracesForPublicApi` conditionally uses `FINAL` based on `shouldUseSkipIndexes`, which checks for `user_id`, `session_id`, and `metadata` in filters.
>   - **Functions**:
>     - Adds `some()` method to `FilterList` in `clickhouse-filter.ts` to check for specific conditions in filters.
>   - **Queries**:
>     - Adjusts `ORDER BY` and `LIMIT` clauses in `observations.ts` and `traces.ts` based on `shouldUseSkipIndexes`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fdc8295dc94a153da555be22f1c5e00ff903a680. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->