### PR TITLE
feat: create new environment materialized views for quick lookups

### DIFF
--- a/packages/shared/clickhouse/migrations/clustered/0009_add_project_environments.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0009_add_project_environments.down.sql
@@ -1,0 +1,7 @@
+-- Drop materialized views
+DROP VIEW IF EXISTS project_environments_traces_mv ON CLUSTER default;
+DROP VIEW IF EXISTS project_environments_observations_mv ON CLUSTER default;
+DROP VIEW IF EXISTS project_environments_scores_mv ON CLUSTER default;
+
+-- Drop the project_environments table
+DROP TABLE IF EXISTS project_environments ON CLUSTER default;

--- a/packages/shared/clickhouse/migrations/clustered/0009_add_project_environments.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0009_add_project_environments.up.sql
@@ -1,0 +1,30 @@
+-- Create the project_environments table with AggregatingMergeTree engine
+CREATE TABLE project_environments ON CLUSTER default (
+    `project_id` String,
+    `environments` SimpleAggregateFunction(groupUniqArrayArray, Array(String))
+) ENGINE = ReplicatedAggregatingMergeTree
+ORDER BY (project_id);
+
+-- Create materialized view for traces
+CREATE MATERIALIZED VIEW project_environments_traces_mv ON CLUSTER default TO project_environments AS
+SELECT
+    project_id,
+    groupUniqArray(environment) AS environments
+FROM traces
+GROUP BY project_id;
+
+-- Create materialized view for observations
+CREATE MATERIALIZED VIEW project_environments_observations_mv ON CLUSTER default TO project_environments AS
+SELECT
+    project_id,
+    groupUniqArray(environment) AS environments
+FROM observations
+GROUP BY project_id;
+
+-- Create materialized view for scores
+CREATE MATERIALIZED VIEW project_environments_scores_mv ON CLUSTER default TO project_environments AS
+SELECT
+    project_id,
+    groupUniqArray(environment) AS environments
+FROM scores
+GROUP BY project_id;

--- a/packages/shared/clickhouse/migrations/unclustered/0009_add_project_environments.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0009_add_project_environments.down.sql
@@ -1,0 +1,7 @@
+-- Drop materialized views
+DROP VIEW IF EXISTS project_environments_traces_mv;
+DROP VIEW IF EXISTS project_environments_observations_mv;
+DROP VIEW IF EXISTS project_environments_scores_mv;
+
+-- Drop the project_environments table
+DROP TABLE IF EXISTS project_environments;

--- a/packages/shared/clickhouse/migrations/unclustered/0009_add_project_environments.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0009_add_project_environments.up.sql
@@ -1,0 +1,30 @@
+-- Create the project_environments table with AggregatingMergeTree engine
+CREATE TABLE project_environments (
+    `project_id` String,
+    `environments` SimpleAggregateFunction(groupUniqArrayArray, Array(String))
+) ENGINE = AggregatingMergeTree
+ORDER BY (project_id);
+
+-- Create materialized view for traces
+CREATE MATERIALIZED VIEW project_environments_traces_mv TO project_environments AS
+SELECT
+    project_id,
+    groupUniqArray(environment) AS environments
+FROM traces
+GROUP BY project_id;
+
+-- Create materialized view for observations
+CREATE MATERIALIZED VIEW project_environments_observations_mv TO project_environments AS
+SELECT
+    project_id,
+    groupUniqArray(environment) AS environments
+FROM observations
+GROUP BY project_id;
+
+-- Create materialized view for scores
+CREATE MATERIALIZED VIEW project_environments_scores_mv TO project_environments AS
+SELECT
+    project_id,
+    groupUniqArray(environment) AS environments
+FROM scores
+GROUP BY project_id;

--- a/packages/shared/src/server/repositories/environments.ts
+++ b/packages/shared/src/server/repositories/environments.ts
@@ -11,7 +11,7 @@ export const getEnvironmentsForProject = async (
 
   const query = `
     SELECT environments
-    FROM project_environments
+    FROM project_environments FINAL
     WHERE project_id = {projectId: String}
   `;
 

--- a/packages/shared/src/server/repositories/environments.ts
+++ b/packages/shared/src/server/repositories/environments.ts
@@ -28,7 +28,9 @@ export const getEnvironmentsForProject = async (
     },
   });
 
-  return (results.length > 0 ? results[0].environments : ["default"]).map(
-    (environment) => ({ environment }),
-  );
+  const environments = results.length > 0 ? results[0].environments : [];
+  environments.push("default");
+  return Array.from(new Set(environments)).map((environment) => ({
+    environment,
+  }));
 };

--- a/web/src/__tests__/async/repositories/environment-repository.servertest.ts
+++ b/web/src/__tests__/async/repositories/environment-repository.servertest.ts
@@ -34,11 +34,12 @@ describe("Clickhouse Project Repository Test", () => {
 
     const environments = await getEnvironmentsForProject({ projectId });
 
-    expect(environments).toHaveLength(2);
+    expect(environments).toHaveLength(3);
     expect(environments).toEqual(
       expect.arrayContaining([
         { environment: environmentId1 },
         { environment: environmentId2 },
+        { environment: "default" },
       ]),
     );
   });

--- a/web/src/__tests__/async/repositories/environment-repository.servertest.ts
+++ b/web/src/__tests__/async/repositories/environment-repository.servertest.ts
@@ -1,0 +1,45 @@
+import {
+  createTracesCh,
+  createTrace,
+  getEnvironmentsForProject,
+} from "@langfuse/shared/src/server";
+import { randomUUID } from "crypto";
+
+describe("Clickhouse Project Repository Test", () => {
+  it("should return default if no environments are found", async () => {
+    const projectId = randomUUID();
+    const environments = await getEnvironmentsForProject({ projectId });
+    expect(environments).toHaveLength(1);
+    expect(environments[0].environment).toEqual("default");
+  });
+
+  it("should return environment from project_environments table after new trace was inserted", async () => {
+    const projectId = randomUUID();
+    const environmentId1 = randomUUID();
+    const environmentId2 = randomUUID();
+    await createTracesCh([
+      createTrace({
+        project_id: projectId,
+        environment: environmentId1,
+      }),
+      createTrace({
+        project_id: projectId,
+        environment: environmentId1,
+      }),
+      createTrace({
+        project_id: projectId,
+        environment: environmentId2,
+      }),
+    ]);
+
+    const environments = await getEnvironmentsForProject({ projectId });
+
+    expect(environments).toHaveLength(2);
+    expect(environments).toEqual(
+      expect.arrayContaining([
+        { environment: environmentId1 },
+        { environment: environmentId2 },
+      ]),
+    );
+  });
+});

--- a/web/src/features/projects/server/projectsRouter.ts
+++ b/web/src/features/projects/server/projectsRouter.ts
@@ -14,7 +14,7 @@ import {
   QueueJobs,
   redis,
   ProjectDeleteQueue,
-  getEnvironmentsForProjectAndTimeFilter,
+  getEnvironmentsForProject,
 } from "@langfuse/shared/src/server";
 import { randomUUID } from "crypto";
 import { timeFilter } from "@langfuse/shared";
@@ -279,16 +279,6 @@ export const projectsRouter = createTRPCRouter({
     }),
 
   environmentFilterOptions: protectedProjectProcedure
-    .input(
-      z.object({
-        projectId: z.string(),
-        timestampFilter: timeFilter.optional(),
-      }),
-    )
-    .query(async ({ input }) => {
-      return getEnvironmentsForProjectAndTimeFilter({
-        projectId: input.projectId,
-        minTimestamp: input.timestampFilter?.value,
-      });
-    }),
+    .input(z.object({ projectId: z.string() }))
+    .query(async ({ input }) => getEnvironmentsForProject(input)),
 });

--- a/web/src/features/projects/server/projectsRouter.ts
+++ b/web/src/features/projects/server/projectsRouter.ts
@@ -17,7 +17,6 @@ import {
   getEnvironmentsForProject,
 } from "@langfuse/shared/src/server";
 import { randomUUID } from "crypto";
-import { timeFilter } from "@langfuse/shared";
 
 export const projectsRouter = createTRPCRouter({
   create: protectedOrganizationProcedure


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add new Clickhouse materialized views and table for efficient environment lookups, update environment retrieval logic, and add tests.
> 
>   - **Database Migrations**:
>     - Add `project_environments` table and materialized views `project_environments_traces_mv`, `project_environments_observations_mv`, and `project_environments_scores_mv` in `0009_add_project_environments.up.sql` for both clustered and unclustered setups.
>     - Drop these views and table in `0009_add_project_environments.down.sql`.
>   - **Repository Changes**:
>     - Modify `getEnvironmentsForProject` in `environments.ts` to query `project_environments` table.
>     - Remove timestamp filtering logic from `getEnvironmentsForProject`.
>   - **Testing**:
>     - Add `environment-repository.servertest.ts` to test environment retrieval logic.
>     - Ensure default environment is returned if no environments are found.
>   - **Router Changes**:
>     - Update `projectsRouter.ts` to use `getEnvironmentsForProject` without timestamp filtering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 73a74b1131da38107ac5a6b5ad2986ca12e2e989. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->