### PR TITLE
fix: disable tracing for resetPassword route

### DIFF
--- a/web/src/features/auth-credentials/server/credentialsRouter.ts
+++ b/web/src/features/auth-credentials/server/credentialsRouter.ts
@@ -1,12 +1,15 @@
 import { z } from "zod";
-import { createTRPCRouter, protectedProcedure } from "@/src/server/api/trpc";
+import {
+  createTRPCRouter,
+  protectedProcedureWithoutTracing,
+} from "@/src/server/api/trpc";
 import { updateUserPassword } from "@/src/features/auth-credentials/lib/credentialsServerUtils";
 import { TRPCError } from "@trpc/server";
 import { isEmailVerifiedWithinCutoff } from "@/src/features/auth-credentials/lib/credentialsUtils";
 import { passwordSchema } from "@/src/features/auth/lib/signupSchema";
 
 export const credentialsRouter = createTRPCRouter({
-  resetPassword: protectedProcedure
+  resetPassword: protectedProcedureWithoutTracing
     .input(
       z.object({
         password: passwordSchema,

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -180,6 +180,10 @@ export const protectedProcedure = withOtelTracingProcedure
   .use(withErrorHandling)
   .use(enforceUserIsAuthed);
 
+export const protectedProcedureWithoutTracing = t.procedure
+  .use(withErrorHandling)
+  .use(enforceUserIsAuthed);
+
 const inputProjectSchema = z.object({
   projectId: z.string(),
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Disables tracing for `resetPassword` route by using `protectedProcedureWithoutTracing` in `credentialsRouter.ts`.
> 
>   - **Behavior**:
>     - Disables tracing for `resetPassword` route in `credentialsRouter.ts` by using `protectedProcedureWithoutTracing`.
>   - **Procedures**:
>     - Adds `protectedProcedureWithoutTracing` in `trpc.ts` without tracing middleware, but with error handling and authentication enforcement.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4e7ec10e8688a9a8376935f1b1cefee330d62756. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->