### PR TITLE
perf: include timestamp on trace retrieval on sessions and datasetrunitemstable

### DIFF
--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -259,7 +259,11 @@ export const SessionPage: React.FC<{
             key={trace.id}
           >
             <div className="col-span-2 overflow-hidden">
-              <SessionIO traceId={trace.id} projectId={projectId} />
+              <SessionIO
+                traceId={trace.id}
+                projectId={projectId}
+                timestamp={trace.timestamp}
+              />
             </div>
             <div className="-mt-1 p-1 opacity-50 transition-opacity group-hover:opacity-100">
               <Link
@@ -317,12 +321,14 @@ export const SessionPage: React.FC<{
 const SessionIO = ({
   traceId,
   projectId,
+  timestamp,
 }: {
   traceId: string;
   projectId: string;
+  timestamp: Date;
 }) => {
   const trace = api.traces.byId.useQuery(
-    { traceId, projectId },
+    { traceId, projectId, timestamp },
     {
       enabled: typeof traceId === "string",
       trpc: {

--- a/web/src/features/datasets/components/DatasetRunItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsTable.tsx
@@ -184,12 +184,14 @@ export function DatasetRunItemsTable(
       enableHiding: true,
       cell: ({ row }) => {
         const trace: DatasetRunItemRowData["trace"] = row.getValue("trace");
+        const runAt: DatasetRunItemRowData["runAt"] = row.getValue("runAt");
         return trace ? (
           <TraceObservationIOCell
             traceId={trace.traceId}
             projectId={props.projectId}
             observationId={trace.observationId}
             io="input"
+            fromTimestamp={runAt}
             singleLine={rowHeight === "s"}
           />
         ) : null;
@@ -203,12 +205,14 @@ export function DatasetRunItemsTable(
       enableHiding: true,
       cell: ({ row }) => {
         const trace: DatasetRunItemRowData["trace"] = row.getValue("trace");
+        const runAt: DatasetRunItemRowData["runAt"] = row.getValue("runAt");
         return trace ? (
           <TraceObservationIOCell
             traceId={trace.traceId}
             projectId={props.projectId}
             observationId={trace.observationId}
             io="output"
+            fromTimestamp={runAt}
             singleLine={rowHeight === "s"}
           />
         ) : null;
@@ -324,17 +328,24 @@ const TraceObservationIOCell = ({
   projectId,
   observationId,
   io,
+  fromTimestamp,
   singleLine = false,
 }: {
   traceId: string;
   projectId: string;
   observationId?: string;
   io: "input" | "output";
+  fromTimestamp: Date;
   singleLine?: boolean;
 }) => {
+  // Subtract 1 day from the fromTimestamp as a buffer in case the trace happened before the run
+  const fromTimestampModified = new Date(
+    fromTimestamp.getTime() - 24 * 60 * 60 * 1000,
+  );
+
   // conditionally fetch the trace or observation depending on the presence of observationId
   const trace = api.traces.byId.useQuery(
-    { traceId, projectId },
+    { traceId, projectId, fromTimestamp: fromTimestampModified },
     {
       enabled: observationId === undefined,
       trpc: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add timestamp parameter to trace retrieval in `SessionPage` and `DatasetRunItemsTable` for improved performance.
> 
>   - **Behavior**:
>     - Add `timestamp` to `SessionIO` in `index.tsx` and `fromTimestamp` to `TraceObservationIOCell` in `DatasetRunItemsTable.tsx` for trace retrieval.
>     - Modify `fromTimestamp` by subtracting 1 day in `TraceObservationIOCell` to handle traces occurring before the run.
>   - **Components**:
>     - Update `SessionIO` in `index.tsx` to include `timestamp` in trace query.
>     - Update `TraceObservationIOCell` in `DatasetRunItemsTable.tsx` to include `fromTimestamp` in trace query.
>   - **Misc**:
>     - Minor refactoring in `index.tsx` and `DatasetRunItemsTable.tsx` to accommodate new parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a7fda957f4b8e7664b0f908d897326ee29a14b5a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->