### PR TITLE
chore: decrease ingestion queue delay outside of date boundaries

### DIFF
--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -55,7 +55,7 @@ const getS3StorageServiceClient = (bucketName: string): StorageService => {
  * @param delay - Delay overwrite. Used if non-null.
  */
 const getDelay = (delay: number | null) => {
-  if (delay) {
+  if (delay !== null) {
     return delay;
   }
   const now = new Date();

--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -48,9 +48,37 @@ const getS3StorageServiceClient = (bucketName: string): StorageService => {
   return s3StorageServiceClient;
 };
 
+/**
+ * Get the delay for the event based on the event type. Uses delay if set, 0 if current UTC timestamp is not between
+ * 23:45 and 00:15, and env.LANGFUSE_INGESTION_QUEUE_DELAY_MS otherwise.
+ * We need the delay around date boundaries to avoid duplicates for out-of-order processing of events.
+ * @param delay - Delay overwrite. Used if non-null.
+ */
+const getDelay = (delay: number | null) => {
+  if (delay) {
+    return delay;
+  }
+  const now = new Date();
+  const hours = now.getUTCHours();
+  const minutes = now.getUTCMinutes();
+
+  if ((hours === 23 && minutes >= 45) || (hours === 0 && minutes <= 15)) {
+    return env.LANGFUSE_INGESTION_QUEUE_DELAY_MS;
+  }
+
+  return 0;
+};
+
+/**
+ * Processes a batch of events.
+ * @param input - Batch of IngestionEventType. Will validate the types first thing and return errors if they are invalid.
+ * @param authCheck - AuthHeaderValidVerificationResult
+ * @param delay - (Optional) Delay in ms to wait before processing events in the batch.
+ */
 export const processEventBatch = async (
   input: unknown[],
   authCheck: AuthHeaderValidVerificationResult,
+  delay: number | null = null,
 ): Promise<{
   successes: { id: string; status: number }[];
   errors: {
@@ -210,9 +238,7 @@ export const processEventBatch = async (
                 authCheck,
               },
             },
-            {
-              delay: env.LANGFUSE_INGESTION_QUEUE_DELAY_MS,
-            },
+            { delay: getDelay(delay) },
           )
         : Promise.reject("Failed to instantiate queue"),
     ),

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -54,7 +54,8 @@ export default withMiddlewares({
       const events: IngestionEventType[] = resourceSpans.flatMap(
         convertOtelSpanToIngestionEvent,
       );
-      return processEventBatch(events, auth);
+      // We set a delay of 0 for OTel, as we never expect updates.
+      return processEventBatch(events, auth, 0);
     },
   }),
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces time-based delay logic in `processEventBatch` and sets a 0 delay for OTel traces to prevent duplicate processing around date boundaries.
> 
>   - **Behavior**:
>     - Introduced `getDelay()` in `processEventBatch.ts` to determine delay based on current UTC time, using `env.LANGFUSE_INGESTION_QUEUE_DELAY_MS` between 23:45 and 00:15, otherwise 0.
>     - Updated `processEventBatch()` to use `getDelay()` for setting delay.
>     - Set delay to 0 for OTel traces in `index.ts` as updates are not expected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e5a0ae6c5e7f3e6f69cb6bfcf516909801cc5b61. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->