### PR TITLE
chore: notify on v2 build failures

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -487,3 +487,11 @@ jobs:
           platforms: |
             linux/amd64
             ${{ startsWith(github.ref, 'refs/tags/') && 'linux/arm64' || '' }}
+      - name: Notify Slack
+        uses: ravsamhq/notify-slack-action@v2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add Slack notification for build failures in CI/CD pipeline using `ravsamhq/notify-slack-action@v2`.
> 
>   - **CI/CD Pipeline**:
>     - Adds a Slack notification step using `ravsamhq/notify-slack-action@v2` in `pipeline.yml`.
>     - Triggers notification on job failure using `notify_when: "failure"`.
>     - Utilizes `SLACK_WEBHOOK_URL` from secrets for authentication.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 75663f39d2f1afeadf8ae90363f85a786c420e49. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->