### PR TITLE
chore: Increase delete queue processing observability

### DIFF
--- a/web/src/__e2e__/create-project.spec.ts
+++ b/web/src/__e2e__/create-project.spec.ts
@@ -120,7 +120,7 @@ test.describe("Create project", () => {
       await page.waitForTimeout(2000);
 
       const projectUrl = await getProjectUrlForEmail("demo@langfuse.com");
-      await page.goto(projectUrl + url);
+      await page.goto(projectUrl + url, { waitUntil: "networkidle" });
       await page.waitForTimeout(2000);
       await expect(page).toHaveURL(projectUrl + url);
       await checkPageHeaderTitle(page, title);

--- a/worker/src/queues/projectDelete.ts
+++ b/worker/src/queues/projectDelete.ts
@@ -4,6 +4,7 @@ import {
   deleteObservationsByProjectId,
   deleteScoresByProjectId,
   deleteTracesByProjectId,
+  getCurrentSpan,
   getEventLogByProjectId,
   logger,
   QueueName,
@@ -51,6 +52,20 @@ export const projectDeleteProcessor: Processor = async (
   job: Job<TQueueJobTypes[QueueName.ProjectDelete]>,
 ): Promise<void> => {
   const { orgId, projectId } = job.data.payload;
+
+  const span = getCurrentSpan();
+  if (span) {
+    span.setAttribute("messaging.bullmq.job.input.id", job.data.id);
+    span.setAttribute(
+      "messaging.bullmq.job.input.projectId",
+      job.data.payload.projectId,
+    );
+    span.setAttribute(
+      "messaging.bullmq.job.input.orgId",
+      job.data.payload.orgId,
+    );
+  }
+
   logger.info(`Deleting ${projectId} in org ${orgId}`);
 
   // Delete media data from S3 for project


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves observability in `projectDelete.ts` by adding span attributes and updates `create-project.spec.ts` to ensure page load completion.
> 
>   - **Observability**:
>     - In `projectDelete.ts`, added span attributes for `job.input.id`, `job.input.projectId`, and `job.input.orgId` using `getCurrentSpan()` to improve tracing.
>   - **Testing**:
>     - In `create-project.spec.ts`, updated `page.goto()` to use `{ waitUntil: "networkidle" }` to ensure page load completion before proceeding.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8424ac5de8d811d24d0be53fca3639b34dc23bdc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->