### PR TITLE
fix(model-prices): gemini 2 vertex AI prices

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1422,10 +1422,10 @@
     "model_name": "gemini-2.0-flash-001",
     "match_pattern": "(?i)^(gemini-2.0-flash-001)(@[a-zA-Z0-9]+)?$",
     "created_at": "2025-02-06T11:11:35.241Z",
-    "updated_at": "2025-02-07T10:11:35.241Z",
+    "updated_at": "2025-02-10T10:11:35.241Z",
     "prices": {
-      "input": 3.75e-8,
-      "output": 1.5e-7
+      "input": 0.15e-6,
+      "output": 0.6e-6
     },
     "tokenizer_config": null,
     "tokenizer_id": null
@@ -1435,10 +1435,10 @@
     "model_name": "gemini-2.0-flash-lite-preview-02-05",
     "match_pattern": "(?i)^(gemini-2.0-flash-lite-preview-02-05)(@[a-zA-Z0-9]+)?$",
     "created_at": "2025-02-06T11:11:35.241Z",
-    "updated_at": "2025-02-07T10:11:35.241Z",
+    "updated_at": "2025-02-10T10:11:35.241Z",
     "prices": {
-      "input": 1.875e-8,
-      "output": 7.5e-8
+      "input": 0.075e-6,
+      "output": 0.3e-6
     },
     "tokenizer_config": null,
     "tokenizer_id": null


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updated input and output prices for `gemini-2.0-flash-001` and `gemini-2.0-flash-lite-preview-02-05` models in `default-model-prices.json`.
> 
>   - **Pricing Updates**:
>     - Updated `input` price for `gemini-2.0-flash-001` from `3.75e-8` to `0.15e-6` and `output` price from `1.5e-7` to `0.6e-6` in `default-model-prices.json`.
>     - Updated `input` price for `gemini-2.0-flash-lite-preview-02-05` from `1.875e-8` to `0.075e-6` and `output` price from `7.5e-8` to `0.3e-6` in `default-model-prices.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f87fe44ea285c2c60250553588b96a740b4cb037. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->