### PR TITLE
fix: parse inputs and outputs correctly when adding to datasets

### DIFF
--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -4,6 +4,7 @@ import {
   type Trace,
   type ScoreSource,
   AnnotationQueueObjectType,
+  parseJsonPrioritised,
 } from "@langfuse/shared";
 import {
   Card,

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -4,7 +4,6 @@ import {
   type Trace,
   type ScoreSource,
   AnnotationQueueObjectType,
-  parseJsonPrioritised,
 } from "@langfuse/shared";
 import {
   Card,
@@ -50,7 +49,11 @@ export const TracePreview = ({
   viewType = "detailed",
   className,
 }: {
-  trace: Trace & { latency?: number };
+  trace: Omit<Trace, "input" | "output"> & {
+    latency?: number;
+    input: string | null;
+    output: string | null;
+  };
   observations: ObservationReturnType[];
   scores: APIScore[];
   commentCounts?: Map<string, number>;

--- a/web/src/components/trace/TraceTimelineView.tsx
+++ b/web/src/components/trace/TraceTimelineView.tsx
@@ -331,7 +331,11 @@ export function TraceTimelineView({
   projectId,
   scores,
 }: {
-  trace: Trace & { latency?: number };
+  trace: Omit<Trace, "input" | "output"> & {
+    latency?: number;
+    input: string | null;
+    output: string | null;
+  };
   observations: Array<ObservationReturnType>;
   projectId: string;
   scores: APIScore[];

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -54,7 +54,10 @@ import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 
 export function Trace(props: {
   observations: Array<ObservationReturnType>;
-  trace: Trace;
+  trace: Omit<Trace, "input" | "output"> & {
+    input: string | null;
+    output: string | null;
+  };
   scores: APIScore[];
   projectId: string;
   viewType?: "detailed" | "focused";

--- a/web/src/features/datasets/components/NewDatasetItemFromObservationButton.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemFromObservationButton.tsx
@@ -28,8 +28,8 @@ export const NewDatasetItemFromTrace = (props: {
   projectId: string;
   traceId: string;
   observationId?: string;
-  input: Prisma.JsonValue;
-  output: Prisma.JsonValue;
+  input: string | null;
+  output: string | null;
   metadata: Prisma.JsonValue;
 }) => {
   const parsedInput =

--- a/web/src/features/datasets/components/NewDatasetItemFromObservationButton.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemFromObservationButton.tsx
@@ -22,6 +22,7 @@ import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAcces
 import { Button } from "@/src/components/ui/button";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useIsAuthenticatedAndProjectMember } from "@/src/features/auth/hooks";
+import { parseJsonPrioritised } from "@langfuse/shared";
 
 export const NewDatasetItemFromTrace = (props: {
   projectId: string;
@@ -31,6 +32,16 @@ export const NewDatasetItemFromTrace = (props: {
   output: Prisma.JsonValue;
   metadata: Prisma.JsonValue;
 }) => {
+  const parsedInput =
+    props.input && typeof props.input === "string"
+      ? (parseJsonPrioritised(props.input) ?? null)
+      : null;
+
+  const parsedOutput =
+    props.output && typeof props.output === "string"
+      ? (parseJsonPrioritised(props.output) ?? null)
+      : null;
+
   const [isFormOpen, setIsFormOpen] = useState(false);
   const isAuthenticatedAndProjectMember = useIsAuthenticatedAndProjectMember(
     props.projectId,
@@ -124,8 +135,8 @@ export const NewDatasetItemFromTrace = (props: {
             traceId={props.traceId}
             observationId={props.observationId}
             projectId={props.projectId}
-            input={props.input}
-            output={props.output}
+            input={parsedInput}
+            output={parsedOutput}
             metadata={props.metadata}
             onFormSuccess={() => setIsFormOpen(false)}
             className="h-full overflow-y-auto"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix parsing of `input` and `output` fields in trace components to handle them as strings or nulls, ensuring correct JSON parsing and consistent handling.
> 
>   - **Behavior**:
>     - Update `Trace` type in `TracePreview`, `TraceTimelineView`, and `index.tsx` to handle `input` and `output` as `string | null`.
>     - Parse `input` and `output` using `parseJsonPrioritised` in `NewDatasetItemFromTrace` to ensure correct JSON parsing.
>   - **Components**:
>     - Modify `TracePreview` and `TraceTimelineView` to use updated `Trace` type.
>     - Update `NewDatasetItemFromTrace` to use parsed `input` and `output` values.
>   - **Misc**:
>     - Ensure consistent handling of `input` and `output` across components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 697ab9136b55bf9646a538f029afcd5945826f94. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->