### PR TITLE
feat: extract logfire.msg as span and trace name

### DIFF
--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -389,6 +389,34 @@ describe("OTel Resource Span Mapping", () => {
       ).toBe(true);
     });
 
+    it("should use logfire.msg as span name", async () => {
+      const resourceSpan = {
+        scopeSpans: [
+          {
+            spans: [
+              {
+                ...defaultSpanProps,
+                name: "wrong name",
+                attributes: [
+                  {
+                    key: "logfire.msg",
+                    value: { stringValue: "right name" },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      // When
+      const langfuseEvents = convertOtelSpanToIngestionEvent(resourceSpan);
+
+      // Then
+      expect(langfuseEvents[0].body.name).toBe("right name");
+      expect(langfuseEvents[1].body.name).toBe("right name");
+    });
+
     it.each([
       [
         "should cast input_tokens from string to number",

--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -248,6 +248,21 @@ const extractEnvironment = (
   return "default";
 };
 
+const extractName = (
+  spanName: string,
+  attributes: Record<string, unknown>,
+): string => {
+  const nameKeys = ["logfire.msg"];
+  for (const key of nameKeys) {
+    if (attributes[key]) {
+      return typeof attributes[key] === "string"
+        ? (attributes[key] as string)
+        : JSON.stringify(attributes[key]);
+    }
+  }
+  return spanName;
+};
+
 const extractUserId = (
   attributes: Record<string, unknown>,
 ): string | undefined => {
@@ -391,7 +406,7 @@ export const convertOtelSpanToIngestionEvent = (
         const trace = {
           id: Buffer.from(span.traceId?.data ?? span.traceId).toString("hex"),
           timestamp: convertNanoTimestampToISO(span.startTimeUnixNano),
-          name: span.name,
+          name: extractName(span.name, attributes),
           metadata: {
             attributes,
             resourceAttributes,
@@ -429,7 +444,7 @@ export const convertOtelSpanToIngestionEvent = (
           "hex",
         ),
         parentObservationId,
-        name: span.name,
+        name: extractName(span.name, attributes),
         startTime: convertNanoTimestampToISO(span.startTimeUnixNano),
         endTime: convertNanoTimestampToISO(span.endTimeUnixNano),
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Extracts `logfire.msg` as span and trace name in OpenTelemetry spans, with tests added for verification.
> 
>   - **Behavior**:
>     - Extracts `logfire.msg` as span and trace name in `convertOtelSpanToIngestionEvent` in `index.ts`.
>     - Adds `extractName()` function to handle name extraction logic.
>   - **Tests**:
>     - Adds test case in `otelMapping.servertest.ts` to verify `logfire.msg` is used as span name.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7512af018591090ab0a98fdd81ea44460cde1bc4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->