### PR TITLE
chore: move the traces timeseries chart to new query builder

### DIFF
--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -26,6 +26,7 @@ export const clickhouseClient = (
     database: env.CLICKHOUSE_DB,
     http_headers: headers,
     clickhouse_settings: {
+      ...(params.opts?.clickhouse_settings ?? {}),
       log_comment: JSON.stringify(params.tags ?? {}),
       async_insert: 1,
       wait_for_async_insert: 1, // if disabled, we won't get errors from clickhouse

--- a/web/src/features/dashboard/components/ModelCostTable.tsx
+++ b/web/src/features/dashboard/components/ModelCostTable.tsx
@@ -29,7 +29,6 @@ export const ModelCostTable = ({
   toTimestamp: Date;
   isLoading?: boolean;
 }) => {
-  // Define the query using the new QueryType structure
   const modelCostQuery: QueryType = {
     view: "observations",
     dimensions: [{ field: "providedModelName" }],
@@ -52,7 +51,6 @@ export const ModelCostTable = ({
     orderBy: null,
   };
 
-  // Execute the query using the new dashboard.executeQuery functionality
   const metrics = api.dashboard.executeQuery.useQuery(
     {
       projectId,

--- a/web/src/features/dashboard/components/TracesTimeSeriesChart.tsx
+++ b/web/src/features/dashboard/components/TracesTimeSeriesChart.tsx
@@ -5,42 +5,48 @@ import { BaseTimeSeriesChart } from "@/src/features/dashboard/components/BaseTim
 import { TotalMetric } from "@/src/features/dashboard/components/TotalMetric";
 import { compactNumberFormatter } from "@/src/utils/numbers";
 import { isEmptyTimeSeries } from "@/src/features/dashboard/components/hooks";
-import {
-  dashboardDateRangeAggregationSettings,
-  type DashboardDateRangeAggregationOption,
-} from "@/src/utils/date-range-utils";
+import { type DashboardDateRangeAggregationOption } from "@/src/utils/date-range-utils";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 import { TabComponent } from "@/src/features/dashboard/components/TabsComponent";
+import {
+  type QueryType,
+  mapLegacyUiTableFilterToView,
+} from "@/src/features/query";
 
 export const TracesAndObservationsTimeSeriesChart = ({
   className,
   projectId,
   globalFilterState,
+  fromTimestamp,
+  toTimestamp,
   agg,
   isLoading = false,
 }: {
   className?: string;
   projectId: string;
   globalFilterState: FilterState;
+  fromTimestamp: Date;
+  toTimestamp: Date;
   agg: DashboardDateRangeAggregationOption;
   isLoading?: boolean;
 }) => {
-  const traces = api.dashboard.chart.useQuery(
+  const tracesQuery: QueryType = {
+    view: "traces",
+    dimensions: [],
+    metrics: [{ measure: "count", aggregation: "count" }],
+    filters: mapLegacyUiTableFilterToView("traces", globalFilterState),
+    timeDimension: {
+      granularity: "auto",
+    },
+    fromTimestamp: fromTimestamp.toISOString(),
+    toTimestamp: toTimestamp.toISOString(),
+    orderBy: null,
+  };
+
+  const traces = api.dashboard.executeQuery.useQuery(
     {
       projectId,
-      from: "traces",
-      select: [{ column: "traceId", agg: "COUNT" }],
-      filter: globalFilterState.map((f) =>
-        f.type === "datetime" ? { ...f, column: "timestamp" } : f,
-      ),
-      groupBy: [
-        {
-          type: "datetime",
-          column: "timestamp",
-          temporalUnit: dashboardDateRangeAggregationSettings[agg].date_trunc,
-        },
-      ],
-      queryName: "traces-timeseries",
+      query: tracesQuery,
     },
     {
       trpc: {
@@ -55,14 +61,11 @@ export const TracesAndObservationsTimeSeriesChart = ({
   const transformedTraces = traces.data
     ? traces.data.map((item) => {
         return {
-          ts: (item.timestamp as Date).getTime(),
+          ts: new Date(item.time_dimension as any).getTime(),
           values: [
             {
               label: "Traces",
-              value:
-                typeof item.countTraceId === "number"
-                  ? item.countTraceId
-                  : undefined,
+              value: Number(item.count_count),
             },
           ],
         };
@@ -70,25 +73,26 @@ export const TracesAndObservationsTimeSeriesChart = ({
     : [];
 
   const total = traces.data?.reduce((acc, item) => {
-    return acc + (item.countTraceId as number);
+    return acc + Number(item.count_count);
   }, 0);
 
-  const observations = api.dashboard.chart.useQuery(
+  const observationsQuery: QueryType = {
+    view: "observations",
+    dimensions: [{ field: "level" }],
+    metrics: [{ measure: "count", aggregation: "count" }],
+    filters: mapLegacyUiTableFilterToView("observations", globalFilterState),
+    timeDimension: {
+      granularity: "auto",
+    },
+    fromTimestamp: fromTimestamp.toISOString(),
+    toTimestamp: toTimestamp.toISOString(),
+    orderBy: null,
+  };
+
+  const observations = api.dashboard.executeQuery.useQuery(
     {
       projectId,
-      from: "traces",
-      select: [{ column: "traceId", agg: "COUNT" }],
-      filter: globalFilterState.map((f) =>
-        f.type === "datetime" ? { ...f, column: "timestamp" } : f,
-      ),
-      groupBy: [
-        {
-          type: "datetime",
-          column: "timestamp",
-          temporalUnit: dashboardDateRangeAggregationSettings[agg].date_trunc,
-        },
-      ],
-      queryName: "observations-status-timeseries",
+      query: observationsQuery,
     },
     {
       trpc: {
@@ -111,7 +115,7 @@ export const TracesAndObservationsTimeSeriesChart = ({
             }
           >
         >((acc, item) => {
-          const ts = (item.start_time_bucket as Date).getTime();
+          const ts = new Date(item.time_dimension as any).getTime();
           if (!acc[ts]) {
             acc[ts] = {
               ts,
@@ -120,7 +124,7 @@ export const TracesAndObservationsTimeSeriesChart = ({
           }
           acc[ts].values.push({
             label: item.level as string,
-            value: typeof item.count === "number" ? item.count : undefined,
+            value: Number(item.count_count),
           });
 
           return acc;
@@ -129,7 +133,7 @@ export const TracesAndObservationsTimeSeriesChart = ({
     : [];
 
   const totalObservations = observations.data?.reduce((acc, item) => {
-    return acc + (item.count as number);
+    return acc + Number(item.count_count);
   }, 0);
 
   const data = [

--- a/web/src/features/dashboard/server/dashboard-router.ts
+++ b/web/src/features/dashboard/server/dashboard-router.ts
@@ -330,6 +330,11 @@ export async function executeQuery(
     const result = await queryClickhouse<Record<string, unknown>>({
       query: compiledQuery,
       params: parameters,
+      clickhouseConfigs: {
+        clickhouse_settings: {
+          date_time_output_format: "iso",
+        },
+      },
       tags: {
         feature: "custom-queries",
         type: query.view,

--- a/web/src/pages/project/[projectId]/index.tsx
+++ b/web/src/pages/project/[projectId]/index.tsx
@@ -254,7 +254,9 @@ export default function Dashboard() {
         <TracesAndObservationsTimeSeriesChart
           className="col-span-1 xl:col-span-3"
           projectId={projectId}
-          globalFilterState={mergedFilterState}
+          globalFilterState={[...userFilterState, ...environmentFilter]}
+          fromTimestamp={fromTimestamp}
+          toTimestamp={toTimestamp}
           agg={agg}
           isLoading={environmentFilterOptions.isLoading}
         />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Moved traces timeseries chart to new query builder, ensuring ISO8601 date format adherence and updating related components and tests.
> 
>   - **Behavior**:
>     - Moved `TracesTimeSeriesChart` to use new query builder in `TracesTimeSeriesChart.tsx`.
>     - Ensures `time_dimension` adheres to ISO8601 format in `queryBuilder.servertest.ts`.
>   - **Query Updates**:
>     - Updated `tracesQuery` and `observationsQuery` in `TracesTimeSeriesChart.tsx` to use new query structure.
>     - Updated `modelCostQuery` in `ModelCostTable.tsx` to use new query structure.
>   - **Tests**:
>     - Added test for ISO8601 format adherence in `queryBuilder.servertest.ts`.
>   - **Misc**:
>     - Added `clickhouse_settings` to `clickhouseClient` in `client.ts` to support custom settings.
>     - Updated `executeQuery` in `dashboard-router.ts` to include `date_time_output_format` setting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d947e7389edfb4f8e99650dbbbb592b42e710321. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->