### PR TITLE
chore(cloud): add posthog for projects and orgs

### DIFF
--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -225,8 +225,8 @@ function UserTracking() {
         posthog.group("project", project.id, {
           id: project.id,
           name: project.name,
-          organizationId: organization.id,
-          plan: organization.plan,
+          organizationId: organization?.id,
+          plan: organization?.plan,
           LANGFUSE_CLOUD_REGION: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
         });
       }

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -36,25 +36,12 @@ import { ThemeProvider } from "@/src/features/theming/ThemeProvider";
 import { MarkdownContextProvider } from "@/src/features/theming/useMarkdownContext";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 
-const setProjectInPosthog = () => {
-  // project
-  const url = window.location.href;
-  const regex = /\/project\/([^\/]+)/;
-  const match = url.match(regex);
-  if (match && match[1]) {
-    posthog.group("project", match[1]);
-  } else {
-    posthog.resetGroups();
-  }
-};
-
 // Check that PostHog is client-side (used to handle Next.js SSR) and that env vars are set
 if (
   typeof window !== "undefined" &&
   process.env.NEXT_PUBLIC_POSTHOG_KEY &&
   process.env.NEXT_PUBLIC_POSTHOG_HOST
 ) {
-  setProjectInPosthog();
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://eu.posthog.com",
     ui_host: "https://eu.posthog.com",
@@ -84,7 +71,6 @@ const MyApp: AppType<{ session: Session | null }> = ({
     // PostHog (cloud.langfuse.com)
     if (env.NEXT_PUBLIC_POSTHOG_KEY && env.NEXT_PUBLIC_POSTHOG_HOST) {
       const handleRouteChange = () => {
-        setProjectInPosthog();
         posthog.capture("$pageview");
       };
       router.events.on("routeChangeComplete", handleRouteChange);
@@ -138,9 +124,8 @@ function UserTracking() {
   const sessionUser = session.data?.user;
   const { organization, project } = useQueryProjectOrOrganization();
 
-  // dedupe the event via useRef, otherwise we'll capture the event multiple times on session refresh
+  // Track user identity and properties
   const lastIdentifiedUser = useRef<string | null>(null);
-
   useEffect(() => {
     if (
       session.status === "authenticated" &&
@@ -168,6 +153,7 @@ function UserTracking() {
       if (emailDomain)
         posthog.group("emailDomain", emailDomain, {
           domain: emailDomain,
+          LANGFUSE_CLOUD_REGION: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
         });
 
       // Sentry
@@ -202,6 +188,50 @@ function UserTracking() {
       setUser(null);
     }
   }, [sessionUser, session.status]);
+
+  // Track organization group
+  const lastIdentifiedOrganization = useRef<string | null>(null);
+  useEffect(() => {
+    if (
+      organization?.id &&
+      lastIdentifiedOrganization.current !== JSON.stringify(organization.id)
+    ) {
+      lastIdentifiedOrganization.current = JSON.stringify(organization.id);
+      if (env.NEXT_PUBLIC_POSTHOG_KEY && env.NEXT_PUBLIC_POSTHOG_HOST) {
+        posthog.group("organization", organization.id, {
+          id: organization.id,
+          name: organization.name,
+          plan: organization.plan,
+          countProjects: organization.projects.length,
+          LANGFUSE_CLOUD_REGION: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
+        });
+      }
+    }
+  }, [organization]);
+
+  // Track project group
+  const lastIdentifiedProjectAndOrg = useRef<string | null>(null);
+  useEffect(() => {
+    if (
+      project?.id &&
+      lastIdentifiedProjectAndOrg.current !==
+        JSON.stringify({ project, organization })
+    ) {
+      lastIdentifiedProjectAndOrg.current = JSON.stringify({
+        project,
+        organization,
+      });
+      if (env.NEXT_PUBLIC_POSTHOG_KEY && env.NEXT_PUBLIC_POSTHOG_HOST) {
+        posthog.group("project", project.id, {
+          id: project.id,
+          name: project.name,
+          organizationId: organization.id,
+          plan: organization.plan,
+          LANGFUSE_CLOUD_REGION: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
+        });
+      }
+    }
+  }, [project, organization]);
 
   // update crisp segments
   const plan = organization?.plan;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds PostHog tracking for projects and organizations in `_app.tsx`, enhancing analytics capabilities and removing the previous project tracking method.
> 
>   - **PostHog Tracking**:
>     - Adds organization and project tracking in `UserTracking()` in `_app.tsx`.
>     - Removes `setProjectInPosthog()` function.
>     - Tracks organization and project groups with `posthog.group()`.
>   - **Environment Variables**:
>     - Uses `env.NEXT_PUBLIC_POSTHOG_KEY` and `env.NEXT_PUBLIC_POSTHOG_HOST` for PostHog initialization and tracking.
>   - **Miscellaneous**:
>     - Adds `LANGFUSE_CLOUD_REGION` to PostHog group properties.
>     - Minor refactoring and cleanup in `UserTracking()` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 072086a5da6a49048efcc3710096cb0c0aaf4cd2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->