### PR TITLE
fix: fix eval status on details page

### DIFF
--- a/web/src/components/level-counts-display.tsx
+++ b/web/src/components/level-counts-display.tsx
@@ -24,7 +24,7 @@ export function LevelCountsDisplay({
   const nonZeroCounts = counts.filter((item) => item.count > 0);
 
   return (
-    <div className="flex min-h-6 flex-row gap-2 overflow-x-auto whitespace-nowrap">
+    <div className="flex min-h-6 flex-row items-center gap-2 overflow-x-auto whitespace-nowrap">
       {nonZeroCounts.map(
         ({ level, count, symbol, customNumberFormatter }, index) => (
           <React.Fragment key={level}>

--- a/web/src/ee/features/evals/components/evaluator-detail.tsx
+++ b/web/src/ee/features/evals/components/evaluator-detail.tsx
@@ -33,7 +33,6 @@ import {
   generateJobExecutionCounts,
 } from "@/src/ee/features/evals/utils/job-execution-utils";
 
-// Component to display job execution counts in a compact way
 const JobExecutionCounts = ({
   jobExecutionsByState,
 }: {
@@ -89,8 +88,7 @@ export const EvaluatorDetail = () => {
       ? {
           ...evaluator.data,
           evalTemplate: evaluator.data.evalTemplate,
-          jobExecutionsByState:
-            (evaluator.data as any).jobExecutionsByState || [],
+          jobExecutionsByState: evaluator.data.jobExecutionsByState,
         }
       : undefined;
 
@@ -118,11 +116,7 @@ export const EvaluatorDetail = () => {
               </div>
             )}
             <StatusBadge
-              type={(
-                evaluator.data?.finalStatus ||
-                evaluator.data?.status ||
-                ""
-              ).toLowerCase()}
+              type={(evaluator.data?.finalStatus).toLowerCase()}
               isLive
               className="max-h-8"
             />

--- a/web/src/ee/features/evals/components/evaluator-detail.tsx
+++ b/web/src/ee/features/evals/components/evaluator-detail.tsx
@@ -88,7 +88,6 @@ export const EvaluatorDetail = () => {
       ? {
           ...evaluator.data,
           evalTemplate: evaluator.data.evalTemplate,
-          jobExecutionsByState: evaluator.data.jobExecutionsByState,
         }
       : undefined;
 

--- a/web/src/ee/features/evals/components/evaluator-detail.tsx
+++ b/web/src/ee/features/evals/components/evaluator-detail.tsx
@@ -115,7 +115,7 @@ export const EvaluatorDetail = () => {
               </div>
             )}
             <StatusBadge
-              type={(evaluator.data?.finalStatus).toLowerCase()}
+              type={evaluator.data?.finalStatus.toLowerCase()}
               isLive
               className="max-h-8"
             />

--- a/web/src/ee/features/evals/components/evaluator-table.tsx
+++ b/web/src/ee/features/evals/components/evaluator-table.tsx
@@ -8,12 +8,12 @@ import useColumnVisibility from "@/src/features/column-visibility/hooks/useColum
 import { InlineFilterState } from "@/src/features/filters/components/filter-builder";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
 import { type RouterOutputs, api } from "@/src/utils/api";
-import { compactNumberFormatter } from "@/src/utils/numbers";
 import { type FilterState, singleFilter } from "@langfuse/shared";
 import { createColumnHelper } from "@tanstack/react-table";
 import { useEffect } from "react";
 import { useQueryParams, withDefault, NumberParam } from "use-query-params";
 import { z } from "zod";
+import { generateJobExecutionCounts } from "@/src/ee/features/evals/utils/job-execution-utils";
 
 export type EvaluatorDataRow = {
   id: string;
@@ -169,44 +169,11 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
   const convertToTableRow = (
     jobConfig: RouterOutputs["evals"]["allConfigs"]["configs"][number],
   ): EvaluatorDataRow => {
-    const result = [
-      {
-        level: "pending",
-        count:
-          jobConfig.jobExecutionsByState.find((je) => je.status === "PENDING")
-            ?._count || 0,
-        symbol: "🕒",
-        customNumberFormatter: compactNumberFormatter,
-      },
-      {
-        level: "error",
-        count:
-          jobConfig.jobExecutionsByState.find((je) => je.status === "ERROR")
-            ?._count || 0,
-        symbol: "❌",
-        customNumberFormatter: compactNumberFormatter,
-      },
-      {
-        level: "succeeded",
-        count:
-          jobConfig.jobExecutionsByState.find((je) => je.status === "COMPLETED")
-            ?._count || 0,
-        symbol: "✅",
-        customNumberFormatter: compactNumberFormatter,
-      },
-    ];
-
-    const finalStatus =
-      jobConfig.timeScope.length === 1 &&
-      jobConfig.timeScope[0] === "EXISTING" &&
-      !jobConfig.jobExecutionsByState.some((je) => je.status === "PENDING") &&
-      jobConfig.jobExecutionsByState.reduce((acc, je) => acc + je._count, 0) > 0
-        ? "FINISHED"
-        : jobConfig.status;
+    const result = generateJobExecutionCounts(jobConfig.jobExecutionsByState);
 
     return {
       id: jobConfig.id,
-      status: finalStatus,
+      status: jobConfig.finalStatus || jobConfig.status,
       createdAt: jobConfig.createdAt.toLocaleString(),
       template: jobConfig.evalTemplate
         ? {

--- a/web/src/ee/features/evals/components/evaluator-table.tsx
+++ b/web/src/ee/features/evals/components/evaluator-table.tsx
@@ -173,7 +173,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
 
     return {
       id: jobConfig.id,
-      status: jobConfig.finalStatus || jobConfig.status,
+      status: jobConfig.finalStatus,
       createdAt: jobConfig.createdAt.toLocaleString(),
       template: jobConfig.evalTemplate
         ? {

--- a/web/src/ee/features/evals/utils/job-execution-utils.ts
+++ b/web/src/ee/features/evals/utils/job-execution-utils.ts
@@ -1,0 +1,40 @@
+import { compactNumberFormatter } from "@/src/utils/numbers";
+
+/**
+ * Type for job execution state data
+ */
+export type JobExecutionState = {
+  status: string;
+  jobConfigurationId: string;
+  _count: number;
+};
+
+export const generateJobExecutionCounts = (
+  jobExecutionsByState?: JobExecutionState[],
+) => {
+  return [
+    {
+      level: "pending",
+      count:
+        jobExecutionsByState?.find((je) => je.status === "PENDING")?._count ||
+        0,
+      symbol: "🕒",
+      customNumberFormatter: compactNumberFormatter,
+    },
+    {
+      level: "error",
+      count:
+        jobExecutionsByState?.find((je) => je.status === "ERROR")?._count || 0,
+      symbol: "❌",
+      customNumberFormatter: compactNumberFormatter,
+    },
+    {
+      level: "succeeded",
+      count:
+        jobExecutionsByState?.find((je) => je.status === "COMPLETED")?._count ||
+        0,
+      symbol: "✅",
+      customNumberFormatter: compactNumberFormatter,
+    },
+  ];
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes eval status display by introducing utilities for job execution counts and final status calculation.
> 
>   - **Behavior**:
>     - Introduces `JobExecutionCounts` component in `evaluator-detail.tsx` to display job execution counts using `LevelCountsDisplay`.
>     - Updates `StatusBadge` in `evaluator-detail.tsx` to use `finalStatus` instead of `status`.
>     - Refactors `convertToTableRow` in `evaluator-table.tsx` to use `generateJobExecutionCounts` and `finalStatus`.
>   - **Utilities**:
>     - Adds `generateJobExecutionCounts` and `calculateEvaluatorFinalStatus` in `job-execution-utils.ts` to compute job execution counts and determine final status.
>     - Implements `fetchJobExecutionsByState` in `router.ts` to fetch job execution data grouped by state.
>   - **Misc**:
>     - Adjusts CSS in `level-counts-display.tsx` to vertically center items.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 917cfd02e8b5f7cc595f2abf54670a8a54954fe7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->