### PR TITLE
chore: delay project delete queue to allow for remaining events to be processed

### DIFF
--- a/packages/shared/src/server/redis/projectDelete.ts
+++ b/packages/shared/src/server/redis/projectDelete.ts
@@ -27,6 +27,7 @@ export class ProjectDeleteQueue {
               removeOnComplete: true,
               removeOnFail: 100_000,
               attempts: 5,
+              delay: 60_000, // 1 minute
               backoff: {
                 type: "exponential",
                 delay: 5000,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a 1-minute delay to `ProjectDeleteQueue` in `projectDelete.ts` to process remaining events before deletion.
> 
>   - **Behavior**:
>     - Adds a 1-minute delay to the `ProjectDeleteQueue` in `projectDelete.ts` to allow for remaining events to be processed before deletion.
>   - **Misc**:
>     - No other changes or refactors in the code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9f35e5d297f360803bc667f2a98af78045025bee. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->