### PR TITLE
fix: do not run snyk in merge groups

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-  merge_group:
+  # Snyk cannot upload results in merge group. Hence, we only run on PRs and when pushingon the main branch https://github.com/github/codeql-action/issues/1572
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevent Snyk from running in merge groups by commenting out the `merge_group` trigger in `snyk.yml`.
> 
>   - **Behavior**:
>     - Prevents Snyk from running in merge groups by commenting out `merge_group` trigger in `.github/workflows/snyk.yml`.
>     - Snyk now only runs on pull requests and pushes to the `main` branch.
>   - **Comments**:
>     - Adds a comment explaining the reason for not running Snyk in merge groups, referencing a GitHub issue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a5a582159de30b334f7e4cbf1d149ef64ba7b182. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->