### PR TITLE
fix: standardize way to get sso blocked domains

### DIFF
--- a/web/src/features/auth-credentials/server/signupApiHandler.ts
+++ b/web/src/features/auth-credentials/server/signupApiHandler.ts
@@ -5,6 +5,14 @@ import { getSsoAuthProviderIdForDomain } from "@/src/ee/features/multi-tenant-ss
 import type { NextApiRequest, NextApiResponse } from "next";
 import { logger } from "@langfuse/shared/src/server";
 
+export function getSSOBlockedDomains() {
+  return (
+    env.AUTH_DOMAINS_WITH_SSO_ENFORCEMENT?.split(",")
+      .map((domain) => domain.trim().toLowerCase())
+      .filter(Boolean) ?? []
+  );
+}
+
 /*
  * Sign-up endpoint (email/password users), creates user in database.
  * SSO users are created by the NextAuth adapters.
@@ -41,10 +49,7 @@ export async function signupApiHandler(
   const body = validBody.data;
 
   // check if email domain is blocked from email/password sign up via env
-  const blockedDomains =
-    env.AUTH_DOMAINS_WITH_SSO_ENFORCEMENT?.split(",")
-      .map((domain) => domain.trim().toLowerCase())
-      .filter(Boolean) ?? [];
+  const blockedDomains = getSSOBlockedDomains();
   const domain = body.email.split("@")[1]?.toLowerCase();
   if (domain && blockedDomains.includes(domain)) {
     res.status(422).json({

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -50,6 +50,7 @@ import {
 } from "@/src/features/entitlements/server/getPlan";
 import { projectRoleAccessRights } from "@/src/features/rbac/constants/projectAccessRights";
 import { hasEntitlementBasedOnPlan } from "@/src/features/entitlements/server/hasEntitlement";
+import { getSSOBlockedDomains } from "@/src/features/auth-credentials/server/signupApiHandler";
 
 function canCreateOrganizations(userEmail: string | null): boolean {
   const instancePlan = getSelfHostedInstancePlanServerSide();
@@ -111,8 +112,7 @@ const staticProviders: Provider[] = [
         }
       }
 
-      const blockedDomains =
-        env.AUTH_DOMAINS_WITH_SSO_ENFORCEMENT?.split(",") ?? [];
+      const blockedDomains = getSSOBlockedDomains();
       const domain = credentials.email.split("@")[1]?.toLowerCase();
       if (domain && blockedDomains.includes(domain)) {
         throw new Error(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Standardizes retrieval of SSO blocked domains by introducing `getSSOBlockedDomains()` function and using it in `signupApiHandler.ts` and `auth.ts`.
> 
>   - **Functionality**:
>     - Introduces `getSSOBlockedDomains()` in `signupApiHandler.ts` to standardize retrieval of SSO blocked domains.
>     - Replaces inline logic with `getSSOBlockedDomains()` in `signupApiHandler.ts` and `auth.ts`.
>   - **Behavior**:
>     - No change in behavior; refactor for consistency and maintainability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7a7a63e61fadf697563ad285bc92b213f0dd3140. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->