### PR TITLE
chore(peek): memoize table body for enhanced front-end performance 

### DIFF
--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -36,7 +36,7 @@ import {
 import { TablePeekView } from "@/src/components/table/peek";
 import { type PeekViewProps } from "@/src/components/table/peek/hooks/usePeekView";
 import { usePeekView } from "@/src/components/table/peek/hooks/usePeekView";
-import _ from "lodash";
+import { isEqual } from "lodash";
 
 interface DataTableProps<TData, TValue> {
   columns: LangfuseColumnDef<TData, TValue>[];
@@ -540,9 +540,9 @@ const MemoizedTableBody = React.memo(TableBodyComponent, (prev, next) => {
   if (prev.rowheighttw !== next.rowheighttw) return false;
 
   // Then do more expensive deep equality checks
-  if (!_.isEqual(prev.columnVisibility, next.columnVisibility)) return false;
-  if (!_.isEqual(prev.columnOrder, next.columnOrder)) return false;
-  if (!_.isEqual(prev.pagination, next.pagination)) return false;
+  if (!isEqual(prev.columnVisibility, next.columnVisibility)) return false;
+  if (!isEqual(prev.columnOrder, next.columnOrder)) return false;
+  if (!isEqual(prev.pagination, next.pagination)) return false;
 
   // If all checks pass, components are equal
   return true;

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -535,7 +535,8 @@ function TableBodyComponent<TData>({
 //
 // See: https://tanstack.com/table/v8/docs/guide/column-sizing#advanced-column-resizing-performance
 const MemoizedTableBody = React.memo(TableBodyComponent, (prev, next) => {
-  if (!prev.tableSnapshot || !next.tableSnapshot) return true;
+  if (!prev.tableSnapshot || !next.tableSnapshot)
+    return !prev.tableSnapshot && !next.tableSnapshot;
 
   // Check reference equality first (faster)
   if (

--- a/web/src/components/table/peek/hooks/usePeekView.ts
+++ b/web/src/components/table/peek/hooks/usePeekView.ts
@@ -2,10 +2,27 @@ import { type DataTablePeekViewProps } from "@/src/components/table/peek";
 import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
 
+/**
+ * Props for configuring a peek view in a data table.
+ *
+ * @template TData The type of data in the table rows
+ *
+ * @property isTableDataComplete - Indicates whether all data (including asynchronously loaded data like metrics)
+ * has finished loading. This is critical for proper table memoization - when false, it ensures the table
+ * continues to re-render as additional data loads, even when the primary data reference remains stable.
+ * Set this to true only when ALL data needed for rendering the table is fully loaded.
+ *
+ * Common usage pattern:
+ * ```
+ * isTableDataComplete: !metricsQuery.isLoading && metricsQuery.data !== undefined
+ * ```
+ */
 export type PeekViewProps<TData> = Omit<
   DataTablePeekViewProps<TData>,
   "selectedRowId" | "row"
->;
+> & {
+  isTableDataComplete: boolean;
+};
 
 function getInitialRow<TData>(
   peekViewId: string | undefined,

--- a/web/src/components/table/peek/hooks/usePeekView.ts
+++ b/web/src/components/table/peek/hooks/usePeekView.ts
@@ -21,7 +21,7 @@ export type PeekViewProps<TData> = Omit<
   DataTablePeekViewProps<TData>,
   "selectedRowId" | "row"
 > & {
-  isTableDataComplete: boolean;
+  tableDataUpdatedAt: number;
 };
 
 function getInitialRow<TData>(

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -945,6 +945,7 @@ export default function ObservationsTable({
           children: (row) => (
             <PeekViewObservationDetail projectId={projectId} row={row} />
           ),
+          isTableDataComplete: generations.isSuccess,
         }}
         data={
           generations.isLoading

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -945,7 +945,7 @@ export default function ObservationsTable({
           children: (row) => (
             <PeekViewObservationDetail projectId={projectId} row={row} />
           ),
-          isTableDataComplete: generations.isSuccess,
+          tableDataUpdatedAt: generations.dataUpdatedAt,
         }}
         data={
           generations.isLoading

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -1097,6 +1097,7 @@ export default function TracesTable({
           onExpand: expandPeek,
           getNavigationPath,
           children: <PeekViewTraceDetail projectId={projectId} />,
+          isTableDataComplete: traces.isSuccess && traceMetrics.isSuccess,
         }}
       />
     </>

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -1097,7 +1097,10 @@ export default function TracesTable({
           onExpand: expandPeek,
           getNavigationPath,
           children: <PeekViewTraceDetail projectId={projectId} />,
-          isTableDataComplete: traces.isSuccess && traceMetrics.isSuccess,
+          tableDataUpdatedAt: Math.max(
+            traces.dataUpdatedAt,
+            traceMetrics.dataUpdatedAt,
+          ),
         }}
       />
     </>

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -31,7 +31,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-150 data-[state=open]:duration-200",
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-100 data-[state=open]:duration-100",
   {
     variants: {
       side: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimize table rendering by memoizing table body to enhance performance during column resizing and peek view navigation.
> 
>   - **Performance Optimization**:
>     - Introduce `MemoizedTableBody` in `data-table.tsx` to prevent unnecessary re-renders during column resizing and peek view navigation.
>     - Use `isEqual` from `lodash` for deep equality checks in `MemoizedTableBody`.
>   - **Peek View Enhancements**:
>     - Add `tableDataUpdatedAt` to `PeekViewProps` in `usePeekView.ts` to track data updates.
>     - Update `observations.tsx`, `traces.tsx`, and `DatasetCompareRunsTable.tsx` to pass `tableDataUpdatedAt` for memoization.
>   - **UI Adjustments**:
>     - Change animation duration in `sheet.tsx` from 150ms to 100ms for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 84915bab8cb0f384c09886881897598917a30c57. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->