### PR TITLE
chore: pin minimum recommended clickhouse version for dev mode

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse/clickhouse-server
+    image: clickhouse/clickhouse-server:24.3
     user: "101:101"
     environment:
       CLICKHOUSE_DB: default


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Pins ClickHouse image to version `24.3` in `docker-compose.dev.yml` for consistent development environment.
> 
>   - **Docker Compose**:
>     - Pins ClickHouse image to version `24.3` in `docker-compose.dev.yml` to ensure consistent development environment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ee83710ea4d11299378b38568c2a210a4d785837. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->