### PR TITLE
fix(prompt-experiments): show form error if name is duplicated

### DIFF
--- a/web/src/ee/features/experiments/hooks/useExperimentNameValidation.tsx
+++ b/web/src/ee/features/experiments/hooks/useExperimentNameValidation.tsx
@@ -13,7 +13,10 @@ export const useExperimentNameValidation = ({
   form,
 }: UseExperimentNameValidationProps) => {
   useEffect(() => {
-    if (!currentName) { form.clearErrors('name'); return; }
+    if (!currentName) {
+      form.clearErrors("name");
+      return;
+    }
 
     const isNewExperiment = !allExperimentNames
       ?.map((experiment) => experiment.value)

--- a/web/src/ee/features/experiments/hooks/useExperimentNameValidation.tsx
+++ b/web/src/ee/features/experiments/hooks/useExperimentNameValidation.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { type UseFormReturn } from "react-hook-form";
+
+interface UseExperimentNameValidationProps {
+  currentName: string | undefined;
+  allExperimentNames: { value: string }[] | undefined;
+  form: UseFormReturn<any>;
+}
+
+export const useExperimentNameValidation = ({
+  currentName,
+  allExperimentNames,
+  form,
+}: UseExperimentNameValidationProps) => {
+  useEffect(() => {
+    if (!currentName) return;
+
+    const isNewExperiment = !allExperimentNames
+      ?.map((experiment) => experiment.value)
+      .includes(currentName);
+
+    if (!isNewExperiment) {
+      form.setError("name", {
+        message: "Experiment name already exists for this dataset.",
+      });
+    } else {
+      form.clearErrors("name");
+    }
+  }, [currentName, allExperimentNames, form]);
+};

--- a/web/src/ee/features/experiments/hooks/useExperimentNameValidation.tsx
+++ b/web/src/ee/features/experiments/hooks/useExperimentNameValidation.tsx
@@ -13,7 +13,7 @@ export const useExperimentNameValidation = ({
   form,
 }: UseExperimentNameValidationProps) => {
   useEffect(() => {
-    if (!currentName) return;
+    if (!currentName) { form.clearErrors('name'); return; }
 
     const isNewExperiment = !allExperimentNames
       ?.map((experiment) => experiment.value)

--- a/web/src/features/prompts/hooks/usePromptNameValidation.tsx
+++ b/web/src/features/prompts/hooks/usePromptNameValidation.tsx
@@ -20,7 +20,7 @@ export const usePromptNameValidation = ({
       .includes(currentName);
 
     if (!isNewPrompt) {
-      form.setError("name", { message: "Prompt name already exist." });
+      form.setError("name", { message: "Prompt name already exists." });
     } else if (currentName === "new") {
       form.setError("name", { message: "Prompt name cannot be 'new'" });
     } else if (!/^[a-zA-Z0-9_\-.]+$/.test(currentName)) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add experiment name validation to prevent duplicates and fix typo in prompt name validation error message.
> 
>   - **Behavior**:
>     - Adds `useExperimentNameValidation` hook in `useExperimentNameValidation.tsx` to validate experiment names, ensuring uniqueness within a dataset.
>     - Updates `CreateExperimentsForm.tsx` to use `useExperimentNameValidation` for name validation, disabling form submission if the name is duplicated.
>   - **Validation**:
>     - `useExperimentNameValidation` clears errors if the name is unique or empty, sets error if duplicated.
>     - Fixes typo in `usePromptNameValidation.tsx` error message from "exist" to "exists".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ba45ba28f0e10452bbd0ea01f40936358ff6ddcd. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->