### PR TITLE
chore(models): updated price for o1-mini

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1116,14 +1116,14 @@
     "model_name": "o1-mini",
     "match_pattern": "(?i)^(o1-mini)$",
     "created_at": "2024-09-13T10:01:35.373Z",
-    "updated_at": "2024-12-03T10:41:55.000Z",
+    "updated_at": "2025-02-01T12:41:55.000Z",
     "prices": {
-      "input": 3e-6,
-      "input_cached_tokens": 1.5e-6,
-      "input_cache_read": 1.5e-6,
-      "output": 12e-6,
-      "output_reasoning_tokens": 12e-6,
-      "output_reasoning": 12e-6
+      "input": 1.1e-6,
+      "input_cached_tokens": 0.55e-6,
+      "input_cache_read": 0.55e-6,
+      "output": 4.4e-6,
+      "output_reasoning_tokens": 4.4e-6,
+      "output_reasoning": 4.4e-6
     },
     "tokenizer_config": null,
     "tokenizer_id": null
@@ -1133,14 +1133,14 @@
     "model_name": "o1-mini-2024-09-12",
     "match_pattern": "(?i)^(o1-mini-2024-09-12)$",
     "created_at": "2024-09-13T10:01:35.373Z",
-    "updated_at": "2024-12-03T10:43:16.000Z",
+    "updated_at": "2025-02-01T12:41:55.000Z",
     "prices": {
-      "input": 3e-6,
-      "input_cached_tokens": 1.5e-6,
-      "input_cache_read": 1.5e-6,
-      "output": 12e-6,
-      "output_reasoning_tokens": 12e-6,
-      "output_reasoning": 12e-6
+      "input": 1.1e-6,
+      "input_cached_tokens": 0.55e-6,
+      "input_cache_read": 0.55e-6,
+      "output": 4.4e-6,
+      "output_reasoning_tokens": 4.4e-6,
+      "output_reasoning": 4.4e-6
     },
     "tokenizer_config": null,
     "tokenizer_id": null


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updated pricing for `o1-mini` and `o1-mini-2024-09-12` models in `default-model-prices.json`.
> 
>   - **Pricing Update**:
>     - Updated prices for `o1-mini` and `o1-mini-2024-09-12` in `default-model-prices.json`.
>     - New prices: `input` 1.1e-6, `input_cached_tokens` 0.55e-6, `input_cache_read` 0.55e-6, `output` 4.4e-6, `output_reasoning_tokens` 4.4e-6, `output_reasoning` 4.4e-6.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2e35a7fc3d87b02c35a0f8f373620e8556befa99. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->