### PR TITLE
perf(chat-prompts): apply debounced save approach with local editor content state

### DIFF
--- a/web/src/components/ChatMessages/ChatMessageComponent.tsx
+++ b/web/src/components/ChatMessages/ChatMessageComponent.tsx
@@ -1,6 +1,6 @@
 import { capitalize } from "lodash";
 import { GripVertical, MinusCircleIcon } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ChatMessageRole,
   SYSTEM_ROLES,
@@ -49,6 +49,19 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
   index,
 }) => {
   const [roleIndex, setRoleIndex] = useState(1);
+  const [content, setContent] = useState(message.content);
+  const isDirtyRef = useRef(false);
+
+  useEffect(() => {
+    const saveInterval = setInterval(() => {
+      if (isDirtyRef.current) {
+        updateMessage(message.id, "content", content);
+        isDirtyRef.current = false;
+      }
+    }, 300);
+
+    return () => clearInterval(saveInterval);
+  }, [message.id, content, updateMessage]);
 
   const {
     attributes,
@@ -109,8 +122,8 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
           <GripVertical className="h-4 w-4" />
         </div>
       )}
-      <CardContent className="ml-4 flex flex-row space-x-1 p-0">
-        <div className="min-w-[5rem]">
+      <CardContent className="ml-4 flex flex-row gap-2 p-0">
+        <div className="min-w-[4rem]">
           <Button
             onClick={toggleRole}
             type="button" // prevents submitting a form if this button is inside a form
@@ -121,8 +134,11 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
           </Button>
         </div>
         <CodeMirrorEditor
-          value={message.content}
-          onChange={(value) => updateMessage(message.id, "content", value)}
+          value={content}
+          onChange={(value) => {
+            setContent(value);
+            isDirtyRef.current = true;
+          }}
           mode="prompt"
           minHeight={30}
           className="w-full"

--- a/web/src/components/ChatMessages/index.tsx
+++ b/web/src/components/ChatMessages/index.tsx
@@ -1,11 +1,8 @@
 import { PlusCircleIcon } from "lucide-react";
 import { useEffect, useRef } from "react";
-
 import { Button } from "@/src/components/ui/button";
 import { ChatMessageRole, SYSTEM_ROLES } from "@langfuse/shared";
-
 import { ChatMessageComponent } from "./ChatMessageComponent";
-
 import type { MessagesContext } from "./types";
 import {
   closestCenter,
@@ -83,8 +80,12 @@ export const ChatMessages: React.FC<ChatMessagesProps> = (props) => {
               {props.messages.map((message, index) => {
                 return (
                   <ChatMessageComponent
-                    {...{ message, ...props, index }}
                     key={message.id}
+                    deleteMessage={props.deleteMessage}
+                    updateMessage={props.updateMessage}
+                    availableRoles={props.availableRoles}
+                    message={message}
+                    index={index}
                   />
                 );
               })}


### PR DESCRIPTION
**Context:** We received degraded performance reports from a handfull of users over the last week.

**Previously:** specifically in our playground performance was impacted for users with large chat prompts especially in case of large nested json and many messages. As our playground works with a context provider that includes the state of messages all consumers will re-render if messages changes. Hence, all messages would re-render on each keystroke. This likely caused the degraded experience. 

**Suggested fix:** Using a debounced save approach with isDirtyRef: Instead of saving on every keystroke, it marks the content as "dirty" (similar to how react forms typically track changes). We update messages every 300ms if content is marked as dirty. We use a ref (isDirtyRef) to track dirty state without causing re-renders. Also, we reduce state updates ie re-renders by defining local content state to handle immediate updates for the editor, with the parent state update called periodically. 

**How to visualise:** Enable re-renders in react developer tools. Compare behaviour 

**Ask:** please comment on implementation. I have tested both prompt creation and playground, but as you wrote the original code it would be great if you could throughly review please. 