### PR TITLE
fix: improve parsing of tags for otel endpoint

### DIFF
--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -874,6 +874,60 @@ describe("OTel Resource Span Mapping", () => {
           entityAttributeValue: "premium",
         },
       ],
+      [
+        "should extract tags from single string from langfuse.tags to trace",
+        {
+          entity: "trace",
+          otelAttributeKey: "langfuse.tags",
+          otelAttributeValue: {
+            stringValue: "2",
+          },
+          entityAttributeKey: "tags",
+          entityAttributeValue: ["2"],
+        },
+      ],
+      [
+        "should extract array input on trace event attributes",
+        {
+          entity: "trace",
+          otelAttributeKey: "langfuse.tags",
+          otelAttributeValue: {
+            arrayValue: {
+              values: [
+                {
+                  stringValue: "2",
+                },
+              ],
+            },
+          },
+          entityAttributeKey: "tags",
+          entityAttributeValue: ["2"],
+        },
+      ],
+      [
+        "should extract array input tags to trace",
+        {
+          entity: "trace",
+          otelAttributeKey: "langfuse.tags",
+          otelAttributeValue: {
+            stringValue: '["2"]',
+          },
+          entityAttributeKey: "tags",
+          entityAttributeValue: ["2"],
+        },
+      ],
+      [
+        "should extract array csv input tags to trace",
+        {
+          entity: "trace",
+          otelAttributeKey: "langfuse.tags",
+          otelAttributeValue: {
+            stringValue: "2,3,4",
+          },
+          entityAttributeKey: "tags",
+          entityAttributeValue: ["2", "3", "4"],
+        },
+      ],
     ])(
       "Attributes: %s",
       (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `extractTags()` to handle various tag formats for OTel endpoint and updates tests in `otelMapping.servertest.ts`.
> 
>   - **Behavior**:
>     - Adds `extractTags()` function in `index.ts` to handle tag extraction from `langfuse.tags` attribute.
>     - Supports array, JSON string, CSV string, and single string formats for tags.
>   - **Tests**:
>     - Adds test cases in `otelMapping.servertest.ts` to verify tag extraction from various input formats.
>     - Tests include single string, array input, JSON string array, and CSV string formats.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0b101c234b449b4352dbc52542dad4abc53a9f9f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->