### PR TITLE
Revert "fix: access all replicas to create dataset score metrics (#6407)

### DIFF
--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -6,6 +6,7 @@ import {
   optionalPaginationZod,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
+import { v4 } from "uuid";
 import { z } from "zod";
 import {
   clickhouseClient,
@@ -78,28 +79,37 @@ export const createDatasetRunsTableWithoutMetrics = async (
 // We need to create a temp table in CH, dump the data in there, and then join in CH.
 export const createDatasetRunsTable = async (input: DatasetRunsTableInput) => {
   const tableName = `dataset_runs_${clickhouseCompliantRandomCharacters()}`;
+  const clickhouseSession = v4();
   try {
     const runs = await getDatasetRunsFromPostgres(input);
 
-    await createTempTableInClickhouse(tableName);
+    await createTempTableInClickhouse(tableName, clickhouseSession);
     await insertPostgresDatasetRunsIntoClickhouse(
       runs,
       tableName,
       input.projectId,
       input.datasetId,
+      clickhouseSession,
     );
 
-    // Read data from the temp table from all replicas to ensure we get the full data
-    const readTableName =
-      env.CLICKHOUSE_CLUSTER_ENABLED === "true"
-        ? `(SELECT DISTINCT * FROM clusterAllReplicas('${env.CLICKHOUSE_CLUSTER_NAME}', '${env.CLICKHOUSE_DB}.${tableName}'))`
-        : tableName;
+    // these calls need to happen sequentially as there can be only one active session with
+    // the same session_id at the time.
+    const scores = await getScoresFromTempTable(
+      input,
+      tableName,
+      clickhouseSession,
+    );
 
-    const [scores, obsAgg, traceAgg] = await Promise.all([
-      getScoresFromTempTable(input, readTableName),
-      getObservationLatencyAndCostForDataset(input, readTableName),
-      getTraceLatencyAndCostForDataset(input, readTableName),
-    ]);
+    const obsAgg = await getObservationLatencyAndCostForDataset(
+      input,
+      tableName,
+      clickhouseSession,
+    );
+    const traceAgg = await getTraceLatencyAndCostForDataset(
+      input,
+      tableName,
+      clickhouseSession,
+    );
 
     const enrichedRuns = runs.map(({ run_items, ...run }) => {
       const observation = obsAgg.find((o) => o.runId === run.run_id);
@@ -130,7 +140,7 @@ export const createDatasetRunsTable = async (input: DatasetRunsTableInput) => {
     logger.error("Failed to fetch dataset runs from clickhouse", e);
     throw e;
   } finally {
-    await deleteTempTableInClickhouse(tableName);
+    await deleteTempTableInClickhouse(tableName, clickhouseSession);
   }
 };
 
@@ -139,6 +149,7 @@ export const insertPostgresDatasetRunsIntoClickhouse = async (
   tableName: string,
   projectId: string,
   datasetId: string,
+  clickhouseSession: string,
 ) => {
   const rows = runs.flatMap((run) =>
     run.run_items.map((item) => ({
@@ -153,6 +164,7 @@ export const insertPostgresDatasetRunsIntoClickhouse = async (
 
   await clickhouseClient({
     tags: { feature: "dataset", projectId },
+    opts: { session_id: clickhouseSession },
   }).insert({
     table: tableName,
     values: rows,
@@ -160,7 +172,10 @@ export const insertPostgresDatasetRunsIntoClickhouse = async (
   });
 };
 
-export const createTempTableInClickhouse = async (tableName: string) => {
+export const createTempTableInClickhouse = async (
+  tableName: string,
+  clickhouseSession: string,
+) => {
   const query = `
       CREATE TABLE IF NOT EXISTS ${tableName} ${env.CLICKHOUSE_CLUSTER_ENABLED === "true" ? "ON CLUSTER " + env.CLICKHOUSE_CLUSTER_NAME : ""}
       (
@@ -171,23 +186,28 @@ export const createTempTableInClickhouse = async (tableName: string) => {
           trace_id String,
           observation_id Nullable(String)
       )  
-      ENGINE = MergeTree() 
+      ENGINE = ${env.CLICKHOUSE_CLUSTER_ENABLED === "true" ? "ReplicatedMergeTree()" : "MergeTree()"} 
       PRIMARY KEY (project_id, dataset_id, run_id, trace_id)
   `;
   await commandClickhouse({
     query,
     params: { tableName },
+    clickhouseConfigs: { session_id: clickhouseSession },
     tags: { feature: "dataset" },
   });
 };
 
-export const deleteTempTableInClickhouse = async (tableName: string) => {
+export const deleteTempTableInClickhouse = async (
+  tableName: string,
+  sessionId: string,
+) => {
   const query = `
       DROP TABLE IF EXISTS ${tableName} ${env.CLICKHOUSE_CLUSTER_ENABLED === "true" ? "ON CLUSTER " + env.CLICKHOUSE_CLUSTER_NAME : ""}
   `;
   await commandClickhouse({
     query,
     params: { tableName },
+    clickhouseConfigs: { session_id: sessionId },
     tags: { feature: "dataset" },
   });
 };
@@ -229,7 +249,10 @@ export const getDatasetRunsFromPostgres = async (
 const getScoresFromTempTable = async (
   input: DatasetRunsTableInput,
   tableName: string,
+  clickhouseSession: string,
 ) => {
+  // adds a setting to read data once it is replicated from the writer node.
+  // Only then, we can guarantee that the created mergetree before was replicated.
   const query = `
       SELECT 
         s.* EXCEPT (metadata),
@@ -242,7 +265,8 @@ const getScoresFromTempTable = async (
       AND tmp.project_id = {projectId: String}
       AND tmp.dataset_id = {datasetId: String}
       ORDER BY s.event_ts DESC
-      LIMIT 1 BY s.id, s.project_id, tmp.run_id;
+      LIMIT 1 BY s.id, s.project_id, tmp.run_id
+      SETTINGS select_sequential_consistency = 1;
   `;
 
   const rows = await queryClickhouse<
@@ -257,6 +281,7 @@ const getScoresFromTempTable = async (
       projectId: input.projectId,
       datasetId: input.datasetId,
     },
+    clickhouseConfigs: { session_id: clickhouseSession },
     tags: { feature: "dataset", projectId: input.projectId },
   });
 
@@ -270,6 +295,7 @@ const getScoresFromTempTable = async (
 const getObservationLatencyAndCostForDataset = async (
   input: DatasetRunsTableInput,
   tableName: string,
+  clickhouseSession: string,
 ) => {
   // the subquery here will improve performance as it allows clickhouse to use skip-indices on
   // the observations table
@@ -309,6 +335,7 @@ const getObservationLatencyAndCostForDataset = async (
       projectId: input.projectId,
       datasetId: input.datasetId,
     },
+    clickhouseConfigs: { session_id: clickhouseSession },
     tags: { feature: "dataset", projectId: input.projectId ?? "" },
   });
 
@@ -322,6 +349,7 @@ const getObservationLatencyAndCostForDataset = async (
 const getTraceLatencyAndCostForDataset = async (
   input: DatasetRunsTableInput,
   tableName: string,
+  clickhouseSession: string,
 ) => {
   const query = `
       WITH agg AS (
@@ -357,6 +385,7 @@ const getTraceLatencyAndCostForDataset = async (
       projectId: input.projectId,
       datasetId: input.datasetId,
     },
+    clickhouseConfigs: { session_id: clickhouseSession },
     tags: { feature: "dataset", projectId: input.projectId ?? "" },
   });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reverts to session-based Clickhouse operations in `service.ts` for dataset score metrics, ensuring sequential consistency and session isolation.
> 
>   - **Behavior**:
>     - Reverts to using session-based operations in Clickhouse for `createDatasetRunsTable` in `service.ts`.
>     - Ensures sequential consistency by using `select_sequential_consistency` setting in `getScoresFromTempTable`.
>   - **Functions**:
>     - Adds `clickhouseSession` parameter to `createTempTableInClickhouse`, `insertPostgresDatasetRunsIntoClickhouse`, `deleteTempTableInClickhouse`, `getScoresFromTempTable`, `getObservationLatencyAndCostForDataset`, and `getTraceLatencyAndCostForDataset`.
>     - Modifies `createDatasetRunsTable` to handle Clickhouse operations sequentially using session IDs.
>   - **Misc**:
>     - Imports `v4` from `uuid` for session ID generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for afa0389e3be0e8071b524ad750658391765bd9cb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->