### PR TITLE
feat(otel): add input/output and name on traces

### DIFF
--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -291,6 +291,7 @@ export const convertOtelSpanToIngestionEvent = (
         const trace = {
           id: Buffer.from(span.traceId?.data ?? span.traceId).toString("hex"),
           timestamp: convertNanoTimestampToISO(span.startTimeUnixNano),
+          name: span.name,
           metadata: {
             attributes,
             resourceAttributes,
@@ -299,6 +300,9 @@ export const convertOtelSpanToIngestionEvent = (
           version: resourceAttributes?.["service.version"] ?? null,
           userId: extractUserId(attributes),
           sessionId: extractSessionId(attributes),
+
+          // Input and Output
+          ...extractInputAndOutput(span?.events ?? [], attributes),
         };
         events.push({
           id: randomUUID(),
@@ -343,11 +347,10 @@ export const convertOtelSpanToIngestionEvent = (
         ...extractInputAndOutput(span?.events ?? [], attributes),
       };
 
-      // If the span has any gen_ai or llm attributes, we consider it a generation
-      const isGeneration = Object.keys(attributes).some(
-        (key) => key.startsWith("gen_ai") || key.startsWith("llm"),
-      );
-
+      // If the span has a model property, we consider it a generation.
+      // Just checking for llm.* or gen_ai.* attributes leads to overreporting and wrong
+      // aggregations for costs.
+      const isGeneration = Boolean(observation.model);
       events.push({
         id: randomUUID(),
         type: isGeneration ? "generation-create" : "span-create",


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/5436
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance trace data in `convertOtelSpanToIngestionEvent` by adding input/output and name, and refine generation event detection based on model property.
> 
>   - **Behavior**:
>     - Add `name` to trace object in `convertOtelSpanToIngestionEvent` in `index.ts`.
>     - Include input/output data in trace and observation objects using `extractInputAndOutput()`.
>     - Change generation event detection to rely on `model` property instead of `llm.*` or `gen_ai.*` attributes.
>   - **Functions**:
>     - Modify `convertOtelSpanToIngestionEvent` to handle new trace and observation data.
>     - Use `extractInputAndOutput()` to extract input/output from span events and attributes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 54b91ba914cc68f80ac1ba8079c91f82e0c5c48d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->