### PR TITLE
chore(ui): render min-level hint in a single line

### DIFF
--- a/web/src/components/trace/ObservationTree.tsx
+++ b/web/src/components/trace/ObservationTree.tsx
@@ -110,18 +110,19 @@ export const ObservationTree = ({
       {props.minLevel && hiddenObservationsCount > 0 ? (
         <span className="flex items-center gap-1 p-2 py-4">
           <InfoIcon className="h-4 w-4 text-muted-foreground" />
-          <span className="flex flex-row gap-1 text-sm text-muted-foreground">
-            <p>
-              {hiddenObservationsCount} observations below {props.minLevel}{" "}
-              level are hidden.
-            </p>
-            <p
+          <p className="text-sm text-muted-foreground">
+            <span>
+              {hiddenObservationsCount}{" "}
+              {hiddenObservationsCount === 1 ? "observation" : "observations"}{" "}
+              below {props.minLevel} level are hidden.{" "}
+            </span>
+            <span
               className="cursor-pointer underline"
               onClick={() => props.setMinLevel?.(ObservationLevel.DEBUG)}
             >
               Show all
-            </p>
-          </span>
+            </span>
+          </p>
         </span>
       ) : null}
     </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Render min-level hint in a single line in `ObservationTree` component by restructuring JSX.
> 
>   - **Behavior**:
>     - Render min-level hint in a single line in `ObservationTree` component.
>     - Replaces nested `<p>` elements with a single `<p>` element for the hint message.
>     - Handles both singular and plural forms of "observation" based on `hiddenObservationsCount`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for eb2ef65a0f32b45f1a21678b5cf38450cb5307de. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->