### PR TITLE
fix(experiments): double brace in json syntax mistaken as variable

### DIFF
--- a/worker/src/ee/experiments/experimentService.ts
+++ b/worker/src/ee/experiments/experimentService.ts
@@ -40,12 +40,17 @@ const replaceVariablesInPrompt = (
   variables: string[],
 ): { role: string; content: string }[] => {
   const processContent = (content: string) => {
-    // Only include the variables that are in the variables array
+    // Extract only relevant variables from itemInput
     const filteredContext = Object.fromEntries(
       Object.entries(itemInput).filter(([key]) => variables.includes(key)),
     );
 
-    return compileHandlebarString(content, filteredContext);
+    // Apply Handlebars ONLY if the content contains `{{variable}}` pattern
+    if (content.includes("{{")) {
+      return compileHandlebarString(content, filteredContext);
+    }
+
+    return content; // Return original content if no placeholders are found
   };
 
   if (typeof prompt === "string") {

--- a/worker/src/features/utilities.ts
+++ b/worker/src/features/utilities.ts
@@ -96,7 +96,7 @@ export function compileHandlebarString(
     const template = Handlebars.compile(handlebarString, { noEscape: true });
     return template(context);
   } catch (error) {
-    console.error("Handlebars compilation error:", error);
+    logger.info("Handlebars compilation error:", error);
     return handlebarString; // Fallback to the original string if Handlebars fails
   }
 }

--- a/worker/src/features/utilities.ts
+++ b/worker/src/features/utilities.ts
@@ -92,6 +92,11 @@ export function compileHandlebarString(
   handlebarString: string,
   context: Record<string, any>,
 ): string {
-  const template = Handlebars.compile(handlebarString);
-  return template(context);
+  try {
+    const template = Handlebars.compile(handlebarString, { noEscape: true });
+    return template(context);
+  } catch (error) {
+    console.error("Handlebars compilation error:", error);
+    return handlebarString; // Fallback to the original string if Handlebars fails
+  }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves Handlebars template handling in `experimentService.ts` and `utilities.ts` by conditionally compiling and logging errors.
> 
>   - **Behavior**:
>     - In `replaceVariablesInPrompt()` in `experimentService.ts`, Handlebars compilation is now conditional on the presence of `{{` in the content.
>     - In `compileHandlebarString()` in `utilities.ts`, added error handling to log and return the original string if Handlebars compilation fails.
>   - **Logging**:
>     - Logs Handlebars compilation errors in `compileHandlebarString()` in `utilities.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f51c7762ccdbb04c3a908f0b5f9b2404e879d2ed. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->