### PR TITLE
style(compare-runs): remove duplicate run column selector

### DIFF
--- a/web/src/components/table/data-table-column-visibility-filter.tsx
+++ b/web/src/components/table/data-table-column-visibility-filter.tsx
@@ -351,82 +351,85 @@ export function DataTableColumnVisibilityFilter<TData, TValue>({
                 (col) => col.accessorKey === columnId,
               );
               if (column) {
-                if (!!column.columns && Boolean(column.columns.length)) {
-                  const groupTotalCount = column.columns.length;
-                  const groupVisibleCount = column.columns.filter(
-                    (col) => columnVisibility[col.accessorKey],
-                  ).length;
-                  return (
-                    <DropdownMenuSub key={index}>
-                      {isColumnOrderingEnabled ? (
-                        <GroupVisibilityDropdownHeader
-                          column={column}
-                          groupTotalCount={groupTotalCount}
-                          groupVisibleCount={groupVisibleCount}
-                        />
-                      ) : (
-                        <DropdownMenuSubTrigger hasCustomIcon>
-                          <Component className="mr-2 h-4 w-4 opacity-50" />
-                          <span>
-                            {column.header && typeof column.header === "string"
-                              ? column.header
-                              : column.accessorKey}
-                          </span>
-                        </DropdownMenuSubTrigger>
-                      )}
-                      <DropdownMenuPortal>
-                        <DropdownMenuSubContent className="max-h-[40dvh] overflow-y-auto">
-                          <DropdownMenuCheckboxItem
-                            checked={
-                              groupVisibleCount === groupTotalCount
-                                ? true
-                                : groupVisibleCount === 0
-                                  ? false
-                                  : "indeterminate"
-                            }
-                            onCheckedChange={() => {
-                              if (
-                                column.header &&
-                                typeof column.header === "string"
-                              ) {
-                                toggleAllColumns(
-                                  groupVisibleCount,
-                                  groupTotalCount,
-                                  column.header,
-                                );
-                              }
-                            }}
-                          >
+                if (!column.isPinned) {
+                  if (!!column.columns && Boolean(column.columns.length)) {
+                    const groupTotalCount = column.columns.length;
+                    const groupVisibleCount = column.columns.filter(
+                      (col) => columnVisibility[col.accessorKey],
+                    ).length;
+                    return (
+                      <DropdownMenuSub key={index}>
+                        {isColumnOrderingEnabled ? (
+                          <GroupVisibilityDropdownHeader
+                            column={column}
+                            groupTotalCount={groupTotalCount}
+                            groupVisibleCount={groupVisibleCount}
+                          />
+                        ) : (
+                          <DropdownMenuSubTrigger hasCustomIcon>
+                            <Component className="mr-2 h-4 w-4 opacity-50" />
                             <span>
-                              {groupTotalCount === groupVisibleCount
-                                ? "Deselect All"
-                                : "Select All"}
+                              {column.header &&
+                              typeof column.header === "string"
+                                ? column.header
+                                : column.accessorKey}
                             </span>
-                          </DropdownMenuCheckboxItem>
-                          <DropdownMenuSeparator />
-                          {column.columns.map((col) => (
-                            <ColumnVisibilityDropdownItem
-                              key={col.accessorKey}
-                              column={col}
-                              columnVisibility={columnVisibility}
-                              toggleColumn={toggleColumn}
-                              isOrderable={false} // grouped columns are not orderable, group may only be ordered as a whole
-                            />
-                          ))}
-                        </DropdownMenuSubContent>
-                      </DropdownMenuPortal>
-                    </DropdownMenuSub>
-                  );
-                } else if (!column.isPinned)
-                  return (
-                    <ColumnVisibilityDropdownItem
-                      key={column.accessorKey}
-                      column={column}
-                      columnVisibility={columnVisibility}
-                      toggleColumn={toggleColumn}
-                      isOrderable={isColumnOrderingEnabled}
-                    />
-                  );
+                          </DropdownMenuSubTrigger>
+                        )}
+                        <DropdownMenuPortal>
+                          <DropdownMenuSubContent className="max-h-[40dvh] overflow-y-auto">
+                            <DropdownMenuCheckboxItem
+                              checked={
+                                groupVisibleCount === groupTotalCount
+                                  ? true
+                                  : groupVisibleCount === 0
+                                    ? false
+                                    : "indeterminate"
+                              }
+                              onCheckedChange={() => {
+                                if (
+                                  column.header &&
+                                  typeof column.header === "string"
+                                ) {
+                                  toggleAllColumns(
+                                    groupVisibleCount,
+                                    groupTotalCount,
+                                    column.header,
+                                  );
+                                }
+                              }}
+                            >
+                              <span>
+                                {groupTotalCount === groupVisibleCount
+                                  ? "Deselect All"
+                                  : "Select All"}
+                              </span>
+                            </DropdownMenuCheckboxItem>
+                            <DropdownMenuSeparator />
+                            {column.columns.map((col) => (
+                              <ColumnVisibilityDropdownItem
+                                key={col.accessorKey}
+                                column={col}
+                                columnVisibility={columnVisibility}
+                                toggleColumn={toggleColumn}
+                                isOrderable={false} // grouped columns are not orderable, group may only be ordered as a whole
+                              />
+                            ))}
+                          </DropdownMenuSubContent>
+                        </DropdownMenuPortal>
+                      </DropdownMenuSub>
+                    );
+                  } else
+                    return (
+                      <ColumnVisibilityDropdownItem
+                        key={column.accessorKey}
+                        column={column}
+                        columnVisibility={columnVisibility}
+                        toggleColumn={toggleColumn}
+                        isOrderable={isColumnOrderingEnabled}
+                      />
+                    );
+                }
               }
               return null;
             })}

--- a/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
+++ b/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
@@ -41,7 +41,6 @@ export const constructDatasetRunAggregateColumns = ({
           description,
         },
       }),
-      enableHiding: true,
       cell: ({ row }: { row: Row<DatasetCompareRunRowData> }) => {
         const runData: RunAggregate = row.getValue("runs") ?? {};
 
@@ -75,8 +74,7 @@ export const getDatasetRunAggregateColumnProps = (isLoading: boolean) => ({
   accessorKey: "runs",
   header: "Runs",
   id: "runs",
-  enableHiding: true,
-  hideByDefault: true,
+  isPinned: true,
   cell: () => {
     return isLoading ? <Skeleton className="h-3 w-1/2" /> : null;
   },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove duplicate column selector logic and improve column visibility handling in `data-table-column-visibility-filter.tsx` and `DatasetRunAggregateColumnHelpers.tsx`.
> 
>   - **Behavior**:
>     - In `data-table-column-visibility-filter.tsx`, added check for `column.isPinned` to prevent duplicate column selector rendering.
>     - In `DatasetRunAggregateColumnHelpers.tsx`, removed `enableHiding` and `hideByDefault` properties, replaced with `isPinned` for `runs` column.
>   - **Misc**:
>     - Minor refactoring in `data-table-column-visibility-filter.tsx` to streamline column visibility logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 44dc96b88b6a2fcd494bc7fed9447683e81f468f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->