### PR TITLE
feat: add support for score name filters on dashboard

### DIFF
--- a/web/src/features/query/dashboardUiTableToViewMapping.ts
+++ b/web/src/features/query/dashboardUiTableToViewMapping.ts
@@ -15,6 +15,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       viewName: "observationName",
     },
     {
+      uiTableName: "Score Name",
+      viewName: "scoreName",
+    },
+    {
       uiTableName: "Tags",
       viewName: "tags",
     },
@@ -47,6 +51,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
     {
       uiTableName: "Observation Name",
       viewName: "name",
+    },
+    {
+      uiTableName: "Score Name",
+      viewName: "scoreName",
     },
     {
       uiTableName: "User",

--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -51,6 +51,12 @@ export const traceView: ViewDeclarationType = {
       type: "string",
       relationTable: "observations",
     },
+    scoreName: {
+      sql: "name",
+      alias: "scoreName",
+      type: "string",
+      relationTable: "scores",
+    },
   },
   measures: {
     count: {
@@ -180,6 +186,12 @@ export const observationsView: ViewDeclarationType = {
       sql: "version",
       type: "string",
       relationTable: "traces",
+    },
+    scoreName: {
+      sql: "name",
+      alias: "scoreName",
+      type: "string",
+      relationTable: "scores",
     },
   },
   measures: {

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -168,6 +168,12 @@ export function WidgetForm({
       internal: "internalValue",
     },
     {
+      name: "Score Name",
+      id: "scoreName",
+      type: "string",
+      internal: "internalValue",
+    },
+    {
       name: "Tags",
       id: "tags",
       type: "arrayOptions",

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -134,6 +134,12 @@ export default function DashboardDetail() {
       internal: "internalValue",
     },
     {
+      name: "Score Name",
+      id: "scoreName",
+      type: "string",
+      internal: "internalValue",
+    },
+    {
       name: "Tags",
       id: "tags",
       type: "arrayOptions",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for filtering by 'Score Name' in dashboard mappings, data models, and UI components.
> 
>   - **Behavior**:
>     - Adds support for filtering by `Score Name` in `dashboardUiTableToViewMapping.ts`, `dataModel.ts`, and `WidgetForm.tsx`.
>     - Updates `viewMappings` in `dashboardUiTableToViewMapping.ts` to include `Score Name` for `traces`, `observations`, `scores-numeric`, and `scores-categorical`.
>     - Updates `traceView` and `observationsView` in `dataModel.ts` to include `scoreName` dimension.
>     - Updates `filterColumns` in `WidgetForm.tsx` and `index.tsx` to include `Score Name`.
>   - **UI Components**:
>     - Adds `Score Name` as a filter option in `WidgetForm.tsx` and `index.tsx`.
>   - **Misc**:
>     - No changes to existing functionality, only additions for new filter support.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 21af705f55bfa0d19d8a41d2b84680e8279224b0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->