### PR TITLE
fix(ui): add deprecated col mapping on traces table for cached filter states

### DIFF
--- a/packages/shared/src/tableDefinitions/mapObservationsTable.ts
+++ b/packages/shared/src/tableDefinitions/mapObservationsTable.ts
@@ -189,7 +189,8 @@ export const observationsTableUiColumnDefinitions: UiColumnMappings = [
     clickhouseTableName: "observations",
     clickhouseSelect: 'o."metadata"',
   },
-  // TODO: remove duplication once session storage cache is outdated
+  // Scores column duplicated to allow renaming column name. Will be removed once session storage cache is outdated
+  // Column names are cached in user sessions - changing them breaks existing filters
   {
     uiTableName: "Scores",
     uiTableId: "scores",

--- a/packages/shared/src/tableDefinitions/mapObservationsTable.ts
+++ b/packages/shared/src/tableDefinitions/mapObservationsTable.ts
@@ -189,6 +189,13 @@ export const observationsTableUiColumnDefinitions: UiColumnMappings = [
     clickhouseTableName: "observations",
     clickhouseSelect: 'o."metadata"',
   },
+  // TODO: remove duplication once session storage cache is outdated
+  {
+    uiTableName: "Scores",
+    uiTableId: "scores",
+    clickhouseTableName: "observations",
+    clickhouseSelect: "s.scores_avg",
+  },
   {
     uiTableName: "Scores (numeric)",
     uiTableId: "scores",

--- a/packages/shared/src/tableDefinitions/mapObservationsTable.ts
+++ b/packages/shared/src/tableDefinitions/mapObservationsTable.ts
@@ -194,19 +194,19 @@ export const observationsTableUiColumnDefinitions: UiColumnMappings = [
   {
     uiTableName: "Scores",
     uiTableId: "scores",
-    clickhouseTableName: "observations",
+    clickhouseTableName: "scores",
     clickhouseSelect: "s.scores_avg",
   },
   {
     uiTableName: "Scores (numeric)",
     uiTableId: "scores",
-    clickhouseTableName: "observations",
+    clickhouseTableName: "scores",
     clickhouseSelect: "s.scores_avg",
   },
   {
     uiTableName: "Scores (categorical)",
     uiTableId: "scores",
-    clickhouseTableName: "observations",
+    clickhouseTableName: "scores",
     clickhouseSelect: "s.score_categories",
   },
   {

--- a/packages/shared/src/tableDefinitions/mapObservationsTable.ts
+++ b/packages/shared/src/tableDefinitions/mapObservationsTable.ts
@@ -206,7 +206,7 @@ export const observationsTableUiColumnDefinitions: UiColumnMappings = [
   {
     uiTableName: "Scores (categorical)",
     uiTableId: "scores",
-    clickhouseTableName: "scores",
+    clickhouseTableName: "observations",
     clickhouseSelect: "s.score_categories",
   },
   {

--- a/packages/shared/src/tableDefinitions/mapTracesTable.ts
+++ b/packages/shared/src/tableDefinitions/mapTracesTable.ts
@@ -130,7 +130,8 @@ export const tracesTableUiColumnDefinitions: UiColumnMappings = [
       "if(mapExists((k, v) -> (k = 'total'), usage_details), usage_details['total'], NULL)",
     clickhouseTypeOverwrite: "Decimal64(3)",
   },
-  // TODO: remove duplication once session storage cache is outdated
+  // Scores column duplicated to allow renaming column name. Will be removed once session storage cache is outdated
+  // Column names are cached in user sessions - changing them breaks existing filters
   {
     uiTableName: "Scores",
     uiTableId: "scores",

--- a/packages/shared/src/tableDefinitions/mapTracesTable.ts
+++ b/packages/shared/src/tableDefinitions/mapTracesTable.ts
@@ -130,6 +130,13 @@ export const tracesTableUiColumnDefinitions: UiColumnMappings = [
       "if(mapExists((k, v) -> (k = 'total'), usage_details), usage_details['total'], NULL)",
     clickhouseTypeOverwrite: "Decimal64(3)",
   },
+  // TODO: remove duplication once session storage cache is outdated
+  {
+    uiTableName: "Scores",
+    uiTableId: "scores",
+    clickhouseTableName: "scores",
+    clickhouseSelect: "s.scores_avg",
+  },
   {
     uiTableName: "Scores (numeric)",
     uiTableId: "scores",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds duplicate 'Scores' column in `mapObservationsTable.ts` and `mapTracesTable.ts` to handle cached filter states temporarily.
> 
>   - **Behavior**:
>     - Adds duplicate `Scores` column in `observationsTableUiColumnDefinitions` in `mapObservationsTable.ts` and `tracesTableUiColumnDefinitions` in `mapTracesTable.ts`.
>     - Temporary solution to handle cached filter states due to session storage caching column names.
>     - Duplicate column will be removed once session storage cache is outdated.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c1e4fa511ca81e280ec4322cb590fad80813f5ac. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->