### PR TITLE
fix(llm-connections): show bedrock error

### DIFF
--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -199,7 +199,7 @@ export function CreateLLMApiKeyForm({
       if (!testResult.success) throw new Error(testResult.error);
     } catch (error) {
       console.error(error);
-      form.setError("secretKey", {
+      form.setError("root", {
         type: "manual",
         message:
           error instanceof Error
@@ -577,7 +577,9 @@ export function CreateLLMApiKeyForm({
           Save new LLM API key
         </Button>
 
-        <FormMessage />
+        {form.formState.errors.root && (
+          <FormMessage>{form.formState.errors.root.message}</FormMessage>
+        )}
       </form>
     </Form>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `CreateLLMApiKeyForm.tsx` to display Bedrock-specific errors at the form root level instead of the `secretKey` field.
> 
>   - **Error Handling**:
>     - Change `form.setError` target from `"secretKey"` to `"root"` in `CreateLLMApiKeyForm.tsx`.
>     - Display error message at form root if `form.formState.errors.root` exists.
>   - **UI**:
>     - Modify `<FormMessage />` to conditionally render error message from `form.formState.errors.root.message`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 35945e7d9f749023589284da35b0bb4a1f348f5a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->