### PR TITLE
fix: align naming of prompt patch docs

### DIFF
--- a/fern/apis/server/definition/prompt-version.yml
+++ b/fern/apis/server/definition/prompt-version.yml
@@ -9,9 +9,9 @@ service:
     update:
       docs: Update labels for a specific prompt version
       method: PATCH
-      path: /prompts/{promptName}/version/{version}
+      path: /prompts/{name}/version/{version}
       path-parameters:
-        promptName:
+        name:
           type: string
           docs: The name of the prompt
         version:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename path parameter `promptName` to `name` in `prompt-version.yml` for the `update` endpoint.
> 
>   - **Path Parameter Renaming**:
>     - In `prompt-version.yml`, rename path parameter `promptName` to `name` in the `update` endpoint path and `path-parameters` section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 89fab099183bc036e6430e436bf5a4f00c792c27. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->