### PR TITLE
fix(dataset-evals): reference `job.observationId` rather than `sourceObservationId`

### DIFF
--- a/worker/src/ee/evaluation/evalService.ts
+++ b/worker/src/ee/evaluation/evalService.ts
@@ -102,9 +102,7 @@ export const createEvalJobs = async ({
     );
 
     const isDatasetConfig = config.target_object === "dataset";
-    let datasetItem:
-      | { id: string; sourceObservationId: string | undefined }
-      | undefined;
+    let datasetItem: { id: string } | undefined;
     if (isDatasetConfig) {
       // If the target object is a dataset and the event type has a datasetItemId, we try to fetch it based on our filter
       if ("datasetItemId" in event && event.datasetItemId) {
@@ -115,9 +113,9 @@ export const createEvalJobs = async ({
         );
 
         const datasetItems = await prisma.$queryRaw<
-          Array<{ id: string; sourceObservationId: string | undefined }>
+          Array<{ id: string }>
         >(Prisma.sql`
-          SELECT id, source_observation_id as "sourceObservationId"
+          SELECT id,
           FROM dataset_items as di
           WHERE project_id = ${event.projectId}
             AND id = ${event.datasetItemId}
@@ -128,9 +126,9 @@ export const createEvalJobs = async ({
         // Otherwise, try to find the dataset item id from datasetRunItems.
         // Here, we can search for the traceId and projectId and should only get one result.
         const datasetItems = await prisma.$queryRaw<
-          Array<{ id: string; sourceObservationId: string | undefined }>
+          Array<{ id: string }>
         >(Prisma.sql`
-          SELECT dataset_item_id as id, observation_id as "sourceObservationId"
+          SELECT dataset_item_id as id
           FROM dataset_run_items as dri
           WHERE project_id = ${event.projectId}
           AND trace_id = ${event.traceId}
@@ -145,7 +143,7 @@ export const createEvalJobs = async ({
     const observationId =
       "observationId" in event && event.observationId
         ? event.observationId
-        : datasetItem?.sourceObservationId;
+        : undefined;
     if (observationId) {
       const observationExists = await checkObservationExists(
         event.projectId,
@@ -223,7 +221,7 @@ export const createEvalJobs = async ({
           ...(datasetItem
             ? {
                 jobInputDatasetItemId: datasetItem.id,
-                jobInputObservationId: datasetItem.sourceObservationId || null,
+                jobInputObservationId: observationId || null,
               }
             : {}),
         },

--- a/worker/src/ee/evaluation/evalService.ts
+++ b/worker/src/ee/evaluation/evalService.ts
@@ -115,7 +115,7 @@ export const createEvalJobs = async ({
         const datasetItems = await prisma.$queryRaw<
           Array<{ id: string }>
         >(Prisma.sql`
-          SELECT id,
+          SELECT id
           FROM dataset_items as di
           WHERE project_id = ${event.projectId}
             AND id = ${event.datasetItemId}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove `sourceObservationId` handling in `createEvalJobs` in `evalService.ts`, using `observationId` from event directly.
> 
>   - **Behavior**:
>     - In `createEvalJobs` in `evalService.ts`, remove `sourceObservationId` from dataset item queries and logic.
>     - Use `observationId` from event directly, setting it to `undefined` if not present.
>   - **Database Queries**:
>     - Update SQL queries in `createEvalJobs` to exclude `sourceObservationId` from `dataset_items` and `dataset_run_items` tables.
>   - **Job Creation**:
>     - Set `jobInputObservationId` to `observationId` or `null` in job creation logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5cc50865e87a5f80f886ed774bd2e83ec79ba1a7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->