### PR TITLE
feat: allow optional metadata param on org / project CRUD API

### DIFF
--- a/fern/apis/organizations/definition/organizations.yml
+++ b/fern/apis/organizations/definition/organizations.yml
@@ -24,6 +24,9 @@ service:
         body:
           properties:
             name: string
+            metadata:
+              type: optional<map<string, unknown>>
+              docs: Optional metadata for the organization
       response: Organization
       errors:
         - commons.Error
@@ -53,6 +56,9 @@ service:
         body:
           properties:
             name: string
+            metadata:
+              type: optional<map<string, unknown>>
+              docs: Optional metadata for the organization
       response: Organization
       errors:
         - commons.Error
@@ -128,6 +134,9 @@ types:
       id: string
       name: string
       createdAt: datetime
+      metadata:
+        type: map<string, unknown>
+        docs: Metadata for the organization
 
   DeleteOrganizationResponse:
     docs: Response for successful organization deletion

--- a/fern/apis/server/definition/projects.yml
+++ b/fern/apis/server/definition/projects.yml
@@ -21,6 +21,9 @@ service:
         body:
           properties:
             name: string
+            metadata:
+              type: optional<map<string, unknown>>
+              docs: Optional metadata for the project
             retention:
               type: integer
               docs: Number of days to retain data. Must be 0 or at least 7 days. Requires data-retention entitlement for non-zero values. Optional.
@@ -37,6 +40,9 @@ service:
         body:
           properties:
             name: string
+            metadata:
+              type: optional<map<string, unknown>>
+              docs: Optional metadata for the project
             retention:
               type: integer
               docs: Number of days to retain data. Must be 0 or at least 7 days. Requires data-retention entitlement for non-zero values. Optional.
@@ -94,6 +100,9 @@ types:
     properties:
       id: string
       name: string
+      metadata:
+        type: map<string, unknown>
+        docs: Metadata for the project
       retentionDays:
         type: integer
         docs: Number of days to retain data. Null or 0 means no retention. Omitted if no retention is configured.

--- a/packages/shared/prisma/generated/types.ts
+++ b/packages/shared/prisma/generated/types.ts
@@ -531,6 +531,7 @@ export type Organization = {
     created_at: Generated<Timestamp>;
     updated_at: Generated<Timestamp>;
     cloud_config: unknown | null;
+    metadata: unknown | null;
 };
 export type OrganizationMembership = {
     id: string;
@@ -564,6 +565,7 @@ export type Project = {
     deleted_at: Timestamp | null;
     name: string;
     retention_days: number | null;
+    metadata: unknown | null;
 };
 export type ProjectMembership = {
     org_membership_id: string;

--- a/packages/shared/prisma/migrations/20250420120553_add_organization_and_project_metadata/migration.sql
+++ b/packages/shared/prisma/migrations/20250420120553_add_organization_and_project_metadata/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "organizations" ADD COLUMN     "metadata" JSONB;
+
+-- AlterTable
+ALTER TABLE "projects" ADD COLUMN     "metadata" JSONB;

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -105,6 +105,7 @@ model Organization {
   createdAt               DateTime                 @default(now()) @map("created_at")
   updatedAt               DateTime                 @default(now()) @updatedAt @map("updated_at")
   cloudConfig             Json?                    @map("cloud_config") // Langfuse Cloud, for zod schema see @/src/features/organizations/utils/cloudConfigSchema
+  metadata                Json?
   organizationMemberships OrganizationMembership[]
   projects                Project[]
   MembershipInvitation    MembershipInvitation[]
@@ -121,6 +122,7 @@ model Project {
   deletedAt              DateTime?                 @map("deleted_at")
   name                   String
   retentionDays          Int?                      @map("retention_days")
+  metadata               Json?
   projectMembers         ProjectMembership[]
   organization           Organization              @relation(fields: [orgId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   apiKeys                ApiKey[]

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -2256,6 +2256,11 @@ paths:
               properties:
                 name:
                   type: string
+                metadata:
+                  type: object
+                  additionalProperties: true
+                  nullable: true
+                  description: Optional metadata for the project
                 retention:
                   type: integer
                   description: >-
@@ -2320,6 +2325,11 @@ paths:
               properties:
                 name:
                   type: string
+                metadata:
+                  type: object
+                  additionalProperties: true
+                  nullable: true
+                  description: Optional metadata for the project
                 retention:
                   type: integer
                   description: >-
@@ -6282,6 +6292,10 @@ components:
           type: string
         name:
           type: string
+        metadata:
+          type: object
+          additionalProperties: true
+          description: Metadata for the project
         retentionDays:
           type: integer
           description: >-
@@ -6290,6 +6304,7 @@ components:
       required:
         - id
         - name
+        - metadata
         - retentionDays
     ProjectDeletionResponse:
       title: ProjectDeletionResponse

--- a/web/public/generated/organizations-api/openapi.yml
+++ b/web/public/generated/organizations-api/openapi.yml
@@ -126,6 +126,11 @@ paths:
               properties:
                 name:
                   type: string
+                metadata:
+                  type: object
+                  additionalProperties: true
+                  nullable: true
+                  description: Optional metadata for the organization
               required:
                 - name
   /api/admin/organizations/{organizationId}:
@@ -224,6 +229,11 @@ paths:
               properties:
                 name:
                   type: string
+                metadata:
+                  type: object
+                  additionalProperties: true
+                  nullable: true
+                  description: Optional metadata for the organization
               required:
                 - name
     delete:
@@ -441,10 +451,15 @@ components:
         createdAt:
           type: string
           format: date-time
+        metadata:
+          type: object
+          additionalProperties: true
+          description: Metadata for the organization
       required:
         - id
         - name
         - createdAt
+        - metadata
     DeleteOrganizationResponse:
       title: DeleteOrganizationResponse
       type: object

--- a/web/public/generated/organizations-postman/collection.json
+++ b/web/public/generated/organizations-postman/collection.json
@@ -80,7 +80,7 @@
             "auth": null,
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"name\": \"example\"\n}",
+              "raw": "{\n    \"name\": \"example\",\n    \"metadata\": {\n        \"example\": \"UNKNOWN\"\n    }\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -152,7 +152,7 @@
             "auth": null,
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"name\": \"example\"\n}",
+              "raw": "{\n    \"name\": \"example\",\n    \"metadata\": {\n        \"example\": \"UNKNOWN\"\n    }\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -1723,7 +1723,7 @@
             "auth": null,
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"name\": \"example\",\n    \"retention\": 0\n}",
+              "raw": "{\n    \"name\": \"example\",\n    \"metadata\": {\n        \"example\": \"UNKNOWN\"\n    },\n    \"retention\": 0\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -1763,7 +1763,7 @@
             "auth": null,
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"name\": \"example\",\n    \"retention\": 0\n}",
+              "raw": "{\n    \"name\": \"example\",\n    \"metadata\": {\n        \"example\": \"UNKNOWN\"\n    },\n    \"retention\": 0\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/web/src/__tests__/async/organizations-api.servertest.ts
+++ b/web/src/__tests__/async/organizations-api.servertest.ts
@@ -13,6 +13,7 @@ const OrganizationResponseSchema = z.object({
   id: z.string(),
   name: z.string(),
   createdAt: z.string().datetime(),
+  metadata: z.object({}),
 });
 
 // Schema for multiple organizations response
@@ -56,6 +57,39 @@ describe("Admin Organizations API", () => {
   describe("POST /api/admin/organizations", () => {
     it("should create a new organization with valid admin authentication", async () => {
       const uniqueOrgName = `Test Org ${randomUUID().substring(0, 8)}`;
+      const metadata = { tier: "testing", users: 5 };
+
+      const response = await makeZodVerifiedAPICall(
+        OrganizationResponseSchema,
+        "POST",
+        "/api/admin/organizations",
+        {
+          name: uniqueOrgName,
+          metadata: metadata,
+        },
+        `Bearer ${ADMIN_API_KEY}`,
+        201, // Expected status code is 201 Created
+      );
+
+      expect(response.status).toBe(201);
+      expect(response.body).toMatchObject({
+        name: uniqueOrgName,
+        metadata: metadata,
+      });
+      expect(response.body.id).toBeDefined();
+      expect(response.body.createdAt).toBeDefined();
+
+      // Verify the organization was actually created in the database
+      const org = await prisma.organization.findUnique({
+        where: { id: response.body.id },
+      });
+      expect(org).not.toBeNull();
+      expect(org?.name).toBe(uniqueOrgName);
+      expect(org?.metadata).toEqual(metadata);
+    });
+
+    it("should create a new organization without metadata", async () => {
+      const uniqueOrgName = `Test Org ${randomUUID().substring(0, 8)}`;
 
       const response = await makeZodVerifiedAPICall(
         OrganizationResponseSchema,
@@ -71,6 +105,7 @@ describe("Admin Organizations API", () => {
       expect(response.status).toBe(201);
       expect(response.body).toMatchObject({
         name: uniqueOrgName,
+        metadata: {},
       });
       expect(response.body.id).toBeDefined();
       expect(response.body.createdAt).toBeDefined();
@@ -81,6 +116,7 @@ describe("Admin Organizations API", () => {
       });
       expect(org).not.toBeNull();
       expect(org?.name).toBe(uniqueOrgName);
+      expect(org?.metadata).toBeNull();
     });
 
     it("should return 401 when no authorization header is provided", async () => {
@@ -142,7 +178,7 @@ describe("Admin Organizations API", () => {
       // Create a test organization to retrieve
       const uniqueOrgName = `Test Org ${randomUUID().substring(0, 8)}`;
       const org = await prisma.organization.create({
-        data: { name: uniqueOrgName },
+        data: { name: uniqueOrgName, metadata: { tier: "testing", users: 5 } },
       });
       testOrgId = org.id;
     });
@@ -175,6 +211,10 @@ describe("Admin Organizations API", () => {
       expect(
         response.body.organizations.some((org) => org.id === testOrgId),
       ).toBe(true);
+      expect(
+        response.body.organizations.find((org) => org.id === testOrgId)
+          ?.metadata,
+      ).toEqual({ tier: "testing", users: 5 });
     });
 
     it("should return 401 when no authorization header is provided", async () => {
@@ -191,7 +231,7 @@ describe("Admin Organizations API", () => {
       // Create a test organization to retrieve
       const uniqueOrgName = `Test Org ${randomUUID().substring(0, 8)}`;
       const org = await prisma.organization.create({
-        data: { name: uniqueOrgName },
+        data: { name: uniqueOrgName, metadata: { tier: "testing", users: 5 } },
       });
       testOrgId = org.id;
     });
@@ -219,6 +259,7 @@ describe("Admin Organizations API", () => {
 
       expect(response.status).toBe(200);
       expect(response.body.id).toBe(testOrgId);
+      expect(response.body.metadata).toEqual({ tier: "testing", users: 5 });
     });
 
     it("should return 404 when getting a non-existent organization", async () => {
@@ -242,7 +283,7 @@ describe("Admin Organizations API", () => {
       // Create a test organization to update
       const uniqueOrgName = `Test Org ${randomUUID().substring(0, 8)}`;
       const org = await prisma.organization.create({
-        data: { name: uniqueOrgName },
+        data: { name: uniqueOrgName, metadata: { tier: "testing", users: 5 } },
       });
       testOrgId = org.id;
     });
@@ -260,6 +301,7 @@ describe("Admin Organizations API", () => {
 
     it("should update an organization with valid admin authentication", async () => {
       const newName = `Updated Org ${randomUUID().substring(0, 8)}`;
+      const newMetadata = { tier: "updated", users: 10, featureX: true };
 
       const response = await makeZodVerifiedAPICall(
         OrganizationResponseSchema,
@@ -267,6 +309,7 @@ describe("Admin Organizations API", () => {
         `/api/admin/organizations/${testOrgId}`,
         {
           name: newName,
+          metadata: newMetadata,
         },
         `Bearer ${ADMIN_API_KEY}`,
         200,
@@ -276,6 +319,7 @@ describe("Admin Organizations API", () => {
       expect(response.body).toMatchObject({
         id: testOrgId,
         name: newName,
+        metadata: newMetadata,
       });
 
       // Verify the organization was actually updated in the database
@@ -284,6 +328,7 @@ describe("Admin Organizations API", () => {
       });
       expect(org).not.toBeNull();
       expect(org?.name).toBe(newName);
+      expect(org?.metadata).toEqual(newMetadata);
     });
 
     it("should return 404 when updating a non-existent organization", async () => {
@@ -336,7 +381,7 @@ describe("Admin Organizations API", () => {
       // Create a test organization to delete
       const uniqueOrgName = `Test Org ${randomUUID().substring(0, 8)}`;
       const org = await prisma.organization.create({
-        data: { name: uniqueOrgName },
+        data: { name: uniqueOrgName, metadata: { tier: "testing", users: 5 } },
       });
       testOrgId = org.id;
     });
@@ -357,7 +402,10 @@ describe("Admin Organizations API", () => {
       const uniqueOrgName = `Test Org ${randomUUID().substring(0, 8)}`;
       const orgId = (
         await prisma.organization.create({
-          data: { name: uniqueOrgName },
+          data: {
+            name: uniqueOrgName,
+            metadata: { tier: "testing", users: 5 },
+          },
         })
       ).id;
 
@@ -440,7 +488,7 @@ describe("Admin Organizations API", () => {
       // Create a test organization
       const uniqueOrgName = `Test Org ${randomUUID().substring(0, 8)}`;
       const org = await prisma.organization.create({
-        data: { name: uniqueOrgName },
+        data: { name: uniqueOrgName, metadata: { tier: "testing", users: 5 } },
       });
       testOrgId = org.id;
 
@@ -508,7 +556,7 @@ describe("Admin Organizations API", () => {
       // Create a test organization
       const uniqueOrgName = `Test Org ${randomUUID().substring(0, 8)}`;
       const org = await prisma.organization.create({
-        data: { name: uniqueOrgName },
+        data: { name: uniqueOrgName, metadata: { tier: "testing", users: 5 } },
       });
       testOrgId = org.id;
     });
@@ -590,7 +638,7 @@ describe("Admin Organizations API", () => {
       // Create a test organization
       const uniqueOrgName = `Test Org ${randomUUID().substring(0, 8)}`;
       const org = await prisma.organization.create({
-        data: { name: uniqueOrgName },
+        data: { name: uniqueOrgName, metadata: { tier: "testing", users: 5 } },
       });
       testOrgId = org.id;
 

--- a/web/src/__tests__/async/projects-api.servertest.ts
+++ b/web/src/__tests__/async/projects-api.servertest.ts
@@ -116,14 +116,8 @@ describe("Projects API", () => {
       expect(response.body.data[0]).toMatchObject({
         id: projectId,
         name: projectName,
+        metadata: {},
       });
-      expect(
-        response.body.data.some((project) => project.id === projectId),
-      ).toBe(true);
-      expect(
-        response.body.data.find((project) => project.id === projectId)
-          ?.metadata,
-      ).toEqual({ plan: "free", features: ["basic"] });
     });
 
     it("should return 401 when invalid API keys are provided", async () => {

--- a/web/src/ee/features/admin-api/organizations/index.ts
+++ b/web/src/ee/features/admin-api/organizations/index.ts
@@ -13,9 +13,15 @@ export async function handleGetOrganizations(
       id: true,
       name: true,
       createdAt: true,
+      metadata: true,
     },
   });
-  return res.status(200).json({ organizations });
+  return res.status(200).json({
+    organizations: organizations.map((org) => ({
+      ...org,
+      metadata: org.metadata ?? {},
+    })),
+  });
 }
 
 export async function handleCreateOrganization(
@@ -35,10 +41,23 @@ export async function handleCreateOrganization(
 
   const { name } = validationResult.data;
 
+  const { metadata } = req.body;
+  if (metadata !== undefined && typeof metadata !== "object") {
+    try {
+      JSON.parse(metadata);
+    } catch (error) {
+      debugger;
+      return res.status(400).json({
+        message: `Invalid metadata. Should be a valid JSON object: ${error}`,
+      });
+    }
+  }
+
   // Create the organization in the database
   const organization = await prisma.organization.create({
     data: {
       name,
+      metadata,
     },
   });
 
@@ -59,5 +78,6 @@ export async function handleCreateOrganization(
     id: organization.id,
     name: organization.name,
     createdAt: organization.createdAt,
+    metadata: organization.metadata ?? {},
   });
 }

--- a/web/src/ee/features/admin-api/organizations/index.ts
+++ b/web/src/ee/features/admin-api/organizations/index.ts
@@ -46,7 +46,6 @@ export async function handleCreateOrganization(
     try {
       JSON.parse(metadata);
     } catch (error) {
-      debugger;
       return res.status(400).json({
         message: `Invalid metadata. Should be a valid JSON object: ${error}`,
       });

--- a/web/src/ee/features/admin-api/organizations/organizationById.ts
+++ b/web/src/ee/features/admin-api/organizations/organizationById.ts
@@ -31,6 +31,7 @@ export async function handleGetOrganizationById(
       id: true,
       name: true,
       createdAt: true,
+      metadata: true,
     },
   });
 
@@ -38,7 +39,10 @@ export async function handleGetOrganizationById(
     return res.status(404).json({ error: "Organization not found" });
   }
 
-  return res.status(200).json(organization);
+  return res.status(200).json({
+    ...organization,
+    metadata: organization.metadata ?? {},
+  });
 }
 
 export async function handleUpdateOrganization(
@@ -61,6 +65,18 @@ export async function handleUpdateOrganization(
 
   const { name } = validationResult.data;
 
+  const { metadata } = req.body;
+  if (metadata !== undefined && typeof metadata !== "object") {
+    try {
+      JSON.parse(metadata);
+    } catch (error) {
+      debugger;
+      return res.status(400).json({
+        message: `Invalid metadata. Should be a valid JSON object: ${error}`,
+      });
+    }
+  }
+
   // Check if organization exists
   const existingOrg = await prisma.organization.findUnique({
     where: { id: organizationId },
@@ -73,7 +89,7 @@ export async function handleUpdateOrganization(
   // Update the organization
   const updatedOrganization = await prisma.organization.update({
     where: { id: organizationId },
-    data: { name },
+    data: { name, metadata },
   });
 
   // Log the update
@@ -94,6 +110,7 @@ export async function handleUpdateOrganization(
     id: updatedOrganization.id,
     name: updatedOrganization.name,
     createdAt: updatedOrganization.createdAt,
+    metadata: updatedOrganization.metadata ?? {},
   });
 }
 

--- a/web/src/ee/features/admin-api/organizations/organizationById.ts
+++ b/web/src/ee/features/admin-api/organizations/organizationById.ts
@@ -70,7 +70,6 @@ export async function handleUpdateOrganization(
     try {
       JSON.parse(metadata);
     } catch (error) {
-      debugger;
       return res.status(400).json({
         message: `Invalid metadata. Should be a valid JSON object: ${error}`,
       });

--- a/web/src/ee/features/admin-api/public/projects/createProject.ts
+++ b/web/src/ee/features/admin-api/public/projects/createProject.ts
@@ -27,7 +27,6 @@ export async function handleCreateProject(
       try {
         JSON.parse(metadata);
       } catch (error) {
-        debugger;
         return res.status(400).json({
           message: `Invalid metadata. Should be a valid JSON object: ${error}`,
         });

--- a/web/src/ee/features/admin-api/public/projects/createProject.ts
+++ b/web/src/ee/features/admin-api/public/projects/createProject.ts
@@ -12,7 +12,7 @@ export async function handleCreateProject(
   scope: ApiAccessScope,
 ) {
   try {
-    const { name, retention } = req.body;
+    const { name, retention, metadata } = req.body;
 
     // Validate project name
     try {
@@ -21,6 +21,17 @@ export async function handleCreateProject(
       return res.status(400).json({
         message: "Invalid project name. Should be between 3 and 60 characters.",
       });
+    }
+
+    if (metadata !== undefined && typeof metadata !== "object") {
+      try {
+        JSON.parse(metadata);
+      } catch (error) {
+        debugger;
+        return res.status(400).json({
+          message: `Invalid metadata. Should be a valid JSON object: ${error}`,
+        });
+      }
     }
 
     // Validate retention days if provided
@@ -69,12 +80,14 @@ export async function handleCreateProject(
         name,
         orgId: scope.orgId,
         retentionDays: retention,
+        metadata,
       },
     });
 
     return res.status(201).json({
       id: project.id,
       name: project.name,
+      metadata: project.metadata ?? {},
       ...(project.retentionDays // Do not add if null or 0
         ? { retentionDays: project.retentionDays }
         : {}),

--- a/web/src/ee/features/admin-api/public/projects/projectById/index.ts
+++ b/web/src/ee/features/admin-api/public/projects/projectById/index.ts
@@ -35,7 +35,6 @@ export async function handleUpdateProject(
       try {
         JSON.parse(metadata);
       } catch (error) {
-        debugger;
         return res.status(400).json({
           message: `Invalid metadata. Should be a valid JSON object: ${error}`,
         });

--- a/web/src/ee/features/admin-api/public/projects/projectById/index.ts
+++ b/web/src/ee/features/admin-api/public/projects/projectById/index.ts
@@ -20,7 +20,7 @@ export async function handleUpdateProject(
   scope: ApiAccessScope,
 ) {
   try {
-    const { name, retention } = req.body;
+    const { name, retention, metadata } = req.body;
 
     // Validate project name
     try {
@@ -29,6 +29,17 @@ export async function handleUpdateProject(
       return res.status(400).json({
         message: "Invalid project name. Should be between 3 and 60 characters.",
       });
+    }
+
+    if (metadata !== undefined && typeof metadata !== "object") {
+      try {
+        JSON.parse(metadata);
+      } catch (error) {
+        debugger;
+        return res.status(400).json({
+          message: `Invalid metadata. Should be a valid JSON object: ${error}`,
+        });
+      }
     }
 
     // Validate retention days using the schema
@@ -64,17 +75,20 @@ export async function handleUpdateProject(
       data: {
         name,
         retentionDays: retention,
+        metadata,
       },
       select: {
         id: true,
         name: true,
         retentionDays: true,
+        metadata: true,
       },
     });
 
     return res.status(200).json({
       id: updatedProject.id,
       name: updatedProject.name,
+      metadata: updatedProject.metadata ?? {},
       ...(updatedProject.retentionDays // Do not add if null or 0
         ? { retentionDays: updatedProject.retentionDays }
         : {}),

--- a/web/src/pages/api/public/projects/index.ts
+++ b/web/src/pages/api/public/projects/index.ts
@@ -3,7 +3,6 @@ import { cors, runMiddleware } from "@/src/features/public-api/server/cors";
 import { prisma } from "@langfuse/shared/src/db";
 import { logger, redis } from "@langfuse/shared/src/server";
 import { handleCreateProject } from "@/src/ee/features/admin-api/public/projects/createProject";
-
 import { type NextApiRequest, type NextApiResponse } from "next";
 import { hasEntitlementBasedOnPlan } from "@/src/features/entitlements/server/hasEntitlement";
 
@@ -50,6 +49,7 @@ export default async function handler(
           id: true,
           name: true,
           retentionDays: true,
+          metadata: true,
         },
         where: {
           id: authCheck.scope.projectId,
@@ -61,6 +61,7 @@ export default async function handler(
         data: projects.map((project) => ({
           id: project.id,
           name: project.name,
+          metadata: project.metadata ?? {},
           ...(project.retentionDays // Do not add if null or 0
             ? { retentionDays: project.retentionDays }
             : {}),

--- a/web/src/pages/organization/[organizationId]/settings/index.tsx
+++ b/web/src/pages/organization/[organizationId]/settings/index.tsx
@@ -42,7 +42,7 @@ export const getOrganizationSettingsPages = ({
   showBillingSettings,
   isLangfuseCloud,
 }: {
-  organization: { id: string; name: string };
+  organization: { id: string; name: string; metadata: Record<string, unknown> };
   showBillingSettings: boolean;
   isLangfuseCloud: boolean;
 }): OrganizationSettingsPage[] => [
@@ -57,7 +57,11 @@ export const getOrganizationSettingsPages = ({
           <Header title="Debug Information" />
           <JSONView
             title="Metadata"
-            json={{ name: organization.name, id: organization.id }}
+            json={{
+              name: organization.name,
+              id: organization.id,
+              ...organization.metadata,
+            }}
           />
         </div>
         <SettingsDangerZone

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -212,8 +212,6 @@ export default function DashboardDetail() {
             )
           : 0;
 
-      debugger;
-
       // Create a new widget placement
       const newWidgetPlacement: WidgetPlacement = {
         id: uuidv4(),

--- a/web/src/pages/project/[projectId]/settings/index.tsx
+++ b/web/src/pages/project/[projectId]/settings/index.tsx
@@ -73,8 +73,8 @@ export const getProjectSettingsPages = ({
   showLLMConnectionsSettings,
   showProtectedLabelsSettings,
 }: {
-  project: { id: string; name: string };
-  organization: { id: string; name: string };
+  project: { id: string; name: string; metadata: Record<string, unknown> };
+  organization: { id: string; name: string; metadata: Record<string, unknown> };
   showBillingSettings: boolean;
   showRetentionSettings: boolean;
   showLLMConnectionsSettings: boolean;
@@ -94,8 +94,16 @@ export const getProjectSettingsPages = ({
           <JSONView
             title="Metadata"
             json={{
-              project: { name: project.name, id: project.id },
-              org: { name: organization.name, id: organization.id },
+              project: {
+                name: project.name,
+                id: project.id,
+                ...project.metadata,
+              },
+              org: {
+                name: organization.name,
+                id: organization.id,
+                ...organization.metadata,
+              },
             }}
           />
         </div>

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -521,6 +521,11 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                           id: orgMembership.organization.id,
                           name: orgMembership.organization.name,
                           role: orgMembership.role,
+                          metadata:
+                            (orgMembership.organization.metadata as Record<
+                              string,
+                              unknown
+                            >) ?? {},
                           cloudConfig: parsedCloudConfig.data,
                           projects: orgMembership.organization.projects
                             .map((project) => {
@@ -535,6 +540,11 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                                 role: projectRole,
                                 retentionDays: project.retentionDays,
                                 deletedAt: project.deletedAt,
+                                metadata:
+                                  (project.metadata as Record<
+                                    string,
+                                    unknown
+                                  >) ?? {},
                               };
                             })
                             // Only include projects where the user has the required role

--- a/web/types/next-auth.d.ts
+++ b/web/types/next-auth.d.ts
@@ -41,11 +41,13 @@ declare module "next-auth" {
       role: Role;
       cloudConfig: CloudConfigSchema | undefined;
       plan: Plan;
+      metadata: Record<string, unknown>;
       projects: {
         id: PrismaProject["id"];
         name: PrismaProject["name"];
         deletedAt: PrismaProject["deletedAt"];
         retentionDays: PrismaProject["retentionDays"];
+        metadata: Record<string, unknown>;
         role: Role; // include only projects where user has a role
       }[];
     }[];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add optional `metadata` parameter to organization and project CRUD operations, update types, API specs, tests, and UI to support it.
> 
>   - **Behavior**:
>     - Add optional `metadata` parameter to organization and project CRUD operations in `organizations.yml` and `projects.yml`.
>     - Update `Organization` and `Project` types in `types.ts` to include `metadata`.
>     - Add `metadata` column to `organizations` and `projects` tables in `migration.sql`.
>   - **API**:
>     - Update `openapi.yml` and `collection.json` to reflect new `metadata` parameter for organization and project endpoints.
>   - **Tests**:
>     - Add tests for `metadata` handling in `organizations-api.servertest.ts` and `projects-api.servertest.ts`.
>   - **UI**:
>     - Display `metadata` in organization and project settings pages in `index.tsx` files.
>   - **Misc**:
>     - Update `auth.ts` and `next-auth.d.ts` to include `metadata` in session and user objects.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for be68220b3074216a0225102c3886a0696bcfe696. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->