### PR TITLE
perf: cache model not found

### DIFF
--- a/packages/shared/src/server/ingestion/modelMatch.ts
+++ b/packages/shared/src/server/ingestion/modelMatch.ts
@@ -139,13 +139,20 @@ export async function findModelInPostgres(
 const NOT_FOUND_TOKEN = "LANGFUSE_MODEL_MATCH_NOT_FOUND" as const;
 
 const addModelNotFoundTokenToRedis = async (p: ModelMatchProps) => {
-  const key = getRedisModelKey(p);
-  await redis?.set(
-    key,
-    NOT_FOUND_TOKEN,
-    "EX",
-    env.LANGFUSE_CACHE_MODEL_MATCH_TTL_SECONDS,
-  );
+  try {
+    const key = getRedisModelKey(p);
+    await redis?.set(
+      key,
+      NOT_FOUND_TOKEN,
+      "EX",
+      env.LANGFUSE_CACHE_MODEL_MATCH_TTL_SECONDS,
+    );
+  } catch (error) {
+    logger.error(
+      `Error adding model not found token for ${JSON.stringify(p)} to Redis`,
+      error,
+    );
+  }
 };
 
 const addModelToRedis = async (p: ModelMatchProps, model: Model) => {

--- a/packages/shared/src/server/ingestion/modelMatch.ts
+++ b/packages/shared/src/server/ingestion/modelMatch.ts
@@ -44,7 +44,7 @@ export async function findModel(p: ModelMatchProps): Promise<Model | null> {
         span.setAttribute("model_match_source", "postgres");
         span.setAttribute("model_cache_set", "false");
       } else {
-        span.setAttribute("model_matched", "false");
+        span.setAttribute("model_match_source", "none");
       }
 
       logger.debug(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Caches not-found models in Redis in `modelMatch.ts` to improve performance by avoiding repeated Postgres queries for non-existent models.
> 
>   - **Behavior**:
>     - `findModel` in `modelMatch.ts` now caches not-found models in Redis using `addModelNotFoundTokenToRedis`.
>     - If a model is not found in Postgres and caching is enabled, a not-found token is stored in Redis.
>     - Subsequent requests for the same model use the cached not-found token, avoiding unnecessary Postgres queries.
>   - **Functions**:
>     - `getModelFromRedis` now returns `NOT_FOUND_TOKEN` if the model is not found in Redis.
>     - `addModelNotFoundTokenToRedis` added to store not-found tokens in Redis.
>   - **Tests**:
>     - Added test in `modelMatch.test.ts` to verify caching of not-found models in Redis.
>     - Ensures that subsequent lookups use the cached not-found result.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 57f04aa3779978f28a2cf8e9a055be7c387bb1df. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->