### PR TITLE
fix: re-enable trace deletion and remove trace S3 files

### DIFF
--- a/packages/shared/src/server/repositories/eventLog.ts
+++ b/packages/shared/src/server/repositories/eventLog.ts
@@ -134,6 +134,9 @@ export const getEventLogByProjectIdAndTraceIds = (
       projectId,
       traceIds,
     },
+    clickhouseConfigs: {
+      request_timeout: 120_000, // 2 minutes
+    },
     tags: {
       feature: "eventLog",
       kind: "list",

--- a/packages/shared/src/server/repositories/eventLog.ts
+++ b/packages/shared/src/server/repositories/eventLog.ts
@@ -121,6 +121,8 @@ export const getEventLogByProjectIdAndTraceIds = (
       from filtered_scores
     )
 
+    -- We use a semi join because we only use the 'filtered_events' as a filter.
+    -- There is no need to build the cartesian product (i.e. the combination) between the event log and the events.
     select el.*
     from event_log el
     left semi join filtered_events fe

--- a/packages/shared/src/server/repositories/eventLog.ts
+++ b/packages/shared/src/server/repositories/eventLog.ts
@@ -121,7 +121,7 @@ export const getEventLogByProjectIdAndTraceIds = (
       from filtered_scores
     )
 
-    select *
+    select el.*
     from event_log el
     left semi join filtered_events fe
     on el.project_id = fe.project_id and el.entity_id = fe.entity_id and el.entity_type = fe.entity_type

--- a/web/src/__tests__/async/traces-trpc.servertest.ts
+++ b/web/src/__tests__/async/traces-trpc.servertest.ts
@@ -6,15 +6,10 @@ import { pruneDatabase } from "@/src/__tests__/test-utils";
 import { prisma } from "@langfuse/shared/src/db";
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
-import {
-  createTrace,
-  createTracesCh,
-  getTraceById,
-} from "@langfuse/shared/src/server";
+import { createTrace, createTracesCh } from "@langfuse/shared/src/server";
 import { randomUUID } from "crypto";
-import waitForExpect from "wait-for-expect";
 
-describe("traces trps", () => {
+describe("traces trpc", () => {
   const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
 
   beforeEach(async () => await pruneDatabase());

--- a/web/src/__tests__/async/traces-trpc.servertest.ts
+++ b/web/src/__tests__/async/traces-trpc.servertest.ts
@@ -6,8 +6,13 @@ import { pruneDatabase } from "@/src/__tests__/test-utils";
 import { prisma } from "@langfuse/shared/src/db";
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
-import { createTrace, createTracesCh } from "@langfuse/shared/src/server";
+import {
+  createTrace,
+  createTracesCh,
+  getTraceById,
+} from "@langfuse/shared/src/server";
 import { randomUUID } from "crypto";
+import waitForExpect from "wait-for-expect";
 
 describe("traces trps", () => {
   const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";

--- a/web/src/components/deleteButton.tsx
+++ b/web/src/components/deleteButton.tsx
@@ -13,6 +13,7 @@ import { api } from "@/src/utils/api";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { Input } from "@/src/components/ui/input";
 import { Label } from "@/src/components/ui/label";
+import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 
 interface DeleteButtonProps {
   itemId: string;
@@ -44,6 +45,11 @@ export function DeleteButton({
   const traceMutation = api.traces.deleteMany.useMutation({
     onSuccess: () => {
       setIsDeleted(true);
+      showSuccessToast({
+        title: "Trace deleted",
+        description:
+          "Selected trace will be deleted. Traces are removed asynchronously and may continue to be visible for up to 15 minutes.",
+      });
       !isTableAction && redirectUrl
         ? void router.push(redirectUrl)
         : invalidateFunc();

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -823,19 +823,16 @@ export default function TracesTable({
       isPinned: true,
       cell: ({ row }) => {
         const traceId: TracesTableRow["id"] = row.getValue("id");
-        return (
-          traceId &&
-          typeof traceId === "string" && (
-            <DeleteButton
-              itemId={traceId}
-              projectId={projectId}
-              scope="traces:delete"
-              invalidateFunc={() => void utils.traces.all.invalidate()}
-              type="trace"
-              isTableAction={true}
-            />
-          )
-        );
+        return traceId && typeof traceId === "string" ? (
+          <DeleteButton
+            itemId={traceId}
+            projectId={projectId}
+            scope="traces:delete"
+            invalidateFunc={() => void utils.traces.all.invalidate()}
+            type="trace"
+            isTableAction={true}
+          />
+        ) : undefined;
       },
     },
   ];

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -55,7 +55,6 @@ import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrde
 import { BatchExportTableButton } from "@/src/components/BatchExportTableButton";
 import { BreakdownTooltip } from "@/src/components/trace/BreakdownToolTip";
 import { InfoIcon } from "lucide-react";
-import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import { Separator } from "@/src/components/ui/separator";
 import React from "react";
 import { TableActionMenu } from "@/src/features/table/components/TableActionMenu";

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -48,6 +48,7 @@ import {
   TabsBarList,
   TabsBarTrigger,
 } from "@/src/components/ui/tabs-bar";
+import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import Page from "@/src/components/layouts/page";
 import { TraceGraphView } from "@/src/features/trace-graph-view/components/TraceGraphView";
 import { isLanggraphTrace } from "@/src/features/trace-graph-view/utils/isLanggraphTrace";
@@ -360,6 +361,8 @@ export function TracePage({
     withDefault(StringParam, "details"),
   );
 
+  const hasTraceDeletionEntitlement = useHasEntitlement("trace-deletion");
+
   if (trace.error?.data?.code === "UNAUTHORIZED")
     return <ErrorPage message="You do not have access to this trace." />;
 
@@ -425,15 +428,17 @@ export function TracePage({
               }}
               listKey="traces"
             />
-            <DeleteButton
-              itemId={traceId}
-              projectId={trace.data.projectId}
-              scope="traces:delete"
-              invalidateFunc={() => void utils.traces.all.invalidate()}
-              type="trace"
-              redirectUrl={`/project/${router.query.projectId as string}/traces`}
-              deleteConfirmation={trace.data.name ?? ""}
-            />
+            {hasTraceDeletionEntitlement && (
+              <DeleteButton
+                itemId={traceId}
+                projectId={trace.data.projectId}
+                scope="traces:delete"
+                invalidateFunc={() => void utils.traces.all.invalidate()}
+                type="trace"
+                redirectUrl={`/project/${router.query.projectId as string}/traces`}
+                deleteConfirmation={trace.data.name ?? ""}
+              />
+            )}
           </>
         ),
       }}

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -361,8 +361,6 @@ export function TracePage({
     withDefault(StringParam, "details"),
   );
 
-  const hasTraceDeletionEntitlement = useHasEntitlement("trace-deletion");
-
   if (trace.error?.data?.code === "UNAUTHORIZED")
     return <ErrorPage message="You do not have access to this trace." />;
 
@@ -428,17 +426,15 @@ export function TracePage({
               }}
               listKey="traces"
             />
-            {hasTraceDeletionEntitlement && (
-              <DeleteButton
-                itemId={traceId}
-                projectId={trace.data.projectId}
-                scope="traces:delete"
-                invalidateFunc={() => void utils.traces.all.invalidate()}
-                type="trace"
-                redirectUrl={`/project/${router.query.projectId as string}/traces`}
-                deleteConfirmation={trace.data.name ?? ""}
-              />
-            )}
+            <DeleteButton
+              itemId={traceId}
+              projectId={trace.data.projectId}
+              scope="traces:delete"
+              invalidateFunc={() => void utils.traces.all.invalidate()}
+              type="trace"
+              redirectUrl={`/project/${router.query.projectId as string}/traces`}
+              deleteConfirmation={trace.data.name ?? ""}
+            />
           </>
         ),
       }}

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -48,7 +48,6 @@ import {
   TabsBarList,
   TabsBarTrigger,
 } from "@/src/components/ui/tabs-bar";
-import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import Page from "@/src/components/layouts/page";
 import { TraceGraphView } from "@/src/features/trace-graph-view/components/TraceGraphView";
 import { isLanggraphTrace } from "@/src/features/trace-graph-view/utils/isLanggraphTrace";

--- a/web/src/features/entitlements/constants/entitlements.ts
+++ b/web/src/features/entitlements/constants/entitlements.ts
@@ -14,7 +14,7 @@ const entitlements = [
   "prompt-experiments",
   "trace-deletion",
   "audit-logs",
-  "data-retention",
+  "data-retention", // Not in use anymore, but necessary to use the TableAction type.
 ] as const;
 export type Entitlement = (typeof entitlements)[number];
 
@@ -25,6 +25,7 @@ const cloudAllPlansEntitlements: Entitlement[] = [
   "integration-posthog",
   "annotation-queues",
   "prompt-experiments",
+  "trace-deletion",
 ];
 
 const selfHostedAllPlansEntitlements: Entitlement[] = ["trace-deletion"];

--- a/web/src/features/entitlements/constants/entitlements.ts
+++ b/web/src/features/entitlements/constants/entitlements.ts
@@ -12,9 +12,9 @@ const entitlements = [
   "self-host-ui-customization",
   "self-host-allowed-organization-creators",
   "prompt-experiments",
-  "trace-deletion",
+  "trace-deletion", // Not in use anymore, but necessary to use the TableAction type.
   "audit-logs",
-  "data-retention", // Not in use anymore, but necessary to use the TableAction type.
+  "data-retention",
 ] as const;
 export type Entitlement = (typeof entitlements)[number];
 

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -273,6 +273,12 @@ export const traceRouter = createTRPCRouter({
         scope: "traces:delete",
       });
 
+      throwIfNoEntitlement({
+        entitlement: "trace-deletion",
+        projectId: input.projectId,
+        sessionUser: ctx.session.user,
+      });
+
       if (input.isBatchAction && input.query) {
         await createBatchActionJob({
           projectId: input.projectId,
@@ -290,12 +296,6 @@ export const traceRouter = createTRPCRouter({
             message: "TraceDeleteQueue not initialized",
           });
         }
-
-        throwIfNoEntitlement({
-          entitlement: "trace-deletion",
-          projectId: input.projectId,
-          sessionUser: ctx.session.user,
-        });
 
         await Promise.all(
           input.traceIds.map((traceId) =>

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -40,6 +40,7 @@ import {
 import { TRPCError } from "@trpc/server";
 import { randomUUID } from "crypto";
 import { createBatchActionJob } from "@/src/features/table/server/createBatchActionJob";
+import { throwIfNoEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
 
 const TraceFilterOptions = z.object({
   projectId: z.string(), // Required for protectedProjectProcedure
@@ -289,6 +290,12 @@ export const traceRouter = createTRPCRouter({
             message: "TraceDeleteQueue not initialized",
           });
         }
+
+        throwIfNoEntitlement({
+          entitlement: "trace-deletion",
+          projectId: input.projectId,
+          sessionUser: ctx.session.user,
+        });
 
         await Promise.all(
           input.traceIds.map((traceId) =>

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { env } from "@/src/env.mjs";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
@@ -29,9 +28,6 @@ import {
   getTracesGroupedByName,
   getTracesGroupedByTags,
   getObservationsViewForTrace,
-  deleteTraces,
-  deleteScoresByTraceIds,
-  deleteObservationsByTraceIds,
   getTraceById,
   logger,
   upsertTrace,
@@ -44,7 +40,6 @@ import {
 import { TRPCError } from "@trpc/server";
 import { randomUUID } from "crypto";
 import { createBatchActionJob } from "@/src/features/table/server/createBatchActionJob";
-import { throwIfNoEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
 
 const TraceFilterOptions = z.object({
   projectId: z.string(), // Required for protectedProjectProcedure

--- a/worker/src/__tests__/dataRetentionProcessing.test.ts
+++ b/worker/src/__tests__/dataRetentionProcessing.test.ts
@@ -9,7 +9,6 @@ import {
   createScoresCh,
   createTrace,
   createTracesCh,
-  getClickhouseEntityType,
   getEventLogByProjectAndEntityId,
   getObservationById,
   getScoreById,

--- a/worker/src/__tests__/traceDeletion.test.ts
+++ b/worker/src/__tests__/traceDeletion.test.ts
@@ -1,0 +1,268 @@
+import { expect, describe, it, beforeAll } from "vitest";
+import {
+  clickhouseClient,
+  createObservation,
+  createObservationsCh,
+  createOrgProjectAndApiKey,
+  createScore,
+  createScoresCh,
+  createTrace,
+  createTracesCh,
+  getEventLogByProjectId,
+  getObservationsViewForTrace,
+  getScoresForTraces,
+  getTracesByIds,
+  StorageService,
+  StorageServiceFactory,
+} from "@langfuse/shared/src/server";
+import { randomUUID } from "crypto";
+import { processClickhouseTraceDelete } from "../features/traces/processClickhouseTraceDelete";
+import { env } from "../env";
+import { prisma } from "@langfuse/shared/src/db";
+
+describe("trace deletion", () => {
+  let eventStorageService: StorageService;
+  let mediaStorageService: StorageService;
+
+  beforeAll(() => {
+    eventStorageService = StorageServiceFactory.getInstance({
+      accessKeyId: env.LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID,
+      secretAccessKey: env.LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY,
+      bucketName: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+      endpoint: env.LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT,
+      region: env.LANGFUSE_S3_EVENT_UPLOAD_REGION,
+      forcePathStyle: env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+    });
+
+    mediaStorageService = StorageServiceFactory.getInstance({
+      accessKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID,
+      secretAccessKey: env.LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY,
+      bucketName: env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
+      endpoint: env.LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT,
+      region: env.LANGFUSE_S3_MEDIA_UPLOAD_REGION,
+      forcePathStyle: env.LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE === "true",
+    });
+  });
+
+  it("should delete all traces, observations, and scores from Clickhouse", async () => {
+    // Setup
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const traceId = randomUUID();
+    await createTracesCh([createTrace({ id: traceId })]);
+    await createObservationsCh([createObservation({ traceId })]);
+    await createScoresCh([createScore({ traceId })]);
+
+    // When
+    await processClickhouseTraceDelete("projectId", [traceId]);
+
+    // Then
+    const traces = await getTracesByIds([traceId], projectId);
+    expect(traces).toHaveLength(0);
+
+    const observations = await getObservationsViewForTrace(traceId, projectId);
+    expect(observations).toHaveLength(0);
+
+    const scores = await getScoresForTraces({
+      projectId,
+      traceIds: [traceId],
+    });
+    expect(scores).toHaveLength(0);
+  });
+
+  it("should delete S3 media files for deleted traces", async () => {
+    // Setup
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const traceId = randomUUID();
+    const observationId = randomUUID();
+
+    await createTracesCh([createTrace({ id: traceId, project_id: projectId })]);
+    await createObservationsCh([
+      createObservation({
+        id: observationId,
+        trace_id: traceId,
+        project_id: projectId,
+      }),
+    ]);
+
+    const fileType = "text/plain";
+    const data = "Hello, world!";
+    const expiresInSeconds = 3600;
+    await Promise.all([
+      mediaStorageService.uploadFile({
+        fileName: `${projectId}/trace-${traceId}.txt`,
+        fileType,
+        data,
+        expiresInSeconds,
+      }),
+      mediaStorageService.uploadFile({
+        fileName: `${projectId}/observation-${observationId}.txt`,
+        fileType,
+        data,
+        expiresInSeconds,
+      }),
+    ]);
+
+    const traceMediaId = randomUUID();
+    await prisma.media.create({
+      data: {
+        id: traceMediaId,
+        sha256Hash: randomUUID(),
+        projectId,
+        createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3), // 3 days in the past
+        bucketPath: `${projectId}/trace-${traceId}.txt`,
+        bucketName: env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
+        contentType: fileType,
+        contentLength: 0,
+      },
+    });
+    await prisma.traceMedia.create({
+      data: {
+        id: randomUUID(),
+        projectId,
+        traceId,
+        mediaId: traceMediaId,
+        field: "test",
+      },
+    });
+
+    const observationMediaId = randomUUID();
+    await prisma.media.create({
+      data: {
+        id: observationMediaId,
+        sha256Hash: randomUUID(),
+        projectId,
+        createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3), // 3 days in the past
+        bucketPath: `${projectId}/observation-${observationId}.txt`,
+        bucketName: env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
+        contentType: fileType,
+        contentLength: 0,
+      },
+    });
+    await prisma.observationMedia.create({
+      data: {
+        id: randomUUID(),
+        projectId,
+        observationId,
+        traceId,
+        mediaId: observationMediaId,
+        field: "test",
+      },
+    });
+
+    // When
+    await processClickhouseTraceDelete(projectId, [traceId]);
+
+    // Then
+    const files = await mediaStorageService.listFiles(projectId);
+    expect(files).toHaveLength(0);
+
+    const media = await prisma.media.findMany({
+      where: {
+        projectId,
+      },
+    });
+    expect(media).toHaveLength(0);
+
+    // No need to check observationMedia and traceMedia as they have a foreign key to media table.
+  });
+
+  it("should delete S3 event files for deleted traces", async () => {
+    // Setup
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const traceId = randomUUID();
+    const observationId = randomUUID();
+    const scoreId = randomUUID();
+
+    await createTracesCh([createTrace({ id: traceId, project_id: projectId })]);
+    await createObservationsCh([
+      createObservation({
+        id: observationId,
+        trace_id: traceId,
+        project_id: projectId,
+      }),
+    ]);
+    await createScoresCh([
+      createScore({ id: scoreId, trace_id: traceId, project_id: projectId }),
+    ]);
+
+    const fileType = "application/json";
+    const data = JSON.stringify({ hello: "world" });
+    const expiresInSeconds = 3600;
+    await Promise.all([
+      eventStorageService.uploadFile({
+        fileName: `${projectId}/traces/${traceId}-trace.json`,
+        fileType,
+        data,
+        expiresInSeconds,
+      }),
+      eventStorageService.uploadFile({
+        fileName: `${projectId}/observation/${traceId}-observation.json`,
+        fileType,
+        data,
+        expiresInSeconds,
+      }),
+      eventStorageService.uploadFile({
+        fileName: `${projectId}/score/${traceId}-score.json`,
+        fileType,
+        data,
+        expiresInSeconds,
+      }),
+    ]);
+
+    await clickhouseClient().insert({
+      table: "event_log",
+      format: "JSONEachRow",
+      values: [
+        {
+          id: randomUUID(),
+          project_id: projectId,
+          entity_type: "trace",
+          entity_id: traceId,
+          event_id: randomUUID(),
+          bucket_name: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+          bucket_path: `${projectId}/traces/${traceId}-trace.json`,
+          created_at: new Date().getTime(),
+          updated_at: new Date().getTime(),
+        },
+        {
+          id: randomUUID(),
+          project_id: projectId,
+          entity_type: "observation",
+          entity_id: observationId,
+          event_id: randomUUID(),
+          bucket_name: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+          bucket_path: `${projectId}/observation/${traceId}-observation.json`,
+          created_at: new Date().getTime(),
+          updated_at: new Date().getTime(),
+        },
+        {
+          id: randomUUID(),
+          project_id: projectId,
+          entity_type: "score",
+          entity_id: scoreId,
+          event_id: randomUUID(),
+          bucket_name: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+          bucket_path: `${projectId}/score/${traceId}-score.json`,
+          created_at: new Date().getTime(),
+          updated_at: new Date().getTime(),
+        },
+      ],
+    });
+
+    // When
+    await processClickhouseTraceDelete(projectId, [traceId]);
+
+    // Then
+    const eventLog = getEventLogByProjectId(projectId);
+    for await (const _ of eventLog) {
+      // Should never happen as the expect event log to be empty
+      expect(true).toBe(false);
+    }
+
+    const files = await eventStorageService.listFiles(projectId);
+    expect(files).toHaveLength(0);
+  });
+});

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -107,9 +107,9 @@ if (env.QUEUE_CONSUMER_TRACE_DELETE_QUEUE_IS_ENABLED === "true") {
   WorkerManager.register(QueueName.TraceDelete, traceDeleteProcessor, {
     concurrency: env.LANGFUSE_TRACE_DELETE_CONCURRENCY,
     limiter: {
-      // Process at most `max` delete jobs per 3 seconds
+      // Process at most `max` delete jobs per 15 seconds
       max: env.LANGFUSE_TRACE_DELETE_CONCURRENCY,
-      duration: 3_000,
+      duration: 15_000,
     },
   });
 }

--- a/worker/src/features/batchAction/handleBatchActionJob.ts
+++ b/worker/src/features/batchAction/handleBatchActionJob.ts
@@ -42,8 +42,10 @@ async function processActionChunk(
   try {
     switch (actionId) {
       case "trace-delete":
-        await processPostgresTraceDelete(projectId, chunkIds);
-        await processClickhouseTraceDelete(projectId, chunkIds);
+        await Promise.all([
+          processPostgresTraceDelete(projectId, chunkIds),
+          processClickhouseTraceDelete(projectId, chunkIds),
+        ]);
         break;
 
       case "trace-add-to-annotation-queue":

--- a/worker/src/features/traces/processClickhouseTraceDelete.ts
+++ b/worker/src/features/traces/processClickhouseTraceDelete.ts
@@ -1,10 +1,48 @@
 import {
+  deleteEventLogByProjectIdAndIds,
   deleteObservationsByTraceIds,
   deleteScoresByTraceIds,
   deleteTraces,
+  getEventLogByProjectIdAndTraceIds,
   logger,
+  StorageService,
+  StorageServiceFactory,
   traceException,
 } from "@langfuse/shared/src/server";
+import { env } from "../../env";
+import { prisma } from "@langfuse/shared/src/db";
+
+let s3MediaStorageClient: StorageService;
+
+const getS3MediaStorageClient = (bucketName: string): StorageService => {
+  if (!s3MediaStorageClient) {
+    s3MediaStorageClient = StorageServiceFactory.getInstance({
+      bucketName,
+      accessKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID,
+      secretAccessKey: env.LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY,
+      endpoint: env.LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT,
+      region: env.LANGFUSE_S3_MEDIA_UPLOAD_REGION,
+      forcePathStyle: env.LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE === "true",
+    });
+  }
+  return s3MediaStorageClient;
+};
+
+let s3EventStorageClient: StorageService;
+
+const getS3EventStorageClient = (bucketName: string): StorageService => {
+  if (!s3EventStorageClient) {
+    s3EventStorageClient = StorageServiceFactory.getInstance({
+      bucketName,
+      accessKeyId: env.LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID,
+      secretAccessKey: env.LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY,
+      endpoint: env.LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT,
+      region: env.LANGFUSE_S3_EVENT_UPLOAD_REGION,
+      forcePathStyle: env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+    });
+  }
+  return s3EventStorageClient;
+};
 
 export const processClickhouseTraceDelete = async (
   projectId: string,
@@ -13,6 +51,82 @@ export const processClickhouseTraceDelete = async (
   logger.info(
     `Deleting traces ${JSON.stringify(traceIds)} in project ${projectId} from Clickhouse`,
   );
+
+  // Delete media files if bucket is configured
+  if (env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET) {
+    const mediaFilesToDelete = await prisma.media.findMany({
+      select: {
+        id: true,
+        bucketPath: true,
+      },
+      where: {
+        projectId,
+        OR: [
+          {
+            TraceMedia: {
+              some: {
+                projectId,
+                traceId: {
+                  in: traceIds,
+                },
+              },
+            },
+          },
+          {
+            ObservationMedia: {
+              some: {
+                projectId,
+                traceId: {
+                  in: traceIds,
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+    const mediaStorageClient = getS3MediaStorageClient(
+      env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
+    );
+    // Delete from Cloud Storage
+    await mediaStorageClient.deleteFiles(
+      mediaFilesToDelete.map((f) => f.bucketPath),
+    );
+    // Delete from postgres. We should automatically remove the corresponding traceMedia and observationMedia
+    await prisma.media.deleteMany({
+      where: {
+        id: {
+          in: mediaFilesToDelete.map((f) => f.id),
+        },
+        projectId,
+      },
+    });
+  }
+
+  const eventLogStream = getEventLogByProjectIdAndTraceIds(projectId, traceIds);
+  let eventLogRecords: { id: string; path: string }[] = [];
+  const eventStorageClient = getS3EventStorageClient(
+    env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+  );
+  for await (const eventLog of eventLogStream) {
+    eventLogRecords.push({ id: eventLog.id, path: eventLog.bucket_path });
+    if (eventLogRecords.length > 500) {
+      // Delete the current batch and reset the list
+      await eventStorageClient.deleteFiles(eventLogRecords.map((r) => r.path));
+      await deleteEventLogByProjectIdAndIds(
+        projectId,
+        eventLogRecords.map((r) => r.id),
+      );
+      eventLogRecords = [];
+    }
+  }
+  // Delete any remaining files
+  await eventStorageClient.deleteFiles(eventLogRecords.map((r) => r.path));
+  await deleteEventLogByProjectIdAndIds(
+    projectId,
+    eventLogRecords.map((r) => r.id),
+  );
+
   try {
     await Promise.all([
       deleteTraces(projectId, traceIds),

--- a/worker/src/queues/traceDelete.ts
+++ b/worker/src/queues/traceDelete.ts
@@ -1,7 +1,6 @@
 import { Job, Processor } from "bullmq";
 import { QueueName, TQueueJobTypes } from "@langfuse/shared/src/server";
 
-import { env } from "../env";
 import { processClickhouseTraceDelete } from "../features/traces/processClickhouseTraceDelete";
 import { processPostgresTraceDelete } from "../features/traces/processPostgresTraceDelete";
 
@@ -14,9 +13,8 @@ export const traceDeleteProcessor: Processor = async (
       ? job.data.payload.traceIds
       : [job.data.payload.traceId];
 
-  await processPostgresTraceDelete(projectId, traceIds);
-
-  if (env.CLICKHOUSE_URL) {
-    await processClickhouseTraceDelete(projectId, traceIds);
-  }
+  await Promise.all([
+    processPostgresTraceDelete(projectId, traceIds),
+    processClickhouseTraceDelete(projectId, traceIds),
+  ]);
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Re-enable trace deletion with S3 file removal, update UI, and add tests for trace and S3 file deletion.
> 
>   - **Trace Deletion**:
>     - Re-enable trace deletion in `traces.ts` by removing previous synchronous deletion logic.
>     - Add `processClickhouseTraceDelete` to handle deletion of traces, observations, scores, and associated S3 files.
>     - Update `traceDeleteProcessor` to use `processClickhouseTraceDelete` and `processPostgresTraceDelete`.
>   - **Event Log**:
>     - Add `getEventLogByProjectIdAndTraceIds` and `deleteEventLogByProjectIdAndIds` in `eventLog.ts` for querying and deleting event logs by trace IDs.
>   - **UI Changes**:
>     - Update `DeleteButton` and `TracesTable` to show success toast and handle trace deletion asynchronously.
>     - Remove temporary hiding of trace deletion action in `traces.tsx`.
>   - **Entitlements**:
>     - Ensure `trace-deletion` entitlement is available in `entitlements.ts`.
>   - **Tests**:
>     - Add `traceDeletion.test.ts` to test deletion of traces and associated S3 files.
>     - Update `dataRetentionProcessing.test.ts` to ensure correct handling of expired files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ad60c8b4d9818b7cf82d85702825341aae84cb01. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->