### PR TITLE
chore(tests): fully unpin node version from temporary fix #6063

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -40,7 +40,7 @@ jobs:
           version: 9.5.0
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.18.3"
+          node-version: 20
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
       - name: install dependencies
@@ -97,7 +97,7 @@ jobs:
     name: tests-web-sync (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }})
     strategy:
       matrix:
-        node-version: ["20.18.3"]
+        node-version: [20]
         postgres-version: [12, 15]
     steps:
       - name: Set Swap Space
@@ -174,7 +174,7 @@ jobs:
     name: tests-web-async (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }}, mode${{ matrix.blob-provider }})
     strategy:
       matrix:
-        node-version: ["20.18.3"]
+        node-version: [20]
         postgres-version: [12, 15]
         blob-provider: ["", "-azure"]
     steps:
@@ -250,7 +250,7 @@ jobs:
     name: tests-worker (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }}, mode${{ matrix.blob-provider }})
     strategy:
       matrix:
-        node-version: ["20.18.3"]
+        node-version: [20]
         postgres-version: [12, 15]
         blob-provider: ["", "-azure"]
     steps:
@@ -322,7 +322,7 @@ jobs:
           version: 9.5.0
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.18.3"
+          node-version: 20
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Login to Docker Hub
@@ -372,7 +372,7 @@ jobs:
           version: 9.5.0
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.18.3"
+          node-version: 20
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
       - name: install dependencies
@@ -459,7 +459,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: "20.18.3"
+          node-version: 20
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Checkout
         uses: actions/checkout@v4

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} node:20.18.3-alpine3.20 AS alpine
+FROM --platform=${TARGETPLATFORM:-linux/amd64} node:20-alpine3.20 AS alpine
 
 # It's important to update the index before installing packages to ensure you're getting the latest versions.
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} node:20.18.3-alpine3.20 AS alpine
+FROM --platform=${TARGETPLATFORM:-linux/amd64} node:20-alpine3.20 AS alpine
 
 # It's important to update the index before installing packages to ensure you're getting the latest versions.
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Unpin Node.js version from `20.18.3` to `20` in CI/CD workflows and Dockerfiles for flexibility in patch updates.
> 
>   - **CI/CD Configuration**:
>     - Unpin Node.js version from `20.18.3` to `20` in `.github/workflows/pipeline.yml` for `setup-node` steps in `lint`, `test-docker-build`, `tests-web-sync`, `tests-web-async`, `tests-worker`, `e2e-tests`, `e2e-server-tests`, and `push-docker-image` jobs.
>   - **Dockerfiles**:
>     - Change Node.js base image from `node:20.18.3-alpine3.20` to `node:20-alpine3.20` in `web/Dockerfile` and `worker/Dockerfile`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8b71290e1cd25b4c48962c892e5dca059e9a09ab. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->