### PR TITLE
chore: enable write to multiple clickhouse services

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -38,8 +38,7 @@ const EnvSchema = z.object({
   CLICKHOUSE_DB: z.string().default("default"),
   CLICKHOUSE_USER: z.string(),
   CLICKHOUSE_PASSWORD: z.string(),
-  CLICKHOUSE_CLUSTER_ENABLED: z.enum(["true", "false"]).default("false"),
-  
+
   // Secondary ClickHouse instance configuration
   CLICKHOUSE_SECONDARY_ENABLED: z.enum(["true", "false"]).default("false"),
   CLICKHOUSE_SECONDARY_URL: z.string().url().optional(),
@@ -47,7 +46,6 @@ const EnvSchema = z.object({
   CLICKHOUSE_SECONDARY_DB: z.string().default("default"),
   CLICKHOUSE_SECONDARY_USER: z.string().optional(),
   CLICKHOUSE_SECONDARY_PASSWORD: z.string().optional(),
-  CLICKHOUSE_SECONDARY_CLUSTER_ENABLED: z.enum(["true", "false"]).default("false"),
 
   LANGFUSE_INGESTION_QUEUE_DELAY_MS: z.coerce
     .number()

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -38,6 +38,16 @@ const EnvSchema = z.object({
   CLICKHOUSE_DB: z.string().default("default"),
   CLICKHOUSE_USER: z.string(),
   CLICKHOUSE_PASSWORD: z.string(),
+  CLICKHOUSE_CLUSTER_ENABLED: z.enum(["true", "false"]).default("false"),
+  
+  // Secondary ClickHouse instance configuration
+  CLICKHOUSE_SECONDARY_ENABLED: z.enum(["true", "false"]).default("false"),
+  CLICKHOUSE_SECONDARY_URL: z.string().url().optional(),
+  CLICKHOUSE_SECONDARY_CLUSTER_NAME: z.string().default("default"),
+  CLICKHOUSE_SECONDARY_DB: z.string().default("default"),
+  CLICKHOUSE_SECONDARY_USER: z.string().optional(),
+  CLICKHOUSE_SECONDARY_PASSWORD: z.string().optional(),
+  CLICKHOUSE_SECONDARY_CLUSTER_ENABLED: z.enum(["true", "false"]).default("false"),
 
   LANGFUSE_INGESTION_QUEUE_DELAY_MS: z.coerce
     .number()

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -1,8 +1,9 @@
-import { createClient } from "@clickhouse/client";
+import { createClient, DataFormat } from "@clickhouse/client";
 import { env } from "../../env";
 import { NodeClickHouseClientConfigOptions } from "@clickhouse/client/dist/config";
 import { getCurrentSpan } from "../instrumentation";
 import { propagation, context } from "@opentelemetry/api";
+import { logger } from "../logger";
 
 export type ClickhouseClientType = ReturnType<typeof createClient>;
 
@@ -42,6 +43,105 @@ export const clickhouseClient = (
       wait_for_async_insert: 1, // if disabled, we won't get errors from clickhouse
     },
   });
+};
+
+/**
+ * Creates a ClickHouse client for the secondary instance if configured
+ */
+export const clickhouseSecondaryClient = (
+  params: {
+    tags?: Record<string, string>;
+    opts?: NodeClickHouseClientConfigOptions;
+  } = {},
+) => {
+  // Only create if secondary is enabled and URL is configured
+  if (
+    env.CLICKHOUSE_SECONDARY_ENABLED !== "true" ||
+    !env.CLICKHOUSE_SECONDARY_URL
+  ) {
+    return null;
+  }
+
+  const headers = params.opts?.http_headers ?? {};
+  const activeSpan = getCurrentSpan();
+  if (activeSpan) {
+    propagation.inject(context.active(), headers);
+  }
+
+  const cloudOptions: Record<string, unknown> = {};
+  if (
+    ["STAGING", "EU", "US"].includes(
+      env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION ?? "",
+    )
+  ) {
+    cloudOptions.input_format_json_throw_on_bad_escape_sequence = 0;
+  }
+
+  return createClient({
+    ...params.opts,
+    url: env.CLICKHOUSE_SECONDARY_URL,
+    username: env.CLICKHOUSE_SECONDARY_USER || env.CLICKHOUSE_USER,
+    password: env.CLICKHOUSE_SECONDARY_PASSWORD || env.CLICKHOUSE_PASSWORD,
+    database: env.CLICKHOUSE_SECONDARY_DB || env.CLICKHOUSE_DB,
+    http_headers: headers,
+    clickhouse_settings: {
+      ...cloudOptions,
+      ...(params.opts?.clickhouse_settings ?? {}),
+      log_comment: JSON.stringify({ ...params.tags, secondary: true } ?? {}),
+      async_insert: 1,
+      wait_for_async_insert: 1,
+    },
+  });
+};
+
+/**
+ * Performs dual write to both primary and secondary ClickHouse instances
+ * Always writes to primary instance, optionally writes to secondary if configured
+ */
+export const dualClickhouseWrite = async <T>(params: {
+  table: string;
+  values: unknown[];
+  format: DataFormat | undefined;
+  tags?: Record<string, string>;
+  opts?: NodeClickHouseClientConfigOptions;
+}) => {
+  // Primary write (always performed)
+  const primaryClient = clickhouseClient({
+    tags: params.tags,
+    opts: params.opts,
+  });
+
+  const primaryResult = await primaryClient.insert({
+    table: params.table,
+    values: params.values,
+    format: params.format,
+  });
+
+  // Secondary write (only if enabled)
+  const secondaryClient = clickhouseSecondaryClient({
+    tags: params.tags,
+    opts: params.opts,
+  });
+
+  if (secondaryClient) {
+    try {
+      await secondaryClient.insert({
+        table: params.table,
+        values: params.values,
+        format: params.format,
+      });
+      logger.debug(
+        `Secondary ClickHouse write completed for table ${params.table}`,
+      );
+    } catch (err) {
+      // Log error but don't propagate
+      logger.error(
+        `Secondary ClickHouse write failed for table ${params.table}: ${err}`,
+      );
+    }
+  }
+
+  return primaryResult;
 };
 
 /**

--- a/packages/shared/src/server/data-deletion/ingestionFileDeletion.ts
+++ b/packages/shared/src/server/data-deletion/ingestionFileDeletion.ts
@@ -5,9 +5,9 @@ import {
   getBlobStorageByProjectIdAndTraceIds,
   getBlobStorageByProjectIdBeforeDate,
   logger,
+  dualClickhouseWrite,
 } from "..";
 import { env } from "../../env";
-import { clickhouseClient } from "../clickhouse/client";
 import { getS3EventStorageClient } from "../s3";
 
 export const deleteIngestionEventsFromS3AndClickhouseForScores = async (p: {
@@ -95,7 +95,7 @@ async function removeIngestionEventsFromS3AndDeleteClickhouseRefs(p: {
 async function softDeleteInClickhouse(
   blobStorageRefs: BlobStorageFileRefRecordReadType[],
 ) {
-  await clickhouseClient().insert({
+  await dualClickhouseWrite({
     table: "blob_storage_file_log",
     values: blobStorageRefs.map((e) => ({
       ...e,

--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -9,7 +9,6 @@ import { prisma } from "@langfuse/shared/src/db";
 import { v4 } from "uuid";
 import { z } from "zod";
 import {
-  clickhouseClient,
   clickhouseCompliantRandomCharacters,
   commandClickhouse,
   convertToScore,

--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -22,6 +22,7 @@ import {
   queryClickhouse,
   type ScoreRecordReadType,
   traceException,
+  dualClickhouseWrite,
 } from "@langfuse/shared/src/server";
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
 import Decimal from "decimal.js";
@@ -162,13 +163,12 @@ export const insertPostgresDatasetRunsIntoClickhouse = async (
     })),
   );
 
-  await clickhouseClient({
-    tags: { feature: "dataset", projectId },
-    opts: { session_id: clickhouseSession },
-  }).insert({
+  await dualClickhouseWrite({
     table: tableName,
     values: rows,
     format: "JSONEachRow",
+    tags: { feature: "dataset", projectId },
+    opts: { session_id: clickhouseSession },
   });
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enable dual write to primary and secondary ClickHouse instances with new configuration and refactored write logic.
> 
>   - **Environment Configuration**:
>     - Added secondary ClickHouse configuration variables in `env.ts`.
>     - Variables include `CLICKHOUSE_SECONDARY_ENABLED`, `CLICKHOUSE_SECONDARY_URL`, `CLICKHOUSE_SECONDARY_CLUSTER_NAME`, `CLICKHOUSE_SECONDARY_DB`, `CLICKHOUSE_SECONDARY_USER`, and `CLICKHOUSE_SECONDARY_PASSWORD`.
>   - **Client and Write Logic**:
>     - Added `clickhouseSecondaryClient` function in `client.ts` to create a client for the secondary ClickHouse instance.
>     - Introduced `dualClickhouseWrite` function in `client.ts` to perform writes to both primary and secondary instances.
>   - **Code Refactoring**:
>     - Replaced direct `clickhouseClient` writes with `dualClickhouseWrite` in `ingestionFileDeletion.ts`, `clickhouse.ts`, `service.ts`, and `ClickhouseWriter/index.ts`.
>     - Ensures writes are attempted on secondary instance if enabled, with error logging but no error propagation on failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0abfa398ee948d6b531c2077cde7c0f2f7632b85. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->