### PR TITLE
fix(evaluator-templates): control editing state

### DIFF
--- a/web/src/ee/features/evals/components/template-form.tsx
+++ b/web/src/ee/features/evals/components/template-form.tsx
@@ -420,7 +420,7 @@ export const InnerEvalTemplateForm = (props: {
                     <CodeMirrorEditor
                       value={field.value}
                       onChange={field.onChange}
-                      editable
+                      editable={props.isEditing}
                       mode="prompt"
                       minHeight={200}
                     />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `template-form.tsx`, the `editable` property of `CodeMirrorEditor` is now conditionally set based on the `isEditing` prop to control editing state.
> 
>   - **Behavior**:
>     - In `template-form.tsx`, the `editable` property of `CodeMirrorEditor` is now set to `props.isEditing` instead of being always `true`. This controls whether the editor is editable based on the `isEditing` prop.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 90e1e1fabf5ac9c0f0351cda338c619518a62c0d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->