### PR TITLE
perf: reduce memory usage for posthog export via join_algo overwrite

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1428,6 +1428,12 @@ export const getGenerationsForPostHog = async function* (
       kind: "analytic",
       projectId,
     },
+    clickhouseConfigs: {
+      clickhouse_settings: {
+        join_algorithm: "grace_hash",
+        grace_hash_join_initial_buckets: "32",
+      },
+    },
   });
 
   const baseUrl = env.NEXTAUTH_URL?.replace("/api/auth", "");

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -930,6 +930,12 @@ export const getScoresForPostHog = async function* (
       kind: "analytic",
       projectId,
     },
+    clickhouseConfigs: {
+      clickhouse_settings: {
+        join_algorithm: "grace_hash",
+        grace_hash_join_initial_buckets: "32",
+      },
+    },
   });
 
   const baseUrl = env.NEXTAUTH_URL?.replace("/api/auth", "");

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -907,6 +907,12 @@ export const getTracesForPostHog = async function* (
       kind: "analytic",
       projectId,
     },
+    clickhouseConfigs: {
+      clickhouse_settings: {
+        join_algorithm: "grace_hash",
+        grace_hash_join_initial_buckets: "32",
+      },
+    },
   });
 
   const baseUrl = env.NEXTAUTH_URL?.replace("/api/auth", "");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize memory usage in PostHog export functions by configuring Clickhouse to use `grace_hash` join algorithm.
> 
>   - **Behavior**:
>     - Optimize memory usage by setting `join_algorithm` to `grace_hash` and `grace_hash_join_initial_buckets` to `32` in Clickhouse queries.
>     - Applied to `getGenerationsForPostHog` in `observations.ts`, `getScoresForPostHog` in `scores.ts`, and `getTracesForPostHog` in `traces.ts`.
>   - **Configuration**:
>     - Updated Clickhouse configuration in the affected functions to include `clickhouse_settings` with the new join algorithm settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a16cd12af64350bd86e6ac9808a26237d97224a0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->