### PR TITLE
fix: do not report usage to stripe for projects which have been deleted

### DIFF
--- a/worker/src/ee/cloudUsageMetering/handleCloudUsageMeteringJob.ts
+++ b/worker/src/ee/cloudUsageMetering/handleCloudUsageMeteringJob.ts
@@ -113,6 +113,9 @@ export const handleCloudUsageMeteringJob = async (job: Job) => {
           select: {
             id: true,
           },
+          where: {
+            deletedAt: null,
+          },
         },
       },
     })


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Exclude deleted projects from usage reporting to Stripe in `handleCloudUsageMeteringJob`.
> 
>   - **Behavior**:
>     - In `handleCloudUsageMeteringJob`, add condition to exclude projects with `deletedAt` not null when reporting usage to Stripe.
>   - **Files**:
>     - Modify `handleCloudUsageMeteringJob.ts` to implement the change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 103aa5362ac9a434f879bac506dc5863957f4feb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->