### PR TITLE
perf: reduce eval create queue concurrency

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -94,7 +94,7 @@ const EnvSchema = z.object({
   LANGFUSE_EVAL_CREATOR_WORKER_CONCURRENCY: z.coerce
     .number()
     .positive()
-    .default(5),
+    .default(2),
   LANGFUSE_TRACE_UPSERT_WORKER_CONCURRENCY: z.coerce
     .number()
     .positive()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce default concurrency for `LANGFUSE_EVAL_CREATOR_WORKER_CONCURRENCY` from 5 to 2 in `env.ts`.
> 
>   - **Behavior**:
>     - Reduce default concurrency for `LANGFUSE_EVAL_CREATOR_WORKER_CONCURRENCY` from 5 to 2 in `env.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 59585eb585cb6405b366f152c34a9b03cbf7e038. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->