### PR TITLE
fix(ui): add playsInline attribute to video players

### DIFF
--- a/web/src/components/ui/LangfuseMediaView.tsx
+++ b/web/src/components/ui/LangfuseMediaView.tsx
@@ -156,7 +156,7 @@ function VideoPlayer({ src }: { src?: string }) {
   if (!src) return null;
 
   return (
-    <video controls className="w-full" preload="metadata">
+    <video controls className="w-full" preload="metadata" playsInline>
       <source src={src} />
       Your browser does not support the video element.
     </video>

--- a/web/src/components/ui/splash-screen.tsx
+++ b/web/src/components/ui/splash-screen.tsx
@@ -58,6 +58,7 @@ function VideoPlayer({ videoSrc }: VideoPlayerProps) {
         autoPlay
         muted
         loop
+        playsInline
         controlsList="nodownload"
         className="w-full"
         onError={() => setHasError(true)}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `playsInline` attribute to video elements in `LangfuseMediaView.tsx` and `splash-screen.tsx` for inline playback on mobile.
> 
>   - **Behavior**:
>     - Add `playsInline` attribute to `<video>` elements in `LangfuseMediaView.tsx` and `splash-screen.tsx` to enable inline playback on mobile browsers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ff5713761393826f787be607cbc33a934e48d575. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->