### PR TITLE
chore(ui): add support for input_text and output_text in markdown rendering

### DIFF
--- a/web/src/components/schemas/ChatMlSchema.ts
+++ b/web/src/components/schemas/ChatMlSchema.ts
@@ -1,8 +1,12 @@
 import { z } from "zod";
 
-// OpenAI API Content Schema defined as per https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages, 20.08.2024
+// OpenAI API Content Schema defined as per https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages, 28.04.2025
 const OpenAITextContentPart = z.object({
-  type: z.literal("text"),
+  type: z.union([
+    z.literal("text"),
+    z.literal("input_text"),
+    z.literal("output_text"),
+  ]),
   text: z.string(),
 });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for `input_text` and `output_text` types in `OpenAITextContentPart` schema in `ChatMlSchema.ts`.
> 
>   - **Schema Update**:
>     - In `ChatMlSchema.ts`, `OpenAITextContentPart` now supports `input_text` and `output_text` types in addition to `text`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e1e32bd3c37ac3032131e66231b6c208cfa5297a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->