### PR TITLE
fix(ui-graph-view): handle single top most node

### DIFF
--- a/web/src/features/trace-graph-view/components/TraceGraphView.tsx
+++ b/web/src/features/trace-graph-view/components/TraceGraphView.tsx
@@ -113,6 +113,8 @@ function parseGraph(params: {
       ) {
         nodeToParentObservationMap.set(node, o.id);
       }
+    } else {
+      nodeToParentObservationMap.set(node, o.id);
     }
   });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes handling of single top-most nodes in `parseGraph()` in `TraceGraphView.tsx` by mapping nodes without `parentObservationId`.
> 
>   - **Behavior**:
>     - Fixes handling of single top-most nodes in `parseGraph()` in `TraceGraphView.tsx` by ensuring nodes without `parentObservationId` are mapped in `nodeToParentObservationMap`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ce9c298f5dd6d26df2cae953f0cd3a5d5fdbcac1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->