### PR TITLE
feat(compare-runs): Allow for variable row height on compare view

### DIFF
--- a/web/src/components/table/data-table-row-height-switch.tsx
+++ b/web/src/components/table/data-table-row-height-switch.tsx
@@ -18,15 +18,27 @@ import {
 } from "react-icons/md";
 
 const heightOptions = [
-  { id: "s", label: "Small", value: "h-6", icon: <MdDensitySmall /> },
-  { id: "m", label: "Medium", value: "h-24", icon: <MdDensityMedium /> },
-  { id: "l", label: "Large", value: "h-64", icon: <MdDensityLarge /> },
+  { id: "s", label: "Small", icon: <MdDensitySmall /> },
+  { id: "m", label: "Medium", icon: <MdDensityMedium /> },
+  { id: "l", label: "Large", icon: <MdDensityLarge /> },
 ] as const;
 
-export type RowHeight = (typeof heightOptions)[number]["id"];
+const defaultHeights: Record<RowHeight, string> = {
+  s: "h-6",
+  m: "h-24",
+  l: "h-64",
+};
 
-export const getRowHeightTailwindClass = (rowHeight: RowHeight | undefined) =>
-  heightOptions.find((h) => h.id === rowHeight)?.value;
+export type RowHeight = (typeof heightOptions)[number]["id"];
+export type CustomHeights = Record<RowHeight, string>;
+
+export const getRowHeightTailwindClass = (
+  rowHeight?: RowHeight,
+  customHeights?: CustomHeights,
+) => {
+  if (!rowHeight) return undefined;
+  return customHeights?.[rowHeight] || defaultHeights[rowHeight];
+};
 
 export function useRowHeightLocalStorage(
   tableName: string,

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -4,6 +4,7 @@ import React, { useState, useMemo, useCallback } from "react";
 import DocPopup from "@/src/components/layouts/doc-popup";
 import { DataTablePagination } from "@/src/components/table/data-table-pagination";
 import {
+  CustomHeights,
   type RowHeight,
   getRowHeightTailwindClass,
 } from "@/src/components/table/data-table-row-height-switch";
@@ -54,6 +55,7 @@ interface DataTableProps<TData, TValue> {
   setOrderBy?: (s: OrderByState) => void;
   help?: { description: string; href: string };
   rowHeight?: RowHeight;
+  customRowHeights?: CustomHeights;
   className?: string;
   shouldRenderGroupHeaders?: boolean;
   onRowClick?: (row: TData) => void;
@@ -107,6 +109,7 @@ export function DataTable<TData extends object, TValue>({
   orderBy,
   setOrderBy,
   rowHeight,
+  customRowHeights,
   className,
   shouldRenderGroupHeaders = false,
   onRowClick,
@@ -114,7 +117,7 @@ export function DataTable<TData extends object, TValue>({
   pinFirstColumn = false,
 }: DataTableProps<TData, TValue>) {
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
-  const rowheighttw = getRowHeightTailwindClass(rowHeight);
+  const rowheighttw = getRowHeightTailwindClass(rowHeight, customRowHeights);
   const capture = usePostHogClientCapture();
   const flattedColumnsByGroup = useMemo(() => {
     const flatColumnsByGroup = new Map<string, string[]>();

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -4,7 +4,7 @@ import React, { useState, useMemo, useCallback } from "react";
 import DocPopup from "@/src/components/layouts/doc-popup";
 import { DataTablePagination } from "@/src/components/table/data-table-pagination";
 import {
-  CustomHeights,
+  type CustomHeights,
   type RowHeight,
   getRowHeightTailwindClass,
 } from "@/src/components/table/data-table-row-height-switch";

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -27,6 +27,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import _ from "lodash";
 import { useDatasetComparePeekState } from "@/src/components/table/peek/hooks/useDatasetComparePeekState";
 import { PeekDatasetCompareDetail } from "@/src/components/table/peek/peek-dataset-compare-detail";
+import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
 
 export type RunMetrics = {
   id: string;
@@ -114,8 +115,10 @@ export function DatasetCompareRunsTable(props: {
     Record<string, number>
   >({});
   const queryClient = useQueryClient();
-
-  const rowHeight = "l";
+  const [rowHeight, setRowHeight] = useRowHeightLocalStorage(
+    "datasetCompareRuns",
+    "m",
+  );
 
   const [paginationState, setPaginationState] = useQueryParams({
     pageIndex: withDefault(NumberParam, 0),
@@ -372,6 +375,7 @@ export function DatasetCompareRunsTable(props: {
         columnVisibility={columnVisibility}
         setColumnVisibility={setColumnVisibility}
         rowHeight={rowHeight}
+        setRowHeight={setRowHeight}
         actionButtons={
           <DropdownMenu open={isMetricsDropdownOpen}>
             <DropdownMenuTrigger asChild>
@@ -439,6 +443,11 @@ export function DatasetCompareRunsTable(props: {
           state: paginationState,
         }}
         rowHeight={rowHeight}
+        customRowHeights={{
+          s: "h-48",
+          m: "h-64",
+          l: "h-96",
+        }}
         peekView={{
           itemType: "DATASET_ITEM",
           urlPathname,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for variable row heights in `DataTable` and implement in `DatasetCompareRunsTable`.
> 
>   - **Behavior**:
>     - `getRowHeightTailwindClass` in `data-table-row-height-switch.tsx` now supports `customHeights` parameter for variable row heights.
>     - `DataTable` in `data-table.tsx` updated to accept `customRowHeights` prop, allowing for dynamic row height adjustments.
>     - `DatasetCompareRunsTable` in `DatasetCompareRunsTable.tsx` uses `useRowHeightLocalStorage` to manage row height state and sets custom row heights for small, medium, and large sizes.
>   - **Types**:
>     - Adds `CustomHeights` type in `data-table-row-height-switch.tsx` to define custom height mappings.
>   - **Misc**:
>     - Minor import reordering in `DatasetCompareRunsTable.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 01e8460c440e2020189136853bcdd5d1830bce87. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->