### PR TITLE
fix(ui): reference errors in prompt detail screen 

### DIFF
--- a/web/src/components/ActionButton.tsx
+++ b/web/src/components/ActionButton.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Lock, AlertCircle, Sparkle } from "lucide-react";
 import { Button, type ButtonProps } from "@/src/components/ui/button";
 import {
@@ -28,19 +29,25 @@ interface ActionButtonProps extends ButtonProps {
   href?: string;
 }
 
-export function ActionButton({
-  loading = false,
-  hasAccess = true,
-  hasEntitlement = true,
-  limitValue,
-  limit = false,
-  disabled = false,
-  children,
-  icon,
-  className,
-  href,
-  ...buttonProps
-}: ActionButtonProps) {
+export const ActionButton = React.forwardRef<
+  HTMLButtonElement,
+  ActionButtonProps
+>(function ActionButton(
+  {
+    loading = false,
+    hasAccess = true,
+    hasEntitlement = true,
+    limitValue,
+    limit = false,
+    disabled = false,
+    children,
+    icon,
+    className,
+    href,
+    ...buttonProps
+  },
+  ref,
+) {
   const hasReachedLimit =
     typeof limit === "number" &&
     limitValue !== undefined &&
@@ -65,6 +72,7 @@ export function ActionButton({
 
   const btnContent = (
     <ButtonContent
+      ref={ref}
       icon={icon}
       isDisabled={isDisabled}
       loading={loading}
@@ -95,31 +103,37 @@ export function ActionButton({
   }
 
   return btnContent;
-}
+});
 
-function ButtonContent({
-  icon,
-  isDisabled,
-  loading,
-  hasAccess,
-  hasEntitlement,
-  hasReachedLimit,
-  className,
-  buttonProps,
-  children,
-  href,
-}: {
-  icon?: React.ReactNode;
-  isDisabled: boolean;
-  loading: boolean;
-  hasAccess: boolean;
-  hasEntitlement: boolean;
-  hasReachedLimit: boolean;
-  className?: string;
-  buttonProps: Omit<ButtonProps, "disabled" | "loading" | "className">;
-  children: React.ReactNode;
-  href?: string;
-}) {
+const ButtonContent = React.forwardRef<
+  HTMLButtonElement,
+  {
+    icon?: React.ReactNode;
+    isDisabled: boolean;
+    loading: boolean;
+    hasAccess: boolean;
+    hasEntitlement: boolean;
+    hasReachedLimit: boolean;
+    className?: string;
+    buttonProps: Omit<ButtonProps, "disabled" | "loading" | "className">;
+    children: React.ReactNode;
+    href?: string;
+  }
+>(function ButtonContent(
+  {
+    icon,
+    isDisabled,
+    loading,
+    hasAccess,
+    hasEntitlement,
+    hasReachedLimit,
+    className,
+    buttonProps,
+    children,
+    href,
+  },
+  ref,
+) {
   const content = (
     <>
       {!hasAccess ? (
@@ -139,6 +153,7 @@ function ButtonContent({
 
   return (
     <Button
+      ref={ref}
       disabled={isDisabled}
       loading={loading}
       className={className}
@@ -148,4 +163,4 @@ function ButtonContent({
       {renderLink ? <Link href={href}>{content}</Link> : content}
     </Button>
   );
-}
+});

--- a/web/src/features/prompts/components/prompt-history.tsx
+++ b/web/src/features/prompts/components/prompt-history.tsx
@@ -43,6 +43,7 @@ const PromptHistoryTraceNode = (props: {
 
   return (
     <CommandItem
+      ref={currentPromptRef}
       value={`# ${prompt.version};${prompt.commitMessage ?? ""};${prompt.labels.join(",")}`}
       style={{
         ["--selected-bg" as string]: "none",
@@ -56,7 +57,6 @@ const PromptHistoryTraceNode = (props: {
     >
       <TimelineItem
         key={prompt.id}
-        ref={currentPromptRef}
         isActive={props.currentPromptVersion === prompt.version}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `ActionButton` and `ButtonContent` to use `React.forwardRef` and fix `ref` usage in `PromptHistoryTraceNode` for scroll behavior.
> 
>   - **Refactoring**:
>     - Convert `ActionButton` and `ButtonContent` in `ActionButton.tsx` to use `React.forwardRef` for better ref handling.
>     - Update `PromptHistoryTraceNode` in `prompt-history.tsx` to correctly use `ref` for `CommandItem` to enable scroll into view behavior.
>   - **Behavior**:
>     - Ensure `ActionButton` and `ButtonContent` can receive and use refs, improving component flexibility.
>     - Fix `ref` usage in `PromptHistoryTraceNode` to ensure the current prompt scrolls into view when selected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d317bfe95293c33f5157f4d9075d245d52ad052b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->