### PR TITLE
fix(prompts): block label deletion if dependent exists

### DIFF
--- a/packages/shared/src/features/prompts/parsePromptDependencyTags.ts
+++ b/packages/shared/src/features/prompts/parsePromptDependencyTags.ts
@@ -22,7 +22,7 @@ export function parsePromptDependencyTags(
 
   const validTags: ParsedPromptDependencyTag[] = [];
 
-  for (const match of matchedTags ?? []) {
+  for (const match of new Set(matchedTags ?? [])) {
     const innerContent = match.replace(/^@@@langfusePrompt:|@@@$/g, "");
     const parts = innerContent.split("|");
     const params: Record<string, string> = {};

--- a/web/src/features/prompts/components/renderContentWithPromptButtons.tsx
+++ b/web/src/features/prompts/components/renderContentWithPromptButtons.tsx
@@ -11,7 +11,7 @@ import { Button } from "@/src/components/ui/button";
 const getPromptUrl = (projectId: string, tag: ParsedPromptDependencyTag) => {
   const baseUrl = `/project/${projectId}/prompts/`;
   if (tag.type === "version") {
-    return `${baseUrl}${encodeURIComponent(tag.name)}?versions=${tag.version}`;
+    return `${baseUrl}${encodeURIComponent(tag.name)}?version=${tag.version}`;
   } else {
     return `${baseUrl}${encodeURIComponent(tag.name)}?label=${encodeURIComponent(tag.label)}`;
   }

--- a/web/src/features/prompts/server/actions/updatePrompts.ts
+++ b/web/src/features/prompts/server/actions/updatePrompts.ts
@@ -1,7 +1,7 @@
 import { logger, PromptService } from "@langfuse/shared/src/server";
 import { removeLabelsFromPreviousPromptVersions } from "@/src/features/prompts/server/utils/updatePromptLabels";
-import { LangfuseNotFoundError } from "@langfuse/shared";
-import { prisma } from "@langfuse/shared/src/db";
+import { InvalidRequestError, LangfuseNotFoundError } from "@langfuse/shared";
+import { prisma, Prisma } from "@langfuse/shared/src/db";
 import { redis } from "@langfuse/shared/src/server";
 
 export type UpdatePromptParams = {
@@ -33,6 +33,53 @@ export const updatePrompt = async (params: UpdatePromptParams) => {
     }
 
     const newLabelsSet = new Set([...newLabels, ...prompt.labels]);
+    const removedLabels = [];
+
+    // Prompts cannot be removed since the newLabelsSet includes the old labels
+    // Keeping this dependent check below as a safeguard in case the above changes
+    for (const oldLabel of prompt.labels) {
+      if (!newLabelsSet.has(oldLabel)) {
+        removedLabels.push(oldLabel);
+      }
+    }
+
+    if (removedLabels.length > 0) {
+      const dependents = await prisma.$queryRaw<
+        {
+          parent_name: string;
+          parent_version: number;
+          child_version: number;
+          child_label: string;
+        }[]
+      >`
+      SELECT
+        p."name" AS "parent_name",
+        p."version" AS "parent_version",
+        pd."child_version" AS "child_version",
+        pd."child_label" AS "child_label"
+      FROM
+        prompt_dependencies pd
+        INNER JOIN prompts p ON p.id = pd.parent_id
+      WHERE
+        p.project_id = ${projectId}
+        AND pd.project_id = ${projectId}
+        AND pd.child_name = ${promptName}
+        AND pd."child_label" IS NOT NULL AND pd."child_label" IN (${Prisma.join(removedLabels)})
+      `;
+
+      if (dependents.length > 0) {
+        const dependencyMessages = dependents
+          .map(
+            (d) =>
+              `${d.parent_name} v${d.parent_version} depends on ${promptName} ${d.child_version ? `v${d.child_version}` : d.child_label}`,
+          )
+          .join("\n");
+
+        throw new InvalidRequestError(
+          `Other prompts are depending on the prompt label you are trying to remove:\n\n${dependencyMessages}\n\nPlease delete the dependent prompts first.`,
+        );
+      }
+    }
 
     logger.info(
       `Setting labels for prompt: ${prompt.id}, ${prompt.name}, ${prompt.version}, ${JSON.stringify(

--- a/web/src/features/prompts/server/actions/updatePrompts.ts
+++ b/web/src/features/prompts/server/actions/updatePrompts.ts
@@ -35,7 +35,7 @@ export const updatePrompt = async (params: UpdatePromptParams) => {
     const newLabelsSet = new Set([...newLabels, ...prompt.labels]);
     const removedLabels = [];
 
-    // Prompts cannot be removed since the newLabelsSet includes the old labels
+    // Prompt labels cannot be removed here since the newLabelsSet includes the old labels
     // Keeping this dependent check below as a safeguard in case the above changes
     for (const oldLabel of prompt.labels) {
       if (!newLabelsSet.has(oldLabel)) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevents prompt label deletion if dependencies exist, with checks in `updatePrompts.ts` and `promptRouter.ts`, and fixes a typo in `renderContentWithPromptButtons.tsx`.
> 
>   - **Behavior**:
>     - Prevents deletion of prompt labels if dependent prompts exist in `updatePrompts.ts` and `promptRouter.ts`.
>     - Throws `InvalidRequestError` or `TRPCError` if dependencies are detected.
>   - **Functions**:
>     - `updatePrompt` in `updatePrompts.ts` checks for dependent prompts before label removal.
>     - `setLabels` and `deleteVersion` in `promptRouter.ts` include dependency checks.
>   - **Misc**:
>     - Fixes query parameter typo from `versions` to `version` in `renderContentWithPromptButtons.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2dcff3525f47a1d266c1b031b43d5cc2008653e9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->