### PR TITLE
fix: include tag filtering support on dashboard

### DIFF
--- a/web/src/__tests__/queryBuilder.servertest.ts
+++ b/web/src/__tests__/queryBuilder.servertest.ts
@@ -523,6 +523,292 @@ describe("queryBuilder", () => {
         expect(fewObsTrace.sum_observations_count).toBe("2");
       });
 
+      it("should use tags as dimension", async () => {
+        // Setup
+        const projectId = randomUUID();
+        const tracesData = [
+          { name: "trace-with-tag-a", tags: ["tag-a", "common-tag"] },
+          { name: "trace-with-tag-b", tags: ["tag-b", "common-tag"] },
+          { name: "trace-with-tag-c", tags: ["tag-c"] },
+          { name: "trace-with-no-tags", tags: [] },
+        ];
+
+        // Create traces with custom tags
+        const traces = [];
+        for (const data of tracesData) {
+          traces.push(
+            createTrace({
+              project_id: projectId,
+              name: data.name,
+              tags: data.tags,
+              timestamp: new Date().getTime(),
+            }),
+          );
+        }
+        await createTracesCh(traces);
+
+        // Define query with a filter for tags using "any of" operator
+        const query: QueryType = {
+          view: "traces",
+          dimensions: [{ field: "tags" }],
+          metrics: [{ measure: "count", aggregation: "count" }],
+          filters: [],
+          timeDimension: null,
+          fromTimestamp: new Date(
+            new Date().setDate(new Date().getDate() - 1),
+          ).toISOString(),
+          toTimestamp: new Date(
+            new Date().setDate(new Date().getDate() + 1),
+          ).toISOString(),
+          orderBy: null,
+        };
+
+        // Execute query
+        const queryBuilder = new QueryBuilder();
+        const { query: compiledQuery, parameters } = queryBuilder.build(
+          query,
+          projectId,
+        );
+        const result = await (
+          await clickhouseClient().query({
+            query: compiledQuery,
+            query_params: parameters,
+          })
+        ).json();
+
+        expect(result.data).toHaveLength(4);
+        // Expect one entry for all so index order does not matter
+        expect(result.data[0].count_count).toBe("1");
+      });
+
+      it("should filter traces by tags using 'any of' operator", async () => {
+        // Setup
+        const projectId = randomUUID();
+        const tracesData = [
+          { name: "trace-with-tag-a", tags: ["tag-a", "common-tag"] },
+          { name: "trace-with-tag-b", tags: ["tag-b", "common-tag"] },
+          { name: "trace-with-tag-c", tags: ["tag-c"] },
+          { name: "trace-with-no-tags", tags: [] },
+        ];
+
+        // Create traces with custom tags
+        const traces = [];
+        for (const data of tracesData) {
+          traces.push(
+            createTrace({
+              project_id: projectId,
+              name: data.name,
+              tags: data.tags,
+              timestamp: new Date().getTime(),
+            }),
+          );
+        }
+        await createTracesCh(traces);
+
+        // Define query with a filter for tags using "any of" operator
+        const query: QueryType = {
+          view: "traces",
+          dimensions: [{ field: "name" }],
+          metrics: [{ measure: "count", aggregation: "count" }],
+          filters: [
+            {
+              column: "tags",
+              operator: "any of",
+              value: ["tag-a", "tag-b"],
+              type: "arrayOptions",
+            },
+          ],
+          timeDimension: null,
+          fromTimestamp: new Date(
+            new Date().setDate(new Date().getDate() - 1),
+          ).toISOString(),
+          toTimestamp: new Date(
+            new Date().setDate(new Date().getDate() + 1),
+          ).toISOString(),
+          orderBy: null,
+        };
+
+        // Execute query
+        const queryBuilder = new QueryBuilder();
+        const { query: compiledQuery, parameters } = queryBuilder.build(
+          query,
+          projectId,
+        );
+        const result = await (
+          await clickhouseClient().query({
+            query: compiledQuery,
+            query_params: parameters,
+          })
+        ).json();
+
+        // Assert - should only return traces with tag-a or tag-b
+        expect(result.data).toHaveLength(2);
+
+        // Find and verify each trace
+        const traceWithTagA = result.data.find(
+          (row: any) => row.name === "trace-with-tag-a",
+        );
+        expect(traceWithTagA).toBeDefined();
+        expect(traceWithTagA.count_count).toBe("1");
+
+        const traceWithTagB = result.data.find(
+          (row: any) => row.name === "trace-with-tag-b",
+        );
+        expect(traceWithTagB).toBeDefined();
+        expect(traceWithTagB.count_count).toBe("1");
+      });
+
+      it("should filter traces by tags using 'all of' operator", async () => {
+        // Setup
+        const projectId = randomUUID();
+        const tracesData = [
+          {
+            name: "trace-with-multiple-tags",
+            tags: ["tag-a", "tag-b", "common-tag"],
+          },
+          { name: "trace-with-tag-a-only", tags: ["tag-a", "common-tag"] },
+          { name: "trace-with-tag-b-only", tags: ["tag-b", "common-tag"] },
+          { name: "trace-with-other-tags", tags: ["tag-c", "common-tag"] },
+        ];
+
+        // Create traces with custom tags
+        const traces = [];
+        for (const data of tracesData) {
+          traces.push(
+            createTrace({
+              project_id: projectId,
+              name: data.name,
+              tags: data.tags,
+              timestamp: new Date().getTime(),
+            }),
+          );
+        }
+        await createTracesCh(traces);
+
+        // Define query with a filter for tags using "all of" operator
+        const query: QueryType = {
+          view: "traces",
+          dimensions: [{ field: "name" }],
+          metrics: [{ measure: "count", aggregation: "count" }],
+          filters: [
+            {
+              column: "tags",
+              operator: "all of",
+              value: ["tag-a", "tag-b"],
+              type: "arrayOptions",
+            },
+          ],
+          timeDimension: null,
+          fromTimestamp: new Date(
+            new Date().setDate(new Date().getDate() - 1),
+          ).toISOString(),
+          toTimestamp: new Date(
+            new Date().setDate(new Date().getDate() + 1),
+          ).toISOString(),
+          orderBy: null,
+        };
+
+        // Execute query
+        const queryBuilder = new QueryBuilder();
+        const { query: compiledQuery, parameters } = queryBuilder.build(
+          query,
+          projectId,
+        );
+        const result = await (
+          await clickhouseClient().query({
+            query: compiledQuery,
+            query_params: parameters,
+          })
+        ).json();
+
+        // Assert - should only return traces with both tag-a and tag-b
+        expect(result.data).toHaveLength(1);
+
+        // Verify the trace has both tags
+        expect(result.data[0].name).toBe("trace-with-multiple-tags");
+        expect(result.data[0].count_count).toBe("1");
+      });
+
+      it("should filter traces by tags using 'none of' operator", async () => {
+        // Setup
+        const projectId = randomUUID();
+        const tracesData = [
+          { name: "trace-with-tag-a", tags: ["tag-a", "common-tag"] },
+          { name: "trace-with-tag-b", tags: ["tag-b", "common-tag"] },
+          {
+            name: "trace-with-other-tags",
+            tags: ["tag-c", "tag-d", "common-tag"],
+          },
+          { name: "trace-with-no-tags", tags: [] },
+        ];
+
+        // Create traces with custom tags
+        const traces = [];
+        for (const data of tracesData) {
+          traces.push(
+            createTrace({
+              project_id: projectId,
+              name: data.name,
+              tags: data.tags,
+              timestamp: new Date().getTime(),
+            }),
+          );
+        }
+        await createTracesCh(traces);
+
+        // Define query with a filter for tags using "none of" operator
+        const query: QueryType = {
+          view: "traces",
+          dimensions: [{ field: "name" }],
+          metrics: [{ measure: "count", aggregation: "count" }],
+          filters: [
+            {
+              column: "tags",
+              operator: "none of",
+              value: ["tag-a", "tag-b"],
+              type: "arrayOptions",
+            },
+          ],
+          timeDimension: null,
+          fromTimestamp: new Date(
+            new Date().setDate(new Date().getDate() - 1),
+          ).toISOString(),
+          toTimestamp: new Date(
+            new Date().setDate(new Date().getDate() + 1),
+          ).toISOString(),
+          orderBy: null,
+        };
+
+        // Execute query
+        const queryBuilder = new QueryBuilder();
+        const { query: compiledQuery, parameters } = queryBuilder.build(
+          query,
+          projectId,
+        );
+        const result = await (
+          await clickhouseClient().query({
+            query: compiledQuery,
+            query_params: parameters,
+          })
+        ).json();
+
+        // Assert - should only return traces without tag-a or tag-b
+        expect(result.data).toHaveLength(2);
+
+        // Find and verify each trace
+        const traceWithOtherTags = result.data.find(
+          (row: any) => row.name === "trace-with-other-tags",
+        );
+        expect(traceWithOtherTags).toBeDefined();
+        expect(traceWithOtherTags.count_count).toBe("1");
+
+        const traceWithNoTags = result.data.find(
+          (row: any) => row.name === "trace-with-no-tags",
+        );
+        expect(traceWithNoTags).toBeDefined();
+        expect(traceWithNoTags.count_count).toBe("1");
+      });
+
       it("should group by environment and calculate metrics correctly", async () => {
         // Setup
         const projectId = randomUUID();

--- a/web/src/features/query/dashboardUiTableToViewMapping.ts
+++ b/web/src/features/query/dashboardUiTableToViewMapping.ts
@@ -11,6 +11,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       viewName: "name",
     },
     {
+      uiTableName: "Tags",
+      viewName: "tags",
+    },
+    {
       uiTableName: "User",
       viewName: "userId",
     },
@@ -33,6 +37,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       viewName: "type",
     },
     {
+      uiTableName: "Tags",
+      viewName: "tags",
+    },
+    {
       uiTableName: "Model",
       viewName: "providedModelName",
     },
@@ -50,6 +58,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       uiTableName: "Scores Data Type",
       viewName: "dataType",
     },
+    {
+      uiTableName: "Tags",
+      viewName: "tags",
+    },
   ],
   "scores-categorical": [
     {
@@ -63,6 +75,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
     {
       uiTableName: "Scores Data Type",
       viewName: "dataType",
+    },
+    {
+      uiTableName: "Tags",
+      viewName: "tags",
     },
   ],
 };

--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -19,6 +19,10 @@ export const traceView: ViewDeclarationType = {
       sql: "name",
       type: "string",
     },
+    tags: {
+      sql: "tags",
+      type: "string[]",
+    },
     userId: {
       sql: "user_id",
       type: "string",
@@ -125,6 +129,11 @@ export const observationsView: ViewDeclarationType = {
       sql: "version",
       type: "string",
     },
+    tags: {
+      sql: "tags",
+      type: "string[]",
+      relationTable: "traces",
+    },
     providedModelName: {
       sql: "provided_model_name",
       type: "string",
@@ -229,6 +238,11 @@ const scoreBaseDimensions: DimensionsDeclarationType = {
     sql: "name",
     alias: "trace_name",
     type: "string",
+    relationTable: "traces",
+  },
+  tags: {
+    sql: "tags",
+    type: "string[]",
     relationTable: "traces",
   },
   userId: {

--- a/web/src/features/query/types.ts
+++ b/web/src/features/query/types.ts
@@ -14,7 +14,7 @@ export const viewDeclaration = z.object({
     z.object({
       sql: z.string(),
       alias: z.string().optional(),
-      type: z.enum(["string", "number", "bool"]),
+      type: z.enum(["string", "number", "bool", "string[]"]),
       relationTable: z.string().optional(),
     }),
   ),


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/6334
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds tag filtering support to dashboard queries and updates data models and view mappings to include tags as a dimension.
> 
>   - **Behavior**:
>     - Adds tag filtering support in `queryBuilder.servertest.ts` with operators: 'any of', 'all of', 'none of'.
>     - Updates `dashboardUiTableToViewMapping.ts` to map 'Tags' to 'tags' in views: `traces`, `observations`, `scores-numeric`, `scores-categorical`.
>   - **Models**:
>     - Adds `tags` dimension to `traceView`, `observationsView`, and `scoreBaseDimensions` in `dataModel.ts`.
>   - **Types**:
>     - Updates `viewDeclaration` in `types.ts` to include `string[]` type for dimensions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a5010e4f759dd928f3d3b77afae5109fefc4ef30. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->