### PR TITLE
Change orderBy to include ID in instances where createdAt is all the same

### DIFF
--- a/web/src/pages/api/public/v2/datasets/index.ts
+++ b/web/src/pages/api/public/v2/datasets/index.ts
@@ -69,10 +69,10 @@ export default withMiddlewares({
         },
         orderBy: [
           {
-            createdAt: "desc",
+            id: "desc",
           },
           {
-            id: "desc",
+            createdAt: "desc",
           },
         ],
         take: query.limit,

--- a/web/src/pages/api/public/v2/datasets/index.ts
+++ b/web/src/pages/api/public/v2/datasets/index.ts
@@ -67,9 +67,14 @@ export default withMiddlewares({
         where: {
           projectId: auth.scope.projectId,
         },
-        orderBy: {
-          createdAt: "desc",
-        },
+        orderBy: [
+          {
+            createdAt: "desc",
+          },
+          {
+            id: "desc",
+          },
+        ],
         take: query.limit,
         skip: (query.page - 1) * query.limit,
       });


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When you add dataset items via csv, they all get the same createdAt time. This is a problem because pagination through the API orders the data via createdAt. I was using the API and noticed that things were really funky, like repeated items on different pages and whatnot. I noticed that annotation queues will also order by id, so I introduce the same logic. You can find out this works [here](https://www.prisma.io/docs/orm/reference/prisma-client-reference#orderby). Basically it'll first sort by id, then sort by createdAt. 

I can add tests if need be

I think sorting by id, then createdAt is probably the desired behavior, because we want createdAt to take precedence. Correct me if I'm wrong

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't added tests that prove my fix is effective or that my feature works

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes pagination issues in `index.ts` by ordering datasets by `id` and `createdAt`.
> 
>   - **Behavior**:
>     - Modifies `GET` route in `index.ts` to order datasets by `id` and `createdAt` to fix pagination issues when `createdAt` timestamps are identical.
>   - **Misc**:
>     - No tests added for this change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a849e6d8d96a0706af6956a119ea689ad45f3e6a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->