### PR TITLE
feat: parse mlflow attributes on otel spans

### DIFF
--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -535,7 +535,7 @@ describe("OTel Resource Span Mapping", () => {
               question: "What is LLM Observability?",
             }),
           },
-          entityAttributeKey: "output",
+          entityAttributeKey: "input",
           entityAttributeValue: JSON.stringify({
             question: "What is LLM Observability?",
           }),

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -526,6 +526,34 @@ describe("OTel Resource Span Mapping", () => {
         },
       ],
       [
+        "should map mlflow.spanInputs to input",
+        {
+          entity: "observation",
+          otelAttributeKey: "mlflow.spanInputs",
+          otelAttributeValue: {
+            stringValue: JSON.stringify({
+              question: "What is LLM Observability?",
+            }),
+          },
+          entityAttributeKey: "output",
+          entityAttributeValue: JSON.stringify({
+            question: "What is LLM Observability?",
+          }),
+        },
+      ],
+      [
+        "should map model to model",
+        {
+          entity: "observation",
+          otelAttributeKey: "model",
+          otelAttributeValue: {
+            stringValue: "gpt-4o-mini",
+          },
+          entityAttributeKey: "model",
+          entityAttributeValue: "gpt-4o-mini",
+        },
+      ],
+      [
         "#5412: should map input.value to input for smolagents",
         {
           entity: "observation",

--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -131,6 +131,13 @@ const extractInputAndOutput = (
     return { input, output };
   }
 
+  // MLFlow sets mlflow.spanInputs and mlflow.spanOutputs
+  input = attributes["mlflow.spanInputs"];
+  output = attributes["mlflow.spanOutputs"];
+  if (input || output) {
+    return { input, output };
+  }
+
   // TraceLoop sets traceloop.entity.input and traceloop.entity.output
   input = attributes["traceloop.entity.input"];
   output = attributes["traceloop.entity.output"];
@@ -225,6 +232,7 @@ const extractModelName = (
     "gen_ai.request.model",
     "gen_ai.response.model",
     "llm.model_name",
+    "model",
   ];
   for (const key of modelNameKeys) {
     if (attributes[key]) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add parsing for MLFlow attributes `mlflow.spanInputs` and `mlflow.spanOutputs` in OpenTelemetry spans, with corresponding test cases.
> 
>   - **Behavior**:
>     - Parse `mlflow.spanInputs` and `mlflow.spanOutputs` in `extractInputAndOutput()` in `index.ts`.
>     - Map `mlflow.spanInputs` to `input` and `mlflow.spanOutputs` to `output` in `otelMapping.servertest.ts`.
>   - **Tests**:
>     - Add test cases for `mlflow.spanInputs` and `mlflow.spanOutputs` mapping in `otelMapping.servertest.ts`.
>   - **Misc**:
>     - Add `model` to `modelNameKeys` in `extractModelName()` in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 73dc2326b02539b7bf8fd80434316f9816087ebc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->