### PR TITLE
chore: confirm pagination behaviour for scores-api

### DIFF
--- a/packages/shared/src/features/scores/scoreTypes.ts
+++ b/packages/shared/src/features/scores/scoreTypes.ts
@@ -9,7 +9,6 @@ import {
 } from "../../utils/zod";
 import { Category as ConfigCategory } from "./scoreConfigTypes";
 import { ScoreDomain } from "../../domain";
-import { logger } from "../../server";
 
 /**
  * Types to use across codebase
@@ -304,7 +303,7 @@ export const legacyFilterAndValidateV1GetScoreList = (
       if (result.success) {
         acc.push(result.data);
       } else {
-        logger.error(`Score parsing error`, result.error);
+        console.error(`Score parsing error ${JSON.stringify(result.error)}`);
         onParseError?.(result.error);
       }
       return acc;

--- a/packages/shared/src/features/scores/scoreTypes.ts
+++ b/packages/shared/src/features/scores/scoreTypes.ts
@@ -9,6 +9,7 @@ import {
 } from "../../utils/zod";
 import { Category as ConfigCategory } from "./scoreConfigTypes";
 import { ScoreDomain } from "../../domain";
+import { logger } from "../../server";
 
 /**
  * Types to use across codebase
@@ -303,7 +304,7 @@ export const legacyFilterAndValidateV1GetScoreList = (
       if (result.success) {
         acc.push(result.data);
       } else {
-        console.error("Score parsing error: ", result.error);
+        logger.error(`Score parsing error`, result.error);
         onParseError?.(result.error);
       }
       return acc;

--- a/web/src/__tests__/async/scores-api.servertest.ts
+++ b/web/src/__tests__/async/scores-api.servertest.ts
@@ -246,6 +246,94 @@ describe("/api/public/scores API Endpoint", () => {
   });
 
   describe("GET /api/public/scores", () => {
+    it("#6396: should correctly list 100s of scores", async () => {
+      const { projectId, auth } = await createOrgProjectAndApiKey();
+
+      // Create a trace to associate with all scores
+      const traceId = v4();
+      const trace = createTrace({
+        id: traceId,
+        project_id: projectId,
+      });
+      await createTracesCh([trace]);
+
+      // Create observation to associate with scores
+      const observationId = v4();
+      const observation = createObservation({
+        id: observationId,
+        project_id: projectId,
+        type: "GENERATION",
+      });
+      await createObservationsCh([observation]);
+
+      // Create about 200 scores
+      const totalScores = 220;
+      const scores = [];
+
+      for (let i = 0; i < totalScores; i++) {
+        scores.push(
+          createScore({
+            id: v4(),
+            project_id: projectId,
+            trace_id: traceId,
+            name: `score-${i}`,
+            value: i,
+            data_type: "NUMERIC",
+            observation_id: observationId,
+          }),
+        );
+      }
+
+      await createScoresCh(scores);
+
+      // Define page size smaller than total to ensure pagination
+      const pageSize = 50;
+      let page = 1;
+      let totalFetched = 0;
+      let hasMorePages = true;
+
+      // Fetch all pages and verify count matches
+      while (hasMorePages) {
+        const response = await makeZodVerifiedAPICall(
+          GetScoresResponse,
+          "GET",
+          `/api/public/scores?limit=${pageSize}&page=${page}`,
+          undefined,
+          auth,
+        );
+
+        expect(response.status).toBe(200);
+
+        // Verify metadata is accurate
+        expect(response.body.meta).toMatchObject({
+          page,
+          limit: pageSize,
+          totalItems: totalScores,
+          totalPages: 5, // totalScores / pageSize
+        });
+
+        // Count fetched items
+        totalFetched += response.body.data.length;
+
+        for (const score of response.body.data) {
+          expect(score).toMatchObject({
+            traceId,
+            observationId,
+            dataType: "NUMERIC",
+          });
+          expect(score.name).toMatch(/^score-\d+$/);
+          expect(score.value).toBe(parseInt(score.name.split("-")[1]));
+        }
+
+        // Check if we need to fetch more pages
+        hasMorePages = page <= response.body.meta.totalPages;
+        page++;
+      }
+
+      // Verify we fetched exactly the number of scores we created
+      expect(totalFetched).toBe(totalScores);
+    });
+
     describe("should Filter scores", () => {
       let configId = "";
       const userId = "user-name";


### PR DESCRIPTION
Contributes to #6396 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a test to confirm pagination behavior for the scores API and improves error logging in `scoreTypes.ts`.
> 
>   - **Tests**:
>     - Adds test in `scores-api.servertest.ts` to verify pagination for `/api/public/scores` endpoint with 220 scores, ensuring correct metadata and data retrieval across pages.
>   - **Logging**:
>     - Improves error logging in `legacyFilterAndValidateV1GetScoreList` in `scoreTypes.ts` by using `JSON.stringify` for error details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ed972fc8e900b413d6b7681a9161566aa8508a7a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->