### PR TITLE
perf(tables): disable link prefetching in viewport, only prefetch on link hover

### DIFF
--- a/web/src/components/table/table-link.tsx
+++ b/web/src/components/table/table-link.tsx
@@ -22,6 +22,7 @@ export default function TableLink({
       )}
       href={path}
       title={value}
+      prefetch={false}
     >
       {icon ? icon : value}
     </Link>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Disable link prefetching in `TableLink` component to optimize performance.
> 
>   - **Performance Optimization**:
>     - Disable link prefetching in `TableLink` component in `table-link.tsx` by setting `prefetch={false}` on the `Link` component.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4ec59737ed7441c738da6e786a3d69220829a6ee. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->