### PR TITLE
memory tuning for clickhouse container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,10 @@ services:
       - "8123:8123"
       - "9000:9000"
     # use also this to tune your memory usage
-    mem_limit: 800M
+    deploy:
+      resources:
+        limits:
+          memory: 800M
     healthcheck:
       test: wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,12 +76,17 @@ services:
       CLICKHOUSE_DB: default
       CLICKHOUSE_USER: clickhouse
       CLICKHOUSE_PASSWORD: clickhouse
+      # since clickhouse is memory intensive, use these two variables to tune your memory usage
+      CLICKHOUSE_MAX_MEMORY_USAGE: "800000000"  # ~800MB
+      CLICKHOUSE_MAX_MEMORY_USAGE_FOR_USER: "800000000"  # ~800MB
     volumes:
       - langfuse_clickhouse_data:/var/lib/clickhouse
       - langfuse_clickhouse_logs:/var/log/clickhouse-server
     ports:
       - "8123:8123"
       - "9000:9000"
+    # use also this to tune your memory usage
+    mem_limit: 800M
     healthcheck:
       test: wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1
       interval: 5s


### PR DESCRIPTION
## What does this PR do?

Adds memory tuning config keys for ClickHouse container 

Fixes # (issue)

Memory issues on low ram instances

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Chore (refactoring code, technical debt, workflow improvements)
- [X] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add memory tuning configurations for ClickHouse container in `docker-compose.yml`.
> 
>   - **Memory Tuning**:
>     - Adds `CLICKHOUSE_MAX_MEMORY_USAGE` and `CLICKHOUSE_MAX_MEMORY_USAGE_FOR_USER` environment variables in `docker-compose.yml` for ClickHouse container, both set to ~800MB.
>     - Sets `mem_limit` to 800M for ClickHouse container in `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e8c3e226c75febe03c4718ba9b2f7858c3f88569. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->