### PR TITLE
feat(playground): allow uppercase in tool / schema names

### DIFF
--- a/web/src/ee/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
+++ b/web/src/ee/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { ArrowUpRight } from "lucide-react";
 import * as z from "zod";
 
 import { Button } from "@/src/components/ui/button";
@@ -24,20 +25,14 @@ import {
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
 import { Textarea } from "@/src/components/ui/textarea";
+import { LLMSchemaNameSchema } from "@/src/features/llm-schemas/validation";
 import { api } from "@/src/utils/api";
 
 import { JSONSchemaFormSchema, type LlmSchema } from "@langfuse/shared";
 import { CodeMirrorEditor } from "@/src/components/editor";
-import { ArrowUpRight } from "lucide-react";
 
 const formSchema = z.object({
-  name: z
-    .string()
-    .regex(
-      /^[a-zA-Z0-9_-]+$/,
-      "Name must contain only alphanumeric letters, hyphens and underscores",
-    )
-    .min(1, "Name is required"),
+  name: LLMSchemaNameSchema,
   description: z.string().min(1, "Description is required"),
   schema: JSONSchemaFormSchema,
 });

--- a/web/src/ee/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
+++ b/web/src/ee/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
@@ -34,8 +34,8 @@ const formSchema = z.object({
   name: z
     .string()
     .regex(
-      /^[a-z0-9_-]+$/,
-      "Name must contain only lowercase letters, numbers, hyphens and underscores",
+      /^[a-zA-Z0-9_-]+$/,
+      "Name must contain only alphanumeric letters, hyphens and underscores",
     )
     .min(1, "Name is required"),
   description: z.string().min(1, "Description is required"),

--- a/web/src/ee/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
+++ b/web/src/ee/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
@@ -34,8 +34,8 @@ const formSchema = z.object({
   name: z
     .string()
     .regex(
-      /^[a-z0-9_-]+$/,
-      "Name must contain only lowercase letters, numbers, hyphens and underscores",
+      /^[a-zA-Z0-9_-]+$/,
+      "Name must contain only alphanumeric letters, hyphens and underscores",
     )
     .min(1, "Name is required"),
   description: z.string().min(1, "Description is required"),

--- a/web/src/ee/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
+++ b/web/src/ee/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { ArrowUpRight } from "lucide-react";
 import * as z from "zod";
 
 import { Button } from "@/src/components/ui/button";
@@ -24,20 +25,14 @@ import {
 } from "@/src/components/ui/form";
 import { Input } from "@/src/components/ui/input";
 import { Textarea } from "@/src/components/ui/textarea";
+import { LLMToolNameSchema } from "@/src/features/llm-tools/validation";
 import { api } from "@/src/utils/api";
 
 import { CodeMirrorEditor } from "@/src/components/editor";
 import { JSONSchemaFormSchema, type LlmTool } from "@langfuse/shared";
-import { ArrowUpRight } from "lucide-react";
 
 const formSchema = z.object({
-  name: z
-    .string()
-    .regex(
-      /^[a-zA-Z0-9_-]+$/,
-      "Name must contain only alphanumeric letters, hyphens and underscores",
-    )
-    .min(1, "Name is required"),
+  name: LLMToolNameSchema,
   description: z.string().min(1, "Description is required"),
   parameters: JSONSchemaFormSchema,
 });

--- a/web/src/features/llm-schemas/validation.ts
+++ b/web/src/features/llm-schemas/validation.ts
@@ -5,8 +5,8 @@ export const LLMSchemaInput = z.object({
   name: z
     .string()
     .regex(
-      /^[a-z0-9_-]+$/,
-      "Name must contain only lowercase letters, numbers, hyphens and underscores",
+      /^[a-zA-Z0-9_-]+$/,
+      "Name must contain only alphanumeric letters, hyphens and underscores",
     )
     .min(1, "Name is required"),
   description: z.string(),

--- a/web/src/features/llm-schemas/validation.ts
+++ b/web/src/features/llm-schemas/validation.ts
@@ -1,14 +1,16 @@
 import { z } from "zod";
 import { LLMJSONSchema } from "@langfuse/shared";
 
+export const LLMSchemaNameSchema = z
+  .string()
+  .regex(
+    /^[a-zA-Z0-9_-]+$/,
+    "Name must contain only alphanumeric letters, hyphens and underscores",
+  )
+  .min(1, "Name is required");
+
 export const LLMSchemaInput = z.object({
-  name: z
-    .string()
-    .regex(
-      /^[a-zA-Z0-9_-]+$/,
-      "Name must contain only alphanumeric letters, hyphens and underscores",
-    )
-    .min(1, "Name is required"),
+  name: LLMSchemaNameSchema,
   description: z.string(),
   schema: LLMJSONSchema,
 });

--- a/web/src/features/llm-tools/validation.ts
+++ b/web/src/features/llm-tools/validation.ts
@@ -1,14 +1,16 @@
 import { z } from "zod";
 import { LLMJSONSchema } from "@langfuse/shared";
 
+export const LLMToolNameSchema = z
+  .string()
+  .regex(
+    /^[a-zA-Z0-9_-]+$/,
+    "Name must contain only alphanumeric letters, hyphens and underscores",
+  )
+  .min(1, "Name is required");
+
 export const LLMToolInput = z.object({
-  name: z
-    .string()
-    .regex(
-      /^[a-zA-Z0-9_-]+$/,
-      "Name must contain only alphanumeric letters, hyphens and underscores",
-    )
-    .min(1, "Name is required"),
+  name: LLMToolNameSchema,
   description: z.string(),
   parameters: LLMJSONSchema,
 });

--- a/web/src/features/llm-tools/validation.ts
+++ b/web/src/features/llm-tools/validation.ts
@@ -5,8 +5,8 @@ export const LLMToolInput = z.object({
   name: z
     .string()
     .regex(
-      /^[a-z0-9_-]+$/,
-      "Name must contain only lowercase letters, numbers, hyphens and underscores",
+      /^[a-zA-Z0-9_-]+$/,
+      "Name must contain only alphanumeric letters, hyphens and underscores",
     )
     .min(1, "Name is required"),
   description: z.string(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Allow uppercase letters in tool and schema names by updating validation schemas.
> 
>   - **Validation**:
>     - Updated `LLMSchemaNameSchema` and `LLMToolNameSchema` in `validation.ts` files to allow uppercase letters in names.
>     - Replaced inline regex with `LLMSchemaNameSchema` in `CreateOrEditLLMSchemaDialog.tsx`.
>     - Replaced inline regex with `LLMToolNameSchema` in `CreateOrEditLLMToolDialog.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 32bbfff2fa1c7db952764de27cb5b5479118d827. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->