### PR TITLE
feat: map pydantic logfire events to langfuse datamodel

### DIFF
--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -145,6 +145,42 @@ const extractInputAndOutput = (
     return { input: eventInput || input, output: eventOutput || output };
   }
 
+  // Logfire uses `prompt` and `all_messages_events` property on spans
+  input = attributes["prompt"];
+  output = attributes["all_messages_events"];
+  if (input || output) {
+    return { input, output };
+  }
+
+  // Logfire uses single `events` array for GenAI events.
+  const eventsArray = attributes["events"];
+  if (typeof eventsArray === "string" || Array.isArray(eventsArray)) {
+    let events = eventsArray as any[];
+    if (typeof eventsArray === "string") {
+      try {
+        events = JSON.parse(eventsArray);
+      } catch (e) {
+        // fallthrough
+      }
+    }
+
+    // Find the gen_ai.choice event for output
+    const choiceEvent = events.find(
+      (event) => event["event.name"] === "gen_ai.choice",
+    );
+    // All other events are considered input
+    const inputEvents = events.filter(
+      (event) => event["event.name"] !== "gen_ai.choice",
+    );
+
+    if (choiceEvent || inputEvents.length > 0) {
+      return {
+        input: inputEvents.length > 0 ? inputEvents : null,
+        output: choiceEvent || null,
+      };
+    }
+  }
+
   // MLFlow sets mlflow.spanInputs and mlflow.spanOutputs
   input = attributes["mlflow.spanInputs"];
   output = attributes["mlflow.spanOutputs"];

--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -161,6 +161,7 @@ const extractInputAndOutput = (
         events = JSON.parse(eventsArray);
       } catch (e) {
         // fallthrough
+        events = [];
       }
     }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `extractInputAndOutput` in `index.ts` to map Logfire events to Langfuse data model by handling specific attributes and parsing events.
> 
>   - **Behavior**:
>     - Update `extractInputAndOutput` in `index.ts` to handle Logfire events by checking `prompt`, `all_messages_events`, and `events` attributes.
>     - Parse `events` attribute as JSON if it's a string and filter for `gen_ai.choice` events for output.
>     - Return input and output based on parsed and filtered events.
>   - **Functions**:
>     - Modify `extractInputAndOutput` to handle Logfire's single `events` array for GenAI events.
>     - Add logic to parse and filter events for input and output extraction.
>   - **Misc**:
>     - Add comments explaining Logfire's use of `prompt` and `all_messages_events` properties.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2b3225986dbddbaafabc971093c21d8aec9fe780. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->