### PR TITLE
ci(v2): run codespell also on v2 branch and prs (#5224)

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,9 +3,14 @@ name: Codespell
 
 on:
   push:
-    branches: [main]
+    branches:
+      - "main"
+    tags:
+      - "v*"
   pull_request:
-    branches: [main]
+    branches:
+      - "**"
+  merge_group:
 
 permissions:
   contents: read

--- a/web/src/ee/features/evals/components/evaluator-form.tsx
+++ b/web/src/ee/features/evals/components/evaluator-form.tsx
@@ -69,7 +69,7 @@ import { showSuccessToast } from "@/src/features/notifications/showSuccessToast"
 const formSchema = z.object({
   scoreName: z.string(),
   target: z.string(),
-  filter: z.array(singleFilter).nullable(), // re-using the filter type from the tables
+  filter: z.array(singleFilter).nullable(), // reusing the filter type from the tables
   mapping: z.array(wipVariableMapping),
   sampling: z.coerce.number().gt(0).lte(1),
   delay: z.coerce.number().optional().default(10),

--- a/web/src/ee/features/evals/server/router.ts
+++ b/web/src/ee/features/evals/server/router.ts
@@ -35,7 +35,7 @@ const APIEvaluatorSchema = z.object({
   evalTemplateId: z.string(),
   scoreName: z.string(),
   targetObject: z.string(),
-  filter: z.array(singleFilter).nullable(), // re-using the filter type from the tables
+  filter: z.array(singleFilter).nullable(), // reusing the filter type from the tables
   variableMapping: z.array(variableMapping),
   sampling: z.instanceof(Prisma.Decimal),
   delay: z.number(),
@@ -91,7 +91,7 @@ const CreateEvalJobSchema = z.object({
   evalTemplateId: z.string(),
   scoreName: z.string().min(1),
   target: z.string(),
-  filter: z.array(singleFilter).nullable(), // re-using the filter type from the tables
+  filter: z.array(singleFilter).nullable(), // reusing the filter type from the tables
   mapping: z.array(variableMapping),
   sampling: z.number().gt(0).lte(1),
   delay: z.number().gte(0).default(DEFAULT_TRACE_JOB_DELAY), // 10 seconds default


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update CI to run codespell on all branches and tags starting with 'v' and fix typos in comments.
> 
>   - **CI Configuration**:
>     - Update `.github/workflows/codespell.yml` to run codespell on all branches and tags starting with 'v'.
>   - **Typo Fixes**:
>     - Corrects "re-using" to "reusing" in comments in `evaluator-form.tsx` and `router.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3a7383fc62f761f578cbf5ceaa2aec6818a20e2f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->