### PR TITLE
chore: expand project and org name limit to 60 chars

### DIFF
--- a/web/src/__tests__/async/organizations-api.servertest.ts
+++ b/web/src/__tests__/async/organizations-api.servertest.ts
@@ -126,7 +126,7 @@ describe("Admin Organizations API", () => {
         "POST",
         "/api/admin/organizations",
         {
-          name: "A".repeat(31), // More than 30 characters
+          name: "A".repeat(61), // More than 60 characters
         },
         `Bearer ${ADMIN_API_KEY}`,
       );

--- a/web/src/features/auth/lib/projectNameSchema.ts
+++ b/web/src/features/auth/lib/projectNameSchema.ts
@@ -5,7 +5,7 @@ export const projectNameSchema = z.object({
   name: z
     .string()
     .min(3, "Must have at least 3 characters")
-    .max(30, "Must have at most 30 characters")
+    .max(60, "Must have at most 60 characters")
     .refine((value) => noHtmlCheck(value), {
       message: "Input should not contain HTML",
     }),

--- a/web/src/features/organizations/components/ProjectOverview.tsx
+++ b/web/src/features/organizations/components/ProjectOverview.tsx
@@ -49,7 +49,9 @@ const OrganizationProjectTiles = ({
         .map((project) => (
           <Card key={project.id}>
             <CardHeader>
-              <CardTitle className="text-base">{project.name}</CardTitle>
+              <CardTitle className="truncate text-base">
+                {project.name}
+              </CardTitle>
             </CardHeader>
             {!project.deletedAt ? (
               <CardFooter className="gap-2">
@@ -213,6 +215,7 @@ const SingleOrganizationProjectOverviewTile = ({
     <div key={orgId} className="mb-10">
       <Header
         title={org.name}
+        className="truncate"
         status={orgId === env.NEXT_PUBLIC_DEMO_ORG_ID ? "Demo Org" : undefined}
         label={
           isCloudPlan(org.plan)

--- a/web/src/features/organizations/utils/organizationNameSchema.ts
+++ b/web/src/features/organizations/utils/organizationNameSchema.ts
@@ -5,7 +5,7 @@ export const organizationNameSchema = z.object({
   name: z
     .string()
     .min(3, "Must have at least 3 characters")
-    .max(30, "Must have at most 30 characters")
+    .max(60, "Must have at most 60 characters")
     .refine((value) => noHtmlCheck(value), {
       message: "Input should not contain HTML",
     }),

--- a/web/src/pages/api/public/projects/index.ts
+++ b/web/src/pages/api/public/projects/index.ts
@@ -88,7 +88,7 @@ export default async function handler(
       } catch (error) {
         return res.status(400).json({
           message:
-            "Invalid project name length. Should be between 3 and 30 characters.",
+            "Invalid project name length. Should be between 3 and 60 characters.",
         });
       }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Expand project and organization name limit to 60 characters and update related validation, UI, and tests.
> 
>   - **Validation**:
>     - Increase max length for `name` in `projectNameSchema` and `organizationNameSchema` from 30 to 60 characters.
>     - Update error message in `index.ts` to reflect new max length.
>   - **UI Components**:
>     - Add `truncate` class to `CardTitle` in `ProjectOverview.tsx` to handle longer project names.
>     - Add `truncate` class to `Header` in `SingleOrganizationProjectOverviewTile` to handle longer organization names.
>   - **Tests**:
>     - Update test in `organizations-api.servertest.ts` to check for names longer than 60 characters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c24c145921d335bad2912277297e1dc3dcc4c18a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->