### PR TITLE
chore: reduce host port mapping for internal docker compose components

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 # Make sure to update the credential placeholders with your own secrets.
 # We mark them with # CHANGEME in the file below.
 # In addition, we recommend to restrict inbound traffic on the host to langfuse-web (port 3000) and minio (port 9090) only.
-# All other components should not be exposed to the public internet. You can use security groups, firewalls, or proxies to achieve this.
+# All other components should not be exposed to the public internet. Therefore, we do not map them to host ports, but
+# you can do so by uncommenting the respective lines in the file below.
 services:
   langfuse-worker:
     image: langfuse/langfuse-worker:3
@@ -15,8 +16,8 @@ services:
         condition: service_healthy
       clickhouse:
         condition: service_healthy
-    ports:
-      - "3030:3030"
+    # ports:
+    #   - "3030:3030"
     environment: &langfuse-worker-env
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres # CHANGEME
       SALT: "mysalt" # CHANGEME
@@ -83,9 +84,9 @@ services:
     volumes:
       - langfuse_clickhouse_data:/var/lib/clickhouse
       - langfuse_clickhouse_logs:/var/log/clickhouse-server
-    ports:
-      - "8123:8123"
-      - "9000:9000"
+    # ports:
+    #   - "8123:8123"
+    #   - "9000:9000"
     healthcheck:
       test: wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1
       interval: 5s
@@ -104,7 +105,7 @@ services:
       MINIO_ROOT_PASSWORD: miniosecret # CHANGEME
     ports:
       - "9090:9000"
-      - "9091:9001"
+    #   - "9091:9001"
     volumes:
       - langfuse_minio_data:/data
     healthcheck:
@@ -117,10 +118,11 @@ services:
   redis:
     image: redis:7
     restart: always
+    # CHANGEME: row below to secure redis password
     command: >
-      --requirepass ${REDIS_AUTH:-myredissecret} # CHANGEME
-    ports:
-      - 6379:6379
+      --requirepass ${REDIS_AUTH:-myredissecret}
+    # ports:
+    #   - 6379:6379
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 3s
@@ -139,8 +141,8 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres # CHANGEME
       POSTGRES_DB: postgres
-    ports:
-      - 5432:5432
+    # ports:
+    #   - 5432:5432
     volumes:
       - langfuse_postgres_data:/var/lib/postgresql/data
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Commented out host port mappings for internal services in `docker-compose.yml` to enhance security by preventing public exposure.
> 
>   - **Security**:
>     - Commented out host port mappings for `langfuse-worker`, `clickhouse`, `redis`, and `postgres` in `docker-compose.yml` to prevent public exposure.
>     - Retained port mapping for `langfuse-web` (port 3000) and `minio` (port 9090) as exceptions.
>   - **Documentation**:
>     - Updated comments in `docker-compose.yml` to guide users on how to enable port mappings if necessary.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1370c43e7dd3053d20355c263d7c2e8ecfd06930. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->