### PR TITLE
fix(ui): padding on single prompt page

### DIFF
--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -258,7 +258,6 @@ export const PromptDetail = () => {
 
   return (
     <Page
-      withPadding
       headerProps={{
         title: prompt.name,
         itemType: "PROMPT",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `withPadding` prop from `Page` component in `prompt-detail.tsx` to adjust padding on the single prompt page.
> 
>   - **UI Change**:
>     - Remove `withPadding` prop from `Page` component in `prompt-detail.tsx`, affecting padding on the single prompt page.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e5399bc9b3eb6570a84f8f3ea5d069217f04a45a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->