### PR TITLE
style(ui): reduce text size of trace/observation name on detail

### DIFF
--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -126,7 +126,7 @@ export const ObservationPreview = ({
             <div className="mt-1.5">
               <ItemBadge type={preloadedObservation.type} isSmall />
             </div>
-            <span className="mb-0 line-clamp-2 min-w-0 break-all text-lg font-medium md:break-normal md:break-words">
+            <span className="mb-0 line-clamp-2 min-w-0 break-all font-medium md:break-normal md:break-words">
               {preloadedObservation.name}
             </span>
           </div>

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -110,7 +110,7 @@ export const TracePreview = ({
             <div className="mt-1.5">
               <ItemBadge type="TRACE" isSmall />
             </div>
-            <span className="mb-0 line-clamp-2 min-w-0 break-all text-lg font-medium md:break-normal md:break-words">
+            <span className="mb-0 line-clamp-2 min-w-0 break-all font-medium md:break-normal md:break-words">
               {trace.name}
             </span>
           </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce text size of trace and observation names in `ObservationPreview.tsx` and `TracePreview.tsx` by removing `text-lg` class.
> 
>   - **Styling Changes**:
>     - Remove `text-lg` class from `span` elements displaying `preloadedObservation.name` in `ObservationPreview.tsx` and `trace.name` in `TracePreview.tsx` to reduce text size.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 52f152ad243bf862fe1325ec26ebe6b7252a7bb7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->