### PR TITLE
feat(llm-connections): allow extraHeaders for azure

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -191,6 +191,9 @@ export async function fetchLLMCompletion(
       callbacks: finalCallbacks,
       maxRetries,
       timeout: 1000 * 60 * 2, // 2 minutes timeout
+      configuration: {
+        defaultHeaders: extraHeaders,
+      },
     });
   } else if (modelParams.adapter === LLMAdapter.Bedrock) {
     const { region } = BedrockConfigSchema.parse(config);

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -409,7 +409,8 @@ export function CreateLLMApiKeyForm({
         )}
 
         {/* Extra Headers */}
-        {currentAdapter === "openai" ? (
+        {currentAdapter === LLMAdapter.OpenAI ||
+        currentAdapter === LLMAdapter.Azure ? (
           <FormField
             control={form.control}
             name="extraHeaders"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for `extraHeaders` in Azure LLM connections in both backend and frontend.
> 
>   - **Backend**:
>     - In `fetchLLMCompletion.ts`, added `extraHeaders` to `configuration` for Azure LLM connections.
>   - **Frontend**:
>     - In `CreateLLMApiKeyForm.tsx`, updated form to allow `extraHeaders` for Azure, similar to OpenAI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e803793d8ca4309bccb830c01b074e6696397a6b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->