### PR TITLE
perf: read S3 ingestion events in chunks

### DIFF
--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -19,6 +19,7 @@ import { prisma } from "@langfuse/shared/src/db";
 import { env } from "../env";
 import { IngestionService } from "../services/IngestionService";
 import { ClickhouseWriter } from "../services/ClickhouseWriter";
+import { chunk } from "lodash";
 
 let s3StorageServiceClient: StorageService;
 
@@ -118,15 +119,28 @@ export const ingestionQueueProcessorBuilder = (
           .map((fileRef) => fileRef.createdAt)
           .sort()
           .shift() ?? new Date();
-      const events: IngestionEventType[] = (
-        await Promise.all(
-          eventFiles.map(async (fileRef) => {
-            const file = await s3Client.download(fileRef.file);
-            const parsedFile = JSON.parse(file);
-            return Array.isArray(parsedFile) ? parsedFile : [parsedFile];
-          }),
-        )
-      ).flat();
+
+      const S3_CONCURRENT_READS = 50;
+      const events: IngestionEventType[] = [];
+
+      // Process files in batches
+      // If a user has 5k events, this will likely take 100 seconds.
+      const downloadAndParseFile = async (fileRef: { file: string }) => {
+        const file = await s3Client.download(fileRef.file);
+        const parsedFile = JSON.parse(file);
+        return Array.isArray(parsedFile) ? parsedFile : [parsedFile];
+      };
+
+      const allEvents = await Promise.all(
+        chunk(eventFiles, S3_CONCURRENT_READS).map(async (batch) => {
+          const batchEvents = await Promise.all(
+            batch.map(downloadAndParseFile),
+          );
+          return batchEvents.flat();
+        }),
+      );
+
+      events.push(...allEvents.flat());
 
       if (events.length === 0) {
         logger.warn(

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -134,7 +134,6 @@ export const ingestionQueueProcessorBuilder = (
       const allEvents = [];
       const batches = chunk(eventFiles, S3_CONCURRENT_READS);
       for (const batch of batches) {
-        console.log(`Downloading batch of ${batch.length}`);
         const batchEvents = await Promise.all(batch.map(downloadAndParseFile));
         allEvents.push(...batchEvents.flat());
       }

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -131,14 +131,13 @@ export const ingestionQueueProcessorBuilder = (
         return Array.isArray(parsedFile) ? parsedFile : [parsedFile];
       };
 
-      const allEvents = await Promise.all(
-        chunk(eventFiles, S3_CONCURRENT_READS).map(async (batch) => {
-          const batchEvents = await Promise.all(
-            batch.map(downloadAndParseFile),
-          );
-          return batchEvents.flat();
-        }),
-      );
+      const allEvents = [];
+      const batches = chunk(eventFiles, S3_CONCURRENT_READS);
+      for (const batch of batches) {
+        console.log(`Downloading batch of ${batch.length}`);
+        const batchEvents = await Promise.all(batch.map(downloadAndParseFile));
+        allEvents.push(...batchEvents.flat());
+      }
 
       events.push(...allEvents.flat());
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimize S3 ingestion event reading by processing in chunks with a concurrency limit of 50 in `ingestionQueueProcessorBuilder`.
> 
>   - **Performance Optimization**:
>     - Read S3 ingestion events in chunks using `chunk` from `lodash` in `ingestionQueueProcessorBuilder`.
>     - Limit concurrent S3 reads to 50 to improve performance.
>   - **Behavior**:
>     - Process files in batches, potentially taking 100 seconds for 5k events.
>     - No change in event processing logic beyond batching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d6b39146b429de321a5180f7a6609950c3d0bb2f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->