### PR TITLE
chore(cost-tracking): add support for openai 4.1 models

### DIFF
--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -254,6 +254,9 @@ export type ExperimentMetadata = z.infer<typeof ExperimentMetadataSchema>;
 
 // NOTE: Update docs page when changing this! https://langfuse.com/docs/playground#openai-playground--anthropic-playground
 export const openAIModels = [
+  "gpt-4.1-2025-04-14",
+  "gpt-4.1-mini-2025-04-14",
+  "gpt-4.1-nano-2025-04-14",
   "gpt-4o",
   "gpt-4o-2024-08-06",
   "gpt-4o-2024-05-13",

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -254,6 +254,7 @@ export type ExperimentMetadata = z.infer<typeof ExperimentMetadataSchema>;
 
 // NOTE: Update docs page when changing this! https://langfuse.com/docs/playground#openai-playground--anthropic-playground
 export const openAIModels = [
+  "gpt-4.1",
   "gpt-4.1-2025-04-14",
   "gpt-4.1-mini-2025-04-14",
   "gpt-4.1-nano-2025-04-14",

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1508,5 +1508,47 @@
       "input_cache_read": 37.5e-6,
       "output": 150e-6
     }
+  },
+  {
+    "id": "cm7qahw732891bpmzy45r3x70",
+    "model_name": "gpt-4.1-2025-04-14",
+    "match_pattern": "(?i)^(gpt-4.1-2025-04-14)$",
+    "created_at": "2025-04-15T10:26:54.132Z",
+    "updated_at": "2025-04-15T10:26:54.132Z",
+    "prices": {
+      "input": 2e-6,
+      "input_cached_tokens": 0.5e-6,
+      "input_cached_text_tokens": 0.5e-6,
+      "input_cache_read": 0.5e-6,
+      "output": 8e-6
+    }
+  },
+  {
+    "id": "cm7sglt825463kxnza72p6v81",
+    "model_name": "gpt-4.1-mini-2025-04-14",
+    "match_pattern": "(?i)^(gpt-4.1-mini-2025-04-14)$",
+    "created_at": "2025-04-15T10:26:54.132Z",
+    "updated_at": "2025-04-15T10:26:54.132Z",
+    "prices": {
+      "input": 0.4e-6,
+      "input_cached_tokens": 0.1e-6,
+      "input_cached_text_tokens": 0.1e-6,
+      "input_cache_read": 0.1e-6,
+      "output": 1.6e-6
+    }
+  },
+  {
+    "id": "cm7vxpz967124dhjtb95w8f92",
+    "model_name": "gpt-4.1-nano-2025-04-14",
+    "match_pattern": "(?i)^(gpt-4.1-nano-2025-04-14)$",
+    "created_at": "2025-04-15T10:26:54.132Z",
+    "updated_at": "2025-04-15T10:26:54.132Z",
+    "prices": {
+      "input": 0.1e-6,
+      "input_cached_tokens": 0.025e-6,
+      "input_cached_text_tokens": 0.025e-6,
+      "input_cache_read": 0.025e-6,
+      "output": 0.4e-6
+    }
   }
 ]

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1510,6 +1510,26 @@
     }
   },
   {
+    "id": "cm7nusn643377tvmzh27m33kl",
+    "model_name": "gpt-4.1",
+    "match_pattern": "(?i)^(gpt-4.1)$",
+    "created_at": "2025-04-15T10:26:54.132Z",
+    "updated_at": "2025-04-15T10:26:54.132Z",
+    "prices": {
+      "input": 2e-6,
+      "input_cached_tokens": 0.5e-6,
+      "input_cached_text_tokens": 0.5e-6,
+      "input_cache_read": 0.5e-6,
+      "output": 8e-6
+    },
+    "tokenizer_config": {
+      "tokensPerName": 1,
+      "tokenizerModel": "gpt-4",
+      "tokensPerMessage": 3
+    },
+    "tokenizer_id": "openai"
+  },
+  {
     "id": "cm7qahw732891bpmzy45r3x70",
     "model_name": "gpt-4.1-2025-04-14",
     "match_pattern": "(?i)^(gpt-4.1-2025-04-14)$",

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1521,7 +1521,13 @@
       "input_cached_text_tokens": 0.5e-6,
       "input_cache_read": 0.5e-6,
       "output": 8e-6
-    }
+    },
+    "tokenizer_config": {
+      "tokensPerName": 1,
+      "tokenizerModel": "gpt-4",
+      "tokensPerMessage": 3
+    },
+    "tokenizer_id": "openai"
   },
   {
     "id": "cm7sglt825463kxnza72p6v81",
@@ -1535,7 +1541,13 @@
       "input_cached_text_tokens": 0.1e-6,
       "input_cache_read": 0.1e-6,
       "output": 1.6e-6
-    }
+    },
+    "tokenizer_config": {
+      "tokensPerName": 1,
+      "tokenizerModel": "gpt-4",
+      "tokensPerMessage": 3
+    },
+    "tokenizer_id": "openai"
   },
   {
     "id": "cm7vxpz967124dhjtb95w8f92",
@@ -1549,6 +1561,12 @@
       "input_cached_text_tokens": 0.025e-6,
       "input_cache_read": 0.025e-6,
       "output": 0.4e-6
-    }
+    },
+    "tokenizer_config": {
+      "tokensPerName": 1,
+      "tokenizerModel": "gpt-4",
+      "tokensPerMessage": 3
+    },
+    "tokenizer_id": "openai"
   }
 ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support and pricing for OpenAI 4.1 models in `types.ts` and `default-model-prices.json`.
> 
>   - **Models**:
>     - Added support for `gpt-4.1`, `gpt-4.1-2025-04-14`, `gpt-4.1-mini-2025-04-14`, and `gpt-4.1-nano-2025-04-14` in `types.ts`.
>   - **Pricing**:
>     - Added pricing details for `gpt-4.1`, `gpt-4.1-2025-04-14`, `gpt-4.1-mini-2025-04-14`, and `gpt-4.1-nano-2025-04-14` in `default-model-prices.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for be5e322fa9534e404ba028d55231e5af20243827. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->