### PR TITLE
fix(tests/e2e): After dashboards beta update, home page is now "Home" instead of "Dashboard"

### DIFF
--- a/web/src/__e2e__/create-project.spec.ts
+++ b/web/src/__e2e__/create-project.spec.ts
@@ -94,7 +94,7 @@ test.describe("Create project", () => {
     expect(page.url()).not.toContain("/setup");
 
     const headings = await page.locator("h2").allTextContents();
-    expect(headings).toContain("Dashboard");
+    expect(headings).toContain("Home");
 
     // Check for console errors
     expect(errors).toHaveLength(0);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `create-project.spec.ts` to expect "Home" instead of "Dashboard" in headings after project creation.
> 
>   - **Tests**:
>     - Update `create-project.spec.ts` to expect "Home" instead of "Dashboard" in the headings on the home page after project creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8dc38a19c6d51e595fc18c545b1888909e6b1210. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->