### PR TITLE
fix(auth): block duplicate membership invites that lead to sign in issues

### DIFF
--- a/packages/shared/prisma/migrations/20250403153555_membership_invitations_no_duplicates/migration.sql
+++ b/packages/shared/prisma/migrations/20250403153555_membership_invitations_no_duplicates/migration.sql
@@ -1,0 +1,17 @@
+-- Delete duplicate membership invitations, keeping only the newest one for each email and org_id combination
+WITH ranked_invitations AS (
+  SELECT 
+    id,
+    email,
+    org_id,
+    ROW_NUMBER() OVER (PARTITION BY email, org_id ORDER BY updated_at DESC) as rn
+  FROM membership_invitations
+)
+DELETE FROM membership_invitations
+WHERE id IN (
+  SELECT id FROM ranked_invitations WHERE rn > 1
+);
+
+
+-- CreateIndex
+CREATE UNIQUE INDEX "membership_invitations_email_org_id_key" ON "membership_invitations"("email", "org_id");

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -257,6 +257,7 @@ model MembershipInvitation {
   createdAt       DateTime     @default(now()) @map("created_at")
   updatedAt       DateTime     @default(now()) @updatedAt @map("updated_at")
 
+  @@unique([email, orgId]) // do not include projectId as this leads to issues when processing the invites, needs new logic
   @@index([projectId])
   @@index([orgId])
   @@index([email])


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix duplicate membership invitations by adding unique constraints and handling errors in `membersRouter.ts`.
> 
>   - **Database Changes**:
>     - Add migration `20250403153555_membership_invitations_no_duplicates/migration.sql` to delete duplicate membership invitations, keeping only the newest for each `email` and `org_id`.
>     - Create unique index `membership_invitations_email_org_id_key` on `membership_invitations` table.
>   - **Schema Changes**:
>     - Add unique constraint `@@unique([email, orgId])` to `MembershipInvitation` model in `schema.prisma`.
>   - **Error Handling**:
>     - In `membersRouter.ts`, wrap membership invitation creation in a `try-catch` block to handle `P2002` error, throwing a `TRPCError` if a duplicate invitation exists.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 727f1761fdd2b8860b4e588859ef7b83dd2dc172. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->