### PR TITLE
fix(evaluator-config): preview execution of dataset run items

### DIFF
--- a/packages/shared/src/server/services/datasets-ui-table-service.ts
+++ b/packages/shared/src/server/services/datasets-ui-table-service.ts
@@ -9,7 +9,7 @@ type FetchDatasetItemsTableProps = {
   filter: FilterState;
 };
 
-const getDatasetItemsTableGeneric = async <T>(
+const getDatasetRunItemsTableGeneric = async <T>(
   props: FetchDatasetItemsTableProps,
 ) => {
   const { select, projectId, filter } = props;
@@ -34,10 +34,10 @@ const getDatasetItemsTableGeneric = async <T>(
   const query = Prisma.sql`
     SELECT 
       ${sqlSelect}
-    FROM dataset_items di
-    WHERE 
-      di.project_id = ${projectId}
-      ${datasetItemsFilter}
+      FROM dataset_run_items as dri
+        JOIN dataset_items as di ON di.id = dri.dataset_item_id AND di.project_id = ${projectId}
+        WHERE dri.project_id = ${projectId}
+        ${datasetItemsFilter}
   `;
 
   const res = await prisma.$queryRaw<T>(query);
@@ -45,11 +45,11 @@ const getDatasetItemsTableGeneric = async <T>(
   return res;
 };
 
-export const getDatasetItemsTableCount = async (props: {
+export const getDatasetRunItemsTableCount = async (props: {
   projectId: string;
   filter: FilterState;
 }) => {
-  const res = await getDatasetItemsTableGeneric<Array<{ count: bigint }>>({
+  const res = await getDatasetRunItemsTableGeneric<Array<{ count: bigint }>>({
     select: "count",
     projectId: props.projectId,
     filter: props.filter,

--- a/web/src/__tests__/async/datasets-ui-table.servertest.ts
+++ b/web/src/__tests__/async/datasets-ui-table.servertest.ts
@@ -1,6 +1,6 @@
 import {
   createOrgProjectAndApiKey,
-  getDatasetItemsTableCount,
+  getDatasetRunItemsTableCount,
 } from "@langfuse/shared/src/server";
 import { v4 as uuidv4 } from "uuid";
 import { prisma } from "@langfuse/shared/src/db";
@@ -23,6 +23,7 @@ describe("trpc.datasets", () => {
 
   beforeAll(async () => {
     const { projectId: newProjectId } = await createOrgProjectAndApiKey();
+    const datasetItemIds = [uuidv4(), uuidv4()];
     projectId = newProjectId;
     datasetIds = [uuidv4(), uuidv4()];
 
@@ -41,10 +42,20 @@ describe("trpc.datasets", () => {
         datasetId: datasetId,
       })),
     });
+
+    await prisma.datasetRunItems.createMany({
+      data: datasetItemIds.map((datasetItemId, index) => ({
+        id: uuidv4(),
+        projectId: projectId,
+        datasetItemId: datasetItemId,
+        traceId: uuidv4(),
+        datasetRunId: datasetIds[index],
+      })),
+    });
   });
   describe("GET datasetItems.countAll", () => {
-    it("should GET all dataset items with no filter", async () => {
-      const { totalCount } = await getDatasetItemsTableCount({
+    it("should GET all dataset run items with no filter", async () => {
+      const { totalCount } = await getDatasetRunItemsTableCount({
         projectId: projectId,
         filter: [],
       });
@@ -52,8 +63,8 @@ describe("trpc.datasets", () => {
       expect(totalCount).toBe(2);
     });
 
-    it("should GET all dataset items with filter", async () => {
-      const { totalCount } = await getDatasetItemsTableCount({
+    it("should GET all dataset run items with filter", async () => {
+      const { totalCount } = await getDatasetRunItemsTableCount({
         projectId: projectId,
         filter: generateFilter([datasetIds[0]]),
       });

--- a/web/src/__tests__/async/datasets-ui-table.servertest.ts
+++ b/web/src/__tests__/async/datasets-ui-table.servertest.ts
@@ -24,6 +24,7 @@ describe("trpc.datasets", () => {
   beforeAll(async () => {
     const { projectId: newProjectId } = await createOrgProjectAndApiKey();
     const datasetItemIds = [uuidv4(), uuidv4()];
+    const datasetRunIds = [uuidv4(), uuidv4()];
     projectId = newProjectId;
     datasetIds = [uuidv4(), uuidv4()];
 
@@ -36,10 +37,19 @@ describe("trpc.datasets", () => {
     });
 
     await prisma.datasetItem.createMany({
-      data: datasetIds.map((datasetId) => ({
-        id: uuidv4(),
+      data: datasetIds.map((datasetId, index) => ({
+        id: datasetItemIds[index],
         projectId: projectId,
         datasetId: datasetId,
+      })),
+    });
+
+    await prisma.datasetRuns.createMany({
+      data: datasetRunIds.map((datasetRunId, index) => ({
+        id: datasetRunId,
+        projectId: projectId,
+        datasetId: datasetIds[index],
+        name: `test-${index}`,
       })),
     });
 
@@ -49,7 +59,7 @@ describe("trpc.datasets", () => {
         projectId: projectId,
         datasetItemId: datasetItemId,
         traceId: uuidv4(),
-        datasetRunId: datasetIds[index],
+        datasetRunId: datasetRunIds[index],
       })),
     });
   });

--- a/web/src/ee/features/evals/components/eval-form-descriptions.tsx
+++ b/web/src/ee/features/evals/components/eval-form-descriptions.tsx
@@ -31,8 +31,8 @@ export function TimeScopeDescription(props: {
         : props.timeScope?.includes("NEW")
           ? "all future"
           : "all existing"}{" "}
-      {props.target === "trace" ? "traces" : "dataset items"} that match these
-      filters.{" "}
+      {props.target === "trace" ? "traces" : "dataset run items"} that match
+      these filters.{" "}
     </div>
   );
 }

--- a/web/src/ee/features/evals/components/execution-count-tooltip.tsx
+++ b/web/src/ee/features/evals/components/execution-count-tooltip.tsx
@@ -78,7 +78,7 @@ export const ExecutionCountTooltip = ({
                 : globalConfig.data,
             )
           )}{" "}
-          {isTraceTarget(item) ? "traces" : "dataset items"}.
+          {isTraceTarget(item) ? "traces" : "dataset run items"}.
         </div>
       </TooltipContent>
     </Tooltip>

--- a/web/src/ee/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/ee/features/evals/components/inner-evaluator-form.tsx
@@ -421,6 +421,7 @@ export const InnerEvaluatorForm = (props: {
                                 : "dataset run items"}
                             </label>
                             {field.value.includes("EXISTING") &&
+                              props.mode !== "edit" &&
                               !props.disabled && (
                                 <ExecutionCountTooltip
                                   projectId={props.projectId}

--- a/web/src/ee/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/ee/features/evals/components/inner-evaluator-form.tsx
@@ -390,7 +390,7 @@ export const InnerEvaluatorForm = (props: {
                               New{" "}
                               {form.watch("target") === "trace"
                                 ? "traces"
-                                : "dataset items"}
+                                : "dataset run items"}
                             </label>
                           </div>
                         </div>
@@ -418,7 +418,7 @@ export const InnerEvaluatorForm = (props: {
                               Existing{" "}
                               {form.watch("target") === "trace"
                                 ? "traces"
-                                : "dataset items"}
+                                : "dataset run items"}
                             </label>
                             {field.value.includes("EXISTING") &&
                               !props.disabled && (

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -16,7 +16,10 @@ import {
   fetchDatasetItems,
   getRunItemsByRunIdOrItemId,
 } from "@/src/features/datasets/server/service";
-import { getDatasetItemsTableCount, logger } from "@langfuse/shared/src/server";
+import {
+  getDatasetRunItemsTableCount,
+  logger,
+} from "@langfuse/shared/src/server";
 import { createId as createCuid } from "@paralleldrive/cuid2";
 
 const formatDatasetItemData = (data: string | null | undefined) => {
@@ -129,6 +132,7 @@ export const datasetRouter = createTRPCRouter({
         datasets,
       };
     }),
+  // counts all dataset run items that match the filter
   countAllDatasetItems: protectedProjectProcedure
     .input(
       z.object({
@@ -137,7 +141,7 @@ export const datasetRouter = createTRPCRouter({
       }),
     )
     .query(async ({ input }) => {
-      const count = await getDatasetItemsTableCount({
+      const count = await getDatasetRunItemsTableCount({
         projectId: input.projectId,
         filter: input.filter ?? [],
       });

--- a/worker/src/ee/evaluation/evalService.ts
+++ b/worker/src/ee/evaluation/evalService.ts
@@ -156,7 +156,7 @@ export const createEvalJobs = async ({
         >(Prisma.sql`
           SELECT dataset_item_id as id
           FROM dataset_run_items as dri
-          JOIN dataset_items as di ON di.id = dri.dataset_item_id
+          JOIN dataset_items as di ON di.id = dri.dataset_item_id AND di.project_id = ${event.projectId}
           WHERE dri.project_id = ${event.projectId}
             AND dri.trace_id = ${event.traceId}
             ${condition}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update terminology from 'dataset items' to 'dataset run items' across codebase, including SQL queries, function names, tests, and UI components.
> 
>   - **Behavior**:
>     - Update SQL query in `getDatasetRunItemsTableGeneric` to join `dataset_run_items` with `dataset_items` in `datasets-ui-table-service.ts`.
>     - Modify `countAllDatasetItems` in `dataset-router.ts` to use `getDatasetRunItemsTableCount`.
>   - **Function Renames**:
>     - Rename `getDatasetItemsTableGeneric` to `getDatasetRunItemsTableGeneric`.
>     - Rename `getDatasetItemsTableCount` to `getDatasetRunItemsTableCount`.
>   - **Tests**:
>     - Update test cases in `datasets-ui-table.servertest.ts` to use `getDatasetRunItemsTableCount` and verify counts for `dataset run items`.
>   - **UI Components**:
>     - Update `TimeScopeDescription`, `ExecutionCountTooltip`, and `InnerEvaluatorForm` to refer to "dataset run items" instead of "dataset items".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f3f81551c4576c186ad4c3a9ae20168d464efb76. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->