### PR TITLE
chore(evals): handle invalid JSON error if maxTokens too low

### DIFF
--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -115,6 +115,8 @@ export const evalJobExecutorQueueProcessor = async (
       (e instanceof BaseError && e.message.includes("API key for provider")) || // api key not provided
       (e instanceof ApiError && e.httpCode >= 400 && e.httpCode < 500) || // do not error and retry on 4xx errors. They are visible to the user in the UI but do not alert us.
       (e instanceof ApiError && e.message.includes("TypeError")) || // Zod parsing the response failed. User should update prompt to consistently return expected output structure.
+      (e instanceof ApiError &&
+        e.message.includes("Error: Unterminated string in JSON at position")) || // When evaluator model is configured with too low max_tokens, the structured output response is invalid JSON
       (e instanceof BaseError &&
         e.message.includes(
           "Please ensure the mapped data exists and consider extending the job delay.",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add error handling for invalid JSON response in `evalJobExecutorQueueProcessor` when `max_tokens` is too low.
> 
>   - **Error Handling**:
>     - In `evalJobExecutorQueueProcessor` in `evalQueue.ts`, added condition to handle `ApiError` with message "Error: Unterminated string in JSON at position".
>     - Prevents retries and logging for invalid JSON response when `max_tokens` is too low.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ce32747bada9972578e8815dcd1d1ab77a8b67a7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->