### PR TITLE
chore(ui): remove setup-tracing from /setup flow

### DIFF
--- a/web/src/features/projects/components/NewProjectForm.tsx
+++ b/web/src/features/projects/components/NewProjectForm.tsx
@@ -12,7 +12,6 @@ import {
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
 import { api } from "@/src/utils/api";
-import { useRouter } from "next/router";
 import { useSession } from "next-auth/react";
 import { chatRunTrigger } from "@/src/features/support-chat/chat";
 import { projectNameSchema } from "@/src/features/auth/lib/projectNameSchema";
@@ -34,11 +33,9 @@ export const NewProjectForm = ({
       name: "",
     },
   });
-  const router = useRouter();
   const createProjectMutation = api.projects.create.useMutation({
-    onSuccess: (newProject) => {
+    onSuccess: () => {
       void updateSession();
-      void router.push(`/project/${newProject.id}/settings`);
     },
     onError: (error) => form.setError("name", { message: error.message }),
   });

--- a/web/src/features/public-api/components/QuickstartExamples.tsx
+++ b/web/src/features/public-api/components/QuickstartExamples.tsx
@@ -10,12 +10,9 @@ import { env } from "@/src/env.mjs";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import Link from "next/link";
 
-export const QuickstartExamples = ({
-  secretKey,
-  publicKey,
-}: {
-  secretKey: string;
-  publicKey: string;
+export const QuickstartExamples = (p: {
+  secretKey?: string;
+  publicKey?: string;
 }) => {
   const uiCustomization = useUiCustomization();
   const capture = usePostHogClientCapture();
@@ -29,6 +26,9 @@ export const QuickstartExamples = ({
     { value: "other", label: "Other" },
   ];
   const host = `${uiCustomization?.hostname ?? window.origin}${env.NEXT_PUBLIC_BASE_PATH ?? ""}`;
+
+  const secretKey = p.secretKey ?? "<secret key>";
+  const publicKey = p.publicKey ?? "<public key>";
 
   // if custom docs link, do not show quickstart examples but refer to docs
   if (uiCustomization?.documentationHref) {

--- a/web/src/features/setup/components/SetupPage.tsx
+++ b/web/src/features/setup/components/SetupPage.tsx
@@ -201,25 +201,17 @@ export function SetupPage() {
         {
           // 4. Setup Tracing
           stepInt === 4 && project && organization && (
-            <div className="space-y-8">
-              <div>
-                <Header title="API Keys" />
-                <p className="mb-4 text-sm text-muted-foreground">
-                  These keys are used to authenticate your API requests. You can
-                  create more keys later in the project settings.
-                </p>
-                <TracingSetup
-                  projectId={project.id}
-                  hasAnyTrace={hasAnyTrace ?? false}
-                />
-              </div>
-            </div>
+            <TracingSetup
+              projectId={project.id}
+              hasAnyTrace={hasAnyTrace ?? false}
+            />
           )
         }
       </Card>
+
       {stepInt === 2 && organization && (
         <Button
-          className="mt-4"
+          className="mt-4 self-start"
           data-testid="btn-skip-add-members"
           onClick={() => router.push(createProjectRoute(organization.id))}
         >
@@ -230,7 +222,7 @@ export function SetupPage() {
         // 4. Setup Tracing
         stepInt === 4 && project && (
           <Button
-            className="mt-4"
+            className="mt-4 self-start"
             onClick={() => router.push(`/project/${project.id}`)}
             variant={hasAnyTrace ? "default" : "secondary"}
           >
@@ -254,54 +246,61 @@ const TracingSetup = ({
   >(null);
   const utils = api.useUtils();
   const mutCreateApiKey = api.apiKeys.create.useMutation({
-    onSuccess: () => {
+    onSuccess: (data) => {
       utils.apiKeys.invalidate();
+      setApiKeys(data);
       showChat();
     },
   });
-  const isLoadingRef = useRef(false);
 
-  useEffect(() => {
-    const createApiKey = async () => {
-      if (projectId && !isLoadingRef.current && !apiKeys) {
-        isLoadingRef.current = true;
-        try {
-          const apiKey = await mutCreateApiKey.mutateAsync({ projectId });
-          setApiKeys(apiKey);
-        } catch (error) {
-          console.error("Error creating API key:", error);
-        } finally {
-          isLoadingRef.current = false;
-        }
-      }
-    };
-    if (!apiKeys) {
-      createApiKey();
+  const createApiKey = async () => {
+    try {
+      await mutCreateApiKey.mutateAsync({ projectId });
+    } catch (error) {
+      console.error("Error creating API key:", error);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  };
 
   return (
     <div className="space-y-8">
       <div>
-        <ApiKeyRender generatedKeys={apiKeys ?? undefined} />
+        <Header title="API Keys" />
+        <p className="mb-4 text-sm text-muted-foreground">
+          These keys are used to authenticate your API requests. You can create
+          more keys later in the project settings.
+        </p>
+        {apiKeys ? (
+          <ApiKeyRender generatedKeys={apiKeys} />
+        ) : (
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-muted-foreground">
+              You need to create an API key to start tracing your application.
+            </p>
+            <Button
+              onClick={createApiKey}
+              loading={mutCreateApiKey.isLoading}
+              className="self-start"
+            >
+              Create API Key
+            </Button>
+          </div>
+        )}
       </div>
-      {apiKeys && (
-        <div>
-          <Header
-            title="Setup Tracing"
-            status={hasAnyTrace ? "active" : "pending"}
-          />
-          <p className="mb-4 text-sm text-muted-foreground">
-            Tracing is used to track and analyze your LLM calls. You can always
-            skip this step and setup tracing later.
-          </p>
-          <QuickstartExamples
-            secretKey={apiKeys.secretKey}
-            publicKey={apiKeys.publicKey}
-          />
-        </div>
-      )}
+
+      <div>
+        <Header
+          title="Setup Tracing"
+          status={hasAnyTrace ? "active" : "pending"}
+        />
+        <p className="mb-4 text-sm text-muted-foreground">
+          Tracing is used to track and analyze your LLM calls. You can always
+          skip this step and setup tracing later.
+        </p>
+        <QuickstartExamples
+          secretKey={apiKeys?.secretKey}
+          publicKey={apiKeys?.publicKey}
+        />
+      </div>
     </div>
   );
 };

--- a/web/src/features/setup/components/SetupPage.tsx
+++ b/web/src/features/setup/components/SetupPage.tsx
@@ -10,66 +10,30 @@ import {
 import { Button } from "@/src/components/ui/button";
 import { Card } from "@/src/components/ui/card";
 import { NewOrganizationForm } from "@/src/features/organizations/components/NewOrganizationForm";
-import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { NewProjectForm } from "@/src/features/projects/components/NewProjectForm";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
-import { ApiKeyRender } from "@/src/features/public-api/components/CreateApiKeyButton";
-import { QuickstartExamples } from "@/src/features/public-api/components/QuickstartExamples";
 import { MembershipInvitesPage } from "@/src/features/rbac/components/MembershipInvitesPage";
 import { MembersTable } from "@/src/features/rbac/components/MembersTable";
 import {
   createProjectRoute,
   inviteMembersRoute,
-  setupTracingRoute,
 } from "@/src/features/setup/setupRoutes";
-import { showChat } from "@/src/features/support-chat/chat";
-import { api } from "@/src/utils/api";
 import { cn } from "@/src/utils/tailwind";
-import { type RouterOutput } from "@/src/utils/types";
 import { Check } from "lucide-react";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
 import { StringParam, useQueryParam } from "use-query-params";
 
 // Multi-step setup process
 // 1. Create Organization: /setup
 // 2. Invite Members: /organization/:orgId/setup
 // 3. Create Project: /organization/:orgId/setup?step=create-project
-// 4. Setup Tracing: /project/:projectId/setup
 export function SetupPage() {
-  const { project, organization } = useQueryProjectOrOrganization();
+  const { organization } = useQueryProjectOrOrganization();
   const router = useRouter();
   const [orgStep] = useQueryParam("orgstep", StringParam); // "invite-members" | "create-project"
-  const queryProjectId = router.query.projectId as string | undefined;
 
   // starts at 1 to align with breadcrumb
-  const stepInt = !organization
-    ? 1
-    : project
-      ? 4
-      : orgStep === "create-project"
-        ? 3
-        : 2;
-
-  const hasAnyTrace = api.traces.hasAny.useQuery(
-    { projectId: queryProjectId as string },
-    {
-      enabled: queryProjectId !== undefined && stepInt === 4,
-      refetchInterval: 5000,
-      trpc: {
-        context: {
-          skipBatch: true,
-        },
-      },
-    },
-  ).data;
-
-  const capture = usePostHogClientCapture();
-  useEffect(() => {
-    if (hasAnyTrace !== undefined) {
-      capture("onboarding:tracing_check_active", { active: hasAnyTrace });
-    }
-  }, [hasAnyTrace, capture]);
+  const stepInt = !organization ? 1 : orgStep === "create-project" ? 3 : 2;
 
   return (
     <ContainerPage
@@ -129,19 +93,6 @@ export function SetupPage() {
               {stepInt > 3 && <Check className="ml-1 inline-block h-3 w-3" />}
             </BreadcrumbPage>
           </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbPage
-              className={cn(
-                stepInt !== 4
-                  ? "text-muted-foreground"
-                  : "font-semibold text-foreground",
-              )}
-            >
-              4. Setup Tracing
-              {stepInt === 4 && <Check className="ml-1 inline-block h-3 w-3" />}
-            </BreadcrumbPage>
-          </BreadcrumbItem>
         </BreadcrumbList>
       </Breadcrumb>
       <Card className="p-3">
@@ -191,24 +142,14 @@ export function SetupPage() {
               </p>
               <NewProjectForm
                 orgId={organization.id}
-                onSuccess={(projectId) =>
-                  router.push(setupTracingRoute(projectId))
-                }
+                onSuccess={(projectId) => {
+                  router.push(`/project/${projectId}`);
+                }}
               />
             </div>
           )
         }
-        {
-          // 4. Setup Tracing
-          stepInt === 4 && project && organization && (
-            <TracingSetup
-              projectId={project.id}
-              hasAnyTrace={hasAnyTrace ?? false}
-            />
-          )
-        }
       </Card>
-
       {stepInt === 2 && organization && (
         <Button
           className="mt-4 self-start"
@@ -218,89 +159,6 @@ export function SetupPage() {
           Next
         </Button>
       )}
-      {
-        // 4. Setup Tracing
-        stepInt === 4 && project && (
-          <Button
-            className="mt-4 self-start"
-            onClick={() => router.push(`/project/${project.id}`)}
-            variant={hasAnyTrace ? "default" : "secondary"}
-          >
-            {hasAnyTrace ? "Open Dashboard" : "Skip for now"}
-          </Button>
-        )
-      }
     </ContainerPage>
   );
 }
-
-const TracingSetup = ({
-  projectId,
-  hasAnyTrace,
-}: {
-  projectId: string;
-  hasAnyTrace?: boolean;
-}) => {
-  const [apiKeys, setApiKeys] = useState<
-    RouterOutput["apiKeys"]["create"] | null
-  >(null);
-  const utils = api.useUtils();
-  const mutCreateApiKey = api.apiKeys.create.useMutation({
-    onSuccess: (data) => {
-      utils.apiKeys.invalidate();
-      setApiKeys(data);
-      showChat();
-    },
-  });
-
-  const createApiKey = async () => {
-    try {
-      await mutCreateApiKey.mutateAsync({ projectId });
-    } catch (error) {
-      console.error("Error creating API key:", error);
-    }
-  };
-
-  return (
-    <div className="space-y-8">
-      <div>
-        <Header title="API Keys" />
-        <p className="mb-4 text-sm text-muted-foreground">
-          These keys are used to authenticate your API requests. You can create
-          more keys later in the project settings.
-        </p>
-        {apiKeys ? (
-          <ApiKeyRender generatedKeys={apiKeys} />
-        ) : (
-          <div className="flex flex-col gap-4">
-            <p className="text-sm text-muted-foreground">
-              You need to create an API key to start tracing your application.
-            </p>
-            <Button
-              onClick={createApiKey}
-              loading={mutCreateApiKey.isLoading}
-              className="self-start"
-            >
-              Create API Key
-            </Button>
-          </div>
-        )}
-      </div>
-
-      <div>
-        <Header
-          title="Setup Tracing"
-          status={hasAnyTrace ? "active" : "pending"}
-        />
-        <p className="mb-4 text-sm text-muted-foreground">
-          Tracing is used to track and analyze your LLM calls. You can always
-          skip this step and setup tracing later.
-        </p>
-        <QuickstartExamples
-          secretKey={apiKeys?.secretKey}
-          publicKey={apiKeys?.publicKey}
-        />
-      </div>
-    </div>
-  );
-};

--- a/web/src/features/setup/components/SetupPage.tsx
+++ b/web/src/features/setup/components/SetupPage.tsx
@@ -28,7 +28,7 @@ import { cn } from "@/src/utils/tailwind";
 import { type RouterOutput } from "@/src/utils/types";
 import { Check } from "lucide-react";
 import { useRouter } from "next/router";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { StringParam, useQueryParam } from "use-query-params";
 
 // Multi-step setup process

--- a/web/src/features/setup/setupRoutes.ts
+++ b/web/src/features/setup/setupRoutes.ts
@@ -7,4 +7,4 @@ export const inviteMembersRoute = (orgId: string) =>
   `/organization/${orgId}/setup?orgstep=invite-members`;
 
 export const setupTracingRoute = (projectId: string) =>
-  `/project/${projectId}/setup`;
+  `/project/${projectId}/setup-tracing`;

--- a/web/src/pages/project/[projectId]/setup-tracing.tsx
+++ b/web/src/pages/project/[projectId]/setup-tracing.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { useRouter } from "next/router";
+import { api } from "@/src/utils/api";
+import { Button } from "@/src/components/ui/button";
+import { ApiKeyRender } from "@/src/features/public-api/components/CreateApiKeyButton";
+import { QuickstartExamples } from "@/src/features/public-api/components/QuickstartExamples";
+import Page from "@/src/components/layouts/page";
+import { type RouterOutput } from "@/src/utils/types";
+
+export default function SetupTracingPage() {
+  const router = useRouter();
+  const projectId = router.query.projectId as string;
+
+  const { data: hasAnyTrace } = api.traces.hasAny.useQuery(
+    { projectId },
+    {
+      enabled: !!projectId,
+      refetchInterval: 5 * 60 * 1000,
+      staleTime: 5 * 60 * 1000,
+      trpc: {
+        context: {
+          skipBatch: true,
+        },
+      },
+    },
+  );
+
+  const [apiKeys, setApiKeys] = useState<
+    RouterOutput["apiKeys"]["create"] | null
+  >(null);
+  const utils = api.useUtils();
+  const mutCreateApiKey = api.apiKeys.create.useMutation({
+    onSuccess: (data) => {
+      utils.apiKeys.invalidate();
+      setApiKeys(data);
+    },
+  });
+
+  const createApiKey = async () => {
+    try {
+      await mutCreateApiKey.mutateAsync({ projectId });
+    } catch (error) {
+      console.error("Error creating API key:", error);
+    }
+  };
+
+  return (
+    <Page
+      headerProps={{
+        title: "Setup Tracing",
+        help: {
+          description: "Configure tracing for your Langfuse project",
+          href: "https://langfuse.com/docs/tracing",
+        },
+        breadcrumb: [
+          { name: "Projects", href: "/projects" },
+          { name: "Setup", href: `/project/${projectId}/setup` },
+          { name: "Tracing" },
+        ],
+      }}
+      withPadding
+    >
+      <div className="space-y-8">
+        <div>
+          <h2 className="mb-2 text-xl font-semibold">API Keys</h2>
+          <p className="mb-4 text-sm text-muted-foreground">
+            These keys are used to authenticate your API requests. You can
+            create more keys later in the project settings.
+          </p>
+          {apiKeys ? (
+            <ApiKeyRender generatedKeys={apiKeys} />
+          ) : (
+            <div className="flex flex-col gap-4">
+              <p className="text-sm text-muted-foreground">
+                You need to create an API key to start tracing your application.
+              </p>
+              <Button
+                onClick={createApiKey}
+                loading={mutCreateApiKey.isLoading}
+                className="self-start"
+              >
+                Create API Key
+              </Button>
+            </div>
+          )}
+        </div>
+
+        <div>
+          <h2 className="mb-2 text-xl font-semibold">
+            Setup Tracing {hasAnyTrace ? "(Active)" : "(Pending)"}
+          </h2>
+          <p className="mb-4 text-sm text-muted-foreground">
+            Tracing is used to track and analyze your LLM calls. You can always
+            skip this step and setup tracing later.
+          </p>
+          <QuickstartExamples
+            secretKey={apiKeys?.secretKey}
+            publicKey={apiKeys?.publicKey}
+          />
+        </div>
+      </div>
+    </Page>
+  );
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes setup tracing from main setup flow and adds a dedicated page for it.
> 
>   - **Behavior**:
>     - Removes setup tracing step from `/setup` flow in `SetupPage`.
>     - Adds a dedicated `SetupTracingPage` for tracing setup at `/project/[projectId]/setup-tracing`.
>   - **Routing**:
>     - Updates `setupTracingRoute` in `setupRoutes.ts` to point to `/setup-tracing`.
>   - **Components**:
>     - `NewProjectForm` no longer redirects to tracing setup on success.
>     - `QuickstartExamples` now uses default keys if none are provided.
>   - **UI**:
>     - Removes tracing setup breadcrumb and UI elements from `SetupPage`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 173ed169f2fc50c669694e08c863507c609f6ca3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->