### PR TITLE
feat: allow management of project api keys via API

### DIFF
--- a/fern/apis/server/definition/projects.yml
+++ b/fern/apis/server/definition/projects.yml
@@ -32,6 +32,39 @@ service:
       response:
         status-code: 202
         type: ProjectDeletionResponse
+        
+    # API Key endpoints
+    getApiKeys:
+      docs: Get all API keys for a project (requires organization-scoped API key)
+      method: GET
+      path: /projects/{projectId}/apiKeys
+      path-parameters:
+        projectId: string
+      response: ApiKeyList
+
+    createApiKey:
+      docs: Create a new API key for a project (requires organization-scoped API key)
+      method: POST
+      path: /projects/{projectId}/apiKeys
+      path-parameters:
+        projectId: string
+      request:
+        name: CreateApiKeyRequest
+        body:
+          properties:
+            note:
+              type: optional<string>
+              docs: Optional note for the API key
+      response: ApiKeyResponse
+
+    deleteApiKey:
+      docs: Delete an API key for a project (requires organization-scoped API key)
+      method: DELETE
+      path: /projects/{projectId}/apiKeys/{apiKeyId}
+      path-parameters:
+        projectId: string
+        apiKeyId: string
+      response: ApiKeyDeletionResponse
 
 types:
   Projects:
@@ -47,3 +80,34 @@ types:
     properties:
       success: boolean
       message: string
+      
+  ApiKeyList:
+    docs: List of API keys for a project
+    properties:
+      apiKeys: list<ApiKeySummary>
+
+  ApiKeySummary:
+    docs: Summary of an API key
+    properties:
+      id: string
+      createdAt: datetime
+      expiresAt: optional<datetime>
+      lastUsedAt: optional<datetime>
+      note: optional<string>
+      publicKey: string
+      displaySecretKey: string
+
+  ApiKeyResponse:
+    docs: Response for API key creation
+    properties:
+      id: string
+      createdAt: datetime
+      publicKey: string
+      secretKey: string
+      displaySecretKey: string
+      note: optional<string>
+      
+  ApiKeyDeletionResponse:
+    docs: Response for API key deletion
+    properties:
+      success: boolean

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -2306,6 +2306,161 @@ paths:
               schema: {}
       security:
         - BasicAuth: []
+  /api/public/projects/{projectId}/apiKeys:
+    get:
+      description: Get all API keys for a project (requires organization-scoped API key)
+      operationId: projects_getApiKeys
+      tags:
+        - Projects
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiKeyList'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+    post:
+      description: >-
+        Create a new API key for a project (requires organization-scoped API
+        key)
+      operationId: projects_createApiKey
+      tags:
+        - Projects
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiKeyResponse'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                note:
+                  type: string
+                  nullable: true
+                  description: Optional note for the API key
+  /api/public/projects/{projectId}/apiKeys/{apiKeyId}:
+    delete:
+      description: Delete an API key for a project (requires organization-scoped API key)
+      operationId: projects_deleteApiKey
+      tags:
+        - Projects
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: apiKeyId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiKeyDeletionResponse'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
   /api/public/v2/prompts/{name}/versions/{version}:
     patch:
       description: Update labels for a specific prompt version
@@ -6071,6 +6226,81 @@ components:
       required:
         - success
         - message
+    ApiKeyList:
+      title: ApiKeyList
+      type: object
+      description: List of API keys for a project
+      properties:
+        apiKeys:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApiKeySummary'
+      required:
+        - apiKeys
+    ApiKeySummary:
+      title: ApiKeySummary
+      type: object
+      description: Summary of an API key
+      properties:
+        id:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        expiresAt:
+          type: string
+          format: date-time
+          nullable: true
+        lastUsedAt:
+          type: string
+          format: date-time
+          nullable: true
+        note:
+          type: string
+          nullable: true
+        publicKey:
+          type: string
+        displaySecretKey:
+          type: string
+      required:
+        - id
+        - createdAt
+        - publicKey
+        - displaySecretKey
+    ApiKeyResponse:
+      title: ApiKeyResponse
+      type: object
+      description: Response for API key creation
+      properties:
+        id:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        publicKey:
+          type: string
+        secretKey:
+          type: string
+        displaySecretKey:
+          type: string
+        note:
+          type: string
+          nullable: true
+      required:
+        - id
+        - createdAt
+        - publicKey
+        - secretKey
+        - displaySecretKey
+    ApiKeyDeletionResponse:
+      title: ApiKeyDeletionResponse
+      type: object
+      description: Response for API key deletion
+      properties:
+        success:
+          type: boolean
+      required:
+        - success
     PromptMetaListResponse:
       title: PromptMetaListResponse
       type: object

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -1764,6 +1764,119 @@
             "body": null
           },
           "response": []
+        },
+        {
+          "_type": "endpoint",
+          "name": "Get Api Keys",
+          "request": {
+            "description": "Get all API keys for a project (requires organization-scoped API key)",
+            "url": {
+              "raw": "{{baseUrl}}/api/public/projects/:projectId/apiKeys",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "public",
+                "projects",
+                ":projectId",
+                "apiKeys"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "key": "projectId",
+                  "value": "",
+                  "description": null
+                }
+              ]
+            },
+            "header": [],
+            "method": "GET",
+            "auth": null,
+            "body": null
+          },
+          "response": []
+        },
+        {
+          "_type": "endpoint",
+          "name": "Create Api Key",
+          "request": {
+            "description": "Create a new API key for a project (requires organization-scoped API key)",
+            "url": {
+              "raw": "{{baseUrl}}/api/public/projects/:projectId/apiKeys",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "public",
+                "projects",
+                ":projectId",
+                "apiKeys"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "key": "projectId",
+                  "value": "",
+                  "description": null
+                }
+              ]
+            },
+            "header": [],
+            "method": "POST",
+            "auth": null,
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"note\": \"example\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": []
+        },
+        {
+          "_type": "endpoint",
+          "name": "Delete Api Key",
+          "request": {
+            "description": "Delete an API key for a project (requires organization-scoped API key)",
+            "url": {
+              "raw": "{{baseUrl}}/api/public/projects/:projectId/apiKeys/:apiKeyId",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "public",
+                "projects",
+                ":projectId",
+                "apiKeys",
+                ":apiKeyId"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "key": "projectId",
+                  "value": "",
+                  "description": null
+                },
+                {
+                  "key": "apiKeyId",
+                  "value": "",
+                  "description": null
+                }
+              ]
+            },
+            "header": [],
+            "method": "DELETE",
+            "auth": null,
+            "body": null
+          },
+          "response": []
         }
       ]
     },

--- a/web/src/pages/api/admin/organizations/[organizationId]/apiKeys/index.ts
+++ b/web/src/pages/api/admin/organizations/[organizationId]/apiKeys/index.ts
@@ -113,7 +113,7 @@ async function handlePost(
   // Create the API key
   const apiKeyMeta = await createAndAddApiKeysToDb({
     prisma,
-    entityId: organizationId, // Using organizationId as projectId for organization scoped keys
+    entityId: organizationId,
     note,
     scope: "ORGANIZATION",
   });

--- a/web/src/pages/api/public/projects/[projectId]/apiKeys/[apiKeyId].ts
+++ b/web/src/pages/api/public/projects/[projectId]/apiKeys/[apiKeyId].ts
@@ -1,0 +1,146 @@
+import { type NextApiRequest, type NextApiResponse } from "next";
+import { prisma } from "@langfuse/shared/src/db";
+import { logger, redis } from "@langfuse/shared/src/server";
+import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
+import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { z } from "zod";
+import { cors, runMiddleware } from "@/src/features/public-api/server/cors";
+
+const validateQueryParams = (
+  query: unknown,
+): { projectId: string; apiKeyId: string } | null => {
+  const inputQuerySchema = z.object({
+    projectId: z.string(),
+    apiKeyId: z.string(),
+  });
+  const validation = inputQuerySchema.safeParse(query);
+  if (!validation.success) {
+    return null;
+  }
+  return validation.data;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  await runMiddleware(req, res, cors);
+
+  try {
+    if (req.method !== "DELETE") {
+      res.status(405).json({ message: "Method Not Allowed" });
+      return;
+    }
+
+    // CHECK AUTH
+    const authCheck = await new ApiAuthService(
+      prisma,
+      redis,
+    ).verifyAuthHeaderAndReturnScope(req.headers.authorization);
+    if (!authCheck.validKey) {
+      return res.status(401).json({
+        message: authCheck.error,
+      });
+    }
+
+    // Check if using an organization API key
+    if (
+      authCheck.scope.accessLevel !== "organization" ||
+      !authCheck.scope.orgId
+    ) {
+      return res.status(403).json({
+        message:
+          "Invalid API key. Organization-scoped API key required for this operation.",
+      });
+    }
+    // END CHECK AUTH
+
+    const params = validateQueryParams(req.query);
+    if (!params) {
+      return res.status(400).json({ message: "Invalid request parameters" });
+    }
+
+    const { projectId, apiKeyId } = params;
+
+    // Check if project exists and belongs to the organization
+    const project = await prisma.project.findFirst({
+      where: {
+        id: projectId,
+        orgId: authCheck.scope.orgId,
+      },
+    });
+
+    if (!project) {
+      return res
+        .status(404)
+        .json({ message: "Project not found or you don't have access to it" });
+    }
+
+    // Handle different HTTP methods
+    switch (req.method) {
+      case "DELETE":
+        return await handleDelete(
+          req,
+          res,
+          projectId,
+          apiKeyId,
+          authCheck.scope.orgId,
+        );
+      default:
+        res.status(405).json({ message: "Method Not Allowed" });
+        return;
+    }
+  } catch (e) {
+    logger.error("Failed to process project API key request", e);
+    res.status(500).json({ message: "Internal server error" });
+  }
+}
+
+async function handleDelete(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  projectId: string,
+  apiKeyId: string,
+  orgId: string,
+) {
+  // Check if API key exists and belongs to the project
+  const apiKey = await prisma.apiKey.findFirst({
+    where: {
+      id: apiKeyId,
+      projectId,
+      scope: "PROJECT",
+    },
+  });
+
+  if (!apiKey) {
+    return res.status(404).json({ message: "API key not found" });
+  }
+
+  // Delete the API key
+  const deleted = await new ApiAuthService(prisma, redis).deleteApiKey(
+    apiKeyId,
+    projectId,
+    "PROJECT",
+  );
+
+  if (!deleted) {
+    return res.status(500).json({ message: "Failed to delete API key" });
+  }
+
+  // Log the API key deletion
+  await auditLog({
+    resourceType: "apiKey",
+    resourceId: apiKeyId,
+    action: "delete",
+    orgId: orgId,
+    projectId: projectId,
+    orgRole: "ADMIN",
+    apiKeyId: "ORG_KEY",
+  });
+
+  logger.info(
+    `Deleted API key ${apiKeyId} for project ${projectId} via public API`,
+  );
+
+  return res.status(200).json({ success: true });
+}

--- a/web/src/pages/api/public/projects/[projectId]/apiKeys/index.ts
+++ b/web/src/pages/api/public/projects/[projectId]/apiKeys/index.ts
@@ -1,0 +1,164 @@
+import { type NextApiRequest, type NextApiResponse } from "next";
+import { prisma } from "@langfuse/shared/src/db";
+import { logger, redis } from "@langfuse/shared/src/server";
+import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
+import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { z } from "zod";
+import { cors, runMiddleware } from "@/src/features/public-api/server/cors";
+import { createAndAddApiKeysToDb } from "@langfuse/shared/src/server/auth/apiKeys";
+
+const validateQueryAndExtractId = (query: unknown): string | null => {
+  const inputQuerySchema = z.object({
+    projectId: z.string(),
+  });
+  const validation = inputQuerySchema.safeParse(query);
+  if (!validation.success) {
+    return null;
+  }
+  return validation.data.projectId;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  await runMiddleware(req, res, cors);
+
+  try {
+    if (req.method !== "POST" && req.method !== "GET") {
+      res.status(405).json({ message: "Method Not Allowed" });
+      return;
+    }
+
+    // CHECK AUTH
+    const authCheck = await new ApiAuthService(
+      prisma,
+      redis,
+    ).verifyAuthHeaderAndReturnScope(req.headers.authorization);
+    if (!authCheck.validKey) {
+      return res.status(401).json({
+        message: authCheck.error,
+      });
+    }
+
+    // Check if using an organization API key
+    if (
+      authCheck.scope.accessLevel !== "organization" ||
+      !authCheck.scope.orgId
+    ) {
+      return res.status(403).json({
+        message:
+          "Invalid API key. Organization-scoped API key required for this operation.",
+      });
+    }
+    // END CHECK AUTH
+
+    const projectId = validateQueryAndExtractId(req.query);
+    if (!projectId) {
+      return res.status(400).json({ message: "Invalid project ID" });
+    }
+
+    // Check if project exists and belongs to the organization
+    const project = await prisma.project.findFirst({
+      where: {
+        id: projectId,
+        orgId: authCheck.scope.orgId,
+      },
+    });
+
+    if (!project) {
+      return res
+        .status(404)
+        .json({ message: "Project not found or you don't have access to it" });
+    }
+
+    // Handle different HTTP methods
+    switch (req.method) {
+      case "GET":
+        return await handleGet(req, res, projectId);
+      case "POST":
+        return await handlePost(req, res, projectId, authCheck.scope.orgId);
+      default:
+        res.status(405).json({ message: "Method Not Allowed" });
+        return;
+    }
+  } catch (e) {
+    logger.error("Failed to process project API key request", e);
+    res.status(500).json({ message: "Internal server error" });
+  }
+}
+
+async function handleGet(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  projectId: string,
+) {
+  const apiKeys = await prisma.apiKey.findMany({
+    where: {
+      projectId,
+      scope: "PROJECT",
+    },
+    select: {
+      id: true,
+      createdAt: true,
+      expiresAt: true,
+      lastUsedAt: true,
+      note: true,
+      publicKey: true,
+      displaySecretKey: true,
+    },
+    orderBy: {
+      createdAt: "asc",
+    },
+  });
+
+  return res.status(200).json({ apiKeys });
+}
+
+async function handlePost(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  projectId: string,
+  orgId: string,
+) {
+  // Validate the request body
+  const createApiKeySchema = z.object({
+    note: z.string().optional(),
+  });
+
+  const validationResult = createApiKeySchema.safeParse(req.body);
+
+  if (!validationResult.success) {
+    return res.status(400).json({
+      message: "Invalid request body",
+      details: validationResult.error.format(),
+    });
+  }
+
+  const { note } = validationResult.data;
+
+  // Create the API key
+  const apiKeyMeta = await createAndAddApiKeysToDb({
+    prisma,
+    entityId: projectId,
+    note,
+    scope: "PROJECT",
+  });
+
+  // Log the API key creation
+  await auditLog({
+    resourceType: "apiKey",
+    resourceId: apiKeyMeta.id,
+    action: "create",
+    orgId: orgId,
+    projectId: projectId,
+    orgRole: "ADMIN",
+    apiKeyId: "ORG_KEY",
+  });
+
+  logger.info(
+    `Created API key ${apiKeyMeta.id} for project ${projectId} via public API`,
+  );
+
+  return res.status(201).json(apiKeyMeta);
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> This PR adds API endpoints for managing project API keys, including creation, retrieval, and deletion, with corresponding tests and authentication checks.
> 
>   - **API Endpoints**:
>     - Added `getApiKeys`, `createApiKey`, and `deleteApiKey` endpoints in `projects.yml` for managing project API keys.
>     - Updated `openapi.yml` and `collection.json` to include new API key management endpoints.
>   - **API Implementation**:
>     - Implemented `GET`, `POST`, and `DELETE` methods in `apiKeys/index.ts` and `apiKeys/[apiKeyId].ts` for project API key management.
>     - Added authentication checks to ensure organization-scoped API keys are used.
>   - **Testing**:
>     - Added tests in `projects-api.servertest.ts` for new API key management endpoints, covering success and error cases.
>     - Tests include scenarios for valid and invalid API keys, and method not allowed errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d9da700dd86fc1e7e4aa6e260afab8c74fd00ce8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->