### PR TITLE
chore: enable datadog profiling for web

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -97,6 +97,8 @@ WORKDIR /app
 
 ARG NEXT_PUBLIC_BUILD_ID
 ENV BUILD_ID=$NEXT_PUBLIC_BUILD_ID
+ARG NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
+ENV NEXT_PUBLIC_LANGFUSE_CLOUD_REGION=$NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
 
 ENV NODE_ENV production
 # Uncomment the following line in case you want to disable telemetry during runtime.
@@ -115,7 +117,12 @@ RUN addgroup --system --gid ${GID} nodejs
 RUN adduser --system --uid ${UID} nextjs
 
 RUN npm install -g --no-package-lock --no-save prisma@6.3.0
-RUN npm install dd-trace
+
+# Install dd-trace only if NEXT_PUBLIC_LANGFUSE_CLOUD_REGION is configured
+ARG NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
+RUN if [ -n "$NEXT_PUBLIC_LANGFUSE_CLOUD_REGION" ]; then \
+        npm install --no-package-lock --no-save dd-trace; \
+    fi
 
 RUN MIGRATE_TARGET_ARCH=$(echo ${TARGETPLATFORM:-linux/amd64} | sed 's/\//-/g') && \
     wget -q -O- https://github.com/golang-migrate/migrate/releases/download/v4.18.2/migrate.$MIGRATE_TARGET_ARCH.tar.gz | tar xvz && \
@@ -142,9 +149,11 @@ USER nextjs
 # Default port to 3000
 ENV PORT 3000
 
-ENV DD_PROFILING_ENABLED=true
-
 ENTRYPOINT ["dumb-init", "--", "./web/entrypoint.sh"]
 
-# startup command
-CMD ["node", "--import", "dd-trace/initialize.mjs", "./web/server.js", "--keepAliveTimeout", "110000"]
+# startup command - use dd-trace if NEXT_PUBLIC_LANGFUSE_CLOUD_REGION is configured
+CMD if [ -n "$NEXT_PUBLIC_LANGFUSE_CLOUD_REGION" ]; then \
+      node --import dd-trace/initialize.mjs ./web/server.js --keepAliveTimeout 110000; \
+    else \
+      node ./web/server.js --keepAliveTimeout 110000; \
+    fi

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -115,6 +115,7 @@ RUN addgroup --system --gid ${GID} nodejs
 RUN adduser --system --uid ${UID} nextjs
 
 RUN npm install -g --no-package-lock --no-save prisma@6.3.0
+RUN npm install dd-trace
 
 RUN MIGRATE_TARGET_ARCH=$(echo ${TARGETPLATFORM:-linux/amd64} | sed 's/\//-/g') && \
     wget -q -O- https://github.com/golang-migrate/migrate/releases/download/v4.18.2/migrate.$MIGRATE_TARGET_ARCH.tar.gz | tar xvz && \
@@ -141,8 +142,9 @@ USER nextjs
 # Default port to 3000
 ENV PORT 3000
 
+ENV DD_PROFILING_ENABLED=true
 
 ENTRYPOINT ["dumb-init", "--", "./web/entrypoint.sh"]
 
 # startup command
-CMD ["node", "./web/server.js", "--keepAliveTimeout", "110000"]
+CMD ["node", "--import", "dd-trace/initialize.mjs", "./web/server.js", "--keepAliveTimeout", "110000"]

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -139,22 +139,22 @@ const nextConfig = {
       // Required to check authentication status from langfuse.com
       ...(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== undefined
         ? [
-          {
-            source: "/api/auth/session",
-            headers: [
-              {
-                key: "Access-Control-Allow-Origin",
-                value: "https://langfuse.com",
-              },
-              { key: "Access-Control-Allow-Credentials", value: "true" },
-              { key: "Access-Control-Allow-Methods", value: "GET,POST" },
-              {
-                key: "Access-Control-Allow-Headers",
-                value: "Content-Type, Authorization",
-              },
-            ],
-          },
-        ]
+            {
+              source: "/api/auth/session",
+              headers: [
+                {
+                  key: "Access-Control-Allow-Origin",
+                  value: "https://langfuse.com",
+                },
+                { key: "Access-Control-Allow-Credentials", value: "true" },
+                { key: "Access-Control-Allow-Methods", value: "GET,POST" },
+                {
+                  key: "Access-Control-Allow-Headers",
+                  value: "Content-Type, Authorization",
+                },
+              ],
+            },
+          ]
         : []),
       // all files in /public/generated are public and can be accessed from any origin, e.g. to render an API reference based on our openapi schema
       {
@@ -179,6 +179,9 @@ const nextConfig = {
       asyncWebAssembly: true,
       layers: true,
     };
+
+    // Exclude Datadog packages from webpack bundling to avoid issues
+    config.externals.push("@datadog/pprof", "dd-trace");
 
     return config;
   },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable Datadog profiling by conditionally installing and using `dd-trace` based on `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION`.
> 
>   - **Dockerfile Changes**:
>     - Add `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` as an ARG and ENV.
>     - Conditionally install `dd-trace` if `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` is set.
>     - Modify `CMD` to use `dd-trace` if `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` is configured.
>   - **next.config.mjs Changes**:
>     - Exclude `@datadog/pprof` and `dd-trace` from webpack bundling to avoid issues.
>     - Adjust headers for `/api/auth/session` based on `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1be4ee4d2ec96c5299b8e5e550b9936d7e8b7870. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->