### PR TITLE
UX enhancement: switch public and secret key positions on creation

### DIFF
--- a/web/src/features/public-api/components/CreateApiKeyButton.tsx
+++ b/web/src/features/public-api/components/CreateApiKeyButton.tsx
@@ -96,16 +96,16 @@ export const ApiKeyRender = ({
   return (
     <>
       <div className="mb-4">
+        <div className="text-md mb-2 font-semibold">Public Key</div>
+        <CodeView content={generatedKeys?.publicKey ?? "Loading ..."} />
+      </div>
+      <div className="mb-4">
         <div className="text-md font-semibold">Secret Key</div>
         <div className="my-2 text-sm">
           This key can only be viewed once. You can always create new keys in
           the project settings.
         </div>
         <CodeView content={generatedKeys?.secretKey ?? "Loading ..."} />
-      </div>
-      <div className="mb-4">
-        <div className="text-md mb-2 font-semibold">Public Key</div>
-        <CodeView content={generatedKeys?.publicKey ?? "Loading ..."} />
       </div>
       <div>
         <div className="text-md mb-2 font-semibold">Host</div>


### PR DESCRIPTION
## What does this PR do?

This PR focuses on improving UX for API key creation.
Since documentation and Basic auth use public key first, it is better for user to comprehend it in the same order.

## Type of change
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't checked if my PR needs changes to the documentation

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switches display order of `Public Key` and `Secret Key` in `ApiKeyRender` to improve UX.
> 
>   - **UI Changes**:
>     - Switches the display order of `Public Key` and `Secret Key` in `ApiKeyRender` in `CreateApiKeyButton.tsx`.
>     - `Public Key` is now displayed before `Secret Key` to align with documentation and Basic auth usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a8c9875deccf2901d7c91a24d181133e9ec2ea3a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->