### PR TITLE
fix(media-ui): fetch i/o media only for authed project member

### DIFF
--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -89,6 +89,7 @@ export const ObservationPreview = ({
       projectId: projectId,
     },
     {
+      enabled: isAuthenticatedAndProjectMember,
       refetchOnWindowFocus: false,
       refetchOnMount: false,
       refetchOnReconnect: false,

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -82,6 +82,7 @@ export const TracePreview = ({
       projectId: trace.projectId,
     },
     {
+      enabled: isAuthenticatedAndProjectMember,
       refetchOnWindowFocus: false,
       refetchOnMount: false,
       refetchOnReconnect: false,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Restrict media fetching to authenticated project members in `ObservationPreview` and `TracePreview`.
> 
>   - **Behavior**:
>     - Add `enabled: isAuthenticatedAndProjectMember` to `observationMedia` query in `ObservationPreview` to fetch media only for authenticated project members.
>     - Add `enabled: isAuthenticatedAndProjectMember` to `traceMedia` query in `TracePreview` to fetch media only for authenticated project members.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for dd5fa6bae383e335f02a5597a72af9465d987447. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->