### PR TITLE
style(compare-runs): label on run metrics visibility settings

### DIFF
--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -394,10 +394,10 @@ export function DatasetCompareRunsTable(props: {
             <DropdownMenuTrigger asChild>
               <Button
                 variant="outline"
-                size="icon"
                 onClick={() => setIsMetricsDropdownOpen(!isMetricsDropdownOpen)}
               >
-                <Cog className="h-4 w-4" />
+                <Cog className="mr-2 h-4 w-4" />
+                <span>Run metrics</span>
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add label "Run metrics" to the button for toggling run metrics visibility in `DatasetCompareRunsTable`.
> 
>   - **UI Update**:
>     - In `DatasetCompareRunsTable`, the button for toggling run metrics visibility now includes a label "Run metrics" next to the `Cog` icon.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 498f864f92fbbdd67497863b4224f45aa7ad5711. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->