### PR TITLE
fix(ui): prevent prompt label popover from rendering off-screen (#6311)

### DIFF
--- a/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
+++ b/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
@@ -143,12 +143,7 @@ export function SetPromptVersionLabels({
         </div>
       </PopoverTrigger>
       <PopoverContent
-        className="fixed max-h-[50vh] overflow-y-auto"
-        style={{
-          top: "var(--popover-top)",
-          left: "var(--popover-left)",
-          transform: "none",
-        }}
+        className="max-h-[50vh] overflow-y-auto"
       >
         <div
           onClick={(event) => event.stopPropagation()}


### PR DESCRIPTION

## What does this PR do?

Fixes the prompt label popover UI issue where the window appears outside the viewport when trying to add labels to prompts at the top of a long list. By removing custom positioning styles, the Radix UI's built-in positioning logic now keeps the popover within screen boundaries.

**Before:**
```tsx
<PopoverContent
  className="fixed max-h-[50vh] overflow-y-auto"
  style={{
    top: "var(--popover-top)",
    left: "var(--popover-left)",
    transform: "none",
  }}
>
  {/* content */}
</PopoverContent>
```

**After:**
```tsx
<PopoverContent
  className="max-h-[50vh] overflow-y-auto"
>
  {/* content */}
</PopoverContent>
```

The custom positioning was preventing Radix UI from applying its built-in positioning logic that keeps popovers within the viewport.

Fixes #6311

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project (`npm run prettier`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`npm run lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked if new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes off-screen rendering of prompt label popover by removing custom positioning styles in `index.tsx`.
> 
>   - **UI Fix**:
>     - Removes custom positioning styles from `PopoverContent` in `index.tsx`.
>     - Allows Radix UI's built-in logic to keep popover within viewport.
>   - **Behavior**:
>     - Fixes issue where prompt label popover rendered off-screen when adding labels to prompts at the top of a long list.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 90cf8a5a8f5499e931e7c7bd0d9a4e1103c04edb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->