### PR TITLE
fix(header): breakpoint header behaviour

### DIFF
--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -31,7 +31,7 @@ const PageHeader = ({
         <div className="border-b">
           <div
             className={cn(
-              "flex min-h-12 items-center gap-3 px-3 py-2 md:max-h-12",
+              "flex min-h-12 items-center gap-3 px-3 py-2",
               container && "lg:container",
             )}
           >
@@ -47,13 +47,13 @@ const PageHeader = ({
         <div className="bg-muted">
           <div
             className={cn(
-              "flex min-h-16 items-center justify-between p-3 md:max-h-16",
+              "flex min-h-12 items-center justify-between p-3",
               container && "lg:container",
             )}
           >
-            <div className="flex-no-wrap flex min-h-16 items-center gap-1 md:max-h-16">
+            <div className="flex-no-wrap flex min-h-12 items-center gap-1">
               {itemType && <ItemBadge type={itemType} showLabel />}
-              <h2 className="line-clamp-2 h-16 min-w-0 place-content-center text-lg font-semibold leading-7">
+              <h2 className="line-clamp-2 h-14 min-w-0 place-content-center text-lg font-semibold leading-7">
                 {title}
               </h2>
               {help && (

--- a/web/src/pages/project/[projectId]/prompts/[promptName]/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/[promptName]/metrics.tsx
@@ -376,6 +376,7 @@ export default function PromptVersionTable() {
     <Page
       headerProps={{
         title: promptName,
+        itemType: "PROMPT",
         help: {
           description:
             "You can use this prompt within your application through the Langfuse SDKs and integrations. Refer to the documentation for more information.",
@@ -392,7 +393,7 @@ export default function PromptVersionTable() {
           },
           { name: `Metrics` },
         ],
-        actionButtonsLeft: (
+        actionButtonsRight: (
           <>
             <Tabs value="metrics">
               <TabsList>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix header breakpoint behavior in `page-header.tsx` and update `PromptVersionTable` props in `metrics.tsx`.
> 
>   - **Header Behavior**:
>     - Removed `md:max-h-12` and `md:max-h-16` constraints in `page-header.tsx` to fix breakpoint behavior.
>     - Adjusted `h-16` to `h-14` for `h2` element in `page-header.tsx`.
>   - **Component Props**:
>     - Added `itemType: "PROMPT"` to `headerProps` in `metrics.tsx`.
>     - Changed `actionButtonsLeft` to `actionButtonsRight` in `metrics.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c2836c3099cbfe049b99ca653a288540d74e0c86. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->