### PR TITLE
chore(datasets): reduce max payload size in csv upload

### DIFF
--- a/web/src/features/datasets/components/PreviewCsvImport.tsx
+++ b/web/src/features/datasets/components/PreviewCsvImport.tsx
@@ -25,7 +25,9 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 
 const MIN_CHUNK_SIZE = 50;
 const DELAY_BETWEEN_CHUNKS = 100; // milliseconds
-const MAX_PAYLOAD_SIZE = 1 * 1024 * 1024; // 1MB in bytes
+
+// Max payload size is 1MB, but we must account for any trpc wrapper data and context
+const MAX_PAYLOAD_SIZE = 500 * 1024; // 500KB in bytes
 
 function getOptimalChunkSize(items: any[], startSize: number): number {
   const getPayloadSize = (size: number) =>
@@ -37,7 +39,7 @@ function getOptimalChunkSize(items: any[], startSize: number): number {
       }),
     ).length;
 
-  // Binary search for largest chunk size under 1MB
+  // Binary search for largest chunk size under MAX_PAYLOAD_SIZE
   let low = MIN_CHUNK_SIZE;
   let high = startSize;
   let best = MIN_CHUNK_SIZE;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce `MAX_PAYLOAD_SIZE` to 500KB in `PreviewCsvImport.tsx` for CSV uploads to account for TRPC overhead.
> 
>   - **Behavior**:
>     - Reduce `MAX_PAYLOAD_SIZE` from 1MB to 500KB in `PreviewCsvImport.tsx` to account for TRPC wrapper data and context.
>     - Adjust binary search logic in `getOptimalChunkSize()` to use new `MAX_PAYLOAD_SIZE`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cae692bbbecfc026e2af2005cff34b215be96093. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->