### PR TITLE
fix: use readonly for the column definitions

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/factory.ts
@@ -3,7 +3,7 @@ import { singleFilter } from "../../../interfaces/filters";
 import { FilterCondition } from "../../../types";
 import { isValidTableName } from "../../clickhouse/schemaUtils";
 import { logger } from "../../logger";
-import { UiColumnMapping } from "../../../tableDefinitions";
+import { UiColumnMappings } from "../../../tableDefinitions";
 import {
   StringFilter,
   DateTimeFilter,
@@ -29,7 +29,7 @@ export class QueryBuilderError extends Error {
 // User input for values (e.g. project_id = <value>) are sent to Clickhouse as parameters to prevent SQL injection
 export const createFilterFromFilterState = (
   filter: FilterCondition[],
-  columnMapping: UiColumnMapping[],
+  columnMapping: UiColumnMappings,
 ) => {
   return filter.map((frontEndFilter) => {
     // checks if the column exists in the clickhouse schema
@@ -120,7 +120,7 @@ export const createFilterFromFilterState = (
 
 const matchAndVerifyTracesUiColumn = (
   filter: z.infer<typeof singleFilter>,
-  uiTableDefinitions: UiColumnMapping[],
+  uiTableDefinitions: UiColumnMappings,
 ) => {
   // tries to match the column name to the clickhouse table name
   logger.debug(`Filter to match: ${JSON.stringify(filter)}`);

--- a/packages/shared/src/server/queries/clickhouse-sql/orderby-factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/orderby-factory.ts
@@ -1,13 +1,13 @@
 import z from "zod";
 import { OrderByState } from "../../../interfaces/orderBy";
-import { UiColumnMapping } from "../../../tableDefinitions";
+import { UiColumnMappings } from "../../../tableDefinitions";
 import { logger } from "../../logger";
 
 type OrderByStateNotNull = Exclude<OrderByState, null>;
 
 export function orderByToClickhouseSql(
   orderBy: OrderByState | OrderByState[] = [],
-  tableColumns: UiColumnMapping[],
+  tableColumns: UiColumnMappings,
 ): string {
   if (
     !orderBy ||

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -17,7 +17,7 @@ import {
 } from "../queries/clickhouse-sql/clickhouse-filter";
 import { TraceRecordReadType } from "./definitions";
 import { tracesTableUiColumnDefinitions } from "../../tableDefinitions/mapTracesTable";
-import { UiColumnMapping } from "../../tableDefinitions";
+import { UiColumnMapping, UiColumnMappings } from "../../tableDefinitions";
 import { convertDateToClickhouseDateTime } from "../clickhouse/client";
 import { convertClickhouseToDomain } from "./traces_converters";
 import { clickhouseSearchCondition } from "../queries/clickhouse-sql/search";
@@ -293,7 +293,7 @@ export const getTraceById = async (
 
 export const getTracesGroupedByName = async (
   projectId: string,
-  tableDefinitions: UiColumnMapping[] = tracesTableUiColumnDefinitions,
+  tableDefinitions: UiColumnMappings = tracesTableUiColumnDefinitions,
   timestampFilter?: FilterState,
 ) => {
   const chFilter = timestampFilter

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -17,7 +17,7 @@ import {
 } from "../queries/clickhouse-sql/clickhouse-filter";
 import { TraceRecordReadType } from "./definitions";
 import { tracesTableUiColumnDefinitions } from "../../tableDefinitions/mapTracesTable";
-import { UiColumnMapping, UiColumnMappings } from "../../tableDefinitions";
+import { UiColumnMappings } from "../../tableDefinitions";
 import { convertDateToClickhouseDateTime } from "../clickhouse/client";
 import { convertClickhouseToDomain } from "./traces_converters";
 import { clickhouseSearchCondition } from "../queries/clickhouse-sql/search";
@@ -345,7 +345,7 @@ export const getTracesGroupedByUsers = async (
   searchQuery?: string,
   limit?: number,
   offset?: number,
-  columns?: UiColumnMapping[],
+  columns?: UiColumnMappings,
 ) => {
   const { tracesFilter } = getProjectIdDefaultFilter(projectId, {
     tracesPrefix: "t",
@@ -404,7 +404,7 @@ export const getTracesGroupedByUsers = async (
 export type GroupedTracesQueryProp = {
   projectId: string;
   filter: FilterState;
-  columns?: UiColumnMapping[];
+  columns?: UiColumnMappings;
 };
 
 export const getTracesGroupedByTags = async (props: GroupedTracesQueryProp) => {

--- a/packages/shared/src/tableDefinitions/mapDashboards.ts
+++ b/packages/shared/src/tableDefinitions/mapDashboards.ts
@@ -1,6 +1,6 @@
-import { UiColumnMapping } from "./types";
+import { UiColumnMappings } from "./types";
 
-export const dashboardColumnDefinitions: UiColumnMapping[] = [
+export const dashboardColumnDefinitions: UiColumnMappings = [
   {
     uiTableName: "Trace Name",
     uiTableId: "traceName",

--- a/packages/shared/src/tableDefinitions/mapObservationsTable.ts
+++ b/packages/shared/src/tableDefinitions/mapObservationsTable.ts
@@ -1,9 +1,9 @@
 // This structure is maintained to relate the frontend table definitions with the clickhouse table definitions.
 // The frontend only sends the column names to the backend. This needs to be changed in the future to send column IDs.
 
-import { UiColumnMapping } from "./types";
+import { UiColumnMappings } from "./types";
 
-export const observationsTableTraceUiColumnDefinitions: UiColumnMapping[] = [
+export const observationsTableTraceUiColumnDefinitions: UiColumnMappings = [
   {
     uiTableName: "Trace Tags",
     uiTableId: "traceTags",
@@ -30,7 +30,7 @@ export const observationsTableTraceUiColumnDefinitions: UiColumnMapping[] = [
   },
 ];
 
-export const observationsTableUiColumnDefinitions: UiColumnMapping[] = [
+export const observationsTableUiColumnDefinitions: UiColumnMappings = [
   ...observationsTableTraceUiColumnDefinitions,
   {
     uiTableName: "Environment",

--- a/packages/shared/src/tableDefinitions/mapScoresTable.ts
+++ b/packages/shared/src/tableDefinitions/mapScoresTable.ts
@@ -1,6 +1,6 @@
-import { UiColumnMapping } from "./types";
+import { UiColumnMappings } from "./types";
 
-export const scoresTableUiColumnDefinitions: UiColumnMapping[] = [
+export const scoresTableUiColumnDefinitions: UiColumnMappings = [
   {
     uiTableName: "ID",
     uiTableId: "id",

--- a/packages/shared/src/tableDefinitions/mapSessionTable.ts
+++ b/packages/shared/src/tableDefinitions/mapSessionTable.ts
@@ -1,6 +1,6 @@
-import { UiColumnMapping } from ".";
+import { UiColumnMappings } from ".";
 
-export const sessionCols: UiColumnMapping[] = [
+export const sessionCols: UiColumnMappings = [
   // we do not access the traces scores in ClickHouse. We default back to the trace timestamps.
 
   {

--- a/packages/shared/src/tableDefinitions/mapTracesTable.ts
+++ b/packages/shared/src/tableDefinitions/mapTracesTable.ts
@@ -1,6 +1,6 @@
-import { UiColumnMapping } from "./types";
+import { UiColumnMappings } from "./types";
 
-export const tracesTableUiColumnDefinitions: UiColumnMapping[] = [
+export const tracesTableUiColumnDefinitions: UiColumnMappings = [
   {
     uiTableName: "⭐️",
     uiTableId: "bookmarked",

--- a/packages/shared/src/tableDefinitions/types.ts
+++ b/packages/shared/src/tableDefinitions/types.ts
@@ -1,11 +1,13 @@
-export type UiColumnMapping = {
+export type UiColumnMappings = readonly UiColumnMapping[];
+
+export type UiColumnMapping = Readonly<{
   uiTableName: string;
   uiTableId: string;
   clickhouseTableName: string;
   clickhouseSelect: string;
   clickhouseTypeOverwrite?: string;
   queryPrefix?: string;
-};
+}>;
 
 export type OptionsDefinition = {
   value: string;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename `UiColumnMapping` to `UiColumnMappings` and update its usage across the codebase to ensure consistency.
> 
>   - **Type Renaming**:
>     - Rename `UiColumnMapping` to `UiColumnMappings` in `types.ts`.
>     - Update type definition to `readonly UiColumnMapping[]`.
>   - **Code Updates**:
>     - Update `createFilterFromFilterState` and `matchAndVerifyTracesUiColumn` in `factory.ts` to use `UiColumnMappings`.
>     - Update `orderByToClickhouseSql` in `orderby-factory.ts` to use `UiColumnMappings`.
>     - Update `getTracesGroupedByName` and `getTracesGroupedByUsers` in `traces.ts` to use `UiColumnMappings`.
>   - **Table Definitions**:
>     - Update `dashboardColumnDefinitions`, `observationsTableTraceUiColumnDefinitions`, `observationsTableUiColumnDefinitions`, `scoresTableUiColumnDefinitions`, and `sessionCols` to use `UiColumnMappings`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 26172649317728f9b0cddd8f5a17b7f6c383fa75. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->