### PR TITLE
chore: remove models page notification

### DIFF
--- a/web/src/components/nav/sidebar-notifications.tsx
+++ b/web/src/components/nav/sidebar-notifications.tsx
@@ -24,11 +24,6 @@ type SidebarNotification = {
 
 const notifications: SidebarNotification[] = [
   {
-    id: "models-redirect",
-    title: "Models page moved",
-    description: "Manage your models in settings from now on",
-  },
-  {
     id: "github-star",
     title: "Star Langfuse",
     description:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes the "Models page moved" notification from the `notifications` array in `sidebar-notifications.tsx`.
> 
>   - **Behavior**:
>     - Removes the "Models page moved" notification from the `notifications` array in `sidebar-notifications.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e0cd316de4a4f6896303bddfba36d2a0df27fc77. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->