### PR TITLE
feat(ui): open cmd+k menu from main menu

### DIFF
--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -15,7 +15,7 @@ import { useUiCustomization } from "@/src/ee/features/ui-customization/useUiCust
 import { hasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 import { SidebarInset, SidebarProvider } from "@/src/components/ui/sidebar";
 import { AppSidebar } from "@/src/components/nav/app-sidebar";
-import { CommandKMenu } from "@/src/components/command-k-menu";
+import { CommandKMenu } from "@/src/features/command-k-menu/CommandMenu";
 
 const signOutUser = async () => {
   localStorage.clear();

--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -15,7 +15,7 @@ import { useUiCustomization } from "@/src/ee/features/ui-customization/useUiCust
 import { hasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 import { SidebarInset, SidebarProvider } from "@/src/components/ui/sidebar";
 import { AppSidebar } from "@/src/components/nav/app-sidebar";
-import { CommandKMenu } from "@/src/features/command-k-menu/CommandMenu";
+import { CommandMenu } from "@/src/features/command-k-menu/CommandMenu";
 
 const signOutUser = async () => {
   localStorage.clear();
@@ -315,7 +315,7 @@ export default function Layout(props: PropsWithChildren) {
           <SidebarInset className="h-dvh max-w-full md:peer-data-[state=collapsed]:w-[calc(100vw-var(--sidebar-width-icon))] md:peer-data-[state=expanded]:w-[calc(100vw-var(--sidebar-width))]">
             <main className="h-full p-3">{props.children}</main>
             <Toaster visibleToasts={1} />
-            <CommandKMenu mainNavigation={navigation} />
+            <CommandMenu mainNavigation={navigation} />
           </SidebarInset>
         </SidebarProvider>
       </div>

--- a/web/src/components/layouts/routes.tsx
+++ b/web/src/components/layouts/routes.tsx
@@ -13,6 +13,8 @@ import {
   Grid2X2,
   Sparkle,
   FileJson,
+  Search,
+  Command,
 } from "lucide-react";
 import { type ReactNode } from "react";
 import { type Entitlement } from "@/src/features/entitlements/constants/entitlements";
@@ -20,6 +22,10 @@ import { type UiCustomizationOption } from "@/src/ee/features/ui-customization/u
 import { type User } from "next-auth";
 import { type OrganizationScope } from "@/src/features/rbac/constants/organizationAccessRights";
 import { SupportMenuDropdown } from "@/src/components/nav/support-menu-dropdown";
+import { Button } from "@/src/components/ui/button";
+import { SidebarMenuButton } from "@/src/components/ui/sidebar";
+import { useCommandMenu } from "@/src/features/command-k-menu/CommandMenuProvider";
+import { Separator } from "@radix-ui/react-dropdown-menu";
 
 export type Route = {
   title: string;
@@ -41,6 +47,12 @@ export type Route = {
 };
 
 export const ROUTES: Route[] = [
+  {
+    title: "Go to...",
+    pathname: "", // Empty pathname since this is a dropdown
+    icon: Search,
+    menuNode: <CommandKButton />,
+  },
   {
     title: "Organizations",
     pathname: "/",
@@ -161,3 +173,25 @@ export const ROUTES: Route[] = [
     menuNode: <SupportMenuDropdown />,
   },
 ];
+
+function CommandKButton() {
+  const { setOpen } = useCommandMenu();
+
+  return (
+    <SidebarMenuButton
+      onClick={() => setOpen(true)}
+      className="whitespace-nowrap"
+    >
+      <Search className="h-4 w-4" />
+      Go to...
+      <kbd className="pointer-events-none ml-auto inline-flex h-5 select-none items-center gap-1 rounded-md border px-1.5 font-mono text-[10px]">
+        {navigator.userAgent.includes("Mac") ? (
+          <span className="text-[12px]">⌘</span>
+        ) : (
+          <span>Ctrl</span>
+        )}
+        <span>K</span>
+      </kbd>
+    </SidebarMenuButton>
+  );
+}

--- a/web/src/components/layouts/routes.tsx
+++ b/web/src/components/layouts/routes.tsx
@@ -14,7 +14,6 @@ import {
   Sparkle,
   FileJson,
   Search,
-  Command,
 } from "lucide-react";
 import { type ReactNode } from "react";
 import { type Entitlement } from "@/src/features/entitlements/constants/entitlements";
@@ -22,10 +21,8 @@ import { type UiCustomizationOption } from "@/src/ee/features/ui-customization/u
 import { type User } from "next-auth";
 import { type OrganizationScope } from "@/src/features/rbac/constants/organizationAccessRights";
 import { SupportMenuDropdown } from "@/src/components/nav/support-menu-dropdown";
-import { Button } from "@/src/components/ui/button";
 import { SidebarMenuButton } from "@/src/components/ui/sidebar";
 import { useCommandMenu } from "@/src/features/command-k-menu/CommandMenuProvider";
-import { Separator } from "@radix-ui/react-dropdown-menu";
 
 export type Route = {
   title: string;
@@ -51,7 +48,7 @@ export const ROUTES: Route[] = [
     title: "Go to...",
     pathname: "", // Empty pathname since this is a dropdown
     icon: Search,
-    menuNode: <CommandKButton />,
+    menuNode: <CommandMenuTrigger />,
   },
   {
     title: "Organizations",
@@ -174,7 +171,7 @@ export const ROUTES: Route[] = [
   },
 ];
 
-function CommandKButton() {
+function CommandMenuTrigger() {
   const { setOpen } = useCommandMenu();
 
   return (

--- a/web/src/components/ui/command.tsx
+++ b/web/src/components/ui/command.tsx
@@ -32,7 +32,10 @@ const CommandDialog = ({
 }) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent
+        className="overflow-hidden p-0 shadow-lg"
+        closeOnInteractionOutside
+      >
         <Command
           filter={filter}
           className="pb-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12"

--- a/web/src/features/command-k-menu/CommandMenu.tsx
+++ b/web/src/features/command-k-menu/CommandMenu.tsx
@@ -16,7 +16,7 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import { useDebounce } from "@/src/hooks/useDebounce";
 import { useCommandMenu } from "@/src/features/command-k-menu/CommandMenuProvider";
 
-export function CommandKMenu({
+export function CommandMenu({
   mainNavigation,
 }: {
   mainNavigation: NavigationItem[];

--- a/web/src/features/command-k-menu/CommandMenu.tsx
+++ b/web/src/features/command-k-menu/CommandMenu.tsx
@@ -9,18 +9,19 @@ import {
   CommandSeparator,
 } from "@/src/components/ui/command";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useSession } from "next-auth/react";
 import { env } from "@/src/env.mjs";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useDebounce } from "@/src/hooks/useDebounce";
+import { useCommandMenu } from "@/src/features/command-k-menu/CommandMenuProvider";
 
 export function CommandKMenu({
   mainNavigation,
 }: {
   mainNavigation: NavigationItem[];
 }) {
-  const [open, setOpen] = useState(false);
+  const { open, setOpen } = useCommandMenu();
   const router = useRouter();
   const { allProjectItems } = useNavigationItems();
   const capture = usePostHogClientCapture();
@@ -61,17 +62,15 @@ export function CommandKMenu({
     const down = (e: KeyboardEvent) => {
       if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        setOpen((open) => {
-          if (open === false) {
-            capture("cmd_k_menu:opened");
-          }
-          return !open;
-        });
+        if (!open) {
+          capture("cmd_k_menu:opened");
+        }
+        setOpen(!open);
       }
     };
     document.addEventListener("keydown", down);
     return () => document.removeEventListener("keydown", down);
-  }, [capture]);
+  }, [capture, setOpen, open]);
 
   return (
     <CommandDialog

--- a/web/src/features/command-k-menu/CommandMenuProvider.tsx
+++ b/web/src/features/command-k-menu/CommandMenuProvider.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+interface CommandMenuContextType {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const CommandMenuContext = createContext<CommandMenuContextType | undefined>(
+  undefined,
+);
+
+export function CommandMenuProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <CommandMenuContext.Provider value={{ open, setOpen }}>
+      {children}
+    </CommandMenuContext.Provider>
+  );
+}
+
+export function useCommandMenu() {
+  const context = useContext(CommandMenuContext);
+  if (context === undefined) {
+    throw new Error("useCommandMenu must be used within a CommandMenuProvider");
+  }
+  return context;
+}

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -4,6 +4,7 @@ import { SessionProvider } from "next-auth/react";
 import { setUser } from "@sentry/nextjs";
 import { useSession } from "next-auth/react";
 import { TooltipProvider } from "@/src/components/ui/tooltip";
+import { CommandMenuProvider } from "@/src/features/command-k-menu/CommandMenuProvider";
 
 import { api } from "@/src/utils/api";
 
@@ -100,17 +101,19 @@ const MyApp: AppType<{ session: Session | null }> = ({
           >
             <DetailPageListsProvider>
               <MarkdownContextProvider>
-                <ThemeProvider
-                  attribute="class"
-                  enableSystem
-                  disableTransitionOnChange
-                >
-                  <Layout>
-                    <Component {...pageProps} />
-                    <UserTracking />
-                  </Layout>
-                  <BetterStackUptimeStatusMessage />
-                </ThemeProvider>
+                <CommandMenuProvider>
+                  <ThemeProvider
+                    attribute="class"
+                    enableSystem
+                    disableTransitionOnChange
+                  >
+                    <Layout>
+                      <Component {...pageProps} />
+                      <UserTracking />
+                    </Layout>
+                    <BetterStackUptimeStatusMessage />
+                  </ThemeProvider>{" "}
+                </CommandMenuProvider>
               </MarkdownContextProvider>
               <CrispWidget />
             </DetailPageListsProvider>

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -92,16 +92,16 @@ const MyApp: AppType<{ session: Session | null }> = ({
   return (
     <QueryParamProvider adapter={NextAdapterPages}>
       <TooltipProvider>
-        <PostHogProvider client={posthog}>
-          <SessionProvider
-            session={session}
-            refetchOnWindowFocus={true}
-            refetchInterval={5 * 60} // 5 minutes
-            basePath={`${env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/auth`}
-          >
-            <DetailPageListsProvider>
-              <MarkdownContextProvider>
-                <CommandMenuProvider>
+        <CommandMenuProvider>
+          <PostHogProvider client={posthog}>
+            <SessionProvider
+              session={session}
+              refetchOnWindowFocus={true}
+              refetchInterval={5 * 60} // 5 minutes
+              basePath={`${env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/auth`}
+            >
+              <DetailPageListsProvider>
+                <MarkdownContextProvider>
                   <ThemeProvider
                     attribute="class"
                     enableSystem
@@ -113,12 +113,12 @@ const MyApp: AppType<{ session: Session | null }> = ({
                     </Layout>
                     <BetterStackUptimeStatusMessage />
                   </ThemeProvider>{" "}
-                </CommandMenuProvider>
-              </MarkdownContextProvider>
-              <CrispWidget />
-            </DetailPageListsProvider>
-          </SessionProvider>
-        </PostHogProvider>
+                </MarkdownContextProvider>
+                <CrispWidget />
+              </DetailPageListsProvider>
+            </SessionProvider>
+          </PostHogProvider>
+        </CommandMenuProvider>
       </TooltipProvider>
     </QueryParamProvider>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add command menu trigger to main menu, refactor command menu component, and introduce provider for state management.
> 
>   - **Behavior**:
>     - Add `CommandMenuTrigger` to `ROUTES` in `routes.tsx` for opening the command menu from the main menu.
>     - Integrate `CommandMenu` in `layout.tsx` to replace `CommandKMenu`.
>     - Add `CommandMenuProvider` in `_app.tsx` to manage command menu state.
>   - **Components**:
>     - Rename `CommandKMenu` to `CommandMenu` and move to `features/command-k-menu/CommandMenu.tsx`.
>     - Add `CommandMenuProvider` in `CommandMenuProvider.tsx` to provide context for command menu state.
>   - **UI**:
>     - Update `CommandDialog` in `command.tsx` to close on interaction outside.
>     - Add `CommandMenuTrigger` component in `routes.tsx` for sidebar menu button.
>   - **Misc**:
>     - Refactor keyboard event handling in `CommandMenu.tsx` to toggle menu with `Cmd+K` or `Ctrl+K`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 366221da3de2125d20450612ee655c03947ecc74. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->