### PR TITLE
perf: skip processing of already seen events in worker

### DIFF
--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -225,6 +225,7 @@ export const processEventBatch = async (
                 data: {
                   type: sortedBatchByEventBodyId[id].type,
                   eventBodyId: sortedBatchByEventBodyId[id].eventBodyId,
+                  fileKey: sortedBatchByEventBodyId[id].key,
                 },
                 authCheck,
               },

--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -47,7 +47,10 @@ const getDelay = (delay: number | null) => {
     return env.LANGFUSE_INGESTION_QUEUE_DELAY_MS;
   }
 
-  return 0;
+  // Use 5s here to avoid duplicate processing on the worker. If the ingestion delay is set to a lower value,
+  // we use this instead.
+  // Values should be revisited based on a cost/performance trade-off.
+  return Math.min(5000, env.LANGFUSE_INGESTION_QUEUE_DELAY_MS);
 };
 
 /**

--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -10,6 +10,7 @@ export const IngestionEvent = z.object({
   data: z.object({
     type: z.nativeEnum(eventTypes),
     eventBodyId: z.string(),
+    fileKey: z.string().optional(),
   }),
   authCheck: z.object({
     validKey: z.literal(true),

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -126,6 +126,10 @@ const EnvSchema = z.object({
     .enum(["true", "false"])
     .default("true"),
 
+  LANGFUSE_ENABLE_REDIS_SEEN_EVENT_CACHE: z
+    .enum(["true", "false"])
+    .default("false"),
+
   // Flags to toggle queue consumers on or off.
   QUEUE_CONSUMER_CLOUD_USAGE_METERING_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -13,6 +13,7 @@ import {
   getCurrentSpan,
   getQueue,
   recordDistribution,
+  recordIncrement,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 
@@ -61,6 +62,35 @@ export const ingestionQueueProcessorBuilder = (
           "messaging.bullmq.job.input.type",
           job.data.payload.data.type,
         );
+        span.setAttribute(
+          "messaging.bullmq.job.input.fileKey",
+          job.data.payload.data.fileKey ?? "",
+        );
+      }
+
+      // If fileKey was processed within the last minutes, i.e. has a match in redis, we skip processing.
+      if (
+        env.LANGFUSE_ENABLE_REDIS_SEEN_EVENT_CACHE === "true" &&
+        redis &&
+        job.data.payload.data.fileKey
+      ) {
+        const key = `langfuse:ingestion:recently-processed:${job.data.payload.authCheck.scope.projectId}:${job.data.payload.data.type}:${job.data.payload.data.eventBodyId}:${job.data.payload.data.fileKey}`;
+        const exists = await redis.exists(key);
+        if (exists) {
+          recordIncrement("langfuse.ingestion.recently_processed_cache", 1, {
+            type: job.data.payload.data.type,
+            skipped: "true",
+          });
+          logger.debug(
+            `Skipping ingestion event ${job.data.payload.data.fileKey} for project ${job.data.payload.authCheck.scope.projectId}`,
+          );
+          return;
+        } else {
+          recordIncrement("langfuse.ingestion.recently_processed_cache", 1, {
+            type: job.data.payload.data.type,
+            skipped: "false",
+          });
+        }
       }
 
       if (
@@ -175,6 +205,21 @@ export const ingestionQueueProcessorBuilder = (
           `No events found for project ${job.data.payload.authCheck.scope.projectId} and event ${job.data.payload.data.eventBodyId}`,
         );
         return;
+      }
+
+      // Set "seen" keys in Redis to avoid reprocessing for fast updates.
+      if (env.LANGFUSE_ENABLE_REDIS_SEEN_EVENT_CACHE === "true" && redis) {
+        const pipeline = redis.pipeline();
+        for (const event of eventFiles) {
+          const key = event.file.split("/").pop() ?? "";
+          pipeline.set(
+            `langfuse:ingestion:recently-processed:${job.data.payload.authCheck.scope.projectId}:${job.data.payload.data.type}:${job.data.payload.data.eventBodyId}:${key?.replace(".json", "")}`,
+            "1",
+            "EX",
+            60 * 5, // 5 minutes
+          );
+        }
+        await pipeline.exec();
       }
 
       // Perform merge of those events


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimize event processing by skipping recently seen events using Redis caching in `ingestionQueue.ts` and `processEventBatch.ts`.
> 
>   - **Behavior**:
>     - Skip processing of events with `fileKey` seen in the last 5 minutes using Redis in `ingestionQueue.ts`.
>     - Add `fileKey` to event data in `processEventBatch()` in `processEventBatch.ts`.
>     - Introduce `LANGFUSE_ENABLE_REDIS_SEEN_EVENT_CACHE` in `env.ts` to toggle Redis caching.
>   - **Schema**:
>     - Update `IngestionEvent` schema in `queues.ts` to include optional `fileKey`.
>   - **Metrics**:
>     - Record cache hits and misses with `recordIncrement()` in `ingestionQueue.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c3db72f6d0764163d3d83b28711d83cefbef3d31. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->