### PR TITLE
fix(trace-ui): usage breakdown on hover

### DIFF
--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -97,7 +97,7 @@ export type TracesTableRow = {
     defaultCount?: bigint;
   };
   latency?: number;
-  usageDetails?: Record<string, number>;
+  tokenDetails?: Record<string, number>;
   totalCost?: Decimal;
   costDetails?: Record<string, number>;
   environment?: string;
@@ -547,8 +547,11 @@ export default function TracesTable({
         if (!value.inputUsage && !value.outputUsage && !value.totalUsage) {
           return null;
         }
+
+        console.log(row.original);
+
         return (
-          <BreakdownTooltip details={row.original.usageDetails ?? []}>
+          <BreakdownTooltip details={row.original.tokenDetails ?? []}>
             <div className="flex items-center gap-1">
               <TokenUsageBadge
                 inputUsage={Number(value.inputUsage ?? 0)}

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -548,7 +548,6 @@ export default function TracesTable({
           return null;
         }
 
-        console.log(row.original);
 
         return (
           <BreakdownTooltip details={row.original.tokenDetails ?? []}>

--- a/web/src/components/trace/BreakdownToolTip.tsx
+++ b/web/src/components/trace/BreakdownToolTip.tsx
@@ -46,7 +46,9 @@ export const BreakdownTooltip = ({
   };
 
   const maxDecimals = isCost
-    ? Math.max(...Object.values(aggregatedDetails).map(getMaxDecimals))
+    ? Math.max(
+        ...Object.values(aggregatedDetails).map((v) => getMaxDecimals(v)),
+      )
     : 0;
 
   return (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renames `usageDetails` to `tokenDetails` and updates its usage in `traces.tsx` and `BreakdownTooltip`.
> 
>   - **Renames**:
>     - `usageDetails` to `tokenDetails` in `TracesTableRow` type in `traces.tsx`.
>     - Updates references from `usageDetails` to `tokenDetails` in `traces.tsx` and `BreakdownTooltip` usage.
>   - **Behavior**:
>     - `BreakdownTooltip` now uses `tokenDetails` for displaying usage breakdown in `traces.tsx`.
>     - Adds a console log for `row.original` in `traces.tsx` for debugging purposes.
>   - **Misc**:
>     - Minor refactor in `BreakdownTooltip` to improve readability of `maxDecimals` calculation in `BreakdownToolTip.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6a2de2077d65682e555924dc2cbb0f0416f20520. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->