### PR TITLE
perf(trace-api): increase observations payload limit to 6mb

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -87,6 +87,9 @@ const EnvSchema = z.object({
   LANGFUSE_CUSTOM_SSO_EMAIL_CLAIM: z.string().default("email"),
   LANGFUSE_CUSTOM_SSO_NAME_CLAIM: z.string().default("name"),
   LANGFUSE_CUSTOM_SSO_SUB_CLAIM: z.string().default("sub"),
+  LANGFUSE_API_TRACE_OBSERVATIONS_SIZE_LIMIT_BYTES: z.coerce
+    .number()
+    .default(6e6), // 6MB
 });
 
 export const env: z.infer<typeof EnvSchema> =

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -176,7 +176,6 @@ export const getObservationsForTrace = async (
   // Thus, limit the size of the payload to 5MB, follows NextJS response size limitation:
   // https://nextjs.org/docs/messages/api-routes-response-size-limit
   // See also LFE-4882 for more details
-  const PAYLOAD_SIZE_LIMIT = 5e6; // 5MB
   let payloadSize = 0;
 
   for (const observation of records) {
@@ -196,8 +195,8 @@ export const getObservationsForTrace = async (
       }
     });
 
-    if (payloadSize >= PAYLOAD_SIZE_LIMIT) {
-      const errorMessage = `Observations in trace are too large: ${(payloadSize / 1e6).toFixed(2)}MB exceeds limit of ${(PAYLOAD_SIZE_LIMIT / 1e6).toFixed(2)}MB`;
+    if (payloadSize >= env.LANGFUSE_API_TRACE_OBSERVATIONS_SIZE_LIMIT_BYTES) {
+      const errorMessage = `Observations in trace are too large: ${(payloadSize / 1e6).toFixed(2)}MB exceeds limit of ${(env.LANGFUSE_API_TRACE_OBSERVATIONS_SIZE_LIMIT_BYTES / 1e6).toFixed(2)}MB`;
 
       throw new Error(errorMessage);
     }

--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -451,7 +451,7 @@ describe("/api/public/traces API Endpoint", () => {
         input: "a".repeat(1e6),
         output: "b".repeat(1e6),
         metadata: {
-          foo: "c".repeat(1e6),
+          foo: "c".repeat(2e6),
         },
       }),
     ]);
@@ -463,7 +463,7 @@ describe("/api/public/traces API Endpoint", () => {
         `/api/public/traces/${traceId}`,
       ),
     ).rejects.toThrow(
-      "Observations in trace are too large: 6.00MB exceeds limit of 5.00MB",
+      "Observations in trace are too large: 7.00MB exceeds limit of 6.00MB",
     );
   });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase trace observations payload limit to 6MB and update related logic and tests.
> 
>   - **Behavior**:
>     - Increase `LANGFUSE_API_TRACE_OBSERVATIONS_SIZE_LIMIT_BYTES` default to 6MB in `env.ts`.
>     - Update `getObservationsForTrace` in `observations.ts` to use the new 6MB limit.
>   - **Tests**:
>     - Update test in `traces-api.servertest.ts` to expect a 7MB payload to exceed the new 6MB limit.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 30da74f8a443b20eb767eb06872511478a0c2816. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->