### PR TITLE
fix(api-prompts): use middleware to send response when updating labels

### DIFF
--- a/web/src/features/prompts/server/handlers/promptVersionHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptVersionHandler.ts
@@ -20,37 +20,29 @@ export const promptVersionHandler = withMiddlewares({
     name: "Update Prompt",
     bodySchema: UpdatePromptBodySchema,
     responseSchema: z.any(),
-    fn: async ({ body, res, req, auth }) => {
-      try {
-        const { newLabels } = UpdatePromptBodySchema.parse(body);
-        const { promptName, promptVersion } = req.query;
+    fn: async ({ body, req, auth }) => {
+      const { newLabels } = UpdatePromptBodySchema.parse(body);
+      const { promptName, promptVersion } = req.query;
 
-        const prompt = await updatePrompt({
-          promptName: promptName as string,
-          projectId: auth.scope.projectId,
-          promptVersion: Number(promptVersion),
-          newLabels,
-        });
+      const prompt = await updatePrompt({
+        promptName: promptName as string,
+        projectId: auth.scope.projectId,
+        promptVersion: Number(promptVersion),
+        newLabels,
+      });
 
-        await auditLog({
-          action: "update",
-          resourceType: "prompt",
-          resourceId: prompt.id,
-          projectId: auth.scope.projectId,
-          orgId: auth.scope.orgId,
-          apiKeyId: auth.scope.apiKeyId,
-        });
+      await auditLog({
+        action: "update",
+        resourceType: "prompt",
+        resourceId: prompt.id,
+        projectId: auth.scope.projectId,
+        orgId: auth.scope.orgId,
+        apiKeyId: auth.scope.apiKeyId,
+      });
 
-        logger.info(`Prompt updated ${JSON.stringify(prompt)}`);
+      logger.info(`Prompt updated ${JSON.stringify(prompt)}`);
 
-        return res.status(200).json(prompt);
-      } catch (e) {
-        logger.error(e);
-        if (e instanceof LangfuseNotFoundError) {
-          return res.status(404).json({ message: e.message });
-        }
-        return res.status(500).json({ message: "Internal server error" });
-      }
+      return prompt;
     },
   }),
 });

--- a/web/src/features/prompts/server/handlers/promptVersionHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptVersionHandler.ts
@@ -4,7 +4,6 @@ import { z } from "zod";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import { updatePrompt } from "@/src/features/prompts/server/actions/updatePrompts";
-import { LangfuseNotFoundError } from "@langfuse/shared";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 
 const UpdatePromptBodySchema = z.object({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `promptVersionHandler` now uses middleware for response handling, removing direct error handling and response logic.
> 
>   - **Behavior**:
>     - `promptVersionHandler` in `promptVersionHandler.ts` now uses middleware for response handling, removing direct `res.status` calls.
>     - Removes error handling for `LangfuseNotFoundError` and generic errors, relying on middleware instead.
>   - **Imports**:
>     - Removes unused import `LangfuseNotFoundError` from `promptVersionHandler.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1fcf26f73100cc073cd3f14b5c10bff7ca64733f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->