### PR TITLE
perf: reduce optimistic lookback for byid queries

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -413,7 +413,7 @@ const getObservationByIdInternal = async (
     projectId,
   };
 
-  // If no fromStartTime or startTime is provided, use a 7-day lookback for a faster query
+  // If no fromStartTime or startTime is provided, use a lookback for a faster query
   const queryFromStartTime = !hasStartTimeFilter
     ? new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 1)
     : fromStartTime;

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -415,7 +415,7 @@ const getObservationByIdInternal = async (
 
   // If no fromStartTime or startTime is provided, use a 7-day lookback for a faster query
   const queryFromStartTime = !hasStartTimeFilter
-    ? new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 7)
+    ? new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 1)
     : fromStartTime;
 
   const queryWithStartTimePromise = queryClickhouse<ObservationRecordReadType>({

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -343,10 +343,11 @@ export const getTraceById = async ({
     projectId,
   };
 
-  // If no fromTimestamp or timestamp is provided, use a 7-day lookback for a faster query
+  // If no fromTimestamp or timestamp is provided, use a 1-day lookback for a faster query
   const queryFromTimestamp = !hasTimestampFilter
-    ? new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 7)
+    ? new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 1)
     : fromTimestamp;
+
   const queryWithTimestampPromise = queryClickhouse<TraceRecordReadType>({
     query: getQuery(timestamp, queryFromTimestamp),
     params: {

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -343,7 +343,7 @@ export const getTraceById = async ({
     projectId,
   };
 
-  // If no fromTimestamp or timestamp is provided, use a 1-day lookback for a faster query
+  // If no fromTimestamp or timestamp is provided, use a lookback for a faster query
   const queryFromTimestamp = !hasTimestampFilter
     ? new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 1)
     : fromTimestamp;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reduces lookback period from 7 days to 1 day for certain queries in `observations.ts` and `traces.ts` to improve performance.
> 
>   - **Behavior**:
>     - Reduces lookback period from 7 days to 1 day for queries without `startTime` or `fromStartTime` in `getObservationByIdInternal()` in `observations.ts`.
>     - Reduces lookback period from 7 days to 1 day for queries without `timestamp` or `fromTimestamp` in `getTraceById()` in `traces.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2ce4e9381110e54da690f0ee392af5143381246f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->