### PR TITLE
chore: remove data retention beta label and allow self-host enterprise plan

### DIFF
--- a/web/src/features/entitlements/constants/entitlements.ts
+++ b/web/src/features/entitlements/constants/entitlements.ts
@@ -126,6 +126,7 @@ export const entitlementAccess: Record<
       "self-host-ui-customization",
       "integration-posthog",
       "audit-logs",
+      "data-retention",
     ],
     entitlementLimits: {
       "annotation-queue-count": false,

--- a/web/src/features/projects/components/ConfigureRetention.tsx
+++ b/web/src/features/projects/components/ConfigureRetention.tsx
@@ -62,7 +62,7 @@ export default function ConfigureRetention() {
 
   return (
     <div>
-      <Header title="Data Retention (Beta)" level="h3" />
+      <Header title="Data Retention" level="h3" />
       <Card className="mb-4 p-3">
         <p className="mb-4 text-sm text-primary">
           Data retention automatically deletes events older than the specified


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove 'Beta' label from 'Data Retention' in UI and update entitlements to include 'data-retention'.
> 
>   - **UI Changes**:
>     - Remove "Beta" label from "Data Retention" header in `ConfigureRetention.tsx`.
>   - **Entitlements**:
>     - Add `"data-retention"` to `entitlementAccess` in `entitlements.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f3e15113a5bf43076d2b0b5d8296f846c58697d9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->