### PR TITLE
fix(prompts): trim prompt names

### DIFF
--- a/web/src/features/prompts/server/utils/validation.ts
+++ b/web/src/features/prompts/server/utils/validation.ts
@@ -26,7 +26,8 @@ export const PromptNameSchema = z
   .string()
   .min(1)
   .regex(/^[^|]*$/, "Name cannot contain '|' character")
-  .transform((s) => s.trim());
+  .transform((s) => s.trim())
+  .refine((s) => s.length > 0, "Name cannot be empty");
 
 const BaseCreateTextPromptSchema = z.object({
   name: PromptNameSchema,

--- a/web/src/features/prompts/server/utils/validation.ts
+++ b/web/src/features/prompts/server/utils/validation.ts
@@ -25,7 +25,8 @@ export const PromptLabelSchema = z
 export const PromptNameSchema = z
   .string()
   .min(1)
-  .regex(/^[^|]*$/, "Name cannot contain '|' character");
+  .regex(/^[^|]*$/, "Name cannot contain '|' character")
+  .transform((s) => s.trim());
 
 const BaseCreateTextPromptSchema = z.object({
   name: PromptNameSchema,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `PromptNameSchema` in `validation.ts` to trim whitespace and ensure non-empty prompt names after trimming.
> 
>   - **Validation**:
>     - In `validation.ts`, `PromptNameSchema` now trims whitespace from prompt names.
>     - Ensures prompt names are not empty after trimming, with a new refinement check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1ffcb270c666a8e114127f4610e7a16c716b3734. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->