### PR TITLE
chore: reduce default batch size of background migrations

### DIFF
--- a/worker/src/backgroundMigrations/addGenerationsCostBackfill.ts
+++ b/worker/src/backgroundMigrations/addGenerationsCostBackfill.ts
@@ -66,7 +66,7 @@ export default class AddGenerationsCostBackfill
     let previousTimeout;
 
     const maxRowsToProcess = Number(args.maxRowsToProcess ?? Infinity);
-    const batchSize = Number(args.batchSize ?? 5000);
+    const batchSize = Number(args.batchSize ?? 1000);
     let currentDateCutoff = args.maxDate ?? new Date().toISOString();
 
     try {

--- a/worker/src/backgroundMigrations/addGenerationsCostBackfill.ts
+++ b/worker/src/backgroundMigrations/addGenerationsCostBackfill.ts
@@ -208,7 +208,7 @@ export default class AddGenerationsCostBackfill
 async function main() {
   const args = parseArgs({
     options: {
-      batchSize: { type: "string", short: "b", default: "5000" },
+      batchSize: { type: "string", short: "b", default: "1000" },
       maxRowsToProcess: { type: "string", short: "r", default: "Infinity" },
       maxDate: {
         type: "string",

--- a/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
@@ -190,7 +190,7 @@ export default class MigrateObservationsFromPostgresToClickhouse
 async function main() {
   const args = parseArgs({
     options: {
-      batchSize: { type: "string", short: "b", default: "5000" },
+      batchSize: { type: "string", short: "b", default: "1000" },
       maxRowsToProcess: { type: "string", short: "r", default: "Infinity" },
       maxDate: {
         type: "string",

--- a/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateObservationsFromPostgresToClickhouse.ts
@@ -104,7 +104,7 @@ export default class MigrateObservationsFromPostgresToClickhouse
     const stateSuffix = (args.stateSuffix as string) ?? "";
     const initialDate = await this.getMaxDate(stateSuffix);
     const maxRowsToProcess = Number(args.maxRowsToProcess ?? Infinity);
-    const batchSize = Number(args.batchSize ?? 5000);
+    const batchSize = Number(args.batchSize ?? 1000);
     const maxDate =
       initialDate ?? new Date((args.maxDate as string) ?? new Date());
 

--- a/worker/src/backgroundMigrations/migrateScoresFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateScoresFromPostgresToClickhouse.ts
@@ -74,7 +74,7 @@ export default class MigrateScoresFromPostgresToClickhouse
       });
 
     const maxRowsToProcess = Number(args.maxRowsToProcess ?? Infinity);
-    const batchSize = Number(args.batchSize ?? 5000);
+    const batchSize = Number(args.batchSize ?? 1000);
     const maxDate = initialMigrationState.state?.maxDate
       ? new Date(initialMigrationState.state.maxDate)
       : new Date((args.maxDate as string) ?? new Date());

--- a/worker/src/backgroundMigrations/migrateScoresFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateScoresFromPostgresToClickhouse.ts
@@ -169,7 +169,7 @@ export default class MigrateScoresFromPostgresToClickhouse
 async function main() {
   const args = parseArgs({
     options: {
-      batchSize: { type: "string", short: "b", default: "5000" },
+      batchSize: { type: "string", short: "b", default: "1000" },
       maxRowsToProcess: { type: "string", short: "r", default: "Infinity" },
       maxDate: {
         type: "string",

--- a/worker/src/backgroundMigrations/migrateTracesFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateTracesFromPostgresToClickhouse.ts
@@ -169,7 +169,7 @@ export default class MigrateTracesFromPostgresToClickhouse
 async function main() {
   const args = parseArgs({
     options: {
-      batchSize: { type: "string", short: "b", default: "5000" },
+      batchSize: { type: "string", short: "b", default: "1000" },
       maxRowsToProcess: { type: "string", short: "r", default: "Infinity" },
       maxDate: {
         type: "string",

--- a/worker/src/backgroundMigrations/migrateTracesFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateTracesFromPostgresToClickhouse.ts
@@ -74,7 +74,7 @@ export default class MigrateTracesFromPostgresToClickhouse
       });
 
     const maxRowsToProcess = Number(args.maxRowsToProcess ?? Infinity);
-    const batchSize = Number(args.batchSize ?? 5000);
+    const batchSize = Number(args.batchSize ?? 1000);
     const maxDate = initialMigrationState.state?.maxDate
       ? new Date(initialMigrationState.state.maxDate)
       : new Date((args.maxDate as string) ?? new Date());


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reduce default batch size from 5000 to 1000 in background migration scripts for consistent processing.
> 
>   - **Behavior**:
>     - Reduce default `batchSize` from `5000` to `1000` in `addGenerationsCostBackfill.ts`, `migrateObservationsFromPostgresToClickhouse.ts`, and `migrateScoresFromPostgresToClickhouse.ts`.
>     - Update `batchSize` default in `main()` function in the same files.
>   - **Misc**:
>     - Consistent batch size reduction across all background migration scripts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a145586f5ad271a07ce49d742c1ef7db78d8c556. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->