### PR TITLE
chore: rename batch exports from generation to observation as table was generalized

### DIFF
--- a/packages/shared/src/features/batchExport/types.ts
+++ b/packages/shared/src/features/batchExport/types.ts
@@ -20,7 +20,7 @@ export enum BatchExportFileFormat {
 export enum BatchExportTableName {
   Sessions = "sessions",
   Traces = "traces",
-  Generations = "generations",
+  Observations = "observations",
   DatasetRunItems = "dataset_run_items",
 }
 

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -873,7 +873,7 @@ export default function ObservationsTable({
         actionButtons={
           <BatchExportTableButton
             {...{ projectId, filterState, orderByState }}
-            tableName={BatchExportTableName.Generations}
+            tableName={BatchExportTableName.Observations}
             key="batchExport"
           />
         }

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -17,11 +17,11 @@ describe("batch export test suite", () => {
   it("should export observations", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
 
-    const generations = [
+    const observations = [
       createObservation({
         project_id: projectId,
         trace_id: randomUUID(),
-        type: "GENERATION",
+        type: "SPAN",
       }),
       createObservation({
         project_id: projectId,
@@ -31,24 +31,24 @@ describe("batch export test suite", () => {
       createObservation({
         project_id: projectId,
         trace_id: randomUUID(),
-        type: "GENERATION",
+        type: "EVENT",
       }),
     ];
 
     const score = createScore({
       project_id: projectId,
       trace_id: randomUUID(),
-      observation_id: generations[0].id,
+      observation_id: observations[0].id,
       name: "test",
       value: 123,
     });
 
     await createScoresCh([score]);
-    await createObservationsCh(generations);
+    await createObservationsCh(observations);
 
     const stream = await getDatabaseReadStream({
       projectId: projectId,
-      tableName: BatchExportTableName.Generations,
+      tableName: BatchExportTableName.Observations,
       cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
       filter: [],
       orderBy: { column: "startTime", order: "DESC" },
@@ -64,17 +64,20 @@ describe("batch export test suite", () => {
     expect(rows).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          id: generations[0].id,
-          name: generations[0].name,
+          id: observations[0].id,
+          name: observations[0].name,
+          type: observations[0].type,
           test: [score.value],
         }),
         expect.objectContaining({
-          id: generations[1].id,
-          name: generations[1].name,
+          id: observations[1].id,
+          name: observations[1].name,
+          type: observations[1].type,
         }),
         expect.objectContaining({
-          id: generations[2].id,
-          name: generations[2].name,
+          id: observations[2].id,
+          name: observations[2].name,
+          type: observations[2].type,
         }),
       ]),
     );
@@ -83,7 +86,7 @@ describe("batch export test suite", () => {
   it("should export observations with filter and sorting", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
 
-    const generations = [
+    const observations = [
       createObservation({
         project_id: projectId,
         trace_id: randomUUID(),
@@ -94,24 +97,24 @@ describe("batch export test suite", () => {
       createObservation({
         project_id: projectId,
         trace_id: randomUUID(),
-        type: "GENERATION",
+        type: "EVENT",
         name: "test2",
         start_time: new Date("2024-01-02").getTime(),
       }),
       createObservation({
         project_id: projectId,
         trace_id: randomUUID(),
-        type: "GENERATION",
+        type: "SPAN",
         name: "test3",
         start_time: new Date("2024-01-03").getTime(),
       }),
     ];
 
-    await createObservationsCh(generations);
+    await createObservationsCh(observations);
 
     const stream = await getDatabaseReadStream({
       projectId: projectId,
-      tableName: BatchExportTableName.Generations,
+      tableName: BatchExportTableName.Observations,
       cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
       filter: [
         {

--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -35,14 +35,14 @@ import Decimal from "decimal.js";
 const tableNameToTimeFilterColumn = {
   sessions: "createdAt",
   traces: "timestamp",
-  generations: "startTime",
+  observations: "startTime",
   dataset_run_items: "createdAt",
 };
 
 const tableNameToTimeFilterColumnCh = {
   sessions: "createdAt",
   traces: "timestamp",
-  generations: "startTime",
+  observations: "startTime",
   dataset_run_items: "createdAt",
 };
 
@@ -172,7 +172,7 @@ export const getDatabaseReadStream = async ({
         1000,
         exportLimit,
       );
-    case "generations": {
+    case "observations": {
       let emptyScoreColumns: Record<string, null>;
 
       return new DatabaseReadStream<unknown>(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Rename `BatchExportTableName.Generations` to `BatchExportTableName.Observations` across enums, components, tests, and functions.
> 
>   - **Enums**:
>     - Rename `BatchExportTableName.Generations` to `BatchExportTableName.Observations` in `types.ts`.
>   - **Components**:
>     - Update `tableName` in `BatchExportTableButton` in `observations.tsx` to use `BatchExportTableName.Observations`.
>   - **Tests**:
>     - Rename `generations` to `observations` in `batchExport.test.ts`.
>     - Update test cases to reflect the new table name and types.
>   - **Functions**:
>     - Update `getDatabaseReadStream` in `handleBatchExportJob.ts` to handle `observations` instead of `generations`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3d6fe90d9eea95c3fcd8a5337d93b28d8bd16652. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->