### PR TITLE
perf: improve performance for trace.id trpc route

### DIFF
--- a/web/src/__tests__/async/traces-trpc.servertest.ts
+++ b/web/src/__tests__/async/traces-trpc.servertest.ts
@@ -1,0 +1,122 @@
+/** @jest-environment node */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import type { Session } from "next-auth";
+import { pruneDatabase } from "@/src/__tests__/test-utils";
+import { prisma } from "@langfuse/shared/src/db";
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import { createTrace, createTracesCh } from "@langfuse/shared/src/server";
+import { randomUUID } from "crypto";
+
+describe("traces trps", () => {
+  const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
+
+  beforeEach(async () => await pruneDatabase());
+
+  const session: Session = {
+    expires: "1",
+    user: {
+      id: "user-1",
+      canCreateOrganizations: true,
+      name: "Demo User",
+      organizations: [
+        {
+          id: "seed-org-id",
+          name: "Test Organization",
+          role: "OWNER",
+          plan: "cloud:hobby",
+          cloudConfig: undefined,
+          projects: [
+            {
+              id: projectId,
+              role: "ADMIN",
+              retentionDays: 30,
+              deletedAt: null,
+              name: "Test Project",
+            },
+          ],
+        },
+      ],
+      featureFlags: {
+        excludeClickhouseRead: false,
+        templateFlag: true,
+      },
+      admin: true,
+    },
+    environment: {} as any,
+  };
+
+  const ctx = createInnerTRPCContext({ session });
+  const caller = appRouter.createCaller({ ...ctx, prisma });
+
+  describe("traces.byId", () => {
+    it("access private trace", async () => {
+      const trace = createTrace({
+        project_id: projectId,
+      });
+
+      await createTracesCh([trace]);
+
+      const traceRes = await caller.traces.byId({
+        projectId,
+        traceId: trace.id,
+      });
+
+      expect(traceRes?.id).toEqual(trace.id);
+      expect(traceRes?.projectId).toEqual(projectId);
+      expect(traceRes?.name).toEqual(trace.name);
+      expect(traceRes?.timestamp).toEqual(new Date(trace.timestamp));
+      expect(traceRes?.tags).toEqual(trace.tags);
+      expect(traceRes?.input).toEqual(trace.input);
+      expect(traceRes?.output).toEqual(trace.output);
+      expect(traceRes?.userId).toEqual(trace.user_id);
+      expect(traceRes?.sessionId).toEqual(trace.session_id);
+    });
+
+    it("access public trace", async () => {
+      const differentProjectId = randomUUID();
+      const trace = createTrace({
+        project_id: differentProjectId,
+        public: true,
+      });
+
+      await createTracesCh([trace]);
+
+      const traceRes = await caller.traces.byId({
+        projectId: differentProjectId,
+        traceId: trace.id,
+      });
+
+      expect(traceRes?.id).toEqual(trace.id);
+      expect(traceRes?.projectId).toEqual(differentProjectId);
+      expect(traceRes?.name).toEqual(trace.name);
+      expect(traceRes?.timestamp).toEqual(new Date(trace.timestamp));
+    });
+
+    it("access trace without any authentication", async () => {
+      const unAuthedSession = createInnerTRPCContext({ session: null });
+      const unAuthedCaller = appRouter.createCaller({
+        ...unAuthedSession,
+        prisma,
+      });
+
+      const trace = createTrace({
+        project_id: projectId,
+        public: true,
+      });
+
+      await createTracesCh([trace]);
+
+      const traceRes = await unAuthedCaller.traces.byId({
+        projectId,
+        traceId: trace.id,
+      });
+
+      expect(traceRes?.id).toEqual(trace.id);
+      expect(traceRes?.projectId).toEqual(projectId);
+      expect(traceRes?.name).toEqual(trace.name);
+      expect(traceRes?.timestamp).toEqual(new Date(trace.timestamp));
+    });
+  });
+});

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -181,22 +181,11 @@ export const traceRouter = createTRPCRouter({
         timestamp: z.date().nullish(), // timestamp of the trace. Used to query CH more efficiently
       }),
     )
-    .query(async ({ input }) => {
-      const trace = await getTraceById(
-        input.traceId,
-        input.projectId,
-        input.timestamp ?? undefined,
-      );
-      if (!trace) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Trace not found",
-        });
-      }
+    .query(async ({ ctx }) => {
       return {
-        ...trace,
-        input: trace.input ? JSON.stringify(trace.input) : undefined,
-        output: trace.output ? JSON.stringify(trace.output) : undefined,
+        ...ctx.trace,
+        input: ctx.trace.input ? JSON.stringify(ctx.trace.input) : undefined,
+        output: ctx.trace.output ? JSON.stringify(ctx.trace.output) : undefined,
       };
     }),
   byIdWithObservationsAndScores: protectedGetTraceProcedure

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -394,6 +394,7 @@ const enforceTraceAccess = t.middleware(async ({ ctx, rawInput, next }) => {
         projectRole:
           ctx.session?.user?.admin === true ? Role.OWNER : sessionProject?.role,
       },
+      trace: trace, // pass the trace to the next middleware so we do not need to fetch it again
     },
   });
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves `traces.byId` performance by using middleware to fetch trace once and adds tests for access cases.
> 
>   - **Performance Improvement**:
>     - `traces.byId` query in `traces.ts` now uses `ctx.trace` to avoid redundant database fetches.
>     - Middleware `enforceTraceAccess` in `trpc.ts` fetches trace and adds it to context.
>   - **Testing**:
>     - Added `traces-trpc.servertest.ts` to test `traces.byId` for private, public, and unauthenticated access cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 532d48328136e27b15b88df0e1d434c9472e7b38. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->