### PR TITLE
fix: do not run snyk in merge queue

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,15 +9,15 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: "CodeQL Advanced"
 
 on:
   push:
-    branches: ["main", "production", "v*"]
+    branches: ["main", "production", "v2"]
   pull_request:
-    branches: ["main", "production", "v*"]
+    branches: ["main", "production", "v2"]
   schedule:
-    - cron: "31 13 * * 0"
+    - cron: "36 20 * * 3"
 
 jobs:
   analyze:
@@ -56,6 +56,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      # Add any setup steps before running the `github/codeql-action/init` action.
+      # This includes steps like installing compilers or runtimes (`actions/setup-node`
+      # or others). This is typically only required for manual builds.
+      # - name: Setup runtime (example)
+      #   uses: actions/setup-example@v1
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -10,6 +10,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Upload result to GitHub Code Scanning
         # Only upload results on PRs, not on merge groups https://github.com/github/codeql-action/issues/1572
-        if: ${{ github.event_name == 'merge_group' && 'never' || 'always' }}
+        if: ${{ github.event_name != 'merge_group' }}
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload result to GitHub Code Scanning
         # Only upload results on PRs, not on merge groups https://github.com/github/codeql-action/issues/1572
-        if: ${{ github.event_name == 'merge_group' && 'never' || 'always' }}
+        if: ${{ github.event_name != 'merge_group' }}
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -31,6 +31,8 @@ jobs:
           args: --file=web/Dockerfile
 
       - name: Upload result to GitHub Code Scanning
+        # Only upload results on PRs, not on merge groups https://github.com/github/codeql-action/issues/1572
+        if: ${{ github.event_name == 'merge_group' && 'never' || 'always' }}
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
@@ -46,6 +48,8 @@ jobs:
           args: --file=worker/Dockerfile
 
       - name: Upload result to GitHub Code Scanning
+        # Only upload results on PRs, not on merge groups https://github.com/github/codeql-action/issues/1572
+        if: ${{ github.event_name == 'merge_group' && 'never' || 'always' }}
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refines CodeQL and Snyk GitHub Actions workflows by renaming, updating branch specifications, adjusting schedules, and adding conditions for result uploads.
> 
>   - **CodeQL Workflow**:
>     - Renamed workflow from `CodeQL` to `CodeQL Advanced` in `codeql.yml`.
>     - Updated branch specifications to `v2` for `push` and `pull_request` events.
>     - Changed cron schedule to `36 20 * * 3`.
>     - Added commented setup steps for runtime installation.
>   - **Snyk Workflow**:
>     - Added condition to only upload results on PRs, not on merge groups, in `snyk.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 10ae00fc7ccb67ed42ffa721d6631489c79cc28e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->