### PR TITLE
chore: add additional attributes to ingestion spans

### DIFF
--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -94,7 +94,10 @@ export const processEventBatch = async (
   // add context of api call to the span
   const currentSpan = getCurrentSpan();
   recordIncrement("langfuse.ingestion.event", input.length);
-  currentSpan?.setAttribute("event_count", input.length);
+  currentSpan?.setAttribute("langfuse.ingestion.batch_size", input.length);
+  currentSpan?.setAttribute("langfuse.project.id", authCheck.scope.projectId);
+  currentSpan?.setAttribute("langfuse.org.id", authCheck.scope.orgId);
+  currentSpan?.setAttribute("langfuse.org.plan", authCheck.scope.plan);
 
   /**************
    * VALIDATION *
@@ -109,7 +112,10 @@ export const processEventBatch = async (
         (span) => {
           const parsedBody = ingestionEvent.safeParse(event);
           if (parsedBody.data?.id !== undefined) {
-            span.setAttribute("object.id", parsedBody.data.id);
+            span.setAttribute(
+              "langfuse.ingestion.entity.id",
+              parsedBody.data.id,
+            );
           }
           return parsedBody;
         },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add additional attributes to spans in `processEventBatch` for enhanced event tracking.
> 
>   - **Behavior**:
>     - In `processEventBatch`, replace `event_count` attribute with `langfuse.ingestion.batch_size`.
>     - Add attributes `langfuse.project.id`, `langfuse.org.id`, and `langfuse.org.plan` to the current span.
>     - Change `object.id` attribute to `langfuse.ingestion.entity.id` for individual event spans.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c756fc3b4b79f92fb19dc956ba839e84f5b0fe31. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->