### PR TITLE
perf: limit concurrency for eval job creations

### DIFF
--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -74,7 +74,7 @@ if (env.QUEUE_CONSUMER_TRACE_UPSERT_QUEUE_IS_ENABLED === "true") {
     QueueName.TraceUpsert,
     evalJobTraceCreatorQueueProcessor,
     {
-      concurrency: env.LANGFUSE_EVAL_CREATOR_WORKER_CONCURRENCY,
+      concurrency: env.LANGFUSE_TRACE_UPSERT_WORKER_CONCURRENCY,
     },
   );
 }

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -91,8 +91,11 @@ const EnvSchema = z.object({
   CLICKHOUSE_CLUSTER_NAME: z.string().default("default"),
   CLICKHOUSE_DB: z.string().default("default"),
   CLICKHOUSE_PASSWORD: z.string(),
-
   LANGFUSE_EVAL_CREATOR_WORKER_CONCURRENCY: z.coerce
+    .number()
+    .positive()
+    .default(5),
+  LANGFUSE_TRACE_UPSERT_WORKER_CONCURRENCY: z.coerce
     .number()
     .positive()
     .default(25),

--- a/worker/src/features/batchAction/handleBatchActionJob.ts
+++ b/worker/src/features/batchAction/handleBatchActionJob.ts
@@ -1,6 +1,7 @@
 import {
   BatchActionProcessingEventType,
   CreateEvalQueue,
+  getCurrentSpan,
   logger,
   QueueJobs,
   QueueName,
@@ -111,6 +112,18 @@ export const handleBatchActionJob = async (
     batchActionJob.payload;
 
   const { actionId } = batchActionEvent;
+
+  const span = getCurrentSpan();
+  if (span) {
+    span.setAttribute(
+      "messaging.bullmq.job.input.projectId",
+      batchActionEvent.projectId,
+    );
+    span.setAttribute(
+      "messaging.bullmq.job.input.actionId",
+      batchActionEvent.actionId,
+    );
+  }
 
   if (
     actionId === "trace-delete" ||


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Limit concurrency for eval job creations and add tracing attributes in batch action job handler.
> 
>   - **Concurrency Limiting**:
>     - Changed `concurrency` in `app.ts` for `QueueName.TraceUpsert` to use `LANGFUSE_TRACE_UPSERT_WORKER_CONCURRENCY`.
>     - Added `LANGFUSE_TRACE_UPSERT_WORKER_CONCURRENCY` to `env.ts` with a default of 25.
>   - **Tracing**:
>     - Added `getCurrentSpan()` and set attributes `projectId` and `actionId` in `handleBatchActionJob()` in `handleBatchActionJob.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0537fc0a346ea6a48e6a4f87f4479296b2d01a0c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->