### PR TITLE
chore: reproduce clickhouse missing surrogate key error

### DIFF
--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -29,6 +29,7 @@ export const clickhouseClient = (
       log_comment: JSON.stringify(params.tags ?? {}),
       async_insert: 1,
       wait_for_async_insert: 1, // if disabled, we won't get errors from clickhouse
+      input_format_json_throw_on_bad_escape_sequence: 0,
     },
   });
 };

--- a/web/src/__tests__/async/ingestion-api.servertest.ts
+++ b/web/src/__tests__/async/ingestion-api.servertest.ts
@@ -79,7 +79,7 @@ describe("/api/public/ingestion API Endpoint", () => {
           id: randomUUID(),
           timestamp: new Date().toISOString(),
           metadata: { hello: "world" },
-          input: "test\ud8000test",
+          input: "test\ud800test",
           environment: "production",
         },
       },

--- a/web/src/__tests__/async/ingestion-api.servertest.ts
+++ b/web/src/__tests__/async/ingestion-api.servertest.ts
@@ -69,6 +69,21 @@ describe("/api/public/ingestion API Endpoint", () => {
         },
       },
     ],
+    [
+      "clickhouse-non-printable-characters",
+      {
+        id: randomUUID(),
+        type: "trace-create",
+        timestamp: new Date().toISOString(),
+        body: {
+          id: randomUUID(),
+          timestamp: new Date().toISOString(),
+          metadata: { hello: "world" },
+          input: "test\ud8000test",
+          environment: "production",
+        },
+      },
+    ],
   ])(
     "should create traces via the ingestion API (%s)",
     async (_name: string, entity: any) => {

--- a/web/src/__tests__/async/ingestion-api.servertest.ts
+++ b/web/src/__tests__/async/ingestion-api.servertest.ts
@@ -117,7 +117,7 @@ describe("/api/public/ingestion API Endpoint", () => {
         id: randomUUID(),
         timestamp: new Date().toISOString(),
         metadata: { hello: "world" },
-        input: "test\ud800test",
+        input: "test\\ud8000test",
         environment: "production",
       },
     };
@@ -131,7 +131,7 @@ describe("/api/public/ingestion API Endpoint", () => {
       expect(trace).toBeDefined();
       expect(trace!.id).toBe(entity.body.id);
       expect(trace!.projectId).toBe(projectId);
-      expect(trace!.input).toEqual("test�test");
+      expect(trace!.input).toContain("test");
     });
   });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add ClickHouse configuration to handle bad escape sequences and test this behavior in `ingestion-api.servertest.ts`.
> 
>   - **Behavior**:
>     - Add `input_format_json_throw_on_bad_escape_sequence: 0` to ClickHouse client configuration in `client.ts` to handle bad escape sequences.
>     - New test in `ingestion-api.servertest.ts` verifies handling of bad escape sequences in input data.
>   - **Tests**:
>     - Add test case in `ingestion-api.servertest.ts` to ensure ClickHouse handles bad escape sequences, expecting status 207 and correct trace retrieval.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for df4dde57f89b90afe746933b8bb3508a8acadfe6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->