### PR TITLE
feat: map otel environment config to langfuse environment

### DIFF
--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -362,6 +362,36 @@ describe("OTel Resource Span Mapping", () => {
 
     it.each([
       [
+        "should extract environment on trace for langfuse.environment",
+        {
+          entity: "trace",
+          otelAttributeKey: "langfuse.environment",
+          otelAttributeValue: { stringValue: "test" },
+          entityAttributeKey: "environment",
+          entityAttributeValue: "test",
+        },
+      ],
+      [
+        "should extract environment on observation for deployment.environment.name",
+        {
+          entity: "observation",
+          otelAttributeKey: "deployment.environment.name",
+          otelAttributeValue: { stringValue: "test" },
+          entityAttributeKey: "environment",
+          entityAttributeValue: "test",
+        },
+      ],
+      [
+        "should fallback to default on observation if no environment present",
+        {
+          entity: "observation",
+          otelAttributeKey: "unused.key",
+          otelAttributeValue: { stringValue: "" },
+          entityAttributeKey: "environment",
+          entityAttributeValue: "default",
+        },
+      ],
+      [
         "should extract promptName on observation from langfuse.prompt.name",
         {
           entity: "observation",
@@ -731,6 +761,36 @@ describe("OTel Resource Span Mapping", () => {
           otelResourceAttributeValue: { stringValue: "1.0.5" },
           entityAttributeKey: "version",
           entityAttributeValue: "1.0.5",
+        },
+      ],
+      [
+        "should extract environment on trace for langfuse.environment",
+        {
+          entity: "trace",
+          otelResourceAttributeKey: "langfuse.environment",
+          otelResourceAttributeValue: { stringValue: "test" },
+          entityAttributeKey: "environment",
+          entityAttributeValue: "test",
+        },
+      ],
+      [
+        "should extract environment on observation for deployment.environment.name",
+        {
+          entity: "observation",
+          otelResourceAttributeKey: "deployment.environment.name",
+          otelResourceAttributeValue: { stringValue: "test" },
+          entityAttributeKey: "environment",
+          entityAttributeValue: "test",
+        },
+      ],
+      [
+        "should fallback to default on observation if no environment present",
+        {
+          entity: "observation",
+          otelResourceAttributeKey: "unused.key",
+          otelResourceAttributeValue: { stringValue: "" },
+          entityAttributeKey: "environment",
+          entityAttributeValue: "default",
         },
       ],
     ])(

--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -177,6 +177,26 @@ const extractInputAndOutput = (
   return { input: null, output: null };
 };
 
+const extractEnvironment = (
+  attributes: Record<string, unknown>,
+  resourceAttributes: Record<string, unknown>,
+): string => {
+  const environmentAttributeKeys = [
+    "langfuse.environment",
+    "deployment.environment.name",
+    "deployment.environment",
+  ];
+  for (const key of environmentAttributeKeys) {
+    if (resourceAttributes[key]) {
+      return resourceAttributes[key] as string;
+    }
+    if (attributes[key]) {
+      return attributes[key] as string;
+    }
+  }
+  return "default";
+};
+
 const extractUserId = (
   attributes: Record<string, unknown>,
 ): string | undefined => {
@@ -334,8 +354,7 @@ export const convertOtelSpanToIngestionEvent = (
             attributes?.["langfuse.public"] === "true",
           tags: attributes?.["langfuse.tags"] ?? [],
 
-          // TODO: Overwrite to OTel based mapping via LFE-4081
-          environment: "default",
+          environment: extractEnvironment(attributes, resourceAttributes),
 
           // Input and Output
           ...extractInputAndOutput(span?.events ?? [], attributes),
@@ -359,8 +378,7 @@ export const convertOtelSpanToIngestionEvent = (
         startTime: convertNanoTimestampToISO(span.startTimeUnixNano),
         endTime: convertNanoTimestampToISO(span.endTimeUnixNano),
 
-        // TODO: Overwrite to OTel based mapping via LFE-4081
-        environment: "default",
+        environment: extractEnvironment(attributes, resourceAttributes),
 
         // Additional fields
         metadata: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Map OpenTelemetry environment attributes to Langfuse environment using `extractEnvironment()` and update tests to verify this behavior.
> 
>   - **Behavior**:
>     - Map OpenTelemetry environment attributes to Langfuse environment using `extractEnvironment()` in `index.ts`.
>     - Handles `langfuse.environment`, `deployment.environment.name`, and `deployment.environment` keys.
>     - Defaults to "default" if no environment attribute is present.
>   - **Tests**:
>     - Add test cases in `otelMapping.servertest.ts` to verify environment extraction for traces and observations.
>     - Test fallback to default environment when no relevant attribute is present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a89db14c68a69b718a195b5333ebcf63d8e1ac4d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->