### PR TITLE
perf: batch read single S3 events

### DIFF
--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -19,6 +19,7 @@ import { prisma } from "@langfuse/shared/src/db";
 import { env } from "../env";
 import { IngestionService } from "../services/IngestionService";
 import { ClickhouseWriter } from "../services/ClickhouseWriter";
+import { chunk } from "lodash";
 
 let s3StorageServiceClient: StorageService;
 
@@ -118,15 +119,28 @@ export const ingestionQueueProcessorBuilder = (
           .map((fileRef) => fileRef.createdAt)
           .sort()
           .shift() ?? new Date();
-      const events: IngestionEventType[] = (
-        await Promise.all(
-          eventFiles.map(async (fileRef) => {
-            const file = await s3Client.download(fileRef.file);
-            const parsedFile = JSON.parse(file);
-            return Array.isArray(parsedFile) ? parsedFile : [parsedFile];
-          }),
-        )
-      ).flat();
+
+      const S3_CONCURRENT_READS = 50;
+      const events: IngestionEventType[] = [];
+
+      // Process files in batches
+      // If a user has 5k events, this will likely take 100 seconds.
+      const downloadAndParseFile = async (fileRef: { file: string }) => {
+        const file = await s3Client.download(fileRef.file);
+        const parsedFile = JSON.parse(file);
+        return Array.isArray(parsedFile) ? parsedFile : [parsedFile];
+      };
+
+      const allEvents = await Promise.all(
+        chunk(eventFiles, S3_CONCURRENT_READS).map(async (batch) => {
+          const batchEvents = await Promise.all(
+            batch.map(downloadAndParseFile),
+          );
+          return batchEvents.flat();
+        }),
+      );
+
+      events.push(...allEvents.flat());
 
       if (events.length === 0) {
         logger.warn(

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -131,14 +131,11 @@ export const ingestionQueueProcessorBuilder = (
         return Array.isArray(parsedFile) ? parsedFile : [parsedFile];
       };
 
-      const allEvents = [];
       const batches = chunk(eventFiles, S3_CONCURRENT_READS);
       for (const batch of batches) {
         const batchEvents = await Promise.all(batch.map(downloadAndParseFile));
-        allEvents.push(...batchEvents.flat());
+        events.push(...batchEvents.flat());
       }
-
-      events.push(...allEvents.flat());
 
       if (events.length === 0) {
         logger.warn(

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -134,7 +134,6 @@ export const ingestionQueueProcessorBuilder = (
       const allEvents = [];
       const batches = chunk(eventFiles, S3_CONCURRENT_READS);
       for (const batch of batches) {
-        console.log(`Downloading batch of ${batch.length}`);
         const batchEvents = await Promise.all(batch.map(downloadAndParseFile));
         allEvents.push(...batchEvents.flat());
       }

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -131,14 +131,13 @@ export const ingestionQueueProcessorBuilder = (
         return Array.isArray(parsedFile) ? parsedFile : [parsedFile];
       };
 
-      const allEvents = await Promise.all(
-        chunk(eventFiles, S3_CONCURRENT_READS).map(async (batch) => {
-          const batchEvents = await Promise.all(
-            batch.map(downloadAndParseFile),
-          );
-          return batchEvents.flat();
-        }),
-      );
+      const allEvents = [];
+      const batches = chunk(eventFiles, S3_CONCURRENT_READS);
+      for (const batch of batches) {
+        console.log(`Downloading batch of ${batch.length}`);
+        const batchEvents = await Promise.all(batch.map(downloadAndParseFile));
+        allEvents.push(...batchEvents.flat());
+      }
 
       events.push(...allEvents.flat());
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Batch S3 event file reads in `ingestionQueueProcessorBuilder` to improve performance by processing files in batches of 50.
> 
>   - **Performance**:
>     - Batch S3 event file reads in `ingestionQueueProcessorBuilder` using `chunk` from `lodash`.
>     - Process files in batches of 50 to improve performance.
>   - **Misc**:
>     - Add `chunk` import from `lodash` in `ingestionQueue.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 09e089fc4bea92827173744926efbf3ef954b18c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->