### PR TITLE
fix: create traces via otel for empty parent span buffer

### DIFF
--- a/web/src/__tests__/async/sessions-ui-table.servertest.ts
+++ b/web/src/__tests__/async/sessions-ui-table.servertest.ts
@@ -383,6 +383,7 @@ describe("trpc.sessions", () => {
 
     expect(sessions[0]).toBeDefined();
     expect(sessions[0]?.trace_count).toBe(2);
-    expect(sessions[0]?.duration).toEqual("1000");
+    expect(parseInt(sessions[0]?.duration as any)).toBeGreaterThan(995);
+    expect(parseInt(sessions[0]?.duration as any)).toBeLessThan(1005);
   });
 });

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -332,6 +332,34 @@ describe("OTel Resource Span Mapping", () => {
       },
     };
 
+    it("should interpret an empty buffer as an unset parentSpanId", async () => {
+      // https://github.com/langchain4j/langchain4j/issues/2328#issuecomment-2686129552
+      // Empty buffers where detected as truthy, i.e. behaved like they had a parent span.
+      // Setup
+      const resourceSpan = {
+        scopeSpans: [
+          {
+            spans: [
+              {
+                ...defaultSpanProps,
+                parentSpanId: {
+                  type: "Buffer",
+                  data: [],
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      // When
+      const langfuseEvents = convertOtelSpanToIngestionEvent(resourceSpan);
+
+      // Then
+      // Expect a span and a trace to be created
+      expect(langfuseEvents).toHaveLength(2);
+    });
+
     it.each([
       [
         "should extract promptName on observation from langfuse.prompt.name",

--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -305,7 +305,13 @@ export const convertOtelSpanToIngestionEvent = (
           return acc;
         }, {}) ?? {};
 
-      if (!span?.parentSpanId) {
+      const parentObservationId = span?.parentSpanId
+        ? Buffer.from(span.parentSpanId?.data ?? span.parentSpanId).toString(
+            "hex",
+          )
+        : null;
+
+      if (!parentObservationId) {
         // Create a trace for any root span
         const trace = {
           id: Buffer.from(span.traceId?.data ?? span.traceId).toString("hex"),
@@ -348,11 +354,7 @@ export const convertOtelSpanToIngestionEvent = (
         traceId: Buffer.from(span.traceId?.data ?? span.traceId).toString(
           "hex",
         ),
-        parentObservationId: span?.parentSpanId
-          ? Buffer.from(span.parentSpanId?.data ?? span.parentSpanId).toString(
-              "hex",
-            )
-          : null,
+        parentObservationId,
         name: span.name,
         startTime: convertNanoTimestampToISO(span.startTimeUnixNano),
         endTime: convertNanoTimestampToISO(span.endTimeUnixNano),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes handling of empty parent span buffers in OpenTelemetry traces by interpreting them as unset, with corresponding test updates.
> 
>   - **Behavior**:
>     - `convertOtelSpanToIngestionEvent` in `index.ts` now interprets empty `parentSpanId` buffers as unset, creating a trace for root spans.
>     - Updated test in `sessions-ui-table.servertest.ts` to check session duration within a range (995-1005 ms).
>   - **Tests**:
>     - Added test in `otelMapping.servertest.ts` to verify empty buffer handling for `parentSpanId`.
>     - Updated test in `sessions-ui-table.servertest.ts` to use `parseInt` for duration checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8201932200f8cbfae578e197c80a0576ac2c0ba5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->