### PR TITLE
fix: search past observations with correct timestamp in evals

### DIFF
--- a/worker/src/ee/evaluation/evalService.ts
+++ b/worker/src/ee/evaluation/evalService.ts
@@ -176,9 +176,8 @@ export const createEvalJobs = async ({
       const observationExists = await checkObservationExists(
         event.projectId,
         observationId,
-        new Date(),
+        "timestamp" in event ? new Date(event.timestamp) : new Date(),
       );
-
       if (!observationExists) {
         logger.warn(
           `Observation ${observationId} not found, retrying dataset eval later`,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes timestamp handling in `createEvalJobs` to correctly evaluate past observations when timestamp is provided, with corresponding test added.
> 
>   - **Behavior**:
>     - Fixes timestamp handling in `createEvalJobs` in `evalService.ts` to use event timestamp if provided, ensuring correct evaluation of past observations.
>     - Adds test `does create eval for observation which is way in the past if timestamp is provided` in `evalService.test.ts` to verify the fix.
>   - **Tests**:
>     - Adds `createObservation` and `createObservationsCh` to imports in `evalService.test.ts`.
>     - Verifies that eval jobs are created for past observations when timestamp is provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9f4d7732d26d379976ab94076b50e10e362a1f61. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->