### PR TITLE
feat: add additional input/output parsing for pydantic via OTel

### DIFF
--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -731,6 +731,36 @@ describe("OTel Resource Span Mapping", () => {
         },
       ],
       [
+        "#6084: should map input to input for pydantic",
+        {
+          entity: "observation",
+          otelAttributeKey: "input",
+          otelAttributeValue: {
+            stringValue: JSON.stringify({
+              task: "Play some chess",
+              stream: false,
+            }),
+          },
+          entityAttributeKey: "input",
+          entityAttributeValue: JSON.stringify({
+            task: "Play some chess",
+            stream: false,
+          }),
+        },
+      ],
+      [
+        "#6084: should map model_config to modelParameters",
+        {
+          entity: "observation",
+          otelAttributeKey: "model_config",
+          otelAttributeValue: {
+            stringValue: '{"max_tokens": 4096}',
+          },
+          entityAttributeKey: "modelParameters.max_tokens",
+          entityAttributeValue: 4096,
+        },
+      ],
+      [
         "#5412: should map input.value to input for smolagents",
         {
           entity: "observation",

--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -203,6 +203,13 @@ const extractInputAndOutput = (
     return { input, output };
   }
 
+  // Pydantic uses input and output
+  input = attributes["input"];
+  output = attributes["output"];
+  if (input || output) {
+    return { input, output };
+  }
+
   // TraceLoop uses attributes property
   const inputAttributes = Object.keys(attributes).filter((key) =>
     key.startsWith("gen_ai.prompt"),
@@ -296,6 +303,14 @@ const extractModelParameters = (
   if (attributes["llm.invocation_parameters"]) {
     try {
       return JSON.parse(attributes["llm.invocation_parameters"] as string);
+    } catch (e) {
+      // fallthrough
+    }
+  }
+
+  if (attributes["model_config"]) {
+    try {
+      return JSON.parse(attributes["model_config"] as string);
     } catch (e) {
       // fallthrough
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add parsing for Pydantic input/output and model configuration in OpenTelemetry spans with corresponding tests.
> 
>   - **Behavior**:
>     - `extractInputAndOutput()` in `index.ts` now handles `input` and `output` attributes for Pydantic.
>     - `extractModelParameters()` in `index.ts` parses `model_config` attribute to extract model parameters.
>   - **Tests**:
>     - Added test cases in `otelMapping.servertest.ts` for mapping `input` to `input` and `model_config` to `modelParameters` for Pydantic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f3f0e7b2ccb1a1239d8ac59b62943a3990376c1e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->