### PR TITLE
fix(ui): scores table pagination state in traces and observations preview uses session storage

### DIFF
--- a/web/src/components/table/hooks/usePagination.ts
+++ b/web/src/components/table/hooks/usePagination.ts
@@ -1,0 +1,74 @@
+import useSessionStorage from "@/src/components/useSessionStorage";
+import { OnChangeFn, Updater } from "@tanstack/react-table";
+import { useState } from "react";
+import { useQueryParams, withDefault, NumberParam } from "use-query-params";
+
+export type PaginationState = {
+  pageIndex: number;
+  pageSize: number;
+};
+
+type PaginationHookResult = {
+  paginationState: PaginationState;
+  setPaginationState: OnChangeFn<PaginationState>;
+};
+
+/**
+ * A hook for managing pagination state, either through URL or local state
+ *
+ * @param isLocalPagination If true, uses local React state in combination with session storage instead of URL parameters
+ * @param initialState The initial pagination state
+ * @param paramNames Optional custom parameter names for URL-based pagination
+ */
+export function usePagination(
+  isLocalPagination = false,
+  initialState: PaginationState = { pageIndex: 0, pageSize: 50 },
+  paramNames: { pageIndex: string; pageSize: string } = {
+    pageIndex: "pageIndex",
+    pageSize: "pageSize",
+  },
+): PaginationHookResult {
+  const [storedPageSize, setStoredPageSize] = useSessionStorage(
+    "scoresPageSize",
+    initialState.pageSize,
+  );
+  const [localState, setLocalState] = useState<PaginationState>({
+    ...initialState,
+    pageSize: storedPageSize,
+  });
+
+  // URL state version
+  const [urlState, setUrlState] = useQueryParams({
+    [paramNames.pageIndex]: withDefault(NumberParam, initialState.pageIndex),
+    [paramNames.pageSize]: withDefault(NumberParam, initialState.pageSize),
+  });
+
+  const paginationState = isLocalPagination
+    ? localState
+    : {
+        pageIndex: urlState[paramNames.pageIndex],
+        pageSize: urlState[paramNames.pageSize],
+      };
+
+  // Create a unified setter function
+  const setPaginationState: OnChangeFn<PaginationState> = (
+    updaterOrValue: Updater<PaginationState>,
+  ) => {
+    const updatedState =
+      typeof updaterOrValue === "function"
+        ? updaterOrValue(paginationState)
+        : { ...paginationState, ...updaterOrValue };
+
+    if (isLocalPagination) {
+      setLocalState(updatedState);
+      setStoredPageSize(updatedState.pageSize);
+    } else {
+      setUrlState({
+        [paramNames.pageIndex]: updatedState.pageIndex,
+        [paramNames.pageSize]: updatedState.pageSize,
+      });
+    }
+  };
+
+  return { paginationState, setPaginationState };
+}

--- a/web/src/components/table/hooks/usePagination.ts
+++ b/web/src/components/table/hooks/usePagination.ts
@@ -22,9 +22,9 @@ type usePaginationProps = {
 /**
  * A hook for managing pagination state, either through URL or local state
  *
- * @param isLocalPagination If true, uses local React state in combination with session storage instead of URL parameters
  * @param initialState The initial pagination state
- * @param paramNames Optional custom parameter names for URL-based pagination
+ * @param isLocalPagination If true, uses local React state in combination with session storage instead of URL parameters
+ * @param tableName The name of the table to store the pagination state in session storage
  */
 export function usePagination({
   initialState = { pageIndex: 0, pageSize: 50 },

--- a/web/src/components/table/hooks/usePagination.ts
+++ b/web/src/components/table/hooks/usePagination.ts
@@ -13,6 +13,12 @@ type PaginationHookResult = {
   setPaginationState: OnChangeFn<PaginationState>;
 };
 
+type usePaginationProps = {
+  initialState: PaginationState;
+  isLocalPagination?: boolean;
+  tableName: string;
+};
+
 /**
  * A hook for managing pagination state, either through URL or local state
  *
@@ -20,16 +26,13 @@ type PaginationHookResult = {
  * @param initialState The initial pagination state
  * @param paramNames Optional custom parameter names for URL-based pagination
  */
-export function usePagination(
+export function usePagination({
+  initialState = { pageIndex: 0, pageSize: 50 },
   isLocalPagination = false,
-  initialState: PaginationState = { pageIndex: 0, pageSize: 50 },
-  paramNames: { pageIndex: string; pageSize: string } = {
-    pageIndex: "pageIndex",
-    pageSize: "pageSize",
-  },
-): PaginationHookResult {
+  tableName,
+}: usePaginationProps): PaginationHookResult {
   const [storedPageSize, setStoredPageSize] = useSessionStorage(
-    "scoresPageSize",
+    `storedPageSize-${tableName}`,
     initialState.pageSize,
   );
   const [localState, setLocalState] = useState<PaginationState>({
@@ -39,15 +42,15 @@ export function usePagination(
 
   // URL state version
   const [urlState, setUrlState] = useQueryParams({
-    [paramNames.pageIndex]: withDefault(NumberParam, initialState.pageIndex),
-    [paramNames.pageSize]: withDefault(NumberParam, initialState.pageSize),
+    pageIndex: withDefault(NumberParam, initialState.pageIndex),
+    pageSize: withDefault(NumberParam, initialState.pageSize),
   });
 
   const paginationState = isLocalPagination
     ? localState
     : {
-        pageIndex: urlState[paramNames.pageIndex],
-        pageSize: urlState[paramNames.pageSize],
+        pageIndex: urlState.pageIndex,
+        pageSize: urlState.pageSize,
       };
 
   // Create a unified setter function
@@ -64,8 +67,8 @@ export function usePagination(
       setStoredPageSize(updatedState.pageSize);
     } else {
       setUrlState({
-        [paramNames.pageIndex]: updatedState.pageIndex,
-        [paramNames.pageSize]: updatedState.pageSize,
+        pageIndex: updatedState.pageIndex,
+        pageSize: updatedState.pageSize,
       });
     }
   };

--- a/web/src/components/table/hooks/usePagination.ts
+++ b/web/src/components/table/hooks/usePagination.ts
@@ -1,5 +1,5 @@
 import useSessionStorage from "@/src/components/useSessionStorage";
-import { OnChangeFn, Updater } from "@tanstack/react-table";
+import { type OnChangeFn, type Updater } from "@tanstack/react-table";
 import { useState } from "react";
 import { useQueryParams, withDefault, NumberParam } from "use-query-params";
 

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -103,10 +103,11 @@ export default function ScoresTable({
 }) {
   const utils = api.useUtils();
   const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
-  const { paginationState, setPaginationState } = usePagination(
+  const { paginationState, setPaginationState } = usePagination({
+    initialState: { pageIndex: 0, pageSize: 50 },
     isLocalPagination,
-    { pageIndex: 0, pageSize: 50 },
-  );
+    tableName: "scores",
+  });
   const { selectAll, setSelectAll } = useSelectAll(projectId, "scores");
 
   const [rowHeight, setRowHeight] = useRowHeightLocalStorage("scores", "s");

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -16,7 +16,6 @@ import {
   scoresTableColsWithOptions,
 } from "@/src/server/api/definitions/scoresTable";
 import { api } from "@/src/utils/api";
-
 import type { RouterOutput } from "@/src/utils/types";
 import {
   isPresent,
@@ -25,7 +24,6 @@ import {
   BatchExportTableName,
   BatchActionType,
 } from "@langfuse/shared";
-import { useQueryParams, withDefault, NumberParam } from "use-query-params";
 import TagList from "@/src/features/tag/components/TagList";
 import { cn } from "@/src/utils/tailwind";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
@@ -44,6 +42,7 @@ import type { RowSelectionState } from "@tanstack/react-table";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import { useSelectAll } from "@/src/features/table/hooks/useSelectAll";
 import { TableSelectionManager } from "@/src/features/table/components/TableSelectionManager";
+import { usePagination } from "@/src/components/table/hooks/usePagination";
 
 export type ScoresTableRow = {
   id: string;
@@ -91,6 +90,7 @@ export default function ScoresTable({
   omittedFilter = [],
   hiddenColumns = [],
   localStorageSuffix = "",
+  isLocalPagination = false,
 }: {
   projectId: string;
   userId?: string;
@@ -99,13 +99,14 @@ export default function ScoresTable({
   omittedFilter?: string[];
   hiddenColumns?: string[];
   localStorageSuffix?: string;
+  isLocalPagination?: boolean;
 }) {
   const utils = api.useUtils();
   const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
-  const [paginationState, setPaginationState] = useQueryParams({
-    pageIndex: withDefault(NumberParam, 0),
-    pageSize: withDefault(NumberParam, 50),
-  });
+  const { paginationState, setPaginationState } = usePagination(
+    isLocalPagination,
+    { pageIndex: 0, pageSize: 50 },
+  );
   const { selectAll, setSelectAll } = useSelectAll(projectId, "scores");
 
   const [rowHeight, setRowHeight] = useRowHeightLocalStorage("scores", "s");

--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -423,6 +423,7 @@ export const ObservationPreview = ({
                     "userId",
                   ]}
                   localStorageSuffix="ObservationPreview"
+                  isLocalPagination
                 />
               </div>
             </TabsBarContent>

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -295,6 +295,7 @@ export const TracePreview = ({
                   traceId={trace.id}
                   hiddenColumns={["traceName", "jobConfigurationId", "userId"]}
                   localStorageSuffix="TracePreview"
+                  isLocalPagination
                 />
               </div>
             </TabsBarContent>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces `usePagination` hook for managing pagination state using session storage or URL parameters, applied to `ScoresTable`, `ObservationPreview`, and `TracePreview`.
> 
>   - **Behavior**:
>     - Introduces `usePagination` hook in `usePagination.ts` to manage pagination state using session storage or URL parameters.
>     - `ScoresTable`, `ObservationPreview`, and `TracePreview` components now use `usePagination` to handle pagination state.
>     - Adds `isLocalPagination` prop to `ScoresTable` to toggle between local and URL-based pagination.
>   - **Components**:
>     - `ScoresTable` updated to use `usePagination` for managing pagination state.
>     - `ObservationPreview` and `TracePreview` components set `isLocalPagination` to true, using session storage for pagination state.
>   - **Misc**:
>     - Removes unused imports related to query parameters in `scores.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 34fc8ef22e431434c8eaf69e3ac01d1b601ada65. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->