### PR TITLE
fix(model-prices): move gemini prices to Google AI values

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1424,8 +1424,8 @@
     "created_at": "2025-02-06T11:11:35.241Z",
     "updated_at": "2025-02-10T10:11:35.241Z",
     "prices": {
-      "input": 0.15e-6,
-      "output": 0.6e-6
+      "input": 0.1e-6,
+      "output": 0.4e-6
     },
     "tokenizer_config": null,
     "tokenizer_id": null


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `gemini-2.0-flash-001` model prices in `default-model-prices.json` to lower input and output costs.
> 
>   - **Pricing Update**:
>     - Update `gemini-2.0-flash-001` model prices in `default-model-prices.json`.
>     - Change `input` price from `0.15e-6` to `0.1e-6`.
>     - Change `output` price from `0.6e-6` to `0.4e-6`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e891f5fee514ea0b52ac92ed2fe6d6a954391163. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->