### PR TITLE
style(dataset-analytics): decrease chart height and width

### DIFF
--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -401,7 +401,7 @@ export function DatasetRunsTable(props: {
     <>
       {Boolean(props.selectedMetrics.length) &&
         Boolean(runAggregatedMetrics?.size) && (
-          <Card className="my-4 max-h-[25dvh] md:max-h-[30dvh]">
+          <Card className="my-4 max-h-64">
             <CardContent className="mt-2 h-full">
               <div className="flex h-full w-full gap-4 overflow-x-auto">
                 {props.selectedMetrics.map((key) => {

--- a/web/src/features/scores/components/TimeseriesChart.tsx
+++ b/web/src/features/scores/components/TimeseriesChart.tsx
@@ -6,7 +6,7 @@ import { type TimeseriesChartProps } from "@/src/features/scores/types";
 
 function ChartWrapper(props: { title: string; children: React.ReactNode }) {
   return (
-    <div className="mb-2 flex w-[80%] flex-none flex-col overflow-hidden md:w-[45%]">
+    <div className="mb-2 flex w-[400px] flex-none flex-col overflow-hidden">
       <div className="shrink-0 text-sm font-medium">{props.title}</div>
       {props.children}
     </div>

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
@@ -274,7 +274,7 @@ export default function DatasetCompare() {
       />
       {Boolean(selectedMetrics.length) &&
         Boolean(runAggregatedMetrics?.size) && (
-          <Card className="my-4 max-h-[25dvh] md:max-h-[30dvh]">
+          <Card className="my-4 max-h-64">
             <CardContent className="mt-2 h-full">
               <div className="flex h-full w-full gap-4 overflow-x-auto">
                 {selectedMetrics.map((key) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce chart dimensions in `DatasetRunsTable.tsx`, `TimeseriesChart.tsx`, and `compare.tsx` for improved UI consistency.
> 
>   - **Styling Changes**:
>     - Decrease chart height in `DatasetRunsTable.tsx` and `compare.tsx` by changing `max-h-[25dvh] md:max-h-[30dvh]` to `max-h-64`.
>     - Adjust chart width in `TimeseriesChart.tsx` from `w-[80%] md:w-[45%]` to `w-[400px]`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7ec3fd92226470835e34535359f767367f03b17b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->