### PR TITLE
security: upgrade jsonpath-plus

### DIFF
--- a/ee/package.json
+++ b/ee/package.json
@@ -48,7 +48,7 @@
   },
   "pnpm": {
     "overrides": {
-      "jsonpath-plus": "10.0.7",
+      "jsonpath-plus": "10.2.0",
       "nanoid": "^3.3.8"
     }
   }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "packageManager": "pnpm@9.5.0",
   "pnpm": {
     "overrides": {
-      "jsonpath-plus": "10.0.7",
+      "jsonpath-plus": "10.2.0",
       "nanoid": "^3.3.8",
       "katex": "^0.16.21"
     },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -122,7 +122,7 @@
   },
   "pnpm": {
     "overrides": {
-      "jsonpath-plus": "10.0.7",
+      "jsonpath-plus": "10.2.0",
       "nanoid": "^3.3.8"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  jsonpath-plus: 10.0.7
+  jsonpath-plus: 10.2.0
   nanoid: ^3.3.8
   katex: ^0.16.21
 
@@ -922,7 +922,7 @@ importers:
         specifier: ^5.4.1
         version: 5.4.1
       jsonpath-plus:
-        specifier: 10.0.7
+        specifier: 10.2.0
         version: 10.2.0
       kysely:
         specifier: ^0.27.4
@@ -8315,11 +8315,6 @@ packages:
 
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
-
-  jsonpath-plus@10.0.7:
-    resolution: {integrity: sha512-GDA8d8fu9+s4QzAzo5LMGiLL/9YjecAX+ytlnqdeXYpU55qME57StDgaHt9R2pA7Dr8U31nwzxNJMJiHkrkRgw==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
 
   jsonpath-plus@10.2.0:
     resolution: {integrity: sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==}
@@ -18934,7 +18929,7 @@ snapshots:
       int64-buffer: 0.1.10
       istanbul-lib-coverage: 3.2.0
       jest-docblock: 29.7.0
-      jsonpath-plus: 10.0.7
+      jsonpath-plus: 10.2.0
       koalas: 1.0.2
       limiter: 1.1.5
       lodash.sortby: 4.7.0
@@ -21302,7 +21297,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.10.5
+      '@types/node': 20.14.8
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -21448,12 +21443,6 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
-
-  jsonpath-plus@10.0.7:
-    dependencies:
-      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
-      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
-      jsep: 1.4.0
 
   jsonpath-plus@10.2.0:
     dependencies:

--- a/web/package.json
+++ b/web/package.json
@@ -202,7 +202,7 @@
   },
   "pnpm": {
     "overrides": {
-      "jsonpath-plus": "10.0.7",
+      "jsonpath-plus": "10.2.0",
       "nanoid": "^3.3.8",
       "katex": "0.16.21"
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Upgrade `jsonpath-plus` to version `10.2.0` across multiple `package.json` files for security reasons.
> 
>   - **Dependencies**:
>     - Upgrade `jsonpath-plus` from `10.0.7` to `10.2.0` in `ee/package.json`, `package.json`, `packages/shared/package.json`, and `web/package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8550359865efb3ef65b590fde06bb6eb53bd1900. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->