### PR TITLE
chore(eval-count-tooltip): refactor to extract business logic into hook

### DIFF
--- a/web/src/ee/features/evals/components/execution-count-tooltip.tsx
+++ b/web/src/ee/features/evals/components/execution-count-tooltip.tsx
@@ -1,8 +1,5 @@
 import { InfoIcon, Loader } from "lucide-react";
-import {
-  type EvalFormType,
-  isTraceTarget,
-} from "@/src/ee/features/evals/utils/evaluator-form-utils";
+import { type EvalFormType } from "@/src/ee/features/evals/utils/evaluator-form-utils";
 import { api } from "@/src/utils/api";
 import { useState } from "react";
 import {
@@ -51,7 +48,7 @@ export const ExecutionCountTooltip = ({
             compactNumberFormatter(
               !globalConfig.data ||
                 (totalCount && totalCount < globalConfig.data)
-                ? (totalCount ?? 0)
+                ? totalCount
                 : globalConfig.data,
             )
           )}{" "}

--- a/web/src/ee/features/evals/hooks/useEvalTargetCount.ts
+++ b/web/src/ee/features/evals/hooks/useEvalTargetCount.ts
@@ -1,0 +1,60 @@
+import { api } from "@/src/utils/api";
+import { useState } from "react";
+import {
+  type EvalFormType,
+  isTraceTarget,
+} from "@/src/ee/features/evals/utils/evaluator-form-utils";
+
+interface UseEvalTargetCountProps {
+  projectId: string;
+  item: string;
+  filter: EvalFormType["filter"];
+  enabled?: boolean;
+}
+
+interface UseEvalTargetCountResult {
+  isLoading: boolean;
+  totalCount: number | null | undefined;
+  isTraceTarget: boolean;
+}
+
+export function useEvalTargetCount({
+  projectId,
+  item,
+  filter,
+  enabled = true,
+}: UseEvalTargetCountProps): UseEvalTargetCountResult {
+  const isTrace = isTraceTarget(item);
+
+  const baseAllCountFilter = {
+    projectId,
+    filter,
+  };
+
+  const tracesAllCountFilter = {
+    ...baseAllCountFilter,
+    searchQuery: null,
+    orderBy: null,
+  };
+
+  const tracesCountQuery = api.traces.countAll.useQuery(tracesAllCountFilter, {
+    enabled: enabled && isTrace,
+  });
+
+  const datasetCountQuery = api.datasets.countAllDatasetItems.useQuery(
+    baseAllCountFilter,
+    {
+      enabled: enabled && !isTrace,
+    },
+  );
+
+  return {
+    isLoading: isTrace
+      ? tracesCountQuery.isLoading
+      : datasetCountQuery.isLoading,
+    totalCount: isTrace
+      ? tracesCountQuery.data?.totalCount
+      : datasetCountQuery.data?.totalCount,
+    isTraceTarget: isTrace,
+  };
+}

--- a/web/src/ee/features/evals/hooks/useEvalTargetCount.ts
+++ b/web/src/ee/features/evals/hooks/useEvalTargetCount.ts
@@ -1,5 +1,4 @@
 import { api } from "@/src/utils/api";
-import { useState } from "react";
 import {
   type EvalFormType,
   isTraceTarget,
@@ -14,8 +13,8 @@ interface UseEvalTargetCountProps {
 
 interface UseEvalTargetCountResult {
   isLoading: boolean;
-  totalCount: number | null | undefined;
   isTraceTarget: boolean;
+  totalCount?: number;
 }
 
 export function useEvalTargetCount({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `ExecutionCountTooltip` to use new `useEvalTargetCount` hook for improved logic separation and performance optimization.
> 
>   - **Refactor**:
>     - Extracts business logic from `ExecutionCountTooltip` in `execution-count-tooltip.tsx` to new hook `useEvalTargetCount` in `useEvalTargetCount.ts`.
>     - `useEvalTargetCount` handles logic for determining `isLoading`, `totalCount`, and `isTraceTarget` based on `projectId`, `item`, and `filter`.
>   - **Behavior**:
>     - `ExecutionCountTooltip` now uses `useEvalTargetCount` to manage query logic and state.
>     - Tooltip queries are enabled only when `isOpen` is true, optimizing performance by avoiding unnecessary queries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d50c9be1a866722d4f0790d0e676c8c2ff5e2386. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->