### PR TITLE
fix(ui): hide jump to playground button when not entitled

### DIFF
--- a/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -60,12 +60,12 @@ export const JumpToPlaygroundButton: React.FC<JumpToPlaygroundButtonProps> = (
   }, [props]);
 
   useEffect(() => {
-    if (capturedState && isEntitled) {
+    if (capturedState) {
       setIsAvailable(true);
     } else {
       setIsAvailable(false);
     }
-  }, [capturedState, isEntitled, setIsAvailable]);
+  }, [capturedState, setIsAvailable]);
 
   const handleClick = () => {
     capture(props.analyticsEventName);
@@ -73,6 +73,8 @@ export const JumpToPlaygroundButton: React.FC<JumpToPlaygroundButtonProps> = (
 
     router.push(`/project/${projectId}/playground`);
   };
+
+  if (!isEntitled) return null;
 
   return (
     <Button


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Hides `JumpToPlaygroundButton` when user is not entitled by checking `isEntitled` state in `JumpToPlaygroundButton.tsx`.
> 
>   - **Behavior**:
>     - Hides `JumpToPlaygroundButton` in `JumpToPlaygroundButton.tsx` when `isEntitled` is false.
>     - Removes `isEntitled` dependency from `useEffect` for setting `isAvailable` state.
>   - **Misc**:
>     - Adds conditional return to prevent rendering when not entitled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 739dbde6197e054cbb05e4ed2e42015ae4f8c251. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->