### PR TITLE
feat: add json and jsonl support for scheduled blob exports

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 64",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 65",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "db:migrate": "DISABLE_ERD=false dotenv -e ../../.env -- npx prisma migrate dev",
     "db:push": "DISABLE_ERD=false dotenv -e ../../.env -- npx prisma db push",

--- a/packages/shared/prisma/generated/types.ts
+++ b/packages/shared/prisma/generated/types.ts
@@ -80,6 +80,12 @@ export const JobExecutionStatus = {
     CANCELLED: "CANCELLED"
 } as const;
 export type JobExecutionStatus = (typeof JobExecutionStatus)[keyof typeof JobExecutionStatus];
+export const BlobStorageIntegrationFileType = {
+    JSON: "JSON",
+    CSV: "CSV",
+    JSONL: "JSONL"
+} as const;
+export type BlobStorageIntegrationFileType = (typeof BlobStorageIntegrationFileType)[keyof typeof BlobStorageIntegrationFileType];
 export const BlobStorageIntegrationType = {
     S3: "S3",
     S3_COMPATIBLE: "S3_COMPATIBLE",
@@ -208,6 +214,7 @@ export type BlobStorageIntegration = {
     last_sync_at: Timestamp | null;
     enabled: boolean;
     export_frequency: string;
+    file_type: Generated<BlobStorageIntegrationFileType>;
     created_at: Generated<Timestamp>;
     updated_at: Generated<Timestamp>;
 };

--- a/packages/shared/prisma/migrations/20250402142320_add_blobstorage_integration_file_type/migration.sql
+++ b/packages/shared/prisma/migrations/20250402142320_add_blobstorage_integration_file_type/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "BlobStorageIntegrationFileType" AS ENUM ('JSON', 'CSV', 'JSONL');
+
+-- AlterTable
+ALTER TABLE "blob_storage_integrations" ADD COLUMN     "file_type" "BlobStorageIntegrationFileType" NOT NULL DEFAULT 'CSV';

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -693,7 +693,6 @@ model PromptProtectedLabels {
   label     String
 
   @@unique([projectId, label])
-
   @@map("prompt_protected_labels")
 }
 
@@ -908,15 +907,24 @@ model BlobStorageIntegration {
   forcePathStyle  Boolean                    @map("force_path_style")
 
   // Integration Config
-  nextSyncAt      DateTime? @map("next_sync_at")
-  lastSyncAt      DateTime? @map("last_sync_at")
+  nextSyncAt      DateTime?                      @map("next_sync_at")
+  lastSyncAt      DateTime?                      @map("last_sync_at")
   enabled         Boolean
-  exportFrequency String    @map("export_frequency")
+  exportFrequency String                         @map("export_frequency")
+  fileType        BlobStorageIntegrationFileType @default(CSV) @map("file_type")
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 
   @@map("blob_storage_integrations")
+}
+
+enum BlobStorageIntegrationFileType {
+  JSON
+  CSV
+  JSONL
+
+  @@map("BlobStorageIntegrationFileType")
 }
 
 enum BlobStorageIntegrationType {

--- a/packages/shared/src/features/batchExport/types.ts
+++ b/packages/shared/src/features/batchExport/types.ts
@@ -15,6 +15,7 @@ export enum BatchExportStatus {
 export enum BatchExportFileFormat {
   JSON = "JSON",
   CSV = "CSV",
+  JSONL = "JSONL",
 }
 
 export enum BatchExportTableName {
@@ -35,6 +36,11 @@ export const exportOptions: Record<
 > = {
   CSV: { label: "CSV", extension: "csv", fileType: "text/csv" },
   JSON: { label: "JSON", extension: "json", fileType: "application/json" },
+  JSONL: {
+    label: "JSONL",
+    extension: "jsonl",
+    fileType: "application/x-ndjson",
+  },
 } as const;
 
 export const BatchExportQuerySchema = z.object({

--- a/packages/shared/src/server/redis/blobStorageIntegrationQueue.ts
+++ b/packages/shared/src/server/redis/blobStorageIntegrationQueue.ts
@@ -42,7 +42,7 @@ export class BlobStorageIntegrationQueue {
           QueueJobs.BlobStorageIntegrationJob,
           {},
           {
-            repeat: { pattern: "* * * * *" }, // every hour at 20 minutes past
+            repeat: { pattern: "20 * * * *" }, // every hour at 20 minutes past
           },
         )
         .catch((err) => {

--- a/packages/shared/src/server/redis/blobStorageIntegrationQueue.ts
+++ b/packages/shared/src/server/redis/blobStorageIntegrationQueue.ts
@@ -42,7 +42,7 @@ export class BlobStorageIntegrationQueue {
           QueueJobs.BlobStorageIntegrationJob,
           {},
           {
-            repeat: { pattern: "20 * * * *" }, // every hour at 20 minutes past
+            repeat: { pattern: "* * * * *" }, // every hour at 20 minutes past
           },
         )
         .catch((err) => {

--- a/packages/shared/src/server/utils/transforms/index.ts
+++ b/packages/shared/src/server/utils/transforms/index.ts
@@ -3,6 +3,7 @@ import { Transform } from "stream";
 import { BatchExportFileFormat } from "../../../features/batchExport/types";
 import { transformStreamToCsv } from "./transformStreamToCsv";
 import { transformStreamToJson } from "./transformStreamToJson";
+import { transformStreamToJsonl } from "./transformStreamToJsonl";
 
 export const streamTransformations: Record<
   BatchExportFileFormat,
@@ -10,4 +11,5 @@ export const streamTransformations: Record<
 > = {
   CSV: transformStreamToCsv,
   JSON: transformStreamToJson,
+  JSONL: transformStreamToJsonl,
 };

--- a/packages/shared/src/server/utils/transforms/transformStreamToJsonl.ts
+++ b/packages/shared/src/server/utils/transforms/transformStreamToJsonl.ts
@@ -1,0 +1,17 @@
+import { Transform, type TransformCallback } from "stream";
+import { stringify } from "./stringify";
+
+export function transformStreamToJsonl(): Transform {
+  return new Transform({
+    objectMode: true,
+
+    transform(
+      row: Record<string, any>,
+      encoding: BufferEncoding,
+      callback: TransformCallback,
+    ): void {
+      this.push(stringify(row) + "\n");
+      callback();
+    },
+  });
+}

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -84,6 +84,7 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
           exportFrequency,
           enabled,
           forcePathStyle,
+          fileType,
         } = input;
 
         const data: Partial<BlobStorageIntegration> = {
@@ -96,6 +97,7 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
           enabled,
           accessKeyId,
           forcePathStyle: forcePathStyle || false,
+          fileType,
         };
 
         // Use a transaction to check if record exists, then create or update

--- a/web/src/features/blobstorage-integration/types.ts
+++ b/web/src/features/blobstorage-integration/types.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { BlobStorageIntegrationType } from "@langfuse/shared";
+import {
+  BlobStorageIntegrationType,
+  BlobStorageIntegrationFileType,
+} from "@langfuse/shared";
 
 export const blobStorageIntegrationFormSchema = z.object({
   type: z.nativeEnum(BlobStorageIntegrationType),
@@ -11,16 +14,19 @@ export const blobStorageIntegrationFormSchema = z.object({
     .string()
     .min(1, { message: "Secret access key is required" })
     .nullable(), // Only required on create
-  prefix: z.string()
-    .refine(
-      (value) => !value || value === "" || value.endsWith("/"), 
-      { message: "Prefix must end with a forward slash (/)" }
-    )
+  prefix: z
+    .string()
+    .refine((value) => !value || value === "" || value.endsWith("/"), {
+      message: "Prefix must end with a forward slash (/)",
+    })
     .optional()
     .or(z.literal("")),
   exportFrequency: z.enum(["hourly", "daily", "weekly"]),
   enabled: z.boolean(),
   forcePathStyle: z.boolean(),
+  fileType: z
+    .nativeEnum(BlobStorageIntegrationFileType)
+    .default(BlobStorageIntegrationFileType.JSONL),
 });
 
 export type BlobStorageIntegrationFormSchema = z.infer<

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -37,6 +37,7 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import {
   BlobStorageIntegrationType,
+  BlobStorageIntegrationFileType,
   type BlobStorageIntegration,
 } from "@langfuse/shared";
 
@@ -150,6 +151,7 @@ const BlobStorageIntegrationSettingsForm = ({
         | "hourly",
       enabled: state?.enabled || false,
       forcePathStyle: state?.forcePathStyle || false,
+      fileType: state?.fileType || BlobStorageIntegrationFileType.JSONL,
     },
     disabled: isLoading,
   });
@@ -169,6 +171,7 @@ const BlobStorageIntegrationSettingsForm = ({
         | "hourly",
       enabled: state?.enabled || false,
       forcePathStyle: state?.forcePathStyle || false,
+      fileType: state?.fileType || BlobStorageIntegrationFileType.JSONL,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state]);
@@ -432,6 +435,35 @@ const BlobStorageIntegrationSettingsForm = ({
               <FormDescription>
                 How often the data should be exported. Changes are taken into
                 consideration from the next run onwards.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={blobStorageForm.control}
+          name="fileType"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>File Type</FormLabel>
+              <FormControl>
+                <Select
+                  defaultValue={field.value}
+                  onValueChange={field.onChange}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select file type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="JSONL">JSONL</SelectItem>
+                    <SelectItem value="CSV">CSV</SelectItem>
+                    <SelectItem value="JSON">JSON</SelectItem>
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormDescription>
+                The file format for exported data.
               </FormDescription>
               <FormMessage />
             </FormItem>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add JSON and JSONL support for scheduled blob exports, update schema, and include tests.
> 
>   - **Behavior**:
>     - Adds support for `JSON` and `JSONL` file formats in blob storage exports in `handleBlobStorageIntegrationProjectJob.ts`.
>     - Updates `streamTransformations` in `index.ts` to include `transformStreamToJsonl`.
>     - Adds `transformStreamToJsonl()` in `transformStreamToJsonl.ts` for JSONL transformation.
>   - **Schema and Types**:
>     - Adds `BlobStorageIntegrationFileType` enum with `JSON`, `CSV`, and `JSONL` in `types.ts` and `schema.prisma`.
>     - Updates `BlobStorageIntegration` model in `schema.prisma` to include `fileType` with default `CSV`.
>     - Adds migration `20250402142320_add_blobstorage_integration_file_type` to create enum and alter table.
>   - **Tests**:
>     - Adds tests in `blobStorageIntegrationProcessing.test.ts` to verify handling of `CSV`, `JSON`, and `JSONL` file types.
>   - **Misc**:
>     - Updates `blobstorage-integration-router.ts` and `types.ts` to handle `fileType` in form schema.
>     - Adjusts `package.json` lint warnings limit from 64 to 65.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for da149572fa3b14aa6f37076cc498b8820c537fad. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->