### PR TITLE
style(dashboard): round to two decimals on model latencies chart

### DIFF
--- a/web/src/utils/numbers.ts
+++ b/web/src/utils/numbers.ts
@@ -19,17 +19,14 @@ export const numberFormatter = (
   }).format(number ?? 0);
 };
 
-export const latencyFormatter = (
-  number?: number | bigint,
-  fractionDigits?: number,
-) => {
+export const latencyFormatter = (number?: number | bigint) => {
   return Intl.NumberFormat("en-US", {
     style: "unit",
     unit: "second",
     unitDisplay: "narrow",
     notation: "compact",
-    minimumFractionDigits: fractionDigits ?? 2,
-    maximumFractionDigits: fractionDigits ?? 2,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
   }).format(number ?? 0);
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `latencyFormatter` in `numbers.ts` now consistently rounds to two decimal places, removing the optional `fractionDigits` parameter.
> 
>   - **Behavior**:
>     - `latencyFormatter` in `numbers.ts` now always rounds to two decimal places, removing the `fractionDigits` parameter.
>   - **Misc**:
>     - Simplifies `latencyFormatter` by removing optional fraction digits parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4f3d1a901e0ec50402e4c64124f3febcc7320ce8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->