### PR TITLE
feat: add posthog events to cmd+k menu

### DIFF
--- a/web/src/components/command-k-menu.tsx
+++ b/web/src/components/command-k-menu.tsx
@@ -25,6 +25,16 @@ export function CommandKMenu({
   const { allProjectItems } = useNavigationItems();
   const capture = usePostHogClientCapture();
 
+  const debouncedSearchChange = useDebounce(
+    (value: string) => {
+      capture("cmd_k_menu:search_entered", {
+        search: value,
+      });
+    },
+    500,
+    false,
+  );
+
   const navItems = mainNavigation
     .flatMap((item) => [
       {
@@ -71,15 +81,7 @@ export function CommandKMenu({
       <CommandInput
         placeholder="Type a command or search..."
         className="border-none focus:border-none focus:outline-none focus:ring-0 focus:ring-transparent"
-        onValueChange={useDebounce(
-          (value: string) => {
-            capture("cmd_k_menu:search_entered", {
-              search: value,
-            });
-          },
-          500,
-          false,
-        )}
+        onValueChange={debouncedSearchChange}
       />
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -152,6 +152,7 @@ const events = {
   help_popup: ["opened", "href_clicked"],
   navigate_detail_pages: ["button_click_prev_or_next"],
   support_chat: ["initiated", "opened", "message_sent"], // also used on landing page for consistency
+  cmd_k_menu: ["opened", "search_entered", "navigated"],
 } as const;
 
 // type that represents all possible event names, e.g. "traces:bookmark"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add PostHog event tracking to Command+K menu for open, search, and navigation events.
> 
>   - **Behavior**:
>     - Add PostHog event tracking to `CommandKMenu` in `command-k-menu.tsx` for events: `cmd_k_menu:opened`, `cmd_k_menu:search_entered`, and `cmd_k_menu:navigated`.
>     - Use `useDebounce` for debouncing search input changes before capturing `cmd_k_menu:search_entered` event.
>   - **Analytics**:
>     - Update `events` in `usePostHogClientCapture.ts` to include `cmd_k_menu` events: `opened`, `search_entered`, `navigated`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 66a08af02a1a8d8f9a1b7be4007825dac49a4795. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->