### PR TITLE
chore(prompt-experiments): set langfuse-native environment

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -82,7 +82,7 @@
     "ioredis": "^5.4.1",
     "kysely": "^0.27.4",
     "langchain": "^0.3.15",
-    "langfuse-langchain": "3.30.3",
+    "langfuse-langchain": "3.37.0",
     "lodash": "^4.17.21",
     "next-auth": "^4.24.11",
     "nodemailer": "^6.9.15",

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -105,7 +105,7 @@ export async function fetchLLMCompletion(
     const handler = new CallbackHandler({
       _projectId: traceParams.projectId,
       _isLocalEventExportEnabled: true,
-      tags: traceParams.tags,
+      environment: traceParams.environment,
     });
     finalCallbacks.push(handler);
 

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -195,11 +195,15 @@ export type LLMApiKey =
     ? z.infer<typeof LLMApiKeySchema>
     : never;
 
+export const PROMPT_EXPERIMENT_ENVIRONMENT =
+  "langfuse-prompt-experiment" as const;
+export type PromptExperimentEnvironment = typeof PROMPT_EXPERIMENT_ENVIRONMENT;
+
 export type TraceParams = {
   traceName: string;
   traceId: string;
   projectId: string;
-  tags: string[];
+  environment: PromptExperimentEnvironment;
   tokenCountDelegate: TokenCountDelegate;
   authCheck: AuthHeaderValidVerificationResult;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,8 +219,8 @@ importers:
         specifier: ^0.3.15
         version: 0.3.15(@langchain/anthropic@0.3.12(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8))))(@langchain/aws@0.1.3(@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0))(@aws-sdk/client-sts@3.668.0)(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8))))(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(@langchain/google-genai@0.1.9(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(zod@3.23.8))(@langchain/google-vertexai@0.1.8(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(zod@3.23.8))(axios@1.8.2)(cheerio@1.0.0)(handlebars@4.7.8)(openai@4.82.0(zod@3.23.8))
       langfuse-langchain:
-        specifier: 3.30.3
-        version: 3.30.3(langchain@0.3.15(@langchain/anthropic@0.3.12(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8))))(@langchain/aws@0.1.3(@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0))(@aws-sdk/client-sts@3.668.0)(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8))))(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(@langchain/google-genai@0.1.9(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(zod@3.23.8))(@langchain/google-vertexai@0.1.8(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(zod@3.23.8))(axios@1.8.2)(cheerio@1.0.0)(handlebars@4.7.8)(openai@4.82.0(zod@3.23.8)))
+        specifier: 3.37.0
+        version: 3.37.0(langchain@0.3.15(@langchain/anthropic@0.3.12(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8))))(@langchain/aws@0.1.3(@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0))(@aws-sdk/client-sts@3.668.0)(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8))))(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(@langchain/google-genai@0.1.9(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(zod@3.23.8))(@langchain/google-vertexai@0.1.8(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(zod@3.23.8))(axios@1.8.2)(cheerio@1.0.0)(handlebars@4.7.8)(openai@4.82.0(zod@3.23.8)))
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -8731,18 +8731,18 @@ packages:
       typeorm:
         optional: true
 
-  langfuse-core@3.30.3:
-    resolution: {integrity: sha512-pO0pUtIGLqCM29tCPZK8DPBzG5YeYnufZlD5Zz824b3rIvEpylkIClqkEZTDOFJ0yNvXWKlf7KySEChBAlXXeA==}
+  langfuse-core@3.37.0:
+    resolution: {integrity: sha512-7ZOFJ51u4dOeCpsQ8otNuNYeMb7xsExVQcOIBOByPFKjjd1mjf/03xF907F44dRzgf7n1U8ZYa0XgMSRgxKNoA==}
     engines: {node: '>=18'}
 
-  langfuse-langchain@3.30.3:
-    resolution: {integrity: sha512-+nV5TykyxzgJtXwcGjhuHbu1pnz2D1n5KTmCuC7j7QfGw0qYtX1JAPLg5eY5ld2bq8esUW+WI+UvyexqEvterQ==}
+  langfuse-langchain@3.37.0:
+    resolution: {integrity: sha512-IleGRb5Je5/gBd1tUQ+KtvhISyFHuaWbCxKEZyfV0iUIcYAa07YTq3USDVN2TYunEfM7gcioOWDFPtz0UnTy2g==}
     engines: {node: '>=18'}
     peerDependencies:
       langchain: '>=0.0.157 <0.4.0'
 
-  langfuse@3.30.3:
-    resolution: {integrity: sha512-cs4BZkkPC3yyLYvjz/qzG8jQooCC3vOtVbbkRPkmDvCAo0nPbQcWxaUUu9iDXgoEXCLCY6Xlcc6V0mddcdOhMg==}
+  langfuse@3.37.0:
+    resolution: {integrity: sha512-NpemB+5i6VT9CXmBwQTE4q1DPOY/DH7OMxBJn8Rcirw+z2HYJpTRH8j48cBjzwqmYtqLdqyJMzAALa2ReQ50hQ==}
     engines: {node: '>=18'}
 
   langium@3.0.0:
@@ -22019,19 +22019,19 @@ snapshots:
       - encoding
       - openai
 
-  langfuse-core@3.30.3:
+  langfuse-core@3.37.0:
     dependencies:
       mustache: 4.2.0
 
-  langfuse-langchain@3.30.3(langchain@0.3.15(@langchain/anthropic@0.3.12(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8))))(@langchain/aws@0.1.3(@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0))(@aws-sdk/client-sts@3.668.0)(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8))))(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(@langchain/google-genai@0.1.9(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(zod@3.23.8))(@langchain/google-vertexai@0.1.8(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(zod@3.23.8))(axios@1.8.2)(cheerio@1.0.0)(handlebars@4.7.8)(openai@4.82.0(zod@3.23.8))):
+  langfuse-langchain@3.37.0(langchain@0.3.15(@langchain/anthropic@0.3.12(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8))))(@langchain/aws@0.1.3(@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0))(@aws-sdk/client-sts@3.668.0)(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8))))(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(@langchain/google-genai@0.1.9(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(zod@3.23.8))(@langchain/google-vertexai@0.1.8(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(zod@3.23.8))(axios@1.8.2)(cheerio@1.0.0)(handlebars@4.7.8)(openai@4.82.0(zod@3.23.8))):
     dependencies:
       langchain: 0.3.15(@langchain/anthropic@0.3.12(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8))))(@langchain/aws@0.1.3(@aws-sdk/client-sso-oidc@3.668.0(@aws-sdk/client-sts@3.668.0))(@aws-sdk/client-sts@3.668.0)(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8))))(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(@langchain/google-genai@0.1.9(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(zod@3.23.8))(@langchain/google-vertexai@0.1.8(@langchain/core@0.3.37(openai@4.82.0(zod@3.23.8)))(zod@3.23.8))(axios@1.8.2)(cheerio@1.0.0)(handlebars@4.7.8)(openai@4.82.0(zod@3.23.8))
-      langfuse: 3.30.3
-      langfuse-core: 3.30.3
+      langfuse: 3.37.0
+      langfuse-core: 3.37.0
 
-  langfuse@3.30.3:
+  langfuse@3.37.0:
     dependencies:
-      langfuse-core: 3.30.3
+      langfuse-core: 3.37.0
 
   langium@3.0.0:
     dependencies:

--- a/worker/src/__tests__/experimentsService.test.ts
+++ b/worker/src/__tests__/experimentsService.test.ts
@@ -406,7 +406,6 @@ describe("create experiment job calls with langfuse server side tracing", async 
       expect.any(String),
       expect.any(String),
       expect.objectContaining({
-        tags: ["langfuse-prompt-experiment"],
         traceName: expect.stringMatching(/^dataset-run-item-/),
         traceId: expect.any(String),
         projectId: mockEvent.projectId,
@@ -417,6 +416,7 @@ describe("create experiment job calls with langfuse server side tracing", async 
             accessLevel: "all",
           }),
         }),
+        environment: "langfuse-prompt-experiment",
       }),
     );
   });

--- a/worker/src/ee/experiments/experimentService.ts
+++ b/worker/src/ee/experiments/experimentService.ts
@@ -7,6 +7,8 @@ import {
   ExperimentMetadataSchema,
   PromptContentSchema,
   DatasetRunItemUpsertQueue,
+  PROMPT_EXPERIMENT_ENVIRONMENT,
+  TraceParams,
 } from "@langfuse/shared/src/server";
 import { kyselyPrisma, prisma } from "@langfuse/shared/src/db";
 import { ExperimentCreateEventSchema } from "@langfuse/shared/src/server";
@@ -265,8 +267,7 @@ export const createExperimentJob = async ({
      * LLM MODEL CALL *
      ********************/
 
-    const traceParams = {
-      tags: ["langfuse-prompt-experiment"], // LFE-2917: filter out any trace in trace upsert queue that has this tag set
+    const traceParams: Omit<TraceParams, "tokenCountDelegate"> = {
       traceName: `dataset-run-item-${runItem.id.slice(0, 5)}`,
       traceId: newTraceId,
       projectId: event.projectId,
@@ -277,6 +278,7 @@ export const createExperimentJob = async ({
           accessLevel: "all",
         } as any,
       },
+      environment: PROMPT_EXPERIMENT_ENVIRONMENT,
     };
 
     await backOff(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `langfuse-langchain` version and modify trace parameters to use `environment` instead of `tags`, introducing a constant for prompt experiment environment.
> 
>   - **Dependencies**:
>     - Update `langfuse-langchain` version from `3.30.3` to `3.37.0` in `package.json`.
>   - **Trace Parameters**:
>     - Replace `tags` with `environment` in `fetchLLMCompletion()` in `fetchLLMCompletion.ts`.
>     - Update `TraceParams` type in `types.ts` to include `environment` instead of `tags`.
>     - Introduce `PROMPT_EXPERIMENT_ENVIRONMENT` constant in `types.ts`.
>   - **Tests**:
>     - Update `experimentsService.test.ts` to check for `environment` instead of `tags` in trace parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b1263786004a2ac61f55ae24aab1efeda2df036b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->