### PR TITLE
fix: navigation issue with organization/project members pages

### DIFF
--- a/web/src/features/rbac/components/MembershipInvitesPage.tsx
+++ b/web/src/features/rbac/components/MembershipInvitesPage.tsx
@@ -10,10 +10,10 @@ import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganiz
 import { api } from "@/src/utils/api";
 import type { RouterOutput } from "@/src/utils/types";
 import { Trash } from "lucide-react";
-import { useQueryParams, withDefault, NumberParam } from "use-query-params";
 import { type Organization, type Role } from "@langfuse/shared";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import Header from "@/src/components/layouts/header";
+import useSessionStorage from "@/src/components/useSessionStorage";
 
 export type tmp = Organization;
 export type InvitesTableRow = {
@@ -37,6 +37,10 @@ export function MembershipInvitesPage({
   orgId: string;
   projectId?: string;
 }) {
+  const paginationKey = projectId
+    ? `projectInvites_${projectId}_pagination`
+    : `orgInvites_${orgId}_pagination`;
+
   const hasOrgViewAccess = useHasOrganizationAccess({
     organizationId: orgId,
     scope: "organizationMembers:read",
@@ -47,10 +51,13 @@ export function MembershipInvitesPage({
       scope: "projectMembers:read",
     }) || hasOrgViewAccess;
 
-  const [paginationState, setPaginationState] = useQueryParams({
-    pageIndex: withDefault(NumberParam, 0),
-    pageSize: withDefault(NumberParam, 10),
-  });
+  const [paginationState, setPaginationState] = useSessionStorage(
+    paginationKey,
+    {
+      pageIndex: 0,
+      pageSize: 10,
+    },
+  );
 
   const invites = projectId
     ? api.members.allInvitesFromProject.useQuery(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix navigation issue by using `useSessionStorage` for pagination state in `MembersTable.tsx` and `MembershipInvitesPage.tsx`.
> 
>   - **Behavior**:
>     - Replaces `useQueryParams` with `useSessionStorage` for pagination state in `MembersTable.tsx` and `MembershipInvitesPage.tsx`.
>     - Pagination state is now stored in session storage, preserving state across navigation.
>   - **Code Changes**:
>     - Removed imports of `useQueryParams`, `withDefault`, and `NumberParam` from `MembersTable.tsx` and `MembershipInvitesPage.tsx`.
>     - Added `useSessionStorage` import to both files.
>     - Created unique pagination keys based on `orgId` and `projectId` in both components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 72ec441f3fc036b9aa8ef77da6af27e892e0506a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->