### PR TITLE
perf(tables): truncate large I/O content preview in tables

### DIFF
--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -214,6 +214,10 @@ export const IOTableCell = ({
   className?: string;
   singleLine?: boolean;
 }) => {
+  if (isLoading) {
+    return <JsonSkeleton className="h-full w-full overflow-hidden px-2 py-1" />;
+  }
+
   const stringifiedJson = data ? stringifyJsonNode(data) : undefined;
 
   // perf: truncate to IO_TABLE_CHAR_LIMIT characters as table becomes unresponsive attempting to render large JSONs with high levels of nesting
@@ -222,9 +226,7 @@ export const IOTableCell = ({
 
   return (
     <>
-      {isLoading ? (
-        <JsonSkeleton className="h-full w-full overflow-hidden px-2 py-1" />
-      ) : singleLine ? (
+      {singleLine ? (
         <div
           className={cn(
             "h-full w-full self-stretch overflow-hidden overflow-y-auto truncate rounded-sm border px-2 py-0.5",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Truncate large JSON content in `IOTableCell` to 10,000 characters to improve table performance.
> 
>   - **Performance**:
>     - Introduce `IO_TABLE_CHAR_LIMIT` constant in `CodeJsonViewer.tsx` to limit JSON content to 10,000 characters in `IOTableCell`.
>     - Truncate JSON content exceeding the limit and display a message indicating truncation in `IOTableCell`.
>   - **UI**:
>     - Modify `IOTableCell` to handle loading state with `JsonSkeleton` and truncate large JSON content.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2beca5d2b69ce6802d6822d0eb6e862402def16e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->