### PR TITLE
chore(cost-tracking): add support for openai o3 and o4-mini models

### DIFF
--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -254,6 +254,10 @@ export type ExperimentMetadata = z.infer<typeof ExperimentMetadataSchema>;
 
 // NOTE: Update docs page when changing this! https://langfuse.com/docs/playground#openai-playground--anthropic-playground
 export const openAIModels = [
+  "o3",
+  "o3-2025-04-16",
+  "o4-mini",
+  "o4-mini-2025-04-16",
   "gpt-4.1",
   "gpt-4.1-2025-04-14",
   "gpt-4.1-mini-2025-04-14",

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1588,5 +1588,73 @@
       "tokensPerMessage": 3
     },
     "tokenizer_id": "openai"
+  },
+  {
+    "id": "cm7wmny967124dhjtb95w8f81",
+    "model_name": "o3",
+    "match_pattern": "(?i)^(o3)$",
+    "created_at": "2025-04-16T23:26:54.132Z",
+    "updated_at": "2025-04-16T23:26:54.132Z",
+    "prices": {
+      "input": 10e-6,
+      "input_cached_tokens": 2.5e-6,
+      "input_cache_read": 2.5e-6,
+      "output": 40e-6,
+      "output_reasoning_tokens": 40e-6,
+      "output_reasoning": 40e-6
+    },
+    "tokenizer_config": null,
+    "tokenizer_id": null
+  },
+  {
+    "id": "cm7wopq3327124dhjtb95w8f81",
+    "model_name": "o3-2025-04-16",
+    "match_pattern": "(?i)^(o3-2025-04-16)$",
+    "created_at": "2025-04-16T23:26:54.132Z",
+    "updated_at": "2025-04-16T23:26:54.132Z",
+    "prices": {
+      "input": 10e-6,
+      "input_cached_tokens": 2.5e-6,
+      "input_cache_read": 2.5e-6,
+      "output": 40e-6,
+      "output_reasoning_tokens": 40e-6,
+      "output_reasoning": 40e-6
+    },
+    "tokenizer_config": null,
+    "tokenizer_id": null
+  },
+  {
+    "id": "cm7wqrs1327124dhjtb95w8f81",
+    "model_name": "o4-mini",
+    "match_pattern": "(?i)^(o4-mini)$",
+    "created_at": "2025-04-16T23:26:54.132Z",
+    "updated_at": "2025-04-16T23:26:54.132Z",
+    "prices": {
+      "input": 1.1e-6,
+      "input_cached_tokens": 0.275e-6,
+      "input_cache_read": 0.275e-6,
+      "output": 4.4e-6,
+      "output_reasoning_tokens": 4.4e-6,
+      "output_reasoning": 4.4e-6
+    },
+    "tokenizer_config": null,
+    "tokenizer_id": null
+  },
+  {
+    "id": "cm7zqrs1327124dhjtb95w8f82",
+    "model_name": "o4-mini-2025-04-16",
+    "match_pattern": "(?i)^(o4-mini-2025-04-16)$",
+    "created_at": "2025-04-16T23:26:54.132Z",
+    "updated_at": "2025-04-16T23:26:54.132Z",
+    "prices": {
+      "input": 1.1e-6,
+      "input_cached_tokens": 0.275e-6,
+      "input_cache_read": 0.275e-6,
+      "output": 4.4e-6,
+      "output_reasoning_tokens": 4.4e-6,
+      "output_reasoning": 4.4e-6
+    },
+    "tokenizer_config": null,
+    "tokenizer_id": null
   }
 ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for OpenAI `o3` and `o4-mini` models with pricing details.
> 
>   - **Models**:
>     - Add `o3`, `o3-2025-04-16`, `o4-mini`, and `o4-mini-2025-04-16` to `openAIModels` in `types.ts`.
>   - **Pricing**:
>     - Add pricing details for `o3`, `o3-2025-04-16`, `o4-mini`, and `o4-mini-2025-04-16` in `default-model-prices.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ddea43edcef67140a35059df2c52beb1eda64986. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->