### PR TITLE
chore(ui): do not auto-generate new api keys in setup-tracing step

### DIFF
--- a/web/src/features/public-api/components/QuickstartExamples.tsx
+++ b/web/src/features/public-api/components/QuickstartExamples.tsx
@@ -10,12 +10,9 @@ import { env } from "@/src/env.mjs";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import Link from "next/link";
 
-export const QuickstartExamples = ({
-  secretKey,
-  publicKey,
-}: {
-  secretKey: string;
-  publicKey: string;
+export const QuickstartExamples = (p: {
+  secretKey?: string;
+  publicKey?: string;
 }) => {
   const uiCustomization = useUiCustomization();
   const capture = usePostHogClientCapture();
@@ -29,6 +26,9 @@ export const QuickstartExamples = ({
     { value: "other", label: "Other" },
   ];
   const host = `${uiCustomization?.hostname ?? window.origin}${env.NEXT_PUBLIC_BASE_PATH ?? ""}`;
+
+  const secretKey = p.secretKey ?? "<secret key>";
+  const publicKey = p.publicKey ?? "<public key>";
 
   // if custom docs link, do not show quickstart examples but refer to docs
   if (uiCustomization?.documentationHref) {

--- a/web/src/features/setup/components/SetupPage.tsx
+++ b/web/src/features/setup/components/SetupPage.tsx
@@ -201,25 +201,17 @@ export function SetupPage() {
         {
           // 4. Setup Tracing
           stepInt === 4 && project && organization && (
-            <div className="space-y-8">
-              <div>
-                <Header title="API Keys" />
-                <p className="mb-4 text-sm text-muted-foreground">
-                  These keys are used to authenticate your API requests. You can
-                  create more keys later in the project settings.
-                </p>
-                <TracingSetup
-                  projectId={project.id}
-                  hasAnyTrace={hasAnyTrace ?? false}
-                />
-              </div>
-            </div>
+            <TracingSetup
+              projectId={project.id}
+              hasAnyTrace={hasAnyTrace ?? false}
+            />
           )
         }
       </Card>
+
       {stepInt === 2 && organization && (
         <Button
-          className="mt-4"
+          className="mt-4 self-start"
           data-testid="btn-skip-add-members"
           onClick={() => router.push(createProjectRoute(organization.id))}
         >
@@ -230,7 +222,7 @@ export function SetupPage() {
         // 4. Setup Tracing
         stepInt === 4 && project && (
           <Button
-            className="mt-4"
+            className="mt-4 self-start"
             onClick={() => router.push(`/project/${project.id}`)}
             variant={hasAnyTrace ? "default" : "secondary"}
           >
@@ -254,54 +246,61 @@ const TracingSetup = ({
   >(null);
   const utils = api.useUtils();
   const mutCreateApiKey = api.apiKeys.create.useMutation({
-    onSuccess: () => {
+    onSuccess: (data) => {
       utils.apiKeys.invalidate();
+      setApiKeys(data);
       showChat();
     },
   });
-  const isLoadingRef = useRef(false);
 
-  useEffect(() => {
-    const createApiKey = async () => {
-      if (projectId && !isLoadingRef.current && !apiKeys) {
-        isLoadingRef.current = true;
-        try {
-          const apiKey = await mutCreateApiKey.mutateAsync({ projectId });
-          setApiKeys(apiKey);
-        } catch (error) {
-          console.error("Error creating API key:", error);
-        } finally {
-          isLoadingRef.current = false;
-        }
-      }
-    };
-    if (!apiKeys) {
-      createApiKey();
+  const createApiKey = async () => {
+    try {
+      await mutCreateApiKey.mutateAsync({ projectId });
+    } catch (error) {
+      console.error("Error creating API key:", error);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  };
 
   return (
     <div className="space-y-8">
       <div>
-        <ApiKeyRender generatedKeys={apiKeys ?? undefined} />
+        <Header title="API Keys" />
+        <p className="mb-4 text-sm text-muted-foreground">
+          These keys are used to authenticate your API requests. You can create
+          more keys later in the project settings.
+        </p>
+        {apiKeys ? (
+          <ApiKeyRender generatedKeys={apiKeys} />
+        ) : (
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-muted-foreground">
+              You need to create an API key to start tracing your application.
+            </p>
+            <Button
+              onClick={createApiKey}
+              loading={mutCreateApiKey.isLoading}
+              className="self-start"
+            >
+              Create API Key
+            </Button>
+          </div>
+        )}
       </div>
-      {apiKeys && (
-        <div>
-          <Header
-            title="Setup Tracing"
-            status={hasAnyTrace ? "active" : "pending"}
-          />
-          <p className="mb-4 text-sm text-muted-foreground">
-            Tracing is used to track and analyze your LLM calls. You can always
-            skip this step and setup tracing later.
-          </p>
-          <QuickstartExamples
-            secretKey={apiKeys.secretKey}
-            publicKey={apiKeys.publicKey}
-          />
-        </div>
-      )}
+
+      <div>
+        <Header
+          title="Setup Tracing"
+          status={hasAnyTrace ? "active" : "pending"}
+        />
+        <p className="mb-4 text-sm text-muted-foreground">
+          Tracing is used to track and analyze your LLM calls. You can always
+          skip this step and setup tracing later.
+        </p>
+        <QuickstartExamples
+          secretKey={apiKeys?.secretKey}
+          publicKey={apiKeys?.publicKey}
+        />
+      </div>
     </div>
   );
 };

--- a/web/src/features/setup/components/SetupPage.tsx
+++ b/web/src/features/setup/components/SetupPage.tsx
@@ -28,7 +28,7 @@ import { cn } from "@/src/utils/tailwind";
 import { type RouterOutput } from "@/src/utils/types";
 import { Check } from "lucide-react";
 import { useRouter } from "next/router";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { StringParam, useQueryParam } from "use-query-params";
 
 // Multi-step setup process


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Removes auto-generation of API keys in tracing setup, requiring manual creation via a button, and updates `QuickstartExamples` to handle optional keys.
> 
>   - **Behavior**:
>     - Removes auto-generation of API keys in `TracingSetup` in `SetupPage.tsx`. Users must now manually create API keys using a button.
>     - Updates `QuickstartExamples` in `QuickstartExamples.tsx` to handle optional `secretKey` and `publicKey` parameters, defaulting to placeholders if not provided.
>   - **UI Changes**:
>     - Adds a button in `TracingSetup` to manually create API keys, with loading state handling.
>     - Adjusts layout in `SetupPage.tsx` to remove unnecessary divs around `TracingSetup`.
>   - **Misc**:
>     - Removes unused `useRef` import from `SetupPage.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 30a5932d8449428f8f4673c4dc7b57e4c03dc14e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->