### PR TITLE
fix(prompt-form): move prompt reference button

### DIFF
--- a/web/src/components/editor/PromptLinkingEditor.tsx
+++ b/web/src/components/editor/PromptLinkingEditor.tsx
@@ -66,7 +66,7 @@ export function PromptLinkingEditor({
       <Button
         type="button"
         variant="outline"
-        className="absolute right-2 top-2 flex items-center gap-1 px-2 py-1"
+        className="absolute bottom-2 right-2 flex items-center gap-1 px-2 py-1"
         onClick={() => setIsDialogOpen(true)}
       >
         <PlusIcon className="h-4 w-4" />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move "Add prompt reference" button to bottom-right in `PromptLinkingEditor.tsx`.
> 
>   - **UI Change**:
>     - Move the "Add prompt reference" button from top-right to bottom-right in `PromptLinkingEditor.tsx` by changing its CSS class from `top-2` to `bottom-2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 051c253e61813b597b0293911fb6c81108d2ff12. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->