### PR TITLE
perf: reduce input validation for dataset items

### DIFF
--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -141,9 +141,9 @@ export const GetDatasetRunV1Response = APIDatasetRun.extend({
 // POST /dataset-items
 export const PostDatasetItemsV1Body = z.object({
   datasetName: z.string(),
-  input: jsonSchema.nullish(),
-  expectedOutput: jsonSchema.nullish(),
-  metadata: jsonSchema.nullish(),
+  input: z.any().nullish(),
+  expectedOutput: z.any().nullish(),
+  metadata: z.any().nullish(),
   id: z.string().nullish(),
   sourceTraceId: z.string().nullish(),
   sourceObservationId: z.string().nullish(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplifies input validation for dataset items by changing `input`, `expectedOutput`, and `metadata` to `z.any().nullish()` in `PostDatasetItemsV1Body`.
> 
>   - **Validation Changes**:
>     - In `PostDatasetItemsV1Body`, change `input`, `expectedOutput`, and `metadata` from `jsonSchema.nullish()` to `z.any().nullish()`.
>   - **Performance**:
>     - Simplifies validation by allowing any type for `input`, `expectedOutput`, and `metadata`, potentially improving performance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 72a80461f696218b5c19759e2c7decfcd58acf8f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->