### PR TITLE
feat(ui): scroll deeplinked observation into view in trace tree

### DIFF
--- a/web/src/components/trace/ObservationTree.tsx
+++ b/web/src/components/trace/ObservationTree.tsx
@@ -7,7 +7,7 @@ import {
   ObservationLevel,
 } from "@langfuse/shared";
 import { GroupedScoreBadges } from "@/src/components/grouped-score-badge";
-import { Fragment, useMemo } from "react";
+import { Fragment, useMemo, useRef, useEffect } from "react";
 import { type ObservationReturnType } from "@/src/server/api/routers/traces";
 import { LevelColors } from "@/src/components/level-colors";
 import { formatIntervalSeconds } from "@/src/utils/dates";
@@ -298,6 +298,23 @@ const ObservationTreeNodeCard = ({
   const duration = observation.endTime
     ? observation.endTime.getTime() - observation.startTime.getTime()
     : undefined;
+
+  // On initial render, scroll node into view if it's the current observation
+  const currentObservationRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (
+      currentObservationId &&
+      currentObservationRef.current &&
+      currentObservationId === observation.id
+    ) {
+      currentObservationRef.current.scrollIntoView({
+        behavior: "smooth",
+      });
+    }
+    // Should only trigger a single time on initial render
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentObservationRef.current]);
+
   return (
     <div className="flex">
       {Array.from({ length: indentationLevel }, (_, i) => (
@@ -310,6 +327,7 @@ const ObservationTreeNodeCard = ({
             ? "bg-muted"
             : "hover:bg-primary-foreground",
         )}
+        ref={currentObservationRef}
         onClick={() => setCurrentObservationId(observation.id)}
       >
         <div className="flex gap-2">

--- a/web/src/components/trace/ObservationTree.tsx
+++ b/web/src/components/trace/ObservationTree.tsx
@@ -211,7 +211,6 @@ const ObservationTreeNode = (props: {
   parentTotalCost?: Decimal;
   parentTotalDuration?: number;
 }) => {
-  const capture = usePostHogClientCapture();
   return (
     <>
       {props.observations
@@ -220,146 +219,24 @@ const ObservationTreeNode = (props: {
           const collapsed = props.collapsedObservations.includes(
             observation.id,
           );
-          const unnestedObservations = unnestObservations(observation);
-          const totalCost = calculateDisplayTotalCost({
-            allObservations: unnestedObservations,
-          });
-          const duration = observation.endTime
-            ? observation.endTime.getTime() - observation.startTime.getTime()
-            : undefined;
+
           return (
             <Fragment key={observation.id}>
-              <div className="flex">
-                {Array.from({ length: props.indentationLevel }, (_, i) => (
-                  <div className="mx-2 border-r" key={i} />
-                ))}
-                <div
-                  className={cn(
-                    "group my-0.5 flex flex-1 cursor-pointer flex-col gap-1 rounded-sm p-1",
-                    props.currentObservationId === observation.id
-                      ? "bg-muted"
-                      : "hover:bg-primary-foreground",
-                  )}
-                  onClick={() => props.setCurrentObservationId(observation.id)}
-                >
-                  <div className="flex gap-2">
-                    <ColorCodedObservationType
-                      observationType={observation.type}
-                    />
-                    <div className="grid flex-1 grid-cols-[auto,1fr] gap-2">
-                      <span className="break-all text-sm">
-                        {observation.name}
-                      </span>
-                      {props.comments ? (
-                        <CommentCountIcon
-                          count={props.comments.get(observation.id)}
-                          className={treeItemColors.get(observation.type)}
-                        />
-                      ) : null}
-                    </div>
-                    {observation.children.length === 0 ? null : (
-                      <Toggle
-                        onClick={(ev) => (
-                          ev.stopPropagation(),
-                          props.toggleCollapsedObservation(observation.id),
-                          capture(
-                            collapsed
-                              ? "trace_detail:observation_tree_expand"
-                              : "trace_detail:observation_tree_collapse",
-                            { type: "single" },
-                          )
-                        )}
-                        variant="default"
-                        pressed={collapsed}
-                        size="xs"
-                        className="-m-1 h-6 w-6"
-                        title={
-                          collapsed ? "Expand children" : "Collapse children"
-                        }
-                      >
-                        {collapsed ? (
-                          <PlusIcon className="h-4 w-4" />
-                        ) : (
-                          <MinusIcon className="h-4 w-4" />
-                        )}
-                      </Toggle>
-                    )}
-                  </div>
-                  {props.showMetrics &&
-                    (observation.promptTokens ||
-                      observation.completionTokens ||
-                      observation.totalTokens ||
-                      duration ||
-                      totalCost) && (
-                      <div className="flex gap-2">
-                        {duration ? (
-                          <span
-                            className={cn(
-                              "text-xs text-muted-foreground",
-                              props.parentTotalDuration &&
-                                props.colorCodeMetrics &&
-                                heatMapTextColor({
-                                  max: props.parentTotalDuration,
-                                  value: duration,
-                                }),
-                            )}
-                          >
-                            {formatIntervalSeconds(duration / 1000)}
-                          </span>
-                        ) : null}
-                        {observation.promptTokens ||
-                        observation.completionTokens ||
-                        observation.totalTokens ? (
-                          <span className="text-xs text-muted-foreground">
-                            {observation.promptTokens} →{" "}
-                            {observation.completionTokens} (∑{" "}
-                            {observation.totalTokens})
-                          </span>
-                        ) : null}
-                        {totalCost ? (
-                          <span
-                            className={cn(
-                              "text-xs text-muted-foreground",
-                              props.parentTotalCost &&
-                                props.colorCodeMetrics &&
-                                heatMapTextColor({
-                                  max: props.parentTotalCost,
-                                  value: totalCost,
-                                }),
-                            )}
-                          >
-                            {usdFormatter(totalCost.toNumber())}
-                          </span>
-                        ) : null}
-                      </div>
-                    )}
-                  {observation.level !== "DEFAULT" ? (
-                    <div className="flex">
-                      <span
-                        className={cn(
-                          "rounded-sm p-0.5 text-xs",
-                          LevelColors[observation.level].bg,
-                          LevelColors[observation.level].text,
-                        )}
-                      >
-                        {observation.level}
-                      </span>
-                    </div>
-                  ) : null}
-                  {props.showScores &&
-                  props.scores.find(
-                    (s) => s.observationId === observation.id,
-                  ) ? (
-                    <div className="flex flex-wrap gap-1">
-                      <GroupedScoreBadges
-                        scores={props.scores.filter(
-                          (s) => s.observationId === observation.id,
-                        )}
-                      />
-                    </div>
-                  ) : null}
-                </div>
-              </div>
+              <ObservationTreeNodeCard
+                observation={observation}
+                collapsed={collapsed}
+                toggleCollapsedObservation={props.toggleCollapsedObservation}
+                scores={props.scores}
+                comments={props.comments}
+                indentationLevel={props.indentationLevel}
+                currentObservationId={props.currentObservationId}
+                setCurrentObservationId={props.setCurrentObservationId}
+                showMetrics={props.showMetrics}
+                showScores={props.showScores}
+                colorCodeMetrics={props.colorCodeMetrics}
+                parentTotalCost={props.parentTotalCost}
+                parentTotalDuration={props.parentTotalDuration}
+              />
               {!collapsed && (
                 <ObservationTreeNode
                   observations={observation.children}
@@ -381,6 +258,167 @@ const ObservationTreeNode = (props: {
           );
         })}
     </>
+  );
+};
+
+const ObservationTreeNodeCard = ({
+  observation,
+  collapsed,
+  toggleCollapsedObservation,
+  indentationLevel,
+  currentObservationId,
+  setCurrentObservationId,
+  comments,
+  showMetrics,
+  showScores,
+  scores,
+  colorCodeMetrics,
+  parentTotalCost,
+  parentTotalDuration,
+}: {
+  observation: NestedObservation;
+  collapsed: boolean;
+  toggleCollapsedObservation: (id: string) => void;
+  scores: APIScore[];
+  comments?: Map<string, number> | undefined;
+  indentationLevel: number;
+  currentObservationId: string | undefined;
+  setCurrentObservationId: (id: string | undefined) => void;
+  showMetrics?: boolean;
+  showScores?: boolean;
+  colorCodeMetrics?: boolean;
+  parentTotalCost?: Decimal;
+  parentTotalDuration?: number;
+}) => {
+  const capture = usePostHogClientCapture();
+  const unnestedObservations = unnestObservations(observation);
+  const totalCost = calculateDisplayTotalCost({
+    allObservations: unnestedObservations,
+  });
+  const duration = observation.endTime
+    ? observation.endTime.getTime() - observation.startTime.getTime()
+    : undefined;
+  return (
+    <div className="flex">
+      {Array.from({ length: indentationLevel }, (_, i) => (
+        <div className="mx-2 border-r" key={i} />
+      ))}
+      <div
+        className={cn(
+          "group my-0.5 flex flex-1 cursor-pointer flex-col gap-1 rounded-sm p-1",
+          currentObservationId === observation.id
+            ? "bg-muted"
+            : "hover:bg-primary-foreground",
+        )}
+        onClick={() => setCurrentObservationId(observation.id)}
+      >
+        <div className="flex gap-2">
+          <ColorCodedObservationType observationType={observation.type} />
+          <div className="grid flex-1 grid-cols-[auto,1fr] gap-2">
+            <span className="break-all text-sm">{observation.name}</span>
+            {comments ? (
+              <CommentCountIcon
+                count={comments.get(observation.id)}
+                className={treeItemColors.get(observation.type)}
+              />
+            ) : null}
+          </div>
+          {observation.children.length === 0 ? null : (
+            <Toggle
+              onClick={(ev) => (
+                ev.stopPropagation(),
+                toggleCollapsedObservation(observation.id),
+                capture(
+                  collapsed
+                    ? "trace_detail:observation_tree_expand"
+                    : "trace_detail:observation_tree_collapse",
+                  { type: "single" },
+                )
+              )}
+              variant="default"
+              pressed={collapsed}
+              size="xs"
+              className="-m-1 h-6 w-6"
+              title={collapsed ? "Expand children" : "Collapse children"}
+            >
+              {collapsed ? (
+                <PlusIcon className="h-4 w-4" />
+              ) : (
+                <MinusIcon className="h-4 w-4" />
+              )}
+            </Toggle>
+          )}
+        </div>
+        {showMetrics &&
+          (observation.promptTokens ||
+            observation.completionTokens ||
+            observation.totalTokens ||
+            duration ||
+            totalCost) && (
+            <div className="flex gap-2">
+              {duration ? (
+                <span
+                  className={cn(
+                    "text-xs text-muted-foreground",
+                    parentTotalDuration &&
+                      colorCodeMetrics &&
+                      heatMapTextColor({
+                        max: parentTotalDuration,
+                        value: duration,
+                      }),
+                  )}
+                >
+                  {formatIntervalSeconds(duration / 1000)}
+                </span>
+              ) : null}
+              {observation.promptTokens ||
+              observation.completionTokens ||
+              observation.totalTokens ? (
+                <span className="text-xs text-muted-foreground">
+                  {observation.promptTokens} → {observation.completionTokens} (∑{" "}
+                  {observation.totalTokens})
+                </span>
+              ) : null}
+              {totalCost ? (
+                <span
+                  className={cn(
+                    "text-xs text-muted-foreground",
+                    parentTotalCost &&
+                      colorCodeMetrics &&
+                      heatMapTextColor({
+                        max: parentTotalCost,
+                        value: totalCost,
+                      }),
+                  )}
+                >
+                  {usdFormatter(totalCost.toNumber())}
+                </span>
+              ) : null}
+            </div>
+          )}
+        {observation.level !== "DEFAULT" ? (
+          <div className="flex">
+            <span
+              className={cn(
+                "rounded-sm p-0.5 text-xs",
+                LevelColors[observation.level].bg,
+                LevelColors[observation.level].text,
+              )}
+            >
+              {observation.level}
+            </span>
+          </div>
+        ) : null}
+        {showScores &&
+        scores.find((s) => s.observationId === observation.id) ? (
+          <div className="flex flex-wrap gap-1">
+            <GroupedScoreBadges
+              scores={scores.filter((s) => s.observationId === observation.id)}
+            />
+          </div>
+        ) : null}
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds feature to scroll deeplinked observation into view in trace tree by refactoring `ObservationTreeNode` and introducing `ObservationTreeNodeCard`.
> 
>   - **Behavior**:
>     - Scrolls deeplinked observation into view on initial render using `useRef` and `useEffect` in `ObservationTreeNodeCard`.
>   - **Components**:
>     - Extracts `ObservationTreeNodeCard` from `ObservationTreeNode` in `ObservationTree.tsx`.
>     - Moves observation rendering logic to `ObservationTreeNodeCard`.
>   - **Imports**:
>     - Adds `useRef` and `useEffect` to imports in `ObservationTree.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 90b8ee23507ea4a0f3dab2797dd6357b94f34ff6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->