### PR TITLE
perf: add new observation views to pre-aggregate statistics

### DIFF
--- a/packages/shared/clickhouse/migrations/clustered/0007_observation_stats.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0007_observation_stats.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE observation_stats ON CLUSTER default;

--- a/packages/shared/clickhouse/migrations/clustered/0007_observation_stats.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0007_observation_stats.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE observation_stats ON CLUSTER default
+(
+    `project_id` String,
+    `trace_id` String,
+    `count` AggregateFunction(uniq, String),
+    `min_start_time` SimpleAggregateFunction(min, Nullable(DateTime64(3))),
+    `max_start_time` SimpleAggregateFunction(max, Nullable(DateTime64(3))),
+    `max_end_time` SimpleAggregateFunction(max, Nullable(DateTime64(3))),
+    `unique_levels` SimpleAggregateFunction(groupUniqArrayArray, Array(String))
+) ENGINE = AggregatingMergeTree()
+ORDER BY (project_id, trace_id);

--- a/packages/shared/clickhouse/migrations/clustered/0008_observation_costs.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0008_observation_costs.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE observation_costs ON CLUSTER default;

--- a/packages/shared/clickhouse/migrations/clustered/0008_observation_costs.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0008_observation_costs.up.sql
@@ -1,0 +1,34 @@
+CREATE TABLE observation_costs ON CLUSTER default (
+    `id` String,
+    `trace_id` String,
+    `project_id` String,
+    `type` LowCardinality(String),
+    `parent_observation_id` Nullable(String),
+    `start_time` DateTime64(3),
+    `end_time` Nullable(DateTime64(3)),
+    `name` String,
+    `metadata` Map(LowCardinality(String), String),
+    `provided_usage_details` Map(LowCardinality(String), UInt64),
+    `usage_details` Map(LowCardinality(String), UInt64),
+    `provided_cost_details` Map(LowCardinality(String), Decimal64(12)),
+    `cost_details` Map(LowCardinality(String), Decimal64(12)),
+    `total_cost` Nullable(Decimal64(12)),
+    `level` LowCardinality(String),
+    `created_at` DateTime64(3) DEFAULT now(),
+    `updated_at` DateTime64(3) DEFAULT now(),
+    event_ts DateTime64(3),
+    is_deleted UInt8
+) ENGINE = ReplacingMergeTree(event_ts, is_deleted) Partition by toYYYYMM(start_time)
+PRIMARY KEY (
+    project_id,
+    trace_id,
+    toDate(start_time),
+    `type`
+)
+ORDER BY (
+    project_id,
+    trace_id,
+    toDate(start_time),
+    `type`,
+    id
+);

--- a/packages/shared/clickhouse/migrations/clustered/0009_observation_stats_view.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0009_observation_stats_view.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW observation_stats_view ON CLUSTER default;

--- a/packages/shared/clickhouse/migrations/clustered/0009_observation_stats_view.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0009_observation_stats_view.up.sql
@@ -1,0 +1,17 @@
+CREATE VIEW observation_stats_view ON CLUSTER default AS
+  SELECT
+    os.project_id,
+    os.trace_id,
+    uniqMerge(os.count) AS count,
+    min(os.min_start_time) AS min_start_time,
+    max(os.max_start_time) AS max_start_time,
+    max(os.max_end_time) AS max_end_time,
+    groupUniqArrayArray(os.unique_levels) as unique_levels,
+    groupArray(oc.level) as levels,
+    sumMap(oc.usage_details) AS usage_details,
+    sumMap(oc.cost_details) AS cost_details,
+    sum(oc.total_cost) AS total_cost
+  FROM observation_stats os FINAL
+  LEFT JOIN observation_costs oc FINAL
+  ON os.project_id = oc.project_id AND os.trace_id = oc.trace_id
+  GROUP BY os.project_id, os.trace_id;

--- a/packages/shared/clickhouse/migrations/clustered/0010_observation_stats_mv.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0010_observation_stats_mv.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW observation_stats_mv ON CLUSTER default;

--- a/packages/shared/clickhouse/migrations/clustered/0010_observation_stats_mv.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0010_observation_stats_mv.up.sql
@@ -1,11 +1,11 @@
 CREATE MATERIALIZED VIEW observation_stats_mv ON CLUSTER default TO observation_stats AS
 SELECT
-    trace_id,
     project_id,
+    trace_id,
     uniqState(id) as count,
     minSimpleState(start_time) as min_start_time,
     maxSimpleState(start_time) as max_start_time,
     maxSimpleState(end_time) as max_end_time,
     groupUniqArrayArraySimpleState([level]) as unique_levels
 FROM observations
-GROUP BY trace_id, project_id;
+GROUP BY project_id, trace_id;

--- a/packages/shared/clickhouse/migrations/clustered/0010_observation_stats_mv.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0010_observation_stats_mv.up.sql
@@ -1,0 +1,11 @@
+CREATE MATERIALIZED VIEW observation_stats_mv ON CLUSTER default TO observation_stats AS
+SELECT
+    trace_id,
+    project_id,
+    uniqState(id) as count,
+    minSimpleState(start_time) as min_start_time,
+    maxSimpleState(start_time) as max_start_time,
+    maxSimpleState(end_time) as max_end_time,
+    groupUniqArrayArraySimpleState([level]) as unique_levels
+FROM observations
+GROUP BY trace_id, project_id;

--- a/packages/shared/clickhouse/migrations/clustered/0011_observation_costs_mv.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0011_observation_costs_mv.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW observation_costs_mv ON CLUSTER default;

--- a/packages/shared/clickhouse/migrations/clustered/0011_observation_costs_mv.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0011_observation_costs_mv.up.sql
@@ -1,0 +1,22 @@
+CREATE MATERIALIZED VIEW observation_costs_mv ON CLUSTER default TO observation_costs AS
+SELECT
+    id,
+    trace_id,
+    project_id,
+    type,
+    parent_observation_id,
+    start_time,
+    end_time,
+    name,
+    metadata,
+    provided_usage_details,
+    usage_details,
+    provided_cost_details,
+    cost_details,
+    total_cost,
+    level,
+    created_at,
+    updated_at,
+    event_ts,
+    is_deleted
+FROM observations

--- a/packages/shared/clickhouse/migrations/clustered/0011_observation_costs_mv.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0011_observation_costs_mv.up.sql
@@ -19,4 +19,4 @@ SELECT
     updated_at,
     event_ts,
     is_deleted
-FROM observations
+FROM observations;

--- a/packages/shared/clickhouse/migrations/unclustered/0006_add_user_id_index.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0006_add_user_id_index.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE traces ON CLUSTER default DROP INDEX IF EXISTS idx_user_id;
+ALTER TABLE traces DROP INDEX IF EXISTS idx_user_id;

--- a/packages/shared/clickhouse/migrations/unclustered/0007_observation_stats.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0007_observation_stats.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE observation_stats;

--- a/packages/shared/clickhouse/migrations/unclustered/0007_observation_stats.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0007_observation_stats.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE observation_stats
+(
+    `project_id` String,
+    `trace_id` String,
+    `count` AggregateFunction(uniq, String),
+    `min_start_time` SimpleAggregateFunction(min, Nullable(DateTime64(3))),
+    `max_start_time` SimpleAggregateFunction(max, Nullable(DateTime64(3))),
+    `max_end_time` SimpleAggregateFunction(max, Nullable(DateTime64(3))),
+    `unique_levels` SimpleAggregateFunction(groupUniqArrayArray, Array(String))
+) ENGINE = AggregatingMergeTree()
+ORDER BY (project_id, trace_id);

--- a/packages/shared/clickhouse/migrations/unclustered/0008_observation_costs.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0008_observation_costs.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE observation_costs;

--- a/packages/shared/clickhouse/migrations/unclustered/0008_observation_costs.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0008_observation_costs.up.sql
@@ -1,0 +1,34 @@
+CREATE TABLE observation_costs (
+    `id` String,
+    `trace_id` String,
+    `project_id` String,
+    `type` LowCardinality(String),
+    `parent_observation_id` Nullable(String),
+    `start_time` DateTime64(3),
+    `end_time` Nullable(DateTime64(3)),
+    `name` String,
+    `metadata` Map(LowCardinality(String), String),
+    `provided_usage_details` Map(LowCardinality(String), UInt64),
+    `usage_details` Map(LowCardinality(String), UInt64),
+    `provided_cost_details` Map(LowCardinality(String), Decimal64(12)),
+    `cost_details` Map(LowCardinality(String), Decimal64(12)),
+    `total_cost` Nullable(Decimal64(12)),
+    `level` LowCardinality(String),
+    `created_at` DateTime64(3) DEFAULT now(),
+    `updated_at` DateTime64(3) DEFAULT now(),
+    event_ts DateTime64(3),
+    is_deleted UInt8
+) ENGINE = ReplacingMergeTree(event_ts, is_deleted) Partition by toYYYYMM(start_time)
+PRIMARY KEY (
+    project_id,
+    trace_id,
+    toDate(start_time),
+    `type`
+)
+ORDER BY (
+    project_id,
+    trace_id,
+    toDate(start_time),
+    `type`,
+    id
+);

--- a/packages/shared/clickhouse/migrations/unclustered/0009_observation_stats_view.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0009_observation_stats_view.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW observation_stats_view;

--- a/packages/shared/clickhouse/migrations/unclustered/0009_observation_stats_view.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0009_observation_stats_view.up.sql
@@ -1,0 +1,17 @@
+CREATE VIEW observation_stats_view AS
+  SELECT
+    os.project_id,
+    os.trace_id,
+    uniqMerge(os.count) AS count,
+    min(os.min_start_time) AS min_start_time,
+    max(os.max_start_time) AS max_start_time,
+    max(os.max_end_time) AS max_end_time,
+    groupUniqArrayArray(os.unique_levels) as unique_levels,
+    groupArray(oc.level) as levels,
+    sumMap(oc.usage_details) AS usage_details,
+    sumMap(oc.cost_details) AS cost_details,
+    sum(oc.total_cost) AS total_cost
+  FROM observation_stats os FINAL
+  LEFT JOIN observation_costs oc FINAL
+  ON os.project_id = oc.project_id AND os.trace_id = oc.trace_id
+  GROUP BY os.project_id, os.trace_id;

--- a/packages/shared/clickhouse/migrations/unclustered/0010_observation_stats_mv.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0010_observation_stats_mv.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW observation_stats_mv;

--- a/packages/shared/clickhouse/migrations/unclustered/0010_observation_stats_mv.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0010_observation_stats_mv.up.sql
@@ -1,11 +1,11 @@
 CREATE MATERIALIZED VIEW observation_stats_mv TO observation_stats AS
 SELECT
-    trace_id,
     project_id,
+    trace_id,
     uniqState(id) as count,
     minSimpleState(start_time) as min_start_time,
     maxSimpleState(start_time) as max_start_time,
     maxSimpleState(end_time) as max_end_time,
     groupUniqArrayArraySimpleState([level]) as unique_levels
 FROM observations
-GROUP BY trace_id, project_id;
+GROUP BY project_id, trace_id;

--- a/packages/shared/clickhouse/migrations/unclustered/0010_observation_stats_mv.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0010_observation_stats_mv.up.sql
@@ -1,0 +1,11 @@
+CREATE MATERIALIZED VIEW observation_stats_mv TO observation_stats AS
+SELECT
+    trace_id,
+    project_id,
+    uniqState(id) as count,
+    minSimpleState(start_time) as min_start_time,
+    maxSimpleState(start_time) as max_start_time,
+    maxSimpleState(end_time) as max_end_time,
+    groupUniqArrayArraySimpleState([level]) as unique_levels
+FROM observations
+GROUP BY trace_id, project_id;

--- a/packages/shared/clickhouse/migrations/unclustered/0011_observation_costs_mv.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0011_observation_costs_mv.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW observation_costs_mv;

--- a/packages/shared/clickhouse/migrations/unclustered/0011_observation_costs_mv.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0011_observation_costs_mv.up.sql
@@ -1,0 +1,22 @@
+CREATE MATERIALIZED VIEW observation_costs_mv TO observation_costs AS
+SELECT
+    id,
+    trace_id,
+    project_id,
+    type,
+    parent_observation_id,
+    start_time,
+    end_time,
+    name,
+    metadata,
+    provided_usage_details,
+    usage_details,
+    provided_cost_details,
+    cost_details,
+    total_cost,
+    level,
+    created_at,
+    updated_at,
+    event_ts,
+    is_deleted
+FROM observations

--- a/packages/shared/clickhouse/migrations/unclustered/0011_observation_costs_mv.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0011_observation_costs_mv.up.sql
@@ -19,4 +19,4 @@ SELECT
     updated_at,
     event_ts,
     is_deleted
-FROM observations
+FROM observations;


### PR DESCRIPTION
We can backfill the new materialized view using 
```sql
insert into observation_costs
    select id, trace_id, project_id, type, parent_observation_id,
       start_time, end_time, name, metadata, provided_usage_details,
       usage_details, provided_cost_details, cost_details, total_cost,
       level, created_at, updated_at, event_ts, is_deleted
    from observations;

insert into observation_stats
  select project_id, trace_id, uniqState(id) as count, min(start_time) as min_start_time,
  max(start_time) as max_start_time, max(end_time) as max_end_time, groupUniqArray(level) as unique_levels
  from observations
  group by project_id, trace_id;
```
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add new tables and materialized views for pre-aggregating observation statistics in ClickHouse, with both clustered and unclustered migrations.
> 
>   - **Tables**:
>     - Create `observation_stats` and `observation_costs` tables in both clustered and unclustered migrations.
>     - `observation_stats` includes fields like `project_id`, `trace_id`, `count`, `min_start_time`, `max_start_time`, `max_end_time`, and `unique_levels`.
>     - `observation_costs` includes fields like `id`, `trace_id`, `project_id`, `type`, `parent_observation_id`, `start_time`, `end_time`, `name`, `metadata`, `provided_usage_details`, `usage_details`, `provided_cost_details`, `cost_details`, `total_cost`, `level`, `created_at`, `updated_at`, `event_ts`, and `is_deleted`.
>   - **Views**:
>     - Create `observation_stats_view` and `observation_costs_mv` materialized views in both clustered and unclustered migrations.
>     - `observation_stats_view` aggregates data from `observation_stats` and `observation_costs`.
>     - `observation_costs_mv` and `observation_stats_mv` materialized views aggregate data from `observations` table.
>   - **Misc**:
>     - Modify `0006_add_user_id_index.down.sql` to remove `ON CLUSTER default` from `DROP INDEX` statement.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 93568782d21971457ed15aa3957d8fa146e3d467. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->