### PR TITLE
fixup(datasets): return empty metadata as hotfix for CPU postgres perf

### DIFF
--- a/web/src/features/datasets/components/DatasetsTable.tsx
+++ b/web/src/features/datasets/components/DatasetsTable.tsx
@@ -194,7 +194,7 @@ export function DatasetsTable(props: { projectId: string }) {
       lastRunAt: item.lastRunAt ?? undefined,
       countItems: item.countDatasetItems,
       countRuns: item.countDatasetRuns,
-      metadata: item.metadata,
+      metadata: "",
     };
   };
 

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -89,7 +89,6 @@ export const datasetRouter = createTRPCRouter({
           "datasets.id",
           "datasets.name",
           "datasets.description",
-          "datasets.metadata",
           "datasets.created_at as createdAt",
           "datasets.updated_at as updatedAt",
           eb.fn.count("dataset_items.id").distinct().as("countDatasetItems"),
@@ -101,7 +100,6 @@ export const datasetRouter = createTRPCRouter({
           "datasets.id",
           "datasets.name",
           "datasets.description",
-          "datasets.metadata",
           "datasets.created_at",
           "datasets.updated_at",
         ])
@@ -113,7 +111,7 @@ export const datasetRouter = createTRPCRouter({
 
       const datasets = await ctx.prisma.$queryRawUnsafe<
         Array<
-          Dataset & {
+          Omit<Dataset, "metadata"> & {
             countDatasetItems: number;
             countDatasetRuns: number;
             lastRunAt: Date | null;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove metadata from dataset queries and set it to an empty string in the frontend to improve Postgres CPU performance.
> 
>   - **Behavior**:
>     - In `DatasetsTable.tsx`, set `metadata` to an empty string in `convertToTableRow()`.
>     - In `dataset-router.ts`, remove `datasets.metadata` from the `allDatasets` query.
>   - **Types**:
>     - Change type in `allDatasets` query to `Omit<Dataset, "metadata">` in `dataset-router.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ab0f93113ea3664e0e64dbf88144e69d7c314f51. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->