### PR TITLE
fix(ui): trace timeline width calculation error 

### DIFF
--- a/web/src/components/trace/TraceTimelineView.tsx
+++ b/web/src/components/trace/TraceTimelineView.tsx
@@ -516,7 +516,7 @@ export function TraceTimelineView({
     const scrollWidth = timelineContentRef.current.scrollWidth;
 
     // Add 20px to account for scrollbar padding
-    const newWidth = Math.max(SCALE_WIDTH, scrollWidth + 20);
+    const newWidth = Math.max(SCALE_WIDTH, scrollWidth);
     if (newWidth !== contentWidth) {
       setContentWidth(newWidth);
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes timeline width calculation in `TraceTimelineView.tsx` by removing unnecessary 20px addition for scrollbar padding.
> 
>   - **Behavior**:
>     - Fixes timeline width calculation in `TraceTimelineView.tsx` by removing unnecessary 20px addition for scrollbar padding.
>   - **Misc**:
>     - Adjusts `newWidth` calculation to use `scrollWidth` directly without extra padding.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b0308d4a7baa0728eef0d10f446df5d7a32905ad. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->