### PR TITLE
feat: add environment column to UI tables

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -510,6 +510,7 @@ const getObservationsTableInternal = async <T>(
         o.provided_cost_details as "provided_cost_details",
         o.cost_details as "cost_details",
         o.level as level,
+        o.environment as "environment",
         o.status_message as "status_message",
         o.version as version,
         o.parent_observation_id as "parent_observation_id",

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -653,6 +653,7 @@ export const getUserMetrics = async (
       WITH stats as (
         SELECT
             t.user_id as user_id,
+            anyLast(t.environment) as environment,
             count(distinct o.id) as obs_count,
             sumMap(usage_details) as sum_usage_details,
             sum(total_cost) as sum_total_cost,
@@ -695,6 +696,7 @@ export const getUserMetrics = async (
                     t.user_id,
                     t.project_id,
                     t.timestamp,
+                    t.environment,
                     ROW_NUMBER() OVER (
                         PARTITION BY id
                         ORDER BY
@@ -721,6 +723,7 @@ export const getUserMetrics = async (
         obs_count,
         trace_count,
         user_id,
+        environment,
         sum_total_cost,
         max_timestamp,
         min_timestamp
@@ -731,6 +734,7 @@ export const getUserMetrics = async (
 
   const rows = await queryClickhouse<{
     user_id: string;
+    environment: string;
     max_timestamp: string;
     min_timestamp: string;
     input_usage: string;
@@ -763,6 +767,7 @@ export const getUserMetrics = async (
 
   return rows.map((row) => ({
     userId: row.user_id,
+    environment: row.environment,
     maxTimestamp: parseClickhouseUTCDateTimeFormat(row.max_timestamp),
     minTimestamp: parseClickhouseUTCDateTimeFormat(row.min_timestamp),
     inputUsage: Number(row.input_usage),

--- a/packages/shared/src/server/services/sessions-ui-table-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-service.ts
@@ -20,6 +20,7 @@ export type SessionDataReturnType = {
   user_ids: string[];
   trace_count: number;
   trace_tags: string[];
+  trace_environment?: string;
 };
 
 export type SessionWithMetricsReturnType = SessionDataReturnType & {
@@ -129,7 +130,8 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
           trace_ids, 
           user_ids, 
           trace_count, 
-          trace_tags`;
+          trace_tags,
+          trace_environment`;
       break;
     case "metrics":
       sqlSelect = `
@@ -140,6 +142,7 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
         user_ids, 
         trace_count, 
         trace_tags,
+        trace_environment,
         total_observations,
         duration,
         session_usage_details,
@@ -269,7 +272,8 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
             groupArray(t.id) AS trace_ids,
             groupUniqArray(t.user_id) AS user_ids,
             count(*) as trace_count,
-            groupUniqArrayArray(t.tags) as trace_tags
+            groupUniqArrayArray(t.tags) as trace_tags,
+            anyLast(t.environment) as trace_environment
             -- Aggregate observations data at session level
             ${
               selectMetrics

--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -35,6 +35,7 @@ export type TracesTableReturnType = Pick<
   | "version"
   | "user_id"
   | "session_id"
+  | "environment"
   | "tags"
   | "public"
 >;
@@ -49,6 +50,7 @@ export type TracesAllUiReturnType = {
   version: string | null;
   public: boolean;
   bookmarked: boolean;
+  environment: string | null;
   sessionId: string | null;
   tags: string[];
 };
@@ -87,6 +89,7 @@ export const convertToUiTableRows = (
     release: row.release ?? null,
     version: row.version ?? null,
     userId: row.user_id ?? null,
+    environment: row.environment ?? null,
     sessionId: row.session_id ?? null,
     public: row.public,
   };
@@ -259,6 +262,7 @@ const getTracesTableGeneric = async <T>(props: FetchTracesTableProps) => {
         t.release as release,
         t.version as version,
         t.user_id as user_id,
+        t.environment as environment,
         t.session_id as session_id,
         t.public as public`;
       break;

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -50,6 +50,7 @@ import {
   useEnvironmentFilter,
   convertSelectedEnvironmentsToFilter,
 } from "@/src/hooks/use-environment-filter";
+import { Badge } from "@/src/components/ui/badge";
 
 export type ObservationsTableRow = {
   id: string;
@@ -84,6 +85,7 @@ export type ObservationsTableRow = {
   promptName?: string;
   promptVersion?: string;
   traceTags?: string[];
+  environment?: string;
 };
 
 export type ObservationsTableProps = {
@@ -308,6 +310,26 @@ export default function ObservationsTable({
             <ColorCodedObservationType observationType={value} />
           </div>
         ) : undefined;
+      },
+    },
+    {
+      accessorKey: "environment",
+      header: "Environment",
+      id: "environment",
+      size: 150,
+      enableHiding: true,
+      enableSorting: true,
+      cell: ({ row }) => {
+        const value: ObservationsTableRow["environment"] =
+          row.getValue("environment");
+        return value ? (
+          <Badge
+            variant="secondary"
+            className="max-w-fit truncate rounded-sm px-1 font-normal"
+          >
+            {value}
+          </Badge>
+        ) : null;
       },
     },
     {
@@ -555,7 +577,6 @@ export default function ObservationsTable({
         );
       },
     },
-
     {
       accessorKey: "modelId",
       id: "modelId",
@@ -564,7 +585,6 @@ export default function ObservationsTable({
       enableHiding: true,
       defaultHidden: true,
     },
-
     {
       accessorKey: "inputTokens",
       id: "inputTokens",
@@ -823,6 +843,7 @@ export default function ObservationsTable({
             traceTags: generation.traceTags ?? undefined,
             usageDetails: generation.usageDetails ?? {},
             costDetails: generation.costDetails ?? {},
+            environment: generation.environment ?? undefined,
           };
         })
       : [];

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -32,6 +32,7 @@ import {
   useEnvironmentFilter,
   convertSelectedEnvironmentsToFilter,
 } from "@/src/hooks/use-environment-filter";
+import { Badge } from "@/src/components/ui/badge";
 
 export type ScoresTableRow = {
   id: string;
@@ -52,12 +53,8 @@ export type ScoresTableRow = {
   userId?: string;
   jobConfigurationId?: string;
   traceTags?: string[];
+  environment?: string;
 };
-
-export type ScoreFilterInput = Omit<
-  RouterInput["scores"]["all"],
-  "projectId" | "userId"
->;
 
 function createFilterState(
   userFilterState: FilterState,
@@ -257,6 +254,25 @@ export default function ScoresTable({
       },
     },
     {
+      accessorKey: "environment",
+      header: "Environment",
+      id: "environment",
+      size: 150,
+      enableHiding: true,
+      enableSorting: true,
+      cell: ({ row }) => {
+        const value = row.getValue("environment") as string | undefined;
+        return value ? (
+          <Badge
+            variant="secondary"
+            className="max-w-fit truncate rounded-sm px-1 font-normal"
+          >
+            {value}
+          </Badge>
+        ) : null;
+      },
+    },
+    {
       accessorKey: "userId",
       header: "User",
       id: "userId",
@@ -449,6 +465,7 @@ export default function ScoresTable({
       userId: score.traceUserId ?? undefined,
       jobConfigurationId: score.jobConfigurationId ?? undefined,
       traceTags: score.traceTags ?? undefined,
+      environment: score.environment ?? undefined,
     };
   };
 

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/src/server/api/definitions/scoresTable";
 import { api } from "@/src/utils/api";
 
-import type { RouterOutput, RouterInput } from "@/src/utils/types";
+import type { RouterOutput } from "@/src/utils/types";
 import {
   isPresent,
   type FilterState,

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -259,6 +259,24 @@ export default function SessionsTable({
       },
     },
     {
+      accessorKey: "sessionDuration",
+      id: "sessionDuration",
+      header: "Duration",
+      size: 130,
+      enableHiding: true,
+      cell: ({ row }) => {
+        const value: SessionTableRow["sessionDuration"] =
+          row.getValue("sessionDuration");
+        if (!sessionMetrics.isSuccess) {
+          return <Skeleton className="h-3 w-1/2" />;
+        }
+        return value && typeof value === "number"
+          ? formatIntervalSeconds(value)
+          : undefined;
+      },
+      enableSorting: true,
+    },
+    {
       accessorKey: "environment",
       header: "Environment",
       id: "environment",
@@ -277,24 +295,6 @@ export default function SessionsTable({
           </Badge>
         ) : null;
       },
-    },
-    {
-      accessorKey: "sessionDuration",
-      id: "sessionDuration",
-      header: "Duration",
-      size: 130,
-      enableHiding: true,
-      cell: ({ row }) => {
-        const value: SessionTableRow["sessionDuration"] =
-          row.getValue("sessionDuration");
-        if (!sessionMetrics.isSuccess) {
-          return <Skeleton className="h-3 w-1/2" />;
-        }
-        return value && typeof value === "number"
-          ? formatIntervalSeconds(value)
-          : undefined;
-      },
-      enableSorting: true,
     },
     {
       accessorKey: "userIds",

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -34,6 +34,7 @@ import {
   useEnvironmentFilter,
   convertSelectedEnvironmentsToFilter,
 } from "@/src/hooks/use-environment-filter";
+import { Badge } from "@/src/components/ui/badge";
 
 export type SessionTableRow = {
   id: string;
@@ -49,6 +50,7 @@ export type SessionTableRow = {
   outputTokens: number | undefined;
   totalTokens: number | undefined;
   traceTags: string[] | undefined;
+  environment?: string;
 };
 
 export type SessionTableProps = {
@@ -254,6 +256,26 @@ export default function SessionsTable({
       cell: ({ row }) => {
         const value: SessionTableRow["createdAt"] = row.getValue("createdAt");
         return value ? <LocalIsoDate date={value} /> : undefined;
+      },
+    },
+    {
+      accessorKey: "environment",
+      header: "Environment",
+      id: "environment",
+      size: 150,
+      enableHiding: true,
+      enableSorting: true,
+      cell: ({ row }) => {
+        const value: SessionTableRow["environment"] =
+          row.getValue("environment");
+        return value ? (
+          <Badge
+            variant="secondary"
+            className="max-w-fit truncate rounded-sm px-1 font-normal"
+          >
+            {value}
+          </Badge>
+        ) : null;
       },
     },
     {
@@ -555,6 +577,7 @@ export default function SessionsTable({
                       outputTokens: session.completionTokens,
                       totalTokens: session.totalTokens,
                       traceTags: session.traceTags,
+                      environment: session.environment,
                     }),
                   ),
                 }

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -2,6 +2,7 @@ import { StarTraceToggle } from "@/src/components/star-toggle";
 import { DataTable } from "@/src/components/table/data-table";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import TableLink from "@/src/components/table/table-link";
+import { Badge } from "@/src/components/ui/badge";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { TagTracePopover } from "@/src/features/tag/components/TagTracePopver";
 import { TokenUsageBadge } from "@/src/components/token-usage-badge";
@@ -99,6 +100,7 @@ export type TracesTableRow = {
   release?: string;
   version?: string;
   sessionId?: string;
+  environment?: string;
   // i/o and metadata not set explicitly, but fetched from the server from the cell
   input?: unknown;
   output?: unknown;
@@ -470,6 +472,26 @@ export default function TracesTable({
       size: 150,
       enableHiding: true,
       enableSorting: true,
+    },
+    {
+      accessorKey: "environment",
+      header: "Environment",
+      id: "environment",
+      size: 150,
+      enableHiding: true,
+      enableSorting: true,
+      cell: ({ row }) => {
+        const value: TracesTableRow["environment"] =
+          row.getValue("environment");
+        return value ? (
+          <Badge
+            variant="secondary"
+            className="max-w-fit truncate rounded-sm px-1 font-normal"
+          >
+            {value}
+          </Badge>
+        ) : null;
+      },
     },
     {
       accessorKey: "userId",
@@ -913,6 +935,7 @@ export default function TracesTable({
             version: trace.version ?? undefined,
             userId: trace.userId ?? "",
             sessionId: trace.sessionId ?? undefined,
+            environment: trace.environment ?? undefined,
             latency: trace.latency === null ? undefined : trace.latency,
             tags: trace.tags,
             usage: {

--- a/web/src/pages/project/[projectId]/users.tsx
+++ b/web/src/pages/project/[projectId]/users.tsx
@@ -28,9 +28,11 @@ import {
   useEnvironmentFilter,
   convertSelectedEnvironmentsToFilter,
 } from "@/src/hooks/use-environment-filter";
+import { Badge } from "@/src/components/ui/badge";
 
 type RowData = {
   userId: string;
+  environment?: string;
   firstEvent: string;
   lastEvent: string;
   totalEvents: string;
@@ -221,6 +223,25 @@ const UsersTable = () => {
       },
     },
     {
+      accessorKey: "environment",
+      header: "Environment",
+      id: "environment",
+      size: 150,
+      enableHiding: true,
+      enableSorting: true,
+      cell: ({ row }) => {
+        const value: RowData["environment"] = row.getValue("environment");
+        return value ? (
+          <Badge
+            variant="secondary"
+            className="max-w-fit truncate rounded-sm px-1 font-normal"
+          >
+            {value}
+          </Badge>
+        ) : null;
+      },
+    },
+    {
       accessorKey: "firstEvent",
       header: "First Event",
       headerTooltip: {
@@ -349,6 +370,7 @@ const UsersTable = () => {
                   data: userRowData.rows?.map((t) => {
                     return {
                       userId: t.id,
+                      environment: t.environment ?? undefined,
                       firstEvent:
                         t.firstTrace?.toLocaleString() ?? "No event yet",
                       lastEvent:

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -78,6 +78,7 @@ export const sessionRouter = createTRPCRouter({
             id: true,
             bookmarked: true,
             public: true,
+            environment: true,
           },
         });
         return {
@@ -93,6 +94,7 @@ export const sessionRouter = createTRPCRouter({
             public:
               prismaSessionInfo.find((p) => p.id === s.session_id)?.public ??
               false,
+            environment: s.trace_environment,
           })),
         };
       } catch (e) {
@@ -179,6 +181,7 @@ export const sessionRouter = createTRPCRouter({
           public:
             prismaSessionInfo.find((p) => p.id === s.session_id)?.public ??
             false,
+          environment: s.trace_environment,
           trace_count: Number(s.trace_count),
           total_observations: Number(s.total_observations),
           sessionDuration: Number(s.duration) / 1000,

--- a/web/src/server/api/routers/users.ts
+++ b/web/src/server/api/routers/users.ts
@@ -84,6 +84,7 @@ export const userRouter = createTRPCRouter({
 
       return metrics.map((metric) => ({
         userId: metric.userId,
+        environment: metric.environment,
         firstTrace: metric.minTimestamp,
         lastTrace: metric.maxTimestamp,
         totalPromptTokens: BigInt(metric.inputUsage),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add 'environment' column to various UI tables and update backend to support this new column.
> 
>   - **Backend Changes**:
>     - Add `environment` field to `getObservationsTableInternal()` in `observations.ts` and `getUserMetrics()` in `traces.ts`.
>     - Update `sessions-ui-table-service.ts` and `traces-ui-table-service.ts` to include `environment` in session and trace data.
>     - Modify API routers in `sessions.ts` and `users.ts` to handle `environment` data.
>   - **Frontend Changes**:
>     - Add `environment` column to tables in `observations.tsx`, `scores.tsx`, `sessions.tsx`, `traces.tsx`, and `users.tsx`.
>     - Use `Badge` component to display `environment` values in the UI tables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a800d53f14309bc17ce4421f3efb00ad4a7c5ebe. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->