### PR TITLE
build: notify slack on failed deployment

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -87,6 +87,15 @@ jobs:
       - name: Check server health
         run: |
           timeout 10 bash -c 'until curl -f http://localhost:3000/api/public/health; do sleep 2; done'
+      - name: Notify Slack # Remove after testing
+        uses: ravsamhq/notify-slack-action@v2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          mention_groups: '!channel'
+          mention_groups_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   tests-web-sync:
     timeout-minutes: 20

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -536,3 +536,12 @@ jobs:
           platforms: |
             linux/amd64
             ${{ startsWith(github.ref, 'refs/tags/') && 'linux/arm64' || '' }}
+      - name: Notify Slack
+        uses: ravsamhq/notify-slack-action@v2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          mention_groups: '!channel'
+          mention_groups_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -87,15 +87,6 @@ jobs:
       - name: Check server health
         run: |
           timeout 10 bash -c 'until curl -f http://localhost:3000/api/public/health; do sleep 2; done'
-      - name: Notify Slack # Remove after testing
-        uses: ravsamhq/notify-slack-action@v2
-        if: always()
-        with:
-          status: ${{ job.status }}
-          mention_groups: '!channel'
-          mention_groups_when: "failure"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   tests-web-sync:
     timeout-minutes: 20
@@ -550,7 +541,6 @@ jobs:
         if: always()
         with:
           status: ${{ job.status }}
-          mention_groups: '!channel'
-          mention_groups_when: "failure"
+          notify_when: "failure"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds Slack notification for deployment failures in the CI/CD pipeline using `ravsamhq/notify-slack-action@v2`.
> 
>   - **CI/CD Workflow**:
>     - Adds a new step `Notify Slack` in `.github/workflows/pipeline.yml`.
>     - Uses `ravsamhq/notify-slack-action@v2` to send notifications.
>     - Configured to notify only on deployment failures using `notify_when: "failure"`.
>     - Utilizes `SLACK_WEBHOOK_URL` from GitHub secrets for authentication.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7641f2002177a29e2234a6aa74ca79935cd3961b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->