### PR TITLE
chore(docker-compose): bind services to localhost

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,8 +10,8 @@ services:
       - langfuse_clickhouse_data:/var/lib/clickhouse
       - langfuse_clickhouse_logs:/var/log/clickhouse-server
     ports:
-      - "8123:8123"
-      - "9000:9000"
+      - 127.0.0.1:8123:8123
+      - 127.0.0.1:9000:9000
     depends_on:
       - postgres
 
@@ -24,8 +24,8 @@ services:
       MINIO_ACCESS_KEY: minio
       MINIO_SECRET_KEY: miniosecret
     ports:
-      - "9090:9000"
-      - "9091:9001"
+      - 127.0.0.1:9090:9000
+      - 127.0.0.1:9091:9001
     volumes:
       - langfuse_minio_data:/data
     healthcheck:
@@ -41,7 +41,7 @@ services:
     command: >
       --requirepass ${REDIS_AUTH:-myredissecret}
     ports:
-      - 6379:6379
+      - 127.0.0.1:6379:6379
 
   postgres:
     image: postgres:${POSTGRES_VERSION:-latest}
@@ -57,7 +57,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=postgres
     ports:
-      - 5432:5432
+      - 127.0.0.1:5432:5432
     volumes:
       - langfuse_postgres_data:/var/lib/postgresql/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 # Make sure to update the credential placeholders with your own secrets.
 # We mark them with # CHANGEME in the file below.
 # In addition, we recommend to restrict inbound traffic on the host to langfuse-web (port 3000) and minio (port 9090) only.
-# All other components should not be exposed to the public internet. Therefore, we do not map them to host ports, but
-# you can do so by uncommenting the respective lines in the file below.
+# All other components are bound to localhost (127.0.0.1) to only accept connections from the local machine.
+# External connections from other machines will not be able to reach these services directly.
 services:
   langfuse-worker:
     image: langfuse/langfuse-worker:3
@@ -16,8 +16,8 @@ services:
         condition: service_healthy
       clickhouse:
         condition: service_healthy
-    # ports:
-    #   - "3030:3030"
+    ports:
+      - 127.0.0.1:3030:3030
     environment: &langfuse-worker-env
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres # CHANGEME
       SALT: "mysalt" # CHANGEME
@@ -58,7 +58,7 @@ services:
     restart: always
     depends_on: *langfuse-depends-on
     ports:
-      - "3000:3000"
+      - 3000:3000
     environment:
       <<: *langfuse-worker-env
       NEXTAUTH_URL: http://localhost:3000
@@ -84,9 +84,9 @@ services:
     volumes:
       - langfuse_clickhouse_data:/var/lib/clickhouse
       - langfuse_clickhouse_logs:/var/log/clickhouse-server
-    # ports:
-    #   - "8123:8123"
-    #   - "9000:9000"
+    ports:
+      - 127.0.0.1:8123:8123
+      - 127.0.0.1:9000:9000
     healthcheck:
       test: wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1
       interval: 5s
@@ -104,8 +104,8 @@ services:
       MINIO_ROOT_USER: minio
       MINIO_ROOT_PASSWORD: miniosecret # CHANGEME
     ports:
-      - "9090:9000"
-    #   - "9091:9001"
+      - 9090:9000
+      - 127.0.0.1:9091:9001
     volumes:
       - langfuse_minio_data:/data
     healthcheck:
@@ -121,8 +121,8 @@ services:
     # CHANGEME: row below to secure redis password
     command: >
       --requirepass ${REDIS_AUTH:-myredissecret}
-    # ports:
-    #   - 6379:6379
+    ports:
+      - 127.0.0.1:6379:6379
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 3s
@@ -141,8 +141,8 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres # CHANGEME
       POSTGRES_DB: postgres
-    # ports:
-    #   - 5432:5432
+    ports:
+      - 127.0.0.1:5432:5432
     volumes:
       - langfuse_postgres_data:/var/lib/postgresql/data
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bind services to localhost in `docker-compose` files to restrict access to local machine only.
> 
>   - **Security**:
>     - Bind Clickhouse, Minio, Redis, and Postgres services to `127.0.0.1` in `docker-compose.dev.yml` and `docker-compose.yml`.
>     - Ensures services only accept connections from the local machine, preventing external access.
>   - **Ports**:
>     - `docker-compose.dev.yml`: Updates ports for Clickhouse (8123, 9000), Minio (9090, 9091), Redis (6379), and Postgres (5432).
>     - `docker-compose.yml`: Updates ports for Clickhouse (8123, 9000), Minio (9090, 9091), Redis (6379), and Postgres (5432).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c103c01f45ae5b60c8fb4ecc263d281919bca64b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->