### PR TITLE
perf: only validate response schema on dev servers

### DIFF
--- a/web/src/features/public-api/server/createAuthedAPIRoute.ts
+++ b/web/src/features/public-api/server/createAuthedAPIRoute.ts
@@ -10,6 +10,7 @@ import {
 } from "@langfuse/shared/src/server";
 import { type RateLimitResource } from "@langfuse/shared";
 import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
+import { env } from "@/src/env.mjs";
 
 type RouteConfig<
   TQuery extends ZodType<any>,
@@ -87,7 +88,7 @@ export const createAuthedAPIRoute = <
       auth,
     });
 
-    if (routeConfig.responseSchema) {
+    if (env.NODE_ENV === "development" && routeConfig.responseSchema) {
       const parsingResult = routeConfig.responseSchema.safeParse(response);
       if (!parsingResult.success) {
         logger.error("Response validation failed:", parsingResult.error);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize `createAuthedAPIRoute` by restricting response schema validation to development environments.
> 
>   - **Behavior**:
>     - Response schema validation in `createAuthedAPIRoute` now only occurs in development (`env.NODE_ENV === "development"`).
>     - In production, response schema validation is skipped, improving performance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 22daaec0aa5c971be8d602c7e68c945fd019a6a3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->