### PR TITLE
security: upgrade nextjs 14.2.26

### DIFF
--- a/ee/package.json
+++ b/ee/package.json
@@ -28,7 +28,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.10.0",
     "axios": "^1.8.2",
     "https-proxy-agent": "^7.0.6",
-    "next": "^14.2.25",
+    "next": "^14.2.26",
     "next-auth": "^4.24.11",
     "zod": "^3.23.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
         specifier: ^7.0.6
         version: 7.0.6
       next:
-        specifier: ^14.2.25
+        specifier: ^14.2.26
         version: 14.2.26(@babel/core@7.24.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-auth:
         specifier: ^4.24.11
@@ -602,7 +602,7 @@ importers:
         specifier: ^0.447.0
         version: 0.447.0(react@18.2.0)
       next:
-        specifier: ^14.2.25
+        specifier: ^14.2.26
         version: 14.2.26(@babel/core@7.24.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-auth:
         specifier: ^4.24.11

--- a/web/package.json
+++ b/web/package.json
@@ -117,7 +117,7 @@
     "langchain": "^0.3.6",
     "lodash": "^4.17.21",
     "lucide-react": "^0.447.0",
-    "next": "^14.2.25",
+    "next": "^14.2.26",
     "next-auth": "^4.24.11",
     "next-query-params": "^5.0.1",
     "next-themes": "^0.3.0",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Upgrade `next` to version `^14.2.26` in `ee/package.json` and `web/package.json` for security.
> 
>   - **Dependencies**:
>     - Upgrade `next` from `^14.2.25` to `^14.2.26` in `ee/package.json` and `web/package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a43d2e86d80ba509809e0d2e8c72139fa9a7f75e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->