### PR TITLE
chore(ui): move "configure tracing" to the right in dashboard header

### DIFF
--- a/web/src/pages/project/[projectId]/index.tsx
+++ b/web/src/pages/project/[projectId]/index.tsx
@@ -147,7 +147,7 @@ export default function Dashboard() {
       scrollable
       headerProps={{
         title: "Dashboard",
-        actionButtonsLeft: <SetupTracingButton />,
+        actionButtonsRight: <SetupTracingButton />,
       }}
     >
       <div className="my-3 flex flex-wrap items-center justify-between gap-2">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move `SetupTracingButton` to the right side of the dashboard header in `index.tsx`.
> 
>   - **UI Change**:
>     - Move `SetupTracingButton` from `actionButtonsLeft` to `actionButtonsRight` in `index.tsx` to reposition it in the dashboard header.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a9ad38f999f40c61e240f20dada74725e297764c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->