### PR TITLE
chore(prompts): throw `400` if prompt name type mismatched

### DIFF
--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -16,7 +16,11 @@ import { type Prompt, Prisma } from "@langfuse/shared/src/db";
 import { createPrompt, duplicatePrompt } from "../actions/createPrompt";
 import { checkHasProtectedLabels } from "../utils/checkHasProtectedLabels";
 import { promptsTableCols } from "@/src/server/api/definitions/promptsTable";
-import { optionalPaginationZod, paginationZod } from "@langfuse/shared";
+import {
+  InvalidRequestError,
+  optionalPaginationZod,
+  paginationZod,
+} from "@langfuse/shared";
 import { orderBy, singleFilter } from "@langfuse/shared";
 import { LATEST_PROMPT_LABEL } from "@/src/features/prompts/constants";
 import {
@@ -236,6 +240,12 @@ export const promptRouter = createTRPCRouter({
         return prompt;
       } catch (e) {
         logger.error(e);
+        if (e instanceof InvalidRequestError) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: e.message,
+          });
+        }
         throw e;
       }
     }),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `promptRouter`, catch `InvalidRequestError` in `create` mutation and throw a `TRPCError` with code `BAD_REQUEST`.
> 
>   - **Error Handling**:
>     - In `promptRouter`, catch `InvalidRequestError` in `create` mutation and throw `TRPCError` with code `BAD_REQUEST` and the original error message.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e88075f49af8c90a760a68cf7d9535bb32521cdd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->