### PR TITLE
fix(patch): hide scores tab on trace/observation preview

### DIFF
--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -33,6 +33,7 @@ import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 import { ItemBadge } from "@/src/components/ItemBadge";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
+import { useRouter } from "next/router";
 
 export const ObservationPreview = ({
   observations,
@@ -66,6 +67,9 @@ export const ObservationPreview = ({
   const hasEntitlement = useHasEntitlement("annotation-queues");
   const isAuthenticatedAndProjectMember =
     useIsAuthenticatedAndProjectMember(projectId);
+  const router = useRouter();
+  const { peek } = router.query;
+  const showScoresTab = isAuthenticatedAndProjectMember && peek === undefined;
 
   const currentObservation = observations.find(
     (o) => o.id === currentObservationId,
@@ -339,7 +343,7 @@ export const ObservationPreview = ({
           {viewType === "detailed" && (
             <TabsBarList>
               <TabsBarTrigger value="preview">Preview</TabsBarTrigger>
-              {isAuthenticatedAndProjectMember && (
+              {showScoresTab && (
                 <TabsBarTrigger value="scores">Scores</TabsBarTrigger>
               )}
               {selectedTab.includes("preview") && isPrettyViewAvailable && (
@@ -404,7 +408,7 @@ export const ObservationPreview = ({
               </div>
             </div>
           </TabsBarContent>
-          {isAuthenticatedAndProjectMember && (
+          {showScoresTab && (
             <TabsBarContent
               value="scores"
               className="mb-2 mr-4 mt-0 flex h-full min-h-0 flex-1 overflow-hidden"

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -35,6 +35,7 @@ import { ItemBadge } from "@/src/components/ItemBadge";
 import Link from "next/link";
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { useRouter } from "next/router";
 
 export const TracePreview = ({
   trace,
@@ -67,6 +68,9 @@ export const TracePreview = ({
     trace.projectId,
   );
   const capture = usePostHogClientCapture();
+  const router = useRouter();
+  const { peek } = router.query;
+  const showScoresTab = isAuthenticatedAndProjectMember && peek === undefined;
 
   const traceMedia = api.media.getByTraceOrObservationId.useQuery(
     {
@@ -231,7 +235,7 @@ export const TracePreview = ({
           {viewType === "detailed" && (
             <TabsBarList>
               <TabsBarTrigger value="preview">Preview</TabsBarTrigger>
-              {isAuthenticatedAndProjectMember && (
+              {showScoresTab && (
                 <TabsBarTrigger value="scores">Scores</TabsBarTrigger>
               )}
               {selectedTab.includes("preview") && isPrettyViewAvailable && (
@@ -283,7 +287,7 @@ export const TracePreview = ({
               </div>
             </div>
           </TabsBarContent>
-          {isAuthenticatedAndProjectMember && (
+          {showScoresTab && (
             <TabsBarContent
               value="scores"
               className="mb-2 mr-4 mt-0 flex h-full min-h-0 w-full overflow-hidden md:flex-1"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Conditionally hide 'Scores' tab in `ObservationPreview` and `TracePreview` based on authentication and 'peek' query parameter.
> 
>   - **Behavior**:
>     - In `ObservationPreview.tsx` and `TracePreview.tsx`, the 'Scores' tab is now conditionally displayed based on `isAuthenticatedAndProjectMember` and absence of `peek` query parameter.
>   - **Functions**:
>     - Introduces `showScoresTab` variable in both `ObservationPreview` and `TracePreview` to manage the visibility of the 'Scores' tab.
>   - **Imports**:
>     - Adds `useRouter` import in both `ObservationPreview.tsx` and `TracePreview.tsx` to access query parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cfb9e56c8da1ce08c8c9e5bf3b8a123df1356816. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->