### PR TITLE
fix: handle data retention on clustered clickhouse deployments

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -998,18 +998,18 @@ export const deleteObservationsByProjectId = async (projectId: string) => {
 
 export const deleteObservationsOlderThanDays = async (
   projectId: string,
-  days: number,
+  beforeDate: Date,
 ) => {
   const query = `
     DELETE FROM observations
     WHERE project_id = {projectId: String}
-    AND start_time < now() - INTERVAL {numDays: Int} DAYS;
+    AND start_time < {cutoffDate: DateTime64(3)};
   `;
   await commandClickhouse({
     query: query,
     params: {
       projectId,
-      numDays: days,
+      cutoffDate: convertDateToClickhouseDateTime(beforeDate),
     },
     clickhouseConfigs: {
       request_timeout: 120_000, // 2 minutes

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -775,18 +775,18 @@ export const deleteScoresByProjectId = async (projectId: string) => {
 
 export const deleteScoresOlderThanDays = async (
   projectId: string,
-  days: number,
+  beforeDate: Date,
 ) => {
   const query = `
     DELETE FROM scores
     WHERE project_id = {projectId: String}
-    AND timestamp < now() - INTERVAL {numDays: Int} DAYS;
+    AND timestamp < {cutoffDate: DateTime64(3)};
   `;
   await commandClickhouse({
     query: query,
     params: {
       projectId,
-      numDays: days,
+      cutoffDate: convertDateToClickhouseDateTime(beforeDate),
     },
     clickhouseConfigs: {
       request_timeout: 120_000, // 2 minutes

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -563,18 +563,18 @@ export const deleteTraces = async (projectId: string, traceIds: string[]) => {
 
 export const deleteTracesOlderThanDays = async (
   projectId: string,
-  days: number,
+  beforeDate: Date,
 ) => {
   const query = `
     DELETE FROM traces
     WHERE project_id = {projectId: String}
-    AND timestamp < now() - INTERVAL {numDays: Int} DAYS;
+    AND timestamp < {cutoffDate: DateTime64(3)};
   `;
   await commandClickhouse({
     query: query,
     params: {
       projectId,
-      numDays: days,
+      cutoffDate: convertDateToClickhouseDateTime(beforeDate),
     },
     clickhouseConfigs: {
       request_timeout: 120_000, // 2 minutes

--- a/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
+++ b/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
@@ -115,9 +115,9 @@ export const handleDataRetentionProcessingJob = async (job: Job) => {
     `[Data Retention] Deleting ClickHouse data older than ${retention} days for project ${projectId}`,
   );
   await Promise.all([
-    deleteTracesOlderThanDays(projectId, retention),
-    deleteObservationsOlderThanDays(projectId, retention),
-    deleteScoresOlderThanDays(projectId, retention),
+    deleteTracesOlderThanDays(projectId, cutoffDate),
+    deleteObservationsOlderThanDays(projectId, cutoffDate),
+    deleteScoresOlderThanDays(projectId, cutoffDate),
     deleteEventLogByProjectIdBeforeDate(projectId, cutoffDate),
   ]);
   logger.info(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switch data retention from days-based to date-based cutoff for ClickHouse data deletion in `observations.ts`, `scores.ts`, and `traces.ts`.
> 
>   - **Behavior**:
>     - Change data retention logic to use a date-based cutoff instead of days-based in `deleteObservationsOlderThanDays`, `deleteScoresOlderThanDays`, and `deleteTracesOlderThanDays`.
>     - Update `handleDataRetentionProcessingJob` to use `cutoffDate` for data deletion.
>   - **Functions**:
>     - Modify `deleteObservationsOlderThanDays` in `observations.ts` to accept `beforeDate`.
>     - Modify `deleteScoresOlderThanDays` in `scores.ts` to accept `beforeDate`.
>     - Modify `deleteTracesOlderThanDays` in `traces.ts` to accept `beforeDate`.
>   - **Misc**:
>     - Update parameter names from `days` to `beforeDate` in affected functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 38881f5478e3051465ddfe3b1ceb04273f6411e7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->