### PR TITLE
fix: detect openinference LLM calls as generations

### DIFF
--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -429,7 +429,10 @@ export const convertOtelSpanToIngestionEvent = (
       // If the span has a model property, we consider it a generation.
       // Just checking for llm.* or gen_ai.* attributes leads to overreporting and wrong
       // aggregations for costs.
-      const isGeneration = Boolean(observation.model);
+      const isGeneration =
+        Boolean(observation.model) ||
+        ("openinference.span.kind" in attributes &&
+          attributes["openinference.span.kind"] === "LLM");
       events.push({
         id: randomUUID(),
         type: isGeneration ? "generation-create" : "span-create",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Detect OpenInference LLM calls as generations in `convertOtelSpanToIngestionEvent` and add corresponding tests.
> 
>   - **Behavior**:
>     - `convertOtelSpanToIngestionEvent` in `index.ts` now detects `openinference.span.kind` with value `LLM` as a generation, creating a `generation-create` event.
>   - **Tests**:
>     - Added test in `otelMapping.servertest.ts` to verify OpenInference LLM calls are interpreted as generations.
>     - Added test cases for extracting `providedModelName` from `llm.model_name` and `usage` from `llm.token_count.prompt`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5b67d4b240d8bf002b0b85d7db90af972263114a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->