### PR TITLE
fix: add bedrock throttling exception to retries for evals

### DIFF
--- a/worker/src/features/utilities.ts
+++ b/worker/src/features/utilities.ts
@@ -40,7 +40,10 @@ export async function callStructuredLLM<T extends ZodSchema>(
 
     return structuredOutputSchema.parse(completion);
   } catch (e) {
-    if (e instanceof Error && e.name === "InsufficientQuotaError") {
+    if (
+      e instanceof Error &&
+      (e.name === "InsufficientQuotaError" || e.name === "ThrottlingException")
+    ) {
       throw new ApiError(e.name, 429);
     }
     logger.error(`Job ${jeId} failed to call LLM. Eval will fail.`, e);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `ThrottlingException` handling to `callStructuredLLM` in `utilities.ts` for retry logic.
> 
>   - **Behavior**:
>     - In `callStructuredLLM` in `utilities.ts`, add `ThrottlingException` to exceptions that trigger an `ApiError` with status 429.
>     - Previously only `InsufficientQuotaError` was handled this way.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 56751ac43b3d8c16f36bb643f2b3daa173460f62. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->