### PR TITLE
chore: set sentry profiling sample rate

### DIFF
--- a/web/sentry.client.config.ts
+++ b/web/sentry.client.config.ts
@@ -31,6 +31,12 @@ Sentry.init({
   replaysOnErrorSampleRate: 1.0,
   debug: false,
 
+  // Set profilesSampleRate to 1.0 to profile every transaction.
+  // Since profilesSampleRate is relative to tracesSampleRate,
+  // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
+  // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
+  // result in 25% of transactions being profiled (0.5*0.5=0.25)
+  profilesSampleRate: 0.5,
   // ...
 
   // Note: if you want to override the automatic release value, do not set a


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `profilesSampleRate` to 0.5 in `sentry.client.config.ts` to profile 50% of transactions.
> 
>   - **Configuration**:
>     - Set `profilesSampleRate` to 0.5 in `sentry.client.config.ts` to profile 50% of transactions.
>     - Profiling rate is calculated as `tracesSampleRate * profilesSampleRate`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for df202b95623e93c8324ba05636b9141dcc81e701. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->