### PR TITLE
chore: skip tracing for LLM Api key routes

### DIFF
--- a/web/src/features/llm-api-key/server/router.ts
+++ b/web/src/features/llm-api-key/server/router.ts
@@ -5,6 +5,7 @@ import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAc
 import {
   createTRPCRouter,
   protectedProjectProcedure,
+  protectedProjectProcedureWithoutTracing,
 } from "@/src/server/api/trpc";
 import {
   type ChatMessage,
@@ -27,7 +28,7 @@ export function getDisplaySecretKey(secretKey: string) {
 }
 
 export const llmApiKeyRouter = createTRPCRouter({
-  create: protectedProjectProcedure
+  create: protectedProjectProcedureWithoutTracing
     .input(CreateLlmApiKey)
     .mutation(async ({ input, ctx }) => {
       try {
@@ -150,7 +151,7 @@ export const llmApiKeyRouter = createTRPCRouter({
       };
     }),
 
-  test: protectedProjectProcedure
+  test: protectedProjectProcedureWithoutTracing
     .input(CreateLlmApiKey)
     .mutation(async ({ input }) => {
       try {

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -274,6 +274,10 @@ export const protectedProjectProcedure = withOtelTracingProcedure
   .use(withErrorHandling)
   .use(enforceUserIsAuthedAndProjectMember);
 
+export const protectedProjectProcedureWithoutTracing = t.procedure
+  .use(withErrorHandling)
+  .use(enforceUserIsAuthedAndProjectMember);
+
 const inputOrganizationSchema = z.object({
   orgId: z.string(),
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Skip tracing for `create` and `test` routes in LLM API key router by using `protectedProjectProcedureWithoutTracing`.
> 
>   - **Behavior**:
>     - Skip tracing for `create` and `test` routes in `llmApiKeyRouter` by using `protectedProjectProcedureWithoutTracing` in `router.ts`.
>   - **Procedures**:
>     - Add `protectedProjectProcedureWithoutTracing` in `trpc.ts` without tracing middleware, using `withErrorHandling` and `enforceUserIsAuthedAndProjectMember`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e6c6c4e0e5460aa623b21b29fd11cb067f033c75. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->