### PR TITLE
perf(sessions): display only first 10 users; show rest in paginated popover 

### DIFF
--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -383,7 +383,9 @@ export function TracePage({
   return (
     <Page
       headerProps={{
-        title: `${trace.data.name}: ${trace.data.id}`,
+        title: trace.data.name
+          ? `${trace.data.name}: ${trace.data.id}`
+          : trace.data.id,
         itemType: "TRACE",
         breadcrumb: [
           {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces `SessionUsers` component for paginated user display in sessions and adjusts trace header title formatting.
> 
>   - **Behavior**:
>     - Introduces `SessionUsers` component in `session/index.tsx` to display only the first 10 users initially, with the rest in a paginated popover.
>     - Adjusts trace header title formatting in `trace/index.tsx` to handle cases where `trace.data.name` is undefined.
>   - **Components**:
>     - Adds `SessionUsers` component to manage user display with pagination.
>     - Utilizes `Popover`, `PopoverContent`, `PopoverTrigger`, and `ScrollArea` for user pagination.
>   - **Constants**:
>     - Defines `INITIAL_USERS_DISPLAY_COUNT` and `USERS_PER_PAGE_IN_POPOVER` in `session/index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 36efe9bef9057c54cbe5ed1236a0757df6e29ca9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->