### PR TITLE
fix(rbac): load trace data in shared sessions

### DIFF
--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -370,12 +370,12 @@ const enforceTraceAccess = t.middleware(async ({ ctx, rawInput, next }) => {
       })
     : null;
 
-  const isSessionPrivate = !!traceSession && !traceSession.public;
+  const isSessionPublic = traceSession?.public === true;
 
   if (
     !trace.public &&
     !sessionProject &&
-    (isSessionPrivate || !trace.sessionId) &&
+    !isSessionPublic &&
     ctx.session?.user?.admin !== true
   ) {
     logger.error(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `enforceTraceAccess` in `trpc.ts` to allow access to public trace sessions.
> 
>   - **Behavior**:
>     - Update `enforceTraceAccess` middleware in `trpc.ts` to check if a trace session is public.
>     - Allows access to trace data if the session is public, even if the user is not a project member or admin.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 76814837208d02981a14948b6d9dfabb65a28723. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->