### PR TITLE
chore: move dashboard button to the right, unify eval headers

### DIFF
--- a/web/src/ee/features/evals/pages/templates.tsx
+++ b/web/src/ee/features/evals/pages/templates.tsx
@@ -33,7 +33,7 @@ export default function TemplatesPage() {
   return (
     <Page
       headerProps={{
-        title: "Eval Templates",
+        title: "Evaluators",
         help: {
           description:
             "Create an evaluation template. Choose from one of the pre-defined templates or create your own.",

--- a/web/src/pages/project/[projectId]/evals/log.tsx
+++ b/web/src/pages/project/[projectId]/evals/log.tsx
@@ -30,7 +30,7 @@ export default function LogPage() {
   return (
     <Page
       headerProps={{
-        title: "Eval Log",
+        title: "Evaluators",
         help: {
           description: "View of all running evals.",
           href: "https://langfuse.com/docs/scores/model-based-evals",

--- a/web/src/pages/project/[projectId]/users/[userId].tsx
+++ b/web/src/pages/project/[projectId]/users/[userId].tsx
@@ -58,7 +58,8 @@ export default function UserPage() {
         title: userId,
         breadcrumb: [{ name: "Users", href: `/project/${projectId}/users` }],
         itemType: "USER",
-        actionButtonsLeft: (
+
+        actionButtonsRight: (
           <>
             <ActionButton
               href={`/project/${projectId}?filter=user%3Bstring%3B%3B%3D%3B${userId}`} // dashboard filter serialization
@@ -67,16 +68,14 @@ export default function UserPage() {
             >
               Dashboard
             </ActionButton>
+            <DetailPageNav
+              currentId={encodeURIComponent(userId)}
+              path={(entry) =>
+                `/project/${projectId}/users/${encodeURIComponent(entry.id)}`
+              }
+              listKey="users"
+            />
           </>
-        ),
-        actionButtonsRight: (
-          <DetailPageNav
-            currentId={encodeURIComponent(userId)}
-            path={(entry) =>
-              `/project/${projectId}/users/${encodeURIComponent(entry.id)}`
-            }
-            listKey="users"
-          />
         ),
       }}
     >


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move `Dashboard` button to the right and rename page titles to `Evaluators`.
> 
>   - **UI Changes**:
>     - Move `Dashboard` button from `actionButtonsLeft` to `actionButtonsRight` in `UserPage`.
>     - Rename page titles from `Eval Templates` and `Eval Log` to `Evaluators` in `templates.tsx` and `log.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8b457e7619bbf08b81c4049548e761ecec8c6009. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->