### PR TITLE
fix(scores/trpc): byid on deleted score resulted in 5xx error instead of 404

### DIFF
--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -142,9 +142,10 @@ export const scoresRouter = createTRPCRouter({
     .query(async ({ input }) => {
       const score = await getScoreById(input.projectId, input.scoreId);
       if (!score) {
-        throw new LangfuseNotFoundError(
-          `No score with id ${input.scoreId} in project ${input.projectId} in Clickhouse`,
-        );
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `No score with id ${input.scoreId} in project ${input.projectId} in Clickhouse`,
+        });
       }
       return score;
     }),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces `LangfuseNotFoundError` with `TRPCError` in `scores.ts` to return 404 instead of 5xx for missing scores.
> 
>   - **Error Handling**:
>     - Replaces `LangfuseNotFoundError` with `TRPCError` in `byId` query in `scores.ts` to return a 404 error instead of a 5xx error when a score is not found.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e958e2ff3369257af00339c1f91aa5e382d8e05e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->