### PR TITLE
chore: refactor score deletions into async queue

### DIFF
--- a/packages/shared/src/features/batchExport/types.ts
+++ b/packages/shared/src/features/batchExport/types.ts
@@ -18,6 +18,7 @@ export enum BatchExportFileFormat {
 }
 
 export enum BatchExportTableName {
+  Scores = "scores",
   Sessions = "sessions",
   Traces = "traces",
   Generations = "generations",

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -28,6 +28,7 @@ export * from "./redis/cloudUsageMeteringQueue";
 export * from "./redis/getQueue";
 export * from "./redis/traceDelete";
 export * from "./redis/projectDelete";
+export * from "./redis/scoreDelete";
 export * from "./redis/datasetRunItemUpsert";
 export * from "./redis/batchExport";
 export * from "./redis/batchActionQueue";

--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -34,6 +34,10 @@ export const TracesQueueEventSchema = z.object({
   projectId: z.string(),
   traceIds: z.array(z.string()),
 });
+export const ScoresQueueEventSchema = z.object({
+  projectId: z.string(),
+  scoreIds: z.array(z.string()),
+});
 export const ProjectQueueEventSchema = z.object({
   projectId: z.string(),
   orgId: z.string(),
@@ -65,6 +69,15 @@ export const DataRetentionProcessingEventSchema = z.object({
 export const BatchActionProcessingEventSchema = z.discriminatedUnion(
   "actionId",
   [
+    z.object({
+      actionId: z.literal("score-delete"),
+      projectId: z.string(),
+      query: BatchActionQuerySchema,
+      tableName: z.nativeEnum(BatchExportTableName),
+      cutoffCreatedAt: z.date(),
+      targetId: z.string().optional(),
+      type: z.nativeEnum(BatchActionType),
+    }),
     z.object({
       actionId: z.literal("trace-delete"),
       projectId: z.string(),
@@ -114,6 +127,7 @@ export type CreateEvalQueueEventType = z.infer<
 export type BatchExportJobType = z.infer<typeof BatchExportJobSchema>;
 export type TraceQueueEventType = z.infer<typeof TraceQueueEventSchema>;
 export type TracesQueueEventType = z.infer<typeof TracesQueueEventSchema>;
+export type ScoresQueueEventType = z.infer<typeof ScoresQueueEventSchema>;
 export type ProjectQueueEventType = z.infer<typeof ProjectQueueEventSchema>;
 export type DatasetRunItemUpsertEventType = z.infer<
   typeof DatasetRunItemUpsertEventSchema
@@ -152,6 +166,7 @@ export enum QueueName {
   DataRetentionProcessingQueue = "data-retention-processing-queue",
   BatchActionQueue = "batch-action-queue",
   CreateEvalQueue = "create-eval-queue",
+  ScoreDelete = "score-delete",
 }
 
 export enum QueueJobs {
@@ -173,6 +188,7 @@ export enum QueueJobs {
   DataRetentionProcessingJob = "data-retention-processing-job",
   BatchActionProcessingJob = "batch-action-processing-job",
   CreateEvalJob = "create-eval-job",
+  ScoreDelete = "score-delete",
 }
 
 export type TQueueJobTypes = {
@@ -187,6 +203,12 @@ export type TQueueJobTypes = {
     id: string;
     payload: TracesQueueEventType | TraceQueueEventType;
     name: QueueJobs.TraceDelete;
+  };
+  [QueueName.ScoreDelete]: {
+    timestamp: Date;
+    id: string;
+    payload: ScoresQueueEventType;
+    name: QueueJobs.ScoreDelete;
   };
   [QueueName.ProjectDelete]: {
     timestamp: Date;

--- a/packages/shared/src/server/redis/getQueue.ts
+++ b/packages/shared/src/server/redis/getQueue.ts
@@ -17,6 +17,7 @@ import { DataRetentionQueue } from "./dataRetentionQueue";
 import { DataRetentionProcessingQueue } from "./dataRetentionProcessingQueue";
 import { BatchActionQueue } from "./batchActionQueue";
 import { CreateEvalQueue } from "./createEvalQueue";
+import { ScoreDeleteQueue } from "./scoreDelete";
 
 export function getQueue(queueName: QueueName): Queue | null {
   switch (queueName) {
@@ -56,6 +57,8 @@ export function getQueue(queueName: QueueName): Queue | null {
       return BatchActionQueue.getInstance();
     case QueueName.CreateEvalQueue:
       return CreateEvalQueue.getInstance();
+    case QueueName.ScoreDelete:
+      return ScoreDeleteQueue.getInstance();
     default:
       const exhaustiveCheckDefault: never = queueName;
       throw new Error(`Queue ${queueName} not found`);

--- a/packages/shared/src/server/redis/scoreDelete.ts
+++ b/packages/shared/src/server/redis/scoreDelete.ts
@@ -1,0 +1,38 @@
+import { QueueName, TQueueJobTypes } from "../queues";
+import { Queue } from "bullmq";
+import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import { logger } from "../logger";
+
+export class ScoreDeleteQueue {
+  private static instance: Queue<TQueueJobTypes[QueueName.ScoreDelete]> | null = null;
+
+  public static getInstance(): Queue<TQueueJobTypes[QueueName.ScoreDelete]> | null {
+    if (ScoreDeleteQueue.instance) return ScoreDeleteQueue.instance;
+
+    const newRedis = createNewRedisInstance({
+      enableOfflineQueue: false,
+      ...redisQueueRetryOptions,
+    });
+
+    ScoreDeleteQueue.instance = newRedis
+      ? new Queue<TQueueJobTypes[QueueName.ScoreDelete]>(QueueName.ScoreDelete, {
+          connection: newRedis,
+          defaultJobOptions: {
+            removeOnComplete: true,
+            removeOnFail: 100_000,
+            attempts: 2,
+            backoff: {
+              type: "exponential",
+              delay: 30_000,
+            },
+          },
+        })
+      : null;
+
+    ScoreDeleteQueue.instance?.on("error", (err) => {
+      logger.error("ScoreDeleteQueue error", err);
+    });
+
+    return ScoreDeleteQueue.instance;
+  }
+} 

--- a/packages/shared/src/server/repositories/eventLog.ts
+++ b/packages/shared/src/server/repositories/eventLog.ts
@@ -81,6 +81,37 @@ export const getEventLogByProjectIdBeforeDate = (
   });
 };
 
+export const getEventLogByProjectIdAndEntityIds = (
+  projectId: string,
+  entityType: "observation" | "trace" | "score",
+  entityIds: string[],
+): AsyncGenerator<EventLogRecordReadType> => {
+  const query = `
+    select *
+    from event_log
+    where project_id = {projectId: String}
+      and entity_type = {entityType: String}
+      and entity_id in ({entityIds: Array(String)})
+  `;
+
+  return queryClickhouseStream<EventLogRecordReadType>({
+    query,
+    params: {
+      projectId,
+      entityType,
+      entityIds,
+    },
+    clickhouseConfigs: {
+      request_timeout: 120_000, // 2 minutes
+    },
+    tags: {
+      feature: "eventLog",
+      kind: "list",
+      projectId,
+    },
+  });
+};
+
 export const getEventLogByProjectIdAndTraceIds = (
   projectId: string,
   traceIds: string[],

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -554,17 +554,17 @@ export const getScoreNames = async (
   }));
 };
 
-export const deleteScore = async (projectId: string, scoreId: string) => {
+export const deleteScores = async (projectId: string, scoreIds: string[]) => {
   const query = `
     DELETE FROM scores
     WHERE project_id = {projectId: String}
-    AND id = {scoreId: String};
+    AND id in ({scoreIds: Array(String)});
   `;
   await commandClickhouse({
     query: query,
     params: {
       projectId,
-      scoreId,
+      scoreIds,
     },
     tags: {
       feature: "tracing",

--- a/web/src/__tests__/test-utils.ts
+++ b/web/src/__tests__/test-utils.ts
@@ -88,11 +88,12 @@ export async function makeZodVerifiedAPICall<T extends z.ZodTypeAny>(
   url: string,
   body?: unknown,
   auth?: string,
+  statusCode = 200,
 ): Promise<{ body: z.infer<T>; status: number }> {
   const { body: resBody, status } = await makeAPICall(method, url, body, auth);
-  if (status !== 200) {
+  if (status !== statusCode) {
     throw new Error(
-      `API call did not return 200, returned status ${status}, body ${JSON.stringify(resBody)}`,
+      `API call did not return ${statusCode}, returned status ${status}, body ${JSON.stringify(resBody)}`,
     );
   }
   const typeCheckResult = responseZodSchema.safeParse(resBody);

--- a/web/src/pages/api/public/scores/[scoreId].ts
+++ b/web/src/pages/api/public/scores/[scoreId].ts
@@ -17,7 +17,6 @@ import {
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { QueueJobs } from "@langfuse/shared/src/server";
 import { randomUUID } from "crypto";
-import { TRPCError } from "@trpc/server";
 
 export default withMiddlewares({
   GET: createAuthedAPIRoute({
@@ -52,10 +51,7 @@ export default withMiddlewares({
 
       const scoreDeleteQueue = ScoreDeleteQueue.getInstance();
       if (!scoreDeleteQueue) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "ScoreDeleteQueue not initialized",
-        });
+        throw new InternalServerError("ScoreDeleteQueue not initialized");
       }
 
       await auditLog({

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -31,7 +31,6 @@ import {
   getScoresUiTable,
   getScoreNames,
   getTracesGroupedByTags,
-  deleteScores,
   upsertScore,
   logger,
   getTraceById,

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -31,7 +31,7 @@ import {
   getScoresUiTable,
   getScoreNames,
   getTracesGroupedByTags,
-  deleteScore,
+  deleteScores,
   upsertScore,
   logger,
   getTraceById,
@@ -348,7 +348,8 @@ export const scoresRouter = createTRPCRouter({
         });
 
         // Delete the score from Clickhouse
-        await deleteScore(input.projectId, clickhouseScore.id);
+        // TODO: Move to queue
+        await deleteScores(input.projectId, [clickhouseScore.id]);
         score = clickhouseScore;
       }
 

--- a/worker/src/__tests__/scoreDeletion.test.ts
+++ b/worker/src/__tests__/scoreDeletion.test.ts
@@ -1,0 +1,95 @@
+import { expect, describe, it, beforeAll } from "vitest";
+import {
+  clickhouseClient,
+  createOrgProjectAndApiKey,
+  createScore,
+  createScoresCh,
+  getEventLogByProjectId,
+  getScoresByIds,
+  StorageService,
+  StorageServiceFactory,
+} from "@langfuse/shared/src/server";
+import { randomUUID } from "crypto";
+import { env } from "../env";
+import { processClickhouseScoreDelete } from "../features/scores/processClickhouseScoreDelete";
+
+describe("score deletion", () => {
+  let eventStorageService: StorageService;
+
+  beforeAll(() => {
+    eventStorageService = StorageServiceFactory.getInstance({
+      accessKeyId: env.LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID,
+      secretAccessKey: env.LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY,
+      bucketName: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+      endpoint: env.LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT,
+      region: env.LANGFUSE_S3_EVENT_UPLOAD_REGION,
+      forcePathStyle: env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+    });
+  });
+
+  it("should delete all scores from Clickhouse", async () => {
+    // Setup
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const score = createScore({ project_id: projectId });
+    await createScoresCh([score]);
+
+    // When
+    await processClickhouseScoreDelete(projectId, [score.id]);
+
+    // Then
+    const scores = await getScoresByIds(projectId, [score.id]);
+    expect(scores).toHaveLength(0);
+  });
+
+  it("should delete S3 event files for deleted scores", async () => {
+    // Setup
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const scoreId = randomUUID();
+    await createScoresCh([createScore({ id: scoreId, project_id: projectId })]);
+
+    const fileType = "application/json";
+    const data = JSON.stringify({ hello: "world" });
+    const expiresInSeconds = 3600;
+    await Promise.all([
+      eventStorageService.uploadFile({
+        fileName: `${projectId}/score/${scoreId}-score.json`,
+        fileType,
+        data,
+        expiresInSeconds,
+      }),
+    ]);
+
+    await clickhouseClient().insert({
+      table: "event_log",
+      format: "JSONEachRow",
+      values: [
+        {
+          id: randomUUID(),
+          project_id: projectId,
+          entity_type: "score",
+          entity_id: scoreId,
+          event_id: randomUUID(),
+          bucket_name: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+          bucket_path: `${projectId}/score/${scoreId}-score.json`,
+          created_at: new Date().getTime(),
+          updated_at: new Date().getTime(),
+        },
+      ],
+    });
+
+    // When
+    await processClickhouseScoreDelete(projectId, [scoreId]);
+
+    // Then
+    const eventLog = getEventLogByProjectId(projectId);
+    for await (const _ of eventLog) {
+      // Should never happen as the expect event log to be empty
+      expect(true).toBe(false);
+    }
+
+    const files = await eventStorageService.listFiles(projectId);
+    expect(files).toHaveLength(0);
+  });
+});

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -45,6 +45,7 @@ import {
   dataRetentionProcessor,
 } from "./queues/dataRetentionQueue";
 import { batchActionQueueProcessor } from "./queues/batchActionQueue";
+import { scoreDeleteProcessor } from "./queues/scoreDelete";
 
 const app = express();
 
@@ -120,6 +121,17 @@ if (env.QUEUE_CONSUMER_TRACE_DELETE_QUEUE_IS_ENABLED === "true") {
     limiter: {
       // Process at most `max` delete jobs per 15 seconds
       max: env.LANGFUSE_TRACE_DELETE_CONCURRENCY,
+      duration: 15_000,
+    },
+  });
+}
+
+if (env.QUEUE_CONSUMER_TRACE_DELETE_QUEUE_IS_ENABLED === "true") {
+  WorkerManager.register(QueueName.ScoreDelete, scoreDeleteProcessor, {
+    concurrency: env.LANGFUSE_SCORE_DELETE_CONCURRENCY,
+    limiter: {
+      // Process at most `max` delete jobs per 15 seconds
+      max: env.LANGFUSE_SCORE_DELETE_CONCURRENCY,
       duration: 15_000,
     },
   });

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -126,7 +126,7 @@ if (env.QUEUE_CONSUMER_TRACE_DELETE_QUEUE_IS_ENABLED === "true") {
   });
 }
 
-if (env.QUEUE_CONSUMER_TRACE_DELETE_QUEUE_IS_ENABLED === "true") {
+if (env.QUEUE_CONSUMER_SCORE_DELETE_QUEUE_IS_ENABLED === "true") {
   WorkerManager.register(QueueName.ScoreDelete, scoreDeleteProcessor, {
     concurrency: env.LANGFUSE_SCORE_DELETE_CONCURRENCY,
     limiter: {

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -101,6 +101,7 @@ const EnvSchema = z.object({
     .positive()
     .default(25),
   LANGFUSE_TRACE_DELETE_CONCURRENCY: z.coerce.number().positive().default(1),
+  LANGFUSE_SCORE_DELETE_CONCURRENCY: z.coerce.number().positive().default(1),
   LANGFUSE_PROJECT_DELETE_CONCURRENCY: z.coerce.number().positive().default(1),
   LANGFUSE_EVAL_EXECUTION_WORKER_CONCURRENCY: z.coerce
     .number()
@@ -160,6 +161,9 @@ const EnvSchema = z.object({
   QUEUE_CONSUMER_TRACE_DELETE_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])
     .default("true"),
+  QUEUE_CONSUMER_SCORE_DELETE_QUEUE_IS_ENABLED: z
+    .enum(["true", "false"])
+    .default("true"),
   QUEUE_CONSUMER_PROJECT_DELETE_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])
     .default("true"),
@@ -209,10 +213,7 @@ const EnvSchema = z.object({
     .enum(["true", "false"])
     .default("false"),
 
-  LANGFUSE_S3_CONCURRENT_READS: z.coerce
-    .number()
-    .positive()
-    .default(50),
+  LANGFUSE_S3_CONCURRENT_READS: z.coerce.number().positive().default(50),
 });
 
 export const env: z.infer<typeof EnvSchema> =

--- a/worker/src/features/batchAction/handleBatchActionJob.ts
+++ b/worker/src/features/batchAction/handleBatchActionJob.ts
@@ -21,6 +21,7 @@ import { processAddToQueue } from "./processAddToQueue";
 import { processPostgresTraceDelete } from "../traces/processPostgresTraceDelete";
 import { prisma } from "@langfuse/shared/src/db";
 import { randomUUID } from "node:crypto";
+import { processClickhouseScoreDelete } from "../scores/processClickhouseScoreDelete";
 
 const CHUNK_SIZE = 1000;
 const convertDatesInQuery = (query: BatchActionQuery) => {
@@ -55,6 +56,10 @@ async function processActionChunk(
 
       case "trace-add-to-annotation-queue":
         await processAddToQueue(projectId, chunkIds, targetId as string);
+        break;
+
+      case "score-delete":
+        await processClickhouseScoreDelete(projectId, chunkIds);
         break;
 
       default:
@@ -127,7 +132,8 @@ export const handleBatchActionJob = async (
 
   if (
     actionId === "trace-delete" ||
-    actionId === "trace-add-to-annotation-queue"
+    actionId === "trace-add-to-annotation-queue" ||
+    actionId === "score-delete"
   ) {
     const { projectId, tableName, query, cutoffCreatedAt, targetId, type } =
       batchActionEvent;

--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -27,12 +27,15 @@ import {
   logger,
   getTracesByIds,
   getSessionsWithMetrics,
+  getScoresByIds,
+  getScoresUiTable,
 } from "@langfuse/shared/src/server";
 import { env } from "../../env";
 import { BatchExportSessionsRow, BatchExportTracesRow } from "./types";
 import Decimal from "decimal.js";
 
 const tableNameToTimeFilterColumn = {
+  scores: "timestamp",
   sessions: "createdAt",
   traces: "timestamp",
   generations: "startTime",
@@ -40,6 +43,7 @@ const tableNameToTimeFilterColumn = {
 };
 
 const tableNameToTimeFilterColumnCh = {
+  scores: "timestamp",
   sessions: "createdAt",
   traces: "timestamp",
   generations: "startTime",
@@ -114,6 +118,21 @@ export const getDatabaseReadStream = async ({
   };
 
   switch (tableName) {
+    case "scores": {
+      return new DatabaseReadStream<unknown>(
+        async (pageSize: number, offset: number) =>
+          getScoresUiTable({
+            projectId,
+            filter: filter ?? [],
+            orderBy,
+            limit: pageSize,
+            offset,
+          }),
+        1000,
+        exportLimit,
+      );
+    }
+
     case "sessions":
       return new DatabaseReadStream<unknown>(
         async (pageSize: number, offset: number) => {

--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -27,7 +27,6 @@ import {
   logger,
   getTracesByIds,
   getSessionsWithMetrics,
-  getScoresByIds,
   getScoresUiTable,
 } from "@langfuse/shared/src/server";
 import { env } from "../../env";

--- a/worker/src/features/scores/processClickhouseScoreDelete.ts
+++ b/worker/src/features/scores/processClickhouseScoreDelete.ts
@@ -1,0 +1,74 @@
+import {
+  deleteScores,
+  deleteEventLogByProjectIdAndIds,
+  logger,
+  StorageService,
+  StorageServiceFactory,
+  traceException,
+  getEventLogByProjectIdAndEntityIds,
+} from "@langfuse/shared/src/server";
+import { env } from "../../env";
+
+let s3EventStorageClient: StorageService;
+
+const getS3EventStorageClient = (bucketName: string): StorageService => {
+  if (!s3EventStorageClient) {
+    s3EventStorageClient = StorageServiceFactory.getInstance({
+      bucketName,
+      accessKeyId: env.LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID,
+      secretAccessKey: env.LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY,
+      endpoint: env.LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT,
+      region: env.LANGFUSE_S3_EVENT_UPLOAD_REGION,
+      forcePathStyle: env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+    });
+  }
+  return s3EventStorageClient;
+};
+
+export const processClickhouseScoreDelete = async (
+  projectId: string,
+  scoreIds: string[],
+) => {
+  logger.info(
+    `Deleting scores ${JSON.stringify(scoreIds)} in project ${projectId} from Clickhouse`,
+  );
+
+  const eventLogStream = getEventLogByProjectIdAndEntityIds(
+    projectId,
+    "score",
+    scoreIds,
+  );
+  let eventLogRecords: { id: string; path: string }[] = [];
+  const eventStorageClient = getS3EventStorageClient(
+    env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+  );
+  for await (const eventLog of eventLogStream) {
+    eventLogRecords.push({ id: eventLog.id, path: eventLog.bucket_path });
+    if (eventLogRecords.length > 500) {
+      // Delete the current batch and reset the list
+      await eventStorageClient.deleteFiles(eventLogRecords.map((r) => r.path));
+      await deleteEventLogByProjectIdAndIds(
+        projectId,
+        eventLogRecords.map((r) => r.id),
+      );
+      eventLogRecords = [];
+    }
+  }
+  // Delete any remaining files
+  await eventStorageClient.deleteFiles(eventLogRecords.map((r) => r.path));
+  await deleteEventLogByProjectIdAndIds(
+    projectId,
+    eventLogRecords.map((r) => r.id),
+  );
+
+  try {
+    await deleteScores(projectId, scoreIds);
+  } catch (e) {
+    logger.error(
+      `Error deleting scores ${JSON.stringify(scoreIds)} in project ${projectId} from Clickhouse`,
+      e,
+    );
+    traceException(e);
+    throw e;
+  }
+};

--- a/worker/src/queues/scoreDelete.ts
+++ b/worker/src/queues/scoreDelete.ts
@@ -1,0 +1,11 @@
+import { Job, Processor } from "bullmq";
+import { QueueName, TQueueJobTypes } from "@langfuse/shared/src/server";
+
+import { processClickhouseScoreDelete } from "../features/scores/processClickhouseScoreDelete";
+
+export const scoreDeleteProcessor: Processor = async (
+  job: Job<TQueueJobTypes[QueueName.ScoreDelete]>,
+): Promise<void> => {
+  const { scoreIds, projectId } = job.data.payload;
+  await processClickhouseScoreDelete(projectId, scoreIds);
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enable score deletion via Langfuse UI by adding a new queue and processor, updating API endpoints, and ensuring related data cleanup.
> 
>   - **Behavior**:
>     - Adds `score-delete` action to `BatchActionProcessingEventSchema` in `queues.ts`.
>     - Implements `ScoreDeleteQueue` in `scoreDelete.ts` for handling score deletion jobs.
>     - Updates `getQueue()` in `getQueue.ts` to include `ScoreDeleteQueue`.
>     - Adds `DELETE /api/public/scores/:scoreId` endpoint in `[scoreId].ts` to queue score deletions.
>     - Implements `processClickhouseScoreDelete()` in `processClickhouseScoreDelete.ts` to delete scores and related event logs from Clickhouse and S3.
>   - **Tests**:
>     - Adds test cases for score deletion in `scores-api.servertest.ts` and `scoreDeletion.test.ts`.
>     - Updates `batchAction.test.ts` to test score deletion via batch actions.
>   - **Misc**:
>     - Updates `env.ts` to include `LANGFUSE_SCORE_DELETE_CONCURRENCY` and `QUEUE_CONSUMER_SCORE_DELETE_QUEUE_IS_ENABLED`.
>     - Registers `scoreDeleteProcessor` in `app.ts` for processing score deletion jobs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1b1efa3979134a834a0b92ff121a9c15714c52ce. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->