### PR TITLE
chore: support uploads of CSV files with just one column

### DIFF
--- a/web/src/features/datasets/components/DatasetForm.tsx
+++ b/web/src/features/datasets/components/DatasetForm.tsx
@@ -17,6 +17,7 @@ import { JsonEditor } from "@/src/components/json-editor";
 import { type Prisma } from "@langfuse/shared";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { Label } from "@/src/components/ui/label";
+import { useRouter } from "next/router";
 
 interface BaseDatasetFormProps {
   mode: "create" | "update" | "delete";
@@ -96,6 +97,7 @@ export const DatasetForm = (props: DatasetFormProps) => {
   });
 
   const utils = api.useUtils();
+  const router = useRouter();
   const createMutation = api.datasets.createDataset.useMutation();
   const renameMutation = api.datasets.updateDataset.useMutation();
   const deleteMutation = api.datasets.deleteDataset.useMutation();
@@ -117,9 +119,8 @@ export const DatasetForm = (props: DatasetFormProps) => {
           void utils.datasets.invalidate();
           props.onFormSuccess?.();
           form.reset();
-          window.open(
+          router.push(
             `/project/${props.projectId}/datasets/${dataset.id}/items`,
-            "_blank",
           );
         })
         .catch((error: Error) => {

--- a/web/src/features/datasets/components/PreviewCsvImport.tsx
+++ b/web/src/features/datasets/components/PreviewCsvImport.tsx
@@ -146,29 +146,33 @@ export function PreviewCsvImport({
         selectedExpectedColumn.size === 0 &&
         selectedMetadataColumn.size === 0
       ) {
-        const defaultInput = new Set([
-          findDefaultColumn(preview.columns, "Input", 0),
-        ]);
-        const defaultExpected = new Set([
-          findDefaultColumn(preview.columns, "Expected", 1),
-        ]);
-        const defaultMetadata = new Set([
-          findDefaultColumn(preview.columns, "Metadata", 2),
-        ]);
+        const defaultInput = findDefaultColumn(preview.columns, "Input", 0);
+        const defaultExpected = findDefaultColumn(
+          preview.columns,
+          "Expected",
+          1,
+        );
+        const defaultMetadata = findDefaultColumn(
+          preview.columns,
+          "Metadata",
+          2,
+        );
 
         // Set default columns based on names
-        setSelectedInputColumn(defaultInput);
-        setSelectedExpectedColumn(defaultExpected);
-        setSelectedMetadataColumn(defaultMetadata);
+        defaultInput && setSelectedInputColumn(new Set([defaultInput]));
+        defaultExpected &&
+          setSelectedExpectedColumn(new Set([defaultExpected]));
+        defaultMetadata &&
+          setSelectedMetadataColumn(new Set([defaultMetadata]));
 
         // Update excluded columns based on current selections
         const newExcluded = new Set(
           preview.columns
             .filter(
               (col) =>
-                !defaultInput.has(col.name) &&
-                !defaultExpected.has(col.name) &&
-                !defaultMetadata.has(col.name),
+                defaultInput !== col.name &&
+                defaultExpected !== col.name &&
+                defaultMetadata !== col.name,
             )
             .map((col) => col.name),
         );
@@ -438,7 +442,11 @@ export function PreviewCsvImport({
             Cancel
           </Button>
           <Button
-            disabled={selectedInputColumn.size === 0}
+            disabled={
+              selectedInputColumn.size === 0 &&
+              selectedExpectedColumn.size === 0 &&
+              selectedMetadataColumn.size === 0
+            }
             onClick={handleImport}
           >
             Import

--- a/web/src/features/datasets/components/UploadDatasetCsv.tsx
+++ b/web/src/features/datasets/components/UploadDatasetCsv.tsx
@@ -58,8 +58,8 @@ export const UploadDatasetCsv = ({
         collectSamples: true,
       });
 
-      if (preview.columns.length < 3) {
-        showErrorToast("Invalid CSV", "CSV must have at least 3 columns");
+      if (!Boolean(preview.columns.length)) {
+        showErrorToast("Invalid CSV", "CSV must have at least 1 column");
         event.target.value = "";
         return;
       }

--- a/web/src/features/datasets/lib/csvHelpers.ts
+++ b/web/src/features/datasets/lib/csvHelpers.ts
@@ -2,7 +2,7 @@ import { parse } from "csv-parse";
 import { type Prisma } from "@langfuse/shared";
 
 const MAX_PREVIEW_ROWS = 10;
-const PREVIEW_FILE_SIZE_BYTES = 64 * 1024; // 64KB
+const PREVIEW_FILE_SIZE_BYTES = 1024 * 1024 * 2; // 2MB
 
 type ColumnType =
   | "string"

--- a/web/src/features/datasets/lib/findDefaultColumn.ts
+++ b/web/src/features/datasets/lib/findDefaultColumn.ts
@@ -5,7 +5,7 @@ export function findDefaultColumn(
   title: string,
   index: number,
 ): string | undefined {
-  if (columns.length < index) {
+  if (columns.length <= index) {
     return undefined;
   }
 

--- a/web/src/features/datasets/lib/findDefaultColumn.ts
+++ b/web/src/features/datasets/lib/findDefaultColumn.ts
@@ -4,7 +4,11 @@ export function findDefaultColumn(
   columns: { name: string }[],
   title: string,
   index: number,
-): string {
+): string | undefined {
+  if (columns.length < index) {
+    return undefined;
+  }
+
   const columnMappings: Record<string, string[]> = {
     Input: ["input", "prompt", "question", "query", "instruction"],
     Expected: [


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance CSV upload to support single-column files and improve column selection logic, with minor navigation update.
> 
>   - **CSV Upload Enhancements**:
>     - `UploadDatasetCsv.tsx`: Allow CSV files with at least 1 column instead of 3.
>     - `csvHelpers.ts`: Increase `PREVIEW_FILE_SIZE_BYTES` to 2MB.
>   - **Column Selection Logic**:
>     - `PreviewCsvImport.tsx`: Update default column selection logic to handle single-column CSVs.
>     - `findDefaultColumn.ts`: Return `undefined` if column index exceeds available columns.
>   - **Navigation**:
>     - `DatasetForm.tsx`: Use `router.push` instead of `window.open` for navigation after dataset creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b8c76ce3350504e80299277e2a6ad15b4891ca42. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->