### PR TITLE
perf: reduce search interval for trace existence check

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -82,7 +82,7 @@ export const checkTraceExists = async (
     SELECT 
       t.id as id, 
       t.project_id as project_id
-    FROM traces t 
+    FROM traces t FINAL
     ${observationFilterRes ? `INNER JOIN observations_agg o ON t.id = o.trace_id AND t.project_id = o.project_id` : ""}
     WHERE ${tracesFilterRes.query}
     AND t.project_id = {projectId: String}

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -82,11 +82,12 @@ export const checkTraceExists = async (
     SELECT 
       t.id as id, 
       t.project_id as project_id
-    FROM traces t FINAL 
+    FROM traces t 
     ${observationFilterRes ? `INNER JOIN observations_agg o ON t.id = o.trace_id AND t.project_id = o.project_id` : ""}
     WHERE ${tracesFilterRes.query}
     AND t.project_id = {projectId: String}
     AND timestamp >= {timestamp: DateTime64(3)} - ${TRACE_TO_OBSERVATIONS_INTERVAL}
+    AND timestamp <= {timestamp: DateTime64(3)} + INTERVAL 2 DAY
     GROUP BY t.id, t.project_id
   `;
 

--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -842,7 +842,7 @@ describe("eval service tests", () => {
       expect(jobs.length).toBe(1);
     }, 10_000);
 
-    test("creates eval for trace with timestamp in the future", async () => {
+    test("create eval for trace with timestamp in the near future", async () => {
       const traceId = randomUUID();
 
       await prisma.jobConfiguration.create({
@@ -863,9 +863,7 @@ describe("eval service tests", () => {
       const trace = createTrace({
         project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
         id: traceId,
-        timestamp: new Date(
-          Date.now() + 1000 * 60 * 60 * 24 * 365 * 1,
-        ).getTime(),
+        timestamp: new Date(Date.now() + 1000 * 60 * 60 * 24).getTime(),
       });
 
       await createTracesCh([trace]);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `checkTraceExists` to extend timestamp search interval and adjust related test case.
> 
>   - **Behavior**:
>     - Update `checkTraceExists` in `traces.ts` to include `timestamp <= {timestamp: DateTime64(3)} + INTERVAL 2 DAY` in the SQL query.
>   - **Tests**:
>     - Modify test "create eval for trace with timestamp in the near future" in `evalService.test.ts` to use a timestamp 1 day in the future instead of 1 year.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3e3726fc1b66c3cee425998626a0142aff9fa133. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->