### PR TITLE
test(trace-api): fix observations too large test

### DIFF
--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -463,7 +463,7 @@ describe("/api/public/traces API Endpoint", () => {
         `/api/public/traces/${traceId}`,
       ),
     ).rejects.toThrow(
-      "Observations in trace are too large: 6.00MB exceeds limit of 4.00MB",
+      "Observations in trace are too large: 6.00MB exceeds limit of 5.00MB",
     );
   });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update test in `traces-api.servertest.ts` to reflect new observation size limit of 5.00MB.
> 
>   - **Test Update**:
>     - In `traces-api.servertest.ts`, updated error message in test to reflect new observation size limit of 5.00MB instead of 4.00MB.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0fb1633826b6433d9e020eb26633e472f068ab2f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->