### PR TITLE
fix(llm-tools): do not strip additional properties in schema

### DIFF
--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -32,6 +32,7 @@ export const JSONSchemaFormSchema = z
         required: z.array(z.string()).optional(),
         additionalProperties: z.boolean().optional(),
       })
+      .passthrough()
       .transform((data) => JSON.stringify(data, null, 2)),
   );
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `types.ts`, `JSONSchemaFormSchema` now retains additional properties using `.passthrough()`, allowing more flexible JSON schema definitions.
> 
>   - **Behavior**:
>     - In `types.ts`, `JSONSchemaFormSchema` now uses `.passthrough()` to retain additional properties in JSON schema objects.
>     - This change affects how JSON schemas are transformed and serialized, allowing for more flexible schema definitions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3bd59e2286278287546614e8cebb9564d647794f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->