### PR TITLE
docs(tracing-users): add header tooltips to user table

### DIFF
--- a/web/src/pages/project/[projectId]/users.tsx
+++ b/web/src/pages/project/[projectId]/users.tsx
@@ -134,6 +134,11 @@ export default function UsersPage() {
       accessorKey: "userId",
       enableColumnFilter: true,
       header: "User ID",
+      headerTooltip: {
+        description:
+          "The unique identifier for the user that was logged in Langfuse. See docs for more details on how to set this up.",
+        href: "https://langfuse.com/docs/tracing-features/users",
+      },
       size: 150,
       cell: ({ row }) => {
         const value: RowData["userId"] = row.getValue("userId");
@@ -150,6 +155,9 @@ export default function UsersPage() {
     {
       accessorKey: "firstEvent",
       header: "First Event",
+      headerTooltip: {
+        description: "The earliest trace recorded for this user.",
+      },
       size: 150,
       cell: ({ row }) => {
         const value: RowData["firstEvent"] = row.getValue("firstEvent");
@@ -164,6 +172,9 @@ export default function UsersPage() {
     {
       accessorKey: "lastEvent",
       header: "Last Event",
+      headerTooltip: {
+        description: "The latest trace recorded for this user.",
+      },
       size: 150,
       cell: ({ row }) => {
         const value: RowData["lastEvent"] = row.getValue("lastEvent");
@@ -178,6 +189,11 @@ export default function UsersPage() {
     {
       accessorKey: "totalEvents",
       header: "Total Events",
+      headerTooltip: {
+        description:
+          "Total number of events for the user, includes traces and observations. See data model for more details.",
+        href: "https://langfuse.com/docs/tracing-data-model",
+      },
       size: 120,
       cell: ({ row }) => {
         const value: RowData["totalEvents"] = row.getValue("totalEvents");
@@ -192,6 +208,11 @@ export default function UsersPage() {
     {
       accessorKey: "totalTokens",
       header: "Total Tokens",
+      headerTooltip: {
+        description:
+          "Total number of tokens used for the user across all generations.",
+        href: "https://langfuse.com/docs/model-usage-and-cost",
+      },
       size: 120,
       cell: ({ row }) => {
         const value: RowData["totalTokens"] = row.getValue("totalTokens");
@@ -206,6 +227,10 @@ export default function UsersPage() {
     {
       accessorKey: "totalCost",
       header: "Total Cost",
+      headerTooltip: {
+        description: "Total cost for the user across all generations.",
+        href: "https://langfuse.com/docs/model-usage-and-cost",
+      },
       size: 120,
       cell: ({ row }) => {
         const value: RowData["totalCost"] = row.getValue("totalCost");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add tooltips to user table headers in `users.tsx` for better context and documentation links.
> 
>   - **UI Enhancements**:
>     - Added `headerTooltip` to `userId`, `firstEvent`, `lastEvent`, `totalEvents`, `totalTokens`, and `totalCost` columns in `users.tsx`.
>     - Tooltips provide descriptions and links to relevant documentation for each column.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a4019926347b8dc83a0369da54c13e9197c6806c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->