### PR TITLE
fix: always return 422 for signup error handler

### DIFF
--- a/web/src/features/auth-credentials/server/signupApiHandler.ts
+++ b/web/src/features/auth-credentials/server/signupApiHandler.ts
@@ -74,7 +74,7 @@ export async function signupApiHandler(
   } catch (error) {
     const message =
       "Signup: Error creating user: " +
-      (error instanceof Error ? error.message : error);
+      (error instanceof Error ? error.message : JSON.stringify(error));
     logger.warn(message, body.email.toLowerCase(), body.name);
     res.status(422).json({ message: message });
 

--- a/web/src/features/auth-credentials/server/signupApiHandler.ts
+++ b/web/src/features/auth-credentials/server/signupApiHandler.ts
@@ -73,7 +73,7 @@ export async function signupApiHandler(
     );
   } catch (error) {
     const message =
-      "Signup: Error creating user" +
+      "Signup: Error creating user: " +
       (error instanceof Error ? error.message : error);
     logger.warn(message, body.email.toLowerCase(), body.name);
     res.status(422).json({ message: message });

--- a/web/src/features/auth-credentials/server/signupApiHandler.ts
+++ b/web/src/features/auth-credentials/server/signupApiHandler.ts
@@ -72,16 +72,12 @@ export async function signupApiHandler(
       body.name,
     );
   } catch (error) {
-    if (error instanceof Error) {
-      logger.warn(
-        "Signup: Error creating user",
-        error.message,
-        body.email.toLowerCase(),
-        body.name,
-        error,
-      );
-      res.status(422).json({ message: error.message });
-    }
+    const message =
+      "Signup: Error creating user" +
+      (error instanceof Error ? error.message : error);
+    logger.warn(message, body.email.toLowerCase(), body.name);
+    res.status(422).json({ message: message });
+
     return;
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure `signupApiHandler` always returns 422 for user creation errors, with consistent error logging.
> 
>   - **Behavior**:
>     - In `signupApiHandler`, always return 422 status for errors during user creation.
>     - Simplifies error handling by consolidating error message construction and logging.
>   - **Logging**:
>     - Logs error message consistently, whether `error` is an instance of `Error` or not.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 898b45b2328aa8886c049eb2e2a5101fe5055870. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->