### PR TITLE
chore: reduce attempts and increase delay on trace delete errors

### DIFF
--- a/packages/shared/src/server/redis/traceDelete.ts
+++ b/packages/shared/src/server/redis/traceDelete.ts
@@ -25,10 +25,10 @@ export class TraceDeleteQueue {
             defaultJobOptions: {
               removeOnComplete: true,
               removeOnFail: 100_000,
-              attempts: 5,
+              attempts: 2,
               backoff: {
                 type: "exponential",
-                delay: 5000,
+                delay: 30_000,
               },
             },
           },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce attempts and increase delay for `TraceDeleteQueue` job options in `traceDelete.ts`.
> 
>   - **Behavior**:
>     - In `traceDelete.ts`, reduce `attempts` from 5 to 2 for `TraceDeleteQueue` job options.
>     - Increase `backoff.delay` from 5000ms to 30000ms for `TraceDeleteQueue` job options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0e7e758483a0f1f63bc794a0c55ccc278ee5dc31. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->