### PR TITLE
chore: revert unintended worker concurrency changes

### DIFF
--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -114,7 +114,7 @@ if (env.LANGFUSE_POSTGRES_METERING_DATA_EXPORT_IS_ENABLED === "true") {
       limiter: {
         // Process at most `max` jobs per 30 seconds
         max: 1,
-        duration: 120_000,
+        duration: 30_000,
       },
     },
   );
@@ -231,7 +231,7 @@ if (
       limiter: {
         // Process at most `max` jobs per 30 seconds
         max: 1,
-        duration: 120_000,
+        duration: 30_000,
       },
     },
   );


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`npm run prettier`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts job processing `duration` from `120_000` to `30_000` in `worker/src/app.ts` for metering data exports.
> 
>   - **Behavior**:
>     - Reverts `duration` from `120_000` to `30_000` in `worker/src/app.ts` for job processing limits in metering data exports.
>     - Affects `MeteringDataPostgresExportQueue` and `CloudUsageMeteringQueue` job processing rates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7dca3fa4994087b4967dfed23dc53f5b8810be34. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->