### PR TITLE
chore(cloud): add more data masking for posthog

### DIFF
--- a/web/src/components/trace/IOPreview.tsx
+++ b/web/src/components/trace/IOPreview.tsx
@@ -160,6 +160,7 @@ export const IOPreview: React.FC<{
               {!(hideIfNull && !input) && !hideInput ? (
                 <MarkdownJsonView
                   title="Input"
+                  className="ph-no-capture"
                   content={input}
                   media={media?.filter((m) => m.field === "input") ?? []}
                 />
@@ -167,6 +168,7 @@ export const IOPreview: React.FC<{
               {!(hideIfNull && !output) && !hideOutput ? (
                 <MarkdownJsonView
                   title="Output"
+                  className="ph-no-capture"
                   content={output}
                   customCodeHeaderClassName="bg-secondary"
                   media={media?.filter((m) => m.field === "output") ?? []}
@@ -181,6 +183,7 @@ export const IOPreview: React.FC<{
           {!(hideIfNull && !input) && !hideInput ? (
             <JSONView
               title="Input"
+              className="ph-no-capture"
               json={input ?? null}
               isLoading={isLoading}
               media={media?.filter((m) => m.field === "input") ?? []}
@@ -189,6 +192,7 @@ export const IOPreview: React.FC<{
           {!(hideIfNull && !output) && !hideOutput ? (
             <JSONView
               title="Output"
+              className="ph-no-capture"
               json={outputClean}
               isLoading={isLoading}
               media={media?.filter((m) => m.field === "output") ?? []}
@@ -221,7 +225,7 @@ export const OpenAiMessageView: React.FC<{
   );
 
   return (
-    <div className="flex max-h-full min-h-0 flex-col gap-2">
+    <div className="ph-no-capture flex max-h-full min-h-0 flex-col gap-2">
       {title && <SubHeaderLabel title={title} className="mt-1" />}
       <div className="flex max-h-full min-h-0 flex-col gap-2">
         <div className="flex flex-col gap-2">

--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -115,7 +115,7 @@ export const ObservationPreview = ({
   if (!preloadedObservation) return <div className="flex-1">Not found</div>;
 
   return (
-    <div className="col-span-2 flex h-full flex-1 flex-col overflow-hidden md:col-span-3">
+    <div className="ph-no-capture col-span-2 flex h-full flex-1 flex-col overflow-hidden md:col-span-3">
       <div className="flex h-full flex-1 flex-col items-start gap-1 overflow-hidden">
         <div className="mt-3 grid w-full grid-cols-[auto,auto] items-start justify-between gap-2">
           <div className="flex w-full flex-row items-start gap-2">

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -91,7 +91,7 @@ export const TracePreview = ({
   );
 
   return (
-    <div className="col-span-2 flex h-full flex-1 flex-col overflow-hidden md:col-span-3">
+    <div className="ph-no-capture col-span-2 flex h-full flex-1 flex-col overflow-hidden md:col-span-3">
       <div className="flex h-full flex-1 flex-col items-start gap-1 overflow-hidden">
         <div className="mt-3 grid w-full grid-cols-[auto,auto] items-start justify-between gap-2">
           <div className="flex w-full flex-row items-start gap-2">

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -251,14 +251,14 @@ export const IOTableCell = ({
       {singleLine ? (
         <div
           className={cn(
-            "h-full w-full self-stretch overflow-hidden overflow-y-auto truncate rounded-sm border px-2 py-0.5",
+            "ph-no-capture h-full w-full self-stretch overflow-hidden overflow-y-auto truncate rounded-sm border px-2 py-0.5",
             className,
           )}
         >
           {stringifiedJson}
         </div>
       ) : shouldTruncate ? (
-        <div className="grid h-full grid-cols-1">
+        <div className="ph-no-capture grid h-full grid-cols-1">
           <JSONView
             json={
               stringifiedJson.slice(0, IO_TABLE_CHAR_LIMIT) +
@@ -275,7 +275,10 @@ export const IOTableCell = ({
       ) : (
         <JSONView
           json={stringifiedJson}
-          className={cn("h-full w-full self-stretch rounded-sm", className)}
+          className={cn(
+            "ph-no-capture h-full w-full self-stretch rounded-sm",
+            className,
+          )}
           codeClassName="py-1 px-2 min-h-0 h-full overflow-y-auto"
           collapseStringsAfterLength={null} // in table, show full strings as row height is fixed
         />

--- a/web/src/features/datasets/components/EditDatasetItem.tsx
+++ b/web/src/features/datasets/components/EditDatasetItem.tsx
@@ -147,7 +147,7 @@ export const EditDatasetItem = ({
               {hasChanges ? "Save changes" : "Saved"}
             </Button>
           </div>
-          <div className="flex-1 overflow-auto">
+          <div className="ph-no-capture flex-1 overflow-auto">
             <div className="space-y-4">
               <div className="grid gap-4 md:grid-cols-2">
                 <FormField

--- a/web/src/features/datasets/components/NewDatasetItemForm.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemForm.tsx
@@ -243,7 +243,7 @@ export const NewDatasetItemForm = (props: {
             )}
           />
         </div>
-        <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="ph-no-capture min-h-0 flex-1 overflow-y-auto">
           <div className="grid gap-4 md:grid-cols-2">
             <FormField
               control={form.control}

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -62,6 +62,13 @@ if (
     loaded: (posthog) => {
       if (process.env.NODE_ENV === "development") posthog.debug();
     },
+    session_recording: {
+      maskCapturedNetworkRequestFn(request) {
+        request.requestBody = request.requestBody ? "REDACTED" : undefined;
+        request.responseBody = request.responseBody ? "REDACTED" : undefined;
+        return request;
+      },
+    },
     autocapture: false,
     enable_heatmaps: false,
   });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add data masking for PostHog by applying `ph-no-capture` class to components and redacting network request data in session recordings.
> 
>   - **Data Masking**:
>     - Add `ph-no-capture` class to `IOPreview`, `ObservationPreview`, `TracePreview`, `CodeJsonViewer`, `EditDatasetItem`, and `NewDatasetItemForm` components to prevent data capture.
>     - Implement `maskCapturedNetworkRequestFn` in `_app.tsx` to redact `requestBody` and `responseBody` in PostHog session recordings.
>   - **Components**:
>     - `IOPreview.tsx`: Add `ph-no-capture` to `MarkdownJsonView` and `JSONView` components.
>     - `ObservationPreview.tsx` and `TracePreview.tsx`: Add `ph-no-capture` to main container divs.
>     - `CodeJsonViewer.tsx`: Add `ph-no-capture` to `IOTableCell` and `JSONView` components.
>     - `EditDatasetItem.tsx` and `NewDatasetItemForm.tsx`: Add `ph-no-capture` to main content divs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5f823454319c3f287572be92bcc27c8812fd1006. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->