### PR TITLE
fix: scoresByRunId is not sort by runs.created_at

### DIFF
--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -166,11 +166,12 @@ export const datasetRouter = createTRPCRouter({
         user: ctx.session.user,
         pgExecution: async () => {
           const scoresByRunId = await ctx.prisma.$queryRaw<
-            Array<{ scores: Array<ScoreSimplified>; runId: string }>
+            Array<{ scores: Array<ScoreSimplified>; runId: string; createdAt: Date}>
           >(Prisma.sql`
         SELECT
-          runs.id "runId",
-          array_agg(s.score) AS "scores"
+          runs.id AS "runId",
+          array_agg(s.score) AS "scores",
+          runs.created_at AS "createdAt"
         FROM
           dataset_runs runs
           JOIN datasets ON datasets.id = runs.dataset_id AND datasets.project_id = ${input.projectId}
@@ -193,7 +194,10 @@ export const datasetRouter = createTRPCRouter({
           AND runs.project_id = ${input.projectId}
           AND s.score IS NOT NULL
         GROUP BY
-          runs.id
+          runs.id,
+          runs.created_at
+        ORDER BY
+          runs.created_at DESC
         LIMIT ${input.limit}
         OFFSET ${input.page * input.limit}
       `);


### PR DESCRIPTION
## What does this PR do?

Fix at dataset page(/project/xxxx/datasets/xxxx) in runs tab. If runs exceed two pages or more, the score will not be fully displayed.
The problem is that the SQL query for getting runs uses ORDER BY runs.created_at DESC; the SQL query for getting scores does not sort, and the problem of data mismatch occurs when paging queries are performed when there is too much data....

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`npm run prettier`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes score display issue on dataset page by adding ORDER BY to scores query in `dataset-router.ts`.
> 
>   - **Behavior**:
>     - Fixes score display issue on dataset page when runs exceed two pages.
>     - Adds `ORDER BY runs.created_at DESC` to scores query in `dataset-router.ts` to ensure alignment with runs query.
>   - **SQL Query**:
>     - Modifies SQL query in `dataset-router.ts` to include `runs.created_at` in `GROUP BY` and `ORDER BY` clauses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for debb8b0fa6c0912f95fafd78fa220ab4334a14b5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->