### PR TITLE
chore: limit event id length

### DIFF
--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -8,6 +8,7 @@ import { type ScoreSourceType } from "../repositories";
 export const idSchema = z
   .string()
   .min(1)
+  .max(800) // AWS S3 allows for 1024 bytes for object keys and we need enough room to construct the entire key/path. https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
   .refine((id) => !id.includes("\r"), {
     message: "ID cannot contain carriage return characters",
   });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Limits `idSchema` string length to 800 characters in `types.ts` for AWS S3 compatibility.
> 
>   - **Behavior**:
>     - Limits `idSchema` string length to a maximum of 800 characters in `types.ts` to ensure compatibility with AWS S3 object key constraints.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9c7577c1e021208ef8b3f2ce553856cb4731dfcc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->