### PR TITLE
chore: optionally log s3 event bucket uploads in postgres

### DIFF
--- a/packages/shared/prisma/generated/types.ts
+++ b/packages/shared/prisma/generated/types.ts
@@ -253,6 +253,17 @@ export type EvalTemplate = {
     vars: Generated<string[]>;
     output_schema: unknown;
 };
+export type EventLog = {
+    id: string;
+    bucket_name: string;
+    bucket_path: string;
+    project_id: string;
+    entity_type: string;
+    entity_id: string;
+    trace_id: string | null;
+    created_at: Generated<Timestamp>;
+    updated_at: Generated<Timestamp>;
+};
 export type Events = {
     id: string;
     created_at: Generated<Timestamp>;
@@ -634,6 +645,7 @@ export type DB = {
     dataset_runs: DatasetRuns;
     datasets: Dataset;
     eval_templates: EvalTemplate;
+    event_log: EventLog;
     events: Events;
     job_configurations: JobConfiguration;
     job_executions: JobExecution;

--- a/packages/shared/prisma/generated/types.ts
+++ b/packages/shared/prisma/generated/types.ts
@@ -260,6 +260,7 @@ export type EventLog = {
     project_id: string;
     entity_type: string;
     entity_id: string;
+    event_id: string;
     trace_id: string | null;
     created_at: Generated<Timestamp>;
     updated_at: Generated<Timestamp>;

--- a/packages/shared/prisma/migrations/20250204180200_add_event_log_table/migration.sql
+++ b/packages/shared/prisma/migrations/20250204180200_add_event_log_table/migration.sql
@@ -8,6 +8,7 @@ CREATE TABLE "event_log" (
     "project_id" TEXT NOT NULL,
     "entity_type" TEXT NOT NULL,
     "entity_id" TEXT NOT NULL,
+    "event_id" TEXT NOT NULL,
 
     "trace_id" TEXT,
 
@@ -16,4 +17,4 @@ CREATE TABLE "event_log" (
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "event_log_project_id_entity_type_entity_id_key" ON "event_log"("project_id", "entity_type", "entity_id");
+CREATE INDEX "event_log_project_id_entity_type_entity_id_idx" ON "event_log"("project_id", "entity_type", "entity_id");

--- a/packages/shared/prisma/migrations/20250204180200_add_event_log_table/migration.sql
+++ b/packages/shared/prisma/migrations/20250204180200_add_event_log_table/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "event_log" (
+    "id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "bucket_name" TEXT NOT NULL,
+    "bucket_path" TEXT NOT NULL,
+    "project_id" TEXT NOT NULL,
+    "entity_type" TEXT NOT NULL,
+    "entity_id" TEXT NOT NULL,
+
+    "trace_id" TEXT,
+
+    CONSTRAINT "event_log_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "event_log_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "event_log_project_id_entity_type_entity_id_key" ON "event_log"("project_id", "entity_type", "entity_id");

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -716,6 +716,7 @@ model EventLog {
   project    Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
   entityType String  @map("entity_type")
   entityId   String  @map("entity_id")
+  eventId    String  @map("event_id")
 
   // traceId is only optional, because we cannot guarantee its presence for observations.
   // We use it to support deletions on traces as we cannot cascade it down to scores and observations otherwise.
@@ -725,7 +726,7 @@ model EventLog {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 
-  @@unique([projectId, entityType, entityId])
+  @@index([projectId, entityType, entityId])
   @@map("event_log")
 }
 

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -141,6 +141,7 @@ model Project {
   TraceMedia          TraceMedia[]
   Media               Media[]
   ObservationMedia    ObservationMedia[]
+  EventLog            EventLog[]
 
   @@index([orgId])
   @@map("projects")
@@ -704,6 +705,28 @@ model Events {
 
   @@index(projectId)
   @@map("events")
+}
+
+model EventLog {
+  id String @id @default(cuid())
+
+  bucketName String  @map("bucket_name")
+  bucketPath String  @map("bucket_path")
+  projectId  String  @map("project_id")
+  project    Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  entityType String  @map("entity_type")
+  entityId   String  @map("entity_id")
+
+  // traceId is only optional, because we cannot guarantee its presence for observations.
+  // We use it to support deletions on traces as we cannot cascade it down to scores and observations otherwise.
+  // We expect a traceId to be present in most cases.
+  traceId String? @map("trace_id")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
+
+  @@unique([projectId, entityType, entityId])
+  @@map("event_log")
 }
 
 model Comment {

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -46,6 +46,9 @@ const EnvSchema = z.object({
   ENABLE_AWS_CLOUDWATCH_METRIC_PUBLISHING: z
     .enum(["true", "false"])
     .default("false"),
+  LANGFUSE_S3_EVENT_UPLOAD_POSTGRES_LOG_ENABLED: z
+    .enum(["true", "false"])
+    .default("false"),
   LANGFUSE_S3_EVENT_UPLOAD_BUCKET: z.string({
     required_error: "Langfuse requires a bucket name for S3 Event Uploads.",
   }),

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -12,6 +12,7 @@ export * from "./llm/utils";
 export * from "./llm/types";
 export * from "./utils/DatabaseReadStream";
 export * from "./utils/transforms";
+export * from "./utils/eventLog";
 export * from "./clickhouse/client";
 export * from "./clickhouse/schemaUtils";
 export * from "./clickhouse/schema";

--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -173,10 +173,10 @@ export const processEventBatch = async (
         const { data, key, type, eventBodyId } = sortedBatchByEventBodyId[id];
         return uploadEventToS3(
           {
-            id: key,
             projectId: authCheck.scope.projectId,
             entityType: getClickhouseEntityType(type),
             entityId: eventBodyId,
+            eventId: key,
             traceId:
               data // Use the first truthy traceId for the event log.
                 .flatMap((event) =>

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -5,31 +5,11 @@ import {
 } from "../clickhouse/client";
 import { logger } from "../logger";
 import { getTracer, instrumentAsync } from "../instrumentation";
-import {
-  StorageService,
-  StorageServiceFactory,
-} from "../services/StorageService";
 import { randomUUID } from "crypto";
 import { getClickhouseEntityType } from "../clickhouse/schemaUtils";
 import { NodeClickHouseClientConfigOptions } from "@clickhouse/client/dist/config";
 import { context, trace } from "@opentelemetry/api";
 import { uploadEventToS3 } from "../utils/eventLog";
-
-let s3StorageServiceClient: StorageService;
-
-const getS3StorageServiceClient = (bucketName: string): StorageService => {
-  if (!s3StorageServiceClient) {
-    s3StorageServiceClient = StorageServiceFactory.getInstance({
-      bucketName,
-      accessKeyId: env.LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID,
-      secretAccessKey: env.LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY,
-      endpoint: env.LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT,
-      region: env.LANGFUSE_S3_EVENT_UPLOAD_REGION,
-      forcePathStyle: env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
-    });
-  }
-  return s3StorageServiceClient;
-};
 
 export async function upsertClickhouse<
   T extends Record<string, unknown>,
@@ -42,9 +22,6 @@ export async function upsertClickhouse<
     // https://opentelemetry.io/docs/specs/semconv/database/database-spans/
     span.setAttribute("ch.query.table", opts.table);
 
-    const s3Client = getS3StorageServiceClient(
-      env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
-    );
     await Promise.all(
       opts.records.map((record) => {
         // drop trailing s and pretend it's always a create.
@@ -58,10 +35,10 @@ export async function upsertClickhouse<
         const eventId = randomUUID();
         return uploadEventToS3(
           {
-            id: eventId,
             projectId: record.project_id as string,
             entityType: getClickhouseEntityType(eventType),
             entityId: record.id as string,
+            eventId,
             traceId: record?.trace_id as string,
           },
           [

--- a/packages/shared/src/server/utils/eventLog.ts
+++ b/packages/shared/src/server/utils/eventLog.ts
@@ -1,0 +1,55 @@
+import { EventLog } from "@prisma/client";
+import { prisma } from "../../db";
+import { logger } from "../logger";
+import { env } from "../../env";
+import {
+  StorageService,
+  StorageServiceFactory,
+} from "../services/StorageService";
+
+let s3StorageServiceClient: StorageService;
+
+const getS3StorageServiceClient = (bucketName: string): StorageService => {
+  if (!s3StorageServiceClient) {
+    s3StorageServiceClient = StorageServiceFactory.getInstance({
+      bucketName,
+      accessKeyId: env.LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID,
+      secretAccessKey: env.LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY,
+      endpoint: env.LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT,
+      region: env.LANGFUSE_S3_EVENT_UPLOAD_REGION,
+      forcePathStyle: env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+    });
+  }
+  return s3StorageServiceClient;
+};
+
+export const uploadEventToS3 = async (
+  event: Omit<
+    EventLog,
+    "createdAt" | "updatedAt" | "bucketPath" | "bucketName"
+  >,
+  data: Record<string, unknown>[],
+) => {
+  // We upload the event in an array to the S3 bucket grouped by the eventBodyId.
+  // That way we batch updates from the same invocation into a single file and reduce
+  // write operations on S3.
+  const bucketPath = `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${event.projectId}/${event.entityType}/${event.entityId}/${event.id}.json`;
+  if (env.LANGFUSE_S3_EVENT_UPLOAD_POSTGRES_LOG_ENABLED === "true") {
+    try {
+      await prisma.eventLog.create({
+        data: {
+          ...event,
+          bucketPath,
+          bucketName: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+        },
+      });
+    } catch (e) {
+      logger.error("Failed to write event log to Postgres", e);
+      // Fallthrough as this shouldn't block further execution right now.
+    }
+  }
+
+  return getS3StorageServiceClient(
+    env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+  ).uploadJson(bucketPath, data);
+};

--- a/packages/shared/src/server/utils/eventLog.ts
+++ b/packages/shared/src/server/utils/eventLog.ts
@@ -26,14 +26,11 @@ const getS3StorageServiceClient = (bucketName: string): StorageService => {
 export const uploadEventToS3 = async (
   event: Omit<
     EventLog,
-    "createdAt" | "updatedAt" | "bucketPath" | "bucketName"
+    "createdAt" | "updatedAt" | "bucketPath" | "bucketName" | "id"
   >,
   data: Record<string, unknown>[],
 ) => {
-  // We upload the event in an array to the S3 bucket grouped by the eventBodyId.
-  // That way we batch updates from the same invocation into a single file and reduce
-  // write operations on S3.
-  const bucketPath = `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${event.projectId}/${event.entityType}/${event.entityId}/${event.id}.json`;
+  const bucketPath = `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${event.projectId}/${event.entityType}/${event.entityId}/${event.eventId}.json`;
   if (env.LANGFUSE_S3_EVENT_UPLOAD_POSTGRES_LOG_ENABLED === "true") {
     try {
       await prisma.eventLog.create({

--- a/worker/src/ee/evaluation/evalService.ts
+++ b/worker/src/ee/evaluation/evalService.ts
@@ -441,10 +441,10 @@ export const evaluate = async ({
     const eventId = randomUUID();
     await uploadEventToS3(
       {
-        id: eventId,
         projectId: event.projectId,
         entityType: "score",
         entityId: scoreId,
+        eventId,
         traceId: job.job_input_trace_id,
       },
       [

--- a/worker/src/ee/evaluation/evalService.ts
+++ b/worker/src/ee/evaluation/evalService.ts
@@ -21,6 +21,7 @@ import {
   getObservationForTraceIdByName,
   DatasetRunItemUpsertEventType,
   TraceQueueEventType,
+  uploadEventToS3,
 } from "@langfuse/shared/src/server";
 import {
   availableTraceEvalVariables,
@@ -439,14 +440,18 @@ export const evaluate = async ({
 
   // Write score to S3 and ingest into queue for Clickhouse processing
   try {
-    const s3Client = getS3StorageServiceClient(
-      env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
-    );
-    await s3Client.uploadJson(
-      `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${event.projectId}/score/${scoreId}/${randomUUID()}.json`,
+    const eventId = randomUUID();
+    await uploadEventToS3(
+      {
+        id: eventId,
+        projectId: event.projectId,
+        entityType: "score",
+        entityId: scoreId,
+        traceId: job.job_input_trace_id,
+      },
       [
         {
-          id: randomUUID(),
+          id: eventId,
           timestamp: new Date().toISOString(),
           type: eventTypes.SCORE_CREATE,
           body: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds optional logging of S3 event uploads to Postgres, with schema updates and function modifications to support this feature.
> 
>   - **Behavior**:
>     - Adds optional logging of S3 event uploads to Postgres, controlled by `LANGFUSE_S3_EVENT_UPLOAD_POSTGRES_LOG_ENABLED` in `env.ts`.
>     - Updates `uploadEventToS3` in `eventLog.ts` to log events to Postgres if enabled.
>   - **Models**:
>     - Adds `EventLog` model to `schema.prisma` and `types.ts`.
>     - Creates `event_log` table in `migration.sql` with relevant fields and indices.
>   - **Functions**:
>     - Refactors `processEventBatch` in `processEventBatch.ts` to use `uploadEventToS3`.
>     - Updates `upsertClickhouse` in `clickhouse.ts` to use `uploadEventToS3`.
>     - Modifies `evaluate` in `evalService.ts` to log scores to S3 and optionally to Postgres.
>   - **Tests**:
>     - Adds a skipped test in `ingestion-api.servertest.ts` for logging S3 uploads to Postgres.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f3039752968236141d7d1089378df93b2104c30e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->