### PR TITLE
fix(prompts): dollar sign in replaceValue breaking resolution

### DIFF
--- a/packages/shared/src/server/services/PromptService/index.ts
+++ b/packages/shared/src/server/services/PromptService/index.ts
@@ -372,7 +372,9 @@ export class PromptService {
             );
             const regex = new RegExp(combinedPattern, "g");
 
-            const replaceValue = JSON.stringify(resolvedDepPrompt).slice(1, -1); // this is necessary to avoid parsing errors as resolved value is unstringified
+            const replaceValue = JSON.stringify(resolvedDepPrompt)
+              .slice(1, -1) // this is necessary to avoid parsing errors as resolved value is unstringified
+              .replace(/\$/g, "$$$$"); // Escape dollar signs in replacement string. $ has special meaning in replace(), so we need to escape it with $$. Since we're in a string that will be used as a replacement, we need to double escape it (hence $$$$)
 
             resolvedPrompt = resolvedPrompt.replace(regex, replaceValue);
           }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes issue with dollar signs in `replaceValue` in `PromptService` by escaping them in `buildAndResolvePromptGraph()`.
> 
>   - **Behavior**:
>     - Fixes issue with dollar signs in `replaceValue` in `PromptService`.
>     - Escapes dollar signs in `replaceValue` to prevent special meaning in `replace()` function.
>   - **Code**:
>     - Modifies `replaceValue` in `buildAndResolvePromptGraph()` to escape dollar signs using `$$$$`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 772bed497ffb20d4e6b6a69650a50c96e0646823. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->