### PR TITLE
feat(run-compare): add detail navigation

### DIFF
--- a/web/src/components/scores-table-cell.tsx
+++ b/web/src/components/scores-table-cell.tsx
@@ -96,7 +96,12 @@ export const ScoresTableCell = ({
       {aggregate.valueCounts.length > COLLAPSE_CATEGORICAL_SCORES_AFTER ? (
         <HoverCard>
           <HoverCardTrigger>
-            <div className="flex cursor-pointer flex-col group-hover:text-accent-dark-blue/55">
+            <div
+              className={cn(
+                "flex cursor-pointer group-hover:text-accent-dark-blue/55",
+                wrap ? "flex-col" : "flex-row",
+              )}
+            >
               <ScoreValueCounts
                 valueCounts={aggregate.valueCounts.slice(
                   0,

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -44,6 +44,8 @@ export type DataTablePeekViewProps<TData> = {
   urlPathname: string;
   /** Function to get navigation path for a list entry */
   getNavigationPath?: (entry: ListEntry) => string;
+  /** Whether to update the row when the peekViewId changes on detail page navigation. Defaults to false. */
+  shouldUpdateRowOnDetailPageNavigation?: boolean;
 
   // Event handlers
   /** Called when the peek view is opened or closed */

--- a/web/src/components/table/peek/hooks/useDatasetComparePeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/useDatasetComparePeekNavigation.ts
@@ -1,0 +1,21 @@
+import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
+
+export const useDatasetComparePeekNavigation = (urlPathname: string) => {
+  const getNavigationPath = (entry: ListEntry) => {
+    const url = new URL(window.location.href);
+
+    // Update the path part
+    url.pathname = urlPathname;
+
+    // Keep all existing query params
+    const params = new URLSearchParams(url.search);
+
+    // Update peek param to the new id
+    params.set("peek", entry.id);
+
+    // Set the search part of the URL
+    return `${url.pathname}?${params.toString()}`;
+  };
+
+  return { getNavigationPath };
+};

--- a/web/src/components/table/peek/hooks/useDatasetComparePeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/useDatasetComparePeekNavigation.ts
@@ -17,5 +17,5 @@ export const useDatasetComparePeekNavigation = (urlPathname: string) => {
     return `${url.pathname}?${params.toString()}`;
   };
 
-  return { getNavigationPath };
+  return { getNavigationPath, shouldUpdateRowOnDetailPageNavigation: true };
 };

--- a/web/src/components/table/peek/hooks/usePeekView.ts
+++ b/web/src/components/table/peek/hooks/usePeekView.ts
@@ -23,7 +23,6 @@ function getInitialRow<TData>(
 type UsePeekViewProps<TData> = {
   getRow: (id: string) => TData | undefined;
   peekView?: PeekViewProps<TData>;
-  shouldUpdateRowOnDetailPageNavigation?: boolean;
 };
 
 /**
@@ -31,7 +30,6 @@ type UsePeekViewProps<TData> = {
  *
  * @param getRow - The React Table's getRow function
  * @param peekView - Optional configuration for the peek view
- * @param shouldUpdateRowOnDetailPageNavigation - Whether to update the row when the peekViewId changes on detail page navigation. If you do not require the row data to be updated, set this to false. Be mindful of this setting as it adds one extra re-render to the table when the detail page is navigated to.
  *
  * @returns An object containing:
  * - handleOnRowClickPeek: Function to handle row clicks for peek view
@@ -45,7 +43,6 @@ type UsePeekViewProps<TData> = {
 export const usePeekView = <TData extends object>({
   getRow,
   peekView,
-  shouldUpdateRowOnDetailPageNavigation = false,
 }: UsePeekViewProps<TData>) => {
   const router = useRouter();
 
@@ -100,7 +97,7 @@ export const usePeekView = <TData extends object>({
 
   // Update the row state when the peekViewId changes on detail page navigation
   useEffect(() => {
-    if (!shouldUpdateRowOnDetailPageNavigation || !peekView) return;
+    if (!peekView || !peekView.shouldUpdateRowOnDetailPageNavigation) return;
 
     const rowId =
       row && "id" in row && typeof row.id === "string" ? row.id : undefined;

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -141,7 +141,6 @@ export function DatasetCompareRunsTable(props: {
         })),
       );
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [baseDatasetItems.isSuccess, baseDatasetItems.data]);
 
   // 1. First, separate the run definitions
@@ -379,7 +378,8 @@ export function DatasetCompareRunsTable(props: {
   const urlPathname = `/project/${props.projectId}/datasets/${props.datasetId}/compare`;
 
   const { setPeekView } = useDatasetComparePeekState(urlPathname);
-  const { getNavigationPath } = useDatasetComparePeekNavigation(urlPathname);
+  const { getNavigationPath, shouldUpdateRowOnDetailPageNavigation } =
+    useDatasetComparePeekNavigation(urlPathname);
 
   return (
     <>
@@ -460,8 +460,8 @@ export function DatasetCompareRunsTable(props: {
           urlPathname,
           onOpenChange: setPeekView,
           getNavigationPath,
+          shouldUpdateRowOnDetailPageNavigation,
           listKey: "dataset-compare-runs",
-          shouldUpdateRowOnDetailPageNavigation: true,
           children: (row?: DatasetCompareRunRowData) => (
             <PeekDatasetCompareDetail
               projectId={props.projectId}

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -135,7 +135,7 @@ export function DatasetCompareRunsTable(props: {
   useEffect(() => {
     if (baseDatasetItems.isSuccess) {
       setDetailPageList(
-        "dataset-compare-runs",
+        "datasetCompareRuns",
         baseDatasetItems.data.datasetItems.map((item) => ({
           id: item.id,
         })),
@@ -461,7 +461,7 @@ export function DatasetCompareRunsTable(props: {
           onOpenChange: setPeekView,
           getNavigationPath,
           shouldUpdateRowOnDetailPageNavigation,
-          listKey: "dataset-compare-runs",
+          listKey: "datasetCompareRuns",
           children: (row?: DatasetCompareRunRowData) => (
             <PeekDatasetCompareDetail
               projectId={props.projectId}

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -141,6 +141,7 @@ export function DatasetCompareRunsTable(props: {
         })),
       );
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [baseDatasetItems.isSuccess, baseDatasetItems.data]);
 
   // 1. First, separate the run definitions

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -10,7 +10,7 @@ import { type ScoreAggregate } from "@langfuse/shared";
 import { type Prisma } from "@langfuse/shared";
 import { NumberParam } from "use-query-params";
 import { useQueryParams, withDefault } from "use-query-params";
-import { useMemo, useState, useCallback } from "react";
+import { useMemo, useState, useCallback, useEffect } from "react";
 import { usdFormatter } from "@/src/utils/numbers";
 import { getScoreDataTypeIcon } from "@/src/features/scores/components/ScoreDetailColumnHelpers";
 import { api, type RouterOutputs } from "@/src/utils/api";
@@ -27,6 +27,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import _ from "lodash";
 import { useDatasetComparePeekState } from "@/src/components/table/peek/hooks/useDatasetComparePeekState";
 import { PeekDatasetCompareDetail } from "@/src/components/table/peek/peek-dataset-compare-detail";
+import { useDatasetComparePeekNavigation } from "@/src/components/table/peek/hooks/useDatasetComparePeekNavigation";
+import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
 
 export type RunMetrics = {
   id: string;
@@ -114,6 +116,7 @@ export function DatasetCompareRunsTable(props: {
     Record<string, number>
   >({});
   const queryClient = useQueryClient();
+  const { setDetailPageList } = useDetailPageLists();
 
   const rowHeight = "l";
 
@@ -128,6 +131,18 @@ export function DatasetCompareRunsTable(props: {
     page: paginationState.pageIndex,
     limit: paginationState.pageSize,
   });
+
+  useEffect(() => {
+    if (baseDatasetItems.isSuccess) {
+      setDetailPageList(
+        "dataset-compare-runs",
+        baseDatasetItems.data.datasetItems.map((item) => ({
+          id: item.id,
+        })),
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [baseDatasetItems.isSuccess, baseDatasetItems.data]);
 
   // 1. First, separate the run definitions
   const runQueries = useMemo(
@@ -364,6 +379,7 @@ export function DatasetCompareRunsTable(props: {
   const urlPathname = `/project/${props.projectId}/datasets/${props.datasetId}/compare`;
 
   const { setPeekView } = useDatasetComparePeekState(urlPathname);
+  const { getNavigationPath } = useDatasetComparePeekNavigation(urlPathname);
 
   return (
     <>
@@ -443,6 +459,9 @@ export function DatasetCompareRunsTable(props: {
           itemType: "DATASET_ITEM",
           urlPathname,
           onOpenChange: setPeekView,
+          getNavigationPath,
+          listKey: "dataset-compare-runs",
+          shouldUpdateRowOnDetailPageNavigation: true,
           children: (row?: DatasetCompareRunRowData) => (
             <PeekDatasetCompareDetail
               projectId={props.projectId}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds detail navigation to dataset comparison view with new navigation path handling and updates to peek view components.
> 
>   - **Navigation**:
>     - Adds `useDatasetComparePeekNavigation` hook to provide `getNavigationPath` and `shouldUpdateRowOnDetailPageNavigation`.
>     - Updates `DatasetCompareRunsTable` to use `getNavigationPath` and `shouldUpdateRowOnDetailPageNavigation` for detail navigation.
>   - **Components**:
>     - Modifies `ScoresTableCell` to conditionally apply `flex-col` or `flex-row` based on `wrap` prop.
>     - Updates `DataTablePeekViewProps` in `peek.tsx` to include `shouldUpdateRowOnDetailPageNavigation`.
>   - **Hooks**:
>     - Removes `shouldUpdateRowOnDetailPageNavigation` from `usePeekView` props and uses it from `peekView` instead.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 50de794cc94c2480f9c94141e9bbfb28f604f5c9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->