### PR TITLE
fix: access all replicas to create dataset score metrics

### DIFF
--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -6,7 +6,6 @@ import {
   optionalPaginationZod,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
-import { v4 } from "uuid";
 import { z } from "zod";
 import {
   clickhouseClient,


### PR DESCRIPTION
Fixes #5919

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> `createDatasetRunsTable` now accesses all Clickhouse replicas for complete data retrieval and removes session ID usage in `service.ts`.
> 
>   - **Behavior**:
>     - `createDatasetRunsTable` now reads data from all replicas in Clickhouse if clustering is enabled, ensuring complete data retrieval.
>     - Removes session ID usage in Clickhouse operations, simplifying the process.
>   - **Functions**:
>     - Updates `createTempTableInClickhouse`, `deleteTempTableInClickhouse`, `insertPostgresDatasetRunsIntoClickhouse`, `getScoresFromTempTable`, `getObservationLatencyAndCostForDataset`, and `getTraceLatencyAndCostForDataset` to remove session ID parameters.
>   - **Misc**:
>     - Removes unused import `v4` from `service.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2187209efb1aa6d98e7bd1c8c289567606fdc7e4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->