### PR TITLE
chore(api): update api reference and postman collection

### DIFF
--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -658,6 +658,56 @@ paths:
               schema: {}
       security:
         - BasicAuth: []
+    delete:
+      description: Delete a dataset run and all its run items. This action is irreversible.
+      operationId: datasets_deleteRun
+      tags:
+        - Datasets
+      parameters:
+        - name: datasetName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: runName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteDatasetRunResponse'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
   /api/public/datasets/{datasetName}/runs:
     get:
       description: Get dataset runs
@@ -3687,6 +3737,14 @@ components:
       required:
         - data
         - meta
+    DeleteDatasetRunResponse:
+      title: DeleteDatasetRunResponse
+      type: object
+      properties:
+        message:
+          type: string
+      required:
+        - message
     HealthResponse:
       title: HealthResponse
       type: object

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -505,6 +505,45 @@
         },
         {
           "_type": "endpoint",
+          "name": "Delete Run",
+          "request": {
+            "description": "Delete a dataset run and all its run items. This action is irreversible.",
+            "url": {
+              "raw": "{{baseUrl}}/api/public/datasets/:datasetName/runs/:runName",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "public",
+                "datasets",
+                ":datasetName",
+                "runs",
+                ":runName"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "key": "datasetName",
+                  "value": "",
+                  "description": null
+                },
+                {
+                  "key": "runName",
+                  "value": "",
+                  "description": null
+                }
+              ]
+            },
+            "header": [],
+            "method": "DELETE",
+            "auth": null,
+            "body": null
+          },
+          "response": []
+        },
+        {
+          "_type": "endpoint",
           "name": "Get Runs",
           "request": {
             "description": "Get dataset runs",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> This PR adds a DELETE endpoint for dataset runs in the OpenAPI spec and updates the Postman collection accordingly.
> 
>   - **API Changes**:
>     - Added `DELETE /api/public/datasets/{datasetName}/runs/{runName}` endpoint in `openapi.yml` to delete a dataset run and its items.
>     - Added `DeleteDatasetRunResponse` schema in `openapi.yml`.
>   - **Postman Collection**:
>     - Added "Delete Run" endpoint to `collection.json` for deleting dataset runs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 07fdbd0e99cb9b863a2f9de1ae21f1eea830b5fe. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->