### PR TITLE
perf: filter relevant observation for data set run item stats

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1139,6 +1139,7 @@ export const getObservationMetricsForPrompts = async (
 export const getLatencyAndTotalCostForObservations = async (
   projectId: string,
   observationIds: string[],
+  timestamp?: Date,
 ) => {
   const query = `
     SELECT
@@ -1147,7 +1148,8 @@ export const getLatencyAndTotalCostForObservations = async (
         dateDiff('millisecond', start_time, end_time) AS latency_ms
     FROM observations FINAL 
     WHERE project_id = {projectId: String} 
-    AND id IN ({observationIds: Array(String)})
+    AND id IN ({observationIds: Array(String)}) 
+    ${timestamp ? `AND start_time >= {timestamp: DateTime64(3)}` : ""}
 `;
   const rows = await queryClickhouse<{
     id: string;
@@ -1158,6 +1160,9 @@ export const getLatencyAndTotalCostForObservations = async (
     params: {
       projectId,
       observationIds,
+      ...(timestamp
+        ? { timestamp: convertDateToClickhouseDateTime(timestamp) }
+        : {}),
     },
     tags: {
       feature: "tracing",
@@ -1177,6 +1182,7 @@ export const getLatencyAndTotalCostForObservations = async (
 export const getLatencyAndTotalCostForObservationsByTraces = async (
   projectId: string,
   traceIds: string[],
+  timestamp?: Date,
 ) => {
   const query = `
     SELECT
@@ -1186,6 +1192,7 @@ export const getLatencyAndTotalCostForObservationsByTraces = async (
     FROM observations FINAL
     WHERE project_id = {projectId: String} 
     AND trace_id IN ({traceIds: Array(String)})
+    ${timestamp ? `AND start_time >= {timestamp: DateTime64(3)}` : ""}
     GROUP BY trace_id
 `;
   const rows = await queryClickhouse<{
@@ -1197,6 +1204,9 @@ export const getLatencyAndTotalCostForObservationsByTraces = async (
     params: {
       projectId,
       traceIds,
+      ...(timestamp
+        ? { timestamp: convertDateToClickhouseDateTime(timestamp) }
+        : {}),
     },
     tags: {
       feature: "tracing",

--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -497,7 +497,7 @@ export const getRunItemsByRunIdOrItemId = async (
 ) => {
   const minTimestamp = runItems
     .map((ri) => ri.createdAt)
-    .sort()
+    .sort((a, b) => a.getTime() - b.getTime())
     .shift();
   // We assume that all events started at most 24h before the earliest run item.
   const filterTimestamp = minTimestamp


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add timestamp filtering to observation queries to improve performance by reducing processed data size.
> 
>   - **Behavior**:
>     - Add optional `timestamp` parameter to `getLatencyAndTotalCostForObservations` and `getLatencyAndTotalCostForObservationsByTraces` in `observations.ts` to filter observations by start time.
>     - In `getRunItemsByRunIdOrItemId` in `service.ts`, calculate `filterTimestamp` as 24 hours before the earliest run item and pass it to observation functions.
>   - **Performance**:
>     - Improves performance by reducing the number of observations processed in `getLatencyAndTotalCostForObservations` and `getLatencyAndTotalCostForObservationsByTraces`.
>   - **Misc**:
>     - Minor query adjustments in `observations.ts` to incorporate the new timestamp filter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a133621654db2eaa8b9b3eb540616ca39b211e5d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->