### PR TITLE
perf(api-traces): increase observations payload limit to 10mb

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -89,7 +89,7 @@ const EnvSchema = z.object({
   LANGFUSE_CUSTOM_SSO_SUB_CLAIM: z.string().default("sub"),
   LANGFUSE_API_TRACE_OBSERVATIONS_SIZE_LIMIT_BYTES: z.coerce
     .number()
-    .default(6e6), // 6MB
+    .default(10e6), // 10MB
 });
 
 export const env: z.infer<typeof EnvSchema> =

--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -451,7 +451,7 @@ describe("/api/public/traces API Endpoint", () => {
         input: "a".repeat(1e6),
         output: "b".repeat(1e6),
         metadata: {
-          foo: "c".repeat(2e6),
+          foo: "c".repeat(6e6),
         },
       }),
     ]);
@@ -463,7 +463,7 @@ describe("/api/public/traces API Endpoint", () => {
         `/api/public/traces/${traceId}`,
       ),
     ).rejects.toThrow(
-      "Observations in trace are too large: 7.00MB exceeds limit of 6.00MB",
+      "Observations in trace are too large: 11.00MB exceeds limit of 10.00MB",
     );
   });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Increase API trace observations payload limit from 6MB to 10MB and update tests accordingly.
> 
>   - **Behavior**:
>     - Increase `LANGFUSE_API_TRACE_OBSERVATIONS_SIZE_LIMIT_BYTES` default from 6MB to 10MB in `env.ts`.
>     - Update error message in `traces-api.servertest.ts` to reflect new 10MB limit.
>   - **Tests**:
>     - Modify test case in `traces-api.servertest.ts` to check for 11MB payload exceeding new 10MB limit.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8e2908e31b783143185a5b9d687620fe13a82605. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->