### PR TITLE
chore(ui): standardize the prompt variable list preview across views

### DIFF
--- a/web/src/ee/features/evals/components/template-form.tsx
+++ b/web/src/ee/features/evals/components/template-form.tsx
@@ -24,7 +24,7 @@ import {
   type ModelParams,
   ZodModelConfig,
 } from "@langfuse/shared";
-import { PromptDescription } from "@/src/features/prompts/components/prompt-description";
+import { PromptVariableListPreview } from "@/src/features/prompts/components/PromptVariableListPreview";
 import {
   Select,
   SelectContent,
@@ -426,8 +426,8 @@ export const InnerEvalTemplateForm = (props: {
                     />
                   </FormControl>
                   <FormMessage />
-                  <PromptDescription
-                    currentExtractedVariables={extractedVariables ?? []}
+                  <PromptVariableListPreview
+                    variables={extractedVariables ?? []}
                   />
                 </FormItem>
               </>

--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -43,7 +43,7 @@ import {
 import { Input } from "@/src/components/ui/input";
 import Link from "next/link";
 import { ArrowTopRightIcon } from "@radix-ui/react-icons";
-import { PromptDescription } from "@/src/features/prompts/components/prompt-description";
+import { PromptVariableListPreview } from "@/src/features/prompts/components/PromptVariableListPreview";
 import { CodeMirrorEditor } from "@/src/components/editor/CodeMirrorEditor";
 import { PromptLinkingEditor } from "@/src/components/editor/PromptLinkingEditor";
 import { PRODUCTION_LABEL } from "@/src/features/prompts/constants";
@@ -318,9 +318,7 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
               </TabsContent>
             </Tabs>
           </FormItem>
-          <PromptDescription
-            currentExtractedVariables={currentExtractedVariables}
-          />
+          <PromptVariableListPreview variables={currentExtractedVariables} />
         </>
 
         {/* Prompt Config field */}

--- a/web/src/features/prompts/components/PromptVariableListPreview.tsx
+++ b/web/src/features/prompts/components/PromptVariableListPreview.tsx
@@ -1,11 +1,11 @@
 import { Badge } from "@/src/components/ui/badge";
 
-export const PromptDescription = ({
-  currentExtractedVariables,
+export const PromptVariableListPreview = ({
+  variables,
 }: {
-  currentExtractedVariables: string[];
+  variables: string[];
 }) => {
-  if (currentExtractedVariables.length === 0) {
+  if (variables.length === 0) {
     return null;
   }
 
@@ -15,7 +15,7 @@ export const PromptDescription = ({
         The following variables are available:
       </p>
       <div className="flex min-h-6 flex-wrap gap-2">
-        {currentExtractedVariables.map((variable) => (
+        {variables.map((variable) => (
           <Badge key={variable} variant="outline">
             {variable}
           </Badge>

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -54,6 +54,7 @@ import { CommentDrawerButton } from "@/src/features/comments/CommentDrawerButton
 import { Command, CommandInput } from "@/src/components/ui/command";
 import { PRODUCTION_LABEL } from "@/src/features/prompts/constants";
 import { renderContentWithPromptButtons } from "@/src/features/prompts/components/renderContentWithPromptButtons";
+import { PromptVariableListPreview } from "@/src/features/prompts/components/PromptVariableListPreview";
 
 const getPythonCode = (
   name: string,
@@ -536,23 +537,7 @@ export const PromptDetail = () => {
                 ) : (
                   <JSONView json={prompt.prompt} title="Prompt" />
                 )}
-                {extractedVariables.length > 0 && (
-                  <div className="flex flex-col">
-                    <div className="my-1 flex flex-shrink-0 items-center justify-between pl-1 text-sm font-medium">
-                      Variables
-                    </div>
-                    <div className="flex flex-wrap gap-2 rounded-md">
-                      {extractedVariables.map((variable) => (
-                        <div
-                          key={variable}
-                          className="flex flex-col gap-1 rounded-md border p-2 text-sm"
-                        >
-                          {`{{${variable}}}`}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
+                <PromptVariableListPreview variables={extractedVariables} />
               </div>
             </TabsBarContent>
             <TabsBarContent

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -10,7 +10,7 @@ import {
   createTRPCRouter,
   protectedProjectProcedure,
 } from "@/src/server/api/trpc";
-import { type Prompt, Prisma, prisma } from "@langfuse/shared/src/db";
+import { type Prompt, Prisma } from "@langfuse/shared/src/db";
 import { createPrompt, duplicatePrompt } from "../actions/createPrompt";
 import { promptsTableCols } from "@/src/server/api/definitions/promptsTable";
 import { optionalPaginationZod, paginationZod } from "@langfuse/shared";
@@ -938,7 +938,7 @@ export const promptRouter = createTRPCRouter({
         },
       });
 
-      const promptService = new PromptService(prisma, redis);
+      const promptService = new PromptService(ctx.prisma, redis);
 
       return promptService.buildAndResolvePromptGraph({
         projectId: input.projectId,

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -938,7 +938,9 @@ export const promptRouter = createTRPCRouter({
         },
       });
 
-      return new PromptService(prisma, redis).buildAndResolvePromptGraph({
+      const promptService = new PromptService(prisma, redis);
+
+      return promptService.buildAndResolvePromptGraph({
         projectId: input.projectId,
         parentPrompt: prompt,
       });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Standardizes the use of `PromptVariableListPreview` across components, replacing `PromptDescription` and updating variable handling.
> 
>   - **Component Standardization**:
>     - Replaces `PromptDescription` with `PromptVariableListPreview` in `template-form.tsx`, `index.tsx`, and `prompt-detail.tsx`.
>     - Updates component usage to pass `variables` instead of `currentExtractedVariables`.
>   - **File Renaming**:
>     - Renames `prompt-description.tsx` to `PromptVariableListPreview.tsx`.
>   - **Code Cleanup**:
>     - Removes unused import of `prisma` in `promptRouter.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for df8e191502efc8f1ac74c017f1c64099aa5aaef0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->