### PR TITLE
style(prompts): always show edit label button for prompt versions

### DIFF
--- a/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
+++ b/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
@@ -125,18 +125,17 @@ export function SetPromptVersionLabels({
               isLive={label === PRODUCTION_LABEL}
             />
           ))}
-          {promptLabels.length === 0 && (
-            <Button
-              variant="outline"
-              className={cn(
-                "h-6 w-6 bg-muted-gray text-primary",
-                showOnlyOnHover && "opacity-0 group-hover:opacity-100",
-                !hasAccess && "cursor-not-allowed group-hover:opacity-50",
-              )}
-            >
-              <CircleFadingArrowUp className="h-3.5 w-3.5 shrink-0" />
-            </Button>
-          )}
+          <Button
+            variant="outline"
+            title="Add prompt version label"
+            className={cn(
+              "h-6 w-6 bg-muted-gray text-primary",
+              showOnlyOnHover && "opacity-0 group-hover:opacity-100",
+              !hasAccess && "cursor-not-allowed group-hover:opacity-50",
+            )}
+          >
+            <CircleFadingArrowUp className="h-3.5 w-3.5 shrink-0" />
+          </Button>
         </div>
       </PopoverTrigger>
       <PopoverContent


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Always show the "Edit label" button in `SetPromptVersionLabels` component, regardless of `promptLabels` length.
> 
>   - **UI Behavior**:
>     - Always show the "Edit label" button in `SetPromptVersionLabels` component, regardless of `promptLabels` length.
>     - Button has `title` attribute set to "Add prompt version label" for accessibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2f6f5649c9bbc6ed465ee1a4056f788f125b8774. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->