### PR TITLE
chore: hide trace deletion button on cloud until enabled again

### DIFF
--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -332,6 +332,8 @@ export default function TracesTable({
   };
 
   const tableActions: TableAction[] = [
+    // temporary: hide if no entitlement until we support trace deletion on cloud again
+    // https://github.com/orgs/langfuse/discussions/5313
     ...(hasTraceDeletionEntitlement
       ? [
           {

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -332,18 +332,22 @@ export default function TracesTable({
   };
 
   const tableActions: TableAction[] = [
-    {
-      id: "trace-delete",
-      type: BatchActionType.Delete,
-      label: "Delete Traces",
-      description:
-        "This action permanently deletes traces and cannot be undone.",
-      accessCheck: {
-        scope: "traces:delete",
-        entitlement: "trace-deletion",
-      },
-      execute: handleDeleteTraces,
-    },
+    ...(hasTraceDeletionEntitlement
+      ? [
+          {
+            id: "trace-delete",
+            type: BatchActionType.Delete,
+            label: "Delete Traces",
+            description:
+              "This action permanently deletes traces and cannot be undone.",
+            accessCheck: {
+              scope: "traces:delete",
+              entitlement: "trace-deletion",
+            },
+            execute: handleDeleteTraces,
+          } as TableAction,
+        ]
+      : []),
     {
       id: "trace-add-to-annotation-queue",
       type: BatchActionType.Create,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Hide "Delete Traces" button in `traces.tsx` if `hasTraceDeletionEntitlement` is false, pending cloud support.
> 
>   - **Behavior**:
>     - In `traces.tsx`, hide "Delete Traces" button if `hasTraceDeletionEntitlement` is false.
>     - Conditional rendering based on `hasTraceDeletionEntitlement` to manage trace deletion visibility.
>   - **Misc**:
>     - Added a comment linking to a GitHub discussion for context on the temporary change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b2c2c53026abde37c90ced6d49d6a3c735507bb4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->