### PR TITLE
feat: add posthog events to cmd+k menu

### DIFF
--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -152,6 +152,7 @@ const events = {
   help_popup: ["opened", "href_clicked"],
   navigate_detail_pages: ["button_click_prev_or_next"],
   support_chat: ["initiated", "opened", "message_sent"], // also used on landing page for consistency
+  cmd_k_menu: ["opened", "search_entered", "navigated"],
 } as const;
 
 // type that represents all possible event names, e.g. "traces:bookmark"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add PostHog event tracking to Command+K menu for open, search, and navigation actions.
> 
>   - **Behavior**:
>     - Add PostHog event tracking to `CommandKMenu` in `command-k-menu.tsx` for `cmd_k_menu:opened`, `cmd_k_menu:search_entered`, and `cmd_k_menu:navigated` events.
>     - Use `useDebounce` for search input to capture `cmd_k_menu:search_entered` after 500ms delay.
>   - **Analytics**:
>     - Update `events` in `usePostHogClientCapture.ts` to include `cmd_k_menu` events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 62cb7fb689b98750c4e7141c97be91b74d5be333. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->