### PR TITLE
fix(dashboards): support all dashboard filters across views

### DIFF
--- a/web/src/features/query/dashboardUiTableToViewMapping.ts
+++ b/web/src/features/query/dashboardUiTableToViewMapping.ts
@@ -45,6 +45,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       viewName: "userId",
     },
     {
+      uiTableName: "Session",
+      viewName: "sessionId",
+    },
+    {
       uiTableName: "Type",
       viewName: "type",
     },
@@ -59,6 +63,14 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
     {
       uiTableName: "Environment",
       viewName: "environment",
+    },
+    {
+      uiTableName: "Release",
+      viewName: "traceRelease",
+    },
+    {
+      uiTableName: "Version",
+      viewName: "traceVersion",
     },
   ],
   "scores-numeric": [
@@ -86,6 +98,22 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       uiTableName: "User",
       viewName: "userId",
     },
+    {
+      uiTableName: "Session",
+      viewName: "sessionId",
+    },
+    {
+      uiTableName: "Trace Name",
+      viewName: "traceName",
+    },
+    {
+      uiTableName: "Release",
+      viewName: "traceRelease",
+    },
+    {
+      uiTableName: "Version",
+      viewName: "traceVersion",
+    },
   ],
   "scores-categorical": [
     {
@@ -111,6 +139,22 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
     {
       uiTableName: "User",
       viewName: "userId",
+    },
+    {
+      uiTableName: "Session",
+      viewName: "sessionId",
+    },
+    {
+      uiTableName: "Trace Name",
+      viewName: "traceName",
+    },
+    {
+      uiTableName: "Release",
+      viewName: "traceRelease",
+    },
+    {
+      uiTableName: "Version",
+      viewName: "traceVersion",
     },
   ],
 };

--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -165,6 +165,16 @@ export const observationsView: ViewDeclarationType = {
       type: "string",
       relationTable: "traces",
     },
+    traceRelease: {
+      sql: "release",
+      type: "string",
+      relationTable: "traces",
+    },
+    traceVersion: {
+      sql: "version",
+      type: "string",
+      relationTable: "traces",
+    },
   },
   measures: {
     count: {
@@ -265,6 +275,16 @@ const scoreBaseDimensions: DimensionsDeclarationType = {
   sessionId: {
     sql: "session_id",
     alias: "sessionId",
+    type: "string",
+    relationTable: "traces",
+  },
+  traceRelease: {
+    sql: "release",
+    type: "string",
+    relationTable: "traces",
+  },
+  traceVersion: {
+    sql: "version",
     type: "string",
     relationTable: "traces",
   },


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/6412

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for 'Session', 'Release', and 'Version' filters across multiple views by updating mappings and data models.
> 
>   - **Behavior**:
>     - Adds support for 'Session', 'Release', and 'Version' filters in `dashboardUiTableToViewMapping.ts` for `traces`, `observations`, `scores-numeric`, and `scores-categorical` views.
>   - **Data Models**:
>     - Updates `observationsView` and `scoreBaseDimensions` in `dataModel.ts` to include `traceRelease` and `traceVersion` dimensions.
>   - **Misc**:
>     - Ensures all dashboard filters are supported across views by updating mappings and data models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3180ecf9c3bb70927431ad5b217c3f50113a8108. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->