### PR TITLE
feat(scores): add filtering by observationIds, sessionIds, and traceIds

### DIFF
--- a/fern/apis/server/definition/score-v2.yml
+++ b/fern/apis/server/definition/score-v2.yml
@@ -47,6 +47,15 @@ service:
           scoreIds:
             type: optional<string>
             docs: Comma-separated list of score IDs to limit the results to.
+          observationIds:
+            type: optional<string>
+            docs: Comma-separated list of observation IDs to limit the results to.
+          sessionIds:
+            type: optional<string>
+            docs: Comma-separated list of session IDs to limit the results to.
+          traceIds:
+            type: optional<string>
+            docs: Comma-separated list of trace IDs to limit the results to.
           configId:
             type: optional<string>
             docs: Retrieve only scores with a specific configId.

--- a/packages/shared/src/features/scores/interfaces/api/shared.ts
+++ b/packages/shared/src/features/scores/interfaces/api/shared.ts
@@ -83,6 +83,27 @@ export const GetScoresQuery = z.object({
       message: "Each score ID must be a string",
     })
     .nullish(),
+  observationIds: z
+    .string()
+    .transform((str) => str.split(",").map((id) => id.trim())) // Split the comma-separated string
+    .refine((arr) => arr.every((id) => typeof id === "string"), {
+      message: "Each observation ID must be a string",
+    })
+    .nullish(),
+  sessionIds: z
+    .string()
+    .transform((str) => str.split(",").map((id) => id.trim())) // Split the comma-separated string
+    .refine((arr) => arr.every((id) => typeof id === "string"), {
+      message: "Each session ID must be a string",
+    })
+    .nullish(),
+  traceIds: z
+    .string()
+    .transform((str) => str.split(",").map((id) => id.trim())) // Split the comma-separated string
+    .refine((arr) => arr.every((id) => typeof id === "string"), {
+      message: "Each trace ID must be a string",
+    })
+    .nullish(),
 });
 
 // POST /scores

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3415,6 +3415,27 @@ paths:
           schema:
             type: string
             nullable: true
+        - name: observationIds
+          in: query
+          description: Comma-separated list of observation IDs to limit the results to.
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: sessionIds
+          in: query
+          description: Comma-separated list of session IDs to limit the results to.
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: traceIds
+          in: query
+          description: Comma-separated list of trace IDs to limit the results to.
+          required: false
+          schema:
+            type: string
+            nullable: true
         - name: configId
           in: query
           description: Retrieve only scores with a specific configId.

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -2468,7 +2468,7 @@
           "request": {
             "description": "Get a list of scores (supports both trace and session scores)",
             "url": {
-              "raw": "{{baseUrl}}/api/public/v2/scores?page=&limit=&userId=&name=&fromTimestamp=&toTimestamp=&environment=&source=&operator=&value=&scoreIds=&configId=&queueId=&dataType=&traceTags=",
+              "raw": "{{baseUrl}}/api/public/v2/scores?page=&limit=&userId=&name=&fromTimestamp=&toTimestamp=&environment=&source=&operator=&value=&scoreIds=&observationIds=&sessionIds=&traceIds=&configId=&queueId=&dataType=&traceTags=",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -2533,6 +2533,21 @@
                   "key": "scoreIds",
                   "value": "",
                   "description": "Comma-separated list of score IDs to limit the results to."
+                },
+                {
+                  "key": "observationIds",
+                  "value": "",
+                  "description": "Comma-separated list of observation IDs to limit the results to."
+                },
+                {
+                  "key": "sessionIds",
+                  "value": "",
+                  "description": "Comma-separated list of session IDs to limit the results to."
+                },
+                {
+                  "key": "traceIds",
+                  "value": "",
+                  "description": "Comma-separated list of trace IDs to limit the results to."
                 },
                 {
                   "key": "configId",

--- a/web/src/__tests__/async/scores-api-v2.servertest.ts
+++ b/web/src/__tests__/async/scores-api-v2.servertest.ts
@@ -801,6 +801,7 @@ describe("/api/public/v2/scores API Endpoint", () => {
       let scoreId_11: string;
       let scoreId_12: string;
       let scoreId_13: string;
+      let scoreId_14: string;
 
       beforeEach(async () => {
         // Create additional resources for ID filtering tests
@@ -816,6 +817,7 @@ describe("/api/public/v2/scores API Endpoint", () => {
         scoreId_11 = v4();
         scoreId_12 = v4();
         scoreId_13 = v4();
+        scoreId_14 = v4();
 
         const observation_1 = createObservation({
           id: obsId_1,
@@ -849,7 +851,6 @@ describe("/api/public/v2/scores API Endpoint", () => {
           project_id: newProjectId,
           trace_id: traceId_4,
           observation_id: obsId_1,
-          session_id: sessionId_1,
           name: "id-filter-score",
           value: 1,
         });
@@ -860,7 +861,6 @@ describe("/api/public/v2/scores API Endpoint", () => {
           project_id: newProjectId,
           trace_id: traceId_5,
           observation_id: obsId_2,
-          session_id: sessionId_2,
           name: "id-filter-score",
           value: 2,
         });
@@ -871,7 +871,6 @@ describe("/api/public/v2/scores API Endpoint", () => {
           project_id: newProjectId,
           trace_id: traceId_4,
           observation_id: obsId_2, // Different observation
-          session_id: sessionId_1,
           name: "id-filter-score",
           value: 3,
         });
@@ -882,7 +881,6 @@ describe("/api/public/v2/scores API Endpoint", () => {
           project_id: newProjectId,
           trace_id: traceId_5,
           observation_id: obsId_1, // Different observation
-          session_id: sessionId_2,
           name: "id-filter-score",
           value: 4,
         });
@@ -905,6 +903,15 @@ describe("/api/public/v2/scores API Endpoint", () => {
           value: 6,
         });
 
+        // Another standalone session score
+        const score_14 = createSessionScore({
+          id: scoreId_14,
+          project_id: newProjectId,
+          session_id: sessionId_2,
+          name: "id-filter-score-session-only",
+          value: 6,
+        });
+
         await createScoresCh([
           score_8,
           score_9,
@@ -912,6 +919,7 @@ describe("/api/public/v2/scores API Endpoint", () => {
           score_11,
           score_12,
           score_13,
+          score_14,
         ]);
       });
 
@@ -1028,19 +1036,19 @@ describe("/api/public/v2/scores API Endpoint", () => {
           authentication,
         );
         expect(getScore.status).toBe(200);
-        expect(getScore.body.meta).toMatchObject({ totalItems: 3 }); // score_8, score_10, score_12
+        expect(getScore.body.meta).toMatchObject({ totalItems: 1 }); // scoreId_12
         expect(getScore.body.data).toEqual(
           expect.arrayContaining([
-            expect.objectContaining({ id: scoreId_8, sessionId: sessionId_1 }),
-            expect.objectContaining({ id: scoreId_10, sessionId: sessionId_1 }),
             expect.objectContaining({ id: scoreId_12, sessionId: sessionId_1 }),
           ]),
         );
         expect(getScore.body.data).not.toEqual(
           expect.arrayContaining([
-            expect.objectContaining({ id: scoreId_9 }), // Belongs to sessionId_2
-            expect.objectContaining({ id: scoreId_11 }), // Belongs to sessionId_2
-            expect.objectContaining({ id: scoreId_13 }), // Belongs to sessionId_2
+            expect.objectContaining({ id: scoreId_14 }),
+            expect.objectContaining({ id: scoreId_8 }),
+            expect.objectContaining({ id: scoreId_9 }),
+            expect.objectContaining({ id: scoreId_11 }),
+            expect.objectContaining({ id: scoreId_13 }),
           ]),
         );
       });
@@ -1057,12 +1065,17 @@ describe("/api/public/v2/scores API Endpoint", () => {
         expect(getScore.body.meta).toMatchObject({ totalItems: 6 }); // All scores except those unrelated to session/trace
         expect(getScore.body.data).toEqual(
           expect.arrayContaining([
-            expect.objectContaining({ id: scoreId_8, sessionId: sessionId_1 }),
-            expect.objectContaining({ id: scoreId_9, sessionId: sessionId_2 }),
-            expect.objectContaining({ id: scoreId_10, sessionId: sessionId_1 }),
-            expect.objectContaining({ id: scoreId_11, sessionId: sessionId_2 }),
             expect.objectContaining({ id: scoreId_12, sessionId: sessionId_1 }),
             expect.objectContaining({ id: scoreId_13, sessionId: sessionId_2 }),
+            expect.objectContaining({ id: scoreId_14, sessionId: sessionId_2 }),
+          ]),
+        );
+        expect(getScore.body.data).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: scoreId_8 }),
+            expect.objectContaining({ id: scoreId_9 }),
+            expect.objectContaining({ id: scoreId_10 }),
+            expect.objectContaining({ id: scoreId_11 }),
           ]),
         );
       });

--- a/web/src/__tests__/async/scores-api-v2.servertest.ts
+++ b/web/src/__tests__/async/scores-api-v2.servertest.ts
@@ -1,14 +1,12 @@
 import {
   createObservation,
-  createTraceScore,
   createTrace,
-  createSessionScore,
-} from "@langfuse/shared/src/server";
-import {
-  createObservationsCh,
   createScoresCh,
   createTracesCh,
+  createObservationsCh,
   createOrgProjectAndApiKey,
+  createTraceScore,
+  createSessionScore,
 } from "@langfuse/shared/src/server";
 import { makeZodVerifiedAPICall } from "@/src/__tests__/test-utils";
 import { GetScoreResponseV2, GetScoresResponseV2 } from "@langfuse/shared";
@@ -17,6 +15,9 @@ import { v4 } from "uuid";
 import { z } from "zod";
 
 describe("/api/public/v2/scores API Endpoint", () => {
+  let authentication: string;
+  let newProjectId: string;
+
   describe("GET /api/public/v2/scores/:scoreId", () => {
     it("should GET a trace score", async () => {
       const { projectId: projectId, auth } = await createOrgProjectAndApiKey();
@@ -165,8 +166,6 @@ describe("/api/public/v2/scores API Endpoint", () => {
       const scoreId_5 = v4();
       const scoreId_6 = v4();
       const scoreId_7 = v4();
-      let authentication: string;
-      let newProjectId: string;
 
       beforeEach(async () => {
         const { projectId, auth } = await createOrgProjectAndApiKey();
@@ -784,6 +783,316 @@ describe("/api/public/v2/scores API Endpoint", () => {
               name: scoreName,
               value: 10.5,
             }),
+          ]),
+        );
+      });
+    });
+
+    describe("should Filter scores by traceIds / observationIds / sessionIds", () => {
+      let obsId_1: string;
+      let obsId_2: string;
+      let sessionId_1: string;
+      let sessionId_2: string;
+      let traceId_4: string;
+      let traceId_5: string;
+      let scoreId_8: string;
+      let scoreId_9: string;
+      let scoreId_10: string;
+      let scoreId_11: string;
+      let scoreId_12: string;
+      let scoreId_13: string;
+
+      beforeEach(async () => {
+        // Create additional resources for ID filtering tests
+        obsId_1 = v4();
+        obsId_2 = v4();
+        sessionId_1 = v4();
+        sessionId_2 = v4();
+        traceId_4 = v4();
+        traceId_5 = v4();
+        scoreId_8 = v4();
+        scoreId_9 = v4();
+        scoreId_10 = v4();
+        scoreId_11 = v4();
+        scoreId_12 = v4();
+        scoreId_13 = v4();
+
+        const observation_1 = createObservation({
+          id: obsId_1,
+          project_id: newProjectId,
+          trace_id: traceId_4,
+          type: "SPAN",
+        });
+        const observation_2 = createObservation({
+          id: obsId_2,
+          project_id: newProjectId,
+          trace_id: traceId_5,
+          type: "SPAN",
+        });
+        await createObservationsCh([observation_1, observation_2]);
+
+        const trace_4 = createTrace({
+          id: traceId_4,
+          project_id: newProjectId,
+          session_id: sessionId_1,
+        });
+        const trace_5 = createTrace({
+          id: traceId_5,
+          project_id: newProjectId,
+          session_id: sessionId_2,
+        });
+        await createTracesCh([trace_4, trace_5]);
+
+        // Score linked to trace 4, obs 1, session 1
+        const score_8 = createTraceScore({
+          id: scoreId_8,
+          project_id: newProjectId,
+          trace_id: traceId_4,
+          observation_id: obsId_1,
+          session_id: sessionId_1,
+          name: "id-filter-score",
+          value: 1,
+        });
+
+        // Score linked to trace 5, obs 2, session 2
+        const score_9 = createTraceScore({
+          id: scoreId_9,
+          project_id: newProjectId,
+          trace_id: traceId_5,
+          observation_id: obsId_2,
+          session_id: sessionId_2,
+          name: "id-filter-score",
+          value: 2,
+        });
+
+        // Score linked to trace 4, obs 2, session 1
+        const score_10 = createTraceScore({
+          id: scoreId_10,
+          project_id: newProjectId,
+          trace_id: traceId_4,
+          observation_id: obsId_2, // Different observation
+          session_id: sessionId_1,
+          name: "id-filter-score",
+          value: 3,
+        });
+
+        // Score linked to trace 5, obs 1, session 2
+        const score_11 = createTraceScore({
+          id: scoreId_11,
+          project_id: newProjectId,
+          trace_id: traceId_5,
+          observation_id: obsId_1, // Different observation
+          session_id: sessionId_2,
+          name: "id-filter-score",
+          value: 4,
+        });
+
+        // Standalone session score
+        const score_12 = createSessionScore({
+          id: scoreId_12,
+          project_id: newProjectId,
+          session_id: sessionId_1,
+          name: "id-filter-score-session-only",
+          value: 5,
+        });
+
+        // Another standalone session score
+        const score_13 = createSessionScore({
+          id: scoreId_13,
+          project_id: newProjectId,
+          session_id: sessionId_2,
+          name: "id-filter-score-session-only",
+          value: 6,
+        });
+
+        await createScoresCh([
+          score_8,
+          score_9,
+          score_10,
+          score_11,
+          score_12,
+          score_13,
+        ]);
+      });
+
+      it("should filter by single traceId", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponseV2,
+          "GET",
+          `/api/public/v2/scores?traceIds=${traceId_4}`,
+          undefined,
+          authentication,
+        );
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({ totalItems: 2 });
+        expect(getScore.body.data).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: scoreId_8, traceId: traceId_4 }),
+            expect.objectContaining({ id: scoreId_10, traceId: traceId_4 }),
+          ]),
+        );
+        expect(getScore.body.data).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: scoreId_9 }), // Belongs to traceId_5
+            expect.objectContaining({ id: scoreId_11 }), // Belongs to traceId_5
+            expect.objectContaining({ id: scoreId_12 }), // No traceId
+            expect.objectContaining({ id: scoreId_13 }), // No traceId
+          ]),
+        );
+      });
+
+      it("should filter by multiple traceIds", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponseV2,
+          "GET",
+          `/api/public/v2/scores?traceIds=${traceId_4},${traceId_5}`,
+          undefined,
+          authentication,
+        );
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({ totalItems: 4 });
+        expect(getScore.body.data).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: scoreId_8, traceId: traceId_4 }),
+            expect.objectContaining({ id: scoreId_9, traceId: traceId_5 }),
+            expect.objectContaining({ id: scoreId_10, traceId: traceId_4 }),
+            expect.objectContaining({ id: scoreId_11, traceId: traceId_5 }),
+          ]),
+        );
+        expect(getScore.body.data).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: scoreId_12 }), // No traceId
+            expect.objectContaining({ id: scoreId_13 }), // No traceId
+          ]),
+        );
+      });
+
+      it("should filter by single observationId", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponseV2,
+          "GET",
+          `/api/public/v2/scores?observationIds=${obsId_1}`,
+          undefined,
+          authentication,
+        );
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({ totalItems: 2 });
+        expect(getScore.body.data).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: scoreId_8, observationId: obsId_1 }),
+            expect.objectContaining({ id: scoreId_11, observationId: obsId_1 }),
+          ]),
+        );
+        expect(getScore.body.data).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: scoreId_9 }), // Belongs to obsId_2
+            expect.objectContaining({ id: scoreId_10 }), // Belongs to obsId_2
+            expect.objectContaining({ id: scoreId_12 }), // No obsId
+            expect.objectContaining({ id: scoreId_13 }), // No obsId
+          ]),
+        );
+      });
+
+      it("should filter by multiple observationIds", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponseV2,
+          "GET",
+          `/api/public/v2/scores?observationIds=${obsId_1},${obsId_2}`,
+          undefined,
+          authentication,
+        );
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({ totalItems: 4 });
+        expect(getScore.body.data).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: scoreId_8, observationId: obsId_1 }),
+            expect.objectContaining({ id: scoreId_9, observationId: obsId_2 }),
+            expect.objectContaining({ id: scoreId_10, observationId: obsId_2 }),
+            expect.objectContaining({ id: scoreId_11, observationId: obsId_1 }),
+          ]),
+        );
+        expect(getScore.body.data).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: scoreId_12 }), // No obsId
+            expect.objectContaining({ id: scoreId_13 }), // No obsId
+          ]),
+        );
+      });
+
+      it("should filter by single sessionId", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponseV2,
+          "GET",
+          `/api/public/v2/scores?sessionIds=${sessionId_1}`,
+          undefined,
+          authentication,
+        );
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({ totalItems: 3 }); // score_8, score_10, score_12
+        expect(getScore.body.data).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: scoreId_8, sessionId: sessionId_1 }),
+            expect.objectContaining({ id: scoreId_10, sessionId: sessionId_1 }),
+            expect.objectContaining({ id: scoreId_12, sessionId: sessionId_1 }),
+          ]),
+        );
+        expect(getScore.body.data).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: scoreId_9 }), // Belongs to sessionId_2
+            expect.objectContaining({ id: scoreId_11 }), // Belongs to sessionId_2
+            expect.objectContaining({ id: scoreId_13 }), // Belongs to sessionId_2
+          ]),
+        );
+      });
+
+      it("should filter by multiple sessionIds", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponseV2,
+          "GET",
+          `/api/public/v2/scores?sessionIds=${sessionId_1},${sessionId_2}`,
+          undefined,
+          authentication,
+        );
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({ totalItems: 6 }); // All scores except those unrelated to session/trace
+        expect(getScore.body.data).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: scoreId_8, sessionId: sessionId_1 }),
+            expect.objectContaining({ id: scoreId_9, sessionId: sessionId_2 }),
+            expect.objectContaining({ id: scoreId_10, sessionId: sessionId_1 }),
+            expect.objectContaining({ id: scoreId_11, sessionId: sessionId_2 }),
+            expect.objectContaining({ id: scoreId_12, sessionId: sessionId_1 }),
+            expect.objectContaining({ id: scoreId_13, sessionId: sessionId_2 }),
+          ]),
+        );
+      });
+
+      it("should filter by combining traceId and observationId", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponseV2,
+          "GET",
+          `/api/public/v2/scores?traceIds=${traceId_4}&observationIds=${obsId_1}`,
+          undefined,
+          authentication,
+        );
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({ totalItems: 1 }); // Only score_8 matches both
+        expect(getScore.body.data).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: scoreId_8,
+              traceId: traceId_4,
+              observationId: obsId_1,
+            }),
+          ]),
+        );
+        expect(getScore.body.data).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: scoreId_9 }),
+            expect.objectContaining({ id: scoreId_10 }),
+            expect.objectContaining({ id: scoreId_11 }),
+            expect.objectContaining({ id: scoreId_12 }),
+            expect.objectContaining({ id: scoreId_13 }),
           ]),
         );
       });

--- a/web/src/features/public-api/server/scores.ts
+++ b/web/src/features/public-api/server/scores.ts
@@ -21,6 +21,9 @@ export type ScoreQueryType = {
   operator?: string;
   scoreIds?: string[];
   dataType?: string;
+  observationIds?: string[];
+  sessionIds?: string[];
+  traceIds?: string[];
 };
 
 /**
@@ -266,6 +269,27 @@ const secureScoreFilterOptions = [
     clickhouseSelect: "data_type",
     clickhouseTable: "scores",
     filterType: "StringFilter",
+    clickhousePrefix: "s",
+  },
+  {
+    id: "observationIds",
+    clickhouseSelect: "observation_id",
+    clickhouseTable: "scores",
+    filterType: "StringOptionsFilter",
+    clickhousePrefix: "s",
+  },
+  {
+    id: "sessionIds",
+    clickhouseSelect: "session_id",
+    clickhouseTable: "scores",
+    filterType: "StringOptionsFilter",
+    clickhousePrefix: "s",
+  },
+  {
+    id: "traceIds",
+    clickhouseSelect: "trace_id",
+    clickhouseTable: "scores",
+    filterType: "StringOptionsFilter",
     clickhousePrefix: "s",
   },
 ];

--- a/web/src/pages/api/public/scores/index.ts
+++ b/web/src/pages/api/public/scores/index.ts
@@ -71,6 +71,9 @@ export default withMiddlewares({
         value: query.value ?? undefined,
         operator: query.operator ?? undefined,
         scoreIds: query.scoreIds ?? undefined,
+        observationIds: query.observationIds ?? undefined,
+        sessionIds: query.sessionIds ?? undefined,
+        traceIds: query.traceIds ?? undefined,
       };
       const [items, count] = await Promise.all([
         scoresApiService.generateScoresForPublicApi(scoreParams),

--- a/web/src/pages/api/public/v2/scores/index.ts
+++ b/web/src/pages/api/public/v2/scores/index.ts
@@ -31,6 +31,9 @@ export default withMiddlewares({
         value: query.value ?? undefined,
         operator: query.operator ?? undefined,
         scoreIds: query.scoreIds ?? undefined,
+        observationIds: query.observationIds ?? undefined,
+        sessionIds: query.sessionIds ?? undefined,
+        traceIds: query.traceIds ?? undefined,
       };
       const scoresApiService = new ScoresApiService("v2");
       const [items, count] = await Promise.all([


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add filtering by `observationIds`, `sessionIds`, and `traceIds` to score queries in the API.
> 
>   - **API Changes**:
>     - Added `observationIds`, `sessionIds`, and `traceIds` as optional query parameters in `score-v2.yml`, `openapi.yml`, and `shared.ts`.
>   - **Backend Logic**:
>     - Updated `ScoreQueryType` in `scores.ts` to include `observationIds`, `sessionIds`, and `traceIds`.
>     - Modified `_handleGenerateScoresForPublicApi` and `_handleGetScoresCountForPublicApi` in `scores.ts` to handle new filters.
>   - **Testing**:
>     - Added tests in `scores-api-v2.servertest.ts` to verify filtering by `observationIds`, `sessionIds`, and `traceIds`.
>   - **Misc**:
>     - Updated `collection.json` to include new query parameters in the API request URL.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b96ea4ea7c889317bbbb9049a248d59702ad3dd7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->