### PR TITLE
feat(otel): map traceloop.entity.input/output to input/output 

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -51,6 +51,13 @@ jobs:
           image: langfuse-langfuse-worker
           args: --file=worker/Dockerfile
 
+      # Workaround for https://github.com/github/codeql-action/issues/2187
+      - name: Replace security-severity undefined for license-related findings
+        run: "sed -i 's/\"security-severity\": \"undefined\"/\"security-severity\": \"0\"/g' snyk.sarif"
+
+      - name: Replace security-severity null for license-related findings
+        run: "sed -i 's/\"security-severity\": \"null\"/\"security-severity\": \"0\"/g' snyk.sarif"
+
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -31,10 +31,10 @@ jobs:
 
       # Workaround for https://github.com/github/codeql-action/issues/2187
       - name: Replace security-severity undefined for license-related findings
-        run: sed -i 's/"security-severity": "undefined"/"security-severity": "0"/g' snyk.sarif
+        run: "sed -i 's/\"security-severity\": \"undefined\"/\"security-severity\": \"0\"/g' snyk.sarif"
 
       - name: Replace security-severity null for license-related findings
-        run: sed -i 's/"security-severity": "null"/"security-severity": "0"/g' snyk.sarif
+        run: "sed -i 's/\"security-severity\": \"null\"/\"security-severity\": \"0\"/g' snyk.sarif"
 
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -29,6 +29,7 @@ jobs:
           image: langfuse-langfuse-web
           args: --file=web/Dockerfile
 
+      # Workaround for https://github.com/github/codeql-action/issues/2187
       - name: Replace security-severity undefined for license-related findings
         run: sed -i 's/"security-severity": "undefined"/"security-severity": "0"/g' snyk.sarif
 

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -29,6 +29,12 @@ jobs:
           image: langfuse-langfuse-web
           args: --file=web/Dockerfile
 
+      - name: Replace security-severity undefined for license-related findings
+        run: sed -i 's/"security-severity": "undefined"/"security-severity": "0"/g' snyk.sarif
+
+      - name: Replace security-severity null for license-related findings
+        run: sed -i 's/"security-severity": "null"/"security-severity": "0"/g' snyk.sarif
+
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -579,6 +579,18 @@ describe("OTel Resource Span Mapping", () => {
           entityAttributeValue: 4096,
         },
       ],
+      [
+        "#5457: should map traceloop.entity.input to input",
+        {
+          entity: "trace",
+          otelAttributeKey: "traceloop.entity.input",
+          otelAttributeValue: {
+            stringValue: '{"foo": "bar"}',
+          },
+          entityAttributeKey: "input",
+          entityAttributeValue: '{"foo": "bar"}',
+        },
+      ],
     ])(
       "Attributes: %s",
       (

--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -127,6 +127,13 @@ const extractInputAndOutput = (
     return { input, output };
   }
 
+  // TraceLoop sets traceloop.entity.input and traceloop.entity.output
+  input = attributes["traceloop.entity.input"];
+  output = attributes["traceloop.entity.output"];
+  if (input || output) {
+    return { input, output };
+  }
+
   // SmolAgents sets input.value and output.value
   input = attributes["input.value"];
   output = attributes["output.value"];


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/5457
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Map `traceloop.entity.input/output` to `input/output` in OpenTelemetry spans and add Snyk workflow workaround for security severity values.
> 
>   - **Behavior**:
>     - Map `traceloop.entity.input` and `traceloop.entity.output` to `input` and `output` in `extractInputAndOutput()` in `index.ts`.
>     - Add test case for mapping `traceloop.entity.input` to `input` in `otelMapping.servertest.ts`.
>   - **Workflows**:
>     - Add workaround in `snyk.yml` to replace `security-severity` values of `undefined` and `null` with `0` in `snyk.sarif`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 105900940c427a5449872e3a6d5ff774c59ab6cc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->