### PR TITLE
fix: wait for clickhouse mutations to succeed

### DIFF
--- a/packages/shared/clickhouse/migrations/clustered/0012_add_session_id_column_scores.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0012_add_session_id_column_scores.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE scores ON CLUSTER default DROP COLUMN IF EXISTS session_id;
+ALTER TABLE scores ON CLUSTER default DROP COLUMN IF EXISTS session_id SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/clustered/0012_add_session_id_column_scores.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0012_add_session_id_column_scores.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE scores ON CLUSTER default ADD COLUMN session_id Nullable(String) AFTER trace_id;
+ALTER TABLE scores ON CLUSTER default ADD COLUMN session_id Nullable(String) AFTER trace_id SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/clustered/0013_drop_scores_trace_id_index.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0013_drop_scores_trace_id_index.down.sql
@@ -1,2 +1,2 @@
-ALTER TABLE scores ON CLUSTER default ADD INDEX IF NOT EXISTS idx_project_trace_observation (project_id, trace_id, observation_id) TYPE bloom_filter(0.001) GRANULARITY 1;
-ALTER TABLE scores ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_project_trace_observation;
+ALTER TABLE scores ON CLUSTER default ADD INDEX IF NOT EXISTS idx_project_trace_observation (project_id, trace_id, observation_id) TYPE bloom_filter(0.001) GRANULARITY 1 SETTINGS mutations_sync = 2;
+ALTER TABLE scores ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_project_trace_observation SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/clustered/0013_drop_scores_trace_id_index.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0013_drop_scores_trace_id_index.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE scores ON CLUSTER default DROP INDEX IF EXISTS idx_project_trace_observation;
+ALTER TABLE scores ON CLUSTER default DROP INDEX IF EXISTS idx_project_trace_observation SETTINGS mutations_sync = 2;
 

--- a/packages/shared/clickhouse/migrations/clustered/0014_scores_modify_nullable_trace_id_column.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0014_scores_modify_nullable_trace_id_column.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE scores ON CLUSTER default MODIFY COLUMN trace_id Nullable(String);
+ALTER TABLE scores ON CLUSTER default MODIFY COLUMN trace_id Nullable(String) SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/clustered/0014_scores_modify_nullable_trace_id_column.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0014_scores_modify_nullable_trace_id_column.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE scores ON CLUSTER default MODIFY COLUMN trace_id Nullable(String);
+ALTER TABLE scores ON CLUSTER default MODIFY COLUMN trace_id Nullable(String) SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/clustered/0015_add_scores_trace_index.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0015_add_scores_trace_index.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE scores ON CLUSTER default DROP INDEX IF EXISTS idx_project_trace_observation;
+ALTER TABLE scores ON CLUSTER default DROP INDEX IF EXISTS idx_project_trace_observation SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/clustered/0015_add_scores_trace_index.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0015_add_scores_trace_index.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE scores ON CLUSTER default ADD INDEX IF NOT EXISTS idx_project_trace_observation (project_id, trace_id, observation_id) TYPE bloom_filter(0.001) GRANULARITY 1;
-ALTER TABLE scores ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_project_trace_observation;
+ALTER TABLE scores ON CLUSTER default ADD INDEX IF NOT EXISTS idx_project_trace_observation (project_id, trace_id, observation_id) TYPE bloom_filter(0.001) GRANULARITY 1 SETTINGS mutations_sync = 2;
+ALTER TABLE scores ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_project_trace_observation SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/clustered/0016_add_scores_session_index.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0016_add_scores_session_index.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE scores ON CLUSTER default DROP INDEX IF EXISTS idx_project_session;
+ALTER TABLE scores ON CLUSTER default DROP INDEX IF EXISTS idx_project_session SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/clustered/0016_add_scores_session_index.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0016_add_scores_session_index.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE scores ON CLUSTER default ADD INDEX IF NOT EXISTS idx_project_session (project_id, session_id) TYPE bloom_filter(0.001) GRANULARITY 1;
-ALTER TABLE scores ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_project_session;
+ALTER TABLE scores ON CLUSTER default ADD INDEX IF NOT EXISTS idx_project_session (project_id, session_id) TYPE bloom_filter(0.001) GRANULARITY 1 SETTINGS mutations_sync = 2;
+ALTER TABLE scores ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_project_session SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/unclustered/0012_add_session_id_column_scores.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0012_add_session_id_column_scores.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE scores DROP COLUMN IF EXISTS session_id;
+ALTER TABLE scores DROP COLUMN IF EXISTS session_id SETTINGS mutations_sync = 1;

--- a/packages/shared/clickhouse/migrations/unclustered/0012_add_session_id_column_scores.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0012_add_session_id_column_scores.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE scores DROP COLUMN IF EXISTS session_id SETTINGS mutations_sync = 1;
+ALTER TABLE scores DROP COLUMN IF EXISTS session_id SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/unclustered/0012_add_session_id_column_scores.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0012_add_session_id_column_scores.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE scores ADD COLUMN session_id Nullable(String) AFTER trace_id SETTINGS mutations_sync = 1;
+ALTER TABLE scores ADD COLUMN session_id Nullable(String) AFTER trace_id SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/unclustered/0012_add_session_id_column_scores.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0012_add_session_id_column_scores.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE scores ADD COLUMN session_id Nullable(String) AFTER trace_id;
+ALTER TABLE scores ADD COLUMN session_id Nullable(String) AFTER trace_id SETTINGS mutations_sync = 1;

--- a/packages/shared/clickhouse/migrations/unclustered/0013_drop_scores_trace_id_index.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0013_drop_scores_trace_id_index.down.sql
@@ -1,2 +1,2 @@
-ALTER TABLE scores ADD INDEX IF NOT EXISTS idx_project_trace_observation (project_id, trace_id, observation_id) TYPE bloom_filter(0.001) GRANULARITY 1;
-ALTER TABLE scores MATERIALIZE INDEX IF EXISTS idx_project_trace_observation;
+ALTER TABLE scores ADD INDEX IF NOT EXISTS idx_project_trace_observation (project_id, trace_id, observation_id) TYPE bloom_filter(0.001) GRANULARITY 1 SETTINGS mutations_sync = 2;
+ALTER TABLE scores MATERIALIZE INDEX IF EXISTS idx_project_trace_observation SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/unclustered/0013_drop_scores_trace_id_index.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0013_drop_scores_trace_id_index.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE scores DROP INDEX IF EXISTS idx_project_trace_observation;
+ALTER TABLE scores DROP INDEX IF EXISTS idx_project_trace_observation SETTINGS mutations_sync = 2;
 

--- a/packages/shared/clickhouse/migrations/unclustered/0014_scores_modify_nullable_trace_id_column.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0014_scores_modify_nullable_trace_id_column.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE scores MODIFY COLUMN trace_id Nullable(String);
+ALTER TABLE scores MODIFY COLUMN trace_id Nullable(String) SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/unclustered/0014_scores_modify_nullable_trace_id_column.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0014_scores_modify_nullable_trace_id_column.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE scores MODIFY COLUMN trace_id Nullable(String);
+ALTER TABLE scores MODIFY COLUMN trace_id Nullable(String) SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/unclustered/0015_add_scores_trace_index.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0015_add_scores_trace_index.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE scores DROP INDEX IF EXISTS idx_project_trace_observation;
+ALTER TABLE scores DROP INDEX IF EXISTS idx_project_trace_observation SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/unclustered/0015_add_scores_trace_index.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0015_add_scores_trace_index.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE scores ADD INDEX IF NOT EXISTS idx_project_trace_observation (project_id, trace_id, observation_id) TYPE bloom_filter(0.001) GRANULARITY 1;
-ALTER TABLE scores MATERIALIZE INDEX IF EXISTS idx_project_trace_observation;
+ALTER TABLE scores ADD INDEX IF NOT EXISTS idx_project_trace_observation (project_id, trace_id, observation_id) TYPE bloom_filter(0.001) GRANULARITY 1 SETTINGS mutations_sync = 2; 
+ALTER TABLE scores MATERIALIZE INDEX IF EXISTS idx_project_trace_observation SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/unclustered/0016_add_scores_session_index.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0016_add_scores_session_index.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE scores DROP INDEX IF EXISTS idx_project_session;
+ALTER TABLE scores DROP INDEX IF EXISTS idx_project_session SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/unclustered/0016_add_scores_session_index.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0016_add_scores_session_index.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE scores ADD INDEX IF NOT EXISTS idx_project_session (project_id, session_id) TYPE bloom_filter(0.001) GRANULARITY 1;
-ALTER TABLE scores MATERIALIZE INDEX IF EXISTS idx_project_session;
+ALTER TABLE scores ADD INDEX IF NOT EXISTS idx_project_session (project_id, session_id) TYPE bloom_filter(0.001) GRANULARITY 1 SETTINGS mutations_sync = 2;
+ALTER TABLE scores MATERIALIZE INDEX IF EXISTS idx_project_session SETTINGS mutations_sync = 2;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Ensure ClickHouse mutations are synchronized by setting `mutations_sync = 2` in migration scripts for `scores` table operations.
> 
>   - **Behavior**:
>     - Ensures ClickHouse mutations are synchronized by setting `mutations_sync = 2` in migration scripts.
>     - Affects operations like adding/dropping columns and indexes, and modifying columns in `scores` table.
>   - **Files Affected**:
>     - Updates in `0012_add_session_id_column_scores.up.sql` and `0012_add_session_id_column_scores.down.sql` for adding/dropping `session_id` column.
>     - Updates in `0013_drop_scores_trace_id_index.up.sql` and `0013_drop_scores_trace_id_index.down.sql` for adding/dropping `idx_project_trace_observation` index.
>     - Updates in `0014_scores_modify_nullable_trace_id_column.up.sql` and `0014_scores_modify_nullable_trace_id_column.down.sql` for modifying `trace_id` column.
>     - Updates in `0015_add_scores_trace_index.up.sql` and `0015_add_scores_trace_index.down.sql` for adding/dropping `idx_project_trace_observation` index.
>     - Updates in `0016_add_scores_session_index.up.sql` and `0016_add_scores_session_index.down.sql` for adding/dropping `idx_project_session` index.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 195f6fa7d84e0c599de26baab83f6083bf5ee0ed. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->