### PR TITLE
fix(prompts): handle resolvePromptGraph on deleted prompt

### DIFF
--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -956,12 +956,19 @@ export const promptRouter = createTRPCRouter({
           scope: "prompts:read",
         });
 
-        const prompt = await ctx.prisma.prompt.findUniqueOrThrow({
+        const prompt = await ctx.prisma.prompt.findUnique({
           where: {
             id: promptId,
             projectId,
           },
         });
+
+        if (!prompt) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Prompt not found",
+          });
+        }
 
         const promptService = new PromptService(ctx.prisma, redis);
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `resolvePromptGraph` in `promptRouter.ts` to handle deleted prompts by throwing `NOT_FOUND` error if prompt is missing.
> 
>   - **Behavior**:
>     - Fix `resolvePromptGraph` in `promptRouter.ts` to handle deleted prompts by checking if the prompt exists.
>     - Throws `TRPCError` with `NOT_FOUND` code if prompt is not found.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for dfa95889c47ae23e3ba28f3ddb7476e3260c1efc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->