### PR TITLE
chore: add missing clickhouse writer metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,8 @@ services:
     depends_on: *langfuse-depends-on
     ports:
       - "3000:3000"
+    deploy:
+      replicas: 2
     environment:
       <<: *langfuse-worker-env
       NEXTAUTH_URL: http://localhost:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,6 @@ services:
     depends_on: *langfuse-depends-on
     ports:
       - "3000:3000"
-    deploy:
-      replicas: 2
     environment:
       <<: *langfuse-worker-env
       NEXTAUTH_URL: http://localhost:3000

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -176,7 +176,7 @@ export class ClickhouseWriter {
           });
         } else {
           // TODO - Add to a dead letter queue in Redis rather than dropping
-          recordIncrement("langfuse.queue.clickhouse_writer.wait_time.error");
+          recordIncrement("langfuse.queue.clickhouse_writer.error");
           logger.error(
             `Max attempts reached for ${tableName} record. Dropping record ${item.data}.`,
           );

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -6,6 +6,7 @@ import {
   ObservationRecordInsertType,
   recordGauge,
   recordHistogram,
+  recordIncrement,
   ScoreRecordInsertType,
   TraceRecordInsertType,
 } from "@langfuse/shared/src/server";
@@ -97,6 +98,7 @@ export class ClickhouseWriter {
         spanKind: SpanKind.CONSUMER,
       },
       async () => {
+        recordIncrement("langfuse.queue.clickhouse_writer.request");
         await Promise.all([
           this.flush(TableName.Traces, fullQueue),
           this.flush(TableName.Scores, fullQueue),
@@ -174,6 +176,7 @@ export class ClickhouseWriter {
           });
         } else {
           // TODO - Add to a dead letter queue in Redis rather than dropping
+          recordIncrement("langfuse.queue.clickhouse_writer.wait_time.error");
           logger.error(
             `Max attempts reached for ${tableName} record. Dropping record ${item.data}.`,
           );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add missing metrics to `ClickhouseWriter` for request and error counting.
> 
>   - **Metrics**:
>     - Add `recordIncrement("langfuse.queue.clickhouse_writer.request")` in `flushAll()` to count requests.
>     - Add `recordIncrement("langfuse.queue.clickhouse_writer.wait_time.error")` in `flush()` to count errors when max attempts are reached.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0dc9e0c33fc301d4fc5d1486d4768c9d3249292c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->