### PR TITLE
chore(ui): improve padding in peek view header

### DIFF
--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -102,7 +102,7 @@ export function TablePeekView<TData>({
                 listKey={pageUrl}
               />
             )}
-            <div className="!mt-0 mr-6 flex h-full flex-row items-center border-l">
+            <div className="!mt-0 mr-8 flex h-full flex-row items-center gap-1 border-l">
               <Button
                 variant="ghost"
                 size="icon-xs"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase right margin and add gap in `TablePeekView` header `div` in `peek.tsx`.
> 
>   - **UI Adjustment**:
>     - In `peek.tsx`, increased right margin from `mr-6` to `mr-8` and added `gap-1` to the `div` in the `TablePeekView` header.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 92f90c3d0338ceeaf5fd31e132a352a8979ee01c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->