### PR TITLE
fix(cloud): only active evals should count towards plan limit

### DIFF
--- a/web/src/ee/features/evals/pages/evaluators.tsx
+++ b/web/src/ee/features/evals/pages/evaluators.tsx
@@ -110,7 +110,7 @@ export default function EvaluatorsPage() {
             variant="outline"
             onClick={() => capture("eval_config:new_form_open")}
             href={`/project/${projectId}/evals/new`}
-            limitValue={countsQuery.data?.configCount ?? 0}
+            limitValue={countsQuery.data?.configActiveCount ?? 0}
             limit={evaluatorLimit}
           >
             New evaluator

--- a/web/src/ee/features/evals/server/router.ts
+++ b/web/src/ee/features/evals/server/router.ts
@@ -149,22 +149,32 @@ export const evalRouter = createTRPCRouter({
         scope: "evalJob:read",
       });
 
-      const [configCount, templateCount] = await Promise.all([
-        ctx.prisma.jobConfiguration.count({
-          where: {
-            projectId: input.projectId,
-            jobType: "EVAL",
-          },
-        }),
-        ctx.prisma.evalTemplate.count({
-          where: {
-            projectId: input.projectId,
-          },
-        }),
-      ]);
+      const [configCount, configActiveCount, templateCount] = await Promise.all(
+        [
+          ctx.prisma.jobConfiguration.count({
+            where: {
+              projectId: input.projectId,
+              jobType: "EVAL",
+            },
+          }),
+          ctx.prisma.jobConfiguration.count({
+            where: {
+              projectId: input.projectId,
+              jobType: "EVAL",
+              status: "ACTIVE",
+            },
+          }),
+          ctx.prisma.evalTemplate.count({
+            where: {
+              projectId: input.projectId,
+            },
+          }),
+        ],
+      );
 
       return {
         configCount,
+        configActiveCount,
         templateCount,
       };
     }),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update evaluator count checks to only consider active evaluators in both frontend and backend.
> 
>   - **Behavior**:
>     - Update `limitValue` in `EvaluatorsPage` to use `configActiveCount` instead of `configCount`.
>     - Modify `counts` query in `evalRouter` to include `configActiveCount` for active evaluators.
>   - **Backend**:
>     - Add `configActiveCount` to `counts` query in `router.ts` to count only active evaluators.
>   - **Frontend**:
>     - Change `limitValue` in `evaluators.tsx` to use `configActiveCount` for plan limit checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8c32c7977c0ea1d20692886d37c8d8311ff963a8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->