### PR TITLE
fix: exclude clickhouse default date from session duration calc

### DIFF
--- a/packages/shared/src/server/services/sessions-ui-table-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-service.ts
@@ -271,7 +271,9 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
                 ? `
             ,
             sum(o.obs_count) as total_observations,
-            date_diff('millisecond', min(min_start_time), max(max_end_time)) as duration,
+            -- Use minIf, because ClickHouse fills 1970-01-01 on left joins. We assume that no
+            -- LLM session started on that date so this behaviour should yield better results.
+            date_diff('millisecond', minIf(min_start_time, min_start_time > '1970-01-01'), max(max_end_time)) as duration,
             sumMap(o.sum_usage_details) as session_usage_details,
             sumMap(o.sum_cost_details) as session_cost_details,
             arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'input') > 0, sumMap(o.sum_cost_details)))) as session_input_cost,

--- a/web/src/__tests__/async/sessions-ui-table.servertest.ts
+++ b/web/src/__tests__/async/sessions-ui-table.servertest.ts
@@ -322,4 +322,67 @@ describe("trpc.sessions", () => {
     expect(Number(session2?.session_output_usage)).toBeGreaterThan(0);
     expect(Number(session2?.session_total_usage)).toBeGreaterThan(0);
   });
+
+  it("LFE-4113: should GET correct metrics for a list of sessions without observations", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const sessionId = v4();
+
+    await prisma.traceSession.createMany({
+      data: [
+        {
+          id: sessionId,
+          projectId: projectId,
+        },
+      ],
+    });
+
+    const traces = [
+      createTrace({
+        session_id: sessionId,
+        project_id: projectId,
+        user_id: "user1",
+      }),
+      createTrace({
+        session_id: sessionId,
+        project_id: projectId,
+        user_id: "user3",
+      }),
+    ];
+
+    await createTracesCh(traces);
+
+    // Only trace 2 has observations
+    const observations = [
+      createObservation({
+        trace_id: traces[1].id,
+        project_id: projectId,
+        start_time: new Date().getTime() - 1000,
+      }),
+      createObservation({
+        trace_id: traces[1].id,
+        project_id: projectId,
+        start_time: new Date().getTime(),
+      }),
+    ];
+
+    await createObservationsCh(observations);
+
+    const sessions = await getSessionsWithMetrics({
+      projectId: projectId,
+      filter: [
+        {
+          column: "id",
+          type: "stringOptions",
+          operator: "any of",
+          value: [sessionId],
+        },
+      ],
+    });
+
+    expect(sessions.length).toBe(1);
+
+    expect(sessions[0]).toBeDefined();
+    expect(sessions[0]?.trace_count).toBe(2);
+    expect(sessions[0]?.duration).toEqual("1000");
+  });
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes session duration calculation by excluding ClickHouse default date in `sessions-ui-table-service.ts` and adds a test case for verification.
> 
>   - **Behavior**:
>     - Fixes session duration calculation in `getSessionsTableGeneric()` in `sessions-ui-table-service.ts` by excluding ClickHouse default date `1970-01-01` using `minIf()`.
>   - **Tests**:
>     - Adds test case in `sessions-ui-table.servertest.ts` to verify correct metrics for sessions without observations, ensuring duration is calculated accurately.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5022479e66e1cc7c3d7311f20e7101c96abb29c5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->