### PR TITLE
fix: map token filters for ui table to fitting clickhouse types

### DIFF
--- a/packages/shared/src/tableDefinitions/mapObservationsTable.ts
+++ b/packages/shared/src/tableDefinitions/mapObservationsTable.ts
@@ -145,6 +145,7 @@ export const observationsTableUiColumnDefinitions: UiColumnMapping[] = [
     clickhouseTableName: "observations",
     clickhouseSelect:
       "arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'input') > 0, usage_details)))",
+    clickhouseTypeOverwrite: "Decimal64(3)",
   },
   {
     uiTableName: "Output Tokens",
@@ -152,6 +153,7 @@ export const observationsTableUiColumnDefinitions: UiColumnMapping[] = [
     clickhouseTableName: "observations",
     clickhouseSelect:
       "arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'output') > 0, usage_details)))",
+    clickhouseTypeOverwrite: "Decimal64(3)",
   },
   {
     uiTableName: "Total Tokens",
@@ -159,6 +161,7 @@ export const observationsTableUiColumnDefinitions: UiColumnMapping[] = [
     clickhouseTableName: "observations",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'total'), usage_details), usage_details['total'], NULL)",
+    clickhouseTypeOverwrite: "Decimal64(3)",
   },
   {
     uiTableName: "Usage",
@@ -166,6 +169,7 @@ export const observationsTableUiColumnDefinitions: UiColumnMapping[] = [
     clickhouseTableName: "observations",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'total'), usage_details), usage_details['total'], NULL)",
+    clickhouseTypeOverwrite: "Decimal64(3)",
   },
   {
     uiTableName: "Metadata",

--- a/packages/shared/src/tableDefinitions/mapTracesTable.ts
+++ b/packages/shared/src/tableDefinitions/mapTracesTable.ts
@@ -98,6 +98,7 @@ export const tracesTableUiColumnDefinitions: UiColumnMapping[] = [
     clickhouseTableName: "observations",
     clickhouseSelect:
       "arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'input') > 0, usage_details)))",
+    clickhouseTypeOverwrite: "Decimal64(3)",
   },
   {
     uiTableName: "Output Tokens",
@@ -105,6 +106,7 @@ export const tracesTableUiColumnDefinitions: UiColumnMapping[] = [
     clickhouseTableName: "observations",
     clickhouseSelect:
       "arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'output') > 0, usage_details)))",
+    clickhouseTypeOverwrite: "Decimal64(3)",
   },
   {
     uiTableName: "Total Tokens",
@@ -112,6 +114,7 @@ export const tracesTableUiColumnDefinitions: UiColumnMapping[] = [
     clickhouseTableName: "observations",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'total'), usage_details), usage_details['total'], NULL)",
+    clickhouseTypeOverwrite: "Decimal64(3)",
   },
   {
     uiTableName: "Usage",
@@ -119,6 +122,7 @@ export const tracesTableUiColumnDefinitions: UiColumnMapping[] = [
     clickhouseTableName: "observations",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'total'), usage_details), usage_details['total'], NULL)",
+    clickhouseTypeOverwrite: "Decimal64(3)",
   },
   {
     uiTableName: "Scores",

--- a/web/src/__tests__/async/traces-ui-table.servertest.ts
+++ b/web/src/__tests__/async/traces-ui-table.servertest.ts
@@ -134,6 +134,22 @@ describe("Traces table API test", () => {
     },
     {
       traceInput: {},
+      observationInput: [
+        { usage_details: { total: 100 } },
+        { usage_details: { total: 200 } },
+      ],
+      filterstate: [
+        {
+          column: "totalTokens",
+          operator: ">" as const,
+          value: 3456789,
+          type: "number" as const,
+        },
+      ],
+      expected: [],
+    },
+    {
+      traceInput: {},
       observationInput: [],
       filterstate: [
         {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update ClickHouse type to `Decimal64(3)` for token columns and add test for large filter values.
> 
>   - **Behavior**:
>     - Update `clickhouseTypeOverwrite` to `Decimal64(3)` for `Input Tokens`, `Output Tokens`, `Total Tokens`, and `Usage` in `mapObservationsTable.ts` and `mapTracesTable.ts`.
>     - Add test case in `traces-ui-table.servertest.ts` to verify handling of large filter values for `totalTokens`.
>   - **Tests**:
>     - Add test case in `traces-ui-table.servertest.ts` for filtering `totalTokens` with large values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 217413e5e61ff0a4226f965565c72a81bdc0f537. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->