### PR TITLE
feat(dashboard): allow filtering by observation name

### DIFF
--- a/web/src/features/query/dashboardUiTableToViewMapping.ts
+++ b/web/src/features/query/dashboardUiTableToViewMapping.ts
@@ -11,6 +11,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       viewName: "name",
     },
     {
+      uiTableName: "Observation Name",
+      viewName: "observationName",
+    },
+    {
       uiTableName: "Tags",
       viewName: "tags",
     },
@@ -39,6 +43,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
     {
       uiTableName: "Trace Name",
       viewName: "traceName",
+    },
+    {
+      uiTableName: "Observation Name",
+      viewName: "name",
     },
     {
       uiTableName: "User",
@@ -107,6 +115,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       viewName: "traceName",
     },
     {
+      uiTableName: "Observation Name",
+      viewName: "observationName",
+    },
+    {
       uiTableName: "Release",
       viewName: "traceRelease",
     },
@@ -149,6 +161,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       viewName: "traceName",
     },
     {
+      uiTableName: "Observation Name",
+      viewName: "observationName",
+    },
+    {
       uiTableName: "Release",
       viewName: "traceRelease",
     },
@@ -169,6 +185,12 @@ const isLegacyUiTableFilter = (
         uiTableId: "sessionId",
         clickhouseTableName: "traces",
         clickhouseSelect: 't."sessionId"',
+      },
+      {
+        uiTableName: "Observation Name",
+        uiTableId: "observationName",
+        clickhouseTableName: "observations",
+        clickhouseSelect: 'o."name"',
       },
     ])
     .some((columnDef) => columnDef.uiTableName === filter.column);

--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -45,6 +45,12 @@ export const traceView: ViewDeclarationType = {
       sql: "environment",
       type: "string",
     },
+    observationName: {
+      sql: "name",
+      alias: "observationName",
+      type: "string",
+      relationTable: "observations",
+    },
   },
   measures: {
     count: {

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -162,6 +162,12 @@ export function WidgetForm({
       internal: "internalValue",
     },
     {
+      name: "Observation Name",
+      id: "observationName",
+      type: "string",
+      internal: "internalValue",
+    },
+    {
       name: "Tags",
       id: "tags",
       type: "arrayOptions",

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -128,6 +128,12 @@ export default function DashboardDetail() {
       internal: "internalValue",
     },
     {
+      name: "Observation Name",
+      id: "observationName",
+      type: "string",
+      internal: "internalValue",
+    },
+    {
       name: "Tags",
       id: "tags",
       type: "arrayOptions",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add 'Observation Name' filter option to dashboard views and update related models and UI components.
> 
>   - **Behavior**:
>     - Adds 'Observation Name' filter option in `dashboardUiTableToViewMapping.ts` for traces, observations, scores-numeric, and scores-categorical views.
>     - Updates `isLegacyUiTableFilter` to include 'Observation Name'.
>   - **Models**:
>     - Adds `observationName` dimension to `traceView` in `dataModel.ts`.
>   - **UI Components**:
>     - Adds 'Observation Name' to filter columns in `WidgetForm.tsx` and `index.tsx` for dashboards.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5ad2b7ab8fbd9810ccf37d2cd6367bb4b1412408. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->