### PR TITLE
feat(evals): allow adding custom value to tags filter

### DIFF
--- a/web/src/ee/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/ee/features/evals/components/inner-evaluator-form.tsx
@@ -456,6 +456,7 @@ export const InnerEvaluatorForm = (props: {
                           filterState={field.value ?? []}
                           onChange={(value) => field.onChange(value)}
                           disabled={props.disabled}
+                          columnsWithCustomSelect={["tags"]}
                         />
                       </FormControl>
                       <FormDescription>

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -194,11 +194,13 @@ export function InlineFilterBuilder({
   filterState,
   onChange,
   disabled,
+  columnsWithCustomSelect,
 }: {
   columns: ColumnDefinition[];
   filterState: FilterState;
   onChange: Dispatch<SetStateAction<FilterState>>;
   disabled?: boolean;
+  columnsWithCustomSelect?: string[];
 }) {
   const [wipFilterState, _setWipFilterState] =
     useState<WipFilterState>(filterState);
@@ -223,6 +225,7 @@ export function InlineFilterBuilder({
         filterState={wipFilterState}
         onChange={setWipFilterState}
         disabled={disabled}
+        columnsWithCustomSelect={columnsWithCustomSelect}
       />
     </div>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable custom values in `tags` filter by adding `columnsWithCustomSelect` prop to filter components.
> 
>   - **Behavior**:
>     - Allow custom values in `tags` filter by adding `columnsWithCustomSelect` prop to `InlineFilterBuilder` and `PopoverFilterBuilder` in `filter-builder.tsx`.
>     - Update `FilterBuilderForm` to enable custom select for columns specified in `columnsWithCustomSelect`.
>   - **Components**:
>     - Modify `InnerEvaluatorForm` in `inner-evaluator-form.tsx` to pass `columnsWithCustomSelect` with `tags` to `InlineFilterBuilder`.
>   - **Misc**:
>     - No changes to existing functionality outside of custom select feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 875dbd4fef40ab7d12b21155a771694c151eec2d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->