### PR TITLE
chore: fetch file list for worker processing from s3 event log

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -38,6 +38,9 @@ const EnvSchema = z.object({
   LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: z
     .enum(["true", "false"])
     .default("false"),
+  LANGFUSE_S3_EVENT_UPLOAD_POSTGRES_LOG_ENABLED: z
+    .enum(["true", "false"])
+    .default("false"),
 
   BATCH_EXPORT_ROW_LIMIT: z.coerce.number().positive().default(50_000),
   BATCH_EXPORT_DOWNLOAD_LINK_EXPIRATION_HOURS: z.coerce

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -101,6 +101,38 @@ export const ingestionQueueProcessorBuilder = (
       const eventFiles = await s3Client.listFiles(
         `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${clickhouseEntityType}/${job.data.payload.data.eventBodyId}/`,
       );
+
+      // Load file list from Postgres event log if enabled and compare with S3 List Result
+      if (env.LANGFUSE_S3_EVENT_UPLOAD_POSTGRES_LOG_ENABLED === "true") {
+        try {
+          const files = await prisma.eventLog.findMany({
+            select: {
+              bucketPath: true,
+              createdAt: true,
+            },
+            where: {
+              projectId: job.data.payload.authCheck.scope.projectId,
+              entityType: clickhouseEntityType,
+              entityId: job.data.payload.data.eventBodyId,
+            },
+          });
+
+          // Compare files from Postgres with S3 result
+          if (files.length !== eventFiles.length) {
+            logger.warn(`Mismatch between Postgres and S3 file list`, {
+              postgres: files,
+              s3: eventFiles,
+            });
+          }
+        } catch (e) {
+          logger.error(
+            `Failed to load event log from Postgres for project ${job.data.payload.authCheck.scope.projectId}`,
+            e,
+          );
+          // Fail silently while feature is experimental
+        }
+      }
+
       recordDistribution(
         "langfuse.ingestion.count_files_distribution",
         eventFiles.length,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds feature to compare S3 and Postgres file lists in `ingestionQueueProcessorBuilder`, logging mismatches and controlled by a new environment variable.
> 
>   - **Behavior**:
>     - Adds comparison of file lists from S3 and Postgres in `ingestionQueueProcessorBuilder` in `ingestionQueue.ts`.
>     - Logs a warning if there is a mismatch between S3 and Postgres file lists.
>     - Silently fails if Postgres log retrieval fails, as the feature is experimental.
>   - **Environment**:
>     - Adds `LANGFUSE_S3_EVENT_UPLOAD_POSTGRES_LOG_ENABLED` to `env.ts` to toggle Postgres log comparison feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5968c6e76e73a7f976d416a0cb305558568cb347. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->