### PR TITLE
fix: handle multiple number types in otel parser

### DIFF
--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -1,4 +1,4 @@
-import { type IngestionEventType, logger } from "@langfuse/shared/src/server";
+import { type IngestionEventType } from "@langfuse/shared/src/server";
 import { randomUUID } from "crypto";
 import { ObservationLevel } from "@prisma/client";
 
@@ -33,6 +33,9 @@ const convertValueToPlainJavascript = (value: Record<string, any>): any => {
   }
   if (value.intValue && value.intValue.high === 0) {
     return value.intValue.low;
+  }
+  if (value.intValue && typeof value.intValue === "number") {
+    return value.intValue;
   }
   if (
     value.intValue &&

--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -1,4 +1,4 @@
-import { type IngestionEventType } from "@langfuse/shared/src/server";
+import { type IngestionEventType, logger } from "@langfuse/shared/src/server";
 import { randomUUID } from "crypto";
 import { ObservationLevel } from "@prisma/client";
 
@@ -6,9 +6,9 @@ const convertNanoTimestampToISO = (timestamp: {
   high: number;
   low: number;
 }) => {
-  return new Date(
-    (timestamp.high * Math.pow(2, 32) + timestamp.low) / 1e6,
-  ).toISOString();
+  const time = (timestamp.high * Math.pow(2, 32) + timestamp.low) / 1e6;
+  logger.info(`Converting timestamp ${time} to ISO`);
+  return new Date(time).toISOString();
 };
 
 const convertValueToPlainJavascript = (value: Record<string, any>): any => {

--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -2,15 +2,20 @@ import { type IngestionEventType, logger } from "@langfuse/shared/src/server";
 import { randomUUID } from "crypto";
 import { ObservationLevel } from "@prisma/client";
 
-const convertNanoTimestampToISO = (timestamp: {
-  high: number;
-  low: number;
-}) => {
-  const time = (timestamp.high * Math.pow(2, 32) + timestamp.low) / 1e6;
-  logger.info(
-    `Calculated ${time} from ${timestamp.high} and ${timestamp.low} to ISO. Using ${JSON.stringify(timestamp)} as input.`,
-  );
-  return new Date(time).toISOString();
+const convertNanoTimestampToISO = (
+  timestamp:
+    | number
+    | {
+        high: number;
+        low: number;
+      },
+) => {
+  if (typeof timestamp === "number") {
+    return new Date(timestamp / 1e6).toISOString();
+  }
+  return new Date(
+    (timestamp.high * Math.pow(2, 32) + timestamp.low) / 1e6,
+  ).toISOString();
 };
 
 const convertValueToPlainJavascript = (value: Record<string, any>): any => {

--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -7,7 +7,9 @@ const convertNanoTimestampToISO = (timestamp: {
   low: number;
 }) => {
   const time = (timestamp.high * Math.pow(2, 32) + timestamp.low) / 1e6;
-  logger.info(`Converting timestamp ${time} to ISO`);
+  logger.info(
+    `Calculated ${time} from ${timestamp.high} and ${timestamp.low} to ISO. Using ${JSON.stringify(timestamp)} as input.`,
+  );
   return new Date(time).toISOString();
 };
 

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -51,6 +51,9 @@ export default withMiddlewares({
         return res.status(400).json({ error: "Failed to parse OTel Trace" });
       }
 
+      logger.info(`Received ${resourceSpans.length} OTel spans`, {
+        resourceSpans,
+      });
       const events: IngestionEventType[] = resourceSpans.flatMap(
         convertOtelSpanToIngestionEvent,
       );

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -51,9 +51,6 @@ export default withMiddlewares({
         return res.status(400).json({ error: "Failed to parse OTel Trace" });
       }
 
-      logger.info(`Received ${resourceSpans.length} OTel spans`, {
-        resourceSpans,
-      });
       const events: IngestionEventType[] = resourceSpans.flatMap(
         convertOtelSpanToIngestionEvent,
       );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `convertNanoTimestampToISO` and `convertValueToPlainJavascript` in `index.ts` to handle multiple number types for OpenTelemetry parsing.
> 
>   - **Behavior**:
>     - `convertNanoTimestampToISO` in `index.ts` now handles `timestamp` as a `number` or an object with `high` and `low` properties.
>     - `convertValueToPlainJavascript` in `index.ts` now returns `intValue` directly if it's a `number`.
>   - **Functions**:
>     - Updated `convertNanoTimestampToISO` to support `number` type timestamps.
>     - Enhanced `convertValueToPlainJavascript` to handle `intValue` as a `number`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 890ab22fe8951b93513fd630b4cdb061bb878e93. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->