### PR TITLE
fix(ui): input changes lost on focus in dataset item edit

### DIFF
--- a/web/src/features/datasets/components/EditDatasetItem.tsx
+++ b/web/src/features/datasets/components/EditDatasetItem.tsx
@@ -82,13 +82,13 @@ export const EditDatasetItem = ({
   useEffect(() => {
     if (datasetItem) {
       form.reset({
-        input: datasetItem?.input
+        input: datasetItem.input
           ? JSON.stringify(datasetItem.input, null, 2)
           : "",
-        expectedOutput: datasetItem?.expectedOutput
+        expectedOutput: datasetItem.expectedOutput
           ? JSON.stringify(datasetItem.expectedOutput, null, 2)
           : "",
-        metadata: datasetItem?.metadata
+        metadata: datasetItem.metadata
           ? JSON.stringify(datasetItem.metadata, null, 2)
           : "",
       });

--- a/web/src/features/datasets/components/EditDatasetItem.tsx
+++ b/web/src/features/datasets/components/EditDatasetItem.tsx
@@ -80,24 +80,21 @@ export const EditDatasetItem = ({
   const utils = api.useUtils();
 
   useEffect(() => {
-    form.setValue(
-      "input",
-      datasetItem?.input ? JSON.stringify(datasetItem.input, null, 2) : "",
-    );
-    form.setValue(
-      "expectedOutput",
-      datasetItem?.expectedOutput
-        ? JSON.stringify(datasetItem.expectedOutput, null, 2)
-        : "",
-    );
-    form.setValue(
-      "metadata",
-      datasetItem?.metadata
-        ? JSON.stringify(datasetItem.metadata, null, 2)
-        : "",
-    );
+    if (datasetItem) {
+      form.reset({
+        input: datasetItem?.input
+          ? JSON.stringify(datasetItem.input, null, 2)
+          : "",
+        expectedOutput: datasetItem?.expectedOutput
+          ? JSON.stringify(datasetItem.expectedOutput, null, 2)
+          : "",
+        metadata: datasetItem?.metadata
+          ? JSON.stringify(datasetItem.metadata, null, 2)
+          : "",
+      });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [datasetItem]);
+  }, [datasetItem?.id]);
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId].tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId].tsx
@@ -81,6 +81,7 @@ export default function Dataset() {
           className="!overflow-y-auto"
         >
           <EditDatasetItem
+            key={item.data?.id}
             projectId={projectId}
             datasetItem={item.data ?? null}
           />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix input changes being lost on focus in dataset item edit by using `form.reset` and adding `key` prop for re-rendering.
> 
>   - **Behavior**:
>     - Use `form.reset` instead of `form.setValue` in `EditDatasetItem.tsx` to initialize form values, preventing loss of input changes on focus.
>     - Add `key` prop to `EditDatasetItem` in `itemId.tsx` to force re-render on dataset item ID change.
>   - **Misc**:
>     - Change dependency in `useEffect` from `datasetItem` to `datasetItem?.id` in `EditDatasetItem.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7a065f090f921c8ff269a3ea95e18b4fcbe20f8f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->