### PR TITLE
chore(ui): always show tag buttons in table cells instead of only on hover

### DIFF
--- a/web/src/features/tag/components/TagList.tsx
+++ b/web/src/features/tag/components/TagList.tsx
@@ -27,11 +27,7 @@ const TagList = ({
       />
     ))
   ) : (
-    <Button
-      variant="tertiary"
-      size="icon-xs"
-      className={isTableCell ? "opacity-0 hover:opacity-100" : ""}
-    >
+    <Button variant={isTableCell ? "ghost" : "tertiary"} size="icon-xs">
       <TagIcon className="h-3.5 w-3.5" />
     </Button>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `TagList.tsx`, tag buttons in table cells are now always visible using `variant="ghost"` instead of hover-dependent opacity.
> 
>   - **Behavior**:
>     - In `TagList.tsx`, `Button` component now uses `variant="ghost"` for `isTableCell` instead of `"tertiary"` with hover opacity.
>     - Ensures tag buttons are always visible in table cells, not just on hover.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c6b144fff7fe21bb10e5c089bf7901b6a411fff1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->