### PR TITLE
fix(prompt-ui): internal type on review chat prompt

### DIFF
--- a/web/src/features/prompts/components/NewPromptForm/ReviewPromptDialog.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/ReviewPromptDialog.tsx
@@ -47,7 +47,7 @@ export const ReviewPromptDialog: React.FC<ReviewPromptDialogProps> = (
       : JSON.stringify(
           newPromptValue?.chatPrompt.map((m) =>
             Object.fromEntries(
-              Object.entries(m).filter(([k, _]) => k !== "id"),
+              Object.entries(m).filter(([k, _]) => k !== "id" && k !== "type"),
             ),
           ) ?? "{}",
           null,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `ReviewPromptDialog` to exclude `type` field when mapping over `chatPrompt` entries for JSON stringification.
> 
>   - **Behavior**:
>     - Fixes `ReviewPromptDialog` in `ReviewPromptDialog.tsx` to exclude `type` field when mapping over `chatPrompt` entries for JSON stringification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 924fa3cca071a59252f6d32fa8db8f2472510e65. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->