### PR TITLE
fix(ui): correct value for accent-foreground color

### DIFF
--- a/web/src/components/editor/shared-theme.ts
+++ b/web/src/components/editor/shared-theme.ts
@@ -10,8 +10,8 @@ export const defaultSettingsBothThemes: CreateThemeOptions["settings"] = {
   gutterBorder: "hsl(var(--sidebar-border))",
   gutterActiveForeground: "hsl(var(--sidebar-primary))",
   selection: "hsl(var(--accent))",
-  selectionMatch: "hsl(var(--accent-foreground))",
-  lineHighlight: "hsl(var(--accent-foreground))",
+  selectionMatch: "hsl(var(--muted))",
+  lineHighlight: "hsl(var(--muted))",
 };
 
 export const bothThemeStyles: CreateThemeOptions["styles"] = [

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -26,7 +26,7 @@
     --secondary-foreground: 222.2 47.4% 11.2%;
 
     --accent: 210 40% 96.1%;
-    --accent-foreground: 210 40% 98%;
+    --accent-foreground: 220 8.9% 46.1%;
 
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
@@ -92,7 +92,7 @@
     --secondary-foreground: 210 40% 88%;
 
     --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: ;
+    --accent-foreground: 210 20% 98%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 85.7% 97.3%;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Corrects `accent-foreground` color value and updates theme settings to use `muted` colors in `shared-theme.ts` and `globals.css`.
> 
>   - **Color Adjustments**:
>     - Update `accent-foreground` color value in `globals.css` for both light and dark themes.
>     - Change `selectionMatch` and `lineHighlight` in `shared-theme.ts` from `accent-foreground` to `muted`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 96cc193ac6c408992945bd459db4b66deee71050. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->