### PR TITLE
fix(cloud): fallback to clickhouse when usage meter cannot be fetched from stripe

### DIFF
--- a/web/src/ee/features/billing/server/cloudBillingRouter.ts
+++ b/web/src/ee/features/billing/server/cloudBillingRouter.ts
@@ -12,7 +12,10 @@ import { TRPCError } from "@trpc/server";
 import * as z from "zod";
 import { throwIfNoOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
-import { getObservationCountOfProjectsSinceCreationDate } from "@langfuse/shared/src/server";
+import {
+  getObservationCountOfProjectsSinceCreationDate,
+  logger,
+} from "@langfuse/shared/src/server";
 
 export const cloudBillingRouter = createTRPCRouter({
   createStripeCheckoutSession: protectedOrganizationProcedure
@@ -377,34 +380,43 @@ export const cloudBillingRouter = createTRPCRouter({
             end: new Date(subscription.current_period_end * 1000),
           };
 
-          const stripeInvoice = await stripeClient.invoices.retrieveUpcoming({
-            subscription: parsedOrg.cloudConfig.stripe.activeSubscriptionId,
-          });
-          const upcomingInvoice = {
-            usdAmount: stripeInvoice.amount_due / 100,
-            date: new Date(stripeInvoice.period_end * 1000),
-          };
-          const usageInvoiceLines = stripeInvoice.lines.data.filter((line) =>
-            Boolean(line.plan?.meter),
-          );
-          const usage = usageInvoiceLines.reduce((acc, line) => {
-            if (line.quantity) {
-              return acc + line.quantity;
-            }
-            return acc;
-          }, 0);
-          // get meter for usage type (events or observations)
-          const meterId = usageInvoiceLines[0]?.plan?.meter;
-          const meter = meterId
-            ? await stripeClient.billing.meters.retrieve(meterId)
-            : undefined;
+          try {
+            const stripeInvoice = await stripeClient.invoices.retrieveUpcoming({
+              subscription: parsedOrg.cloudConfig.stripe.activeSubscriptionId,
+            });
+            const upcomingInvoice = {
+              usdAmount: stripeInvoice.amount_due / 100,
+              date: new Date(stripeInvoice.period_end * 1000),
+            };
+            const usageInvoiceLines = stripeInvoice.lines.data.filter((line) =>
+              Boolean(line.plan?.meter),
+            );
+            const usage = usageInvoiceLines.reduce((acc, line) => {
+              if (line.quantity) {
+                return acc + line.quantity;
+              }
+              return acc;
+            }, 0);
+            // get meter for usage type (events or observations)
+            const meterId = usageInvoiceLines[0]?.plan?.meter;
+            const meter = meterId
+              ? await stripeClient.billing.meters.retrieve(meterId)
+              : undefined;
 
-          return {
-            usageCount: usage,
-            usageType: meter?.display_name.toLowerCase() ?? "events",
-            billingPeriod,
-            upcomingInvoice,
-          };
+            return {
+              usageCount: usage,
+              usageType: meter?.display_name.toLowerCase() ?? "events",
+              billingPeriod,
+              upcomingInvoice,
+            };
+          } catch (e) {
+            logger.warning(
+              "Failed to get usage from Stripe, using usage from Clickhouse",
+              {
+                error: e,
+              },
+            );
+          }
         }
       }
 
@@ -419,39 +431,6 @@ export const cloudBillingRouter = createTRPCRouter({
           projectIds,
           start: thirtyDaysAgo,
         });
-
-      // const usageArr = await Promise.all([
-      //   ctx.prisma.observation.count({
-      //     where: {
-      //       project: {
-      //         orgId: input.orgId,
-      //       },
-      //       createdAt: {
-      //         gte: thirtyDaysAgo,
-      //       },
-      //     },
-      //   }),
-      //   ctx.prisma.trace.count({
-      //     where: {
-      //       project: {
-      //         orgId: input.orgId,
-      //       },
-      //       createdAt: {
-      //         gte: thirtyDaysAgo,
-      //       },
-      //     },
-      //   }),
-      //   ctx.prisma.score.count({
-      //     where: {
-      //       project: {
-      //         orgId: input.orgId,
-      //       },
-      //       createdAt: {
-      //         gte: thirtyDaysAgo,
-      //       },
-      //     },
-      //   }),
-      // ]);
 
       return {
         usageCount: countObservations,

--- a/web/src/ee/features/billing/server/cloudBillingRouter.ts
+++ b/web/src/ee/features/billing/server/cloudBillingRouter.ts
@@ -410,7 +410,7 @@ export const cloudBillingRouter = createTRPCRouter({
               upcomingInvoice,
             };
           } catch (e) {
-            logger.warning(
+            logger.error(
               "Failed to get usage from Stripe, using usage from Clickhouse",
               {
                 error: e,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds fallback to Clickhouse for usage data in `getUsage` when Stripe fetch fails, with error logging.
> 
>   - **Behavior**:
>     - Adds a fallback to Clickhouse for usage data retrieval in `getUsage` in `cloudBillingRouter.ts` when Stripe data fetch fails.
>     - Logs error to `logger` when Stripe usage fetch fails.
>   - **Imports**:
>     - Adds `logger` import from `@langfuse/shared/src/server`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 80c8a6385b53cd1931922e4da95d3e4f3a50f214. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->