### PR TITLE
chore(ui): remove redundant className props from splash screens

### DIFF
--- a/web/src/components/onboarding/TracesOnboarding.tsx
+++ b/web/src/components/onboarding/TracesOnboarding.tsx
@@ -51,7 +51,6 @@ export function TracesOnboarding({ projectId }: TracesOnboardingProps) {
         href: "https://langfuse.com/docs/tracing",
       }}
       videoSrc="https://static.langfuse.com/prod-assets/onboarding/tracing-overview-v1.mp4"
-      className="bg-background dark:bg-background dark:text-white"
     />
   );
 }

--- a/web/src/components/onboarding/UsersOnboarding.tsx
+++ b/web/src/components/onboarding/UsersOnboarding.tsx
@@ -52,7 +52,6 @@ export function UsersOnboarding() {
         </span>
       }
       videoSrc="https://static.langfuse.com/prod-assets/onboarding/users-overview-v1.mp4"
-      className="bg-background dark:bg-background dark:text-white"
     />
   );
 }

--- a/web/src/components/ui/splash-screen.tsx
+++ b/web/src/components/ui/splash-screen.tsx
@@ -76,15 +76,9 @@ export function SplashScreen({
   primaryAction,
   secondaryAction,
   gettingStarted,
-  className,
 }: SplashScreenProps) {
   return (
-    <div
-      className={cn(
-        "mx-auto flex max-w-4xl flex-col items-center p-8",
-        className,
-      )}
-    >
+    <div className={cn("mx-auto flex max-w-4xl flex-col items-center p-8")}>
       <div className="mb-6 text-center">
         <h2 className="mb-2 text-2xl font-bold">{title}</h2>
         <p className="text-muted-foreground">{description}</p>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `className` prop from `SplashScreen` in onboarding components and `splash-screen.tsx`.
> 
>   - **Components**:
>     - Remove `className` prop from `SplashScreen` in `TracesOnboarding.tsx` and `UsersOnboarding.tsx`.
>   - **UI**:
>     - Remove `className` prop usage in `SplashScreen` component in `splash-screen.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for af523a21baa0b8d7b60b2364cbc0ac39793b6f56. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->