### PR TITLE
fix: only delete media items with no remaining references

### DIFF
--- a/worker/src/__tests__/traceDeletion.test.ts
+++ b/worker/src/__tests__/traceDeletion.test.ts
@@ -168,6 +168,83 @@ describe("trace deletion", () => {
     // No need to check observationMedia and traceMedia as they have a foreign key to media table.
   });
 
+  it("should NOT delete S3 media files for deleted traces if referenced by other entity", async () => {
+    // Setup
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const traceId1 = randomUUID();
+    const traceId2 = randomUUID();
+
+    await createTracesCh([
+      createTrace({ id: traceId1, project_id: projectId }),
+      createTrace({ id: traceId2, project_id: projectId }),
+    ]);
+
+    const fileType = "text/plain";
+    const data = "Hello, world!";
+    const expiresInSeconds = 3600;
+    await mediaStorageService.uploadFile({
+      fileName: `${projectId}/trace-${traceId1}.txt`,
+      fileType,
+      data,
+      expiresInSeconds,
+    });
+
+    const traceMediaId = randomUUID();
+    await prisma.media.create({
+      data: {
+        id: traceMediaId,
+        sha256Hash: randomUUID(),
+        projectId,
+        createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3), // 3 days in the past
+        bucketPath: `${projectId}/trace-${traceId1}.txt`,
+        bucketName: env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
+        contentType: fileType,
+        contentLength: 0,
+      },
+    });
+    // Create TWO references to media item
+    await prisma.traceMedia.create({
+      data: {
+        id: randomUUID(),
+        projectId,
+        traceId: traceId1,
+        mediaId: traceMediaId,
+        field: "test",
+      },
+    });
+    await prisma.traceMedia.create({
+      data: {
+        id: randomUUID(),
+        projectId,
+        traceId: traceId2,
+        mediaId: traceMediaId,
+        field: "test",
+      },
+    });
+
+    // When
+    await processClickhouseTraceDelete(projectId, [traceId1]);
+
+    // Then
+    const files = await mediaStorageService.listFiles(projectId);
+    expect(files).toHaveLength(1);
+
+    const media = await prisma.media.findMany({
+      where: {
+        projectId,
+      },
+    });
+    expect(media).toHaveLength(1);
+
+    const traceMedia = await prisma.traceMedia.findMany({
+      where: {
+        projectId,
+      },
+    });
+    expect(traceMedia).toHaveLength(1);
+  });
+
   it("should delete S3 event files for deleted traces", async () => {
     // Setup
     const { projectId } = await createOrgProjectAndApiKey();

--- a/worker/src/features/traces/processClickhouseTraceDelete.ts
+++ b/worker/src/features/traces/processClickhouseTraceDelete.ts
@@ -87,6 +87,11 @@ const deleteMediaItemsForTraces = async (
     },
     where: {
       projectId,
+      id: {
+        in: [...traceMediaItems, ...observationMediaItems].map(
+          (ref) => ref.mediaId,
+        ),
+      },
       TraceMedia: {
         every: {
           id: {

--- a/worker/src/features/traces/processClickhouseTraceDelete.ts
+++ b/worker/src/features/traces/processClickhouseTraceDelete.ts
@@ -44,6 +44,105 @@ const getS3EventStorageClient = (bucketName: string): StorageService => {
   return s3EventStorageClient;
 };
 
+const deleteMediaItemsForTraces = async (
+  projectId: string,
+  traceIds: string[],
+): Promise<void> => {
+  if (!env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET) {
+    return;
+  }
+  // First, find all records associated with the traces to be deleted
+  const [traceMediaItems, observationMediaItems] = await Promise.all([
+    prisma.traceMedia.findMany({
+      select: {
+        id: true,
+        mediaId: true,
+      },
+      where: {
+        projectId,
+        traceId: {
+          in: traceIds,
+        },
+      },
+    }),
+    prisma.observationMedia.findMany({
+      select: {
+        id: true,
+        mediaId: true,
+      },
+      where: {
+        projectId,
+        traceId: {
+          in: traceIds,
+        },
+      },
+    }),
+  ]);
+
+  // Find media items that will have no remaining references after deletion
+  const mediaDeleteCandidates = await prisma.media.findMany({
+    select: {
+      id: true,
+      bucketPath: true,
+    },
+    where: {
+      projectId,
+      TraceMedia: {
+        every: {
+          id: {
+            in: traceMediaItems.map((ref) => ref.id),
+          },
+        },
+      },
+      ObservationMedia: {
+        every: {
+          id: {
+            in: observationMediaItems.map((ref) => ref.id),
+          },
+        },
+      },
+    },
+  });
+
+  // Remove the media items that will have no remaining references
+  if (mediaDeleteCandidates.length > 0) {
+    // Delete from Cloud Storage
+    await getS3MediaStorageClient(
+      env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET ?? "", // Fallback is never used.
+    ).deleteFiles(mediaDeleteCandidates.map((f) => f.bucketPath));
+
+    // Delete from postgres
+    await prisma.media.deleteMany({
+      where: {
+        id: {
+          in: mediaDeleteCandidates.map((f) => f.id),
+        },
+        projectId,
+      },
+    });
+  }
+
+  // Remove all traceMedia and observationMedia items that we found earlier
+  await Promise.all([
+    prisma.traceMedia.deleteMany({
+      where: {
+        projectId,
+        id: {
+          in: traceMediaItems.map((ref) => ref.id),
+        },
+      },
+    }),
+    prisma.observationMedia.deleteMany({
+      where: {
+        projectId,
+        id: {
+          in: observationMediaItems.map((ref) => ref.id),
+        },
+      },
+    }),
+  ]);
+};
+
 export const processClickhouseTraceDelete = async (
   projectId: string,
   traceIds: string[],
@@ -52,56 +151,7 @@ export const processClickhouseTraceDelete = async (
     `Deleting traces ${JSON.stringify(traceIds)} in project ${projectId} from Clickhouse`,
   );
 
-  // Delete media files if bucket is configured
-  if (env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET) {
-    const mediaFilesToDelete = await prisma.media.findMany({
-      select: {
-        id: true,
-        bucketPath: true,
-      },
-      where: {
-        projectId,
-        OR: [
-          {
-            TraceMedia: {
-              some: {
-                projectId,
-                traceId: {
-                  in: traceIds,
-                },
-              },
-            },
-          },
-          {
-            ObservationMedia: {
-              some: {
-                projectId,
-                traceId: {
-                  in: traceIds,
-                },
-              },
-            },
-          },
-        ],
-      },
-    });
-    const mediaStorageClient = getS3MediaStorageClient(
-      env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
-    );
-    // Delete from Cloud Storage
-    await mediaStorageClient.deleteFiles(
-      mediaFilesToDelete.map((f) => f.bucketPath),
-    );
-    // Delete from postgres. We should automatically remove the corresponding traceMedia and observationMedia
-    await prisma.media.deleteMany({
-      where: {
-        id: {
-          in: mediaFilesToDelete.map((f) => f.id),
-        },
-        projectId,
-      },
-    });
-  }
+  await deleteMediaItemsForTraces(projectId, traceIds);
 
   const eventLogStream = getEventLogByProjectIdAndTraceIds(projectId, traceIds);
   let eventLogRecords: { id: string; path: string }[] = [];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Ensure media items are only deleted if no remaining references exist in `processClickhouseTraceDelete`.
> 
>   - **Behavior**:
>     - `processClickhouseTraceDelete` now ensures media items are only deleted if no remaining references exist.
>     - Introduces `deleteMediaItemsForTraces` to handle media deletion logic.
>   - **Tests**:
>     - Adds test case in `traceDeletion.test.ts` to verify media items are not deleted if referenced by other entities.
>   - **Misc**:
>     - Refactors media deletion logic into `deleteMediaItemsForTraces` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0aea9374b0850542c96aa6614287023a29cc0aae. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->