### PR TITLE
feat(otel): accept application/json content type spans

### DIFF
--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -5,11 +5,15 @@ import { ObservationLevel } from "@prisma/client";
 const convertNanoTimestampToISO = (
   timestamp:
     | number
+    | string
     | {
         high: number;
         low: number;
       },
 ) => {
+  if (typeof timestamp === "string") {
+    return new Date(parseInt(timestamp, 10) / 1e6).toISOString();
+  }
   if (typeof timestamp === "number") {
     return new Date(timestamp / 1e6).toISOString();
   }

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -37,7 +37,7 @@ export default withMiddlewares({
       }
 
       let resourceSpans: any;
-      switch (req.headers["content-type"]) {
+      switch (req.headers["content-type"]?.toLowerCase()) {
         case "application/x-protobuf": {
           try {
             const parsed =

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -37,18 +37,38 @@ export default withMiddlewares({
       }
 
       let resourceSpans: any;
-      try {
-        const parsed =
-          $root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest.decode(
-            body,
-          );
-        resourceSpans =
-          $root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest.toObject(
-            parsed,
-          ).resourceSpans;
-      } catch (e) {
-        logger.error(`Failed to parse OTel Trace`, e);
-        return res.status(400).json({ error: "Failed to parse OTel Trace" });
+      switch (req.headers["content-type"]) {
+        case "application/x-protobuf": {
+          try {
+            const parsed =
+              $root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest.decode(
+                body,
+              );
+            resourceSpans =
+              $root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest.toObject(
+                parsed,
+              ).resourceSpans;
+          } catch (e) {
+            logger.error(`Failed to parse OTel Protobuf`, e);
+            return res
+              .status(400)
+              .json({ error: "Failed to parse OTel Protobuf Trace" });
+          }
+          break;
+        }
+        case "application/json": {
+          try {
+            resourceSpans = JSON.parse(body.toString()).resourceSpans;
+          } catch (e) {
+            logger.error(`Failed to parse OTel JSON`, e);
+            return res
+              .status(400)
+              .json({ error: "Failed to parse OTel JSON Trace" });
+          }
+          break;
+        }
+        default:
+          return res.status(400).json({ error: "Unsupported content type" });
       }
 
       const events: IngestionEventType[] = resourceSpans.flatMap(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for `application/json` content type in OpenTelemetry traces, with updated parsing and error handling.
> 
>   - **Behavior**:
>     - `index.ts`: Adds support for `application/json` content type in OpenTelemetry traces.
>     - Handles JSON parsing errors and returns appropriate error messages.
>   - **Functions**:
>     - `convertNanoTimestampToISO` in `index.ts`: Now handles string timestamps by parsing them as integers.
>   - **Error Handling**:
>     - Logs specific errors for JSON parsing failures in `index.ts` and `traces/index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 342e015160e92bdda7bb2d583afa99ad6718b6cc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->