### PR TITLE
fix: retry failed connections in RateLimiter and disable offlinequeue

### DIFF
--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -13,6 +13,7 @@ import {
   type ApiAccessScope,
   logger,
   createNewRedisInstance,
+  redisQueueRetryOptions,
 } from "@langfuse/shared/src/server";
 import { type NextApiResponse } from "next";
 
@@ -32,6 +33,8 @@ export class RateLimitService {
         redis ??
         createNewRedisInstance({
           enableAutoPipelining: false, // This may help avoid https://github.com/redis/ioredis/issues/1931
+          enableOfflineQueue: false,
+          ...redisQueueRetryOptions,
         });
       RateLimitService.instance = new RateLimitService();
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add retry options for Redis connections and disable offline queue in `RateLimitService.ts`.
> 
>   - **Behavior**:
>     - In `RateLimitService.ts`, Redis connections now include `redisQueueRetryOptions` for retrying failed connections.
>     - `enableOfflineQueue` is set to `false` to prevent queuing commands when Redis is offline.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4aaa255d36edfb08b596cc356bc5971fcb4ffffb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->