### PR TITLE
fix(tables): rename usage column to tokens column

### DIFF
--- a/packages/shared/src/observationsTable.ts
+++ b/packages/shared/src/observationsTable.ts
@@ -154,8 +154,8 @@ export const observationsTableCols: ColumnDefinition[] = [
     nullable: true,
   },
   {
-    name: "Usage",
-    id: "usage",
+    name: "Tokens",
+    id: "tokens",
     type: "number",
     internal: 'o."total_tokens"',
   },

--- a/packages/shared/src/tableDefinitions/mapObservationsTable.ts
+++ b/packages/shared/src/tableDefinitions/mapObservationsTable.ts
@@ -176,8 +176,8 @@ export const observationsTableUiColumnDefinitions: UiColumnMappings = [
     clickhouseTypeOverwrite: "Decimal64(3)",
   },
   {
-    uiTableName: "Usage",
-    uiTableId: "usage",
+    uiTableName: "Tokens",
+    uiTableId: "tokens",
     clickhouseTableName: "observations",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'total'), usage_details), usage_details['total'], NULL)",

--- a/packages/shared/src/tableDefinitions/mapTracesTable.ts
+++ b/packages/shared/src/tableDefinitions/mapTracesTable.ts
@@ -123,8 +123,8 @@ export const tracesTableUiColumnDefinitions: UiColumnMappings = [
     clickhouseTypeOverwrite: "Decimal64(3)",
   },
   {
-    uiTableName: "Usage",
-    uiTableId: "usage",
+    uiTableName: "Tokens",
+    uiTableId: "tokens",
     clickhouseTableName: "observations",
     clickhouseSelect:
       "if(mapExists((k, v) -> (k = 'total'), usage_details), usage_details['total'], NULL)",

--- a/packages/shared/src/tableDefinitions/tracesTable.ts
+++ b/packages/shared/src/tableDefinitions/tracesTable.ts
@@ -131,8 +131,8 @@ export const tracesTableCols: ColumnDefinition[] = [
     nullable: true,
   },
   {
-    name: "Usage",
-    id: "usage",
+    name: "Tokens",
+    id: "tokens",
     type: "number",
     internal: 'generation_metrics."totalTokens"',
     nullable: true,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renames 'Usage' column to 'Tokens' across table definitions and mappings, updating both UI and internal identifiers.
> 
>   - **Column Renaming**:
>     - Renames `Usage` column to `Tokens` in `observationsTable.ts` and `tracesTable.ts`.
>     - Updates `uiTableName` and `uiTableId` from `Usage` to `Tokens` in `mapObservationsTable.ts` and `mapTracesTable.ts`.
>   - **Internal Changes**:
>     - Updates internal identifiers from `usage` to `tokens` in SQL queries and mappings in `mapObservationsTable.ts` and `mapTracesTable.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 585b1d9553fd9efa3863ba342e9b04617b9b6d43. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->