### PR TITLE
fix(datasets): broken link in compare view

### DIFF
--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -108,7 +108,7 @@ export const PromptDetail = () => {
       description: "Waiting for experiment to complete...",
       link: {
         text: "View experiment",
-        href: `/project/${projectId}/datasets/${data.datasetId}/compare?runIds=${data.runId}`,
+        href: `/project/${projectId}/datasets/${data.datasetId}/compare?runs=${data.runId}`,
       },
     });
   };

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
@@ -156,7 +156,7 @@ export default function DatasetCompare() {
     return [...apiRuns, ...localRuns];
   }, [runsData.data, localRuns]);
 
-  if (!runsData.data || !router.isReady) {
+  if (!runsData.data || !router.isReady || runs.length === 0) {
     return <span>Loading...</span>;
   }
 
@@ -248,7 +248,7 @@ export default function DatasetCompare() {
             options={runs.map((run) => ({
               key: run.key,
               value: run.value,
-              disabled: runIds?.includes(run.key) && runIds.length === 2,
+              disabled: runIds?.includes(run.key) && runIds.length === 1,
             }))}
             values={runs.filter((run) => runIds?.includes(run.key))}
             onValueChange={(values, changedValueId, selectedValueKeys) => {

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
@@ -101,7 +101,7 @@ export default function Dataset() {
       description: "Waiting for experiment to complete...",
       link: {
         text: "View experiment",
-        href: `/project/${projectId}/datasets/${data.datasetId}/compare?runIds=${data.runId}`,
+        href: `/project/${projectId}/datasets/${data.datasetId}/compare?runs=${data.runId}`,
       },
     });
   };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix broken link in compare view by changing query parameter from `runIds` to `runs` and adjust logic for loading and option disabling in `compare.tsx`.
> 
>   - **Link Fix**:
>     - Change query parameter from `runIds` to `runs` in `prompt-detail.tsx`, `compare.tsx`, and `index.tsx`.
>   - **Logic Adjustment**:
>     - In `compare.tsx`, add condition to display loading message if `runs` length is 0.
>     - Modify condition for disabling options in `MultiSelectKeyValues` to `runIds.length === 1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8aa9a2073a357f5cd74c3049899b42274c630558. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->