### PR TITLE
fix: support gzip encoding on otel endpoint

### DIFF
--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -8,6 +8,7 @@ import {
 import { z } from "zod";
 import { $root } from "@/src/pages/api/public/otel/otlp-proto/generated/root";
 import { convertOtelSpanToIngestionEvent } from "@/src/features/otel/server";
+import { gunzip } from "node:zlib";
 
 export const config = {
   api: {
@@ -34,6 +35,21 @@ export default withMiddlewares({
       } catch (e) {
         logger.error(`Failed to read request body`, e);
         return res.status(400).json({ error: "Failed to read request body" });
+      }
+
+      if (req.headers["content-encoding"] === "gzip") {
+        try {
+          body = await new Promise((resolve, reject) => {
+            gunzip(body, (err, result) =>
+              err ? reject(err) : resolve(result),
+            );
+          });
+        } catch (e) {
+          logger.error(`Failed to decompress request body`, e);
+          return res
+            .status(400)
+            .json({ error: "Failed to decompress request body" });
+        }
       }
 
       let resourceSpans: any;

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -37,7 +37,7 @@ export default withMiddlewares({
         return res.status(400).json({ error: "Failed to read request body" });
       }
 
-      if (req.headers["content-encoding"] === "gzip") {
+      if (req.headers["content-encoding"]?.includes("gzip")) {
         try {
           body = await new Promise((resolve, reject) => {
             gunzip(body, (err, result) =>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds support for gzip-encoded request bodies in OpenTelemetry endpoint by decompressing using `gunzip` in `index.ts`.
> 
>   - **Behavior**:
>     - Adds support for gzip-encoded request bodies in `index.ts`.
>     - Checks `Content-Encoding` header for "gzip" and decompresses using `gunzip`.
>     - Logs error and returns 400 status if decompression fails.
>   - **Imports**:
>     - Imports `gunzip` from `node:zlib` for decompression.
>   - **Error Handling**:
>     - Logs decompression errors and sends 400 response with error message.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bf249e7ea4e1d34c7dbe4623260b4032de712bb4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->