### PR TITLE
perf(exports): increase max row limit to 1M

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -39,7 +39,7 @@ const EnvSchema = z.object({
     .enum(["true", "false"])
     .default("false"),
 
-  BATCH_EXPORT_ROW_LIMIT: z.coerce.number().positive().default(50_000),
+  BATCH_EXPORT_ROW_LIMIT: z.coerce.number().positive().default(1_000_000),
   BATCH_EXPORT_DOWNLOAD_LINK_EXPIRATION_HOURS: z.coerce
     .number()
     .positive()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase `BATCH_EXPORT_ROW_LIMIT` default to 1,000,000 in `env.ts` for larger data exports.
> 
>   - **Behavior**:
>     - Increase `BATCH_EXPORT_ROW_LIMIT` default from 50,000 to 1,000,000 in `env.ts` to support larger data exports.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1cf60691e10f9d93e2f351473da55bc3a49873b5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->