### PR TITLE
feat: map langfuse data model to further otel attributes

### DIFF
--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -334,6 +334,16 @@ describe("OTel Resource Span Mapping", () => {
 
     it.each([
       [
+        "should extract promptName on observation from langfuse.prompt.name",
+        {
+          entity: "observation",
+          otelAttributeKey: "langfuse.prompt.name",
+          otelAttributeValue: { stringValue: "test" },
+          entityAttributeKey: "promptName",
+          entityAttributeValue: "test",
+        },
+      ],
+      [
         "should extract userId on trace from user.id",
         {
           entity: "trace",

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -344,6 +344,26 @@ describe("OTel Resource Span Mapping", () => {
         },
       ],
       [
+        "should extract public on trace from langfuse.public",
+        {
+          entity: "trace",
+          otelAttributeKey: "langfuse.public",
+          otelAttributeValue: { boolValue: true },
+          entityAttributeKey: "public",
+          entityAttributeValue: true,
+        },
+      ],
+      [
+        "should not treat truthy values as public true",
+        {
+          entity: "trace",
+          otelAttributeKey: "langfuse.public",
+          otelAttributeValue: { stringValue: "false" },
+          entityAttributeKey: "public",
+          entityAttributeValue: false,
+        },
+      ],
+      [
         "should extract userId on trace from user.id",
         {
           entity: "trace",

--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -316,9 +316,17 @@ export const convertOtelSpanToIngestionEvent = (
             resourceAttributes,
             scope: scopeSpan?.scope,
           },
-          version: resourceAttributes?.["service.version"] ?? null,
+          version:
+            attributes?.["langfuse.version"] ??
+            resourceAttributes?.["service.version"] ??
+            null,
+          release: attributes?.["langfuse.release"] ?? null,
           userId: extractUserId(attributes),
           sessionId: extractSessionId(attributes),
+          public:
+            attributes?.["langfuse.public"] === true ||
+            attributes?.["langfuse.public"] === "true",
+          tags: attributes?.["langfuse.tags"] ?? [],
 
           // Input and Output
           ...extractInputAndOutput(span?.events ?? [], attributes),
@@ -356,8 +364,16 @@ export const convertOtelSpanToIngestionEvent = (
           span.status?.code === 2
             ? ObservationLevel.ERROR
             : ObservationLevel.DEFAULT,
+        statusMessage: span.status?.message ?? null,
+        version:
+          attributes?.["langfuse.version"] ??
+          resourceAttributes?.["service.version"] ??
+          null,
         modelParameters: extractModelParameters(attributes) as any,
         model: extractModelName(attributes),
+
+        promptName: attributes?.["langfuse.prompt.name"] ?? null,
+        promptVersion: attributes?.["langfuse.prompt.version"] ?? null,
 
         usageDetails: extractUsageDetails(attributes) as any,
         costDetails: extractCostDetails(attributes) as any,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance OTel to Langfuse attribute mapping in `convertOtelSpanToIngestionEvent` and update tests for new mappings.
> 
>   - **Behavior**:
>     - Map `langfuse.prompt.name` to `promptName` and `langfuse.public` to `public` in `convertOtelSpanToIngestionEvent`.
>     - Handle `langfuse.public` as boolean, treating only `true` or "true" as true.
>     - Add `langfuse.version` and `langfuse.release` mappings to `version` and `release`.
>     - Extract `langfuse.tags` to `tags` array.
>   - **Tests**:
>     - Add test cases in `otelMapping.servertest.ts` for new attribute mappings: `langfuse.prompt.name`, `langfuse.public`, `langfuse.version`, `langfuse.release`, and `langfuse.tags`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d93822afdfea338f7d8ff009546781e5798c61ed. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->