### PR TITLE
chore: replace logger.warning with logger.warn

### DIFF
--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -355,7 +355,7 @@ export const handleBatchExportJob = async (
     );
   }
   if (jobDetails.status !== BatchExportStatus.QUEUED) {
-    logger.warning(
+    logger.warn(
       `Job ${batchExportId} has invalid status: ${jobDetails.status}. Retrying anyway.`,
     );
   }

--- a/worker/src/queues/projectDelete.ts
+++ b/worker/src/queues/projectDelete.ts
@@ -144,7 +144,7 @@ export const projectDeleteProcessor: Processor = async (
   } catch (e) {
     if (e instanceof Prisma.PrismaClientKnownRequestError) {
       if (e.code === "P2025" || e.code === "P2016") {
-        logger.warning(
+        logger.warn(
           `Tried to delete project ${projectId} in org ${orgId}, but it does not exist`,
         );
         return;


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/5644
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `logger.warning` with `logger.warn` in `handleBatchExportJob.ts` and `projectDelete.ts`.
> 
>   - **Logging**:
>     - Replace `logger.warning` with `logger.warn` in `handleBatchExportJob.ts` for invalid job status logging.
>     - Replace `logger.warning` with `logger.warn` in `projectDelete.ts` for non-existent project deletion logging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d6a4cefb3eef7c85974a5c2a431770531557400a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->