### PR TITLE
Update azure openai api version to 2025-02-01-preview

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -439,8 +439,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ghcr.io/langfuse/langfuse # GitHub
-            langfuse/langfuse # Docker Hub
+            ghcr.io/Mostafa-Goher/langfuse # GitHub
+            mostafagoher/langfuse # Docker Hub
           flavor: |
             latest=false
           tags: |
@@ -467,8 +467,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ghcr.io/langfuse/langfuse-worker # GitHub
-            langfuse/langfuse-worker # Docker Hub
+            ghcr.io/Mostafa-Goher/langfuse-worker # GitHub
+            mostafagoher/langfuse-worker # Docker Hub
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -170,7 +170,7 @@ export async function fetchLLMCompletion(
       azureOpenAIApiKey: apiKey,
       azureOpenAIBasePath: baseURL,
       azureOpenAIApiDeploymentName: modelParams.model,
-      azureOpenAIApiVersion: "2024-02-01",
+      azureOpenAIApiVersion: "2025-02-01-preview",
       temperature: modelParams.temperature,
       maxTokens: modelParams.max_tokens,
       topP: modelParams.top_p,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,8 +163,8 @@ importers:
         specifier: ^0.3.18
         version: 0.3.18(openai@4.72.0(zod@3.23.8))
       '@langchain/openai':
-        specifier: ^0.3.14
-        version: 0.3.14(@langchain/core@0.3.18(openai@4.72.0(zod@3.23.8)))
+        specifier: ^0.5.5
+        version: 0.5.5(@langchain/core@0.3.18(openai@4.72.0(zod@3.23.8)))
       '@opentelemetry/api':
         specifier: '>=1.0.0 <1.10.0'
         version: 1.9.0

--- a/web/package.json
+++ b/web/package.json
@@ -37,7 +37,7 @@
     "@hookform/resolvers": "^3.3.4",
     "@langchain/anthropic": "^0.3.8",
     "@langchain/core": "^0.3.18",
-    "@langchain/openai": "^0.3.14",
+    "@langchain/openai": "^0.5.5",
     "@langfuse/ee": "workspace:*",
     "@langfuse/shared": "workspace:*",
     "@marsidev/react-turnstile": "^0.5.4",


### PR DESCRIPTION
## What does this PR do?

update azure openai api version to 2025-02-01-preview
Fixes #5936

## Type of change
- Bug fix (non-breaking change which fixes an issue)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates Azure OpenAI API version to `2025-02-01-preview` in `fetchLLMCompletion.ts`, fixing issue #5936.
> 
>   - **API Version Update**:
>     - Updates `azureOpenAIApiVersion` to `2025-02-01-preview` in `fetchLLMCompletion.ts`.
>   - **Issue Fix**:
>     - Fixes issue #5936 by updating the API version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ba0bb4616975ad56d02944198b32a3eda7744737. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->