### PR TITLE
fix: allow sessions filter on widgets

### DIFF
--- a/web/src/features/query/dashboardUiTableToViewMapping.ts
+++ b/web/src/features/query/dashboardUiTableToViewMapping.ts
@@ -162,9 +162,16 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
 const isLegacyUiTableFilter = (
   filter: z.infer<typeof singleFilter>,
 ): boolean => {
-  return dashboardColumnDefinitions.some(
-    (columnDef) => columnDef.uiTableName === filter.column,
-  );
+  return dashboardColumnDefinitions
+    .concat([
+      {
+        uiTableName: "Session",
+        uiTableId: "sessionId",
+        clickhouseTableName: "traces",
+        clickhouseSelect: 't."sessionId"',
+      },
+    ])
+    .some((columnDef) => columnDef.uiTableName === filter.column);
 };
 
 export const mapLegacyUiTableFilterToView = (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Allows filtering by 'Session' in legacy UI tables by updating `isLegacyUiTableFilter()` in `dashboardUiTableToViewMapping.ts`.
> 
>   - **Behavior**:
>     - Allows filtering by 'Session' in legacy UI tables by adding a new column definition in `isLegacyUiTableFilter()`.
>     - Updates `isLegacyUiTableFilter()` to include 'Session' with `uiTableId` as 'sessionId' and `clickhouseTableName` as 'traces'.
>   - **Functions**:
>     - Modifies `isLegacyUiTableFilter()` in `dashboardUiTableToViewMapping.ts` to handle 'Session' filters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ea17696c998712971b8dd291a7ec90b24dcd1395. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->