### PR TITLE
build: increase nextjs static page generation timeout

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -61,6 +61,7 @@ const nextConfig = {
       "kysely",
     ],
   },
+  staticPageGenerationTimeout: 500, // 5 minutes - default 60 seconds.
   poweredByHeader: false,
   basePath: env.NEXT_PUBLIC_BASE_PATH,
 
@@ -128,22 +129,22 @@ const nextConfig = {
       // Required to check authentication status from langfuse.com
       ...(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== undefined
         ? [
-          {
-            source: "/api/auth/session",
-            headers: [
-              {
-                key: "Access-Control-Allow-Origin",
-                value: "https://langfuse.com",
-              },
-              { key: "Access-Control-Allow-Credentials", value: "true" },
-              { key: "Access-Control-Allow-Methods", value: "GET,POST" },
-              {
-                key: "Access-Control-Allow-Headers",
-                value: "Content-Type, Authorization",
-              },
-            ],
-          },
-        ]
+            {
+              source: "/api/auth/session",
+              headers: [
+                {
+                  key: "Access-Control-Allow-Origin",
+                  value: "https://langfuse.com",
+                },
+                { key: "Access-Control-Allow-Credentials", value: "true" },
+                { key: "Access-Control-Allow-Methods", value: "GET,POST" },
+                {
+                  key: "Access-Control-Allow-Headers",
+                  value: "Content-Type, Authorization",
+                },
+              ],
+            },
+          ]
         : []),
       // all files in /public/generated are public and can be accessed from any origin, e.g. to render an API reference based on our openapi schema
       {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase `staticPageGenerationTimeout` to 500 seconds in `next.config.mjs`.
> 
>   - **Configuration**:
>     - Increase `staticPageGenerationTimeout` to 500 seconds in `next.config.mjs` to allow more time for static page generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bf8222c2c635992b07e0143d642fa107f0d67208. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->