### PR TITLE
fix(gemini): pricing units

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1422,7 +1422,7 @@
     "model_name": "gemini-2.0-flash-001",
     "match_pattern": "(?i)^(gemini-2.0-flash-001)(@[a-zA-Z0-9]+)?$",
     "created_at": "2025-02-06T11:11:35.241Z",
-    "updated_at": "2025-02-06T11:11:35.241Z",
+    "updated_at": "2025-02-07T10:11:35.241Z",
     "prices": {
       "input": 3.75e-8,
       "output": 1.5e-7
@@ -1435,7 +1435,7 @@
     "model_name": "gemini-2.0-flash-lite-preview-02-05",
     "match_pattern": "(?i)^(gemini-2.0-flash-lite-preview-02-05)(@[a-zA-Z0-9]+)?$",
     "created_at": "2025-02-06T11:11:35.241Z",
-    "updated_at": "2025-02-06T11:11:35.241Z",
+    "updated_at": "2025-02-07T10:11:35.241Z",
     "prices": {
       "input": 1.875e-8,
       "output": 7.5e-8

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1424,8 +1424,8 @@
     "created_at": "2025-02-06T11:11:35.241Z",
     "updated_at": "2025-02-06T11:11:35.241Z",
     "prices": {
-      "input": 3.75e-5,
-      "output": 1.5e-4
+      "input": 3.75e-8,
+      "output": 1.5e-7
     },
     "tokenizer_config": null,
     "tokenizer_id": null
@@ -1437,8 +1437,8 @@
     "created_at": "2025-02-06T11:11:35.241Z",
     "updated_at": "2025-02-06T11:11:35.241Z",
     "prices": {
-      "input": 1.875e-5,
-      "output": 7.5e-5
+      "input": 1.875e-8,
+      "output": 7.5e-8
     },
     "tokenizer_config": null,
     "tokenizer_id": null


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update pricing units and `updated_at` timestamps for `gemini-2.0-flash-001` and `gemini-2.0-flash-lite-preview-02-05` models in `default-model-prices.json`.
> 
>   - **Pricing Updates**:
>     - Update `input` price from `3.75e-5` to `3.75e-8` and `output` price from `1.5e-4` to `1.5e-7` for `gemini-2.0-flash-001`.
>     - Update `input` price from `1.875e-5` to `1.875e-8` and `output` price from `7.5e-5` to `7.5e-8` for `gemini-2.0-flash-lite-preview-02-05`.
>   - **Metadata Update**:
>     - Change `updated_at` timestamp to `2025-02-07T10:11:35.241Z` for both models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8aea834407fd316d84b5bda30798b2f2e8239a04. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->