### PR TITLE
chore: add env.HOSTNAME support for worker container

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -7,6 +7,7 @@ const EnvSchema = z.object({
     .enum(["development", "test", "production"])
     .default("development"),
   DATABASE_URL: z.string(),
+  HOSTNAME: z.string().default("0.0.0.0"),
   PORT: z.coerce
     .number({
       description:

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3,6 +3,6 @@ import app from "./app";
 import { env } from "./env";
 import { logger } from "@langfuse/shared/src/server";
 
-export const server = app.listen(env.PORT, () => {
-  logger.info(`Listening: http://localhost:${env.PORT}`);
+export const server = app.listen(env.PORT, env.HOSTNAME, () => {
+  logger.info(`Listening: http://${env.HOSTNAME}:${env.PORT}`);
 });


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/5699
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `HOSTNAME` environment variable support for worker container, updating server configuration in `index.ts`.
> 
>   - **Environment Variables**:
>     - Add `HOSTNAME` to `EnvSchema` in `env.ts` with default `"0.0.0.0"`.
>   - **Server Configuration**:
>     - Update `app.listen` in `index.ts` to use `env.HOSTNAME` for server hostname.
>     - Log server URL with `env.HOSTNAME` in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4bfb094e0cf40ea43720c124db6448277c95063b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->