### PR TITLE
chore(ui): alignment and sizing consitency in ObservationTree / GroupedScoreBadge

### DIFF
--- a/web/src/components/grouped-score-badge.tsx
+++ b/web/src/components/grouped-score-badge.tsx
@@ -4,7 +4,7 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@/src/components/ui/hover-card";
-import { MessageCircleMore } from "lucide-react";
+import { MessageCircleMoreIcon } from "lucide-react";
 
 import { type APIScore, type LastUserScore } from "@langfuse/shared";
 
@@ -30,7 +30,7 @@ export const GroupedScoreBadges = <T extends APIScore | LastUserScore>({
           <Badge
             variant="tertiary"
             key={name}
-            className="flex flex-row gap-1 px-1 font-normal"
+            className="flex items-center gap-1 px-2.5 text-xs font-normal"
           >
             <div className="w-fit max-w-20 truncate" title={name}>
               {name}:
@@ -39,13 +39,13 @@ export const GroupedScoreBadges = <T extends APIScore | LastUserScore>({
               {scores.map((s, i) => (
                 <span
                   key={i}
-                  className="group/score ml-1 flex items-center gap-0.5 rounded-sm font-medium first:ml-0"
+                  className="group/score ml-1 flex items-center gap-1 rounded-sm first:ml-0"
                 >
                   {s.stringValue ?? s.value?.toFixed(2) ?? ""}
                   {s.comment && (
                     <HoverCard>
-                      <HoverCardTrigger className="mb-1 inline-block cursor-pointer">
-                        <MessageCircleMore size={12} />
+                      <HoverCardTrigger className="inline-block">
+                        <MessageCircleMoreIcon className="mb-[0.0625rem] !size-3" />
                       </HoverCardTrigger>
                       <HoverCardContent className="overflow-hidden whitespace-normal break-normal">
                         <p>{s.comment}</p>

--- a/web/src/components/trace/ObservationTree.tsx
+++ b/web/src/components/trace/ObservationTree.tsx
@@ -171,7 +171,7 @@ const ObservationTreeTraceNode = (props: {
       onSelect={() => props.setCurrentObservationId(undefined)}
     >
       <div className="flex w-full flex-row items-start justify-between gap-1 py-1">
-        <div className="flex w-full flex-col items-start gap-2 -space-y-1">
+        <div className="flex w-full flex-col items-start gap-2 -space-y-1 py-1.5">
           <div className="flex flex-wrap items-center gap-2">
             <ItemBadge
               type="TRACE"


### PR DESCRIPTION
### Before:

![image](https://github.com/user-attachments/assets/9ac52698-d56a-46d5-8d4f-acd9a4515b68)
![image](https://github.com/user-attachments/assets/34f22801-6e32-4ad7-bad1-4fb0b2dda170)

### After:

![image](https://github.com/user-attachments/assets/206fe2fb-f242-498e-a592-dec33fffdbcf)
![image](https://github.com/user-attachments/assets/7c7371b4-ab07-428b-a595-58ff962a8acd)

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> UI alignment and sizing adjustments in `GroupedScoreBadges` and `ObservationTreeTraceNode`, with a minor import rename in `grouped-score-badge.tsx`.
> 
>   - **UI Consistency**:
>     - In `grouped-score-badge.tsx`, adjusted `Badge` class to `flex items-center gap-1 px-2.5 text-xs font-normal` for consistent alignment and sizing.
>     - In `ObservationTree.tsx`, added `py-1.5` to `ObservationTreeTraceNode` for consistent vertical spacing.
>   - **Imports**:
>     - Renamed `MessageCircleMore` to `MessageCircleMoreIcon` in `grouped-score-badge.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e7b53ad41d30d27feb4ec91afaa3e0ae0843bb64. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->