### PR TITLE
perf: return only on API if no trace found

### DIFF
--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -36,6 +36,13 @@ export default withMiddlewares({
         traceId,
         projectId: auth.scope.projectId,
       });
+
+      if (!trace) {
+        throw new LangfuseNotFoundError(
+          `Trace ${traceId} not found within authorized project`,
+        );
+      }
+
       const [observations, scores] = await Promise.all([
         getObservationsForTrace(
           traceId,
@@ -91,12 +98,6 @@ export default withMiddlewares({
           totalPrice,
         };
       });
-
-      if (!trace) {
-        throw new LangfuseNotFoundError(
-          `Trace ${traceId} not found within authorized project`,
-        );
-      }
 
       const outObservations = observationsView.map(transformDbToApiObservation);
       const validatedScores = filterAndValidateDbScoreList({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimizes `[traceId].ts` by moving trace existence check earlier to avoid unnecessary database calls.
> 
>   - **Behavior**:
>     - Moved trace existence check earlier in `GET` handler in `[traceId].ts`.
>     - If trace not found, `LangfuseNotFoundError` is thrown immediately, avoiding further database calls.
>   - **Performance**:
>     - Reduces unnecessary database calls when trace is not found.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3d578074a0f5ebdfc8027931488c31a0a7dd52ba. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->