### PR TITLE
fix(dataset-analytics): latency label should denote seconds (s)

### DIFF
--- a/web/src/features/dashboard/lib/score-analytics-utils.ts
+++ b/web/src/features/dashboard/lib/score-analytics-utils.ts
@@ -12,7 +12,7 @@ export const RESOURCE_METRICS = [
     key: "latency",
     value: "Latency",
     objectKey: "avgLatency",
-    label: "Latency (ms)",
+    label: "Latency (s)",
   },
   {
     key: "cost",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update latency label in `score-analytics-utils.ts` to denote seconds instead of milliseconds.
> 
>   - **Behavior**:
>     - Update `label` for latency metric in `score-analytics-utils.ts` from "Latency (ms)" to "Latency (s)" to correctly denote seconds instead of milliseconds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2268067ff62d96ff4596d5e8b88f3cec36ddf8a3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->