### PR TITLE
chore: increase static page generation timeout nextjs

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -47,7 +47,7 @@ const reportToHeader = {
 
 /** @type {import("next").NextConfig} */
 const nextConfig = {
-  staticPageGenerationTimeout: 100, // default is 60. Required for build process for amd
+  staticPageGenerationTimeout: 120, // default is 60. Required for build process for amd
   transpilePackages: ["@langfuse/shared"],
   reactStrictMode: true,
   experimental: {

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -47,6 +47,7 @@ const reportToHeader = {
 
 /** @type {import("next").NextConfig} */
 const nextConfig = {
+  staticPageGenerationTimeout: 100, // default is 60. Required for build process for amd
   transpilePackages: ["@langfuse/shared"],
   reactStrictMode: true,
   experimental: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Increase `staticPageGenerationTimeout` to 120 seconds in `next.config.mjs` for better build process handling.
> 
>   - **Configuration**:
>     - Increase `staticPageGenerationTimeout` to 120 seconds in `next.config.mjs` for improved build process handling, especially for AMD.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a1d6e2a14dce5cee313e8737a072b80be691838b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->