### PR TITLE
chore(llm-keys): rename vertex-ai to google-vertex-ai

### DIFF
--- a/packages/shared/prisma/migrations/20250128144418_llm_adapter_rename_google_vertex_ai/migration.sql
+++ b/packages/shared/prisma/migrations/20250128144418_llm_adapter_rename_google_vertex_ai/migration.sql
@@ -1,0 +1,1 @@
+UPDATE "llm_api_keys" SET adapter = 'google-vertex-ai' WHERE adapter = 'vertex-ai';

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -18,7 +18,7 @@ export enum LLMAdapter {
   OpenAI = "openai",
   Azure = "azure",
   Bedrock = "bedrock",
-  VertexAI = "vertex-ai",
+  VertexAI = "google-vertex-ai",
 }
 
 export enum ChatMessageRole {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renames `vertex-ai` to `google-vertex-ai` in `LLMAdapter` enum and updates `llm_api_keys` table accordingly.
> 
>   - **Behavior**:
>     - Renames `vertex-ai` to `google-vertex-ai` in `LLMAdapter` enum in `types.ts`.
>     - Updates `llm_api_keys` table in `migration.sql` to reflect the new adapter name.
>   - **Database**:
>     - Adds migration script `migration.sql` to update existing records in `llm_api_keys` table.
>   - **Enums**:
>     - Updates `LLMAdapter.VertexAI` to `google-vertex-ai` in `types.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0798a4f37a6b4a6529466259843b4e2a8e47f8a3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->