### PR TITLE
feat: add dlx retry queue and service

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -41,6 +41,7 @@ export * from "./redis/dataRetentionProcessingQueue";
 export * from "./redis/coreDataS3ExportQueue";
 export * from "./redis/meteringDataPostgresExportQueue";
 export * from "./redis/experimentCreateQueue";
+export * from "./redis/dlxRetryQueue";
 export * from "./auth/types";
 export * from "./queues";
 export * from "./orderByToPrisma";

--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -123,6 +123,10 @@ export const CreateEvalQueueEventSchema = DatasetRunItemUpsertEventSchema.and(
   ),
 );
 
+export const DeadLetterRetryQueueEventSchema = z.object({
+  timestamp: z.date(),
+});
+
 export type CreateEvalQueueEventType = z.infer<
   typeof CreateEvalQueueEventSchema
 >;
@@ -151,6 +155,9 @@ export type BatchActionProcessingEventType = z.infer<
 export type BlobStorageIntegrationProcessingEventType = z.infer<
   typeof BlobStorageIntegrationProcessingEventSchema
 >;
+export type DeadLetterRetryQueueEventType = z.infer<
+  typeof DeadLetterRetryQueueEventSchema
+>;
 
 export enum QueueName {
   TraceUpsert = "trace-upsert", // Ingestion pipeline adds events on each Trace upsert
@@ -174,6 +181,7 @@ export enum QueueName {
   BatchActionQueue = "batch-action-queue",
   CreateEvalQueue = "create-eval-queue",
   ScoreDelete = "score-delete",
+  DeadLetterRetryQueue = "dead-letter-retry-queue",
 }
 
 export enum QueueJobs {
@@ -198,6 +206,7 @@ export enum QueueJobs {
   BatchActionProcessingJob = "batch-action-processing-job",
   CreateEvalJob = "create-eval-job",
   ScoreDelete = "score-delete",
+  DeadLetterRetryJob = "dead-letter-retry-job",
 }
 
 export type TQueueJobTypes = {
@@ -290,5 +299,11 @@ export type TQueueJobTypes = {
     id: string;
     payload: BlobStorageIntegrationProcessingEventType;
     name: QueueJobs.BlobStorageIntegrationProcessingJob;
+  };
+  [QueueName.DeadLetterRetryQueue]: {
+    timestamp: Date;
+    id: string;
+    payload: DeadLetterRetryQueueEventType;
+    name: QueueJobs.DeadLetterRetryJob;
   };
 };

--- a/packages/shared/src/server/redis/dlxRetryQueue.ts
+++ b/packages/shared/src/server/redis/dlxRetryQueue.ts
@@ -42,7 +42,7 @@ export class DeadLetterRetryQueue {
           QueueJobs.DeadLetterRetryJob,
           { timestamp: new Date() },
           {
-            repeat: { pattern: "*/10 * * * *" }, // every 10 minutes
+            repeat: { pattern: "0 */10 * * * *" }, // every 10 minutes (with seconds precision)
           },
         )
         .catch((err) => {

--- a/packages/shared/src/server/redis/dlxRetryQueue.ts
+++ b/packages/shared/src/server/redis/dlxRetryQueue.ts
@@ -1,0 +1,55 @@
+import { Queue } from "bullmq";
+import { QueueName, QueueJobs } from "../queues";
+import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import { logger } from "../logger";
+
+export class DeadLetterRetryQueue {
+  private static instance: Queue | null = null;
+
+  public static getInstance(): Queue | null {
+    if (DeadLetterRetryQueue.instance) {
+      return DeadLetterRetryQueue.instance;
+    }
+
+    const newRedis = createNewRedisInstance({
+      enableOfflineQueue: false,
+      ...redisQueueRetryOptions,
+    });
+
+    DeadLetterRetryQueue.instance = newRedis
+      ? new Queue(QueueName.DeadLetterRetryQueue, {
+          connection: newRedis,
+          defaultJobOptions: {
+            removeOnComplete: true,
+            removeOnFail: 100,
+            attempts: 5,
+            backoff: {
+              type: "exponential",
+              delay: 5000,
+            },
+          },
+        })
+      : null;
+
+    DeadLetterRetryQueue.instance?.on("error", (err) => {
+      logger.error("DeadLetterRetryQueue error", err);
+    });
+
+    if (DeadLetterRetryQueue.instance) {
+      logger.debug("Scheduling jobs for DeadLetterRetryQueue");
+      DeadLetterRetryQueue.instance
+        .add(
+          QueueJobs.DeadLetterRetryJob,
+          { timestamp: new Date() },
+          {
+            repeat: { pattern: "*/10 * * * *" }, // every 10 minutes
+          },
+        )
+        .catch((err) => {
+          logger.error("Error adding DeadLetterRetryQueue schedule", err);
+        });
+    }
+
+    return DeadLetterRetryQueue.instance;
+  }
+}

--- a/packages/shared/src/server/redis/getQueue.ts
+++ b/packages/shared/src/server/redis/getQueue.ts
@@ -20,6 +20,7 @@ import { DataRetentionProcessingQueue } from "./dataRetentionProcessingQueue";
 import { BatchActionQueue } from "./batchActionQueue";
 import { CreateEvalQueue } from "./createEvalQueue";
 import { ScoreDeleteQueue } from "./scoreDelete";
+import { DeadLetterRetryQueue } from "./dlxRetryQueue";
 
 export function getQueue(queueName: QueueName): Queue | null {
   switch (queueName) {
@@ -65,6 +66,8 @@ export function getQueue(queueName: QueueName): Queue | null {
       return CreateEvalQueue.getInstance();
     case QueueName.ScoreDelete:
       return ScoreDeleteQueue.getInstance();
+    case QueueName.DeadLetterRetryQueue:
+      return DeadLetterRetryQueue.getInstance();
     default:
       const exhaustiveCheckDefault: never = queueName;
       throw new Error(`Queue ${queueName} not found`);

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -28,6 +28,7 @@ import {
   QueueName,
   logger,
   BlobStorageIntegrationQueue,
+  DeadLetterRetryQueue,
 } from "@langfuse/shared/src/server";
 import { env } from "./env";
 import { ingestionQueueProcessorBuilder } from "./queues/ingestionQueue";
@@ -51,6 +52,7 @@ import {
 } from "./queues/dataRetentionQueue";
 import { batchActionQueueProcessor } from "./queues/batchActionQueue";
 import { scoreDeleteProcessor } from "./queues/scoreDelete";
+import { DlxRetryService } from "./services/dlx/dlxRetryService";
 
 const app = express();
 
@@ -305,6 +307,19 @@ if (env.QUEUE_CONSUMER_DATA_RETENTION_QUEUE_IS_ENABLED === "true") {
   WorkerManager.register(
     QueueName.DataRetentionProcessingQueue,
     dataRetentionProcessingProcessor,
+    {
+      concurrency: 1,
+    },
+  );
+}
+
+if (env.QUEUE_CONSUMER_DEAD_LETTER_RETRY_QUEUE_IS_ENABLED === "true") {
+  // Instantiate the queue to trigger scheduled jobs
+  DeadLetterRetryQueue.getInstance();
+
+  WorkerManager.register(
+    QueueName.DeadLetterRetryQueue,
+    DlxRetryService.retryDeadLetterQueue,
     {
       concurrency: 1,
     },

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -190,6 +190,9 @@ const EnvSchema = z.object({
   QUEUE_CONSUMER_DATA_RETENTION_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])
     .default("true"),
+  QUEUE_CONSUMER_DEAD_LETTER_RETRY_QUEUE_IS_ENABLED: z
+    .enum(["true", "false"])
+    .default("true"),
 
   // Core data S3 upload - Langfuse Cloud
   LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED: z

--- a/worker/src/services/dlx/dlxRetryService.ts
+++ b/worker/src/services/dlx/dlxRetryService.ts
@@ -1,0 +1,52 @@
+import { QueueName, recordHistogram } from "@langfuse/shared/src/server";
+import { getQueue } from "@langfuse/shared/src/server";
+
+export class DlxRetryService {
+  private static queueRetryConfigs = {
+    [QueueName.ProjectDelete]: {},
+    [QueueName.TraceDelete]: {},
+    [QueueName.ScoreDelete]: {},
+  };
+
+  public static async init() {}
+
+  // called each 10 minutes, defined by the bull cron job
+  public static async retryDeadLetterQueue() {
+    for (const [queueName, config] of Object.entries(this.queueRetryConfigs)) {
+      const queue = getQueue(queueName as QueueName);
+
+      if (!queue) {
+        console.error(`Queue ${queueName} not found`);
+        continue;
+      }
+
+      // Find failed jobs
+      const failedJobs = await queue.getFailed();
+      for (const job of failedJobs) {
+        try {
+          const projectId = job.data.payload.projectId;
+          const ts = job.data.timestamp;
+          const name = job.data.name;
+
+          const dlxDelay = Date.now() - ts;
+
+          recordHistogram("dlx_retry_delay", dlxDelay, {
+            unit: "milliseconds",
+            projectId,
+            name,
+          });
+
+          await job.retry();
+          console.log(
+            `Retried job ${JSON.stringify(job)} in queue ${queueName}`,
+          );
+        } catch (error) {
+          console.error(
+            `Failed to retry job ${JSON.stringify(job)} in queue ${queueName}:`,
+            error,
+          );
+        }
+      }
+    }
+  }
+}

--- a/worker/src/services/dlx/dlxRetryService.ts
+++ b/worker/src/services/dlx/dlxRetryService.ts
@@ -14,6 +14,7 @@ export class DlxRetryService {
 
   // called each 10 minutes, defined by the bull cron job
   public static async retryDeadLetterQueue() {
+    logger.info("Retrying dead letter queue");
     const retryQueues = DlxRetryService.retryQueues;
     for (const queueName of retryQueues) {
       const queue = getQueue(queueName as QueueName);

--- a/worker/src/services/dlx/dlxRetryService.ts
+++ b/worker/src/services/dlx/dlxRetryService.ts
@@ -1,4 +1,8 @@
-import { QueueName, recordHistogram } from "@langfuse/shared/src/server";
+import {
+  logger,
+  QueueName,
+  recordHistogram,
+} from "@langfuse/shared/src/server";
 import { getQueue } from "@langfuse/shared/src/server";
 
 export class DlxRetryService {
@@ -16,7 +20,7 @@ export class DlxRetryService {
       const queue = getQueue(queueName as QueueName);
 
       if (!queue) {
-        console.error(`Queue ${queueName} not found`);
+        logger.error(`Queue ${queueName} not found`);
         continue;
       }
 
@@ -37,11 +41,11 @@ export class DlxRetryService {
           });
 
           await job.retry();
-          console.log(
+          logger.info(
             `Retried job ${JSON.stringify(job)} in queue ${queueName}`,
           );
         } catch (error) {
-          console.error(
+          logger.error(
             `Failed to retry job ${JSON.stringify(job)} in queue ${queueName}:`,
             error,
           );

--- a/worker/src/services/dlx/dlxRetryService.ts
+++ b/worker/src/services/dlx/dlxRetryService.ts
@@ -2,17 +2,17 @@ import { QueueName, recordHistogram } from "@langfuse/shared/src/server";
 import { getQueue } from "@langfuse/shared/src/server";
 
 export class DlxRetryService {
-  private static queueRetryConfigs = {
-    [QueueName.ProjectDelete]: {},
-    [QueueName.TraceDelete]: {},
-    [QueueName.ScoreDelete]: {},
-  };
+  private static retryQueues = [
+    QueueName.ProjectDelete,
+    QueueName.TraceDelete,
+    QueueName.ScoreDelete,
+  ];
 
   public static async init() {}
 
   // called each 10 minutes, defined by the bull cron job
   public static async retryDeadLetterQueue() {
-    for (const [queueName, config] of Object.entries(this.queueRetryConfigs)) {
+    for (const queueName of this.retryQueues) {
       const queue = getQueue(queueName as QueueName);
 
       if (!queue) {

--- a/worker/src/services/dlx/dlxRetryService.ts
+++ b/worker/src/services/dlx/dlxRetryService.ts
@@ -12,11 +12,10 @@ export class DlxRetryService {
     QueueName.ScoreDelete,
   ];
 
-  public static async init() {}
-
   // called each 10 minutes, defined by the bull cron job
   public static async retryDeadLetterQueue() {
-    for (const queueName of this.retryQueues) {
+    const retryQueues = DlxRetryService.retryQueues;
+    for (const queueName of retryQueues) {
       const queue = getQueue(queueName as QueueName);
 
       if (!queue) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces a Dead Letter Retry Queue and service to retry failed jobs in specific queues, with integration into the existing queue management system.
> 
>   - **Behavior**:
>     - Adds `DeadLetterRetryQueue` class in `dlxRetryQueue.ts` to manage a retry queue for failed jobs, scheduled every 10 minutes.
>     - Introduces `DlxRetryService` in `dlxRetryService.ts` to retry failed jobs in `ProjectDelete`, `TraceDelete`, and `ScoreDelete` queues.
>     - Updates `app.ts` to register `DeadLetterRetryQueue` and `DlxRetryService.retryDeadLetterQueue` with `WorkerManager`.
>   - **Queues**:
>     - Adds `DeadLetterRetryQueueEventSchema` and `DeadLetterRetryQueueEventType` in `queues.ts`.
>     - Updates `QueueName` and `QueueJobs` enums in `queues.ts` to include `DeadLetterRetryQueue` and `DeadLetterRetryJob`.
>     - Modifies `getQueue.ts` to return `DeadLetterRetryQueue` instance.
>   - **Environment**:
>     - Adds `QUEUE_CONSUMER_DEAD_LETTER_RETRY_QUEUE_IS_ENABLED` to `env.ts` with default `true`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f3efd24bc4b8a26b009664e7a77072300f72f4ad. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->