### PR TITLE
fix: correctly extract jsonpath form observations for evals

### DIFF
--- a/worker/src/ee/evaluation/evalService.ts
+++ b/worker/src/ee/evaluation/evalService.ts
@@ -680,10 +680,7 @@ export async function extractVariablesFromTracingData({
 
         return {
           var: variable,
-          value: parseDatabaseRowToString(
-            observation as Record<string, unknown>,
-            mapping,
-          ),
+          value: parseDatabaseRowToString(observation, mapping),
           environment: observation.environment,
         };
       }

--- a/worker/src/ee/evaluation/evalService.ts
+++ b/worker/src/ee/evaluation/evalService.ts
@@ -680,8 +680,9 @@ export async function extractVariablesFromTracingData({
 
         return {
           var: variable,
-          value: parseUnknownToString(
-            (observation as Record<string, unknown>)[mapping.selectedColumnId],
+          value: parseDatabaseRowToString(
+            observation as Record<string, unknown>,
+            mapping,
           ),
           environment: observation.environment,
         };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `extractVariablesFromTracingData` in `evalService.ts` to use `parseDatabaseRowToString` for JSON path extraction from observations.
> 
>   - **Behavior**:
>     - Refactor `extractVariablesFromTracingData` in `evalService.ts` to use `parseDatabaseRowToString` instead of `parseUnknownToString` for extracting values from observations.
>     - Handles JSON path extraction using `parseDatabaseRowToString`.
>   - **Functions**:
>     - `parseDatabaseRowToString` now processes JSON paths and falls back to original value on error.
>     - `parseUnknownToString` remains unchanged but is no longer used in `extractVariablesFromTracingData`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bd7bacdc42a8fb9139ad4ad697042071dda732dd. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->