### PR TITLE
fix(score-analytics): display categorical data in dashboard

### DIFF
--- a/web/src/features/dashboard/lib/score-analytics-utils.ts
+++ b/web/src/features/dashboard/lib/score-analytics-utils.ts
@@ -110,16 +110,19 @@ function aggregateCategoricalScoreData(data: DatabaseRow[]): {
   const labels: string[] = [];
 
   const categoryCounts = data.reduce((acc: CategoryCounts, row) => {
-    const label = row["stringValue"];
+    const label = row["scoreValue"];
     if (typeof label === "string") {
       labels.push(label);
-      const currentBinCount = (row["countStringValue"] as number) ?? 0;
+      const currentBinCount = (row["count"] as number) ?? 0;
       return { ...acc, [label]: currentBinCount };
     }
     return acc;
   }, {} as CategoryCounts);
 
-  return { categoryCounts, labels };
+  return {
+    categoryCounts,
+    labels,
+  };
 }
 
 function groupCategoricalScoreDataByTimestamp(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes categorical data display in dashboard by updating property access in `aggregateCategoricalScoreData()` in `score-analytics-utils.ts`.
> 
>   - **Behavior**:
>     - Fixes categorical data display in dashboard by updating `aggregateCategoricalScoreData()` in `score-analytics-utils.ts`.
>     - Changes property access from `stringValue` to `scoreValue` and `countStringValue` to `count`.
>   - **Misc**:
>     - Minor formatting changes in `aggregateCategoricalScoreData()` return statement.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8e71df5f8663bf02480f79db2c897f9b393b1adb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->