### PR TITLE
fix: do not allow to deactivate eval configs which are only on existing objects

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -89,7 +89,7 @@ jobs:
           timeout 10 bash -c 'until curl -f http://localhost:3000/api/public/health; do sleep 2; done'
 
   tests-web-sync:
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     needs:
       - pre-job
@@ -165,7 +165,7 @@ jobs:
         run: pnpm --filter=web run test-client
 
   tests-web-async:
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     needs:
       - pre-job

--- a/web/src/__tests__/async/evals-trpc.servertest.ts
+++ b/web/src/__tests__/async/evals-trpc.servertest.ts
@@ -6,7 +6,6 @@ import { pruneDatabase } from "@/src/__tests__/test-utils";
 import { prisma } from "@langfuse/shared/src/db";
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
-import Redis from "ioredis";
 
 describe("evals trpc", () => {
   const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";

--- a/web/src/__tests__/teardown.ts
+++ b/web/src/__tests__/teardown.ts
@@ -1,5 +1,6 @@
 export default async function teardown() {
   const { redis } = await import("@langfuse/shared/src/server");
+  const { prisma } = await import("@langfuse/shared/src/db");
   console.log(`Redis status ${redis?.status}`);
   if (!redis) {
     return;
@@ -9,5 +10,6 @@ export default async function teardown() {
     return;
   }
   redis?.disconnect();
+  await prisma.$disconnect();
   console.log("Teardown complete");
 }

--- a/web/src/__tests__/teardown.ts
+++ b/web/src/__tests__/teardown.ts
@@ -1,6 +1,5 @@
 export default async function teardown() {
   const { redis } = await import("@langfuse/shared/src/server");
-  const { prisma } = await import("@langfuse/shared/src/db");
   console.log(`Redis status ${redis?.status}`);
   if (!redis) {
     return;
@@ -10,6 +9,5 @@ export default async function teardown() {
     return;
   }
   redis?.disconnect();
-  await prisma.$disconnect();
   console.log("Teardown complete");
 }

--- a/web/src/ee/features/evals/components/evaluator-detail.tsx
+++ b/web/src/ee/features/evals/components/evaluator-detail.tsx
@@ -223,7 +223,11 @@ export function DeactivateEvaluator({
       <PopoverTrigger asChild>
         <div className="flex items-center">
           <Switch
-            disabled={!hasAccess}
+            disabled={
+              !hasAccess ||
+              (evaluator?.timeScope?.length === 1 &&
+                evaluator.timeScope[0] === "EXISTING")
+            }
             checked={isActive}
             className={isActive ? "data-[state=checked]:bg-dark-green" : ""}
           />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Prevent deactivation of evaluator configurations with `timeScope` set to `EXISTING` only, with UI and test updates to enforce this behavior.
> 
>   - **Behavior**:
>     - Prevent deactivation of evaluators with `timeScope` set to `EXISTING` only in `updateEvalJob` in `router.ts`.
>     - Allow deactivation if `timeScope` includes both `EXISTING` and `NEW`.
>     - Throw `TRPCError` for invalid deactivation attempts.
>   - **UI**:
>     - Disable `Switch` in `DeactivateEvaluator` in `evaluator-detail.tsx` if `timeScope` is `EXISTING` only.
>   - **Tests**:
>     - Add tests in `evals-trpc.servertest.ts` to verify deactivation restrictions and error messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c275eac0296d1dc1df9613fe68cd1c1b4a3daeba. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->