### PR TITLE
chore: log dropped data items correctly in clickhouse writer

### DIFF
--- a/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
+++ b/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
@@ -143,9 +143,11 @@ describe("ClickhouseWriter", () => {
     await vi.advanceTimersByTimeAsync(writer.writeInterval);
 
     expect(mockInsert).toHaveBeenCalledTimes(writer.maxAttempts);
-    expect(logger.error).toHaveBeenCalledWith(
-      expect.stringContaining("Max attempts reached"),
-    );
+    expect(
+      logger.error.mock.calls.some((call) =>
+        call[0].includes("Max attempts reached"),
+      ),
+    ).toBe(true);
     expect(writer["queue"][TableName.Traces]).toHaveLength(0);
   });
 

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -178,7 +178,8 @@ export class ClickhouseWriter {
           // TODO - Add to a dead letter queue in Redis rather than dropping
           recordIncrement("langfuse.queue.clickhouse_writer.error");
           logger.error(
-            `Max attempts reached for ${tableName} record. Dropping record ${item.data}.`,
+            `Max attempts reached for ${tableName} record. Dropping record.`,
+            { item: item.data },
           );
         }
       });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improve logging for dropped data items in ClickhouseWriter by including item data in error logs when max attempts are reached.
> 
>   - **Logging**:
>     - In `index.ts`, update error logging in `flush()` to include item data when max attempts are reached.
>   - **Tests**:
>     - In `ClickhouseWriter.unit.test.ts`, modify test to check for updated logging behavior when max attempts are reached.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bb280ce6459e83f51be8465630a80431336aa201. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->