### PR TITLE
fix: pass tracing input / output as string via trpc

### DIFF
--- a/web/src/server/api/routers/observations.ts
+++ b/web/src/server/api/routers/observations.ts
@@ -33,6 +33,8 @@ export const observationsRouter = createTRPCRouter({
         }
         return {
           ...obs,
+          input: JSON.stringify(obs.input),
+          output: JSON.stringify(obs.output),
           internalModel: obs?.internalModelId,
         };
       } catch (e) {

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -312,6 +312,8 @@ export const sessionRouter = createTRPCRouter({
           traces: clickhouseTraces.map((t) => ({
             ...t,
             scores: validatedScores.filter((s) => s.traceId === t.id),
+            input: JSON.stringify(t.input),
+            output: JSON.stringify(t.output),
           })),
           totalCost: costData ?? 0,
           users: [

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -312,8 +312,6 @@ export const sessionRouter = createTRPCRouter({
           traces: clickhouseTraces.map((t) => ({
             ...t,
             scores: validatedScores.filter((s) => s.traceId === t.id),
-            input: JSON.stringify(t.input),
-            output: JSON.stringify(t.output),
           })),
           totalCost: costData ?? 0,
           users: [

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -188,7 +188,11 @@ export const traceRouter = createTRPCRouter({
           message: "Trace not found",
         });
       }
-      return trace;
+      return {
+        ...trace,
+        input: JSON.stringify(trace.input),
+        output: JSON.stringify(trace.output),
+      };
     }),
   byIdWithObservationsAndScores: protectedGetTraceProcedure
     .input(
@@ -249,9 +253,15 @@ export const traceRouter = createTRPCRouter({
 
       return {
         ...trace,
+        input: JSON.stringify(trace.input),
+        output: JSON.stringify(trace.output),
         scores: validatedScores,
         latency: latencyMs !== undefined ? latencyMs / 1000 : undefined,
-        observations: observations as ObservationReturnType[],
+        observations: observations.map((o) => ({
+          ...o,
+          input: JSON.stringify(o.input),
+          output: JSON.stringify(o.output),
+        })),
       };
     }),
   deleteMany: protectedProjectProcedure

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -259,9 +259,9 @@ export const traceRouter = createTRPCRouter({
         latency: latencyMs !== undefined ? latencyMs / 1000 : undefined,
         observations: observations.map((o) => ({
           ...o,
-          input: JSON.stringify(o.input),
-          output: JSON.stringify(o.output),
-        })),
+          input: null, // this is not queried above.
+          output: null,
+        })) as ObservationReturnType[],
       };
     }),
   deleteMany: protectedProjectProcedure


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Serialize `input` and `output` fields as JSON strings in `observations.ts` and `traces.ts` to ensure consistent data handling.
> 
>   - **Behavior**:
>     - Serialize `input` and `output` fields as JSON strings in `byId` and `byIdWithObservationsAndScores` in `traces.ts`.
>     - Serialize `input` and `output` fields as JSON strings in `byId` in `observations.ts`.
>     - Set `input` and `output` to `null` in `observations` array in `byIdWithObservationsAndScores` in `traces.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c4386f1d152c8e45656cf848cbe0bfd53d090fed. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->