### PR TITLE
allow foldable code bases on toggle in trace view

### DIFF
--- a/web/src/components/ui/Codeblock.tsx
+++ b/web/src/components/ui/Codeblock.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/utils/tailwind";
-import { Check, Copy } from "lucide-react";
+import { Check, Copy, ChevronDown, ChevronUp } from "lucide-react";
 import { type FC, memo, useState } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import {
@@ -46,13 +46,26 @@ export const programmingLanguages: languageMap = {
   // add more file extensions here, make sure the key is same as language prop in CodeBlock.tsx component
 };
 
+const COLLAPSE_LINE_THRESHOLD = 8;
+
 const CodeBlock: FC<Props> = memo(({ language, value, theme, className }) => {
   const [isCopied, setIsCopied] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(
+    value.split("\n").length > COLLAPSE_LINE_THRESHOLD,
+  );
+
   const handleCopy = () => {
     setIsCopied(true);
     void navigator.clipboard.writeText(value ?? "");
     setTimeout(() => setIsCopied(false), 1000);
   };
+
+  const lines = value.split("\n");
+  const shouldCollapse = lines.length > COLLAPSE_LINE_THRESHOLD;
+  const displayedValue =
+    isCollapsed && shouldCollapse
+      ? lines.slice(0, COLLAPSE_LINE_THRESHOLD).join("\n") + "\n..."
+      : value;
 
   return (
     <div className="codeblock relative w-full overflow-hidden rounded border font-sans dark:bg-zinc-950">
@@ -63,7 +76,27 @@ const CodeBlock: FC<Props> = memo(({ language, value, theme, className }) => {
         )}
       >
         <span className="text-xs lowercase">{language}</span>
-        <div className="flex items-center py-1">
+        <div className="flex items-center gap-1 py-1">
+          {shouldCollapse && (
+            <Button
+              variant="ghost"
+              size="xs"
+              className="text-xs hover:bg-border focus-visible:ring-1 focus-visible:ring-offset-0"
+              onClick={() => setIsCollapsed((prev) => !prev)}
+              aria-expanded={!isCollapsed}
+              aria-label={isCollapsed ? "Show more code" : "Show less code"}
+            >
+              {isCollapsed ? (
+                <>
+                  <ChevronDown className="mr-1 h-3 w-3" /> Show more
+                </>
+              ) : (
+                <>
+                  <ChevronUp className="mr-1 h-3 w-3" /> Show less
+                </>
+              )}
+            </Button>
+          )}
           <Button
             variant="ghost"
             size="xs"
@@ -97,7 +130,7 @@ const CodeBlock: FC<Props> = memo(({ language, value, theme, className }) => {
           },
         }}
       >
-        {value}
+        {displayedValue}
       </SyntaxHighlighter>
     </div>
   );


### PR DESCRIPTION
## What does this PR do?

This PR allows a long `(>8 lines)` code section in the markdown to be foldable, which can be toggled via `show more` or `show less`

A visual presentation of how it looks is also attached below.

Fixes #6074 

https://github.com/user-attachments/assets/02389713-862a-4a7f-85bb-0937f7366823

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds foldable functionality to code blocks longer than 8 lines in `Codeblock.tsx` with a toggle button.
> 
>   - **Behavior**:
>     - Code blocks longer than 8 lines in `Codeblock.tsx` are now foldable with a toggle button.
>     - Toggle button shows "Show more" or "Show less" based on the collapsed state.
>   - **UI Components**:
>     - Adds `ChevronDown` and `ChevronUp` icons for toggle button in `Codeblock.tsx`.
>     - Button toggles `isCollapsed` state to show/hide additional lines.
>   - **State Management**:
>     - Introduces `isCollapsed` state in `CodeBlock` to manage foldable behavior.
>     - `displayedValue` conditionally renders based on `isCollapsed` and line count.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b3c58ce440fea8ace83430eafc52e735de5a175f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->