### PR TITLE
fix(ui): hide project-level routes in project overview main menu, disable active project in cmd+k menu

### DIFF
--- a/web/src/components/command-k-menu.tsx
+++ b/web/src/components/command-k-menu.tsx
@@ -36,16 +36,21 @@ export function CommandKMenu({
   );
 
   const navItems = mainNavigation
-    .flatMap((item) => [
-      {
-        title: item.title,
-        url: item.url,
-      },
-      ...(item.items?.map((child) => ({
-        title: `${item.title} > ${child.title}`,
-        url: child.url,
-      })) ?? []),
-    ])
+    .flatMap((item) => {
+      if (item.items) {
+        // if the item has children, return the children and not the parent
+        return item.items.map((child) => ({
+          title: `${item.title} > ${child.title}`,
+          url: child.url,
+        }));
+      }
+      return [
+        {
+          title: item.title,
+          url: item.url,
+        },
+      ];
+    })
     .filter(
       (item) =>
         Boolean(item.url) && // no empty urls
@@ -114,6 +119,7 @@ export function CommandKMenu({
                   key={item.url}
                   value={item.title}
                   keywords={item.keywords}
+                  disabled={item.active}
                   onSelect={() => {
                     router.push(item.url);
                     capture("cmd_k_menu:navigated", {
@@ -176,6 +182,7 @@ export const useNavigationItems = () => {
           org.projects.map((proj) => ({
             title: `${org.name} > ${proj.name}`,
             url: getProjectPath(proj.id),
+            active: router.query.projectId === proj.id,
             keywords: [
               "project",
               org.name.toLowerCase(),

--- a/web/src/components/layouts/routes.tsx
+++ b/web/src/components/layouts/routes.tsx
@@ -59,7 +59,7 @@ export const ROUTES: Route[] = [
   },
   {
     title: "Tracing",
-    pathname: "",
+    pathname: `/project/[projectId]/traces`,
     icon: ListTree,
     items: [
       {
@@ -83,7 +83,7 @@ export const ROUTES: Route[] = [
   {
     title: "Evaluation",
     icon: Lightbulb,
-    pathname: "",
+    pathname: `/project/[projectId]/annotation-queues`,
     entitlements: ["annotation-queues", "model-based-evaluations"],
     projectRbacScopes: ["annotationQueues:read", "evalJob:read"],
     items: [


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> UI changes to hide project-level routes in the main menu and disable active project selection in cmd+k menu.
> 
>   - **UI Behavior**:
>     - In `command-k-menu.tsx`, project-level routes are hidden in the main menu by only displaying child items if available.
>     - Disables active project selection in the cmd+k menu by setting `disabled` attribute for active projects.
>   - **Routes**:
>     - Updates `pathname` for "Tracing" and "Evaluation" routes in `routes.tsx` to include project-level paths.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bfc632d9fa21476a1642c1383f7e8b3ab925be17. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->