### PR TITLE
fix: update column mapping for categorical score charts

### DIFF
--- a/web/src/features/dashboard/components/score-analytics/CategoricalScoreChart.tsx
+++ b/web/src/features/dashboard/components/score-analytics/CategoricalScoreChart.tsx
@@ -78,7 +78,7 @@ export function CategoricalScoreChart(props: {
     const adapter = new DashboardCategoricalScoreAdapter(
       scores.data.map((row) => ({
         ...row,
-        scoreValue: row.string_value,
+        scoreValue: row.stringValue,
         count: row.count_count,
       })) as DatabaseRow[],
       "time_dimension",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes property name from `string_value` to `stringValue` in `CategoricalScoreChart.tsx` for correct data mapping.
> 
>   - **Behavior**:
>     - Fixes property name from `string_value` to `stringValue` in `CategoricalScoreChart.tsx`.
>     - Ensures correct mapping of `scoreValue` in `DashboardCategoricalScoreAdapter`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 010829d6efd6f24fed84c5cdbe3478a609650813. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->