### PR TITLE
feat(datasets): add archive/unarchive functionality for dataset items on single item view

### DIFF
--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId].tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId].tsx
@@ -112,8 +112,9 @@ export default function Dataset() {
                           : "Unarchive this item?"}
                       </h4>
                       <p className="text-sm text-muted-foreground">
-                        Archiving an item will exclude it from new experiment
-                        runs.
+                        {item.data.status === DatasetStatus.ACTIVE
+                          ? "Archiving an item will exclude it from new experiment runs."
+                          : "Unarchiving an item will include it back in new experiment runs."}
                       </p>
                     </div>
                     <Button

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId].tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId].tsx
@@ -13,12 +13,25 @@ import { api } from "@/src/utils/api";
 import { ListTree } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { DatasetStatus } from "@langfuse/shared";
+import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/src/components/ui/popover";
+import { useState } from "react";
 
 export default function Dataset() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
   const datasetId = router.query.datasetId as string;
   const itemId = router.query.itemId as string;
+  const hasAccess = useHasProjectAccess({ projectId, scope: "datasets:CUD" });
+  const capture = usePostHogClientCapture();
+  const utils = api.useUtils();
+  const [isArchivePopoverOpen, setIsArchivePopoverOpen] = useState(false);
 
   const dataset = api.datasets.byId.useQuery({
     datasetId,
@@ -34,6 +47,33 @@ export default function Dataset() {
       refetchOnWindowFocus: false, // breaks dirty form state
     },
   );
+
+  const mutUpdate = api.datasets.updateDatasetItem.useMutation({
+    onSuccess: () => {
+      utils.datasets.invalidate();
+      setIsArchivePopoverOpen(false);
+    },
+  });
+
+  const toggleArchiveStatus = () => {
+    if (!item.data?.status || !hasAccess || mutUpdate.isLoading) return;
+
+    const newStatus =
+      item.data.status === DatasetStatus.ARCHIVED
+        ? DatasetStatus.ACTIVE
+        : DatasetStatus.ARCHIVED;
+
+    capture("dataset_item:archive_toggle", {
+      status: newStatus === DatasetStatus.ARCHIVED ? "archived" : "unarchived",
+    });
+
+    mutUpdate.mutate({
+      projectId,
+      datasetId,
+      datasetItemId: itemId,
+      status: newStatus,
+    });
+  };
 
   return (
     <Page
@@ -53,8 +93,51 @@ export default function Dataset() {
         ],
         actionButtonsLeft: (
           <>
+            {item.data?.status && (
+              <Popover
+                open={isArchivePopoverOpen}
+                onOpenChange={setIsArchivePopoverOpen}
+              >
+                <PopoverTrigger asChild>
+                  <Button variant="ghost" size="xs">
+                    {item.data.status}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-80" align="start" side="bottom">
+                  <div className="flex flex-col gap-4">
+                    <div className="space-y-2">
+                      <h4 className="font-medium leading-none">
+                        {item.data.status === DatasetStatus.ACTIVE
+                          ? "Archive this item?"
+                          : "Unarchive this item?"}
+                      </h4>
+                      <p className="text-sm text-muted-foreground">
+                        Archiving an item will exclude it from new experiment
+                        runs.
+                      </p>
+                    </div>
+                    <Button
+                      onClick={toggleArchiveStatus}
+                      disabled={!hasAccess || mutUpdate.isLoading}
+                      variant={
+                        item.data.status === DatasetStatus.ACTIVE
+                          ? "destructive"
+                          : "default"
+                      }
+                      size="sm"
+                    >
+                      {mutUpdate.isLoading
+                        ? "Processing..."
+                        : item.data.status === DatasetStatus.ACTIVE
+                          ? "Archive"
+                          : "Unarchive"}
+                    </Button>
+                  </div>
+                </PopoverContent>
+              </Popover>
+            )}
             {item.data?.sourceTraceId && (
-              <Button variant="outline" asChild>
+              <Button variant="ghost" size="icon-xs" asChild>
                 <Link
                   href={`/project/${projectId}/traces/${item.data.sourceTraceId}`}
                   title={`View source ${item.data.sourceObservationId ? "observation" : "trace"}`}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds archive/unarchive functionality for dataset items and introduces LLM connections settings page.
> 
>   - **Dataset Item Archive/Unarchive**:
>     - Adds archive/unarchive functionality in `items/[itemId].tsx`.
>     - Uses `Popover` for UI interaction to toggle item status between `ACTIVE` and `ARCHIVED`.
>     - Utilizes `useMutation` for updating dataset item status and `usePostHogClientCapture` for analytics.
>   - **Settings Page Enhancements**:
>     - Adds "LLM Connections" settings page in `settings/index.tsx`.
>     - Uses `useEntitlements` to conditionally show the LLM connections page based on entitlements.
>     - Updates `getProjectSettingsPages` to include LLM connections settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 25116dfbbe2ef3b6e6b3076730c36842da71fe7d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->