### PR TITLE
fix(ui): require annotation queue selection for bulk action

### DIFF
--- a/web/src/features/table/components/TableActionDialog.tsx
+++ b/web/src/features/table/components/TableActionDialog.tsx
@@ -123,7 +123,7 @@ export function TableActionDialog({
                   hasAccess={hasAccess}
                   hasEntitlement={hasEntitlement}
                   loading={isInProgress.isLoading}
-                  disabled={isInProgress.data}
+                  disabled={isInProgress.data || !form.watch("targetId")}
                 >
                   Confirm
                 </ActionButton>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> In `TableActionDialog`, the 'Confirm' button is now disabled unless a `targetId` is selected, ensuring annotation queue selection for bulk actions.
> 
>   - **Behavior**:
>     - In `TableActionDialog`, the 'Confirm' button is now disabled if no `targetId` is selected, in addition to when `isInProgress.data` is true.
>   - **UI**:
>     - Ensures users must select an annotation queue before performing a bulk action.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c323d129fde4e9dcfb1a325a0d64fa6c7e01d6f5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->