### PR TITLE
fix(media-api): handle retries on existing UUIDs

### DIFF
--- a/web/src/pages/api/public/media/index.ts
+++ b/web/src/pages/api/public/media/index.ts
@@ -81,7 +81,8 @@ export default withMiddlewares({
           };
         }
 
-        const mediaId = getMediaId({ projectId, sha256Hash });
+        const mediaId =
+          existingMedia?.id ?? getMediaId({ projectId, sha256Hash });
 
         if (!env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET)
           throw new InternalServerError(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `mediaId` assignment in `index.ts` to use existing media ID if available, preventing duplicate records on retries.
> 
>   - **Behavior**:
>     - Modify `mediaId` assignment in `index.ts` to use `existingMedia.id` if available, preventing duplicate media records on retries.
>   - **Error Handling**:
>     - No changes to error handling, but ensures existing media is reused to avoid unnecessary errors.
>   - **Misc**:
>     - No changes to logging or other functionalities.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 542f4cb55a19bf47dbed186a420c5ac6d0b58a3e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->