### PR TITLE
fix(ui): overlapping variables for chat prompt

### DIFF
--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -455,10 +455,12 @@ export const PromptDetail = () => {
             >
               <div className="mb-2 flex max-h-full min-h-0 w-full flex-col gap-2 overflow-y-auto">
                 {prompt.type === PromptType.Chat && chatMessages ? (
-                  <OpenAiMessageView
-                    messages={chatMessages}
-                    collapseLongHistory={false}
-                  />
+                  <div className="w-full">
+                    <OpenAiMessageView
+                      messages={chatMessages}
+                      collapseLongHistory={false}
+                    />
+                  </div>
                 ) : typeof prompt.prompt === "string" ? (
                   <CodeView content={prompt.prompt} title="Text Prompt" />
                 ) : (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Wraps `OpenAiMessageView` in a `div` in `prompt-detail.tsx` to prevent overlapping variables in chat prompts.
> 
>   - **UI Fix**:
>     - Wraps `OpenAiMessageView` in a `div` in `prompt-detail.tsx` to prevent overlapping variables in chat prompts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 41bc6557604c8dfb17d2356c0206c3c4134e8c67. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->