### PR TITLE
fix(prompts): prompt label popover overflows screen bounds

### DIFF
--- a/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
+++ b/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
@@ -143,12 +143,10 @@ export function SetPromptVersionLabels({
         </div>
       </PopoverTrigger>
       <PopoverContent
-        className="fixed max-h-[50vh] overflow-y-auto"
-        style={{
-          top: "var(--popover-top)",
-          left: "var(--popover-left)",
-          transform: "none",
-        }}
+        className="max-h-[50vh] overflow-y-auto"
+        align="start"
+        side="bottom"
+        sideOffset={5}
       >
         <div
           onClick={(event) => event.stopPropagation()}


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes popover overflow issue in `SetPromptVersionLabels` by adjusting alignment and positioning.
> 
>   - **UI Fix**:
>     - In `index.tsx`, `PopoverContent` alignment changed to `start` and positioned to `bottom` with `sideOffset` of 5 to prevent overflow.
>     - Removed fixed positioning and custom transform styles from `PopoverContent`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1c099fdab18984cedce63d11befd5aa51eef1b07. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

co-authored by: @doganarif