### PR TITLE
fix(ui): overlapping status message on trace detail page

### DIFF
--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -375,23 +375,27 @@ export const ObservationPreview = ({
                   setIsPrettyViewAvailable={setIsPrettyViewAvailable}
                 />
               </div>
-              {preloadedObservation.statusMessage && (
-                <JSONView
-                  key={preloadedObservation.id + "-status"}
-                  title="Status Message"
-                  json={preloadedObservation.statusMessage}
-                />
-              )}
-              {observationWithInputAndOutput.data?.metadata && (
-                <JSONView
-                  key={observationWithInputAndOutput.data.id + "-metadata"}
-                  title="Metadata"
-                  json={observationWithInputAndOutput.data.metadata}
-                  media={observationMedia.data?.filter(
-                    (m) => m.field === "metadata",
-                  )}
-                />
-              )}
+              <div>
+                {preloadedObservation.statusMessage && (
+                  <JSONView
+                    key={preloadedObservation.id + "-status"}
+                    title="Status Message"
+                    json={preloadedObservation.statusMessage}
+                  />
+                )}
+              </div>
+              <div>
+                {observationWithInputAndOutput.data?.metadata && (
+                  <JSONView
+                    key={observationWithInputAndOutput.data.id + "-metadata"}
+                    title="Metadata"
+                    json={observationWithInputAndOutput.data.metadata}
+                    media={observationMedia.data?.filter(
+                      (m) => m.field === "metadata",
+                    )}
+                  />
+                )}
+              </div>
             </div>
           </TabsBarContent>
           {isAuthenticatedAndProjectMember && (

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -260,14 +260,16 @@ export const TracePreview = ({
                   setIsPrettyViewAvailable={setIsPrettyViewAvailable}
                 />
               </div>
-              <JSONView
-                key={trace.id + "-metadata"}
-                title="Metadata"
-                json={trace.metadata}
-                media={
-                  traceMedia.data?.filter((m) => m.field === "metadata") ?? []
-                }
-              />
+              <div>
+                <JSONView
+                  key={trace.id + "-metadata"}
+                  title="Metadata"
+                  json={trace.metadata}
+                  media={
+                    traceMedia.data?.filter((m) => m.field === "metadata") ?? []
+                  }
+                />
+              </div>
             </div>
           </TabsBarContent>
           {isAuthenticatedAndProjectMember && (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes overlapping status messages on trace detail page by wrapping `JSONView` components in `div` elements in `ObservationPreview.tsx` and `TracePreview.tsx`.
> 
>   - **UI Fix**:
>     - Wraps `JSONView` components in `div` elements in `ObservationPreview.tsx` and `TracePreview.tsx` to prevent overlapping of status messages and metadata.
>   - **Files Affected**:
>     - `ObservationPreview.tsx`: Wraps `statusMessage` and `metadata` `JSONView` components in `div` elements.
>     - `TracePreview.tsx`: Wraps `metadata` `JSONView` component in a `div` element.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 752e1f6c7ae14c5aa1133f2c90adbf4d04512e30. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->