### PR TITLE
chore: prevent sorting by environment in UI tables

### DIFF
--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -318,7 +318,6 @@ export default function ObservationsTable({
       id: "environment",
       size: 150,
       enableHiding: true,
-      enableSorting: true,
       cell: ({ row }) => {
         const value: ObservationsTableRow["environment"] =
           row.getValue("environment");

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -311,7 +311,6 @@ export default function ScoresTable({
       id: "environment",
       size: 150,
       enableHiding: true,
-      enableSorting: true,
       cell: ({ row }) => {
         const value = row.getValue("environment") as string | undefined;
         return value ? (

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -282,7 +282,6 @@ export default function SessionsTable({
       id: "environment",
       size: 150,
       enableHiding: true,
-      enableSorting: true,
       cell: ({ row }) => {
         const value: SessionTableRow["environment"] =
           row.getValue("environment");

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -479,7 +479,6 @@ export default function TracesTable({
       id: "environment",
       size: 150,
       enableHiding: true,
-      enableSorting: true,
       cell: ({ row }) => {
         const value: TracesTableRow["environment"] =
           row.getValue("environment");

--- a/web/src/pages/project/[projectId]/users.tsx
+++ b/web/src/pages/project/[projectId]/users.tsx
@@ -228,7 +228,6 @@ const UsersTable = () => {
       id: "environment",
       size: 150,
       enableHiding: true,
-      enableSorting: true,
       cell: ({ row }) => {
         const value: RowData["environment"] = row.getValue("environment");
         return value ? (


### PR DESCRIPTION
## What

Backend is not optimized for sorting by environment and filtering seems more useful.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disables sorting by `environment` in multiple UI tables due to backend optimization issues.
> 
>   - **Behavior**:
>     - Disables sorting by `environment` in `ObservationsTable`, `ScoresTable`, `SessionsTable`, `TracesTable`, and `UsersTable`.
>     - Sorting by `environment` was not optimized in the backend, making filtering more useful.
>   - **Files Affected**:
>     - `observations.tsx`: Removed `enableSorting: true` for `environment` column.
>     - `scores.tsx`: Removed `enableSorting: true` for `environment` column.
>     - `sessions.tsx`: Removed `enableSorting: true` for `environment` column.
>     - `traces.tsx`: Removed `enableSorting: true` for `environment` column.
>     - `users.tsx`: Removed `enableSorting: true` for `environment` column.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for da9345bbc0bb2d14946c8e3f8a2588c0f6f1dcb5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->