### PR TITLE
docs: add zod type strict() to public api cursor rule

### DIFF
--- a/.cursor/rules/public-api.mdc
+++ b/.cursor/rules/public-api.mdc
@@ -9,7 +9,7 @@ alwaysApply: false
 - All public api routes are in /web/src/pages/api/public
 - New api routes should follow these guidelines:
   - Use [withMiddlewares.ts](mdc:web/src/features/public-api/server/withMiddlewares.ts) as a wrapper
-  - Define types of api request and response in /web/src/features/public-api/types
+  - Define types of api request and response in /web/src/features/public-api/types, use strict() for all zod objects
   - Add end-to-end test, similar to [datasets-api.servertest.ts](mdc:web/src/__tests__/async/datasets-api.servertest.ts)
   - Add fern configuration in /fern, learn more about structure here: https://buildwithfern.com/learn/api-definition/fern/overview
   - Prompt user to regenerate the OpenAPI spec via the fern CLI


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `.cursor/rules/public-api.mdc` to include `strict()` usage for zod objects in API types.
> 
>   - **Documentation**:
>     - Update `.cursor/rules/public-api.mdc` to include `strict()` usage for all zod objects in API request and response types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 729684261bfa43fb956e503abb630380644d46d4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->