### PR TITLE
fix(users): adjust pagination calculation for user retrieval

### DIFF
--- a/web/src/server/api/routers/users.ts
+++ b/web/src/server/api/routers/users.ts
@@ -45,7 +45,7 @@ export const userRouter = createTRPCRouter({
           input.filter ?? [],
           input.searchQuery ?? undefined,
           input.limit,
-          input.page,
+          input.page * input.limit,
           undefined,
         ),
         getTotalUserCount(


### PR DESCRIPTION
## What does this PR do?

This fixes an issue where on the User page, pagination does not work properly. Instead of paging forward by the page size, it pages forward by 1 row for each page. When postgres was used instead of Clickhouse a similar multiplication of page * limit was done in the query, but this was not present in the Clickhouse query.

Fixes #6452

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't added tests that prove my fix is effective or that my feature works

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes user pagination in `userRouter.all` by correctly calculating offset as `page * limit`.
> 
>   - **Pagination Fix**:
>     - In `userRouter.all` in `users.ts`, corrects pagination offset by passing `input.page * input.limit` to `getTracesGroupedByUsers` instead of just `input.page`.
>     - Ensures each page advances by the full page size, not just one row.
>   - No changes to other files or functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 54b77f6fe801e6f1a48cb36a9015625dab8a8f56. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->