### PR TITLE
chore(csv-upload): reduce min chunk size

### DIFF
--- a/web/src/features/datasets/components/PreviewCsvImport.tsx
+++ b/web/src/features/datasets/components/PreviewCsvImport.tsx
@@ -23,7 +23,7 @@ import { MAX_FILE_SIZE_BYTES } from "@/src/features/datasets/components/UploadDa
 import { Progress } from "@/src/components/ui/progress";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
-const MIN_CHUNK_SIZE = 50;
+const MIN_CHUNK_SIZE = 1;
 const DELAY_BETWEEN_CHUNKS = 100; // milliseconds
 
 // Max payload size is 1MB, but we must account for any trpc wrapper data and context

--- a/web/src/features/datasets/components/PreviewCsvImport.tsx
+++ b/web/src/features/datasets/components/PreviewCsvImport.tsx
@@ -24,6 +24,7 @@ import { Progress } from "@/src/components/ui/progress";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 const MIN_CHUNK_SIZE = 1;
+const CHUNK_START_SIZE = 50;
 const DELAY_BETWEEN_CHUNKS = 100; // milliseconds
 
 // Max payload size is 1MB, but we must account for any trpc wrapper data and context
@@ -276,7 +277,7 @@ export function PreviewCsvImport({
         },
       });
 
-      const optimalChunkSize = getOptimalChunkSize(items, MIN_CHUNK_SIZE);
+      const optimalChunkSize = getOptimalChunkSize(items, CHUNK_START_SIZE);
       const chunks = chunkArray(items, optimalChunkSize);
 
       for (const [index, chunk] of chunks.entries()) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reduce `MIN_CHUNK_SIZE` to 1 and introduce `CHUNK_START_SIZE` in `PreviewCsvImport.tsx` for CSV uploads.
> 
>   - **Behavior**:
>     - Reduce `MIN_CHUNK_SIZE` from 50 to 1 in `PreviewCsvImport.tsx`.
>     - Introduce `CHUNK_START_SIZE` set to 50 in `PreviewCsvImport.tsx`.
>     - Update `getOptimalChunkSize` to use `CHUNK_START_SIZE` instead of `MIN_CHUNK_SIZE`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ef5a20b3fc4d2630cf285112708c9a06115320c0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->