### PR TITLE
chore: skip token count for secondary queue projects without usage

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -620,6 +620,7 @@ export class IngestionService {
     const final_usage_details = this.getUsageUnits(
       observationRecord,
       internalModel,
+      projectId,
     );
     const modelPrices = await this.getModelPrices(internalModel?.id);
 
@@ -653,6 +654,7 @@ export class IngestionService {
   private getUsageUnits(
     observationRecord: ObservationRecordInsertType,
     model: Model | null | undefined,
+    projectId: string,
   ): Pick<
     ObservationRecordInsertType,
     "usage_details" | "provided_usage_details"
@@ -668,6 +670,16 @@ export class IngestionService {
       model &&
       Object.keys(providedUsageDetails).length === 0
     ) {
+      if (
+        (
+          env.LANGFUSE_SECONDARY_INGESTION_QUEUE_ENABLED_PROJECT_IDS?.split(
+            ",",
+          ) ?? []
+        ).includes(projectId)
+      ) {
+        return { usage_details: {}, provided_usage_details: {} };
+      }
+
       const newInputCount = tokenCount({
         text: observationRecord.input,
         model,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `getUsageUnits()` in `IngestionService` skips token counting for projects in `LANGFUSE_SECONDARY_INGESTION_QUEUE_ENABLED_PROJECT_IDS`.
> 
>   - **Behavior**:
>     - In `IngestionService`, `getUsageUnits()` now skips token counting for projects in `LANGFUSE_SECONDARY_INGESTION_QUEUE_ENABLED_PROJECT_IDS`.
>     - If project ID is in the list, returns empty `usage_details` and `provided_usage_details`.
>   - **Functions**:
>     - `getUsageUnits()` in `index.ts` updated to include `projectId` parameter.
>     - Checks `projectId` against `LANGFUSE_SECONDARY_INGESTION_QUEUE_ENABLED_PROJECT_IDS` environment variable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cc8c1426905f5cdfdbb7ea358266fa246e4ad843. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->