### PR TITLE
feat: remove data beyond retention limit from clickhouse

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -972,6 +972,27 @@ export const deleteObservationsByProjectId = async (projectId: string) => {
   });
 };
 
+export const deleteObservationsOlderThanDays = async (
+  projectId: string,
+  days: number,
+) => {
+  const query = `
+    DELETE FROM observations
+    WHERE project_id = {projectId: String}
+    AND start_time < now() - INTERVAL {numDays: Int} DAYS;
+  `;
+  await commandClickhouse({
+    query: query,
+    params: {
+      projectId,
+      numDays: days,
+    },
+    clickhouseConfigs: {
+      request_timeout: 120_000, // 2 minutes
+    },
+  });
+};
+
 export const getObservationsWithPromptName = async (
   projectId: string,
   promptNames: string[],

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -536,6 +536,27 @@ export const deleteScoresByProjectId = async (projectId: string) => {
   });
 };
 
+export const deleteOScoresOlderThanDays = async (
+  projectId: string,
+  days: number,
+) => {
+  const query = `
+    DELETE FROM scores
+    WHERE project_id = {projectId: String}
+    AND timestamp < now() - INTERVAL {numDays: Int} DAYS;
+  `;
+  await commandClickhouse({
+    query: query,
+    params: {
+      projectId,
+      numDays: days,
+    },
+    clickhouseConfigs: {
+      request_timeout: 120_000, // 2 minutes
+    },
+  });
+};
+
 export const getNumericScoreHistogram = async (
   projectId: string,
   filter: FilterState,

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -536,7 +536,7 @@ export const deleteScoresByProjectId = async (projectId: string) => {
   });
 };
 
-export const deleteOScoresOlderThanDays = async (
+export const deleteScoresOlderThanDays = async (
   projectId: string,
   days: number,
 ) => {

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -442,6 +442,27 @@ export const deleteTraces = async (projectId: string, traceIds: string[]) => {
   });
 };
 
+export const deleteTracesOlderThanDays = async (
+  projectId: string,
+  days: number,
+) => {
+  const query = `
+    DELETE FROM traces
+    WHERE project_id = {projectId: String}
+    AND timestamp < now() - INTERVAL {numDays: Int} DAYS;
+  `;
+  await commandClickhouse({
+    query: query,
+    params: {
+      projectId,
+      numDays: days,
+    },
+    clickhouseConfigs: {
+      request_timeout: 120_000, // 2 minutes
+    },
+  });
+};
+
 export const deleteTracesByProjectId = async (projectId: string) => {
   const query = `
     DELETE FROM traces

--- a/worker/src/__tests__/dataRetentionProcessingTest.test.ts
+++ b/worker/src/__tests__/dataRetentionProcessingTest.test.ts
@@ -1,13 +1,23 @@
-import { expect, test, describe, beforeAll } from "vitest";
+import { expect, it, describe, beforeAll } from "vitest";
 import { env } from "../env";
 import { randomUUID } from "crypto";
 import {
+  createObservation,
+  createObservationsCh,
+  createScore,
+  createScoresCh,
+  createTrace,
+  createTracesCh,
+  getObservationById,
+  getScoreById,
+  getTraceById,
   StorageService,
   StorageServiceFactory,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { handleDataRetentionProcessingJob } from "../ee/dataRetention/handleDataRetentionProcessingJob";
 import { Job } from "bullmq";
+import { LangfuseNotFoundError } from "@langfuse/shared";
 
 describe("DataRetentionProcessingJob", () => {
   let storageService: StorageService;
@@ -24,7 +34,7 @@ describe("DataRetentionProcessingJob", () => {
     });
   });
 
-  test("should delete media files from cloud storage and database if expired", async () => {
+  it("should delete media files from cloud storage and database if expired", async () => {
     // Setup
     const fileName = `${randomUUID()}.txt`;
     const fileType = "text/plain";
@@ -80,5 +90,90 @@ describe("DataRetentionProcessingJob", () => {
       where: { mediaId },
     });
     expect(traceMedia).toBeNull();
+  });
+
+  it("should delete traces older than retention days", async () => {
+    // Setup
+    const baseId = randomUUID();
+    await createTracesCh([
+      createTrace({
+        id: `${baseId}-trace-old`,
+        project_id: projectId,
+        timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).getTime(), // 30 days in the past
+      }),
+      createTrace({
+        id: `${baseId}-trace-new`,
+        project_id: projectId,
+      }),
+    ]);
+
+    // When
+    await handleDataRetentionProcessingJob({
+      data: { payload: { projectId, retention: 7 } }, // Delete after 7 days
+    } as Job);
+
+    // Then
+    const traceOld = await getTraceById(`${baseId}-trace-old`, projectId);
+    expect(traceOld).toBeUndefined();
+    const traceNew = await getTraceById(`${baseId}-trace-new`, projectId);
+    expect(traceNew).toBeDefined();
+  });
+
+  it("should delete observations older than retention days", async () => {
+    // Setup
+    const baseId = randomUUID();
+    await createObservationsCh([
+      createObservation({
+        id: `${baseId}-observation-old`,
+        project_id: projectId,
+        start_time: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).getTime(), // 30 days in the past
+      }),
+      createObservation({
+        id: `${baseId}-observation-new`,
+        project_id: projectId,
+      }),
+    ]);
+
+    // When
+    await handleDataRetentionProcessingJob({
+      data: { payload: { projectId, retention: 7 } }, // Delete after 7 days
+    } as Job);
+
+    // Then
+    expect(() =>
+      getObservationById(`${baseId}-observation-old`, projectId),
+    ).rejects.toThrowError("not found");
+    const observationNew = await getObservationById(
+      `${baseId}-observation-new`,
+      projectId,
+    );
+    expect(observationNew).toBeDefined();
+  });
+
+  it("should delete scores older than retention days", async () => {
+    // Setup
+    const baseId = randomUUID();
+    await createScoresCh([
+      createScore({
+        id: `${baseId}-score-old`,
+        project_id: projectId,
+        timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).getTime(), // 30 days in the past
+      }),
+      createScore({
+        id: `${baseId}-score-new`,
+        project_id: projectId,
+      }),
+    ]);
+
+    // When
+    await handleDataRetentionProcessingJob({
+      data: { payload: { projectId, retention: 7 } }, // Delete after 7 days
+    } as Job);
+
+    // Then
+    const scoresOld = await getScoreById(projectId, `${baseId}-score-old`);
+    expect(scoresOld).toBeUndefined();
+    const scoresNew = await getScoreById(projectId, `${baseId}-score-new`);
+    expect(scoresNew).toBeDefined();
   });
 });

--- a/worker/src/__tests__/dataRetentionProcessingTest.test.ts
+++ b/worker/src/__tests__/dataRetentionProcessingTest.test.ts
@@ -17,7 +17,6 @@ import {
 import { prisma } from "@langfuse/shared/src/db";
 import { handleDataRetentionProcessingJob } from "../ee/dataRetention/handleDataRetentionProcessingJob";
 import { Job } from "bullmq";
-import { LangfuseNotFoundError } from "@langfuse/shared";
 
 describe("DataRetentionProcessingJob", () => {
   let storageService: StorageService;

--- a/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
+++ b/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
@@ -80,7 +80,7 @@ export const handleDataRetentionProcessingJob = async (job: Job) => {
     deleteOScoresOlderThanDays(projectId, retention),
   ]);
   logger.info(
-    `[Data Retention] Deleted ClickHouse data for project ${projectId}`,
+    `[Data Retention] Deleted ClickHouse data older than ${retention} days for project ${projectId}`,
   );
 
   // Set S3 Lifecycle for deletion (Future)

--- a/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
+++ b/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
@@ -1,6 +1,6 @@
 import {
   deleteObservationsOlderThanDays,
-  deleteOScoresOlderThanDays,
+  deleteScoresOlderThanDays,
   deleteTracesOlderThanDays,
   logger,
   StorageService,
@@ -77,7 +77,7 @@ export const handleDataRetentionProcessingJob = async (job: Job) => {
   await Promise.all([
     deleteTracesOlderThanDays(projectId, retention),
     deleteObservationsOlderThanDays(projectId, retention),
-    deleteOScoresOlderThanDays(projectId, retention),
+    deleteScoresOlderThanDays(projectId, retention),
   ]);
   logger.info(
     `[Data Retention] Deleted ClickHouse data older than ${retention} days for project ${projectId}`,

--- a/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
+++ b/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
@@ -1,4 +1,7 @@
 import {
+  deleteObservationsOlderThanDays,
+  deleteOScoresOlderThanDays,
+  deleteTracesOlderThanDays,
   logger,
   StorageService,
   StorageServiceFactory,
@@ -68,6 +71,17 @@ export const handleDataRetentionProcessingJob = async (job: Job) => {
   }
 
   // Delete ClickHouse (TTL / Delete Queries)
+  logger.info(
+    `[Data Retention] Deleting ClickHouse data older than ${retention} days for project ${projectId}`,
+  );
+  await Promise.all([
+    deleteTracesOlderThanDays(projectId, retention),
+    deleteObservationsOlderThanDays(projectId, retention),
+    deleteOScoresOlderThanDays(projectId, retention),
+  ]);
+  logger.info(
+    `[Data Retention] Deleted ClickHouse data for project ${projectId}`,
+  );
 
   // Set S3 Lifecycle for deletion (Future)
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds functionality to delete data older than retention period from ClickHouse and S3, with tests for data retention processing.
> 
>   - **Behavior**:
>     - Adds `deleteObservationsOlderThanDays`, `deleteScoresOlderThanDays`, and `deleteTracesOlderThanDays` functions to remove data older than specified days from ClickHouse in `observations.ts`, `scores.ts`, and `traces.ts`.
>     - Updates `handleDataRetentionProcessingJob` in `handleDataRetentionProcessingJob.ts` to delete media files from S3 and data from ClickHouse older than retention days.
>   - **Tests**:
>     - Adds tests in `dataRetentionProcessingTest.test.ts` to verify deletion of traces, observations, and scores older than retention days.
>     - Verifies deletion of media files from S3 and database if expired.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 17aea804082e8f831c9e1463fbac7999430b5292. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->