### PR TITLE
fix(public-api): list observations with name filter

### DIFF
--- a/web/src/features/public-api/server/observations.ts
+++ b/web/src/features/public-api/server/observations.ts
@@ -40,7 +40,7 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
         trace_id,
         project_id,
         type,
-        start_time,
+        toUnixTimestamp(start_time),
       FROM observations o ${shouldUseSkipIndexes ? "" : "FINAL"}
       ${traceFilter ? `LEFT JOIN traces t ON o.trace_id = t.id AND t.project_id = o.project_id` : ""}
       WHERE o.project_id = {projectId: String}
@@ -82,7 +82,7 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
       FROM observations o ${shouldUseSkipIndexes ? "" : "FINAL"}
       
       WHERE o.project_id = {projectId: String}
-      AND (id, trace_id, project_id, type, start_time) in (select * from clickhouse_keys)
+      AND (id, trace_id, project_id, type, toUnixTimestamp(start_time)) in (select * from clickhouse_keys)
 
       ${shouldUseSkipIndexes ? "ORDER BY start_time desc, event_ts desc LIMIT 1 by id, project_id" : "ORDER BY start_time DESC"}
       `;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes filtering of observations by `name` in public API by updating `generateFilter` and SQL queries in `observations.ts`.
> 
>   - **Behavior**:
>     - Fixes filtering of observations by `name` in `generateObservationsForPublicApi` and `getObservationsCountForPublicApi` in `observations.ts`.
>     - Adds `name` filter to `generateFilter` function, allowing observations to be filtered by name.
>   - **Functions**:
>     - Updates `generateFilter` to include `name` in `filterParams`.
>     - Modifies SQL queries in `generateObservationsForPublicApi` to use `toUnixTimestamp(start_time)` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 480e5b1756305cb4dede777274fb39f29b3885df. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->