### PR TITLE
fix: return nulls for left-joins for correct session durations

### DIFF
--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -29,6 +29,7 @@ export const clickhouseClient = (
       log_comment: JSON.stringify(params.tags ?? {}),
       async_insert: 1,
       wait_for_async_insert: 1, // if disabled, we won't get errors from clickhouse
+      join_use_nulls: 1, // Return `null` if a left join doesn't have a match
     },
   });
 };

--- a/web/src/__tests__/async/sessions-ui-table.servertest.ts
+++ b/web/src/__tests__/async/sessions-ui-table.servertest.ts
@@ -325,12 +325,12 @@ describe("trpc.sessions", () => {
 
   it("LFE-4113: should GET correct metrics for a list of sessions without observations", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
-    const sessionId1 = v4();
+    const sessionId = v4();
 
     await prisma.traceSession.createMany({
       data: [
         {
-          id: sessionId1,
+          id: sessionId,
           projectId: projectId,
         },
       ],
@@ -338,17 +338,12 @@ describe("trpc.sessions", () => {
 
     const traces = [
       createTrace({
-        session_id: sessionId1,
+        session_id: sessionId,
         project_id: projectId,
         user_id: "user1",
       }),
       createTrace({
-        session_id: sessionId1,
-        project_id: projectId,
-        user_id: "user2",
-      }),
-      createTrace({
-        session_id: sessionId1,
+        session_id: sessionId,
         project_id: projectId,
         user_id: "user3",
       }),
@@ -356,15 +351,15 @@ describe("trpc.sessions", () => {
 
     await createTracesCh(traces);
 
-    // Only sessionId2 has traces with observations
+    // Only trace 2 has observations
     const observations = [
       createObservation({
-        trace_id: traces[2].id,
+        trace_id: traces[1].id,
         project_id: projectId,
         start_time: new Date().getTime() - 1000,
       }),
       createObservation({
-        trace_id: traces[2].id,
+        trace_id: traces[1].id,
         project_id: projectId,
         start_time: new Date().getTime(),
       }),
@@ -379,7 +374,7 @@ describe("trpc.sessions", () => {
           column: "id",
           type: "stringOptions",
           operator: "any of",
-          value: [sessionId1],
+          value: [sessionId],
         },
       ],
     });

--- a/web/src/__tests__/async/sessions-ui-table.servertest.ts
+++ b/web/src/__tests__/async/sessions-ui-table.servertest.ts
@@ -382,7 +382,7 @@ describe("trpc.sessions", () => {
     expect(sessions.length).toBe(1);
 
     expect(sessions[0]).toBeDefined();
-    expect(sessions[0]?.trace_count).toBe(3);
+    expect(sessions[0]?.trace_count).toBe(2);
     expect(sessions[0]?.duration).toEqual("1000");
   });
 });

--- a/web/src/__tests__/async/sessions-ui-table.servertest.ts
+++ b/web/src/__tests__/async/sessions-ui-table.servertest.ts
@@ -322,4 +322,72 @@ describe("trpc.sessions", () => {
     expect(Number(session2?.session_output_usage)).toBeGreaterThan(0);
     expect(Number(session2?.session_total_usage)).toBeGreaterThan(0);
   });
+
+  it("LFE-4113: should GET correct metrics for a list of sessions without observations", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const sessionId1 = v4();
+
+    await prisma.traceSession.createMany({
+      data: [
+        {
+          id: sessionId1,
+          projectId: projectId,
+        },
+      ],
+    });
+
+    const traces = [
+      createTrace({
+        session_id: sessionId1,
+        project_id: projectId,
+        user_id: "user1",
+      }),
+      createTrace({
+        session_id: sessionId1,
+        project_id: projectId,
+        user_id: "user2",
+      }),
+      createTrace({
+        session_id: sessionId1,
+        project_id: projectId,
+        user_id: "user3",
+      }),
+    ];
+
+    await createTracesCh(traces);
+
+    // Only sessionId2 has traces with observations
+    const observations = [
+      createObservation({
+        trace_id: traces[2].id,
+        project_id: projectId,
+        start_time: new Date().getTime() - 1000,
+      }),
+      createObservation({
+        trace_id: traces[2].id,
+        project_id: projectId,
+        start_time: new Date().getTime(),
+      }),
+    ];
+
+    await createObservationsCh(observations);
+
+    const sessions = await getSessionsWithMetrics({
+      projectId: projectId,
+      filter: [
+        {
+          column: "id",
+          type: "stringOptions",
+          operator: "any of",
+          value: [sessionId1],
+        },
+      ],
+    });
+
+    expect(sessions.length).toBe(1);
+
+    expect(sessions[0]).toBeDefined();
+    expect(sessions[0]?.trace_count).toBe(3);
+    expect(sessions[0]?.duration).toEqual("1000");
+  });
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Set `join_use_nulls: 1` in ClickHouse client to handle left joins correctly and added a test for sessions without observations.
> 
>   - **Behavior**:
>     - Set `join_use_nulls: 1` in `clickhouseClient` in `client.ts` to return `null` for unmatched left joins.
>   - **Testing**:
>     - Add test case in `sessions-ui-table.servertest.ts` to verify correct metrics for sessions without observations, ensuring session duration is calculated correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for beb8420402a7cd07fba703ce87e0efa15c20fd49. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->