### PR TITLE
fix(llm-keys): drop top_p from test call

### DIFF
--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -253,7 +253,7 @@ export const ExperimentMetadataSchema = z
 export type ExperimentMetadata = z.infer<typeof ExperimentMetadataSchema>;
 
 // NOTE: Update docs page when changing this! https://langfuse.com/docs/playground#openai-playground--anthropic-playground
-// WARNING: The first entry in the array is chosen as the default model to add LLM API keys. Make sure it supports top_p, max_tokens and temperature.
+// WARNING: The first entry in the array is chosen as the default model to add LLM API keys
 export const openAIModels = [
   "gpt-4.1",
   "gpt-4.1-2025-04-14",
@@ -293,7 +293,7 @@ export const openAIModels = [
 export type OpenAIModel = (typeof openAIModels)[number];
 
 // NOTE: Update docs page when changing this! https://langfuse.com/docs/playground#openai-playground--anthropic-playground
-// WARNING: The first entry in the array is chosen as the default model to add LLM API keys. Make sure it supports top_p, max_tokens and temperature.
+// WARNING: The first entry in the array is chosen as the default model to add LLM API keys
 export const anthropicModels = [
   "claude-3-7-sonnet-20250219",
   "claude-3-5-sonnet-20241022",
@@ -307,7 +307,7 @@ export const anthropicModels = [
   "claude-instant-1.2",
 ] as const;
 
-// WARNING: The first entry in the array is chosen as the default model to add LLM API keys. Make sure it supports top_p, max_tokens and temperature.
+// WARNING: The first entry in the array is chosen as the default model to add LLM API keys
 export const vertexAIModels = [
   "gemini-2.5-pro-exp-03-25",
   "gemini-2.0-pro-exp-02-05",

--- a/web/src/features/llm-api-key/server/router.ts
+++ b/web/src/features/llm-api-key/server/router.ts
@@ -188,7 +188,6 @@ export const llmApiKeyRouter = createTRPCRouter({
             adapter: input.adapter,
             provider: input.provider,
             model,
-            top_p: 0.9, // Langchain sets 1 as default that is not supported HuggingFace
           },
           baseURL: input.baseURL,
           apiKey: input.secretKey,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes `top_p` parameter from test call in `router.ts` and updates comments in `types.ts` to reflect this change.
> 
>   - **Behavior**:
>     - Removes `top_p` parameter from test call in `llmApiKeyRouter` in `router.ts`.
>   - **Comments**:
>     - Updates comments in `types.ts` to remove mention of `top_p` requirement for default model selection in `openAIModels`, `anthropicModels`, and `vertexAIModels`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e87ad6b9fa1e573fe99f5587afa4c3a4afd3cce9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->