### PR TITLE
chore: pin dev clickhouse version to 24.3

### DIFF
--- a/docker-compose.dev-azure.yml
+++ b/docker-compose.dev-azure.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse/clickhouse-server
+    image: clickhouse/clickhouse-server:24.3
     user: "101:101"
     environment:
       CLICKHOUSE_DB: default

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse/clickhouse-server
+    image: clickhouse/clickhouse-server:24.3
     user: "101:101"
     environment:
       CLICKHOUSE_DB: default

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { removeEmptyEnvVariables } from "./utils/environment";
 
 const EnvSchema = z.object({
+  NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: z.string().optional(),
   NODE_ENV: z
     .enum(["development", "test", "production"])
     .default("development"),

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -19,7 +19,11 @@ export const clickhouseClient = (
   }
 
   const cloudOptions: Record<string, unknown> = {};
-  if (Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION)) {
+  if (
+    ["STAGING", "EU", "US"].includes(
+      env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION ?? "",
+    )
+  ) {
     cloudOptions.input_format_json_throw_on_bad_escape_sequence = 0;
   }
 

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -18,6 +18,11 @@ export const clickhouseClient = (
     propagation.inject(context.active(), headers);
   }
 
+  const cloudOptions: Record<string, unknown> = {};
+  if (Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION)) {
+    cloudOptions.input_format_json_throw_on_bad_escape_sequence = 0;
+  }
+
   return createClient({
     ...params.opts,
     url: env.CLICKHOUSE_URL,
@@ -26,11 +31,11 @@ export const clickhouseClient = (
     database: env.CLICKHOUSE_DB,
     http_headers: headers,
     clickhouse_settings: {
+      ...cloudOptions,
       ...(params.opts?.clickhouse_settings ?? {}),
       log_comment: JSON.stringify(params.tags ?? {}),
       async_insert: 1,
       wait_for_async_insert: 1, // if disabled, we won't get errors from clickhouse
-      input_format_json_throw_on_bad_escape_sequence: 0,
     },
   });
 };

--- a/web/src/__tests__/async/ingestion-api.servertest.ts
+++ b/web/src/__tests__/async/ingestion-api.servertest.ts
@@ -108,32 +108,33 @@ describe("/api/public/ingestion API Endpoint", () => {
     },
   );
 
-  it("should replace bad escape sequences on clickhouse", async () => {
-    const entity = {
-      id: randomUUID(),
-      type: "trace-create",
-      timestamp: new Date().toISOString(),
-      body: {
-        id: randomUUID(),
-        timestamp: new Date().toISOString(),
-        metadata: { hello: "world" },
-        input: "test\\ud8000test",
-        environment: "production",
-      },
-    };
-    const response = await makeAPICall("POST", "/api/public/ingestion", {
-      batch: [entity],
-    });
-
-    expect(response.status).toBe(207);
-    await waitForExpect(async () => {
-      const trace = await getTraceById(entity.body.id, projectId);
-      expect(trace).toBeDefined();
-      expect(trace!.id).toBe(entity.body.id);
-      expect(trace!.projectId).toBe(projectId);
-      expect(trace!.input).toContain("test");
-    });
-  });
+  // Disabled within test sequence as we're using a clickhouse version which doesn't support this
+  // it("should replace bad escape sequences on clickhouse", async () => {
+  //   const entity = {
+  //     id: randomUUID(),
+  //     type: "trace-create",
+  //     timestamp: new Date().toISOString(),
+  //     body: {
+  //       id: randomUUID(),
+  //       timestamp: new Date().toISOString(),
+  //       metadata: { hello: "world" },
+  //       input: "test\\ud8000test",
+  //       environment: "production",
+  //     },
+  //   };
+  //   const response = await makeAPICall("POST", "/api/public/ingestion", {
+  //     batch: [entity],
+  //   });
+  //
+  //   expect(response.status).toBe(207);
+  //   await waitForExpect(async () => {
+  //     const trace = await getTraceById(entity.body.id, projectId);
+  //     expect(trace).toBeDefined();
+  //     expect(trace!.id).toBe(entity.body.id);
+  //     expect(trace!.projectId).toBe(projectId);
+  //     expect(trace!.input).toContain("test");
+  //   });
+  // });
 
   it.each([
     [


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Pin ClickHouse version to 24.3 in development environments and adjust configurations and tests accordingly.
> 
>   - **Docker Configuration**:
>     - Pin ClickHouse version to `24.3` in `docker-compose.dev-azure.yml` and `docker-compose.dev.yml`.
>   - **Environment Variables**:
>     - Add `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` as an optional string in `env.ts`.
>   - **ClickHouse Client**:
>     - Add conditional `cloudOptions` in `client.ts` to handle `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` values `STAGING`, `EU`, `US`.
>     - Remove `input_format_json_throw_on_bad_escape_sequence` from default settings.
>   - **Tests**:
>     - Comment out test for bad escape sequences in `ingestion-api.servertest.ts` due to ClickHouse version limitations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8b74f370ac3ab7ba1027c9d7d75c68cf4aa211e2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->