### PR TITLE
chore: track distribution of ingested event body size

### DIFF
--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -14,6 +14,7 @@ import {
   getCurrentSpan,
   instrumentAsync,
   instrumentSync,
+  recordDistribution,
   recordIncrement,
   traceException,
 } from "../instrumentation";
@@ -94,6 +95,8 @@ export const processEventBatch = async (
   // add context of api call to the span
   const currentSpan = getCurrentSpan();
   recordIncrement("langfuse.ingestion.event", input.length);
+  recordDistribution("langfuse.ingestion.event_distribution", input.length);
+
   currentSpan?.setAttribute("langfuse.ingestion.batch_size", input.length);
   currentSpan?.setAttribute("langfuse.project.id", authCheck.scope.projectId);
   currentSpan?.setAttribute("langfuse.org.id", authCheck.scope.orgId);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `recordDistribution` in `processEventBatch` to track ingested event body size distribution.
> 
>   - **Metrics**:
>     - Add `recordDistribution` call in `processEventBatch` to track distribution of ingested event body sizes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ec15b4a7d17974bc7b5037c1a761f5035a108c8a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->