### PR TITLE
fix: delete media and event files from S3 on project delete

### DIFF
--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -54,7 +54,8 @@ export async function upsertClickhouse<
         const eventId = randomUUID();
         const bucketPath = `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${record.project_id}/${getClickhouseEntityType(eventType)}/${record.id}/${eventId}.json`;
 
-        // Write new file directly to ClickHouse as the writer lives in the worker as we don't expect much traffic on this endpoint
+        // Write new file directly to ClickHouse. We don't use the ClickHouse writer here as we expect more limited traffic
+        // and are not worried that much about latency.
         await clickhouseClient().insert({
           table: "event_log",
           values: [

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -42,7 +42,7 @@ export async function upsertClickhouse<
     span.setAttribute("ch.query.table", opts.table);
 
     await Promise.all(
-      opts.records.map((record) => {
+      opts.records.map(async (record) => {
         // drop trailing s and pretend it's always a create.
         // Only applicable to scores and traces.
         let eventType = `${opts.table.slice(0, -1)}-create`;
@@ -53,6 +53,24 @@ export async function upsertClickhouse<
 
         const eventId = randomUUID();
         const bucketPath = `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${record.project_id}/${getClickhouseEntityType(eventType)}/${record.id}/${eventId}.json`;
+
+        // Write new file directly to ClickHouse as the writer lives in the worker as we don't expect much traffic on this endpoint
+        await clickhouseClient().insert({
+          table: "event_log",
+          values: [
+            {
+              id: randomUUID(),
+              project_id: record.project_id,
+              entity_type: getClickhouseEntityType(eventType),
+              entity_id: record.id,
+              event_id: eventId,
+              bucket_name: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+              bucket_path: bucketPath,
+            },
+          ],
+          format: "JSONEachRow",
+        });
+
         return getS3StorageServiceClient(
           env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
         ).uploadJson(bucketPath, [

--- a/packages/shared/src/server/repositories/eventLog.ts
+++ b/packages/shared/src/server/repositories/eventLog.ts
@@ -1,4 +1,8 @@
-import { queryClickhouse } from "./clickhouse";
+import {
+  commandClickhouse,
+  queryClickhouse,
+  queryClickhouseStream,
+} from "./clickhouse";
 import { EventLogRecordReadType } from "./definitions";
 
 export const getEventLogByProjectAndEntityId = async (
@@ -20,6 +24,41 @@ export const getEventLogByProjectAndEntityId = async (
       projectId,
       entityType,
       entityId,
+    },
+  });
+};
+
+export const getEventLogByProjectId = (
+  projectId: string,
+): AsyncGenerator<EventLogRecordReadType> => {
+  const query = `
+    select *
+    from event_log
+    where project_id = {projectId: String}
+  `;
+
+  return queryClickhouseStream<EventLogRecordReadType>({
+    query,
+    params: {
+      projectId,
+    },
+  });
+};
+
+export const deleteEventLogByProjectId = async (
+  projectId: string,
+): Promise<void> => {
+  const query = `
+    DELETE FROM event_log
+    WHERE project_id = {projectId: String};
+  `;
+  await commandClickhouse({
+    query: query,
+    params: {
+      projectId,
+    },
+    clickhouseConfigs: {
+      request_timeout: 120_000, // 2 minutes
     },
   });
 };

--- a/worker/src/__tests__/dataRetentionProcessing.test.ts
+++ b/worker/src/__tests__/dataRetentionProcessing.test.ts
@@ -78,7 +78,7 @@ describe("DataRetentionProcessingJob", () => {
 
     // Then
     const files = await storageService.listFiles("");
-    expect(files).not.toContain(fileName);
+    expect(files.map((file) => file.file)).not.toContain(fileName);
 
     const media = await prisma.media.findUnique({
       where: { id: mediaId },

--- a/worker/src/__tests__/projectDeletionProcessing.test.ts
+++ b/worker/src/__tests__/projectDeletionProcessing.test.ts
@@ -213,7 +213,7 @@ describe("ProjectDeletionProcessingJob", () => {
         id: mediaId,
         sha256Hash: randomUUID(),
         projectId,
-        createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30), // 30 days in the past
+        createdAt: new Date(),
         bucketPath: fileName,
         bucketName: env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
         contentType: fileType,

--- a/worker/src/__tests__/projectDeletionProcessing.test.ts
+++ b/worker/src/__tests__/projectDeletionProcessing.test.ts
@@ -1,0 +1,253 @@
+import { expect, it, describe, beforeAll } from "vitest";
+import { env } from "../env";
+import { randomUUID } from "crypto";
+import {
+  convertDateToClickhouseDateTime,
+  createObservation,
+  createObservationsCh,
+  createScore,
+  createScoresCh,
+  createTrace,
+  createTracesCh,
+  getEventLogByProjectAndEntityId,
+  getObservationById,
+  getScoreById,
+  getTraceById,
+  StorageService,
+  StorageServiceFactory,
+  upsertTrace,
+} from "@langfuse/shared/src/server";
+import { prisma } from "@langfuse/shared/src/db";
+import { Job } from "bullmq";
+import { projectDeleteProcessor } from "../queues/projectDelete";
+
+describe("ProjectDeletionProcessingJob", () => {
+  let storageService: StorageService;
+  const orgId = "seed-org-id";
+
+  beforeAll(() => {
+    storageService = StorageServiceFactory.getInstance({
+      accessKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID,
+      secretAccessKey: env.LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY,
+      bucketName: env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
+      endpoint: env.LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT,
+      region: env.LANGFUSE_S3_MEDIA_UPLOAD_REGION,
+      forcePathStyle: env.LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE === "true",
+    });
+  });
+
+  it("should delete the project record after processing has completed", async () => {
+    // Setup
+    const projectId = randomUUID();
+    await prisma.project.create({
+      data: {
+        id: projectId,
+        orgId,
+        name: `Project-${randomUUID()}`,
+      },
+    });
+
+    // When
+    await projectDeleteProcessor({
+      data: { payload: { projectId, orgId } },
+    } as Job);
+
+    // Then
+    const projects = await prisma.project.findMany({
+      where: {
+        id: projectId,
+      },
+    });
+    expect(projects).toHaveLength(0);
+  });
+
+  it("should delete related table data via Prisma dependencies", async () => {
+    // Setup
+    const projectId = randomUUID();
+    await prisma.project.create({
+      data: {
+        id: projectId,
+        orgId,
+        name: `Project-${randomUUID()}`,
+      },
+    });
+    // Create a dummy dataset for the projectId
+    await prisma.dataset.create({
+      data: {
+        id: randomUUID(),
+        projectId,
+        name: "Dataset",
+      },
+    });
+
+    // When
+    await projectDeleteProcessor({
+      data: { payload: { projectId, orgId } },
+    } as Job);
+
+    // Then
+    const datasets = await prisma.dataset.findMany({
+      where: {
+        projectId,
+      },
+    });
+    expect(datasets).toHaveLength(0);
+  });
+
+  it("should delete clickhouse event data on project delete", async () => {
+    // Setup
+    const projectId = randomUUID();
+    await prisma.project.create({
+      data: {
+        id: projectId,
+        orgId,
+        name: `Project-${randomUUID()}`,
+      },
+    });
+
+    const baseId = randomUUID();
+    await Promise.all([
+      createTracesCh([
+        createTrace({
+          id: `${baseId}-trace`,
+          project_id: projectId,
+        }),
+      ]),
+      createObservationsCh([
+        createObservation({
+          id: `${baseId}-observation`,
+          trace_id: `${baseId}-trace`,
+          project_id: projectId,
+        }),
+      ]),
+      createScoresCh([
+        createScore({
+          id: `${baseId}-score`,
+          trace_id: `${baseId}-trace`,
+          project_id: projectId,
+        }),
+      ]),
+    ]);
+
+    // When
+    await projectDeleteProcessor({
+      data: { payload: { projectId, orgId } },
+    } as Job);
+
+    // Then
+    const trace = await getTraceById(`${baseId}-trace`, projectId);
+    expect(trace).toBeUndefined();
+    expect(() =>
+      getObservationById(`${baseId}-observation`, projectId),
+    ).rejects.toThrowError("not found");
+    const score = await getScoreById(projectId, `${baseId}-score`);
+    expect(score).toBeUndefined();
+  });
+
+  it("should delete event data from S3 for the project", async () => {
+    // Setup
+    const projectId = randomUUID();
+    await prisma.project.create({
+      data: {
+        id: projectId,
+        orgId,
+        name: `Project-${randomUUID()}`,
+      },
+    });
+
+    // Use upsertTrace here as this also creates an S3 event record
+    const baseId = randomUUID();
+    await upsertTrace({
+      id: `${baseId}-trace`,
+      project_id: projectId,
+      timestamp: convertDateToClickhouseDateTime(new Date()),
+      created_at: convertDateToClickhouseDateTime(new Date()),
+      updated_at: convertDateToClickhouseDateTime(new Date()),
+    });
+
+    // When
+    await projectDeleteProcessor({
+      data: { payload: { projectId, orgId } },
+    } as Job);
+
+    // Then
+    const files = await storageService.listFiles("");
+    expect(files.some((file) => file.file.includes(`${baseId}-trace`))).toBe(
+      false,
+    );
+
+    const eventLogRecord = await getEventLogByProjectAndEntityId(
+      projectId,
+      "trace",
+      `${baseId}-trace`,
+    );
+    expect(eventLogRecord).toHaveLength(0);
+  });
+
+  it("should delete all media assets for the project", async () => {
+    // Setup
+    const projectId = randomUUID();
+    await prisma.project.create({
+      data: {
+        id: projectId,
+        orgId,
+        name: `Project-${randomUUID()}`,
+      },
+    });
+
+    const fileName = `${randomUUID()}.txt`;
+    const fileType = "text/plain";
+    const data = "Hello, world!";
+    const expiresInSeconds = 3600;
+    await storageService.uploadFile({
+      fileName,
+      fileType,
+      data,
+      expiresInSeconds,
+    });
+
+    const mediaId = randomUUID();
+    const traceId = randomUUID();
+    await prisma.media.create({
+      data: {
+        id: mediaId,
+        sha256Hash: randomUUID(),
+        projectId,
+        createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30), // 30 days in the past
+        bucketPath: fileName,
+        bucketName: env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
+        contentType: fileType,
+        contentLength: 0,
+      },
+    });
+
+    await prisma.traceMedia.create({
+      data: {
+        id: randomUUID(),
+        projectId,
+        traceId,
+        mediaId,
+        field: "test",
+      },
+    });
+
+    // When
+    await projectDeleteProcessor({
+      data: { payload: { projectId, orgId } },
+    } as Job);
+
+    // Then
+    const files = await storageService.listFiles("");
+    expect(files.map((file) => file.file)).not.toContain(fileName);
+
+    const media = await prisma.media.findUnique({
+      where: { id: mediaId },
+    });
+    expect(media).toBeNull();
+
+    const traceMedia = await prisma.traceMedia.findFirst({
+      where: { mediaId },
+    });
+    expect(traceMedia).toBeNull();
+  });
+});

--- a/worker/src/queues/projectDelete.ts
+++ b/worker/src/queues/projectDelete.ts
@@ -1,14 +1,51 @@
 import { Job, Processor } from "bullmq";
 import {
+  deleteEventLogByProjectId,
   deleteObservationsByProjectId,
   deleteScoresByProjectId,
   deleteTracesByProjectId,
+  getEventLogByProjectId,
   logger,
   QueueName,
+  StorageService,
+  StorageServiceFactory,
   TQueueJobTypes,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { Prisma } from "@prisma/client";
+import { env } from "../env";
+
+let s3MediaStorageClient: StorageService;
+
+const getS3MediaStorageClient = (bucketName: string): StorageService => {
+  if (!s3MediaStorageClient) {
+    s3MediaStorageClient = StorageServiceFactory.getInstance({
+      bucketName,
+      accessKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID,
+      secretAccessKey: env.LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY,
+      endpoint: env.LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT,
+      region: env.LANGFUSE_S3_MEDIA_UPLOAD_REGION,
+      forcePathStyle: env.LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE === "true",
+    });
+  }
+  return s3MediaStorageClient;
+};
+
+let s3EventStorageClient: StorageService;
+
+const getS3EventStorageClient = (bucketName: string): StorageService => {
+  if (!s3EventStorageClient) {
+    s3EventStorageClient = StorageServiceFactory.getInstance({
+      bucketName,
+      accessKeyId: env.LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID,
+      secretAccessKey: env.LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY,
+      endpoint: env.LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT,
+      region: env.LANGFUSE_S3_EVENT_UPLOAD_REGION,
+      forcePathStyle: env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+    });
+  }
+  return s3EventStorageClient;
+};
 
 export const projectDeleteProcessor: Processor = async (
   job: Job<TQueueJobTypes[QueueName.ProjectDelete]>,
@@ -16,11 +53,51 @@ export const projectDeleteProcessor: Processor = async (
   const { orgId, projectId } = job.data.payload;
   logger.info(`Deleting ${projectId} in org ${orgId}`);
 
+  // Delete media data from S3 for project
+  if (env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET) {
+    const mediaFilesToDelete = await prisma.media.findMany({
+      select: {
+        id: true,
+        projectId: true,
+        bucketPath: true,
+      },
+      where: {
+        projectId,
+      },
+    });
+    const mediaStorageClient = getS3MediaStorageClient(
+      env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
+    );
+    // Delete from Cloud Storage
+    await mediaStorageClient.deleteFiles(
+      mediaFilesToDelete.map((f) => f.bucketPath),
+    );
+    // No need to delete from table as this will be done below via Prisma
+  }
+
+  // Remove event files from S3
+  const eventLogStream = getEventLogByProjectId(projectId);
+  let eventLogPaths: string[] = [];
+  const eventStorageClient = getS3EventStorageClient(
+    env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+  );
+  for await (const eventLog of eventLogStream) {
+    eventLogPaths.push(eventLog.bucket_path);
+    if (eventLogPaths.length > 500) {
+      // Delete the current batch and reset the list
+      await eventStorageClient.deleteFiles(eventLogPaths);
+      eventLogPaths = [];
+    }
+  }
+  // Delete any remaining files
+  await eventStorageClient.deleteFiles(eventLogPaths);
+
   // Delete project data from ClickHouse first
   await Promise.all([
     deleteTracesByProjectId(projectId),
     deleteObservationsByProjectId(projectId),
     deleteScoresByProjectId(projectId),
+    deleteEventLogByProjectId(projectId),
   ]);
 
   // Try to delete traces, observations, and scores from Prisma individually


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance project deletion to remove associated media and event files from S3 and ClickHouse, with added tests for verification.
> 
>   - **Behavior**:
>     - `projectDeleteProcessor` in `projectDelete.ts` now deletes media and event files from S3 when a project is deleted.
>     - Deletes ClickHouse data using `deleteEventLogByProjectId()` in `eventLog.ts`.
>   - **Functions**:
>     - Adds `getEventLogByProjectId()` and `deleteEventLogByProjectId()` in `eventLog.ts` for querying and deleting event logs by project ID.
>   - **Tests**:
>     - Adds `projectDeletionProcessing.test.ts` to test project deletion, ensuring all related data is removed from S3 and databases.
>     - Updates `dataRetentionProcessing.test.ts` to check for correct deletion of expired media files.
>   - **Misc**:
>     - Renames `dataRetentionProcessingTest.test.ts` to `dataRetentionProcessing.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 101c66cc5917c8d7c978297a21e22853e8091959. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->