### PR TITLE
perf: improve trpc session.id performance

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -908,6 +908,7 @@ export const getObservationsGroupedByPromptName = async (
 
 export const getCostForTraces = async (
   projectId: string,
+  timestamp: Date,
   traceIds: string[],
 ) => {
   // Wrapping the query in a CTE allows us to skip FINAL which allows Clickhouse to use skip indexes.
@@ -917,6 +918,7 @@ export const getCostForTraces = async (
       FROM observations o
       WHERE o.project_id = {projectId: String}
       AND o.trace_id IN ({traceIds: Array(String)})
+      AND o.start_time >= {timestamp: DateTime64(3)} - INTERVAL ${OBSERVATIONS_TO_TRACE_INTERVAL}
       ORDER BY o.event_ts DESC
       LIMIT 1 BY o.id, o.project_id
     )
@@ -930,6 +932,7 @@ export const getCostForTraces = async (
     params: {
       projectId,
       traceIds,
+      timestamp: convertDateToClickhouseDateTime(timestamp),
     },
   });
   return res.length > 0 ? Number(res[0].total_cost) : undefined;

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -918,7 +918,7 @@ export const getCostForTraces = async (
       FROM observations o
       WHERE o.project_id = {projectId: String}
       AND o.trace_id IN ({traceIds: Array(String)})
-      AND o.start_time >= {timestamp: DateTime64(3)} - INTERVAL ${OBSERVATIONS_TO_TRACE_INTERVAL}
+      AND o.start_time >= {timestamp: DateTime64(3)} - ${OBSERVATIONS_TO_TRACE_INTERVAL}
       ORDER BY o.event_ts DESC
       LIMIT 1 BY o.id, o.project_id
     )

--- a/web/src/__tests__/async/sessions-trpc.servertest.ts
+++ b/web/src/__tests__/async/sessions-trpc.servertest.ts
@@ -1,0 +1,106 @@
+/** @jest-environment node */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import type { Session } from "next-auth";
+import { pruneDatabase } from "@/src/__tests__/test-utils";
+import { prisma } from "@langfuse/shared/src/db";
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import {
+  createObservation,
+  createObservationsCh,
+  createTrace,
+  createTracesCh,
+} from "@langfuse/shared/src/server";
+import { randomUUID } from "crypto";
+
+describe("traces trps", () => {
+  const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
+
+  beforeEach(async () => await pruneDatabase());
+
+  const session: Session = {
+    expires: "1",
+    user: {
+      id: "user-1",
+      canCreateOrganizations: true,
+      name: "Demo User",
+      organizations: [
+        {
+          id: "seed-org-id",
+          name: "Test Organization",
+          role: "OWNER",
+          plan: "cloud:hobby",
+          cloudConfig: undefined,
+          projects: [
+            {
+              id: projectId,
+              role: "ADMIN",
+              retentionDays: 30,
+              deletedAt: null,
+              name: "Test Project",
+            },
+          ],
+        },
+      ],
+      featureFlags: {
+        excludeClickhouseRead: false,
+        templateFlag: true,
+      },
+      admin: true,
+    },
+    environment: {} as any,
+  };
+
+  const ctx = createInnerTRPCContext({ session });
+  const caller = appRouter.createCaller({ ...ctx, prisma });
+
+  describe("sessions.byId", () => {
+    it("access private session", async () => {
+      const sessionId = randomUUID();
+
+      await prisma.traceSession.create({
+        data: {
+          id: sessionId,
+          projectId,
+        },
+      });
+
+      const trace = createTrace({
+        project_id: projectId,
+        session_id: sessionId,
+      });
+
+      const trace2 = createTrace({
+        project_id: projectId,
+        session_id: sessionId,
+      });
+
+      await createTracesCh([trace, trace2]);
+
+      const observation = createObservation({
+        project_id: projectId,
+        trace_id: trace.id,
+      });
+
+      const observation2 = createObservation({
+        project_id: projectId,
+        trace_id: trace2.id,
+      });
+
+      const observation3 = createObservation({
+        project_id: projectId,
+        trace_id: trace2.id,
+      });
+
+      await createObservationsCh([observation, observation2, observation3]);
+
+      const sessionRes = await caller.sessions.byId({
+        projectId,
+        sessionId,
+      });
+
+      console.log(sessionRes);
+    });
+  });
+});

--- a/web/src/__tests__/async/sessions-trpc.servertest.ts
+++ b/web/src/__tests__/async/sessions-trpc.servertest.ts
@@ -100,7 +100,32 @@ describe("traces trps", () => {
         sessionId,
       });
 
-      console.log(sessionRes);
+      expect(sessionRes).toEqual({
+        id: sessionId,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        projectId: projectId,
+        bookmarked: false,
+        public: false,
+        traces: expect.arrayContaining([
+          expect.objectContaining({
+            id: trace.id,
+            userId: trace.user_id,
+            name: trace.name,
+            timestamp: new Date(trace.timestamp),
+            scores: [],
+          }),
+          expect.objectContaining({
+            id: trace2.id,
+            userId: trace2.user_id,
+            name: trace2.name,
+            timestamp: new Date(trace2.timestamp),
+            scores: [],
+          }),
+        ]),
+        totalCost: expect.any(Number),
+        users: expect.arrayContaining([trace.user_id, trace2.user_id]),
+      });
     });
   });
 });

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -279,7 +279,7 @@ export const sessionRouter = createTRPCRouter({
 
         const chunks = chunk(clickhouseTraces, 500);
 
-        // in the below queryes, take the lowest timestamp as a filter condition
+        // in the below queries, take the lowest timestamp as a filter condition
         // to improve performance
         const [scores, costs] = await Promise.all([
           Promise.all(

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -279,6 +279,8 @@ export const sessionRouter = createTRPCRouter({
 
         const chunks = chunk(clickhouseTraces, 500);
 
+        // in the below queryes, take the lowest timestamp as a filter condition
+        // to improve performance
         const [scores, costs] = await Promise.all([
           Promise.all(
             chunks.map((chunk) =>

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -31,6 +31,7 @@ import {
   logger,
   getSessionsWithMetrics,
 } from "@langfuse/shared/src/server";
+import { chunk } from "lodash";
 
 const SessionFilterOptions = z.object({
   projectId: z.string(), // Required for protectedProjectProcedure
@@ -276,12 +277,7 @@ export const sessionRouter = createTRPCRouter({
           input.sessionId,
         );
 
-        const chunkSize = 500;
-        const chunks = [];
-
-        for (let i = 0; i < clickhouseTraces.length; i += chunkSize) {
-          chunks.push(clickhouseTraces.slice(i, i + chunkSize));
-        }
+        const chunks = chunk(clickhouseTraces, 500);
 
         const [scores, costs] = await Promise.all([
           Promise.all(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improve `getCostForTraces` performance by adding a timestamp filter and update `sessions.byId` to utilize this filter, with new tests added.
> 
>   - **Performance Improvement**:
>     - Add `timestamp` parameter to `getCostForTraces` in `observations.ts` to filter observations by start time.
>     - Update `sessions.byId` in `sessions.ts` to use the new `timestamp` filter for performance optimization.
>   - **Testing**:
>     - Add `sessions-trpc.servertest.ts` to test `sessions.byId` functionality with the new performance improvements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b3c662e9f6f75c140de8b1861661b9b5bd5652d9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->