### PR TITLE
fix(api): add environment to ingestion spec

### DIFF
--- a/fern/apis/server/definition/ingestion.yml
+++ b/fern/apis/server/definition/ingestion.yml
@@ -168,6 +168,7 @@ types:
       statusMessage: optional<string>
       parentObservationId: optional<string>
       version: optional<string>
+      environment: optional<string>
 
   CreateEventBody:
     extends: OptionalObservationBody
@@ -232,6 +233,7 @@ types:
       level: optional<commons.ObservationLevel>
       statusMessage: optional<string>
       parentObservationId: optional<string>
+      environment: optional<string>
 
   TraceBody:
     properties:
@@ -246,6 +248,7 @@ types:
       version: optional<string>
       metadata: optional<unknown>
       tags: optional<list<string>>
+      environment: optional<string>
       public:
         type: optional<boolean>
         docs: Make trace publicly accessible via url
@@ -259,6 +262,7 @@ types:
       id: optional<string>
       traceId: string
       name: string
+      environment: optional<string>
       value:
         type: commons.CreateScoreValue
         docs: The value of the score. Must be passed as string for categorical scores, and numeric for boolean and numeric scores. Boolean score values must equal either 1 or 0 (true or false)

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3755,6 +3755,9 @@ components:
         version:
           type: string
           nullable: true
+        environment:
+          type: string
+          nullable: true
     CreateEventBody:
       title: CreateEventBody
       type: object
@@ -3922,6 +3925,9 @@ components:
         parentObservationId:
           type: string
           nullable: true
+        environment:
+          type: string
+          nullable: true
       required:
         - type
     TraceBody:
@@ -3961,6 +3967,9 @@ components:
           items:
             type: string
           nullable: true
+        environment:
+          type: string
+          nullable: true
         public:
           type: boolean
           nullable: true
@@ -3985,6 +3994,9 @@ components:
         name:
           type: string
           example: novelty
+        environment:
+          type: string
+          nullable: true
         value:
           $ref: '#/components/schemas/CreateScoreValue'
           description: >-


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add optional `environment` field to various event bodies in ingestion and OpenAPI specifications.
> 
>   - **Ingestion Specification**:
>     - Added `environment: optional<string>` to `OptionalObservationBody`, `TraceBody`, `ScoreBody`, and `ObservationBody` in `ingestion.yml`.
>   - **OpenAPI Specification**:
>     - Added `environment` field to corresponding schemas in `openapi.yml` to match `ingestion.yml` changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 087bd1c8bfd4770728180059471a09f0d3864461. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->