### PR TITLE
fix(model-prices): vertex claude sonnet 3-7 version

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1446,7 +1446,7 @@
   {
     "id": "cm7ka7561000108js3t9tb3at",
     "model_name": "claude-3.7-sonnet-20250219",
-    "match_pattern": "(?i)^(claude-3.7-sonnet-20250219|anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
+    "match_pattern": "(?i)^(claude-3.7-sonnet-20250219|anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet@20250219)$",
     "created_at": "2025-02-25T09:35:39.000Z",
     "updated_at": "2025-02-27T12:07:29.000Z",
     "prices": {


### PR DESCRIPTION
## What does this PR do?

In model prices, fixes the Claude Sonnet 3.7 model string when used through Google Vertex

Fixes # (issue)

The last model string is for Vertex (Bedrock one is the 2nd one), but the 3.7 one [doesn't contain a v1/v2 designation on the vertex side](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude#model-list)

```
For Claude 3.7 Sonnet, use claude-3-7-sonnet@20250219.
For Claude 3.5 Sonnet v2, use claude-3-5-sonnet-v2@20241022.
```

For double confirmation, the current string Langfuse uses [has zero hits on Google](https://www.google.com/search?q=%22claude-3-7-sonnet-V2%4020250219%22)

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `match_pattern` for Claude Sonnet 3.7 in `default-model-prices.json` to ensure compatibility with Google Vertex.
> 
>   - **Bug Fix**:
>     - Corrects `match_pattern` for Claude Sonnet 3.7 in `default-model-prices.json` to remove incorrect `V1` designation.
>     - Ensures compatibility with Google Vertex by using `claude-3-7-sonnet@20250219` format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a0a3f78d4f1cfb52f21de6eb4f960cf33e4aa37e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->