### PR TITLE
fix(ui): tabIndex on sign in page to skip password reset and cloud region info

### DIFF
--- a/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
+++ b/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
@@ -116,6 +116,7 @@ const DataRegionInfo = () => (
         href="#"
         className="ml-1 text-xs text-primary-accent hover:text-hover-primary-accent"
         title="What is this?"
+        tabIndex={-1}
       >
         (what is this?)
       </a>

--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -484,6 +484,7 @@ export default function SignIn({
                           <Link
                             href="/auth/reset-password"
                             className="ml-1 text-xs text-primary-accent hover:text-hover-primary-accent"
+                            tabIndex={-1}
                             title="What is this?"
                           >
                             (forgot password?)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `tabIndex={-1}` for certain links on the sign-in page to improve tab navigation.
> 
>   - **UI/UX Improvements**:
>     - Set `tabIndex={-1}` for the "What is this?" link in `AuthCloudRegionSwitch.tsx` to skip it during tab navigation.
>     - Set `tabIndex={-1}` for the "forgot password?" link in `sign-in.tsx` to skip it during tab navigation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f55d05c0549791d1fb0c555f60485e3b85fdf46b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->