### PR TITLE
perf: retry failed S3 deletions

### DIFF
--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -541,7 +541,7 @@ class S3StorageService implements StorageService {
         const result = await this.client.send(command);
         if (result?.Errors && result?.Errors?.length > 0) {
           const errors = result.Errors.map((e) => e.Key).join(", ");
-          logger.error(`ailed to delete files from S3: ${errors} `, {
+          logger.error(`Failed to delete files from S3: ${errors} `, {
             errors: result.Errors,
           });
           throw new Error(`Failed to delete files from S3: ${errors}`);

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -17,6 +17,7 @@ import {
 import { Storage, Bucket, GetSignedUrlConfig } from "@google-cloud/storage";
 import { logger } from "../logger";
 import { env } from "../../env";
+import { backOff } from "exponential-backoff";
 
 type UploadFile = {
   fileName: string;
@@ -241,6 +242,12 @@ class AzureBlobStorageService implements StorageService {
   }
 
   public async deleteFiles(paths: string[]): Promise<void> {
+    await backOff(() => this.deleteFileNonRetrying(paths), {
+      numOfAttempts: 3,
+    });
+  }
+
+  async deleteFileNonRetrying(paths: string[]): Promise<void> {
     try {
       await this.createContainerIfNotExists();
 
@@ -509,6 +516,12 @@ class S3StorageService implements StorageService {
   }
 
   public async deleteFiles(paths: string[]): Promise<void> {
+    await backOff(() => this.deleteFilesNonRetrying(paths), {
+      numOfAttempts: 3,
+    });
+  }
+
+  async deleteFilesNonRetrying(paths: string[]): Promise<void> {
     const chunkSize = 900;
     const chunks = [];
 
@@ -527,10 +540,11 @@ class S3StorageService implements StorageService {
         });
         const result = await this.client.send(command);
         if (result?.Errors && result?.Errors?.length > 0) {
-          logger.error("Failed to delete files from S3", {
+          const errors = result.Errors.map((e) => e.Key).join(", ");
+          logger.error(`ailed to delete files from S3: ${errors} `, {
             errors: result.Errors,
           });
-          throw new Error("Failed to delete files from S3");
+          throw new Error(`Failed to delete files from S3: ${errors}`);
         }
       }
     } catch (err) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds retry logic with exponential backoff for failed S3 and Azure Blob Storage deletions, improving error logging.
> 
>   - **Behavior**:
>     - Adds retry logic with exponential backoff for `deleteFiles()` in `AzureBlobStorageService` and `S3StorageService`.
>     - Retries up to 3 times on failure.
>   - **Logging**:
>     - Logs specific file keys that failed to delete in `S3StorageService`.
>     - Improves error message clarity by including specific file keys in `S3StorageService`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e403340277bfaf3516a15a92462862ec39787e11. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->