### PR TITLE
chore: add test cases for projects api

### DIFF
--- a/web/src/__tests__/async/projects-api.servertest.ts
+++ b/web/src/__tests__/async/projects-api.servertest.ts
@@ -4,9 +4,7 @@ import {
   makeZodVerifiedAPICall,
   makeAPICall,
 } from "@/src/__tests__/test-utils";
-import { prisma } from "@langfuse/shared/src/db";
 import { z } from "zod";
-import { randomUUID } from "crypto";
 import { createBasicAuthHeader } from "@langfuse/shared/src/server";
 
 // Schema for project response

--- a/web/src/__tests__/async/projects-api.servertest.ts
+++ b/web/src/__tests__/async/projects-api.servertest.ts
@@ -20,7 +20,7 @@ const ProjectResponseSchema = z.object({
 describe("Public Projects API", () => {
   // Test variables
   const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
-  const projectName = "llm-app";
+  const projectName = "Seed Project";
   const projectApiKey = "pk-lf-1234567890";
   const projectSecretKey = "sk-lf-1234567890";
   const invalidApiKey = "pk-lf-invalid";

--- a/web/src/__tests__/async/projects-api.servertest.ts
+++ b/web/src/__tests__/async/projects-api.servertest.ts
@@ -1,0 +1,92 @@
+/** @jest-environment node */
+
+import {
+  makeZodVerifiedAPICall,
+  makeAPICall,
+} from "@/src/__tests__/test-utils";
+import { prisma } from "@langfuse/shared/src/db";
+import { z } from "zod";
+import { randomUUID } from "crypto";
+import { createBasicAuthHeader } from "@langfuse/shared/src/server";
+
+// Schema for project response
+const ProjectResponseSchema = z.object({
+  data: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+});
+
+describe("Public Projects API", () => {
+  // Test variables
+  const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
+  const projectName = "llm-app";
+  const projectApiKey = "pk-lf-1234567890";
+  const projectSecretKey = "sk-lf-1234567890";
+  const invalidApiKey = "pk-lf-invalid";
+  const invalidSecretKey = "sk-lf-invalid";
+
+  describe("GET /api/public/projects", () => {
+    it("should return project data with valid project API key authentication", async () => {
+      const response = await makeZodVerifiedAPICall(
+        ProjectResponseSchema,
+        "GET",
+        "/api/public/projects",
+        undefined,
+        createBasicAuthHeader(projectApiKey, projectSecretKey),
+        200, // Expected status code is 200 OK
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toHaveLength(1);
+      expect(response.body.data[0]).toMatchObject({
+        id: projectId,
+        name: projectName,
+      });
+    });
+
+    it("should return 401 when invalid API keys are provided", async () => {
+      const result = await makeAPICall(
+        "GET",
+        "/api/public/projects",
+        undefined,
+        createBasicAuthHeader(invalidApiKey, invalidSecretKey),
+      );
+      expect(result.status).toBe(401);
+      expect(result.body.message).toBeDefined();
+    });
+
+    it("should return 405 for non-GET methods", async () => {
+      const result = await makeAPICall(
+        "POST",
+        "/api/public/projects",
+        {},
+        createBasicAuthHeader(projectApiKey, projectSecretKey),
+      );
+      expect(result.status).toBe(405);
+      expect(result.body.message).toContain("Method not allowed");
+    });
+
+    it("should handle different authentication formats", async () => {
+      // Test with Bearer token format
+      const bearerResult = await makeAPICall(
+        "GET",
+        "/api/public/projects",
+        undefined,
+        `Bearer ${projectSecretKey}`,
+      );
+      expect(bearerResult.status).toBe(401);
+
+      // Test with just the secret key (no Bearer prefix)
+      const secretKeyResult = await makeAPICall(
+        "GET",
+        "/api/public/projects",
+        undefined,
+        projectSecretKey,
+      );
+      expect(secretKeyResult.status).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add test cases for Projects API to verify authentication and method handling using Jest and Zod.
> 
>   - **Tests Added**:
>     - `GET /api/public/projects` returns project data with valid API key.
>     - Returns 401 for invalid API keys.
>     - Returns 405 for non-GET methods.
>     - Tests different authentication formats (Bearer token, secret key).
>   - **Utilities**:
>     - Uses `makeZodVerifiedAPICall` and `makeAPICall` from `test-utils`.
>     - Defines `ProjectResponseSchema` using `zod` for response validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b1b3affb58e2d582472abc2515bacf501064f495. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->