### PR TITLE
fix(model-prices): bedrock claude sonnet 3-7 version

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1446,9 +1446,9 @@
   {
     "id": "cm7ka7561000108js3t9tb3at",
     "model_name": "claude-3.7-sonnet-20250219",
-    "match_pattern": "(?i)^(claude-3.7-sonnet-20250219|anthropic\\.claude-3.7-sonnet-20250219-v2:0|claude-3-7-sonnet-V2@20250219)$",
+    "match_pattern": "(?i)^(claude-3.7-sonnet-20250219|anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V2@20250219)$",
     "created_at": "2025-02-25T09:35:39.000Z",
-    "updated_at": "2025-02-25T09:35:39.000Z",
+    "updated_at": "2025-02-27T12:07:29.000Z",
     "prices": {
       "input": 3e-6,
       "input_tokens": 3e-6,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updated `match_pattern` for `claude-3.7-sonnet-20250219` in `default-model-prices.json` to use `v1:0` instead of `v2:0`.
> 
>   - **Behavior**:
>     - Updated `match_pattern` for `claude-3.7-sonnet-20250219` in `default-model-prices.json` to use `v1:0` instead of `v2:0`.
>     - Updated `updated_at` timestamp to `2025-02-27T12:07:29.000Z`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b0f1cc2a358c512468fccf1dc61f1c67e73c2cba. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->