### PR TITLE
fix(ui): experiment from the prompt screen -> window does not fit screen

### DIFF
--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -377,7 +377,7 @@ export const PromptDetail = () => {
                         </span>
                       </Button>
                     </DialogTrigger>
-                    <DialogContent>
+                    <DialogContent className="max-h-[90vh] overflow-y-auto">
                       <CreateExperimentsForm
                         key={`create-experiment-form-${prompt.id}`}
                         projectId={projectId as string}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes dialog content overflow in `prompt-detail.tsx` by setting max height and enabling scrolling.
> 
>   - **UI Fix**:
>     - In `prompt-detail.tsx`, updated `DialogContent` to have a maximum height of `90vh` and enable vertical scrolling to ensure the dialog fits within the screen.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3ea47533587a4e61aa6e5203ef2b357df40148d3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->