### PR TITLE
fix: do not return all executions for eval config list trpc

### DIFF
--- a/web/src/__tests__/async/evals-trpc.servertest.ts
+++ b/web/src/__tests__/async/evals-trpc.servertest.ts
@@ -1,0 +1,142 @@
+/** @jest-environment node */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import type { Session } from "next-auth";
+import { pruneDatabase } from "@/src/__tests__/test-utils";
+import { prisma } from "@langfuse/shared/src/db";
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+
+describe("evals trpc", () => {
+  const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
+
+  beforeEach(async () => await pruneDatabase());
+
+  const session: Session = {
+    expires: "1",
+    user: {
+      id: "user-1",
+      canCreateOrganizations: true,
+      name: "Demo User",
+      organizations: [
+        {
+          id: "seed-org-id",
+          name: "Test Organization",
+          role: "OWNER",
+          plan: "cloud:hobby",
+          cloudConfig: undefined,
+          projects: [
+            {
+              id: projectId,
+              role: "ADMIN",
+              retentionDays: 30,
+              deletedAt: null,
+              name: "Test Project",
+            },
+          ],
+        },
+      ],
+      featureFlags: {
+        excludeClickhouseRead: false,
+        templateFlag: true,
+      },
+      admin: true,
+    },
+    environment: {} as any,
+  };
+
+  const ctx = createInnerTRPCContext({ session });
+  const caller = appRouter.createCaller({ ...ctx, prisma });
+
+  describe("evals.allConfigs", () => {
+    it("should retrieve all evaluator configurations with execution status counts", async () => {
+      const evalJobConfig1 = await prisma.jobConfiguration.create({
+        data: {
+          projectId,
+          jobType: "EVAL",
+          scoreName: "test-score",
+          filter: [],
+          targetObject: "trace",
+          variableMapping: [],
+          sampling: 1,
+          delay: 0,
+          status: "ACTIVE",
+        },
+      });
+
+      await prisma.jobExecution.create({
+        data: {
+          jobConfigurationId: evalJobConfig1.id,
+          status: "PENDING",
+          projectId,
+        },
+      });
+
+      await prisma.jobExecution.create({
+        data: {
+          jobConfigurationId: evalJobConfig1.id,
+          status: "COMPLETED",
+          projectId,
+        },
+      });
+
+      await prisma.jobExecution.create({
+        data: {
+          jobConfigurationId: evalJobConfig1.id,
+          status: "ERROR",
+          projectId,
+        },
+      });
+
+      const evalJobConfig2 = await prisma.jobConfiguration.create({
+        data: {
+          projectId,
+          jobType: "EVAL",
+          scoreName: "test-score",
+          filter: [],
+          targetObject: "trace",
+          variableMapping: [],
+          sampling: 1,
+          delay: 0,
+          status: "ACTIVE",
+        },
+      });
+
+      const response = await caller.evals.allConfigs({
+        projectId,
+        limit: 10,
+        page: 0,
+      });
+
+      expect(response).toEqual({
+        configs: expect.arrayContaining([
+          expect.objectContaining({
+            id: evalJobConfig1.id,
+            jobExecutionsByState: expect.arrayContaining([
+              expect.objectContaining({
+                status: "PENDING",
+                _count: 1,
+                jobConfigurationId: evalJobConfig1.id,
+              }),
+              expect.objectContaining({
+                status: "COMPLETED",
+                _count: 1,
+                jobConfigurationId: evalJobConfig1.id,
+              }),
+              expect.objectContaining({
+                status: "ERROR",
+                _count: 1,
+                jobConfigurationId: evalJobConfig1.id,
+              }),
+            ]),
+          }),
+          expect.objectContaining({
+            id: evalJobConfig2.id,
+            jobExecutionsByState: expect.arrayContaining([]),
+          }),
+        ]),
+        totalCount: expect.any(Number),
+      });
+    });
+  });
+});

--- a/web/src/__tests__/async/evals-trpc.servertest.ts
+++ b/web/src/__tests__/async/evals-trpc.servertest.ts
@@ -10,7 +10,12 @@ import { createInnerTRPCContext } from "@/src/server/api/trpc";
 describe("evals trpc", () => {
   const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
 
-  beforeEach(async () => await pruneDatabase());
+  beforeEach(async () => {
+    await pruneDatabase();
+    await prisma.jobExecution.deleteMany();
+    await prisma.jobConfiguration.deleteMany();
+    await prisma.evalTemplate.deleteMany();
+  });
 
   const session: Session = {
     expires: "1",

--- a/web/src/ee/features/evals/components/evaluator-table.tsx
+++ b/web/src/ee/features/evals/components/evaluator-table.tsx
@@ -169,34 +169,28 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
   const convertToTableRow = (
     jobConfig: RouterOutputs["evals"]["allConfigs"]["configs"][number],
   ): EvaluatorDataRow => {
-    const statusCounts = jobConfig.jobExecutions.reduce(
-      (acc, je) => {
-        acc[je.status.toString()] = (acc[je.status.toString()] || 0) + 1;
-        return acc;
-      },
-      {
-        PENDING: 0,
-        ERROR: 0,
-        COMPLETED: 0,
-      } as Record<string, number>,
-    );
-
     const result = [
       {
         level: "pending",
-        count: statusCounts.PENDING,
+        count: jobConfig.jobExecutionsByState.filter(
+          (je) => je.status === "PENDING",
+        ).length,
         symbol: "🕒",
         customNumberFormatter: compactNumberFormatter,
       },
       {
         level: "error",
-        count: statusCounts.ERROR,
+        count: jobConfig.jobExecutionsByState.filter(
+          (je) => je.status === "ERROR",
+        ).length,
         symbol: "❌",
         customNumberFormatter: compactNumberFormatter,
       },
       {
         level: "succeeded",
-        count: statusCounts.COMPLETED,
+        count: jobConfig.jobExecutionsByState.filter(
+          (je) => je.status === "COMPLETED",
+        ).length,
         symbol: "✅",
         customNumberFormatter: compactNumberFormatter,
       },
@@ -205,8 +199,8 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
     const finalStatus =
       jobConfig.timeScope.length === 1 &&
       jobConfig.timeScope[0] === "EXISTING" &&
-      !jobConfig.jobExecutions.some((je) => je.status === "PENDING") &&
-      jobConfig.jobExecutions.length > 0
+      !jobConfig.jobExecutionsByState.some((je) => je.status === "PENDING") &&
+      jobConfig.jobExecutionsByState.length > 0
         ? "FINISHED"
         : jobConfig.status;
 

--- a/web/src/ee/features/evals/components/evaluator-table.tsx
+++ b/web/src/ee/features/evals/components/evaluator-table.tsx
@@ -172,25 +172,25 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
     const result = [
       {
         level: "pending",
-        count: jobConfig.jobExecutionsByState.filter(
-          (je) => je.status === "PENDING",
-        ).length,
+        count:
+          jobConfig.jobExecutionsByState.find((je) => je.status === "PENDING")
+            ?._count || 0,
         symbol: "🕒",
         customNumberFormatter: compactNumberFormatter,
       },
       {
         level: "error",
-        count: jobConfig.jobExecutionsByState.filter(
-          (je) => je.status === "ERROR",
-        ).length,
+        count:
+          jobConfig.jobExecutionsByState.find((je) => je.status === "ERROR")
+            ?._count || 0,
         symbol: "❌",
         customNumberFormatter: compactNumberFormatter,
       },
       {
         level: "succeeded",
-        count: jobConfig.jobExecutionsByState.filter(
-          (je) => je.status === "COMPLETED",
-        ).length,
+        count:
+          jobConfig.jobExecutionsByState.find((je) => je.status === "COMPLETED")
+            ?._count || 0,
         symbol: "✅",
         customNumberFormatter: compactNumberFormatter,
       },

--- a/web/src/ee/features/evals/components/evaluator-table.tsx
+++ b/web/src/ee/features/evals/components/evaluator-table.tsx
@@ -200,7 +200,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       jobConfig.timeScope.length === 1 &&
       jobConfig.timeScope[0] === "EXISTING" &&
       !jobConfig.jobExecutionsByState.some((je) => je.status === "PENDING") &&
-      jobConfig.jobExecutionsByState.length > 0
+      jobConfig.jobExecutionsByState.reduce((acc, je) => acc + je._count, 0) > 0
         ? "FINISHED"
         : jobConfig.status;
 

--- a/web/src/ee/features/evals/server/router.ts
+++ b/web/src/ee/features/evals/server/router.ts
@@ -161,7 +161,6 @@ export const evalRouter = createTRPCRouter({
         },
         include: {
           evalTemplate: true,
-          JobExecution: true,
         },
         orderBy: {
           status: "asc",
@@ -176,10 +175,24 @@ export const evalRouter = createTRPCRouter({
           jobType: "EVAL",
         },
       });
+
+      const jobExecutionsByState = await ctx.prisma.jobExecution.groupBy({
+        where: {
+          jobConfiguration: {
+            projectId: input.projectId,
+            jobType: "EVAL",
+          },
+        },
+        by: ["status", "jobConfigurationId"],
+        _count: true,
+      });
+
       return {
         configs: configs.map((config) => ({
           ...config,
-          jobExecutions: config.JobExecution,
+          jobExecutionsByState: jobExecutionsByState.filter(
+            (je) => je.jobConfigurationId === config.id,
+          ),
         })),
         totalCount: count,
       };

--- a/web/src/ee/features/evals/server/router.ts
+++ b/web/src/ee/features/evals/server/router.ts
@@ -181,7 +181,9 @@ export const evalRouter = createTRPCRouter({
           jobConfiguration: {
             projectId: input.projectId,
             jobType: "EVAL",
+            id: { in: configs.map((c) => c.id) },
           },
+          projectId: input.projectId,
         },
         by: ["status", "jobConfigurationId"],
         _count: true,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `evals.allConfigs` now returns job execution counts by state, updating related components and tests.
> 
>   - **Behavior**:
>     - `evals.allConfigs` now returns job execution counts by state instead of all executions in `router.ts`.
>     - Updates `EvaluatorTable` in `evaluator-table.tsx` to use `jobExecutionsByState` for displaying execution counts.
>   - **Tests**:
>     - Adds test in `evals-trpc.servertest.ts` to verify `evals.allConfigs` returns execution counts by state.
>   - **Misc**:
>     - Removes `JobExecution` from `include` in `router.ts` for `evals.allConfigs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4bc21e6d596423bd45efab8f5a4ccd6709a01179. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->