### PR TITLE
fix(llm-api-key): overwrite default top_p on key test

### DIFF
--- a/web/src/features/llm-api-key/server/router.ts
+++ b/web/src/features/llm-api-key/server/router.ts
@@ -178,6 +178,7 @@ export const llmApiKeyRouter = createTRPCRouter({
             adapter: input.adapter,
             provider: input.provider,
             model,
+            top_p: 0.9, // Langchain sets 1 as default that is not supported HuggingFace
           },
           baseURL: input.baseURL,
           apiKey: input.secretKey,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Sets `top_p` to 0.9 in `test` mutation in `router.ts` for HuggingFace compatibility.
> 
>   - **Behavior**:
>     - Sets `top_p` to 0.9 in `fetchLLMCompletion` call within `test` mutation in `router.ts` to ensure compatibility with HuggingFace models.
>   - **Misc**:
>     - Comment added explaining the reason for setting `top_p` to 0.9.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b31d4255ddf4d1d961df0a4442e3ff36a667da25. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->