### PR TITLE
fix(ui): overlap on dataset runs screen

### DIFF
--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -49,11 +49,11 @@ const PageHeader = ({
         <div className="bg-header">
           <div
             className={cn(
-              "grid min-h-12 min-w-0 max-w-full grid-cols-[minmax(auto,1fr)_auto] items-center justify-between gap-1 px-3 py-1",
+              "grid min-h-12 min-w-0 max-w-full grid-cols-[1fr,1fr] items-center justify-between gap-1 px-3 py-1 md:grid-cols-[auto,auto]",
               container && "lg:container",
             )}
           >
-            <div className="flex min-w-0 max-w-full items-center gap-1">
+            <div className="flex grow items-center gap-1 overflow-y-auto md:min-w-28">
               {itemType && (
                 <div className="flex h-12 items-center">
                   <ItemBadge type={itemType} showLabel />
@@ -76,9 +76,11 @@ const PageHeader = ({
                   </span>
                 </h2>
               </div>
-              <div className="flex items-center gap-1">{actionButtonsLeft}</div>
+              <div className="flex flex-shrink items-center gap-1 overflow-y-auto">
+                {actionButtonsLeft}
+              </div>
             </div>
-            <div className="flex flex-row flex-wrap items-center justify-end gap-1">
+            <div className="flex flex-wrap items-center justify-end gap-1">
               {actionButtonsRight}
             </div>
           </div>

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
@@ -189,7 +189,7 @@ export default function DatasetCompare() {
                 onClick={() => capture("dataset_run:new_form_open")}
               >
                 <FlaskConical className="h-4 w-4" />
-                <span className="ml-2">New experiment</span>
+                <span className="ml-2 hidden md:block">New experiment</span>
               </Button>
             </DialogTrigger>
             <DialogContent className="max-h-[90vh] overflow-y-auto">
@@ -209,7 +209,7 @@ export default function DatasetCompare() {
             <PopoverTrigger asChild>
               <Button variant="outline">
                 <FolderKanban className="mr-2 h-4 w-4" />
-                Dataset details
+                <span className="hidden md:block">Dataset details</span>
               </Button>
             </PopoverTrigger>
             <PopoverContent className="mx-2 max-h-[50vh] w-[50vw] overflow-y-auto md:w-[25vw]">

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
@@ -159,7 +159,7 @@ export default function Dataset() {
                   onClick={() => capture("dataset_run:new_form_open")}
                 >
                   <FlaskConical className="h-4 w-4" />
-                  <span className="ml-2">New experiment</span>
+                  <span className="ml-2 hidden md:block">New experiment</span>
                 </Button>
               </DialogTrigger>
               <DialogContent className="max-h-[90vh] overflow-y-auto">
@@ -216,7 +216,7 @@ export default function Dataset() {
               <PopoverTrigger asChild>
                 <Button variant="outline">
                   <FolderKanban className="mr-2 h-4 w-4" />
-                  Dataset details
+                  <span className="hidden md:block">Dataset details</span>
                 </Button>
               </PopoverTrigger>
               <PopoverContent className="mx-2 max-h-[50vh] w-[50vw] overflow-y-auto md:w-[25vw]">

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/items.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/items.tsx
@@ -76,7 +76,7 @@ export default function DatasetItems() {
               <PopoverTrigger asChild>
                 <Button variant="outline">
                   <FolderKanban className="mr-2 h-4 w-4" />
-                  Dataset details
+                  <span className="hidden md:block">Dataset details</span>
                 </Button>
               </PopoverTrigger>
               <PopoverContent className="mx-2 max-h-[50vh] w-[50vw] overflow-y-auto md:w-[25vw]">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> UI adjustments in dataset pages to prevent overlap and improve responsiveness, including grid layout changes and conditional text visibility.
> 
>   - **UI Layout Adjustments**:
>     - In `page-header.tsx`, changed grid layout to `grid-cols-[1fr,1fr]` and added `md:grid-cols-[auto,auto]` for responsive design.
>     - Adjusted `flex` properties and added `overflow-y-auto` to prevent overlap and ensure proper display of elements.
>   - **Responsive Text Visibility**:
>     - In `compare.tsx`, `index.tsx`, and `items.tsx`, wrapped text elements like "New experiment" and "Dataset details" in `<span className="hidden md:block">` to hide them on smaller screens.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e0a9c48493dc68d2989f6d8d37b7ecd9a4c1a74b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->