### PR TITLE
chore: propagate otel trace context to clickhouse spans

### DIFF
--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -1,27 +1,34 @@
 import { createClient } from "@clickhouse/client";
 import { env } from "../../env";
 import { NodeClickHouseClientConfigOptions } from "@clickhouse/client/dist/config";
+import { getCurrentSpan } from "../instrumentation";
+import { propagation, context } from "@opentelemetry/api";
 
 export type ClickhouseClientType = ReturnType<typeof createClient>;
 
-export const clickhouseClient = (opts?: NodeClickHouseClientConfigOptions) =>
-  createClient({
+export const clickhouseClient = (opts?: NodeClickHouseClientConfigOptions) => {
+  const headers = opts?.http_headers ?? {};
+  const activeSpan = getCurrentSpan();
+  if (activeSpan) {
+    propagation.inject(context.active(), headers);
+  }
+  return createClient({
     ...opts,
     url: env.CLICKHOUSE_URL,
     username: env.CLICKHOUSE_USER,
     password: env.CLICKHOUSE_PASSWORD,
     database: env.CLICKHOUSE_DB,
+    http_headers: headers,
     clickhouse_settings: {
       async_insert: 1,
       wait_for_async_insert: 1, // if disabled, we won't get errors from clickhouse
     },
   });
+};
 
-export const defaultClickhouseClient = clickhouseClient();
 /**
  * Accepts a JavaScript date and returns the DateTime in format YYYY-MM-DD HH:MM:SS
  */
-
 export const convertDateToClickhouseDateTime = (date: Date): string => {
   // 2024-11-06T20:37:00.123Z -> 2024-11-06 21:37:00.123
   return date.toISOString().replace("T", " ").replace("Z", "");

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -1,5 +1,6 @@
 import {
-  defaultClickhouseClient,
+  clickhouseClient,
+  ClickhouseClientType,
   EventLogRecordInsertType,
   getCurrentSpan,
   ObservationRecordInsertType,
@@ -16,6 +17,7 @@ import { SpanKind } from "@opentelemetry/api";
 
 export class ClickhouseWriter {
   private static instance: ClickhouseWriter | null = null;
+  private static client: ClickhouseClientType | null = null;
   batchSize: number;
   writeInterval: number;
   maxAttempts: number;
@@ -41,7 +43,15 @@ export class ClickhouseWriter {
     this.start();
   }
 
-  public static getInstance() {
+  /**
+   * Get the singleton instance of ClickhouseWriter.
+   * Client parameter is only used for testing.
+   */
+  public static getInstance(clickhouseClient?: ClickhouseClientType) {
+    if (clickhouseClient) {
+      ClickhouseWriter.client = clickhouseClient;
+    }
+
     if (!ClickhouseWriter.instance) {
       ClickhouseWriter.instance = new ClickhouseWriter();
     }
@@ -198,7 +208,7 @@ export class ClickhouseWriter {
   }): Promise<void> {
     const startTime = Date.now();
 
-    await defaultClickhouseClient
+    await (ClickhouseWriter.client ?? clickhouseClient())
       .insert({
         table: params.table,
         format: "JSONEachRow",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Propagate OpenTelemetry trace context to Clickhouse spans and refactor tests to use a mock client for context propagation verification.
> 
>   - **Behavior**:
>     - Propagate OpenTelemetry trace context to Clickhouse spans by injecting context into HTTP headers in `clickhouseClient()` in `client.ts`.
>   - **Testing**:
>     - Refactor `ClickhouseWriter.unit.test.ts` to use a mock Clickhouse client, `clickhouseClientMock`, for testing insert operations.
>     - Update tests to verify behavior with the mock client, ensuring trace context propagation is tested.
>   - **Misc**:
>     - Remove `defaultClickhouseClient` mock from `ClickhouseWriter.unit.test.ts` and replace with `clickhouseClientMock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7293bc9f36c77d6443c9f26142e47a8c72de69a8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->