### PR TITLE
chore: run test suite against redis 6

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -36,7 +36,7 @@ services:
       start_period: 1s
 
   redis:
-    image: redis:7.2.4
+    image: redis:6.0
     restart: always
     command: >
       --requirepass ${REDIS_AUTH:-myredissecret}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Downgrade Redis image to version 6.0 in `docker-compose.dev.yml`.
> 
>   - **Docker Compose**:
>     - Downgrade Redis image from `redis:7.2.4` to `redis:6.0` in `docker-compose.dev.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1e21d26a307b5ea9ae5a33cde333a41286cb6818. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->