### PR TITLE
chore: lock dd-trace to 5.36.0

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -121,7 +121,7 @@ RUN npm install -g --no-package-lock --no-save prisma@6.3.0
 # Install dd-trace only if NEXT_PUBLIC_LANGFUSE_CLOUD_REGION is configured
 ARG NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
 RUN if [ -n "$NEXT_PUBLIC_LANGFUSE_CLOUD_REGION" ]; then \
-        npm install --no-package-lock --no-save dd-trace; \
+        npm install --no-package-lock --no-save dd-trace@5.36.0; \
     fi
 
 RUN MIGRATE_TARGET_ARCH=$(echo ${TARGETPLATFORM:-linux/amd64} | sed 's/\//-/g') && \


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Locks `dd-trace` version to `5.36.0` in `web/Dockerfile` for consistent builds.
> 
>   - **Dependency Management**:
>     - Locks `dd-trace` version to `5.36.0` in `web/Dockerfile` to ensure consistent builds when `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` is configured.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a9636862ae137cf35a72baaf65ab897b06491bda. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->