### PR TITLE
perf(public-api-traces): raise early error if observations are too large

### DIFF
--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -417,6 +417,56 @@ describe("/api/public/traces API Endpoint", () => {
     });
   });
 
+  it("should return 5XX if observations are too large when fetching single trace", async () => {
+    // See LFE-4882 for context
+    const traceId = randomUUID();
+    const trace = createTrace({
+      id: traceId,
+      name: "trace-name1",
+      project_id: projectId,
+      metadata: { key: JSON.stringify({ foo: "bar" }) },
+      input: JSON.stringify({
+        args: [
+          {
+            foo: "bar",
+          },
+        ],
+      }),
+    });
+
+    await createTracesCh([trace]);
+    await createObservationsCh([
+      createObservation({
+        trace_id: traceId,
+        project_id: projectId,
+        input: "a".repeat(1e6),
+        output: "b".repeat(1e6),
+        metadata: {
+          foo: "c".repeat(1e6),
+        },
+      }),
+      createObservation({
+        trace_id: traceId,
+        project_id: projectId,
+        input: "a".repeat(1e6),
+        output: "b".repeat(1e6),
+        metadata: {
+          foo: "c".repeat(1e6),
+        },
+      }),
+    ]);
+
+    await expect(
+      makeZodVerifiedAPICall(
+        GetTraceV1Response,
+        "GET",
+        `/api/public/traces/${traceId}`,
+      ),
+    ).rejects.toThrow(
+      "Observations in trace are too large: 6.00MB exceeds limit of 4.00MB",
+    );
+  });
+
   it("should delete a single trace via DELETE /traces/:traceId", async () => {
     // Setup
     const createdTrace = createTrace({
@@ -465,9 +515,15 @@ describe("/api/public/traces API Endpoint", () => {
     // Then
     expect(deleteResponse.status).toBe(200);
     await waitForExpect(async () => {
-      const trace1 = await getTraceById({ traceId: createdTrace1.id, projectId });
+      const trace1 = await getTraceById({
+        traceId: createdTrace1.id,
+        projectId,
+      });
       expect(trace1).toBeUndefined();
-      const trace2 = await getTraceById({ traceId: createdTrace2.id, projectId });
+      const trace2 = await getTraceById({
+        traceId: createdTrace2.id,
+        projectId,
+      });
       expect(trace2).toBeUndefined();
     }, 40_000);
   }, 60_000);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a 4MB payload size limit for observations in `getObservationsForTrace` and tests error handling for exceeding this limit.
> 
>   - **Behavior**:
>     - Adds a payload size limit of 4MB for observations in `getObservationsForTrace` in `observations.ts`.
>     - Throws an error if the payload size exceeds the limit, detailing the size exceeded.
>   - **Tests**:
>     - Adds a test in `traces-api.servertest.ts` to verify a 5XX error is returned when observations exceed the size limit.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7390ce0b4eedd41776fe2bcbb800b416eb53be6a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->