### PR TITLE
chore: disable dlx retry for oss

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -192,7 +192,7 @@ const EnvSchema = z.object({
     .default("true"),
   QUEUE_CONSUMER_DEAD_LETTER_RETRY_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])
-    .default("true"),
+    .default("false"),
 
   // Core data S3 upload - Langfuse Cloud
   LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED: z

--- a/worker/src/services/dlx/dlxRetryService.ts
+++ b/worker/src/services/dlx/dlxRetryService.ts
@@ -34,7 +34,7 @@ export class DlxRetryService {
 
           const dlxDelay = Date.now() - ts;
 
-          recordHistogram("dlx_retry_delay", dlxDelay, {
+          recordHistogram("langfuse.dlx_retry_delay", dlxDelay, {
             unit: "milliseconds",
             projectId,
             name,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Disable dead letter retry queue by default and update metric name in `DlxRetryService`.
> 
>   - **Behavior**:
>     - Change default of `QUEUE_CONSUMER_DEAD_LETTER_RETRY_QUEUE_IS_ENABLED` to `false` in `env.ts`.
>   - **Metrics**:
>     - Rename metric `dlx_retry_delay` to `langfuse.dlx_retry_delay` in `DlxRetryService` in `dlxRetryService.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5bb962c6fe6f44611a9f959ef323eb01b57c48e8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->