### PR TITLE
fix: use aes-gcm 12 bytes for IV

### DIFF
--- a/packages/shared/src/encryption/index.ts
+++ b/packages/shared/src/encryption/index.ts
@@ -2,7 +2,7 @@ import crypto from "crypto";
 import { env } from "../env";
 
 const ENCRYPTION_KEY: string | undefined = env.ENCRYPTION_KEY; // Must be 256 bits (32 bytes, 64 hex characters)
-const IV_LENGTH: number = 16; // For AES, this is always 16
+const IV_LENGTH: number = 12; // For AES-GCM, this is always 16
 
 // Alternatively: openssl rand -hex 32
 export function keyGen() {
@@ -23,7 +23,7 @@ export function encrypt(plainText: string): string {
   const cipher = crypto.createCipheriv(
     "aes-256-gcm",
     Buffer.from(ENCRYPTION_KEY, "hex"),
-    iv
+    iv,
   );
   let encrypted = cipher.update(plainText, "utf8", "hex");
   encrypted += cipher.final("hex");
@@ -49,7 +49,7 @@ export function decrypt(text: string): string {
   const decipher = crypto.createDecipheriv(
     "aes-256-gcm",
     Buffer.from(ENCRYPTION_KEY, "hex"),
-    iv
+    iv,
   );
   decipher.setAuthTag(authTag);
 

--- a/packages/shared/src/encryption/index.ts
+++ b/packages/shared/src/encryption/index.ts
@@ -2,7 +2,7 @@ import crypto from "crypto";
 import { env } from "../env";
 
 const ENCRYPTION_KEY: string | undefined = env.ENCRYPTION_KEY; // Must be 256 bits (32 bytes, 64 hex characters)
-const IV_LENGTH: number = 12; // For AES-GCM, this is always 16
+const IV_LENGTH: number = 12; // For AES-GCM, this is always 12
 
 // Alternatively: openssl rand -hex 32
 export function keyGen() {

--- a/web/src/ee/features/playground/server/chatCompletionHandler.ts
+++ b/web/src/ee/features/playground/server/chatCompletionHandler.ts
@@ -34,6 +34,8 @@ export default async function chatCompletionHandler(req: NextRequest) {
       },
     });
 
+    console.log("LLMApiKey", JSON.stringify(LLMApiKey, null, 2));
+
     if (!LLMApiKey)
       throw new InvalidRequestError(
         `No ${modelParams.provider} API key found in project. Please add one in the project settings.`,

--- a/web/src/ee/features/playground/server/chatCompletionHandler.ts
+++ b/web/src/ee/features/playground/server/chatCompletionHandler.ts
@@ -34,8 +34,6 @@ export default async function chatCompletionHandler(req: NextRequest) {
       },
     });
 
-    console.log("LLMApiKey", JSON.stringify(LLMApiKey, null, 2));
-
     if (!LLMApiKey)
       throw new InvalidRequestError(
         `No ${modelParams.provider} API key found in project. Please add one in the project settings.`,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change `IV_LENGTH` to 12 bytes for AES-GCM in `index.ts`, updating `encrypt()` and `decrypt()` functions accordingly.
> 
>   - **Behavior**:
>     - Change `IV_LENGTH` from 16 to 12 in `index.ts` for AES-GCM encryption.
>     - Update `encrypt()` and `decrypt()` functions to use 12-byte IVs.
>   - **Misc**:
>     - No changes to the logic of encryption or decryption, only the IV length is adjusted.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 162779b976b6f4ecc434eb1e92e9542b7b701f86. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->