### PR TITLE
chore: auto-close stale issues

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale. Please reopen if the issue persists."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a GitHub Actions workflow to automatically close stale issues after 44 days of inactivity.
> 
>   - **Workflow Addition**:
>     - Adds `stale_issues.yml` to `.github/workflows/` to automate closing of stale issues.
>     - Scheduled to run daily at 1:30 AM UTC.
>   - **Stale Issue Handling**:
>     - Marks issues as stale after 30 days of inactivity.
>     - Closes issues 14 days after being marked as stale.
>     - Uses `actions/stale@v9` with custom messages for stale and closed issues.
>   - **Permissions**:
>     - Requires write permissions for issues and pull requests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2aa7a29c24d11769406b63c4c7226f9575b5f23d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->