### PR TITLE
perf: remove redundant trace fetch for traces.byIdWithObservationsAndScores

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -302,17 +302,27 @@ export const getTraceCountOfProjectsSinceCreationDate = async ({
   return Number(rows[0]?.count ?? 0);
 };
 
-export const getTraceById = async (
-  traceId: string,
-  projectId: string,
-  timestamp?: Date,
-) => {
+/**
+ * Retrieves a trace record by its ID and associated project ID, with optional filtering by timestamp range.
+ */
+export const getTraceById = async ({
+  traceId,
+  projectId,
+  timestamp,
+  fromTimestamp,
+}: {
+  traceId: string;
+  projectId: string;
+  timestamp?: Date;
+  fromTimestamp?: Date;
+}) => {
   const query = `
     SELECT * 
     FROM traces
     WHERE id = {traceId: String} 
     AND project_id = {projectId: String}
     ${timestamp ? `AND toDate(timestamp) = toDate({timestamp: DateTime64(3)})` : ""} 
+    ${fromTimestamp ? `AND timestamp >= {fromTimestamp: DateTime64(3)}` : ""} 
     ORDER BY event_ts DESC 
     LIMIT 1
   `;
@@ -324,6 +334,9 @@ export const getTraceById = async (
       projectId,
       ...(timestamp
         ? { timestamp: convertDateToClickhouseDateTime(timestamp) }
+        : {}),
+      ...(fromTimestamp
+        ? { fromTimestamp: convertDateToClickhouseDateTime(fromTimestamp) }
         : {}),
     },
     tags: {

--- a/web/src/__e2e__/api.servertest.ts
+++ b/web/src/__e2e__/api.servertest.ts
@@ -111,7 +111,7 @@ describe("Ingestion Pipeline", () => {
         expect(traceResponse.body).not.toBeNull();
         expect((await traceResponse.json()).id).toBe(traceId);
 
-        const trace = await getTraceById(traceId, projectId);
+        const trace = await getTraceById({ traceId, projectId });
         expect(trace).not.toBeNull();
         expect(trace?.name).toBe("test trace");
 

--- a/web/src/__tests__/async/ingestion-api.servertest.ts
+++ b/web/src/__tests__/async/ingestion-api.servertest.ts
@@ -94,7 +94,7 @@ describe("/api/public/ingestion API Endpoint", () => {
       expect(response.status).toBe(207);
 
       await waitForExpect(async () => {
-        const trace = await getTraceById(entity.body.id, projectId);
+        const trace = await getTraceById({ traceId: entity.body.id, projectId });
         expect(trace).toBeDefined();
         expect(trace!.id).toBe(entity.body.id);
         expect(trace!.projectId).toBe(projectId);
@@ -128,7 +128,7 @@ describe("/api/public/ingestion API Endpoint", () => {
   //
   //   expect(response.status).toBe(207);
   //   await waitForExpect(async () => {
-  //     const trace = await getTraceById(entity.body.id, projectId);
+  //     const trace = await getTraceById({ traceId: entity.body.id, projectId });
   //     expect(trace).toBeDefined();
   //     expect(trace!.id).toBe(entity.body.id);
   //     expect(trace!.projectId).toBe(projectId);
@@ -330,7 +330,7 @@ describe("/api/public/ingestion API Endpoint", () => {
     expect(response.status).toBe(207);
 
     await waitForExpect(async () => {
-      const trace = await getTraceById(`${traceId}-${char}-test`, projectId);
+      const trace = await getTraceById({ traceId: `${traceId}-${char}-test`, projectId });
       expect(trace).toBeDefined();
       expect(trace!.id).toBe(`${traceId}-${char}-test`);
       expect(trace!.projectId).toBe(projectId);
@@ -526,7 +526,7 @@ describe("/api/public/ingestion API Endpoint", () => {
       expect(response.status).toBe(207);
 
       await waitForExpect(async () => {
-        const trace = await getTraceById(traceId, projectId);
+        const trace = await getTraceById({ traceId, projectId });
         expect(trace).toBeDefined();
         expect(trace!.id).toBe(traceId);
         expect(JSON.stringify(trace!.metadata)).toBe(

--- a/web/src/__tests__/async/repositories/trace-repository.servertest.ts
+++ b/web/src/__tests__/async/repositories/trace-repository.servertest.ts
@@ -16,7 +16,7 @@ describe("Clickhouse Traces Repository Test", () => {
   });
 
   it("should throw if no traces are found", async () => {
-    expect(await getTraceById(v4(), v4())).toBeUndefined();
+    expect(await getTraceById({ traceId: v4(), projectId: v4() })).toBeUndefined();
   });
 
   it("should return a trace if it exists", async () => {
@@ -51,11 +51,11 @@ describe("Clickhouse Traces Repository Test", () => {
 
     await createTracesCh([trace]);
 
-    const result = await getTraceById(
+    const result = await getTraceById({
       traceId,
       projectId,
-      new Date(trace.timestamp),
-    );
+      timestamp: new Date(trace.timestamp),
+    });
     expect(result).not.toBeNull();
     if (!result) {
       return;
@@ -102,7 +102,7 @@ describe("Clickhouse Traces Repository Test", () => {
 
     await createTracesCh([trace]);
 
-    const result = await getTraceById(traceId, projectId);
+    const result = await getTraceById({ traceId, projectId });
     expect(result).not.toBeNull();
     if (!result) {
       return;

--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -435,7 +435,7 @@ describe("/api/public/traces API Endpoint", () => {
     // Then
     expect(deleteResponse.status).toBe(200);
     await waitForExpect(async () => {
-      const trace = await getTraceById(createdTrace.id, projectId);
+      const trace = await getTraceById({ traceId: createdTrace.id, projectId });
       expect(trace).toBeUndefined();
     }, 10_000);
   }, 10_000);
@@ -465,9 +465,9 @@ describe("/api/public/traces API Endpoint", () => {
     // Then
     expect(deleteResponse.status).toBe(200);
     await waitForExpect(async () => {
-      const trace1 = await getTraceById(createdTrace1.id, projectId);
+      const trace1 = await getTraceById({ traceId: createdTrace1.id, projectId });
       expect(trace1).toBeUndefined();
-      const trace2 = await getTraceById(createdTrace2.id, projectId);
+      const trace2 = await getTraceById({ traceId: createdTrace2.id, projectId });
       expect(trace2).toBeUndefined();
     }, 40_000);
   }, 60_000);

--- a/web/src/features/comments/validateCommentReferenceObject.ts
+++ b/web/src/features/comments/validateCommentReferenceObject.ts
@@ -23,7 +23,10 @@ export const validateCommentReferenceObject = async ({
     if (objectType === CommentObjectType.OBSERVATION) {
       clickhouseObject = await getObservationById(objectId, projectId);
     } else {
-      clickhouseObject = await getTraceById(objectId, projectId);
+      clickhouseObject = await getTraceById({
+        traceId: objectId,
+        projectId,
+      });
     }
 
     return !!clickhouseObject

--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -32,7 +32,10 @@ export default withMiddlewares({
     responseSchema: GetTraceV1Response,
     fn: async ({ query, auth }) => {
       const { traceId } = query;
-      const trace = await getTraceById(traceId, auth.scope.projectId);
+      const trace = await getTraceById({
+        traceId,
+        projectId: auth.scope.projectId,
+      });
       const [observations, scores] = await Promise.all([
         getObservationsForTrace(
           traceId,

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -270,10 +270,10 @@ export const scoresRouter = createTRPCRouter({
         scope: "scores:CUD",
       });
 
-      const clickhouseTrace = await getTraceById(
-        input.traceId,
-        input.projectId,
-      );
+      const clickhouseTrace = await getTraceById({
+        traceId: input.traceId,
+        projectId: input.projectId,
+      });
 
       if (!clickhouseTrace) {
         logger.error(

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -352,7 +352,11 @@ const enforceTraceAccess = t.middleware(async ({ ctx, rawInput, next }) => {
   const projectId = result.data.projectId;
   const timestamp = result.data.timestamp;
 
-  const trace = await getTraceById(traceId, projectId, timestamp ?? undefined);
+  const trace = await getTraceById({
+    traceId,
+    projectId,
+    timestamp: timestamp ?? undefined,
+  });
 
   if (!trace) {
     logger.error(`Trace with id ${traceId} not found for project ${projectId}`);

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -335,6 +335,7 @@ const inputTraceSchema = z.object({
   traceId: z.string(),
   projectId: z.string(),
   timestamp: z.date().nullish(),
+  fromTimestamp: z.date().nullish(),
 });
 
 const enforceTraceAccess = t.middleware(async ({ ctx, rawInput, next }) => {
@@ -351,11 +352,13 @@ const enforceTraceAccess = t.middleware(async ({ ctx, rawInput, next }) => {
   const traceId = result.data.traceId;
   const projectId = result.data.projectId;
   const timestamp = result.data.timestamp;
+  const fromTimestamp = result.data.fromTimestamp;
 
   const trace = await getTraceById({
     traceId,
     projectId,
     timestamp: timestamp ?? undefined,
+    fromTimestamp: fromTimestamp ?? undefined,
   });
 
   if (!trace) {

--- a/worker/src/__tests__/dataRetentionProcessing.test.ts
+++ b/worker/src/__tests__/dataRetentionProcessing.test.ts
@@ -270,9 +270,9 @@ describe("DataRetentionProcessingJob", () => {
     } as Job);
 
     // Then
-    const traceOld = await getTraceById(`${baseId}-trace-old`, projectId);
+    const traceOld = await getTraceById({ traceId: `${baseId}-trace-old`, projectId });
     expect(traceOld).toBeUndefined();
-    const traceNew = await getTraceById(`${baseId}-trace-new`, projectId);
+    const traceNew = await getTraceById({ traceId: `${baseId}-trace-new`, projectId });
     expect(traceNew).toBeDefined();
   });
 

--- a/worker/src/__tests__/projectDeletionProcessing.test.ts
+++ b/worker/src/__tests__/projectDeletionProcessing.test.ts
@@ -135,7 +135,7 @@ describe("ProjectDeletionProcessingJob", () => {
     } as Job);
 
     // Then
-    const trace = await getTraceById(`${baseId}-trace`, projectId);
+    const trace = await getTraceById({ traceId: `${baseId}-trace`, projectId });
     expect(trace).toBeUndefined();
     expect(() =>
       getObservationById(`${baseId}-observation`, projectId),

--- a/worker/src/ee/evaluation/evalService.ts
+++ b/worker/src/ee/evaluation/evalService.ts
@@ -709,7 +709,7 @@ export async function extractVariablesFromTracingData({
           return { var: variable, value: "" };
         }
 
-        const trace = await getTraceById(traceId, projectId);
+        const trace = await getTraceById({ traceId, projectId });
 
         // user facing errors
         if (!trace) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `getTraceById` to accept an object with parameters and update all usages to improve performance and maintainability.
> 
>   - **Function Changes**:
>     - `getTraceById` in `traces.ts` now accepts an object with `traceId`, `projectId`, `timestamp`, and `fromTimestamp`.
>     - Adds optional `fromTimestamp` parameter for filtering by minimum timestamp.
>   - **Refactoring**:
>     - Updates all calls to `getTraceById` to use the new object parameter format in `api.servertest.ts`, `ingestion-api.servertest.ts`, `trace-repository.servertest.ts`, `traces-api.servertest.ts`, `validateCommentReferenceObject.ts`, `[traceId].ts`, `scores.ts`, `traces.ts`, `trpc.ts`, `dataRetentionProcessing.test.ts`, `projectDeletionProcessing.test.ts`, `evalService.ts`.
>   - **Behavior**:
>     - Removes redundant trace fetch in `traces.byIdWithObservationsAndScores` in `traces.ts` by using context trace.
>   - **Testing**:
>     - Updates tests to align with the new `getTraceById` function signature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a8d3fba182bf5f9c398681d2e4820bbaa0dc40b7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->