### PR TITLE
fix: disable autopipelining for rate limits to avoid uncaught exceptions

### DIFF
--- a/web/src/__tests__/rate-limit.servertest.ts
+++ b/web/src/__tests__/rate-limit.servertest.ts
@@ -71,7 +71,7 @@ describe("RateLimitService", () => {
 
     expect(redis).toBeDefined();
 
-    const rateLimitService = new RateLimitService(redis!);
+    const rateLimitService = RateLimitService.getInstance();
     const result = await rateLimitService.rateLimitRequest(scope, "public-api");
 
     expect(result?.res).toEqual({
@@ -102,7 +102,7 @@ describe("RateLimitService", () => {
       rateLimitOverrides: [],
     };
 
-    const rateLimitService = new RateLimitService(redis!);
+    const rateLimitService = RateLimitService.getInstance();
     await rateLimitService.rateLimitRequest(scope, "public-api");
 
     const result = await rateLimitService.rateLimitRequest(scope, "public-api");
@@ -130,7 +130,7 @@ describe("RateLimitService", () => {
       ],
     };
 
-    const rateLimitService = new RateLimitService(redis!);
+    const rateLimitService = RateLimitService.getInstance();
     await rateLimitService.rateLimitRequest(scope, "public-api");
 
     const firstResult = await rateLimitService.rateLimitRequest(
@@ -180,7 +180,7 @@ describe("RateLimitService", () => {
       ],
     };
 
-    const rateLimitService = new RateLimitService(redis!);
+    const rateLimitService = RateLimitService.getInstance();
 
     for (let i = 0; i < 5; i++) {
       await rateLimitService.rateLimitRequest(scope, "public-api");
@@ -211,7 +211,7 @@ describe("RateLimitService", () => {
       ],
     };
 
-    const rateLimitService = new RateLimitService(redis!);
+    const rateLimitService = RateLimitService.getInstance();
 
     const result = await rateLimitService.rateLimitRequest(scope, "public-api");
 
@@ -237,7 +237,7 @@ describe("RateLimitService", () => {
       ],
     };
 
-    const rateLimitService = new RateLimitService(redis!);
+    const rateLimitService = RateLimitService.getInstance();
 
     const result = await rateLimitService.rateLimitRequest(scope, "prompts");
 
@@ -256,7 +256,7 @@ describe("RateLimitService", () => {
       ],
     };
 
-    const rateLimitService = new RateLimitService(redis!);
+    const rateLimitService = RateLimitService.getInstance();
 
     const result = await rateLimitService.rateLimitRequest(scope, "ingestion");
 
@@ -291,7 +291,7 @@ describe("RateLimitService", () => {
       rateLimitOverrides: [],
     };
 
-    const rateLimitService = new RateLimitService(redis!);
+    const rateLimitService = RateLimitService.getInstance();
 
     const result = await rateLimitService.rateLimitRequest(scope, "public-api");
 

--- a/web/src/__tests__/rate-limit.servertest.ts
+++ b/web/src/__tests__/rate-limit.servertest.ts
@@ -11,6 +11,7 @@ describe("RateLimitService", () => {
   beforeAll(() => {
     redis = new Redis("redis://:myredissecret@127.0.0.1:6379", {
       maxRetriesPerRequest: null,
+      enableAutoPipelining: false, // Align with our settings overwrite for rate limit service
     });
   });
 
@@ -71,7 +72,7 @@ describe("RateLimitService", () => {
 
     expect(redis).toBeDefined();
 
-    const rateLimitService = RateLimitService.getInstance();
+    const rateLimitService = RateLimitService.getInstance(redis);
     const result = await rateLimitService.rateLimitRequest(scope, "public-api");
 
     expect(result?.res).toEqual({
@@ -102,7 +103,7 @@ describe("RateLimitService", () => {
       rateLimitOverrides: [],
     };
 
-    const rateLimitService = RateLimitService.getInstance();
+    const rateLimitService = RateLimitService.getInstance(redis);
     await rateLimitService.rateLimitRequest(scope, "public-api");
 
     const result = await rateLimitService.rateLimitRequest(scope, "public-api");
@@ -130,7 +131,7 @@ describe("RateLimitService", () => {
       ],
     };
 
-    const rateLimitService = RateLimitService.getInstance();
+    const rateLimitService = RateLimitService.getInstance(redis);
     await rateLimitService.rateLimitRequest(scope, "public-api");
 
     const firstResult = await rateLimitService.rateLimitRequest(
@@ -180,7 +181,7 @@ describe("RateLimitService", () => {
       ],
     };
 
-    const rateLimitService = RateLimitService.getInstance();
+    const rateLimitService = RateLimitService.getInstance(redis);
 
     for (let i = 0; i < 5; i++) {
       await rateLimitService.rateLimitRequest(scope, "public-api");
@@ -211,7 +212,7 @@ describe("RateLimitService", () => {
       ],
     };
 
-    const rateLimitService = RateLimitService.getInstance();
+    const rateLimitService = RateLimitService.getInstance(redis);
 
     const result = await rateLimitService.rateLimitRequest(scope, "public-api");
 
@@ -237,7 +238,7 @@ describe("RateLimitService", () => {
       ],
     };
 
-    const rateLimitService = RateLimitService.getInstance();
+    const rateLimitService = RateLimitService.getInstance(redis);
 
     const result = await rateLimitService.rateLimitRequest(scope, "prompts");
 
@@ -256,7 +257,7 @@ describe("RateLimitService", () => {
       ],
     };
 
-    const rateLimitService = RateLimitService.getInstance();
+    const rateLimitService = RateLimitService.getInstance(redis);
 
     const result = await rateLimitService.rateLimitRequest(scope, "ingestion");
 
@@ -291,7 +292,7 @@ describe("RateLimitService", () => {
       rateLimitOverrides: [],
     };
 
-    const rateLimitService = RateLimitService.getInstance();
+    const rateLimitService = RateLimitService.getInstance(redis);
 
     const result = await rateLimitService.rateLimitRequest(scope, "public-api");
 

--- a/web/src/__tests__/rate-limit.servertest.ts
+++ b/web/src/__tests__/rate-limit.servertest.ts
@@ -264,24 +264,25 @@ describe("RateLimitService", () => {
     expect(result?.res).toBeUndefined();
   });
 
-  it("should not apply rate limits when redis is not defined", async () => {
-    const scope = {
-      orgId: orgId,
-      plan: "cloud:hobby" as const,
-      projectId: "test-project-id",
-      accessLevel: "all" as const,
-      rateLimitOverrides: [
-        { resource: "public-api" as const, points: 5, durationInSec: 10 },
-      ],
-    };
-
-    const rateLimitService = new RateLimitService(null);
-
-    const result = await rateLimitService.rateLimitRequest(scope, "public-api");
-
-    expect(result?.res).toBeUndefined();
-    expect(result?.isRateLimited()).toBe(false);
-  });
+  // Not applicable now that the RateLimitService instantiates its own Redis
+  // it("should not apply rate limits when redis is not defined", async () => {
+  //   const scope = {
+  //     orgId: orgId,
+  //     plan: "cloud:hobby" as const,
+  //     projectId: "test-project-id",
+  //     accessLevel: "all" as const,
+  //     rateLimitOverrides: [
+  //       { resource: "public-api" as const, points: 5, durationInSec: 10 },
+  //     ],
+  //   };
+  //
+  //   const rateLimitService = new RateLimitService(null);
+  //
+  //   const result = await rateLimitService.rateLimitRequest(scope, "public-api");
+  //
+  //   expect(result?.res).toBeUndefined();
+  //   expect(result?.isRateLimited()).toBe(false);
+  // });
 
   it("should not apply rate limits for OSS plan", async () => {
     const scope = {

--- a/web/src/features/prompts/server/handlers/promptNameHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptNameHandler.ts
@@ -3,7 +3,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { getPromptByName } from "@/src/features/prompts/server/actions/getPromptByName";
 import { GetPromptByNameSchema } from "@/src/features/prompts/server/utils/validation";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
-import { redis } from "@langfuse/shared/src/server";
 import { authorizePromptRequestOrThrow } from "../utils/authorizePromptRequest";
 import { LangfuseNotFoundError } from "@langfuse/shared";
 import { PRODUCTION_LABEL } from "@/src/features/prompts/constants";
@@ -15,7 +14,7 @@ const getPromptNameHandler = async (
 ) => {
   const authCheck = await authorizePromptRequestOrThrow(req);
 
-  const rateLimitCheck = await new RateLimitService(redis).rateLimitRequest(
+  const rateLimitCheck = await RateLimitService.getInstance().rateLimitRequest(
     authCheck.scope,
     "prompts",
   );

--- a/web/src/features/prompts/server/handlers/promptsHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptsHandler.ts
@@ -8,14 +8,13 @@ import {
 } from "@/src/features/prompts/server/utils/validation";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { prisma } from "@langfuse/shared/src/db";
-import { redis } from "@langfuse/shared/src/server";
 import { authorizePromptRequestOrThrow } from "../utils/authorizePromptRequest";
 import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
 
 const getPromptsHandler = async (req: NextApiRequest, res: NextApiResponse) => {
   const authCheck = await authorizePromptRequestOrThrow(req);
 
-  const rateLimitCheck = await new RateLimitService(redis).rateLimitRequest(
+  const rateLimitCheck = await RateLimitService.getInstance().rateLimitRequest(
     authCheck.scope,
     "prompts",
   );
@@ -39,7 +38,7 @@ const postPromptsHandler = async (
 ) => {
   const authCheck = await authorizePromptRequestOrThrow(req);
 
-  const rateLimitCheck = await new RateLimitService(redis).rateLimitRequest(
+  const rateLimitCheck = await RateLimitService.getInstance().rateLimitRequest(
     authCheck.scope,
     "prompts",
   );

--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -12,6 +12,7 @@ import {
   recordIncrement,
   type ApiAccessScope,
   logger,
+  createNewRedisInstance,
 } from "@langfuse/shared/src/server";
 import { type NextApiResponse } from "next";
 
@@ -22,10 +23,17 @@ import { type NextApiResponse } from "next";
 // - isRateLimited returns false for self-hosters
 // - sendRestResponseIfLimited sends a 429 response with headers if the rate limit is exceeded. Return this from the route handler.
 export class RateLimitService {
-  private redis: Redis | null;
+  private static redis: Redis | null;
+  private static instance: RateLimitService | null = null;
 
-  constructor(redis: Redis | null) {
-    this.redis = redis;
+  public static getInstance() {
+    if (!RateLimitService.instance) {
+      RateLimitService.redis = createNewRedisInstance({
+        enableAutoPipelining: false, // This may help avoid https://github.com/redis/ioredis/issues/1931
+      });
+      RateLimitService.instance = new RateLimitService();
+    }
+    return RateLimitService.instance;
   }
 
   async rateLimitRequest(
@@ -41,7 +49,7 @@ export class RateLimitService {
       return new RateLimitHelper(undefined);
     }
 
-    if (!this.redis) {
+    if (!RateLimitService.redis) {
       logger.warn("Rate limiting not available without Redis");
       return new RateLimitHelper(undefined);
     }
@@ -70,7 +78,7 @@ export class RateLimitService {
       duration: effectiveConfig.durationInSec, // Per second(s)
 
       keyPrefix: this.rateLimitPrefix(resource), // must be unique for limiters with different purpose
-      storeClient: this.redis,
+      storeClient: RateLimitService.redis,
       rejectIfRedisNotReady: true,
     });
 

--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -36,6 +36,12 @@ export class RateLimitService {
     return RateLimitService.instance;
   }
 
+  public static shutdown() {
+    if (RateLimitService.redis && RateLimitService.redis.status !== "end") {
+      RateLimitService.redis.disconnect();
+    }
+  }
+
   async rateLimitRequest(
     scope: ApiAccessScope,
     resource: z.infer<typeof RateLimitResource>,

--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -26,11 +26,13 @@ export class RateLimitService {
   private static redis: Redis | null;
   private static instance: RateLimitService | null = null;
 
-  public static getInstance() {
+  public static getInstance(redis: Redis | null = null) {
     if (!RateLimitService.instance) {
-      RateLimitService.redis = createNewRedisInstance({
-        enableAutoPipelining: false, // This may help avoid https://github.com/redis/ioredis/issues/1931
-      });
+      RateLimitService.redis =
+        redis ??
+        createNewRedisInstance({
+          enableAutoPipelining: false, // This may help avoid https://github.com/redis/ioredis/issues/1931
+        });
       RateLimitService.instance = new RateLimitService();
     }
     return RateLimitService.instance;

--- a/web/src/features/public-api/server/createAuthedAPIRoute.ts
+++ b/web/src/features/public-api/server/createAuthedAPIRoute.ts
@@ -54,12 +54,11 @@ export const createAuthedAPIRoute = <
       return;
     }
 
-    const rateLimitResponse = await new RateLimitService(
-      redis,
-    ).rateLimitRequest(
-      auth.scope,
-      routeConfig.rateLimitResource || "public-api",
-    );
+    const rateLimitResponse =
+      await RateLimitService.getInstance().rateLimitRequest(
+        auth.scope,
+        routeConfig.rateLimitResource || "public-api",
+      );
 
     if (rateLimitResponse?.isRateLimited()) {
       return rateLimitResponse.sendRestResponseIfLimited(res);

--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -80,10 +80,11 @@ export default async function handler(
     }
 
     try {
-      const rateLimitCheck = await new RateLimitService(redis).rateLimitRequest(
-        authCheck.scope,
-        "ingestion",
-      );
+      const rateLimitCheck =
+        await RateLimitService.getInstance().rateLimitRequest(
+          authCheck.scope,
+          "ingestion",
+        );
 
       if (rateLimitCheck?.isRateLimited()) {
         return rateLimitCheck.sendRestResponseIfLimited(res);

--- a/web/src/pages/api/public/projects.ts
+++ b/web/src/pages/api/public/projects.ts
@@ -33,10 +33,11 @@ export default async function handler(
         },
       });
 
-      const rateLimitCheck = await new RateLimitService(redis).rateLimitRequest(
-        authCheck.scope,
-        "public-api",
-      );
+      const rateLimitCheck =
+        await RateLimitService.getInstance().rateLimitRequest(
+          authCheck.scope,
+          "public-api",
+        );
 
       if (rateLimitCheck?.isRateLimited()) {
         return rateLimitCheck.sendRestResponseIfLimited(res);

--- a/web/src/pages/api/public/prompts.ts
+++ b/web/src/pages/api/public/prompts.ts
@@ -56,10 +56,11 @@ export default async function handler(
       const promptName = searchParams.name;
       const version = searchParams.version ?? undefined;
 
-      const rateLimitCheck = await new RateLimitService(redis).rateLimitRequest(
-        authCheck.scope,
-        "prompts",
-      );
+      const rateLimitCheck =
+        await RateLimitService.getInstance().rateLimitRequest(
+          authCheck.scope,
+          "prompts",
+        );
 
       if (rateLimitCheck?.isRateLimited()) {
         return rateLimitCheck.sendRestResponseIfLimited(res);

--- a/web/src/utils/shutdown.ts
+++ b/web/src/utils/shutdown.ts
@@ -6,6 +6,7 @@
 
 import { logger, redis } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
+import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
 
 const TIMEOUT = 110_000;
 
@@ -33,6 +34,8 @@ export const shutdown = async (signal: PrexitSignal) => {
 
     return await new Promise<void>((resolve) => {
       setTimeout(async () => {
+        RateLimitService.shutdown();
+
         logger.info(`Redis status ${redis?.status}`);
         if (!redis) {
           return;


### PR DESCRIPTION
Hopefully avoids https://github.com/redis/ioredis/issues/1931 and https://github.com/animir/node-rate-limiter-flexible/issues/228

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Disables Redis autopipelining in `RateLimitService` and refactors to use a singleton pattern, updating related tests and handlers.
> 
>   - **Behavior**:
>     - Disables `enableAutoPipelining` in `RateLimitService` to avoid uncaught exceptions related to Redis.
>     - Updates `RateLimitService` to use a singleton pattern with `getInstance()` method.
>     - Removes test case for undefined Redis in `rate-limit.servertest.ts` as `RateLimitService` now instantiates its own Redis.
>   - **Code Refactoring**:
>     - Replaces `new RateLimitService(redis)` with `RateLimitService.getInstance(redis)` in `promptNameHandler.ts`, `promptsHandler.ts`, and `createAuthedAPIRoute.ts`.
>     - Adds `RateLimitService.shutdown()` in `shutdown.ts` to handle graceful shutdown of Redis connections.
>   - **Testing**:
>     - Updates `rate-limit.servertest.ts` to align with new `RateLimitService` instantiation method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5633e2e3727ec8d8595868e2f8c4365344b1de55. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->