### PR TITLE
chore: fix flaky traces-api test

### DIFF
--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -60,7 +60,7 @@ describe("/api/public/traces API Endpoint", () => {
     expect(trace.body.externalId).toBeNull();
     expect(trace.body.version).toBe("2.0.0");
     expect(trace.body.projectId).toBe("7a88fb47-b4e2-43b8-a06c-a5ce950dc53a");
-    expect(trace.body.latency).toBe(100);
+    expect(trace.body.latency).toBeCloseTo(100, 2);
     expect(trace.body.observations.length).toBe(2);
     expect(trace.body.scores.length).toBe(0);
     expect(trace.body.observations).toEqual(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `traces-api.servertest.ts` to use `toBeCloseTo` for `latency` assertion to handle minor variations.
> 
>   - **Tests**:
>     - Update `traces-api.servertest.ts` to use `toBeCloseTo` instead of `toBe` for `latency` assertion, allowing for minor variations in latency values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 642cd1aa9ffec948933dbdb1b478b54be7f5e204. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->