### PR TITLE
fix: add clickhouse final for traces grouped by name dashboard

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -269,7 +269,7 @@ export const getTracesGroupedByName = async (
       select 
         name as name,
         count(*) as count
-      from traces t
+      from traces t FINAL
       WHERE t.project_id = {projectId: String}
       AND t.name IS NOT NULL
       ${timestampFilterRes?.query ? `AND ${timestampFilterRes.query}` : ""}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `FINAL` keyword to SQL query in `getTracesGroupedByName` function to ensure data consistency.
> 
>   - **Behavior**:
>     - Add `FINAL` keyword to SQL query in `getTracesGroupedByName` function in `traces.ts` to ensure data consistency when grouping traces by name.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b01f1997a41d39d60397555ce7f3ecd6c22ed8fc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->