### PR TITLE
feat: extract top-level metadata from langfuse.metadata

### DIFF
--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -826,6 +826,30 @@ describe("OTel Resource Span Mapping", () => {
           entityAttributeValue: '{"foo": "bar"}',
         },
       ],
+      [
+        "should map langfuse.metadata string to top-level metadata for trace",
+        {
+          entity: "trace",
+          otelAttributeKey: "langfuse.metadata",
+          otelAttributeValue: {
+            stringValue: '{"customer_id": "123", "experiment": "test-run-1"}',
+          },
+          entityAttributeKey: "metadata.customer_id",
+          entityAttributeValue: "123",
+        },
+      ],
+      [
+        "should map langfuse.metadata string to top-level metadata for observation",
+        {
+          entity: "observation",
+          otelAttributeKey: "langfuse.metadata",
+          otelAttributeValue: {
+            stringValue: '{"customer_id": "123", "experiment": "test-run-1"}',
+          },
+          entityAttributeKey: "metadata.customer_id",
+          entityAttributeValue: "123",
+        },
+      ],
     ])(
       "Attributes: %s",
       (

--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -451,7 +451,8 @@ export const convertOtelSpanToIngestionEvent = (
           )
         : null;
 
-      const metadata = extractMetadata(attributes);
+      const spanAttributeMetadata = extractMetadata(attributes);
+      const resourceAttributeMetadata = extractMetadata(resourceAttributes);
       if (!parentObservationId) {
         // Create a trace for any root span
         const trace = {
@@ -459,7 +460,8 @@ export const convertOtelSpanToIngestionEvent = (
           timestamp: convertNanoTimestampToISO(span.startTimeUnixNano),
           name: extractName(span.name, attributes),
           metadata: {
-            ...metadata,
+            ...resourceAttributeMetadata,
+            ...spanAttributeMetadata,
             attributes,
             resourceAttributes,
             scope: scopeSpan?.scope,
@@ -504,7 +506,8 @@ export const convertOtelSpanToIngestionEvent = (
 
         // Additional fields
         metadata: {
-          ...metadata,
+          ...resourceAttributeMetadata,
+          ...spanAttributeMetadata,
           attributes,
           resourceAttributes,
           scope: scopeSpan?.scope,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance metadata extraction from `langfuse.metadata` in OpenTelemetry spans and add corresponding tests.
> 
>   - **Behavior**:
>     - Extracts top-level metadata from `langfuse.metadata` attributes in `convertOtelSpanToIngestionEvent` in `index.ts`.
>     - Handles both string and object types for `langfuse.metadata`.
>     - Supports extraction from `langfuse.metadata.*` keys.
>   - **Tests**:
>     - Adds test cases in `otelMapping.servertest.ts` for metadata extraction from `langfuse.metadata` for both trace and observation entities.
>     - Verifies extraction from resource attributes and nested keys.
>   - **Misc**:
>     - Updates `expect` logic in `otelMapping.servertest.ts` to handle nested object paths.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1468b2e4e64405e620741f9c373aba9c5d4f88bb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->