### PR TITLE
fix: enforce ints on usageDetails

### DIFF
--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -58,21 +58,25 @@ export const usage = MixedUsage.nullish()
   // ensure output is always of new usage model
   .pipe(Usage.nullish());
 
-const RawUsageOrCostDetails = z.record(
+const CostDetails = z
+  .record(z.string(), z.number().nonnegative().nullish())
+  .nullish();
+
+const RawUsageDetails = z.record(
   z.string(),
-  z.number().nonnegative().nullish(),
+  z.number().int().nonnegative().nullish(),
 );
 
 const OpenAIUsageSchema = z
   .object({
-    prompt_tokens: z.number().nonnegative(),
-    completion_tokens: z.number().nonnegative(),
-    total_tokens: z.number().nonnegative(),
+    prompt_tokens: z.number().int().nonnegative(),
+    completion_tokens: z.number().int().nonnegative(),
+    total_tokens: z.number().int().nonnegative(),
     prompt_tokens_details: z
-      .record(z.string(), z.number().nonnegative())
+      .record(z.string(), z.number().int().nonnegative())
       .nullish(),
     completion_tokens_details: z
-      .record(z.string(), z.number().nonnegative())
+      .record(z.string(), z.number().int().nonnegative())
       .nullish(),
   })
   .strict()
@@ -86,7 +90,7 @@ const OpenAIUsageSchema = z
       prompt_tokens_details,
       completion_tokens_details,
     } = v;
-    const result: z.infer<typeof RawUsageOrCostDetails> & {
+    const result: z.infer<typeof RawUsageDetails> & {
       input: number;
       output: number;
       total: number;
@@ -112,10 +116,10 @@ const OpenAIUsageSchema = z
 
     return result;
   })
-  .pipe(RawUsageOrCostDetails);
+  .pipe(RawUsageDetails);
 
-export const UsageOrCostDetails = z
-  .union([OpenAIUsageSchema, RawUsageOrCostDetails])
+export const UsageDetails = z
+  .union([OpenAIUsageSchema, RawUsageDetails])
   .nullish();
 
 export const EnvironmentName = z
@@ -195,8 +199,8 @@ export const CreateGenerationBody = CreateSpanBody.extend({
     )
     .nullish(),
   usage: usage,
-  usageDetails: UsageOrCostDetails,
-  costDetails: UsageOrCostDetails,
+  usageDetails: UsageDetails,
+  costDetails: CostDetails,
   promptName: z.string().nullish(),
   promptVersion: z.number().int().nullish(),
 }).refine((value) => {
@@ -225,8 +229,8 @@ export const UpdateGenerationBody = UpdateSpanBody.extend({
     )
     .nullish(),
   usage: usage,
-  usageDetails: UsageOrCostDetails,
-  costDetails: UsageOrCostDetails,
+  usageDetails: UsageDetails,
+  costDetails: CostDetails,
   promptName: z.string().nullish(),
   promptVersion: z.number().int().nullish(),
 }).refine((value) => {
@@ -381,8 +385,8 @@ export const LegacyObservationBody = z.object({
   input: jsonSchema.nullish(),
   output: jsonSchema.nullish(),
   usage: usage,
-  usageDetails: UsageOrCostDetails,
-  costDetails: UsageOrCostDetails,
+  usageDetails: UsageDetails,
+  costDetails: CostDetails,
   metadata: jsonSchema.nullish(),
   parentObservationId: z.string().nullish(),
   level: ObservationLevel.nullish(),

--- a/web/src/__tests__/async/ingestion-api.servertest.ts
+++ b/web/src/__tests__/async/ingestion-api.servertest.ts
@@ -275,6 +275,36 @@ describe("/api/public/ingestion API Endpoint", () => {
     expect(response.body.errors[0].message).toBe("Invalid request data");
   });
 
+  it("should fail for float in usageDetails", async () => {
+    const traceId = v4();
+
+    const response = await makeAPICall("POST", "/api/public/ingestion", {
+      batch: [
+        {
+          id: v4(),
+          type: "trace-create",
+          timestamp: new Date().toISOString(),
+          body: {
+            id: traceId,
+            userId: "user-1",
+            metadata: { key: "value" },
+            release: "1.0.0",
+            version: "2.0.0",
+            usageDetails: {
+              key: 0.1,
+            },
+          },
+        },
+      ],
+    });
+
+    expect(response.status).toBe(207);
+    expect("errors" in response.body).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(response.body.errors.length).toBe(1);
+    expect(response.body.errors[0].message).toBe("Invalid request data");
+  });
+
   it.each([
     "langfuse-test",
     ".invalidcharacter!",

--- a/web/src/__tests__/async/ingestion-api.servertest.ts
+++ b/web/src/__tests__/async/ingestion-api.servertest.ts
@@ -282,14 +282,16 @@ describe("/api/public/ingestion API Endpoint", () => {
       batch: [
         {
           id: v4(),
-          type: "trace-create",
+          type: "generation-create",
           timestamp: new Date().toISOString(),
           body: {
-            id: traceId,
-            userId: "user-1",
-            metadata: { key: "value" },
-            release: "1.0.0",
-            version: "2.0.0",
+            id: randomUUID(),
+            traceId: randomUUID(),
+            parentObservationId: randomUUID(),
+            startTime: new Date().toISOString(),
+            model: "gpt-4",
+            input: { text: "input" },
+            output: { text: "output" },
             usageDetails: {
               key: 0.1,
             },

--- a/web/src/__tests__/async/ingestion-api.servertest.ts
+++ b/web/src/__tests__/async/ingestion-api.servertest.ts
@@ -276,8 +276,6 @@ describe("/api/public/ingestion API Endpoint", () => {
   });
 
   it("should fail for float in usageDetails", async () => {
-    const traceId = v4();
-
     const response = await makeAPICall("POST", "/api/public/ingestion", {
       batch: [
         {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enforces integer values for `usageDetails` in ingestion API, renaming related schemas, and adds a test for float value failure.
> 
>   - **Behavior**:
>     - Enforces integer values in `usageDetails` in `types.ts`.
>     - If a float is provided in `usageDetails`, an error is returned.
>   - **Schema Changes**:
>     - Renames `RawUsageOrCostDetails` to `RawUsageDetails`.
>     - Renames `UsageOrCostDetails` to `UsageDetails`.
>   - **Tests**:
>     - Adds test in `ingestion-api.servertest.ts` to ensure failure when float is used in `usageDetails`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for adb6d5ccd3fd1bc3956c77043d9c32adde922a5e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->