### PR TITLE
chore(datasets): increase csv upload limit to 10MB

### DIFF
--- a/web/src/features/datasets/components/UploadDatasetCsv.tsx
+++ b/web/src/features/datasets/components/UploadDatasetCsv.tsx
@@ -15,7 +15,7 @@ import {
   parseCsvClient,
 } from "@/src/features/datasets/lib/csvHelpers";
 
-export const MAX_FILE_SIZE_BYTES = 1024 * 1024 * 1; // 1MB
+export const MAX_FILE_SIZE_BYTES = 1024 * 1024 * 1 * 10; // 10MB
 const ACCEPTED_FILE_TYPES = ["text/csv"] as const;
 
 const FileSchema = z.object({
@@ -46,7 +46,7 @@ export const UploadDatasetCsv = ({
     }
 
     if (file.size > MAX_FILE_SIZE_BYTES) {
-      showErrorToast("File too large", "Maximum file size is 1MB");
+      showErrorToast("File too large", "Maximum file size is 10MB");
       event.target.value = "";
       return;
     }
@@ -57,6 +57,13 @@ export const UploadDatasetCsv = ({
         isPreview: true,
         collectSamples: true,
       });
+
+      if (preview.columns.length < 3) {
+        showErrorToast("Invalid CSV", "CSV must have at least 3 columns");
+        event.target.value = "";
+        return;
+      }
+
       setPreview(preview);
     } catch (error) {
       showErrorToast(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase CSV upload limit to 10MB, add column validation, and optimize chunk size for processing in `PreviewCsvImport.tsx` and `UploadDatasetCsv.tsx`.
> 
>   - **Behavior**:
>     - Increase CSV upload limit from 1MB to 10MB in `PreviewCsvImport.tsx` and `UploadDatasetCsv.tsx`.
>     - Add validation for CSV files to have at least 3 columns in `UploadDatasetCsv.tsx`.
>   - **Functions**:
>     - Add `getOptimalChunkSize()` in `PreviewCsvImport.tsx` to determine optimal chunk size for processing CSV data.
>     - Use `getOptimalChunkSize()` to dynamically set chunk size in `PreviewCsvImport.tsx`.
>   - **Misc**:
>     - Update error messages to reflect new file size limit in `PreviewCsvImport.tsx` and `UploadDatasetCsv.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 537b4ea72e0a308db6562f69942cdab12bf8427b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->