### PR TITLE
chore: deduplicate postgres event list by bucketPath

### DIFF
--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -115,6 +115,7 @@ export const ingestionQueueProcessorBuilder = (
               entityType: clickhouseEntityType,
               entityId: job.data.payload.data.eventBodyId,
             },
+            distinct: ["bucketPath"],
           });
 
           // Compare files from Postgres with S3 result


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add deduplication by `bucketPath` to Postgres query in `ingestionQueueProcessorBuilder`.
> 
>   - **Behavior**:
>     - Add `distinct: ["bucketPath"]` to Postgres query in `ingestionQueueProcessorBuilder` to deduplicate event list by `bucketPath`.
>     - Ensures unique file paths are compared between Postgres and S3.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1d183202825b33ddcc13f01da9c44d2c34d92036. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->