### PR TITLE
fix(ingestion): environment to immutable keys

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -61,13 +61,20 @@ const immutableEntityKeys: {
   [TableName.Scores]: (keyof ScoreRecordInsertType)[];
   [TableName.Observations]: (keyof ObservationRecordInsertType)[];
 } = {
-  [TableName.Traces]: ["id", "project_id", "timestamp", "created_at"],
+  [TableName.Traces]: [
+    "id",
+    "project_id",
+    "timestamp",
+    "created_at",
+    "environment",
+  ],
   [TableName.Scores]: [
     "id",
     "project_id",
     "timestamp",
     "trace_id",
     "created_at",
+    "environment",
   ],
   [TableName.Observations]: [
     "id",
@@ -75,6 +82,7 @@ const immutableEntityKeys: {
     "trace_id",
     "start_time",
     "created_at",
+    "environment",
   ],
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `environment` to immutable keys for `Traces`, `Scores`, and `Observations` to prevent overwriting during merges.
> 
>   - **Behavior**:
>     - Add `environment` to immutable keys for `Traces`, `Scores`, and `Observations` in `index.ts`.
>     - Ensures `environment` is not overwritten during record merges in `mergeRecords()` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 070220954ee8e691bc0b39c8b0fd529585fe0d76. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->