### PR TITLE
feat(datasets): deletion of dataset runs via api

### DIFF
--- a/fern/apis/server/definition/datasets.yml
+++ b/fern/apis/server/definition/datasets.yml
@@ -41,6 +41,14 @@ service:
         datasetName: string
         runName: string
       response: commons.DatasetRunWithItems
+    deleteRun:
+      method: DELETE
+      docs: Delete a dataset run and all its run items. This action is irreversible.
+      path: /datasets/{datasetName}/runs/{runName}
+      path-parameters:
+        datasetName: string
+        runName: string
+      response: DeleteDatasetRunResponse
     getRuns:
       method: GET
       docs: Get dataset runs
@@ -72,3 +80,6 @@ types:
     properties:
       data: list<commons.DatasetRun>
       meta: pagination.MetaResponse
+  DeleteDatasetRunResponse:
+    properties:
+      message: string

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -237,3 +237,14 @@ export const GetDatasetV1Response = APIDataset.extend({
   items: z.array(APIDatasetItem),
   runs: z.array(z.string()), // dataset run names
 }).strict();
+
+// DELETE /datasets/{name}/runs/{runName}
+export const DeleteDatasetRunV1Query = z.object({
+  name: queryStringZod, // dataset name from URL
+  runName: queryStringZod,
+});
+export const DeleteDatasetRunV1Response = z
+  .object({
+    message: z.literal("Dataset run successfully deleted"),
+  })
+  .strict();

--- a/web/src/pages/api/public/datasets/[name]/runs/[runName].ts
+++ b/web/src/pages/api/public/datasets/[name]/runs/[runName].ts
@@ -63,7 +63,7 @@ export default withMiddlewares({
     responseSchema: DeleteDatasetRunV1Response,
     fn: async ({ query, auth }) => {
       // First get the dataset run to check if it exists
-      const datasetRun = await prisma.datasetRuns.findFirst({
+      const datasetRuns = await prisma.datasetRuns.findMany({
         where: {
           projectId: auth.scope.projectId,
           name: query.runName,
@@ -74,9 +74,15 @@ export default withMiddlewares({
         },
       });
 
-      if (!datasetRun) {
+      if (datasetRuns.length === 0) {
         throw new LangfuseNotFoundError("Dataset run not found");
       }
+      if (datasetRuns.length > 1) {
+        throw new ApiError(
+          "Found more than one dataset run with this name and dataset",
+        );
+      }
+      const datasetRun = datasetRuns[0];
 
       // Delete the dataset run
       await prisma.datasetRuns.delete({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add API endpoint to delete dataset runs and their items, with backend implementation and tests.
> 
>   - **API Changes**:
>     - Add `deleteRun` endpoint in `datasets.yml` to delete a dataset run and its items.
>     - Define `DeleteDatasetRunResponse` type in `datasets.yml`.
>   - **Backend Implementation**:
>     - Implement DELETE method in `[name]/runs/[runName].ts` to handle dataset run deletion.
>     - Use `prisma.datasetRuns.delete` to remove dataset runs from the database.
>   - **Validation**:
>     - Check for multiple or non-existent dataset runs before deletion in `[name]/runs/[runName].ts`.
>   - **Testing**:
>     - Add test `should delete a dataset run and its run items` in `datasets-api.servertest.ts`.
>     - Verify deletion with correct and incorrect auth, and non-existent runs.
>   - **Types**:
>     - Add `DeleteDatasetRunV1Response` in `datasets.ts` for response validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e3505c44e1b70f7b70d808db9a3e1373eb4a5834. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->