### PR TITLE
chore: Increase project deletion retries

### DIFF
--- a/packages/shared/src/server/redis/projectDelete.ts
+++ b/packages/shared/src/server/redis/projectDelete.ts
@@ -26,7 +26,7 @@ export class ProjectDeleteQueue {
             defaultJobOptions: {
               removeOnComplete: true,
               removeOnFail: 100_000,
-              attempts: 5,
+              attempts: 10,
               delay: 60_000, // 1 minute
               backoff: {
                 type: "exponential",

--- a/web/src/__e2e__/create-project.spec.ts
+++ b/web/src/__e2e__/create-project.spec.ts
@@ -120,7 +120,7 @@ test.describe("Create project", () => {
       await page.waitForTimeout(2000);
 
       const projectUrl = await getProjectUrlForEmail("demo@langfuse.com");
-      await page.goto(projectUrl + url);
+      await page.goto(projectUrl + url, { waitUntil: "networkidle" });
       await page.waitForTimeout(2000);
       await expect(page).toHaveURL(projectUrl + url);
       await checkPageHeaderTitle(page, title);

--- a/worker/src/queues/projectDelete.ts
+++ b/worker/src/queues/projectDelete.ts
@@ -4,6 +4,7 @@ import {
   deleteObservationsByProjectId,
   deleteScoresByProjectId,
   deleteTracesByProjectId,
+  getCurrentSpan,
   getEventLogByProjectId,
   logger,
   QueueName,
@@ -51,6 +52,20 @@ export const projectDeleteProcessor: Processor = async (
   job: Job<TQueueJobTypes[QueueName.ProjectDelete]>,
 ): Promise<void> => {
   const { orgId, projectId } = job.data.payload;
+
+  const span = getCurrentSpan();
+  if (span) {
+    span.setAttribute("messaging.bullmq.job.input.id", job.data.id);
+    span.setAttribute(
+      "messaging.bullmq.job.input.projectId",
+      job.data.payload.projectId,
+    );
+    span.setAttribute(
+      "messaging.bullmq.job.input.orgId",
+      job.data.payload.orgId,
+    );
+  }
+
   logger.info(`Deleting ${projectId} in org ${orgId}`);
 
   // Delete media data from S3 for project


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase project deletion retry attempts and add tracing attributes for better observability, with test improvements for navigation reliability.
> 
>   - **Behavior**:
>     - Increase `attempts` from 5 to 10 in `ProjectDeleteQueue` in `projectDelete.ts`.
>     - Add tracing attributes in `projectDeleteProcessor` in `projectDelete.ts` for job ID, project ID, and org ID.
>   - **Tests**:
>     - Modify `create-project.spec.ts` to use `{ waitUntil: "networkidle" }` when navigating to project URLs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a3e7f758f65d35e6c7668423d992ff691a5bc2ce. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->