### PR TITLE
fix: propagate userId correctly to downstream tables

### DIFF
--- a/web/src/features/query/dashboardUiTableToViewMapping.ts
+++ b/web/src/features/query/dashboardUiTableToViewMapping.ts
@@ -41,6 +41,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       viewName: "traceName",
     },
     {
+      uiTableName: "User",
+      viewName: "userId",
+    },
+    {
       uiTableName: "Type",
       viewName: "type",
     },
@@ -78,6 +82,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       uiTableName: "Environment",
       viewName: "environment",
     },
+    {
+      uiTableName: "User",
+      viewName: "userId",
+    },
   ],
   "scores-categorical": [
     {
@@ -99,6 +107,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
     {
       uiTableName: "Environment",
       viewName: "environment",
+    },
+    {
+      uiTableName: "User",
+      viewName: "userId",
     },
   ],
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `User` to `userId` mapping in `viewMappings` for multiple views in `dashboardUiTableToViewMapping.ts`.
> 
>   - **Mappings**:
>     - Add `User` to `userId` mapping in `viewMappings` for `traces`, `observations`, `scores-numeric`, and `scores-categorical` in `dashboardUiTableToViewMapping.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e05292b40676a6ecb726a71c89703d1c78ee5e68. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->