### PR TITLE
chore: increase ingestion delay to 10s to test possible worker deduplication

### DIFF
--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -66,10 +66,10 @@ const getDelay = (delay: number | null) => {
     return env.LANGFUSE_INGESTION_QUEUE_DELAY_MS;
   }
 
-  // Use 5s here to avoid duplicate processing on the worker. If the ingestion delay is set to a lower value,
+  // Use 10s here to avoid duplicate processing on the worker. If the ingestion delay is set to a lower value,
   // we use this instead.
   // Values should be revisited based on a cost/performance trade-off.
-  return Math.min(5000, env.LANGFUSE_INGESTION_QUEUE_DELAY_MS);
+  return Math.min(10000, env.LANGFUSE_INGESTION_QUEUE_DELAY_MS);
 };
 
 /**


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase default ingestion delay from 5s to 10s in `getDelay()` in `processEventBatch.ts` to test worker deduplication.
> 
>   - **Behavior**:
>     - Increase default ingestion delay from 5s to 10s in `getDelay()` in `processEventBatch.ts` to test worker deduplication.
>     - Delay is used when `env.LANGFUSE_INGESTION_QUEUE_DELAY_MS` is lower than 10s.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 65b562843211ed2708048f2cf50d15979b899b49. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->