### PR TITLE
feat(ui): add local iso date with utc on hover and ms precision on traces

### DIFF
--- a/web/src/components/LocalIsoDate.tsx
+++ b/web/src/components/LocalIsoDate.tsx
@@ -7,7 +7,7 @@ export const LocalIsoDate = ({
   date: Date;
   accuracy?: Accuracy;
 }) => {
-  if (!(date instanceof Date)) {
+  if (!(date instanceof Date) || isNaN(date.getTime())) {
     return null;
   }
 

--- a/web/src/components/LocalIsoDate.tsx
+++ b/web/src/components/LocalIsoDate.tsx
@@ -1,0 +1,41 @@
+type Accuracy = "minute" | "second" | "millisecond";
+
+export const LocalIsoDate = ({
+  date,
+  accuracy = "second",
+}: {
+  date: Date;
+  accuracy?: Accuracy;
+}) => {
+  if (!(date instanceof Date)) {
+    return null;
+  }
+
+  const formatDate = (date: Date, useUTC = false, pAccuracy: Accuracy) => {
+    const pad = (num: number) => String(num).padStart(2, "0");
+
+    const year = useUTC ? date.getUTCFullYear() : date.getFullYear();
+    const month = useUTC ? date.getUTCMonth() + 1 : date.getMonth() + 1;
+    const day = useUTC ? date.getUTCDate() : date.getDate();
+    const hours = useUTC ? date.getUTCHours() : date.getHours();
+    const minutes = useUTC ? date.getUTCMinutes() : date.getMinutes();
+    const seconds = useUTC ? date.getUTCSeconds() : date.getSeconds();
+    const ms = useUTC ? date.getUTCMilliseconds() : date.getMilliseconds();
+
+    let formatted = `${year}-${pad(month)}-${pad(day)} ${pad(hours)}:${pad(minutes)}`;
+
+    if (["second", "millisecond"].includes(pAccuracy)) {
+      formatted += `:${pad(seconds)}`;
+    }
+    if (pAccuracy === "millisecond") {
+      formatted += `.${String(ms).padStart(3, "0")}`;
+    }
+
+    return formatted;
+  };
+
+  const localDateString = formatDate(date, false, accuracy);
+  const utcDateString = formatDate(date, true, "millisecond");
+
+  return <span title={`UTC: ${utcDateString}`}>{localDateString}</span>;
+};

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -45,6 +45,7 @@ import { BreakdownTooltip } from "@/src/components/trace/BreakdownToolTip";
 import { InfoIcon, PlusCircle } from "lucide-react";
 import { UpsertModelFormDrawer } from "@/src/features/models/components/UpsertModelFormDrawer";
 import { ColorCodedObservationType } from "@/src/components/trace/ObservationTree";
+import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 
 export type ObservationsTableRow = {
   id: string;
@@ -52,7 +53,7 @@ export type ObservationsTableRow = {
   startTime: Date;
   level?: ObservationLevel;
   statusMessage?: string;
-  endTime?: string;
+  endTime?: Date;
   completionStartTime?: Date;
   latency?: number;
   timeToFirstToken?: number;
@@ -314,7 +315,7 @@ export default function ObservationsTable({
       enableSorting: true,
       cell: ({ row }) => {
         const value: Date = row.getValue("startTime");
-        return value.toLocaleString();
+        return <LocalIsoDate date={value} />;
       },
     },
     {
@@ -324,6 +325,10 @@ export default function ObservationsTable({
       size: 150,
       enableHiding: true,
       enableSorting: true,
+      cell: ({ row }) => {
+        const value: Date | undefined = row.getValue("endTime");
+        return value ? <LocalIsoDate date={value} /> : undefined;
+      },
     },
     {
       accessorKey: "timeToFirstToken",
@@ -763,7 +768,7 @@ export default function ObservationsTable({
             type: generation.type ?? undefined,
             traceName: generation.traceName ?? "",
             startTime: generation.startTime,
-            endTime: generation.endTime?.toLocaleString() ?? undefined,
+            endTime: generation.endTime ?? undefined,
             timeToFirstToken: generation.timeToFirstToken ?? undefined,
             scores: verifyAndPrefixScoreDataAgainstKeys(
               scoreKeysAndProps,

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -27,11 +27,12 @@ import { useQueryParams, withDefault, NumberParam } from "use-query-params";
 import TagList from "@/src/features/tag/components/TagList";
 import { cn } from "@/src/utils/tailwind";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
+import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 
 export type ScoresTableRow = {
   id: string;
   traceId: string;
-  timestamp: string;
+  timestamp: Date;
   source: string;
   name: string;
   dataType: ScoreDataType;
@@ -254,6 +255,10 @@ export default function ScoresTable({
       enableHiding: true,
       enableSorting: true,
       size: 150,
+      cell: ({ row }) => {
+        const value: ScoresTableRow["timestamp"] = row.getValue("timestamp");
+        return value ? <LocalIsoDate date={value} /> : undefined;
+      },
     },
     {
       accessorKey: "source",
@@ -391,7 +396,7 @@ export default function ScoresTable({
   ): ScoresTableRow => {
     return {
       id: score.id,
-      timestamp: score.timestamp.toLocaleString(),
+      timestamp: score.timestamp,
       source: score.source,
       name: score.name,
       dataType: score.dataType,

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -29,10 +29,11 @@ import TagList from "@/src/features/tag/components/TagList";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
 import { cn } from "@/src/utils/tailwind";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
+import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 
 export type SessionTableRow = {
   id: string;
-  createdAt: string;
+  createdAt: Date;
   bookmarked: boolean;
   userIds: string[] | undefined;
   countTraces: number | undefined;
@@ -219,6 +220,10 @@ export default function SessionsTable({
       size: 150,
       enableHiding: true,
       enableSorting: true,
+      cell: ({ row }) => {
+        const value: SessionTableRow["createdAt"] = row.getValue("createdAt");
+        return value ? <LocalIsoDate date={value} /> : undefined;
+      },
     },
     {
       accessorKey: "sessionDuration",
@@ -503,7 +508,7 @@ export default function SessionsTable({
                     (session) => ({
                       id: session.id,
                       bookmarked: session.bookmarked,
-                      createdAt: session.createdAt.toLocaleString(),
+                      createdAt: session.createdAt,
                       userIds: session.userIds,
                       countTraces: session.countTraces,
                       sessionDuration: session.sessionDuration,

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -58,6 +58,7 @@ import { InfoIcon } from "lucide-react";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import { Separator } from "@/src/components/ui/separator";
 import React from "react";
+import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 
 export type TracesTableRow = {
   bookmarked: boolean;
@@ -339,7 +340,7 @@ export default function TracesTable({
       enableSorting: true,
       cell: ({ row }) => {
         const value: TracesTableRow["timestamp"] = row.getValue("timestamp");
-        return value ? new Date(value).toLocaleString() : undefined;
+        return value ? <LocalIsoDate date={value} /> : undefined;
       },
     },
     {

--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -40,6 +40,7 @@ import {
 import { BreakdownTooltip } from "./BreakdownToolTip";
 import { InfoIcon, PlusCircle } from "lucide-react";
 import { UpsertModelFormDrawer } from "@/src/features/models/components/UpsertModelFormDrawer";
+import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 
 export const ObservationPreview = ({
   observations,
@@ -158,7 +159,10 @@ export const ObservationPreview = ({
               <span>{preloadedObservation.name}</span>
             </CardTitle>
             <CardDescription className="flex gap-2">
-              {preloadedObservation.startTime.toLocaleString()}
+              <LocalIsoDate
+                date={preloadedObservation.startTime}
+                accuracy="millisecond"
+              />
             </CardDescription>
             {viewType === "detailed" && (
               <div className="flex flex-wrap gap-2">

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/src/components/ui/tabs-bar";
 import { BreakdownTooltip } from "@/src/components/trace/BreakdownToolTip";
 import { InfoIcon } from "lucide-react";
+import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 
 export const TracePreview = ({
   trace,
@@ -131,7 +132,7 @@ export const TracePreview = ({
               <span>{trace.name}</span>
             </CardTitle>
             <CardDescription>
-              {trace.timestamp.toLocaleString()}
+              <LocalIsoDate date={trace.timestamp} accuracy="millisecond" />
             </CardDescription>
             {viewType === "detailed" && (
               <div className="flex flex-wrap gap-2">

--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -27,6 +27,7 @@ import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAcces
 import { type CsvPreviewResult } from "@/src/features/datasets/lib/csvHelpers";
 import { PreviewCsvImport } from "@/src/features/datasets/components/PreviewCsvImport";
 import { UploadDatasetCsv } from "@/src/features/datasets/components/UploadDatasetCsv";
+import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 
 type RowData = {
   id: string;
@@ -35,7 +36,7 @@ type RowData = {
     observationId?: string;
   };
   status: DatasetItem["status"];
-  createdAt: string;
+  createdAt: Date;
   input: Prisma.JsonValue;
   expectedOutput: Prisma.JsonValue;
   metadata: Prisma.JsonValue;
@@ -154,6 +155,10 @@ export function DatasetItemsTable({
       id: "createdAt",
       size: 150,
       enableHiding: true,
+      cell: ({ row }) => {
+        const value: RowData["createdAt"] = row.getValue("createdAt");
+        return <LocalIsoDate date={value} />;
+      },
     },
     {
       accessorKey: "input",
@@ -260,7 +265,7 @@ export function DatasetItemsTable({
           }
         : undefined,
       status: item.status,
-      createdAt: item.createdAt.toLocaleString(),
+      createdAt: item.createdAt,
       input: item.input,
       expectedOutput: item.expectedOutput,
       metadata: item.metadata,

--- a/web/src/features/datasets/components/DatasetRunItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsTable.tsx
@@ -98,7 +98,7 @@ export function DatasetRunItemsTable(
       id: "runAt",
       size: 150,
       cell: ({ row }) => {
-        const value: DatasetRunItemRowData["runAt"] = row.getValue("createdAt");
+        const value: DatasetRunItemRowData["runAt"] = row.getValue("runAt");
         return <LocalIsoDate date={value} />;
       },
     },

--- a/web/src/features/datasets/components/DatasetRunItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsTable.tsx
@@ -21,10 +21,11 @@ import {
 import { type ScoreAggregate } from "@langfuse/shared";
 import { useIndividualScoreColumns } from "@/src/features/scores/hooks/useIndividualScoreColumns";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
+import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 
 export type DatasetRunItemRowData = {
   id: string;
-  runAt: string;
+  runAt: Date;
   datasetItemId: string;
   trace?: {
     traceId: string;
@@ -96,6 +97,10 @@ export function DatasetRunItemsTable(
       header: "Run At",
       id: "runAt",
       size: 150,
+      cell: ({ row }) => {
+        const value: DatasetRunItemRowData["runAt"] = row.getValue("createdAt");
+        return <LocalIsoDate date={value} />;
+      },
     },
     {
       accessorKey: "datasetItemId",
@@ -235,7 +240,7 @@ export function DatasetRunItemsTable(
       ? runItems.data.runItems.map((item) => {
           return {
             id: item.id,
-            runAt: item.createdAt.toLocaleString(),
+            runAt: item.createdAt,
             datasetItemId: item.datasetItemId,
             trace: !!item.trace?.id
               ? {

--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -45,11 +45,12 @@ import { Card, CardContent } from "@/src/components/ui/card";
 import { CompareViewAdapter } from "@/src/features/scores/adapters";
 import { isNumericDataType } from "@/src/features/scores/lib/helpers";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 
 export type DatasetRunRowData = {
   id: string;
   name: string;
-  createdAt: string;
+  createdAt: Date;
   countRunItems: string;
   avgLatency: number | undefined;
   avgTotalCost: string | undefined;
@@ -316,6 +317,10 @@ export function DatasetRunsTable(props: {
       id: "createdAt",
       size: 150,
       enableHiding: true,
+      cell: ({ row }) => {
+        const value: DatasetRunRowData["createdAt"] = row.getValue("createdAt");
+        return <LocalIsoDate date={value} />;
+      },
     },
     {
       accessorKey: "metadata",
@@ -367,7 +372,7 @@ export function DatasetRunsTable(props: {
     return {
       id: item.id,
       name: item.name,
-      createdAt: item.createdAt.toLocaleString(),
+      createdAt: item.createdAt,
       countRunItems: item.countRunItems.toString(),
       avgLatency: item.avgLatency,
       avgTotalCost: item.avgTotalCost

--- a/web/src/features/datasets/components/DatasetsTable.tsx
+++ b/web/src/features/datasets/components/DatasetsTable.tsx
@@ -21,6 +21,7 @@ import { type Prisma } from "@langfuse/shared";
 import { IOTableCell } from "@/src/components/ui/CodeJsonViewer";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
+import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 
 type RowData = {
   key: {
@@ -28,8 +29,8 @@ type RowData = {
     name: string;
   };
   description?: string;
-  createdAt: string;
-  lastRunAt?: string;
+  createdAt: Date;
+  lastRunAt?: Date;
   countItems: number;
   countRuns: number;
   metadata: Prisma.JsonValue;
@@ -109,6 +110,10 @@ export function DatasetsTable(props: { projectId: string }) {
       id: "createdAt",
       enableHiding: true,
       size: 150,
+      cell: ({ row }) => {
+        const value: RowData["createdAt"] = row.getValue("createdAt");
+        return <LocalIsoDate date={value} />;
+      },
     },
     {
       accessorKey: "lastRunAt",
@@ -116,6 +121,10 @@ export function DatasetsTable(props: { projectId: string }) {
       id: "lastRunAt",
       enableHiding: true,
       size: 150,
+      cell: ({ row }) => {
+        const value: RowData["lastRunAt"] = row.getValue("lastRunAt");
+        return value ? <LocalIsoDate date={value} /> : undefined;
+      },
     },
     {
       accessorKey: "metadata",
@@ -173,8 +182,8 @@ export function DatasetsTable(props: { projectId: string }) {
     return {
       key: { id: item.id, name: item.name },
       description: item.description ?? "",
-      createdAt: item.createdAt.toLocaleString(),
-      lastRunAt: item.lastRunAt?.toLocaleString() ?? "",
+      createdAt: item.createdAt,
+      lastRunAt: item.lastRunAt ?? undefined,
       countItems: item.countDatasetItems,
       countRuns: item.countDatasetRuns,
       metadata: item.metadata,

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -22,6 +22,7 @@ import { Skeleton } from "@/src/components/ui/skeleton";
 import { useDebounce } from "@/src/hooks/useDebounce";
 import { ActionButton } from "@/src/components/ActionButton";
 import { useEntitlementLimit } from "@/src/features/entitlements/hooks";
+import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 
 type PromptTableRow = {
   name: string;
@@ -181,7 +182,7 @@ export function PromptTable() {
       size: 200,
       cell: (row) => {
         const createdAt = row.getValue();
-        return createdAt.toLocaleString();
+        return <LocalIsoDate date={createdAt} />;
       },
     }),
     columnHelper.accessor("numberOfObservations", {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces `LocalIsoDate` component for consistent date formatting across tables, replacing `toLocaleString()` and updating date fields to `Date` type.
> 
>   - **New Component**:
>     - Adds `LocalIsoDate` component in `LocalIsoDate.tsx` to format dates with local and UTC representations, supporting minute, second, and millisecond precision.
>   - **Integration**:
>     - Replaces `toLocaleString()` with `LocalIsoDate` in `observations.tsx`, `scores.tsx`, `sessions.tsx`, `traces.tsx`, `ObservationPreview.tsx`, `TracePreview.tsx`, `DatasetItemsTable.tsx`, `DatasetRunItemsTable.tsx`, `DatasetRunsTable.tsx`, `DatasetsTable.tsx`, and `prompts-table.tsx` for consistent date formatting.
>   - **Data Type Changes**:
>     - Changes date-related fields from `string` to `Date` in `observations.tsx`, `scores.tsx`, `sessions.tsx`, `traces.tsx`, `DatasetItemsTable.tsx`, `DatasetRunItemsTable.tsx`, `DatasetRunsTable.tsx`, `DatasetsTable.tsx`, and `prompts-table.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3b22b7ca5cf4ae67641c86e0e8d8860cd129c46f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->