### PR TITLE
feat: map additional properties for otel llm spans

### DIFF
--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -525,6 +525,60 @@ describe("OTel Resource Span Mapping", () => {
           entityAttributeValue: "Observing LLMs",
         },
       ],
+      [
+        "#5412: should map input.value to input for smolagents",
+        {
+          entity: "observation",
+          otelAttributeKey: "input.value",
+          otelAttributeValue: {
+            stringValue: JSON.stringify({
+              task: "Play some chess",
+              stream: false,
+            }),
+          },
+          entityAttributeKey: "input",
+          entityAttributeValue: JSON.stringify({
+            task: "Play some chess",
+            stream: false,
+          }),
+        },
+      ],
+      [
+        "#5412: should map llm.token_count.completion to provided_usage_details.output",
+        {
+          entity: "observation",
+          otelAttributeKey: "llm.token_count.completion",
+          otelAttributeValue: {
+            intValue: { low: 100, high: 0, unsigned: false },
+          },
+          entityAttributeKey: "usageDetails.output",
+          entityAttributeValue: 100,
+        },
+      ],
+      [
+        "#5412: should map llm.token_count.total to provided_usage_details.total",
+        {
+          entity: "observation",
+          otelAttributeKey: "llm.token_count.total",
+          otelAttributeValue: {
+            intValue: { low: 100, high: 0, unsigned: false },
+          },
+          entityAttributeKey: "usageDetails.total",
+          entityAttributeValue: 100,
+        },
+      ],
+      [
+        "#5412: should map llm.invocation_parameters to modelParameters",
+        {
+          entity: "observation",
+          otelAttributeKey: "llm.invocation_parameters",
+          otelAttributeValue: {
+            stringValue: '{"max_tokens": 4096}',
+          },
+          entityAttributeKey: "modelParameters.max_tokens",
+          entityAttributeValue: 4096,
+        },
+      ],
     ])(
       "Attributes: %s",
       (


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/5412
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add mappings for new LLM-related OTel span attributes in `convertOtelSpanToIngestionEvent` and update tests accordingly.
> 
>   - **Behavior**:
>     - Map `input.value` to `input` and `llm.token_count.completion` to `usageDetails.output` in `convertOtelSpanToIngestionEvent`.
>     - Map `llm.token_count.total` to `usageDetails.total` and `llm.invocation_parameters` to `modelParameters`.
>     - Consider spans with `gen_ai` or `llm` attributes as generation spans.
>   - **Functions**:
>     - Update `extractInputAndOutput()` to handle `input.value` and `output.value`.
>     - Update `extractModelParameters()` to parse `llm.invocation_parameters`.
>     - Update `extractUsageDetails()` to handle `llm.token_count` attributes.
>   - **Tests**:
>     - Add test cases in `otelMapping.servertest.ts` for new mappings like `input.value` and `llm.token_count` attributes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f743c3a05c1af5d8977c1dda5b975de1663b10b7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->