### PR TITLE
chore(evals): fall back to bullmq `job.data.timestamp` allowing for successful retries

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -38,7 +38,7 @@ import { ClickHouseClientConfigOptions } from "@clickhouse/client";
 /**
  * Checks if observation exists in clickhouse.
  *
- * @param {Object} projectId - Project ID for the observation
+ * @param {string} projectId - Project ID for the observation
  * @param {string} id - ID of the observation
  * @param {Date} startTime - Timestamp for time-based filtering, uses event payload or job timestamp
  * @returns {Promise<boolean>} - True if observation exists

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -35,6 +35,18 @@ import {
 import { env } from "../../env";
 import { ClickHouseClientConfigOptions } from "@clickhouse/client";
 
+/**
+ * Checks if observation exists in clickhouse.
+ *
+ * @param {Object} projectId - Project ID for the observation
+ * @param {string} id - ID of the observation
+ * @param {Date} startTime - Timestamp for time-based filtering, uses event payload or job timestamp
+ * @returns {Promise<boolean>} - True if observation exists
+ *
+ * Notes:
+ * • Filters with two days lookback window subject to startTime
+ * • Used for validating observation references before eval job creation
+ */
 export const checkObservationExists = async (
   projectId: string,
   id: string,

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -28,6 +28,18 @@ import {
 import { env } from "../../env";
 import { ClickHouseClientConfigOptions } from "@clickhouse/client";
 
+/**
+ * Checks if trace exists in clickhouse.
+ *
+ * @param {Object} projectId - Project ID for the trace
+ * @param {string} traceId - ID of the trace to check
+ * @param {Date} timestamp - Timestamp for time-based filtering, uses event payload or job timestamp
+ * @returns {Promise<boolean>} - True if trace exists
+ *
+ * Notes:
+ * • Filters within ±2 day window
+ * • Used for validating trace references before eval job creation
+ */
 export const checkTraceExists = async (
   projectId: string,
   traceId: string,

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -31,9 +31,10 @@ import { ClickHouseClientConfigOptions } from "@clickhouse/client";
 /**
  * Checks if trace exists in clickhouse.
  *
- * @param {Object} projectId - Project ID for the trace
+ * @param {string} projectId - Project ID for the trace
  * @param {string} traceId - ID of the trace to check
  * @param {Date} timestamp - Timestamp for time-based filtering, uses event payload or job timestamp
+ * @param {FilterState} filter - Filter for the trace
  * @returns {Promise<boolean>} - True if trace exists
  *
  * Notes:

--- a/worker/src/__tests__/evalService.filtering.test.ts
+++ b/worker/src/__tests__/evalService.filtering.test.ts
@@ -157,6 +157,7 @@ const test = baseTest.extend<{
           traceId: traceId1,
           ...event1,
         },
+        jobTimestamp: new Date(),
       });
       await createEvalJobs({
         event: {
@@ -164,6 +165,7 @@ const test = baseTest.extend<{
           traceId: traceId2,
           ...event2,
         },
+        jobTimestamp: new Date(),
       });
     });
   },

--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -45,6 +45,7 @@ const openAIServer = new OpenAIServer({
   hasActiveKey,
   useDefaultResponse: false,
 });
+const jobTimestamp = new Date();
 
 beforeAll(openAIServer.setup);
 beforeEach(async () => {
@@ -97,7 +98,7 @@ describe("eval service tests", () => {
         traceId: traceId,
       };
 
-      await createEvalJobs({ event: payload });
+      await createEvalJobs({ event: payload, jobTimestamp });
 
       const jobs = await kyselyPrisma.$kysely
         .selectFrom("job_executions")
@@ -177,7 +178,7 @@ describe("eval service tests", () => {
         observationId: observationId,
       };
 
-      await createEvalJobs({ event: payload });
+      await createEvalJobs({ event: payload, jobTimestamp });
 
       const jobs = await kyselyPrisma.$kysely
         .selectFrom("job_executions")
@@ -260,7 +261,7 @@ describe("eval service tests", () => {
       };
 
       // This should exit early without an error as there is no trace yet.
-      await createEvalJobs({ event: payloadDataset });
+      await createEvalJobs({ event: payloadDataset, jobTimestamp });
 
       const jobsAfterDataset = await kyselyPrisma.$kysely
         .selectFrom("job_executions")
@@ -285,7 +286,7 @@ describe("eval service tests", () => {
         traceId: traceId,
       };
 
-      await createEvalJobs({ event: payloadTrace });
+      await createEvalJobs({ event: payloadTrace, jobTimestamp });
 
       const jobsAfterTrace = await kyselyPrisma.$kysely
         .selectFrom("job_executions")
@@ -346,7 +347,7 @@ describe("eval service tests", () => {
       };
 
       // This should exit early without an error as there is no trace yet.
-      await createEvalJobs({ event: payloadTrace });
+      await createEvalJobs({ event: payloadTrace, jobTimestamp });
 
       const jobsAfterDataset = await kyselyPrisma.$kysely
         .selectFrom("job_executions")
@@ -374,7 +375,7 @@ describe("eval service tests", () => {
         datasetItemId,
       };
 
-      await createEvalJobs({ event: payloadDataset });
+      await createEvalJobs({ event: payloadDataset, jobTimestamp });
 
       const jobsAfterTrace = await kyselyPrisma.$kysely
         .selectFrom("job_executions")
@@ -415,7 +416,7 @@ describe("eval service tests", () => {
         traceId: traceId,
       };
 
-      await createEvalJobs({ event: payload });
+      await createEvalJobs({ event: payload, jobTimestamp });
 
       const jobs = await kyselyPrisma.$kysely
         .selectFrom("job_executions")
@@ -469,8 +470,8 @@ describe("eval service tests", () => {
         traceId: traceId,
       };
 
-      await createEvalJobs({ event: payload });
-      await createEvalJobs({ event: payload }); // calling it twice to check it is only generated once
+      await createEvalJobs({ event: payload, jobTimestamp });
+      await createEvalJobs({ event: payload, jobTimestamp }); // calling it twice to check it is only generated once
 
       const jobs = await kyselyPrisma.$kysely
         .selectFrom("job_executions")
@@ -509,7 +510,7 @@ describe("eval service tests", () => {
         traceId: traceId,
       };
 
-      await createEvalJobs({ event: payload });
+      await createEvalJobs({ event: payload, jobTimestamp });
 
       const jobs = await kyselyPrisma.$kysely
         .selectFrom("job_executions")
@@ -555,7 +556,7 @@ describe("eval service tests", () => {
         traceId: traceId,
       };
 
-      await createEvalJobs({ event: payload });
+      await createEvalJobs({ event: payload, jobTimestamp });
 
       const jobs = await kyselyPrisma.$kysely
         .selectFrom("job_executions")
@@ -637,7 +638,7 @@ describe("eval service tests", () => {
         traceId: traceId,
       };
 
-      await createEvalJobs({ event: payload });
+      await createEvalJobs({ event: payload, jobTimestamp });
 
       // Wait for .5s
       await new Promise((resolve) => setTimeout(resolve, 500));
@@ -653,6 +654,7 @@ describe("eval service tests", () => {
 
       await createEvalJobs({
         event: payload,
+        jobTimestamp,
       }); // calling it twice to check it is only generated once
 
       const jobs = await kyselyPrisma.$kysely
@@ -718,6 +720,7 @@ describe("eval service tests", () => {
 
       await createEvalJobs({
         event: payload,
+        jobTimestamp,
         enforcedJobTimeScope: "NEW", // the config must contain NEW
       });
 
@@ -771,6 +774,7 @@ describe("eval service tests", () => {
 
       await createEvalJobs({
         event: payload,
+        jobTimestamp,
         enforcedJobTimeScope: "NEW", // the config must contain NEW
       });
 
@@ -829,6 +833,7 @@ describe("eval service tests", () => {
 
       await createEvalJobs({
         event: payload,
+        jobTimestamp,
         enforcedJobTimeScope: "EXISTING", // the config must contain NEW
       });
 
@@ -873,6 +878,7 @@ describe("eval service tests", () => {
           projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
           traceId: traceId,
         },
+        jobTimestamp,
       });
 
       const jobs = await kyselyPrisma.$kysely

--- a/worker/src/ee/evaluation/evalService.ts
+++ b/worker/src/ee/evaluation/evalService.ts
@@ -96,48 +96,46 @@ const getS3StorageServiceClient = (bucketName: string): StorageService => {
  *                └──────────────────┬───────────┴──────────────────────────────┘
  *                                   │
  *                                   ▼
- *                     ┌────────────────────────────┐
- *                     │                            │
- *                     │  createEvalJobs            │
- *                     │  - Fetches job configs     │
- *                     │  - Filters by time scope   │
- *                     │  - Creates evaluation jobs │
- *                     │                            │
- *                     └───────────────┬────────────┘
- *                                     │
- *                                     ▼
- *                     ┌────────────────────────────┐
- *                     │                            │
- *                     │  Validation Checks         │
- *                     │                            │
- *                     ├────────────────────────────┤
- *                     │  ┌────────────────────┐    │
- *                     │  │ traceExists        │◄───┼── Always run for all events
- *                     │  └────────────────────┘    │
- *                     │                            │
- *                     │  ┌────────────────────┐    │
- *                     │  │ observationExists  │◄───┼── Only run for DatasetRunItemUpsert
- *                     │  └────────────────────┘    │    and CreateEvalQueue if observationId is set
- *                     │                            │
- *                     └───────────────┬────────────┘
- *                                     │
- *                                     ▼
- *                     ┌────────────────────────────┐
- *                     │                            │
- *                     │  EvaluationExecution Queue │
- *                     │  - Jobs queued with delay  │
- *                     │  - Includes job parameters │
- *                     │                            │
- *                     └───────────────┬────────────┘
- *                                     │
- *                                     ▼
- *                     ┌────────────────────────────┐
- *                     │                            │
- *                     │  Worker Process            │
- *                     │  - Processes eval jobs     │
- *                     │  - Executes LLM completion │
- *                     │                            │
- *                     └────────────────────────────┘
+ * ┌───────────────────────────────────────────────────────────────────────────────────────┐
+ * │                                                                                       │
+ * │  createEvalJobs function                                                              │
+ * │  ───────────────────────                                                              │
+ * │                                                                                       │
+ * │                     ┌────────────────────────────┐                                    │
+ * │                     │                            │                                    │
+ * │                     │  1. Fetch & Filter         │                                    │
+ * │                     │  - Fetches job configs     │                                    │
+ * │                     │  - Filters by time scope   │                                    │
+ * │                     │  - Creates evaluation jobs │                                    │
+ * │                     │                            │                                    │
+ * │                     └───────────────┬────────────┘                                    │
+ * │                                     │                                                 │
+ * │                                     ▼                                                 │
+ * │                     ┌────────────────────────────┐                                    │
+ * │                     │                            │                                    │
+ * │                     │  2. Validation Checks      │                                    │
+ * │                     │                            │                                    │
+ * │                     ├────────────────────────────┤                                    │
+ * │                     │  ┌────────────────────┐    │                                    │
+ * │                     │  │ traceExists        │◄───┼── Always run for all events        │
+ * │                     │  └────────────────────┘    │                                    │
+ * │                     │                            │                                    │
+ * │                     │  ┌────────────────────┐    │                                    │
+ * │                     │  │ observationExists  │◄───┼── Only run for DatasetRunItemUpsert│
+ * │                     │  └────────────────────┘    │    and CreateEvalQueue if          │
+ * │                     │                            │    observationId is set            │
+ * │                     └───────────────┬────────────┘                                    │
+ * │                                     │                                                 │
+ * │                                     ▼                                                 │
+ * │                     ┌────────────────────────────┐                                    │
+ * │                     │                            │                                    │
+ * │                     │  3. EvaluationExecution    │                                    │
+ * │                     │  - Jobs queued with delay  │                                    │
+ * │                     │  - Includes job parameters │                                    │
+ * │                     │                            │                                    │
+ * │                     └────────────────────────────┘                                    │
+ * │                                                                                       │
+ * └───────────────────────────────────────────────────────────────────────────────────────┘
  *
  * ─────────────────────────────────────────────────────────────────────────────────────────── │
  */

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -19,6 +19,7 @@ export const evalJobTraceCreatorQueueProcessor = async (
   try {
     await createEvalJobs({
       event: job.data.payload,
+      jobTimestamp: job.data.timestamp,
       enforcedJobTimeScope: "NEW", // we must not execute evals which are intended for existing data only.
     });
     return true;
@@ -38,6 +39,7 @@ export const evalJobDatasetCreatorQueueProcessor = async (
   try {
     await createEvalJobs({
       event: job.data.payload,
+      jobTimestamp: job.data.timestamp,
       enforcedJobTimeScope: "NEW", // we must not execute evals which are intended for existing data only.
     });
     return true;
@@ -57,6 +59,7 @@ export const evalJobCreatorQueueProcessor = async (
   try {
     await createEvalJobs({
       event: job.data.payload,
+      jobTimestamp: job.data.timestamp,
     });
     return true;
   } catch (e) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `createEvalJobs` now uses `jobTimestamp` as a fallback for missing `event.timestamp` to ensure successful retries.
> 
>   - **Behavior**:
>     - `createEvalJobs` in `evalService.ts` now falls back to `jobTimestamp` if `event.timestamp` is not set, ensuring retries are successful.
>     - Applies to `checkTraceExists` and `checkObservationExists` calls within `createEvalJobs`.
>   - **Tests**:
>     - Updated tests in `evalService.test.ts` and `evalService.filtering.test.ts` to include `jobTimestamp` parameter in `createEvalJobs` calls.
>     - Ensures tests cover scenarios where `event.timestamp` is missing.
>   - **Queue Processors**:
>     - `evalJobTraceCreatorQueueProcessor`, `evalJobDatasetCreatorQueueProcessor`, and `evalJobCreatorQueueProcessor` in `evalQueue.ts` now pass `job.data.timestamp` to `createEvalJobs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4bac6c8b1d6ae5dcbd38e5657487e07aface74e4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->