### PR TITLE
chore: add dummy route that accepts all otel metrics calls

### DIFF
--- a/web/src/pages/api/public/otel/v1/metrics/index.ts
+++ b/web/src/pages/api/public/otel/v1/metrics/index.ts
@@ -1,0 +1,22 @@
+import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
+import { createAuthedAPIRoute } from "@/src/features/public-api/server/createAuthedAPIRoute";
+import { z } from "zod";
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+export default withMiddlewares({
+  POST: createAuthedAPIRoute({
+    name: "OTel Metrics",
+    querySchema: z.any(),
+    responseSchema: z.any(),
+    rateLimitResource: "ingestion",
+    fn: async ({ res }) => {
+      // Just return a 200 status code without processing the request body
+      return res.status(200).json({ status: "ok" });
+    },
+  }),
+});


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/6395
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a new API route to handle OpenTelemetry metrics calls by returning a 200 status code without processing the request body.
> 
>   - **New Route**:
>     - Adds `index.ts` in `web/src/pages/api/public/otel/v1/metrics/` to handle OpenTelemetry metrics calls.
>     - Uses `withMiddlewares` and `createAuthedAPIRoute` to define a POST route.
>     - Returns a 200 status code with `{ status: "ok" }` without processing the request body.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2c6b675bc87a8a79574f8ab62fdc6dabd9e5eaa7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->