### PR TITLE
chore: add copy ID button to trace/observation preview

### DIFF
--- a/web/src/components/trace/CopyIdsPopover.tsx
+++ b/web/src/components/trace/CopyIdsPopover.tsx
@@ -1,0 +1,107 @@
+import { Button } from "@/src/components/ui/button";
+import { CopyIcon, CheckIcon } from "lucide-react";
+import { useState } from "react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/src/components/ui/popover";
+import { cn } from "@/src/utils/tailwind";
+import { Label } from "@/src/components/ui/label";
+
+interface IdItem {
+  name: string;
+  id: string;
+}
+
+export const CopyIdsPopover = ({
+  idItems,
+  className,
+}: {
+  idItems: IdItem[];
+  className?: string;
+}) => {
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const handleCopy = (textToCopy: string) => {
+    navigator.clipboard.writeText(textToCopy);
+    setCopiedId(textToCopy);
+    setTimeout(() => setCopiedId(null), 1500);
+  };
+
+  // If only one idItem provided, use simple button with only one ID
+  if (idItems.length === 1) {
+    return (
+      <Button
+        variant="ghost"
+        title="Copy ID"
+        className={cn("h-fit p-1", className)}
+        onClick={() => handleCopy(idItems[0].id)}
+      >
+        {copiedId === idItems[0].id ? (
+          <CheckIcon className="h-3 w-3 text-muted-green" />
+        ) : (
+          <CopyIcon className="h-3 w-3" />
+        )}
+        <span className="ml-1 text-xs">ID</span>
+      </Button>
+    );
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          title="Copy ID"
+          className={cn("h-fit px-1", className)}
+        >
+          <CopyIcon className="h-3 w-3" />
+          <span className="ml-1 text-xs">ID</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="max-h-[50vh] w-auto min-w-[300px] overflow-y-auto p-0"
+        align="start"
+      >
+        <Label className="p-2 text-base capitalize">Copy IDs</Label>
+        <div className="bg-card text-card-foreground shadow-sm">
+          <div className="flex flex-col">
+            {idItems.map((item) => (
+              <div
+                key={item.id}
+                className="flex items-center justify-between border-b p-2 last:border-0"
+              >
+                <div className="flex flex-col">
+                  <span className="text-xs font-medium text-muted-foreground">
+                    {item.name}
+                  </span>
+                  <div className="flex items-center">
+                    <span
+                      className="mr-2 max-w-[250px] truncate font-mono text-sm"
+                      title={item.id}
+                    >
+                      {item.id}
+                    </span>
+                  </div>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => handleCopy(item.id)}
+                >
+                  {copiedId === item.id ? (
+                    <CheckIcon className="h-3 w-3 text-muted-green" />
+                  ) : (
+                    <CopyIcon className="h-3 w-3" />
+                  )}
+                </Button>
+              </div>
+            ))}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -34,6 +34,7 @@ import { ItemBadge } from "@/src/components/ItemBadge";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
 import { useRouter } from "next/router";
+import { CopyIdsPopover } from "@/src/components/trace/CopyIdsPopover";
 
 export const ObservationPreview = ({
   observations,
@@ -122,13 +123,19 @@ export const ObservationPreview = ({
     <div className="ph-no-capture col-span-2 flex h-full flex-1 flex-col overflow-hidden md:col-span-3">
       <div className="flex h-full flex-1 flex-col items-start gap-1 overflow-hidden">
         <div className="mt-3 grid w-full grid-cols-[auto,auto] items-start justify-between gap-2">
-          <div className="flex w-full flex-row items-start gap-2">
+          <div className="flex w-full flex-row items-start gap-1">
             <div className="mt-1.5">
               <ItemBadge type={preloadedObservation.type} isSmall />
             </div>
-            <span className="mb-0 line-clamp-2 min-w-0 break-all font-medium md:break-normal md:break-words">
+            <span className="mb-0 ml-1 line-clamp-2 min-w-0 break-all font-medium md:break-normal md:break-words">
               {preloadedObservation.name}
             </span>
+            <CopyIdsPopover
+              idItems={[
+                { id: preloadedObservation.traceId, name: "Trace ID" },
+                { id: preloadedObservation.id, name: "Observation ID" },
+              ]}
+            />
           </div>
           <div className="mr-3 flex h-full flex-wrap content-start items-start justify-end gap-1">
             {observationWithInputAndOutput.data && (

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -36,6 +36,7 @@ import Link from "next/link";
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useRouter } from "next/router";
+import { CopyIdsPopover } from "@/src/components/trace/CopyIdsPopover";
 
 export const TracePreview = ({
   trace,
@@ -106,13 +107,14 @@ export const TracePreview = ({
     <div className="ph-no-capture col-span-2 flex h-full flex-1 flex-col overflow-hidden md:col-span-3">
       <div className="flex h-full flex-1 flex-col items-start gap-1 overflow-hidden">
         <div className="mt-3 grid w-full grid-cols-[auto,auto] items-start justify-between gap-2">
-          <div className="flex w-full flex-row items-start gap-2">
+          <div className="flex w-full flex-row items-start gap-1">
             <div className="mt-1.5">
               <ItemBadge type="TRACE" isSmall />
             </div>
-            <span className="mb-0 line-clamp-2 min-w-0 break-all font-medium md:break-normal md:break-words">
+            <span className="mb-0 ml-1 line-clamp-2 min-w-0 break-all font-medium md:break-normal md:break-words">
               {trace.name}
             </span>
+            <CopyIdsPopover idItems={[{ id: trace.id, name: "Trace ID" }]} />
           </div>
           <div className="mr-3 flex h-full flex-wrap content-start items-start justify-end gap-1">
             <NewDatasetItemFromExistingObject


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `CopyIdsPopover` component to copy trace and observation IDs, integrated into `ObservationPreview` and `TracePreview`.
> 
>   - **New Component**:
>     - Adds `CopyIdsPopover` in `CopyIdsPopover.tsx` to copy trace and observation IDs.
>     - Handles single and multiple IDs with a button and popover respectively.
>   - **Integration**:
>     - Integrates `CopyIdsPopover` in `ObservationPreview.tsx` for trace and observation IDs.
>     - Integrates `CopyIdsPopover` in `TracePreview.tsx` for trace ID.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 70f7920196718bb9a490706c9999a48dea681cd1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->