### PR TITLE
WIP on multi-prompt playground

### DIFF
--- a/web/src/components/ChatMessages/index.tsx
+++ b/web/src/components/ChatMessages/index.tsx
@@ -24,6 +24,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { isString } from "@/src/utils/types";
+import { Variables } from "@/src/ee/features/playground/page/components/Variables";
 
 type ChatMessagesProps = MessagesContext;
 export const ChatMessages: React.FC<ChatMessagesProps> = (props) => {
@@ -93,6 +94,9 @@ export const ChatMessages: React.FC<ChatMessagesProps> = (props) => {
         </div>
         <div className="py-3">
           <AddMessageButton {...props} />
+        </div>
+        <div className="py-3">
+          <Variables />
         </div>
       </div>
     </DndContext>

--- a/web/src/components/ModelParameters/index.tsx
+++ b/web/src/components/ModelParameters/index.tsx
@@ -20,6 +20,15 @@ import {
 
 import { LLMApiKeyComponent } from "./LLMApiKeyComponent";
 import { FormDescription } from "@/src/components/ui/form";
+import { useState } from "react";
+import {
+  CircleChevronDown,
+  CircleChevronUp,
+  CircleChevronUpIcon,
+  Dot,
+} from "lucide-react";
+import { Button } from "@/src/components/ui/button";
+import { Separator } from "@/src/components/ui/separator";
 
 export type ModelParamsContext = {
   modelParams: UIModelParams;
@@ -32,6 +41,7 @@ export type ModelParamsContext = {
   setModelParamEnabled?: (key: keyof UIModelParams, enabled: boolean) => void;
   formDisabled?: boolean;
   modelParamsDescription?: string;
+  defaultCollapsed?: boolean;
 };
 
 export const ModelParameters: React.FC<ModelParamsContext> = ({
@@ -42,13 +52,17 @@ export const ModelParameters: React.FC<ModelParamsContext> = ({
   setModelParamEnabled,
   formDisabled = false,
   modelParamsDescription,
+  defaultCollapsed = false,
 }) => {
+  // "use client";
+
   const projectId = useProjectIdFromURL();
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
 
   if (!projectId) return null;
 
   return (
-    <div className="flex flex-col space-y-4">
+    <div className="flex flex-col space-y-2">
       <p className="font-semibold">Model</p>
       {availableProviders.length === 0 ? (
         <>
@@ -57,77 +71,97 @@ export const ModelParameters: React.FC<ModelParamsContext> = ({
         </>
       ) : (
         <div className="space-y-4">
-          <ModelParamsSelect
-            title="Provider"
-            modelParamsKey="provider"
-            disabled={formDisabled}
-            value={modelParams.provider.value}
-            options={availableProviders}
-            updateModelParam={updateModelParamValue}
-          />
-          <ModelParamsSelect
-            title="Model name"
-            modelParamsKey="model"
-            disabled={formDisabled}
-            value={modelParams.model.value}
-            options={availableModels}
-            updateModelParam={updateModelParamValue}
-            modelParamsDescription={modelParamsDescription}
-          />
-          {modelParams.model.value?.startsWith("o1-") ? (
-            <p className="text-sm text-dark-yellow">
-              For {modelParams.model.value}, the system message and the
-              temperature, max_tokens and top_p setting are not supported while
-              it is in beta.{" "}
-              <a
-                href="https://platform.openai.com/docs/guides/reasoning/beta-limitations"
-                target="_blank"
-                rel="noreferrer noopener"
-              >
-                More info ↗
-              </a>
-            </p>
-          ) : null}
-          <ModelParamsSlider
-            title="Temperature"
-            modelParamsKey="temperature"
-            formDisabled={formDisabled}
-            enabled={modelParams.temperature.enabled}
-            setModelParamEnabled={setModelParamEnabled}
-            value={modelParams.temperature.value}
-            min={0}
-            max={modelParams.maxTemperature.value}
-            step={0.01}
-            tooltip="The sampling temperature. Higher values will make the output more random, while lower values will make it more focused and deterministic."
-            updateModelParam={updateModelParamValue}
-          />
-          <ModelParamsSlider
-            title="Output token limit"
-            modelParamsKey="max_tokens"
-            formDisabled={formDisabled}
-            enabled={modelParams.max_tokens.enabled}
-            setModelParamEnabled={setModelParamEnabled}
-            value={modelParams.max_tokens.value}
-            min={1}
-            max={16384}
-            step={1}
-            tooltip="The maximum number of tokens that can be generated in the chat completion."
-            updateModelParam={updateModelParamValue}
-          />
-          <ModelParamsSlider
-            title="Top P"
-            modelParamsKey="top_p"
-            formDisabled={formDisabled}
-            enabled={modelParams.top_p.enabled}
-            setModelParamEnabled={setModelParamEnabled}
-            value={modelParams.top_p.value}
-            min={0}
-            max={1}
-            step={0.01}
-            tooltip="An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both."
-            updateModelParam={updateModelParamValue}
-          />
-          <LLMApiKeyComponent {...{ projectId, modelParams }} />
+          <div className="flex items-baseline space-x-4">
+            <ModelParamsSelect
+              title="Provider"
+              modelParamsKey="provider"
+              disabled={formDisabled}
+              value={modelParams.provider.value}
+              options={availableProviders}
+              updateModelParam={updateModelParamValue}
+              inline
+            />
+            <ModelParamsSelect
+              title="Model name"
+              modelParamsKey="model"
+              disabled={formDisabled}
+              value={modelParams.model.value}
+              options={availableModels}
+              updateModelParam={updateModelParamValue}
+              modelParamsDescription={modelParamsDescription}
+              inline
+            />
+            <div className="flex-1" />
+            <Button
+              variant="ghost"
+              className="m-0 aspect-square self-center rounded-full p-0"
+              onClick={() => setCollapsed((prev) => !prev)}
+            >
+              {collapsed ? (
+                <CircleChevronDown size={16} />
+              ) : (
+                <CircleChevronUp size={16} />
+              )}
+            </Button>
+          </div>
+          {!collapsed && (
+            <>
+              {modelParams.model.value?.startsWith("o1-") ? (
+                <p className="text-sm text-dark-yellow">
+                  For {modelParams.model.value}, the system message and the
+                  temperature, max_tokens and top_p setting are not supported
+                  while it is in beta.{" "}
+                  <a
+                    href="https://platform.openai.com/docs/guides/reasoning/beta-limitations"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    More info ↗
+                  </a>
+                </p>
+              ) : null}
+              <ModelParamsSlider
+                title="Temperature"
+                modelParamsKey="temperature"
+                formDisabled={formDisabled}
+                enabled={modelParams.temperature.enabled}
+                setModelParamEnabled={setModelParamEnabled}
+                value={modelParams.temperature.value}
+                min={0}
+                max={modelParams.maxTemperature.value}
+                step={0.01}
+                tooltip="The sampling temperature. Higher values will make the output more random, while lower values will make it more focused and deterministic."
+                updateModelParam={updateModelParamValue}
+              />
+              <ModelParamsSlider
+                title="Output token limit"
+                modelParamsKey="max_tokens"
+                formDisabled={formDisabled}
+                enabled={modelParams.max_tokens.enabled}
+                setModelParamEnabled={setModelParamEnabled}
+                value={modelParams.max_tokens.value}
+                min={1}
+                max={16384}
+                step={1}
+                tooltip="The maximum number of tokens that can be generated in the chat completion."
+                updateModelParam={updateModelParamValue}
+              />
+              <ModelParamsSlider
+                title="Top P"
+                modelParamsKey="top_p"
+                formDisabled={formDisabled}
+                enabled={modelParams.top_p.enabled}
+                setModelParamEnabled={setModelParamEnabled}
+                value={modelParams.top_p.value}
+                min={0}
+                max={1}
+                step={0.01}
+                tooltip="An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both."
+                updateModelParam={updateModelParamValue}
+              />
+              <LLMApiKeyComponent {...{ projectId, modelParams }} />
+            </>
+          )}
         </div>
       )}
     </div>
@@ -142,6 +176,7 @@ type ModelParamsSelectProps = {
   updateModelParam: ModelParamsContext["updateModelParamValue"];
   disabled?: boolean;
   modelParamsDescription?: string;
+  inline?: boolean;
 };
 const ModelParamsSelect = ({
   title,
@@ -151,16 +186,19 @@ const ModelParamsSelect = ({
   updateModelParam,
   disabled,
   modelParamsDescription,
+  inline = false,
 }: ModelParamsSelectProps) => {
   return (
-    <div className="space-y-2">
+    <div className={inline ? "flex space-x-2" : "space-y-2"}>
       <p
         className={cn(
           "text-xs font-semibold",
           disabled && "text-muted-foreground",
+          inline && "flex items-center text-nowrap",
         )}
       >
         {title}
+        {inline && ":"}
       </p>
       <Select
         disabled={disabled}

--- a/web/src/components/ModelParameters/index.tsx
+++ b/web/src/components/ModelParameters/index.tsx
@@ -21,14 +21,8 @@ import {
 import { LLMApiKeyComponent } from "./LLMApiKeyComponent";
 import { FormDescription } from "@/src/components/ui/form";
 import { useState } from "react";
-import {
-  CircleChevronDown,
-  CircleChevronUp,
-  CircleChevronUpIcon,
-  Dot,
-} from "lucide-react";
+import { CircleChevronDown, CircleChevronUp } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
-import { Separator } from "@/src/components/ui/separator";
 
 export type ModelParamsContext = {
   modelParams: UIModelParams;

--- a/web/src/ee/features/playground/page/components/GenerationOutput.tsx
+++ b/web/src/ee/features/playground/page/components/GenerationOutput.tsx
@@ -71,7 +71,7 @@ export const GenerationOutput = () => {
         ref={scrollAreaRef}
       >
         <div className="mb-4 flex w-full items-center">
-          <p className="flex-1 text-xs font-semibold">Output</p>
+          <p className="flex-1 text-sm font-semibold">Output</p>
           {copyButton}
         </div>
         <pre className="whitespace-break-spaces break-words text-xs">

--- a/web/src/ee/features/playground/page/components/Messages.tsx
+++ b/web/src/ee/features/playground/page/components/Messages.tsx
@@ -13,6 +13,7 @@ import {
 export const Messages: React.FC<MessagesContext> = (props) => {
   return (
     <div className="flex h-full flex-col space-y-4 pr-4">
+      <p className="font-semibold">Messages</p>
       <ResizablePanelGroup direction="vertical">
         <ResizablePanel minSize={10}>
           <ChatMessages {...props} />

--- a/web/src/ee/features/playground/page/components/Prompt.tsx
+++ b/web/src/ee/features/playground/page/components/Prompt.tsx
@@ -1,0 +1,26 @@
+import { ModelParameters } from "@/src/components/ModelParameters";
+import { usePlaygroundContext } from "../context";
+import { Messages } from "../components/Messages";
+import { SaveToPromptButton } from "@/src/ee/features/playground/page/components/SaveToPromptButton";
+
+export default function Prompt() {
+  const playgroundContext = usePlaygroundContext();
+
+  return (
+    <>
+      <div className="flex h-full min-w-[64ch] flex-col space-y-3 rounded-md border py-3">
+        <div className="flex items-center border-b px-3 pb-3">
+          <p className="font-semibold">Prompt Config</p>
+          <div className="flex-1" />
+          <SaveToPromptButton />
+        </div>
+        <div className="px-3">
+          <ModelParameters defaultCollapsed {...playgroundContext} />
+        </div>
+        <div className="min-h-96 flex-1 overflow-auto px-3">
+          <Messages {...playgroundContext} />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/web/src/ee/features/playground/page/context/index.tsx
+++ b/web/src/ee/features/playground/page/context/index.tsx
@@ -55,12 +55,14 @@ export const usePlaygroundContext = () => {
   return context;
 };
 
-export const PlaygroundProvider: React.FC<PropsWithChildren> = ({
-  children,
-}) => {
+export const PlaygroundProvider: React.FC<
+  PropsWithChildren<{
+    promptKey: number;
+  }>
+> = ({ children, promptKey }) => {
   const capture = usePostHogClientCapture();
   const projectId = useProjectIdFromURL();
-  const { playgroundCache, setPlaygroundCache } = usePlaygroundCache();
+  const { playgroundCache, setPlaygroundCache } = usePlaygroundCache(promptKey);
   const [promptVariables, setPromptVariables] = useState<PromptVariable[]>([]);
   const [output, setOutput] = useState("");
   const [outputJson, setOutputJson] = useState("");

--- a/web/src/ee/features/playground/page/hooks/usePlaygroundCache.ts
+++ b/web/src/ee/features/playground/page/hooks/usePlaygroundCache.ts
@@ -3,9 +3,10 @@ import { useEffect, useState } from "react";
 import { type PlaygroundCache } from "../types";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 
-const playgroundCacheKey = "playgroundCache";
+const playgroundCacheKeyBase = "playgroundCache";
 
-export default function usePlaygroundCache() {
+export default function usePlaygroundCache(promptKey: number) {
+  const playgroundCacheKey = playgroundCacheKeyBase + "_" + promptKey;
   const [cache, setCache] = useState<PlaygroundCache>(null);
   const available = useHasEntitlement("playground");
   const setPlaygroundCache = (cache: PlaygroundCache) => {
@@ -21,10 +22,10 @@ export default function usePlaygroundCache() {
         console.error("Failed to parse playground cache", e);
       }
     }
-  }, []);
+  }, [playgroundCacheKey]);
 
   return {
     playgroundCache: available ? cache : null,
-    setPlaygroundCache: available ? setPlaygroundCache : () => {},
+    setPlaygroundCache: available ? setPlaygroundCache : () => { },
   };
 }

--- a/web/src/ee/features/playground/page/index.tsx
+++ b/web/src/ee/features/playground/page/index.tsx
@@ -1,7 +1,5 @@
 import { ResetPlaygroundButton } from "@/src/ee/features/playground/page/components/ResetPlaygroundButton";
-import { SaveToPromptButton } from "@/src/ee/features/playground/page/components/SaveToPromptButton";
 import Page from "@/src/components/layouts/page";
-import { PlaygroundProvider } from "@/src/ee/features/playground/page/context";
 import Playground from "@/src/ee/features/playground/page/playground";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 

--- a/web/src/ee/features/playground/page/index.tsx
+++ b/web/src/ee/features/playground/page/index.tsx
@@ -9,26 +9,20 @@ export default function PlaygroundPage() {
   const available = useHasEntitlement("playground");
   if (!available) return null;
   return (
-    <PlaygroundProvider>
-      <Page
-        headerProps={{
-          title: "Playground",
-          help: {
-            description: "A sandbox to test and iterate your prompts",
-            href: "https://langfuse.com/docs/playground",
-          },
-          actionButtonsRight: (
-            <>
-              <SaveToPromptButton />
-              <ResetPlaygroundButton />
-            </>
-          ),
-        }}
-      >
-        <div className="flex-1 overflow-auto">
-          <Playground />
-        </div>
-      </Page>
-    </PlaygroundProvider>
+    <Page
+      headerProps={{
+        title: "Playground",
+        help: {
+          description: "A sandbox to test and iterate your prompts",
+          href: "https://langfuse.com/docs/playground",
+        },
+        actionButtonsRight: <ResetPlaygroundButton />,
+      }}
+      withPadding={false}
+    >
+      <div className="flex-1 overflow-auto">
+        <Playground />
+      </div>
+    </Page>
   );
 }

--- a/web/src/ee/features/playground/page/playground.tsx
+++ b/web/src/ee/features/playground/page/playground.tsx
@@ -1,25 +1,33 @@
-import { ModelParameters } from "@/src/components/ModelParameters";
-import { usePlaygroundContext } from "./context";
-import { Variables } from "./components/Variables";
-import { Messages } from "./components/Messages";
+import { PlaygroundProvider } from "./context";
+import { CirclePlus } from "lucide-react";
+import { Button } from "@/src/components/ui/button";
+import Prompt from "@/src/ee/features/playground/page/components/Prompt";
+import { useState } from "react";
 
 export default function Playground() {
-  const playgroundContext = usePlaygroundContext();
+  const [lastPromptId, setLastPromptId] = useState(0);
+  const [prompts, setPrompts] = useState([0]);
+  const newPrompt = () => {
+    const nextPromptId = lastPromptId + 1;
+    setLastPromptId(nextPromptId);
+    setPrompts([...prompts, nextPromptId]);
+  };
 
   return (
-    <div className="flex h-full flex-row space-x-8">
-      <div className="h-full basis-3/4 overflow-auto">
-        <Messages {...playgroundContext} />
-      </div>
-      <div className="max-h-full min-h-0 basis-1/4 pr-2">
-        <div className="grid h-full grid-rows-[minmax(20dvh,max-content),minmax(20dvh,auto)] overflow-auto">
-          <div className="mb-4 max-h-[80dvh] min-h-[20dvh] overflow-y-auto">
-            <ModelParameters {...playgroundContext} />
-          </div>
-          <div className="min-h-[20dvh]">
-            <Variables />
-          </div>
-        </div>
+    <div className="flex h-full space-x-3 overflow-y-auto p-3">
+      {prompts.map((promptKey) => (
+        <PlaygroundProvider key={promptKey} promptKey={promptKey}>
+          <Prompt />
+        </PlaygroundProvider>
+      ))}
+      <div className="flex h-full flex-col items-center justify-center py-3">
+        <Button
+          variant="ghost"
+          className="m-0 aspect-square self-center rounded-full p-0"
+          onClick={newPrompt}
+        >
+          <CirclePlus size={24} />
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
The Context and Cache of the playground require refactoring such that instead of creating a full playground provider per open prompt and a separate sessionStorage cache key per prompt they are handled in one context managing an array of prompts which is then also serialized as a JSON array into the cache. Furthermore the different actions re-used from the single page need to be adapted to the new context model once that has been reworked. Also there is functionality missing to duplicate prompts, load prompts from the backend and to select versions as well as hint at unsaved changes. CSS around the sizing of the prompt components depending on how many are present in the list is also missing.

## What does this PR do?

As discussed in person, we were exploring the refactoring of the playground page to include multiple prompt components and the ability to quickly iterate and compare prompts.

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't commented my code, particularly in hard-to-understand areas
  - Code is WIP as of now and PR was created as per request of @maxdeichmann 
- I haven't checked if my PR needs changes to the documentation
  - Changes are required still.
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
