### PR TITLE
chore: download 20 S3 ingestion events at a time

### DIFF
--- a/worker/src/scripts/refill-ingestion-events.ts
+++ b/worker/src/scripts/refill-ingestion-events.ts
@@ -47,7 +47,7 @@ const main = async () => {
   const ingestionQueue = IngestionQueue.getInstance();
 
   // Process each record
-  const BATCH_SIZE = 50; // Process 100 events at a time
+  const BATCH_SIZE = 20;
 
   for (let i = 0; i < unprocessedRecords.length; i += BATCH_SIZE) {
     const batch = unprocessedRecords.slice(i, i + BATCH_SIZE);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce `BATCH_SIZE` from 50 to 20 in `refill-ingestion-events.ts` for S3 ingestion event processing.
> 
>   - **Behavior**:
>     - Change `BATCH_SIZE` from 50 to 20 in `refill-ingestion-events.ts`, affecting the number of S3 ingestion events processed per batch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 91e8d694724edb15f136f7e56ee4d44cd54f5819. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->