### PR TITLE
fix: return empty results in dashboard if from is larger than to

### DIFF
--- a/web/src/features/dashboard/server/dashboard-router.ts
+++ b/web/src/features/dashboard/server/dashboard-router.ts
@@ -28,6 +28,8 @@ import {
   getNumericScoreTimeSeries,
   getCategoricalScoreTimeSeries,
   getObservationsStatusTimeSeries,
+  extractFromAndToTimestampsFromFilter,
+  logger,
 } from "@langfuse/shared/src/server";
 import { type DatabaseRow } from "@/src/server/api/services/queryBuilder";
 import { dashboardColumnDefinitions } from "@langfuse/shared";
@@ -61,6 +63,15 @@ export const dashboardRouter = createTRPCRouter({
       }),
     )
     .query(async ({ input }) => {
+      const [from, to] = extractFromAndToTimestampsFromFilter(input.filter);
+
+      if (from.value > to.value) {
+        logger.error(
+          `from > to, returning empty result: from=${from}, to=${to}`,
+        );
+        return [];
+      }
+
       switch (input.queryName) {
         case "traces-total":
           const count = await getTotalTraces(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a check in `dashboard-router.ts` to return empty results and log an error if 'from' timestamp is greater than 'to' timestamp.
> 
>   - **Behavior**:
>     - In `dashboard-router.ts`, added a check to return empty results if `from` timestamp is greater than `to` timestamp.
>     - Logs an error using `logger` if `from > to` condition is met.
>   - **Functions**:
>     - Utilizes `extractFromAndToTimestampsFromFilter` to obtain `from` and `to` timestamps from input filter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 23cd58de88586fba0a54ba5581b14948b962d4d1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->