### PR TITLE
fix: preserve new lines when displaying score comments on single trace view

### DIFF
--- a/web/src/components/grouped-score-badge.tsx
+++ b/web/src/components/grouped-score-badge.tsx
@@ -52,7 +52,7 @@ const ScoreGroupBadge = <T extends APIScore | LastUserScore>({
                   <MessageCircleMoreIcon className="mb-[0.0625rem] !size-3" />
                 </HoverCardTrigger>
                 <HoverCardContent className="overflow-hidden whitespace-normal break-normal">
-                  <p>{s.comment}</p>
+                  <p className="whitespace-pre-wrap">{s.comment}</p>
                 </HoverCardContent>
               </HoverCard>
             )}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `grouped-score-badge.tsx` to preserve whitespace in comments using `whitespace-pre-wrap`.
> 
>   - **UI Update**:
>     - In `grouped-score-badge.tsx`, updated `<p>` tag in `HoverCardContent` to use `whitespace-pre-wrap` for `s.comment` to preserve whitespace and line breaks in comments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b884fb7563dca74a1dc5d772d3a192f8c4b8197b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->