### PR TITLE
fix(peek-view): ensure `onClickRow` action smoothly keeps peek view open; onClick of select cells independent of peek view state

### DIFF
--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -139,9 +139,18 @@ export function DataTable<TData extends object, TValue>({
   }, [columns]);
 
   const handleOnRowClick = (row: TData) => {
-    const rowId = "id" in row && typeof row.id === "string" ? row.id : null;
     if (peekView) {
-      peekView.onOpenChange(peekViewId !== rowId, row);
+      const rowId =
+        "id" in row && typeof row.id === "string" ? row.id : undefined;
+
+      // If clicking the same row that's already open, close it
+      if (rowId === peekViewId) {
+        peekView.onOpenChange(false);
+      }
+      // If clicking a different row, update without closing first
+      else {
+        peekView.onOpenChange(true, row);
+      }
     }
     onRowClick?.(row);
   };

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -39,8 +39,7 @@ export function TablePeekView<TData>({
     <Sheet
       open={!!selectedRowId}
       onOpenChange={(open) => {
-        // Ignore close events from checkbox or button clicks
-        console.log("role", document.activeElement);
+        // Ignore close events from checkbox or button clicks to ensure integrity of table row actions
         if (
           !open &&
           (document.activeElement?.closest('[role="checkbox"]') ||

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -39,8 +39,13 @@ export function TablePeekView<TData>({
     <Sheet
       open={!!selectedRowId}
       onOpenChange={(open) => {
-        // Ignore close events from checkbox clicks
-        if (!open && document.activeElement?.closest('[role="checkbox"]')) {
+        // Ignore close events from checkbox or button clicks
+        console.log("role", document.activeElement);
+        if (
+          !open &&
+          (document.activeElement?.closest('[role="checkbox"]') ||
+            document.activeElement?.closest("button"))
+        ) {
           return;
         }
         onOpenChange(open);

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -36,8 +36,22 @@ export function TablePeekView<TData>({
   const pageUrl = mapItemTypeToPageUrl[itemType];
 
   return (
-    <Sheet open={!!selectedRowId} onOpenChange={onOpenChange} modal={false}>
+    <Sheet
+      open={!!selectedRowId}
+      onOpenChange={(open) => {
+        // Ignore close events from checkbox clicks
+        if (!open && document.activeElement?.closest('[role="checkbox"]')) {
+          return;
+        }
+        onOpenChange(open);
+      }}
+      modal={false}
+    >
       <SheetContent
+        onPointerDownOutside={(e) => {
+          // Prevent the default behavior of closing when clicking outside when we set modal={false}
+          e.preventDefault();
+        }}
         side="right"
         className="flex max-h-full min-h-0 min-w-[60vw] flex-col gap-0 overflow-hidden rounded-l-xl p-0"
       >

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -1068,10 +1068,14 @@ export default function TracesTable({
               return;
             }
 
-            router.replace({
-              pathname: `/project/${projectId}/traces`,
-              query: params.toString(),
-            });
+            router.replace(
+              {
+                pathname: `/project/${projectId}/traces`,
+                query: params.toString(),
+              },
+              undefined,
+              { shallow: true },
+            );
           },
           onExpand: (openInNewTab: boolean) => {
             if (peekViewId) {

--- a/web/src/features/table/components/TableSelectionManager.tsx
+++ b/web/src/features/table/components/TableSelectionManager.tsx
@@ -48,15 +48,21 @@ export function TableSelectionManager<TData>({
         </div>
       ),
       cell: ({ row }: { row: Row<TData> }) => (
-        <Checkbox
-          checked={row.getIsSelected()}
-          onCheckedChange={(value) => {
-            row.toggleSelected(!!value);
-            if (!value) setSelectAll(false);
+        <div
+          onClick={(e) => {
+            e.stopPropagation();
           }}
-          aria-label="Select row"
-          className="opacity-60"
-        />
+        >
+          <Checkbox
+            checked={row.getIsSelected()}
+            onCheckedChange={(value) => {
+              row.toggleSelected(!!value);
+              if (!value) setSelectAll(false);
+            }}
+            aria-label="Select row"
+            className="opacity-60"
+          />
+        </div>
       ),
     },
   };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves peek view behavior and row selection handling in data tables, ensuring smooth interactions and state integrity.
> 
>   - **Behavior**:
>     - In `data-table.tsx`, `handleOnRowClick` now closes the peek view if the same row is clicked again, and opens it for a different row without closing first.
>     - In `peek.tsx`, `TablePeekView` ignores close events from checkbox or button clicks to maintain row action integrity.
>     - In `traces.tsx`, `router.replace` uses shallow routing to update URL without full page reload.
>   - **Components**:
>     - `TableSelectionManager.tsx` wraps `Checkbox` in a `div` to prevent row click propagation.
>     - `peek.tsx` prevents default behavior of closing when clicking outside the `SheetContent`.
>   - **Misc**:
>     - Minor adjustments to `TableSelectionManager` to ensure `setSelectAll` is called appropriately.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 984af6b5f31f47af6dd289106a4454132f9cc213. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->