### PR TITLE
feat(datasets): add multi-delete for dataset runs table

### DIFF
--- a/web/src/features/datasets/components/DeleteDatasetRunButton.tsx
+++ b/web/src/features/datasets/components/DeleteDatasetRunButton.tsx
@@ -31,7 +31,7 @@ export const DeleteDatasetRunButton = ({
   });
   const utils = api.useUtils();
   const router = useRouter();
-  const mutDelete = api.datasets.deleteDatasetRun.useMutation({
+  const mutDelete = api.datasets.deleteDatasetRuns.useMutation({
     onSuccess: () => {
       redirectUrl ? router.push(redirectUrl) : utils.datasets.invalidate();
     },
@@ -78,7 +78,7 @@ export const DeleteDatasetRunButton = ({
             capture("dataset_run:delete_form_submit");
             await mutDelete.mutateAsync({
               projectId,
-              datasetRunId,
+              datasetRunIds: [datasetRunId],
             });
             setIsDialogOpen(false);
           }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add multi-delete functionality for dataset runs with confirmation dialog and batch deletion support.
> 
>   - **Behavior**:
>     - Add multi-delete functionality for dataset runs in `DatasetRunsTable.tsx`.
>     - Introduce delete confirmation dialog in `DatasetRunsTable.tsx`.
>     - Update `DeleteDatasetRunButton.tsx` to use `deleteDatasetRuns` mutation.
>   - **API**:
>     - Rename `deleteDatasetRun` to `deleteDatasetRuns` in `dataset-router.ts`.
>     - Modify `deleteDatasetRuns` to accept multiple `datasetRunIds` and log each deletion.
>   - **UI Components**:
>     - Add `Trash` icon to `DatasetRunsTable.tsx` for delete action.
>     - Implement `Dialog` for delete confirmation in `DatasetRunsTable.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 544a0694118b561d40489fb9483b5fcc971dffa9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->