### PR TITLE
chore: add name mappings to sync prisma schema with reality

### DIFF
--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -293,6 +293,7 @@ model LegacyPrismaTrace {
   release    String?
   version    String?
   projectId  String   @map("project_id")
+  project    Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
   public     Boolean  @default(false)
   bookmarked Boolean  @default(false)
   tags       String[] @default([])
@@ -301,7 +302,6 @@ model LegacyPrismaTrace {
   sessionId  String?  @map("session_id")
   createdAt  DateTime @default(now()) @map("created_at")
   updatedAt  DateTime @default(now()) @updatedAt @map("updated_at")
-  project    Project  @relation(fields: [projectId], references: [id])
 
   @@index([projectId, timestamp])
   @@index([sessionId])
@@ -318,6 +318,7 @@ model LegacyPrismaObservation {
   id                   String                       @id @default(cuid())
   traceId              String?                      @map("trace_id")
   projectId            String                       @map("project_id")
+  project              Project                      @relation(fields: [projectId], references: [id], onDelete: Cascade)
   type                 LegacyPrismaObservationType
   startTime            DateTime                     @default(now()) @map("start_time")
   endTime              DateTime?                    @map("end_time")
@@ -349,7 +350,6 @@ model LegacyPrismaObservation {
   calculatedOutputCost Decimal?                     @map("calculated_output_cost")
   calculatedTotalCost  Decimal?                     @map("calculated_total_cost")
   completionStartTime  DateTime?                    @map("completion_start_time")
-  project              Project                      @relation(fields: [projectId], references: [id], onDelete: Cascade)
   promptId             String?                      @map("prompt_id") // no fk constraint, prompt can be deleted
 
   @@unique([id, projectId])
@@ -371,6 +371,8 @@ enum LegacyPrismaObservationType {
   SPAN
   EVENT
   GENERATION
+
+  @@map("ObservationType")
 }
 
 enum LegacyPrismaObservationLevel {
@@ -378,12 +380,15 @@ enum LegacyPrismaObservationLevel {
   DEFAULT
   WARNING
   ERROR
+
+  @@map("ObservationLevel")
 }
 
 model LegacyPrismaScore {
   id            String                  @id @default(cuid())
   timestamp     DateTime                @default(now())
   projectId     String                  @map("project_id")
+  project       Project                 @relation(fields: [projectId], references: [id], onDelete: Cascade)
   name          String
   value         Float? // always defined if data type is NUMERIC or BOOLEAN, optional for CATEGORICAL
   source        LegacyPrismaScoreSource
@@ -398,7 +403,6 @@ model LegacyPrismaScore {
   updatedAt     DateTime                @default(now()) @updatedAt @map("updated_at")
   dataType      ScoreDataType           @default(NUMERIC) @map("data_type")
   scoreConfig   ScoreConfig?            @relation(fields: [configId], references: [id], onDelete: SetNull)
-  project       Project                 @relation(fields: [projectId], references: [id])
 
   @@unique([id, projectId]) // used for upserts via prisma
   @@index(timestamp)
@@ -417,6 +421,8 @@ enum LegacyPrismaScoreSource {
   ANNOTATION
   API
   EVAL
+
+  @@map("ScoreSource")
 }
 
 model ScoreConfig {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `onDelete: Cascade` to relations and `@@map` to enums in `schema.prisma` for better schema synchronization.
> 
>   - **Schema Changes**:
>     - Add `onDelete: Cascade` to `project` relations in `LegacyPrismaTrace`, `LegacyPrismaObservation`, and `LegacyPrismaScore` models.
>     - Add `@@map` to `LegacyPrismaObservationType`, `LegacyPrismaObservationLevel`, and `LegacyPrismaScoreSource` enums for name mapping.
>   - **Misc**:
>     - Remove duplicate `project` relation in `LegacyPrismaTrace`, `LegacyPrismaObservation`, and `LegacyPrismaScore` models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0dee62be29f15c52d5aae61044951ba36c9ff4d1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->