### PR TITLE
fix(prompt-ui): state stuck in showing prompt diff cycle

### DIFF
--- a/web/src/components/trace/TraceTimelineView.tsx
+++ b/web/src/components/trace/TraceTimelineView.tsx
@@ -515,7 +515,8 @@ export function TraceTimelineView({
     // Use scrollWidth which accounts for all content, including overflow
     const scrollWidth = timelineContentRef.current.scrollWidth;
 
-    const newWidth = Math.max(SCALE_WIDTH, scrollWidth);
+    // Add 20px to account for scrollbar padding
+    const newWidth = Math.max(SCALE_WIDTH, scrollWidth + 20);
     if (newWidth !== contentWidth) {
       setContentWidth(newWidth);
     }

--- a/web/src/features/prompts/components/PromptVersionDiffDialog.tsx
+++ b/web/src/features/prompts/components/PromptVersionDiffDialog.tsx
@@ -49,7 +49,12 @@ export const PromptVersionDiffDialog: React.FC<PromptVersionDiffDialogProps> = (
 
       <DialogContent
         className="max-w-screen-xl"
+        // prevent event bubbling up and triggering the row's click handler
         onClick={(event) => event.stopPropagation()}
+        onPointerDownOutside={(e) => {
+          setIsOpen(false);
+          e.stopPropagation();
+        }}
       >
         <DialogHeader>
           <DialogTitle>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes UI bug in `TraceTimelineView.tsx` and improves event handling in `PromptVersionDiffDialog.tsx`.
> 
>   - **TraceTimelineView.tsx**:
>     - Fixes content width calculation by adding 20px for scrollbar padding in `useLayoutEffect`.
>   - **PromptVersionDiffDialog.tsx**:
>     - Adds `onPointerDownOutside` event to close dialog and stop event propagation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 78886349473ecb66c11b08f48019e6efe921fbb2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->