### PR TITLE
build: update end to end tests after dashboard change

### DIFF
--- a/web/src/__e2e__/create-project.spec.ts
+++ b/web/src/__e2e__/create-project.spec.ts
@@ -87,14 +87,14 @@ test.describe("Create project", () => {
     const projectUrl = new URL(page.url());
     const projectId = projectUrl.pathname.split("/")[2];
 
-    // check that the project exists by navigating to its dashboard
+    // check that the project exists by navigating to its home screen
     await page.goto("/project/" + projectId);
     await page.waitForTimeout(2000);
     expect(page.url()).toContain("/project/" + projectId);
     expect(page.url()).not.toContain("/setup");
 
     const headings = await page.locator("h2").allTextContents();
-    expect(headings).toContain("Dashboard");
+    expect(headings).toContain("Home");
 
     // Check for console errors
     expect(errors).toHaveLength(0);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `create-project.spec.ts` to expect "Home" instead of "Dashboard" after project creation.
> 
>   - **Test Update**:
>     - In `create-project.spec.ts`, update expected heading from "Dashboard" to "Home" when verifying project creation.
>     - Adjust comment to reflect navigation to "home screen" instead of "dashboard".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 642cc9a029936c67e82599cfeffe89302f28d006. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->