### PR TITLE
fix(ui): For Checkbox component we stop event propagation on CheckboxPrimitive.Root such that our DataTable on row click events do not trigger when selecting a row; should not have unwanted side effects as we do not expect a checkbox to propagate a click

### DIFF
--- a/web/src/components/ui/checkbox.tsx
+++ b/web/src/components/ui/checkbox.tsx
@@ -9,7 +9,7 @@ import { cn } from "@/src/utils/tailwind";
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
->(({ className, ...props }, ref) => (
+>(({ className, onClick, ...props }, ref) => (
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
@@ -18,6 +18,7 @@ const Checkbox = React.forwardRef<
     )}
     onClick={(e) => {
       e.stopPropagation();
+      onClick?.(e);
     }}
     {...props}
   >

--- a/web/src/components/ui/checkbox.tsx
+++ b/web/src/components/ui/checkbox.tsx
@@ -16,6 +16,9 @@ const Checkbox = React.forwardRef<
       "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
       className,
     )}
+    onClick={(e) => {
+      e.stopPropagation();
+    }}
     {...props}
   >
     <CheckboxPrimitive.Indicator


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `onClick` handler to `CheckboxPrimitive.Root` in `checkbox.tsx` to stop event propagation, preventing DataTable row click events when a checkbox is clicked.
> 
>   - **Behavior**:
>     - In `checkbox.tsx`, added `onClick` handler to `CheckboxPrimitive.Root` to stop event propagation.
>     - Prevents DataTable row click events from triggering when a checkbox is clicked.
>   - **Misc**:
>     - No expected side effects as checkboxes typically do not propagate click events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c6aa92f2f83d33f1fd9f27d1cd2c9dfedbaab385. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->