### PR TITLE
chore(ui): clamp `page-header` title to one line

### DIFF
--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -62,8 +62,8 @@ const PageHeader = ({
                   </div>
                 )}
                 <div className="relative inline-block max-w-md md:max-w-none">
-                  <h2 className="inline text-lg font-semibold leading-7">
-                    <span className="break-words">
+                  <h2 className="line-clamp-1 text-lg font-semibold leading-7">
+                    <span className="break-words" title={title}>
                       {title}
                       {help && (
                         <span className="whitespace-nowrap">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Clamp `PageHeader` title to one line and add tooltip for full title in `page-header.tsx`.
> 
>   - **UI Change**:
>     - In `page-header.tsx`, modify `<h2>` to use `line-clamp-1` class, clamping the title to one line.
>     - Add `title` attribute to `<span>` for displaying full title on hover.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 27eb84eabbd60444cbea873d79273970a4b49268. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->