### PR TITLE
fix(ui): overflow behaviour on trace timeline

### DIFF
--- a/web/src/components/trace/TraceTimelineView.tsx
+++ b/web/src/components/trace/TraceTimelineView.tsx
@@ -537,7 +537,10 @@ export function TraceTimelineView({
             )}
           </div>
         </div>
-        <div style={{ width: `${SCALE_WIDTH}px` }} className="overflow-hidden">
+        <div
+          style={{ width: `${SCALE_WIDTH}px` }}
+          className="overflow-y-auto overflow-x-hidden"
+        >
           <SimpleTreeView
             expandedItems={expandedItems}
             onExpandedItemsChange={(_, itemIds) => setExpandedItems(itemIds)}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify overflow behavior in `TraceTimelineView.tsx` to allow vertical scrolling and hide horizontal overflow.
> 
>   - **UI Behavior**:
>     - In `TraceTimelineView.tsx`, change overflow behavior of a div to `overflow-y-auto overflow-x-hidden` to allow vertical scrolling and hide horizontal overflow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for eef622b0a5b4a0e81074c5508e8c16681a2678e4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->