### PR TITLE
feat(datasets): show run name on runitems table

### DIFF
--- a/web/src/features/datasets/components/DatasetRunItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsTable.tsx
@@ -27,6 +27,7 @@ export type DatasetRunItemRowData = {
   id: string;
   runAt: Date;
   datasetItemId: string;
+  datasetRunName?: string;
   trace?: {
     traceId: string;
     observationId?: string;
@@ -100,6 +101,17 @@ export function DatasetRunItemsTable(
       cell: ({ row }) => {
         const value: DatasetRunItemRowData["runAt"] = row.getValue("runAt");
         return <LocalIsoDate date={value} />;
+      },
+    },
+    {
+      accessorKey: "datasetRunName",
+      header: "Run Name",
+      id: "datasetRunName",
+      size: 150,
+      cell: ({ row }) => {
+        const datasetRunName: string | undefined =
+          row.getValue("datasetRunName");
+        return datasetRunName || "-";
       },
     },
     {
@@ -242,6 +254,7 @@ export function DatasetRunItemsTable(
             id: item.id,
             runAt: item.createdAt,
             datasetItemId: item.datasetItemId,
+            datasetRunName: item.datasetRunName,
             trace: !!item.trace?.id
               ? {
                   traceId: item.trace.id,

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -766,6 +766,7 @@ export const datasetRouter = createTRPCRouter({
           datasetItemId: string;
           projectId: string;
           datasetRunId: string;
+          datasetRunName: string;
         }>
       >`
         SELECT 
@@ -777,11 +778,15 @@ export const datasetRouter = createTRPCRouter({
           dri.created_at AS "createdAt",
           dri.updated_at AS "updatedAt",
           dri.project_id AS "projectId",
-          dri.dataset_run_id AS "datasetRunId"
+          dri.dataset_run_id AS "datasetRunId",
+          dr.name AS "datasetRunName"
         FROM dataset_run_items dri
         INNER JOIN dataset_items di
           ON dri.dataset_item_id = di.id 
           AND dri.project_id = di.project_id
+        INNER JOIN dataset_runs dr
+          ON dri.dataset_run_id = dr.id
+          AND dri.project_id = dr.project_id
         WHERE 
           dri.project_id = ${input.projectId}
           ${filterQuery}
@@ -801,10 +806,19 @@ export const datasetRouter = createTRPCRouter({
         },
       });
 
+      // Add scores to the run items while also keeping the datasetRunName
+      const parsedRunItems = (
+        await getRunItemsByRunIdOrItemId(input.projectId, runItems)
+      ).map((ri) => ({
+        ...ri,
+        datasetRunName: runItems.find((rawRunItem) => ri.id === rawRunItem.id)
+          ?.datasetRunName,
+      }));
+
       // Note: We early return in case of no run items, when adding parameters here, make sure to update the early return above
       return {
         totalRunItems,
-        runItems: await getRunItemsByRunIdOrItemId(input.projectId, runItems),
+        runItems: parsedRunItems,
       };
     }),
   datasetItemsBasedOnTraceOrObservation: protectedProjectProcedure

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -807,12 +807,19 @@ export const datasetRouter = createTRPCRouter({
       });
 
       // Add scores to the run items while also keeping the datasetRunName
+      const runItemNameMap = runItems.reduce(
+        (map, item) => {
+          map[item.id] = item.datasetRunName;
+          return map;
+        },
+        {} as Record<string, string>,
+      );
+
       const parsedRunItems = (
         await getRunItemsByRunIdOrItemId(input.projectId, runItems)
       ).map((ri) => ({
         ...ri,
-        datasetRunName: runItems.find((rawRunItem) => ri.id === rawRunItem.id)
-          ?.datasetRunName,
+        datasetRunName: runItemNameMap[ri.id],
       }));
 
       // Note: We early return in case of no run items, when adding parameters here, make sure to update the early return above

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -814,7 +814,6 @@ export const datasetRouter = createTRPCRouter({
         },
         {} as Record<string, string>,
       );
-
       const parsedRunItems = (
         await getRunItemsByRunIdOrItemId(input.projectId, runItems)
       ).map((ri) => ({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add dataset run name column to `DatasetRunItemsTable` and update backend to fetch run names.
> 
>   - **Frontend**:
>     - Add `datasetRunName` to `DatasetRunItemRowData` in `DatasetRunItemsTable.tsx`.
>     - Add new column for `datasetRunName` in `DatasetRunItemsTable`.
>   - **Backend**:
>     - Modify SQL query in `dataset-router.ts` to join `dataset_runs` and select `dr.name AS datasetRunName`.
>     - Update `runitemsByRunIdOrItemId` to include `datasetRunName` in response.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 955fc7b933769bff71fc983c7dc657a26d6d9f92. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->