### PR TITLE
feat(playground): persist selected model

### DIFF
--- a/web/src/ee/features/playground/page/hooks/useModelParams.ts
+++ b/web/src/ee/features/playground/page/hooks/useModelParams.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useCallback, useState } from "react";
 
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 import { api } from "@/src/utils/api";
@@ -57,22 +57,24 @@ export const useModelParams = () => {
     [selectedProviderApiKey],
   );
 
-  const updateModelParamValue: ModelParamsContext["updateModelParamValue"] = (
-    key,
-    value,
-  ) => {
-    setModelParams((prev) => ({
-      ...prev,
-      [key]: { ...prev[key], value },
-    }));
+  const updateModelParamValue = useCallback<
+    ModelParamsContext["updateModelParamValue"]
+  >(
+    (key, value) => {
+      setModelParams((prev) => ({
+        ...prev,
+        [key]: { ...prev[key], value },
+      }));
 
-    if (value && key === "model") {
-      setPersistedModelName(String(value));
-    }
-    if (value && key === "provider") {
-      setPersistedModelProvider(String(value));
-    }
-  };
+      if (value && key === "model") {
+        setPersistedModelName(String(value));
+      }
+      if (value && key === "provider") {
+        setPersistedModelProvider(String(value));
+      }
+    },
+    [setPersistedModelName, setPersistedModelProvider, setModelParams],
+  );
 
   const setModelParamEnabled: ModelParamsContext["setModelParamEnabled"] = (
     key,
@@ -96,7 +98,12 @@ export const useModelParams = () => {
         updateModelParamValue("provider", availableProviders[0]);
       }
     }
-  }, [availableProviders, modelParams.provider.value, persistedModelProvider]);
+  }, [
+    availableProviders,
+    modelParams.provider.value,
+    updateModelParamValue,
+    persistedModelProvider,
+  ]);
 
   useEffect(() => {
     if (
@@ -109,7 +116,12 @@ export const useModelParams = () => {
         updateModelParamValue("model", availableModels[0]);
       }
     }
-  }, [availableModels, modelParams.model.value, persistedModelName]);
+  }, [
+    availableModels,
+    modelParams.model.value,
+    updateModelParamValue,
+    persistedModelName,
+  ]);
 
   // Update adapter, max temperature, temperature, max_tokens, top_p when provider changes
   useEffect(() => {

--- a/web/src/ee/features/playground/page/hooks/useModelParams.ts
+++ b/web/src/ee/features/playground/page/hooks/useModelParams.ts
@@ -103,10 +103,6 @@ export const useModelParams = () => {
       (availableModels.length > 0 && !modelParams.model.value) ||
       !availableModels.includes(modelParams.model.value)
     ) {
-      console.log({
-        persistedModelName,
-        availableModels,
-      });
       if (persistedModelName && availableModels.includes(persistedModelName)) {
         updateModelParamValue("model", persistedModelName);
       } else {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Persist selected model and provider in `useModelParams` using local storage for session continuity.
> 
>   - **Behavior**:
>     - Persist selected model and provider using `useLocalStorage` in `useModelParams`.
>     - Default to persisted model/provider if available and valid, otherwise use first available option.
>   - **Functions**:
>     - Add `persistedModelName` and `persistedModelProvider` state using `useLocalStorage`.
>     - Update `updateModelParamValue` to store model/provider in local storage when changed.
>   - **Effects**:
>     - Modify `useEffect` to set default model/provider based on persisted values or available options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b035cf4cbfe3010295df670ce206c83461d8fec8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->