### PR TITLE
chore(cloud): cache response of cloudStatus api for 5 minutes

### DIFF
--- a/web/src/features/cloud-status-notification/components/CloudStatusMenu.tsx
+++ b/web/src/features/cloud-status-notification/components/CloudStatusMenu.tsx
@@ -7,8 +7,11 @@ import { SidebarMenuButton } from "@/src/components/ui/sidebar";
 export function CloudStatusMenu() {
   const { data, isLoading } = api.cloudStatus.getStatus.useQuery(undefined, {
     refetchOnMount: false,
-    // Refresh status data every 5 minutes
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    // Refresh status data every 5 minutes, keep response cached for 5 minutes
     refetchInterval: 5 * 60 * 1000,
+    staleTime: 5 * 60 * 1000,
     enabled: !!env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
   });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Caches `cloudStatus` API response for 5 minutes in `CloudStatusMenu.tsx`, disabling refetch on reconnect and window focus.
> 
>   - **Behavior**:
>     - Adds `staleTime: 5 * 60 * 1000` to cache `cloudStatus` API response for 5 minutes in `CloudStatusMenu.tsx`.
>     - Disables `refetchOnReconnect` and `refetchOnWindowFocus` to prevent unnecessary API calls.
>     - Maintains `refetchInterval` of 5 minutes for periodic updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bf097b54debb62b9ead869a5ff9bccf4de010144. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->