### PR TITLE
feat(prompts): scroll selected prompt version into view

### DIFF
--- a/web/src/components/trace/ObservationTree.tsx
+++ b/web/src/components/trace/ObservationTree.tsx
@@ -309,6 +309,7 @@ const ObservationTreeNodeCard = ({
     ) {
       currentObservationRef.current.scrollIntoView({
         behavior: "smooth",
+        block: "center",
       });
     }
     // Should only trigger a single time on initial render

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -12,7 +12,6 @@ import { PromptType } from "@/src/features/prompts/server/utils/validation";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 import { api } from "@/src/utils/api";
 import { extractVariables } from "@langfuse/shared";
-import { ScrollArea } from "@radix-ui/react-scroll-area";
 import { TagPromptDetailsPopover } from "@/src/features/tag/components/TagPromptDetailsPopover";
 import { PromptHistoryNode } from "./prompt-history";
 import Generations from "@/src/components/table/use-cases/observations";
@@ -29,7 +28,7 @@ import { Lock, Plus, FlaskConical } from "lucide-react";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { Button } from "@/src/components/ui/button";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
-import { ScrollScreenPage } from "@/src/components/layouts/scroll-screen-page";
+import { FullScreenPage } from "@/src/components/layouts/full-screen-page";
 import {
   Dialog,
   DialogContent,
@@ -139,7 +138,7 @@ export const PromptDetail = () => {
   }
 
   return (
-    <ScrollScreenPage>
+    <FullScreenPage>
       <Header
         title={prompt.name}
         help={{
@@ -254,7 +253,7 @@ export const PromptDetail = () => {
           </>
         }
       />
-      <div className="grid grid-cols-3 gap-4">
+      <div className="grid grid-cols-3 gap-4 overflow-hidden">
         <div className="col-span-3">
           <div className="mb-5 rounded-lg border bg-card font-semibold text-card-foreground">
             <div className="flex flex-row items-center gap-3 px-3 py-1">
@@ -270,7 +269,7 @@ export const PromptDetail = () => {
             </div>
           </div>
         </div>
-        <div className="col-span-2 md:h-full">
+        <div className="col-span-2 overflow-y-auto">
           {prompt.type === PromptType.Chat && chatMessages ? (
             <OpenAiMessageView
               title="Chat prompt"
@@ -351,19 +350,15 @@ export const PromptDetail = () => {
             cardView
           />
         </div>
-        <div className="flex flex-col">
-          <div className="text-m px-3 font-medium">
-            <ScrollArea className="flex border-l pl-2">
-              <PromptHistoryNode
-                prompts={promptHistory.data.promptVersions}
-                currentPromptVersion={prompt.version}
-                setCurrentPromptVersion={setCurrentPromptVersion}
-                totalCount={promptHistory.data.totalCount}
-              />
-            </ScrollArea>
-          </div>
+        <div className="text-m flex flex-col overflow-y-auto border-l px-3 pl-2 font-medium">
+          <PromptHistoryNode
+            prompts={promptHistory.data.promptVersions}
+            currentPromptVersion={prompt.version}
+            setCurrentPromptVersion={setCurrentPromptVersion}
+            totalCount={promptHistory.data.totalCount}
+          />
         </div>
       </div>
-    </ScrollScreenPage>
+    </FullScreenPage>
   );
 };

--- a/web/src/features/prompts/components/prompt-history.tsx
+++ b/web/src/features/prompts/components/prompt-history.tsx
@@ -4,7 +4,7 @@ import { SetPromptVersionLabels } from "@/src/features/prompts/components/SetPro
 import { PRODUCTION_LABEL } from "@/src/features/prompts/constants";
 import { type RouterOutputs } from "@/src/utils/api";
 import { type NextRouter, useRouter } from "next/router";
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { PromptVersionDiffDialog } from "./PromptVersionDiffDialog";
 
 const PromptHistoryTraceNode = (props: {
@@ -21,6 +21,26 @@ const PromptHistoryTraceNode = (props: {
   const [isLabelPopoverOpen, setIsLabelPopoverOpen] = useState(false);
   const [isPromptDiffOpen, setIsPromptDiffOpen] = useState(false);
   const { prompt } = props;
+
+  // Add ref for scroll into view
+  const currentPromptRef = useRef<HTMLDivElement>(null);
+
+  // Add useEffect for scroll into view behavior
+  useEffect(() => {
+    if (
+      props.currentPromptVersion &&
+      currentPromptRef.current &&
+      props.currentPromptVersion === prompt.version
+    ) {
+      currentPromptRef.current.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
+    }
+    // Should only trigger a single time on initial render
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentPromptRef.current]);
+
   let badges: JSX.Element[] = prompt.labels
     .sort((a, b) =>
       a === PRODUCTION_LABEL
@@ -41,6 +61,7 @@ const PromptHistoryTraceNode = (props: {
 
   return (
     <div
+      ref={currentPromptRef}
       className={`group mb-2 flex w-full cursor-pointer flex-col gap-1 rounded-sm p-2 hover:bg-primary-foreground ${
         props.currentPromptVersion === prompt.version ? "bg-muted" : ""
       }`}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance prompt version selection by scrolling it into view and updating UI components for better user experience.
> 
>   - **Behavior**:
>     - Scrolls the selected prompt version into view in `ObservationTreeNodeCard` and `PromptHistoryTraceNode` using `scrollIntoView` with `behavior: "smooth"` and `block: "center"`.
>   - **UI Components**:
>     - Replaces `ScrollScreenPage` with `FullScreenPage` in `prompt-detail.tsx`.
>     - Adds `overflow-y-auto` to divs in `prompt-detail.tsx` for better scrolling behavior.
>   - **Imports**:
>     - Removes unused `ScrollArea` import from `prompt-detail.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9b75a4580a907075cd6e1743193c6922ff8bc7f4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->