### PR TITLE
feat(messages-ui): allow removing system message

### DIFF
--- a/web/src/components/ChatMessages/ChatMessageComponent.tsx
+++ b/web/src/components/ChatMessages/ChatMessageComponent.tsx
@@ -13,13 +13,14 @@ import { CSS } from "@dnd-kit/utilities";
 type ChatMessageProps = Pick<
   MessagesContext,
   "deleteMessage" | "updateMessage" | "availableRoles"
-> & { message: ChatMessageWithId };
+> & { message: ChatMessageWithId; index: number };
 
 export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
   message,
   updateMessage,
   deleteMessage,
   availableRoles,
+  index,
 }) => {
   const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
   const [textAreaRows, setTextAreaRows] = useState(1);
@@ -35,8 +36,6 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
   } = useSortable({ id: message.id });
 
   const toggleRole = () => {
-    if (message.role === ChatMessageRole.System) return;
-
     // if user has set custom roles, available roles will be non-empty and we toggle through custom and default roles (assistant, user)
     if (!!availableRoles && Boolean(availableRoles.length)) {
       let randomRole = availableRoles[roleIndex % availableRoles.length];
@@ -52,7 +51,9 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
         "role",
         message.role === ChatMessageRole.User
           ? ChatMessageRole.Assistant
-          : ChatMessageRole.User,
+          : message.role === ChatMessageRole.Assistant && index === 0
+            ? ChatMessageRole.System
+            : ChatMessageRole.User,
       );
     }
   };
@@ -119,7 +120,6 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
           type="button" // prevents submitting a form if this button is inside a form
           size="icon"
           onClick={() => deleteMessage(message.id)}
-          disabled={message.role === ChatMessageRole.System}
         >
           <MinusCircleIcon size={16} />
         </Button>

--- a/web/src/components/ChatMessages/index.tsx
+++ b/web/src/components/ChatMessages/index.tsx
@@ -81,10 +81,10 @@ export const ChatMessages: React.FC<ChatMessagesProps> = (props) => {
               items={props.messages.map((message) => message.id)}
               strategy={verticalListSortingStrategy}
             >
-              {props.messages.map((message) => {
+              {props.messages.map((message, index) => {
                 return (
                   <ChatMessageComponent
-                    {...{ message, ...props }}
+                    {...{ message, ...props, index }}
                     key={message.id}
                   />
                 );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable removal and role toggling of system messages in `ChatMessageComponent.tsx`.
> 
>   - **Behavior**:
>     - Allow removal of system messages by enabling the delete button in `ChatMessageComponent.tsx`.
>     - Modify `toggleRole` in `ChatMessageComponent.tsx` to allow toggling to `ChatMessageRole.System` for the first message.
>   - **Props**:
>     - Add `index` prop to `ChatMessageComponent` in `ChatMessageComponent.tsx` and `index.tsx` to handle role toggling logic.
>   - **Misc**:
>     - Remove restriction on toggling role for system messages in `toggleRole` function in `ChatMessageComponent.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5f7800d0d7d193a0651f8794121859ffd632255d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->