### PR TITLE
chore: bump static page generation timeout

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -47,7 +47,7 @@ const reportToHeader = {
 
 /** @type {import("next").NextConfig} */
 const nextConfig = {
-  staticPageGenerationTimeout: 120, // default is 60. Required for build process for amd
+  staticPageGenerationTimeout: 500, // default is 60. Required for build process for amd
   transpilePackages: ["@langfuse/shared", "vis-network/standalone"],
   reactStrictMode: true,
   experimental: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase `staticPageGenerationTimeout` to 500 in `next.config.mjs` for build process needs.
> 
>   - **Configuration**:
>     - Increase `staticPageGenerationTimeout` from 120 to 500 in `next.config.mjs` to accommodate build process requirements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5b3bc45dc73fcecbf000cc1ace60109d81bc6f6c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->