### PR TITLE
fix(ui): dom nesting error `data-table-row-height-switch`

### DIFF
--- a/web/src/components/table/data-table-row-height-switch.tsx
+++ b/web/src/components/table/data-table-row-height-switch.tsx
@@ -50,7 +50,7 @@ export const DataTableRowHeightSwitch = ({
   const capture = usePostHogClientCapture();
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger>
+      <DropdownMenuTrigger asChild>
         <Button variant="outline" size="icon" title="Row height">
           <Rows3 className="h-4 w-4" />
         </Button>

--- a/web/src/features/datasets/components/DatasetRunItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsTable.tsx
@@ -4,7 +4,6 @@ import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { api } from "@/src/utils/api";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import { useQueryParams, withDefault, NumberParam } from "use-query-params";
-
 import { usdFormatter } from "../../../utils/numbers";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix DOM nesting error in `data-table-row-height-switch.tsx` and remove unused import in `DatasetRunItemsTable.tsx`.
> 
>   - **DOM Nesting Fix**:
>     - In `data-table-row-height-switch.tsx`, changed `DropdownMenuTrigger` to use `asChild` prop to fix DOM nesting error.
>   - **Code Cleanup**:
>     - Removed unused import in `DatasetRunItemsTable.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 83f86a56337ce6c49a392a150274edf511016ff8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->