### PR TITLE
chore: bump timeout for posthog export queries

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1429,6 +1429,7 @@ export const getGenerationsForPostHog = async function* (
       projectId,
     },
     clickhouseConfigs: {
+      request_timeout: 300_000, // 5 minutes
       clickhouse_settings: {
         join_algorithm: "grace_hash",
         grace_hash_join_initial_buckets: "32",

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -931,6 +931,7 @@ export const getScoresForPostHog = async function* (
       projectId,
     },
     clickhouseConfigs: {
+      request_timeout: 300_000, // 5 minutes
       clickhouse_settings: {
         join_algorithm: "grace_hash",
         grace_hash_join_initial_buckets: "32",

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -908,6 +908,7 @@ export const getTracesForPostHog = async function* (
       projectId,
     },
     clickhouseConfigs: {
+      request_timeout: 300_000, // 5 minutes
       clickhouse_settings: {
         join_algorithm: "grace_hash",
         grace_hash_join_initial_buckets: "32",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase timeout for PostHog export queries to 5 minutes in `observations.ts`, `scores.ts`, and `traces.ts`.
> 
>   - **Behavior**:
>     - Increase `request_timeout` to 300,000 ms (5 minutes) for PostHog export queries in `getGenerationsForPostHog()` in `observations.ts`, `getScoresForPostHog()` in `scores.ts`, and `getTracesForPostHog()` in `traces.ts`.
>   - **Misc**:
>     - No other changes or refactoring were made.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 46d7e4963ba5921bf12194f836ca3b4bda5ecff8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->