### PR TITLE
ci: run codespell also on v2 branch and prs

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,9 +3,13 @@ name: Codespell
 
 on:
   push:
-    branches: [main]
+    branches:
+      - "main"
+    tags:
+      - "v*"
   pull_request:
-    branches: [main]
+    branches:
+      - "**"
   merge_group:
 
 permissions:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Expand Codespell CI to run on all branches and 'v*' tags in `.github/workflows/codespell.yml`.
> 
>   - **CI Configuration**:
>     - Update `.github/workflows/codespell.yml` to run Codespell on all branches and tags starting with 'v'.
>     - Expands pull request trigger to all branches (`"**"`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 65908b8e13065111a67874fabf6d1ea8976d87b2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->