### PR TITLE
style(traces): style traces delete button in more menu in table

### DIFF
--- a/web/src/components/deleteButton.tsx
+++ b/web/src/components/deleteButton.tsx
@@ -23,6 +23,7 @@ interface DeleteButtonProps {
   type: "trace" | "dataset";
   redirectUrl?: string;
   deleteConfirmation?: string;
+  icon?: boolean;
 }
 
 export function DeleteButton({
@@ -34,6 +35,7 @@ export function DeleteButton({
   type,
   redirectUrl,
   deleteConfirmation,
+  icon = false,
 }: DeleteButtonProps) {
   const [isDeleted, setIsDeleted] = useState(false);
   const router = useRouter();
@@ -62,7 +64,8 @@ export function DeleteButton({
     <Popover key={itemId}>
       <PopoverTrigger asChild>
         <Button
-          variant="ghost"
+          variant={icon ? "outline" : "ghost"}
+          size={icon ? "icon" : "default"}
           disabled={!hasAccess}
           onClick={(e) => {
             e.stopPropagation();
@@ -75,8 +78,14 @@ export function DeleteButton({
                 });
           }}
         >
-          <TrashIcon className="mr-2 h-4 w-4" />
-          Delete
+          {icon ? (
+            <TrashIcon className="h-4 w-4" />
+          ) : (
+            <>
+              <TrashIcon className="mr-2 h-4 w-4" />
+              Delete
+            </>
+          )}
         </Button>
       </PopoverTrigger>
       <PopoverContent onClick={(e) => e.stopPropagation()}>

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -54,7 +54,7 @@ import { Skeleton } from "@/src/components/ui/skeleton";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 import { BatchExportTableButton } from "@/src/components/BatchExportTableButton";
 import { BreakdownTooltip } from "@/src/components/trace/BreakdownToolTip";
-import { InfoIcon } from "lucide-react";
+import { InfoIcon, MoreVertical } from "lucide-react";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import { Separator } from "@/src/components/ui/separator";
 import React from "react";
@@ -64,6 +64,13 @@ import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 import { TableSelectionManager } from "@/src/features/table/components/TableSelectionManager";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { type TableAction } from "@/src/features/table/types";
+import {
+  DropdownMenuContent,
+  DropdownMenu,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/src/components/ui/dropdown-menu";
+import { Button } from "@/src/components/ui/button";
 
 export type TracesTableRow = {
   bookmarked: boolean;
@@ -834,14 +841,25 @@ export default function TracesTable({
         return traceId &&
           typeof traceId === "string" &&
           hasTraceDeletionEntitlement ? (
-          <DeleteButton
-            itemId={traceId}
-            projectId={projectId}
-            scope="traces:delete"
-            invalidateFunc={() => void utils.traces.all.invalidate()}
-            type="trace"
-            isTableAction={true}
-          />
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost">
+                <MoreVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuItem asChild>
+                <DeleteButton
+                  itemId={traceId}
+                  projectId={projectId}
+                  scope="traces:delete"
+                  invalidateFunc={() => void utils.traces.all.invalidate()}
+                  type="trace"
+                  isTableAction={true}
+                />
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         ) : undefined;
       },
     },

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -437,6 +437,7 @@ export function TracePage({
                 type="trace"
                 redirectUrl={`/project/${router.query.projectId as string}/traces`}
                 deleteConfirmation={trace.data.name ?? ""}
+                icon
               />
             )}
           </>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add icon-only styling option to `DeleteButton` and integrate it into dropdown menus in traces table and trace page.
> 
>   - **Delete Button Styling**:
>     - Add `icon` prop to `DeleteButton` in `deleteButton.tsx` to toggle between icon-only and default button styles.
>     - Modify button variant and size based on `icon` prop.
>     - Adjust button content to show only `TrashIcon` when `icon` is true.
>   - **Traces Table Integration**:
>     - Wrap `DeleteButton` in a `DropdownMenu` in `traces.tsx` for trace rows.
>     - Use `MoreVertical` icon as trigger for dropdown menu.
>   - **Trace Page Integration**:
>     - Use `icon` prop for `DeleteButton` in `TracePage` in `index.tsx` to display icon-only button.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 537c9b20b62c2531f29cb6a3a940d8f818d8d91e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->