### PR TITLE
feat(datasets): allow for deletion of dataset items in ui and public API

### DIFF
--- a/fern/apis/server/definition/dataset-items.yml
+++ b/fern/apis/server/definition/dataset-items.yml
@@ -37,8 +37,21 @@ service:
             type: optional<integer>
             docs: limit of items per page
       response: PaginatedDatasetItems
+    delete:
+      docs: Delete a dataset item and all its run items. This action is irreversible.
+      method: DELETE
+      path: /dataset-items/{id}
+      path-parameters:
+        id:
+          type: string
+      response: DeleteDatasetItemResponse
 
 types:
+  DeleteDatasetItemResponse:
+    properties:
+      message:
+        type: string
+        docs: Success message after deletion
   CreateDatasetItemRequest:
     properties:
       datasetName: string

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -366,6 +366,53 @@ paths:
               schema: {}
       security:
         - BasicAuth: []
+    delete:
+      description: >-
+        Delete a dataset item and all its run items. This action is
+        irreversible.
+      operationId: datasetItems_delete
+      tags:
+        - DatasetItems
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteDatasetItemResponse'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
   /api/public/dataset-run-items:
     post:
       description: Create a dataset run item
@@ -3522,6 +3569,15 @@ components:
         - NUMERIC
         - BOOLEAN
         - CATEGORICAL
+    DeleteDatasetItemResponse:
+      title: DeleteDatasetItemResponse
+      type: object
+      properties:
+        message:
+          type: string
+          description: Success message after deletion
+      required:
+        - message
     CreateDatasetItemRequest:
       title: CreateDatasetItemRequest
       type: object

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -280,6 +280,38 @@
             "body": null
           },
           "response": []
+        },
+        {
+          "_type": "endpoint",
+          "name": "Delete",
+          "request": {
+            "description": "Delete a dataset item and all its run items. This action is irreversible.",
+            "url": {
+              "raw": "{{baseUrl}}/api/public/dataset-items/:id",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "public",
+                "dataset-items",
+                ":id"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "key": "id",
+                  "value": "",
+                  "description": null
+                }
+              ]
+            },
+            "header": [],
+            "method": "DELETE",
+            "auth": null,
+            "body": null
+          },
+          "response": []
         }
       ]
     },

--- a/web/src/__tests__/async/datasets-api.servertest.ts
+++ b/web/src/__tests__/async/datasets-api.servertest.ts
@@ -19,6 +19,7 @@ import {
   PostDatasetRunItemsV1Response,
   PostDatasetsV1Response,
   PostDatasetsV2Response,
+  DeleteDatasetItemV1Response,
 } from "@/src/features/public-api/types/datasets";
 import { v4 as uuidv4 } from "uuid";
 import {
@@ -1125,5 +1126,127 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
         }),
       ]),
     );
+  });
+
+  it("should delete a dataset item and its run items", async () => {
+    const datasetName = `dataset-${uuidv4()}`;
+    const itemId = `item-${uuidv4()}`;
+    const nonExistentItemId = `non-existent-${uuidv4()}`;
+
+    // Create a dataset
+    const dataset = await makeZodVerifiedAPICall(
+      PostDatasetsV1Response,
+      "POST",
+      "/api/public/datasets",
+      {
+        name: datasetName,
+      },
+      auth,
+    );
+    expect(dataset.status).toBe(200);
+
+    // Create a dataset item
+    const datasetItem = await makeZodVerifiedAPICall(
+      PostDatasetItemsV1Response,
+      "POST",
+      "/api/public/dataset-items",
+      {
+        datasetName,
+        id: itemId,
+        input: { key: "value" },
+        expectedOutput: { key: "value" },
+        metadata: { key: "value" },
+      },
+      auth,
+    );
+    expect(datasetItem.status).toBe(200);
+    expect(datasetItem.body.id).toBe(itemId);
+
+    // Create another project and auth to test cross-project access
+    const { auth: otherAuth } = await createOrgProjectAndApiKey();
+
+    // Attempt to delete item with different project's auth should fail
+    const deleteWithWrongAuth = await makeAPICall(
+      "DELETE",
+      `/api/public/dataset-items/${itemId}`,
+      undefined,
+      otherAuth,
+    );
+    expect(deleteWithWrongAuth.status).toBe(404);
+
+    // Attempt to delete non-existent item should fail
+    const deleteNonExistent = await makeAPICall(
+      "DELETE",
+      `/api/public/dataset-items/${nonExistentItemId}`,
+      undefined,
+      auth,
+    );
+    expect(deleteNonExistent.status).toBe(404);
+
+    // Create a run item associated with the dataset item
+    const runItem = await makeZodVerifiedAPICall(
+      PostDatasetRunItemsV1Response,
+      "POST",
+      "/api/public/dataset-run-items",
+      {
+        datasetItemId: itemId,
+        traceId: traceId,
+        runName: `run-${uuidv4()}`,
+        metadata: { key: "value" },
+      },
+      auth,
+    );
+    expect(runItem.status).toBe(200);
+
+    // Verify run item exists in database
+    const dbRunItem = await prisma.datasetRunItems.findFirst({
+      where: {
+        datasetItemId: itemId,
+        projectId: dataset.body.projectId,
+      },
+    });
+    expect(dbRunItem).not.toBeNull();
+
+    // Delete the item and verify response matches DeleteDatasetItemV1Response
+    const deleteResponse = await makeZodVerifiedAPICall(
+      DeleteDatasetItemV1Response,
+      "DELETE",
+      `/api/public/dataset-items/${itemId}`,
+      undefined,
+      auth,
+    );
+    expect(deleteResponse.status).toBe(200);
+    expect(deleteResponse.body).toEqual({
+      message: "Dataset item successfully deleted",
+    });
+
+    // Verify item no longer exists
+    const getDeletedItem = await makeAPICall(
+      "GET",
+      `/api/public/dataset-items/${itemId}`,
+      undefined,
+      auth,
+    );
+    expect(getDeletedItem.status).toBe(404);
+
+    // Verify item is removed from database
+    const dbItem = await prisma.datasetItem.findUnique({
+      where: {
+        id_projectId: {
+          id: itemId,
+          projectId: dataset.body.projectId,
+        },
+      },
+    });
+    expect(dbItem).toBeNull();
+
+    // Verify run items are also deleted
+    const dbRunItemAfterDelete = await prisma.datasetRunItems.findFirst({
+      where: {
+        datasetItemId: itemId,
+        projectId: dataset.body.projectId,
+      },
+    });
+    expect(dbRunItemAfterDelete).toBeNull();
   });
 });

--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
 import { useQueryParams, withDefault, NumberParam } from "use-query-params";
-import { Archive, ListTree, MoreVertical } from "lucide-react";
+import { Archive, ListTree, MoreVertical, Trash2 } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import { type DatasetItem, DatasetStatus, type Prisma } from "@langfuse/shared";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
@@ -86,6 +86,10 @@ export function DatasetItemsTable({
   }, [items.isSuccess, items.data]);
 
   const mutUpdate = api.datasets.updateDatasetItem.useMutation({
+    onSuccess: () => utils.datasets.invalidate(),
+  });
+
+  const mutDelete = api.datasets.deleteDatasetItem.useMutation({
     onSuccess: () => utils.datasets.invalidate(),
   });
 
@@ -245,6 +249,27 @@ export function DatasetItemsTable({
               >
                 <Archive className="mr-2 h-4 w-4" />
                 {status === DatasetStatus.ARCHIVED ? "Unarchive" : "Archive"}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={!hasAccess}
+                className="text-destructive"
+                onClick={() => {
+                  if (
+                    window.confirm(
+                      "Are you sure you want to delete this item? This will also delete all run items that belong to this item.",
+                    )
+                  ) {
+                    capture("dataset_item:delete");
+                    mutDelete.mutate({
+                      projectId: projectId,
+                      datasetId: datasetId,
+                      datasetItemId: id,
+                    });
+                  }
+                }}
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Delete
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/web/src/features/datasets/components/NewDatasetItemFromExistingObject.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemFromExistingObject.tsx
@@ -79,8 +79,8 @@ export const NewDatasetItemFromExistingObject = (props: {
     <>
       {props.isCopyItem ? (
         <ActionButton
-          variant="ghost"
-          size="icon-xs"
+          variant="outline"
+          size="icon"
           hasAccess={hasAccess}
           title="Copy item"
           aria-label="Copy item"

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -8,6 +8,7 @@ import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAc
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { DB } from "@/src/server/db";
 import { paginationZod, DatasetStatus } from "@langfuse/shared";
+import { TRPCError } from "@trpc/server";
 import {
   createDatasetRunsTable,
   createDatasetRunsTableWithoutMetrics,
@@ -481,7 +482,10 @@ export const datasetRouter = createTRPCRouter({
       });
 
       if (!item) {
-        throw new Error("Dataset item not found");
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Dataset item not found",
+        });
       }
 
       // Delete the dataset item
@@ -534,7 +538,10 @@ export const datasetRouter = createTRPCRouter({
         },
       });
       if (!dataset) {
-        throw new Error("Dataset not found");
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Dataset not found",
+        });
       }
 
       // find a unique name for the new dataset
@@ -625,7 +632,10 @@ export const datasetRouter = createTRPCRouter({
         },
       });
       if (!dataset) {
-        throw new Error("Dataset not found");
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Dataset not found",
+        });
       }
 
       const datasetItem = await ctx.prisma.datasetItem.create({
@@ -684,7 +694,10 @@ export const datasetRouter = createTRPCRouter({
       });
 
       if (datasets.length !== datasetIds.length) {
-        throw new Error("One or more datasets not found");
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "One or more datasets not found",
+        });
       }
 
       const itemsWithIds = input.items.map((item) => ({

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -104,6 +104,7 @@ const events = {
     "new_from_trace_form_open",
     "upload_csv_button_click",
     "upload_csv_form_submit",
+    "delete",
   ],
   dataset_run: [
     "delete_form_open",

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -171,6 +171,16 @@ export const GetDatasetItemV1Query = z.object({
 });
 export const GetDatasetItemV1Response = APIDatasetItem.strict();
 
+// DELETE /dataset-items/{datasetItemId}
+export const DeleteDatasetItemV1Query = z.object({
+  datasetItemId: z.string(),
+});
+export const DeleteDatasetItemV1Response = z
+  .object({
+    message: z.literal("Dataset item successfully deleted"),
+  })
+  .strict();
+
 // POST /dataset-run-items
 export const PostDatasetRunItemsV1Body = z
   .object({

--- a/web/src/pages/api/public/dataset-items/[datasetItemId].ts
+++ b/web/src/pages/api/public/dataset-items/[datasetItemId].ts
@@ -4,6 +4,8 @@ import { createAuthedAPIRoute } from "@/src/features/public-api/server/createAut
 import {
   GetDatasetItemV1Query,
   GetDatasetItemV1Response,
+  DeleteDatasetItemV1Query,
+  DeleteDatasetItemV1Response,
   transformDbDatasetItemToAPIDatasetItem,
 } from "@/src/features/public-api/types/datasets";
 import { LangfuseNotFoundError } from "@langfuse/shared";
@@ -41,6 +43,42 @@ export default withMiddlewares({
         ...datasetItemBody,
         datasetName: dataset.name,
       });
+    },
+  }),
+  DELETE: createAuthedAPIRoute({
+    name: "Delete Dataset Item",
+    querySchema: DeleteDatasetItemV1Query,
+    responseSchema: DeleteDatasetItemV1Response,
+    fn: async ({ query, auth }) => {
+      const { datasetItemId } = query;
+
+      // First get the item to check if it exists
+      const datasetItem = await prisma.datasetItem.findUnique({
+        where: {
+          id_projectId: {
+            projectId: auth.scope.projectId,
+            id: datasetItemId,
+          },
+        },
+      });
+
+      if (!datasetItem) {
+        throw new LangfuseNotFoundError("Dataset item not found");
+      }
+
+      // Delete the dataset item
+      await prisma.datasetItem.delete({
+        where: {
+          id_projectId: {
+            projectId: auth.scope.projectId,
+            id: datasetItemId,
+          },
+        },
+      });
+
+      return {
+        message: "Dataset item successfully deleted" as const,
+      };
     },
   }),
 });

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId].tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId].tsx
@@ -166,18 +166,6 @@ export default function Dataset() {
                 </PopoverContent>
               </Popover>
             )}
-            {item.data && (
-              <NewDatasetItemFromExistingObject
-                projectId={projectId}
-                fromDatasetId={item.data.datasetId}
-                traceId={item.data.sourceTraceId ?? undefined}
-                observationId={item.data.sourceObservationId ?? undefined}
-                input={JSON.stringify(item.data.input)}
-                output={JSON.stringify(item.data.expectedOutput)}
-                metadata={JSON.stringify(item.data.metadata)}
-                isCopyItem
-              />
-            )}
             {item.data?.sourceTraceId && (
               <Button variant="ghost" size="icon-xs" asChild>
                 <Link
@@ -199,6 +187,18 @@ export default function Dataset() {
               }
               listKey="datasetItems"
             />
+            {item.data && (
+              <NewDatasetItemFromExistingObject
+                projectId={projectId}
+                fromDatasetId={item.data.datasetId}
+                traceId={item.data.sourceTraceId ?? undefined}
+                observationId={item.data.sourceObservationId ?? undefined}
+                input={JSON.stringify(item.data.input)}
+                output={JSON.stringify(item.data.expectedOutput)}
+                metadata={JSON.stringify(item.data.metadata)}
+                isCopyItem
+              />
+            )}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="outline" size="icon">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add feature to delete dataset items via UI and public API, including backend logic, UI updates, and tests.
> 
>   - **API Changes**:
>     - Add DELETE `/dataset-items/{id}` endpoint in `dataset-items.yml` and `openapi.yml`.
>     - Define `DeleteDatasetItemResponse` type in `dataset-items.yml` and `openapi.yml`.
>     - Implement DELETE logic in `dataset-router.ts` and `[datasetItemId].ts`.
>   - **UI Changes**:
>     - Add delete option in `DatasetItemsTable.tsx` and `[itemId].tsx` using `DropdownMenuItem` with `Trash2` icon.
>     - Update `NewDatasetItemFromExistingObject.tsx` to use `ActionButton` for copy item.
>   - **Testing**:
>     - Add test for deleting dataset items in `datasets-api.servertest.ts`.
>   - **Analytics**:
>     - Add `dataset_item:delete` event in `usePostHogClientCapture.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 884dbb1371be1b444e9f8abd60bb9eed72d6c399. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->