### PR TITLE
fix: plain not available on some page loads

### DIFF
--- a/web/src/features/support-chat/PlainChat.tsx
+++ b/web/src/features/support-chat/PlainChat.tsx
@@ -75,7 +75,8 @@ const PlainChat = () => {
 
 export default PlainChat;
 
-export const chatAvailable = !!env.NEXT_PUBLIC_PLAIN_APP_ID;
+export const chatAvailable =
+  !!env.NEXT_PUBLIC_PLAIN_APP_ID && window.Plain !== undefined;
 
 export const showChat = (): void => {
   if (chatAvailable) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `chatAvailable` in `PlainChat.tsx` to check for `window.Plain` to prevent errors on some page loads.
> 
>   - **Behavior**:
>     - Fixes `chatAvailable` export in `PlainChat.tsx` to check for `window.Plain` being defined, preventing errors on some page loads.
>   - **Functions**:
>     - Updates `chatAvailable` to `!!env.NEXT_PUBLIC_PLAIN_APP_ID && window.Plain !== undefined` in `PlainChat.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1443b922793149f3da307362e2127b107ee7d229. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->