### PR TITLE
perf: do not load all models by default in the dashboards

### DIFF
--- a/packages/shared/scripts/prepareClickhouse.ts
+++ b/packages/shared/scripts/prepareClickhouse.ts
@@ -97,16 +97,10 @@ export const prepareClickhouse = async (
       repeat('input', toInt64(randExponential(1 / 100))) AS input,
       repeat('output', toInt64(randExponential(1 / 100))) AS output,
       if("type" = 'GENERATION',
-        case
-          when number % 2 = 0 then 'claude-3-haiku-20240307'
-          else 'gpt-4'
-        end,
+        generateUUIDv4(),
         NULL) as provided_model_name,
       if("type" = 'GENERATION',
-        case
-          when number % 2 = 0 then 'cltr0w45b000008k1407o9qv1'
-          else 'clrntkjgy000f08jx79v9g1xj'
-        end,
+        generateUUIDv4(),
         NULL) as internal_model_id,
       if("type" = 'GENERATION',
         '{"temperature": 0.7, "max_tokens": 150}',

--- a/packages/shared/scripts/prepareClickhouse.ts
+++ b/packages/shared/scripts/prepareClickhouse.ts
@@ -96,12 +96,14 @@ export const prepareClickhouse = async (
       'version' AS version,
       repeat('input', toInt64(randExponential(1 / 100))) AS input,
       repeat('output', toInt64(randExponential(1 / 100))) AS output,
-      if("type" = 'GENERATION',
-        generateUUIDv4(),
-        NULL) as provided_model_name,
-      if("type" = 'GENERATION',
-        generateUUIDv4(),
-        NULL) as internal_model_id,
+      case
+        when number % 2 = 0 then 'clause-3-haiku-20230407'
+        else 'gpt-4'
+      end as provided_model_name,
+      case
+        when number % 2 = 0 then 'cltra4wbs0000k1407g0ya3'
+        else '1cmtk9y0000y3y79x9jgxj'
+      end as internal_model_id,
       if("type" = 'GENERATION',
         '{"temperature": 0.7, "max_tokens": 150}',
         '{}') AS model_parameters,

--- a/web/src/features/dashboard/components/LatencyChart.tsx
+++ b/web/src/features/dashboard/components/LatencyChart.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { api } from "@/src/utils/api";
 import { type FilterState } from "@langfuse/shared";
 import {
@@ -15,6 +16,10 @@ import {
   type DashboardDateRangeAggregationOption,
 } from "@/src/utils/date-range-utils";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
+import {
+  ModelSelectorPopover,
+  useModelSelection,
+} from "@/src/features/dashboard/components/ModelSelector";
 
 export const GenerationLatencyChart = ({
   className,
@@ -27,6 +32,15 @@ export const GenerationLatencyChart = ({
   globalFilterState: FilterState;
   agg: DashboardDateRangeAggregationOption;
 }) => {
+  const {
+    allModels,
+    selectedModels,
+    setSelectedModels,
+    isAllSelected,
+    buttonText,
+    handleSelectAll,
+  } = useModelSelection(projectId, globalFilterState);
+
   const latencies = api.dashboard.chart.useQuery(
     {
       projectId,
@@ -47,6 +61,12 @@ export const GenerationLatencyChart = ({
           operator: "=",
           value: "GENERATION",
         },
+        {
+          type: "stringOptions",
+          column: "model",
+          operator: "any of",
+          value: selectedModels,
+        } as const,
       ],
       groupBy: [
         {
@@ -59,6 +79,7 @@ export const GenerationLatencyChart = ({
       queryName: "model-latencies-over-time",
     },
     {
+      enabled: selectedModels.length > 0 && allModels.length > 0,
       trpc: {
         context: {
           skipBatch: true,
@@ -67,10 +88,8 @@ export const GenerationLatencyChart = ({
     },
   );
 
-  const allModels = getAllModels(projectId, globalFilterState);
-
   const getData = (valueColumn: string) => {
-    return latencies.data && allModels.length > 0
+    return latencies.data && selectedModels.length > 0
       ? fillMissingValuesAndTransform(
           extractTimeSeriesData(latencies.data, "startTime", [
             {
@@ -78,7 +97,7 @@ export const GenerationLatencyChart = ({
               valueColumn: valueColumn,
             },
           ]),
-          allModels,
+          selectedModels,
         )
       : [];
   };
@@ -111,7 +130,19 @@ export const GenerationLatencyChart = ({
       className={className}
       title="Model latencies"
       description="Latencies (seconds) per LLM generation"
-      isLoading={latencies.isLoading}
+      isLoading={latencies.isLoading && selectedModels.length > 0}
+      headerRight={
+        <div className="flex items-center justify-end">
+          <ModelSelectorPopover
+            allModels={allModels}
+            selectedModels={selectedModels}
+            setSelectedModels={setSelectedModels}
+            buttonText={buttonText}
+            isAllSelected={isAllSelected}
+            handleSelectAll={handleSelectAll}
+          />
+        </div>
+      }
     >
       <TabComponent
         tabs={data.map((item) => {

--- a/web/src/features/dashboard/components/LatencyChart.tsx
+++ b/web/src/features/dashboard/components/LatencyChart.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useState } from "react";
 import { api } from "@/src/utils/api";
 import { type FilterState } from "@langfuse/shared";
 import {
-  getAllModels,
   extractTimeSeriesData,
   fillMissingValuesAndTransform,
   isEmptyTimeSeries,

--- a/web/src/features/dashboard/components/ModelSelector.tsx
+++ b/web/src/features/dashboard/components/ModelSelector.tsx
@@ -14,7 +14,6 @@ import {
   PopoverTrigger,
 } from "@/src/components/ui/popover";
 import { getAllModels } from "@/src/features/dashboard/components/hooks";
-import { api } from "@/src/utils/api";
 import { cn } from "@/src/utils/tailwind";
 import { type FilterState } from "@langfuse/shared";
 import { Check, ChevronsUpDown } from "lucide-react";

--- a/web/src/features/dashboard/components/ModelSelector.tsx
+++ b/web/src/features/dashboard/components/ModelSelector.tsx
@@ -1,0 +1,139 @@
+import { Button } from "@/src/components/ui/button";
+import {
+  InputCommand,
+  InputCommandEmpty,
+  InputCommandGroup,
+  InputCommandInput,
+  InputCommandItem,
+  InputCommandList,
+  InputCommandSeparator,
+} from "@/src/components/ui/input-command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/src/components/ui/popover";
+import { getAllModels } from "@/src/features/dashboard/components/hooks";
+import { api } from "@/src/utils/api";
+import { cn } from "@/src/utils/tailwind";
+import { type FilterState } from "@langfuse/shared";
+import { Check, ChevronsUpDown } from "lucide-react";
+import { useEffect, useState } from "react";
+
+export const ModelSelectorPopover = ({
+  allModels,
+  selectedModels,
+  setSelectedModels,
+  buttonText,
+  isAllSelected,
+  handleSelectAll,
+}: {
+  allModels: { model: string }[];
+  selectedModels: string[];
+  setSelectedModels: React.Dispatch<React.SetStateAction<string[]>>;
+  buttonText: string;
+  isAllSelected: boolean;
+  handleSelectAll: () => void;
+}) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-56 justify-between"
+        >
+          {buttonText}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-56 p-0">
+        <InputCommand>
+          <InputCommandInput placeholder="Search models..." />
+          <InputCommandEmpty>No model found.</InputCommandEmpty>
+          <InputCommandGroup>
+            <InputCommandItem onSelect={handleSelectAll}>
+              <Check
+                className={cn(
+                  "mr-2 h-4 w-4",
+                  isAllSelected ? "opacity-100" : "opacity-0",
+                )}
+              />
+              <span>
+                <p className="font-semibold">Select All</p>
+              </span>
+            </InputCommandItem>
+            <InputCommandSeparator className="my-1" />
+            <InputCommandList>
+              {allModels.map((model) => (
+                <InputCommandItem
+                  key={model.model}
+                  onSelect={() => {
+                    setSelectedModels((prev) =>
+                      prev.includes(model.model)
+                        ? prev.filter((m) => m !== model.model)
+                        : [...prev, model.model],
+                    );
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      selectedModels.includes(model.model)
+                        ? "opacity-100"
+                        : "opacity-0",
+                    )}
+                  />
+                  {!model.model || model.model === "" ? (
+                    <i>none</i>
+                  ) : (
+                    model.model
+                  )}
+                </InputCommandItem>
+              ))}
+            </InputCommandList>
+          </InputCommandGroup>
+        </InputCommand>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export const useModelSelection = (
+  projectId: string,
+  globalFilterState: FilterState,
+) => {
+  const allModels = getAllModels(projectId, globalFilterState);
+
+  const [selectedModels, setSelectedModels] = useState<string[]>([]);
+  const [firstAllModelUpdate, setFirstAllModelUpdate] = useState(true);
+
+  const isAllSelected = selectedModels.length === allModels.length;
+
+  const buttonText = isAllSelected
+    ? "All models"
+    : `${selectedModels.length} selected`;
+
+  const handleSelectAll = () => {
+    setSelectedModels(isAllSelected ? [] : [...allModels.map((m) => m.model)]);
+  };
+
+  useEffect(() => {
+    if (firstAllModelUpdate && allModels.length > 0) {
+      setSelectedModels(allModels.slice(0, 10).map((model) => model.model));
+      setFirstAllModelUpdate(false);
+    }
+  }, [allModels, firstAllModelUpdate]);
+
+  return {
+    allModels,
+    selectedModels,
+    setSelectedModels,
+    isAllSelected,
+    buttonText,
+    handleSelectAll,
+  };
+};

--- a/web/src/features/dashboard/components/ModelUsageChart.tsx
+++ b/web/src/features/dashboard/components/ModelUsageChart.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 import { env } from "@/src/env.mjs";
 import { BaseTimeSeriesChart } from "@/src/features/dashboard/components/BaseTimeSeriesChart";
@@ -6,7 +5,6 @@ import { DashboardCard } from "@/src/features/dashboard/components/cards/Dashboa
 import {
   extractTimeSeriesData,
   fillMissingValuesAndTransform,
-  getAllModels,
   isEmptyTimeSeries,
 } from "@/src/features/dashboard/components/hooks";
 import { TabComponent } from "@/src/features/dashboard/components/TabsComponent";

--- a/web/src/features/dashboard/components/hooks.ts
+++ b/web/src/features/dashboard/components/hooks.ts
@@ -36,10 +36,15 @@ export const getAllModels = (
   return allModels.data ? extractAllModels(allModels.data) : [];
 };
 
-const extractAllModels = (data: DatabaseRow[]): string[] => {
+const extractAllModels = (
+  data: DatabaseRow[],
+): { model: string; count: number }[] => {
   return data
     .filter((item) => item.model !== null)
-    .map((item) => item.model as string);
+    .map((item) => ({
+      model: item.model as string,
+      count: item.count as number,
+    }));
 };
 
 type ChartData = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimizes dashboard performance by allowing model selection, reducing default model loading.
> 
>   - **Behavior**:
>     - Introduced `ModelSelectorPopover` and `useModelSelection` in `ModelSelector.tsx` to allow users to select specific models instead of loading all by default.
>     - Updated `GenerationLatencyChart` and `ModelUsageChart` to use selected models for data queries.
>   - **Queries**:
>     - Modified `getDistinctModels` in `dashboards.ts` to return models with counts, ordered by count, and limited to 1000.
>     - Updated queries in `LatencyChart.tsx` and `ModelUsageChart.tsx` to filter by selected models.
>   - **Misc**:
>     - Removed `getAllModels` from `LatencyChart.tsx` and `ModelUsageChart.tsx` as it's now handled by `useModelSelection`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e0c63ac5c1bca328849f5ee7da5bc5eccaeabf85. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->