### PR TITLE
perf: reduce memory consumption on observations query

### DIFF
--- a/web/src/features/public-api/server/observations.ts
+++ b/web/src/features/public-api/server/observations.ts
@@ -25,14 +25,6 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
   const appliedFilter = chFilter.apply();
   const traceFilter = chFilter.find((f) => f.clickhouseTable === "traces");
 
-  // This _must_ be updated if we add a new skip index column to the observations table.
-  // Otherwise, we will ignore it in most cases due to `FINAL`.
-  const shouldUseSkipIndexes = chFilter.some(
-    (f) =>
-      f.clickhouseTable === "observations" &&
-      ["trace_id"].some((skipIndexCol) => f.field.includes(skipIndexCol)),
-  );
-
   const query = `
     with clickhouse_keys as (
       SELECT DISTINCT

--- a/web/src/features/public-api/server/observations.ts
+++ b/web/src/features/public-api/server/observations.ts
@@ -35,18 +35,17 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
 
   const query = `
     with clickhouse_keys as (
-      SELECT
+      SELECT DISTINCT
         id,
-        trace_id,
         project_id,
         type,
-        toUnixTimestamp(start_time),
-      FROM observations o ${shouldUseSkipIndexes ? "" : "FINAL"}
+        toDate(start_time),
+      FROM observations o
       ${traceFilter ? `LEFT JOIN traces t ON o.trace_id = t.id AND t.project_id = o.project_id` : ""}
       WHERE o.project_id = {projectId: String}
       ${traceFilter ? `AND t.project_id = {projectId: String}` : ""}
       AND ${appliedFilter.query}
-      ${shouldUseSkipIndexes ? "ORDER BY start_time desc, event_ts desc LIMIT 1 by id, project_id" : "ORDER BY start_time DESC"}
+      ORDER BY start_time DESC
       ${props.limit !== undefined && props.page !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
     )
       SELECT 
@@ -80,13 +79,11 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
         created_at,
         updated_at,
         event_ts
-      FROM observations o ${shouldUseSkipIndexes ? "" : "FINAL"}
-      
+      FROM observations o FINAL
       WHERE o.project_id = {projectId: String}
-      AND (id, trace_id, project_id, type, toUnixTimestamp(start_time)) in (select * from clickhouse_keys)
-
-      ${shouldUseSkipIndexes ? "ORDER BY start_time desc, event_ts desc LIMIT 1 by id, project_id" : "ORDER BY start_time DESC"}
-      `;
+      AND (id, project_id, type, toDate(start_time)) in (select * from clickhouse_keys)
+      ORDER BY start_time DESC
+    `;
 
   const result = await queryClickhouse<ObservationRecordReadType>({
     query,


### PR DESCRIPTION
## What

- Set the main query to always use `FINAL` since we should very efficiently filter the results down with the sub-query. That should allow for sufficient performance and guarantees we only return the latest results.
- Use distinct over the sorting keys in the CTE as this returns all relevant fields and makes optimal use of the sorting index in the main query. That way we can also drop all deduplication as it happens towards the end with DISTINCT.
- Drop the trace_id from the query as the result should be sufficiently unique without it.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Optimize `generateObservationsForPublicApi()` query in `observations.ts` by using `FINAL`, `DISTINCT`, and removing `trace_id` for better performance.
> 
>   - **Query Optimization**:
>     - Use `FINAL` in main query to ensure latest results in `generateObservationsForPublicApi()`.
>     - Use `DISTINCT` over sorting keys in CTE for efficient deduplication.
>     - Remove `trace_id` from query as results are unique without it.
>   - **Code Changes**:
>     - Remove `shouldUseSkipIndexes` logic in `generateObservationsForPublicApi()`.
>     - Simplify `ORDER BY` clause in `generateObservationsForPublicApi()` and `getObservationsCountForPublicApi()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for de0c46c9f28538d170f6e5048ea0ec51b624c527. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->