### PR TITLE
chore: add environment columns in clickhouse

### DIFF
--- a/packages/shared/clickhouse/migrations/clustered/0008_add_environments_column.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0008_add_environments_column.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE traces ON CLUSTER default DROP COLUMN IF EXISTS environment;
+ALTER TABLE observations ON CLUSTER default DROP COLUMN IF EXISTS environment;
+ALTER TABLE scores ON CLUSTER default DROP COLUMN IF EXISTS environment;

--- a/packages/shared/clickhouse/migrations/clustered/0008_add_environments_column.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0008_add_environments_column.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE traces ON CLUSTER default ADD COLUMN environment LowCardinality(String) DEFAULT 'default' AFTER project_id;
+ALTER TABLE observations ON CLUSTER default ADD COLUMN environment LowCardinality(String) DEFAULT 'default' AFTER project_id;
+ALTER TABLE scores ON CLUSTER default ADD COLUMN environment LowCardinality(String) DEFAULT 'default' AFTER project_id;

--- a/packages/shared/clickhouse/migrations/unclustered/0008_add_environments_column.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0008_add_environments_column.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE traces DROP COLUMN IF EXISTS environment;
+ALTER TABLE observations DROP COLUMN IF EXISTS environment;
+ALTER TABLE scores DROP COLUMN IF EXISTS environment;

--- a/packages/shared/clickhouse/migrations/unclustered/0008_add_environments_column.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0008_add_environments_column.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE traces ADD COLUMN environment LowCardinality(Nullable(String)) AFTER project_id;
+ALTER TABLE observations ADD COLUMN environment LowCardinality(Nullable(String)) AFTER project_id;
+ALTER TABLE scores ADD COLUMN environment LowCardinality(Nullable(String)) AFTER project_id;

--- a/packages/shared/clickhouse/migrations/unclustered/0008_add_environments_column.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0008_add_environments_column.up.sql
@@ -1,3 +1,3 @@
-ALTER TABLE traces ADD COLUMN environment LowCardinality(Nullable(String)) AFTER project_id;
-ALTER TABLE observations ADD COLUMN environment LowCardinality(Nullable(String)) AFTER project_id;
-ALTER TABLE scores ADD COLUMN environment LowCardinality(Nullable(String)) AFTER project_id;
+ALTER TABLE traces ADD COLUMN environment LowCardinality(String) DEFAULT 'default' AFTER project_id;
+ALTER TABLE observations ADD COLUMN environment LowCardinality(String) DEFAULT 'default' AFTER project_id;
+ALTER TABLE scores ADD COLUMN environment LowCardinality(String) DEFAULT 'default' AFTER project_id;

--- a/packages/shared/scripts/prepareClickhouse.ts
+++ b/packages/shared/scripts/prepareClickhouse.ts
@@ -67,6 +67,7 @@ export const prepareClickhouse = async (
       concat('release_', toString(randUniform(0, 100))) AS release,
       concat('version_', toString(randUniform(0, 100))) AS version,
       '${projectId}' AS project_id,
+      'default' AS environment,
       if(rand() < 0.8, true, false) as public,
       if(rand() < 0.8, true, false) as bookmarked,
       array('tag1', 'tag2') as tags,
@@ -85,6 +86,7 @@ export const prepareClickhouse = async (
     SELECT toString(number) AS id,
       toString(floor(randUniform(0, ${tracesPerProject}))) AS trace_id,
       '${projectId}' AS project_id,
+      'default' AS environment,
       if(randUniform(0, 1) < 0.47, 'GENERATION', if(randUniform(0, 1) < 0.94, 'SPAN', 'EVENT')) AS type,
       toString(rand()) AS parent_observation_id,
       toDateTime(now() - randUniform(0, ${opts.numberOfDays} * 24 * 60 * 60)) AS start_time,
@@ -146,6 +148,7 @@ export const prepareClickhouse = async (
     SELECT toString(floor(randUniform(0, 100))) AS id,
       toDateTime(now() - randUniform(0, ${opts.numberOfDays} * 24 * 60 * 60)) AS timestamp,
       '${projectId}' AS project_id,
+      'default' AS environment,
       toString(floor(randUniform(0, ${tracesPerProject}))) AS trace_id,
       if(
         rand() > 0.9,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `environment` column to Clickhouse tables and update data preparation script to include it.
> 
>   - **Migrations**:
>     - Add `environment` column to `traces`, `observations`, and `scores` tables in `0008_add_environments_column.up.sql` for both clustered and unclustered setups.
>     - Drop `environment` column in `0008_add_environments_column.down.sql` for both clustered and unclustered setups.
>   - **Scripts**:
>     - Update `prepareClickhouse.ts` to include `environment` column with default value 'default' in data preparation for `traces`, `observations`, and `scores`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1651204e528c0aa39529e5fdcc38842467c3e9fa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->