### PR TITLE
perf(api-traces): increase byId size limit to 5MB

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -174,10 +174,10 @@ export const getObservationsForTrace = async (
 
   // Large number of observations in trace with large input / output / metadata will lead to
   // high CPU and memory consumption in the convertObservation step, where parsing occurs
-  // Thus, limit the size of the payload to 4MB, follows NextJS response size limitation:
+  // Thus, limit the size of the payload to 5MB, follows NextJS response size limitation:
   // https://nextjs.org/docs/messages/api-routes-response-size-limit
   // See also LFE-4882 for more details
-  const PAYLOAD_SIZE_LIMIT = 4e6; // 4MB
+  const PAYLOAD_SIZE_LIMIT = 5e6; // 5MB
   let payloadSize = 0;
 
   for (const observation of records) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase payload size limit from 4MB to 5MB in `getObservationsForTrace` function to align with NextJS response size limitations.
> 
>   - **Behavior**:
>     - Increase payload size limit from 4MB to 5MB in `getObservationsForTrace` function in `observations.ts`.
>     - Aligns with NextJS response size limitation.
>   - **Misc**:
>     - Update comment to reflect new payload size limit.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 51af6a5fd0135720ea6e496638b18faf8db1d8c8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->