### PR TITLE
chore: remove superfluous container_name overwrites

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -80,8 +80,6 @@ services:
   clickhouse:
     image: clickhouse/clickhouse-server
     user: "101:101"
-    container_name: clickhouse
-    hostname: clickhouse
     environment:
       CLICKHOUSE_DB: default
       CLICKHOUSE_USER: clickhouse
@@ -101,7 +99,6 @@ services:
 
   minio:
     image: minio/minio
-    container_name: minio
     entrypoint: sh
     # create the 'langfuse' bucket before starting the service
     command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" --console-address ":9001" /data'

--- a/docker-compose.dev-azure.yml
+++ b/docker-compose.dev-azure.yml
@@ -2,8 +2,6 @@ services:
   clickhouse:
     image: clickhouse/clickhouse-server
     user: "101:101"
-    container_name: clickhouse
-    hostname: clickhouse
     environment:
       CLICKHOUSE_DB: default
       CLICKHOUSE_USER: clickhouse
@@ -19,7 +17,6 @@ services:
 
   azurite:
     image: mcr.microsoft.com/azure-storage/azurite
-    container_name: azurite
     command: azurite-blob --blobHost 0.0.0.0
     ports:
       - "10000:10000"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,8 +2,6 @@ services:
   clickhouse:
     image: clickhouse/clickhouse-server
     user: "101:101"
-    container_name: clickhouse
-    hostname: clickhouse
     environment:
       CLICKHOUSE_DB: default
       CLICKHOUSE_USER: clickhouse
@@ -19,7 +17,6 @@ services:
 
   minio:
     image: minio/minio
-    container_name: minio
     entrypoint: sh
     # create the 'langfuse' bucket before starting the service
     command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" --console-address ":9001" /data'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,8 +72,6 @@ services:
     image: clickhouse/clickhouse-server
     restart: always
     user: "101:101"
-    container_name: clickhouse
-    hostname: clickhouse
     environment:
       CLICKHOUSE_DB: default
       CLICKHOUSE_USER: clickhouse
@@ -94,7 +92,6 @@ services:
   minio:
     image: minio/minio
     restart: always
-    container_name: minio
     entrypoint: sh
     # create the 'langfuse' bucket before starting the service
     command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" --console-address ":9001" /data'


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/5601
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unnecessary `container_name` and `hostname` fields from `docker-compose` files for `clickhouse`, `minio`, and `azurite`.
> 
>   - **Configuration Changes**:
>     - Removed `container_name` and `hostname` for `clickhouse` in `docker-compose.build.yml`, `docker-compose.dev-azure.yml`, `docker-compose.dev.yml`, and `docker-compose.yml`.
>     - Removed `container_name` for `minio` in `docker-compose.build.yml`, `docker-compose.dev.yml`, and `docker-compose.yml`.
>     - Removed `container_name` for `azurite` in `docker-compose.dev-azure.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2773c9c39a6795fc0a6ccbb11f80d2cfedecca7b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->