### PR TITLE
perf: reduce redundant parsing operations within ingestionservice

### DIFF
--- a/packages/shared/src/utils/json.ts
+++ b/packages/shared/src/utils/json.ts
@@ -1,6 +1,4 @@
-import { z } from "zod";
-import { merge } from "lodash";
-import { JsonNested, jsonSchema } from "./zod";
+import { JsonNested } from "./zod";
 
 /**
  * Deeply parses a JSON string or object for nested stringified JSON
@@ -39,16 +37,6 @@ export function deepParseJson(json: unknown): unknown {
 
   return json;
 }
-
-export const mergeJson = (
-  json1?: z.infer<typeof jsonSchema>,
-  json2?: z.infer<typeof jsonSchema>,
-) => {
-  if (json1 === undefined) {
-    return json2;
-  }
-  return merge(json1, json2);
-};
 
 export const parseJsonPrioritised = (
   json: string,

--- a/packages/shared/src/utils/json.ts
+++ b/packages/shared/src/utils/json.ts
@@ -59,24 +59,3 @@ export const parseJsonPrioritised = (
     return json;
   }
 };
-
-export const convertRecordToJsonSchema = (
-  record: Record<string, string>,
-): JsonNested | undefined => {
-  const jsonSchema: JsonNested = {};
-
-  // if record is empty, return undefined
-  if (Object.keys(record).length === 0) {
-    return undefined;
-  }
-
-  for (const key in record) {
-    try {
-      jsonSchema[key] = JSON.parse(record[key]);
-    } catch (e) {
-      jsonSchema[key] = record[key];
-    }
-  }
-
-  return jsonSchema;
-};

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -271,6 +271,9 @@ export class IngestionService {
     finalTraceRecord.output = this.stringify(
       combinedTraceRecords.find((record) => record?.output),
     );
+    finalTraceRecord.metadata = convertRecordValuesToString(
+      finalTraceRecord.metadata,
+    );
 
     // If the trace has a sessionId, we upsert the corresponding session into Postgres.
     if (finalTraceRecord.session_id) {
@@ -394,6 +397,9 @@ export class IngestionService {
     );
     finalObservationRecord.output = this.stringify(
       combinedObservationRecords.find((record) => record?.output),
+    );
+    finalObservationRecord.metadata = convertRecordValuesToString(
+      finalObservationRecord.metadata,
     );
 
     // Backward compat: create wrapper trace for SDK < 2.0.0 events that do not have a traceId
@@ -519,7 +525,6 @@ export class IngestionService {
       result = overwriteObject(result, record, immutableEntityKeys);
     }
 
-    result.metadata = convertRecordValuesToString(result.metadata);
     result.event_ts = new Date().getTime();
 
     return result;

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -262,7 +262,7 @@ export class IngestionService {
 
     // Search for the first non-null input and output in the trace events and set them on the merged result.
     // Fallback to the ClickHouse input/output if none are found within the events list.
-    const reversedRawRecords = timeSortedEvents.reverse();
+    const reversedRawRecords = timeSortedEvents.slice().reverse();
     finalTraceRecord.input = this.stringify(
       reversedRawRecords.find((record) => record?.body?.input)?.body?.input ??
         clickhouseTraceRecord?.input,
@@ -389,7 +389,7 @@ export class IngestionService {
 
     // Search for the first non-null input and output in the trace events and set them on the merged result.
     // Fallback to the ClickHouse input/output if none are found within the events list.
-    const reversedRawRecords = timeSortedEvents.reverse();
+    const reversedRawRecords = timeSortedEvents.slice().reverse();
     finalObservationRecord.input = this.stringify(
       reversedRawRecords.find((record) => record?.body?.input)?.body?.input ??
         clickhouseObservationRecord?.input,

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -384,7 +384,7 @@ export class IngestionService {
       clickhouseObservationRecord?.created_at ?? createdAtTimestamp.getTime();
     mergedObservationRecord.level = mergedObservationRecord.level ?? "DEFAULT";
 
-    // Search for the first non-null input and output in the trace events and set them on the merged result.
+    // Search for the first non-null input and output in the observation events and set them on the merged result.
     // Fallback to the ClickHouse input/output if none are found within the events list.
     const reversedRawRecords = timeSortedEvents.slice().reverse();
     mergedObservationRecord.input = this.stringify(

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -261,15 +261,15 @@ export class IngestionService {
       clickhouseTraceRecord?.created_at ?? createdAtTimestamp.getTime();
 
     // Search for the first non-null input and output in the trace events and set them on the merged result.
-    const combinedTraceRecords = [
-      clickhouseTraceRecord,
-      ...traceRecords,
-    ].reverse();
+    // Fallback to the ClickHouse input/output if none are found within the events list.
+    const reversedRawRecords = timeSortedEvents.reverse();
     finalTraceRecord.input = this.stringify(
-      combinedTraceRecords.find((record) => record?.input),
+      reversedRawRecords.find((record) => record?.body?.input)?.body?.input ??
+        clickhouseTraceRecord?.input,
     );
     finalTraceRecord.output = this.stringify(
-      combinedTraceRecords.find((record) => record?.output),
+      reversedRawRecords.find((record) => record?.body?.output)?.body?.output ??
+        clickhouseTraceRecord?.output,
     );
     finalTraceRecord.metadata = convertRecordValuesToString(
       finalTraceRecord.metadata,
@@ -388,15 +388,15 @@ export class IngestionService {
     finalObservationRecord.level = finalObservationRecord.level ?? "DEFAULT";
 
     // Search for the first non-null input and output in the trace events and set them on the merged result.
-    const combinedObservationRecords = [
-      clickhouseObservationRecord,
-      ...observationRecords,
-    ].reverse();
+    // Fallback to the ClickHouse input/output if none are found within the events list.
+    const reversedRawRecords = timeSortedEvents.reverse();
     finalObservationRecord.input = this.stringify(
-      combinedObservationRecords.find((record) => record?.input),
+      reversedRawRecords.find((record) => record?.body?.input)?.body?.input ??
+        clickhouseObservationRecord?.input,
     );
     finalObservationRecord.output = this.stringify(
-      combinedObservationRecords.find((record) => record?.output),
+      reversedRawRecords.find((record) => record?.body?.output)?.body?.output ??
+        clickhouseObservationRecord?.output,
     );
     finalObservationRecord.metadata = convertRecordValuesToString(
       finalObservationRecord.metadata,

--- a/worker/src/services/IngestionService/utils.ts
+++ b/worker/src/services/IngestionService/utils.ts
@@ -1,10 +1,5 @@
-import {
-  JsonNested,
-  convertRecordToJsonSchema,
-  mergeJson,
-} from "@langfuse/shared";
+import { JsonNested, mergeJson } from "@langfuse/shared";
 import { mergeWith } from "lodash";
-import { logger } from "@langfuse/shared/src/server";
 
 export const convertJsonSchemaToRecord = (
   jsonSchema: JsonNested,
@@ -30,18 +25,6 @@ export const convertJsonSchemaToRecord = (
     }
   }
   return record;
-};
-
-const mergeRecords = (
-  record1?: Record<string, string>,
-  record2?: Record<string, string>,
-): Record<string, string> | undefined => {
-  const merged = mergeJson(
-    record1 ? (convertRecordToJsonSchema(record1) ?? undefined) : undefined,
-    record2 ? (convertRecordToJsonSchema(record2) ?? undefined) : undefined,
-  );
-
-  return merged ? convertJsonSchemaToRecord(merged) : undefined;
 };
 
 export function overwriteObject(
@@ -76,7 +59,7 @@ export function overwriteObject(
       ? b.metadata
       : !b.metadata && a.metadata
         ? a.metadata
-        : (mergeRecords(a.metadata, b.metadata) ?? {});
+        : (mergeJson(a.metadata, b.metadata) ?? {});
 
   if ("tags" in result) {
     result.tags = Array.from(

--- a/worker/src/services/IngestionService/utils.ts
+++ b/worker/src/services/IngestionService/utils.ts
@@ -1,5 +1,5 @@
-import { JsonNested, mergeJson } from "@langfuse/shared";
-import { mergeWith } from "lodash";
+import { JsonNested } from "@langfuse/shared";
+import { mergeWith, merge } from "lodash";
 
 export const convertJsonSchemaToRecord = (
   jsonSchema: JsonNested,
@@ -63,7 +63,7 @@ export function overwriteObject(
       ? b.metadata
       : !b.metadata && a.metadata
         ? a.metadata
-        : (mergeJson(a.metadata, b.metadata) ?? {});
+        : (merge(a.metadata, b.metadata) ?? {});
 
   if ("tags" in result) {
     result.tags = Array.from(

--- a/worker/src/services/IngestionService/utils.ts
+++ b/worker/src/services/IngestionService/utils.ts
@@ -1,6 +1,8 @@
 import { JsonNested } from "@langfuse/shared";
 import { mergeWith, merge } from "lodash";
 
+// Theoretically this returns Record<string, unknown>, but it would be hard to align the typing accordingly.
+// It's easier to pretend here and let JavaScript do its magic.
 export const convertJsonSchemaToRecord = (
   jsonSchema: JsonNested,
 ): Record<string, string> => {
@@ -18,7 +20,7 @@ export const convertJsonSchemaToRecord = (
     return record;
   }
 
-  return record;
+  return jsonSchema as Record<string, string>;
 };
 
 export const convertRecordValuesToString = (

--- a/worker/src/services/IngestionService/utils.ts
+++ b/worker/src/services/IngestionService/utils.ts
@@ -18,13 +18,17 @@ export const convertJsonSchemaToRecord = (
     return record;
   }
 
-  if (typeof jsonSchema === "object") {
-    for (const key in jsonSchema) {
-      const value = jsonSchema[key];
-      record[key] = typeof value === "string" ? value : JSON.stringify(value);
-    }
-  }
   return record;
+};
+
+export const convertRecordValuesToString = (
+  record: Record<string, unknown>,
+): Record<string, string> => {
+  for (const key in record) {
+    const value = record[key];
+    record[key] = typeof value === "string" ? value : JSON.stringify(value);
+  }
+  return record as Record<string, string>;
 };
 
 export function overwriteObject(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimized JSON parsing and merging in the ingestion service by removing redundant operations and improving performance.
> 
>   - **Performance Improvements**:
>     - Removed `mergeJson` and `convertRecordToJsonSchema` from `json.ts` to reduce redundant parsing.
>     - Optimized JSON stringification in `index.ts` by deferring it until necessary, specifically in `processTraceEventList()` and `processObservationEventList()`.
>     - Replaced `mergeRecords` with `merge` from `lodash` in `utils.ts` for metadata merging.
>   - **Behavior Changes**:
>     - In `index.ts`, `finalTraceRecord` and `mergedObservationRecord` now prioritize the last non-null input/output from events.
>     - Adjusted `mergeObservationRecords()` to include generation usage directly in `index.ts`.
>   - **Code Cleanup**:
>     - Removed unused imports and functions in `json.ts` and `utils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5a210e4d1df7075b41d318265578139a5fff1fca. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->