### PR TITLE
fix(security): remove hyperlinks from organization invitation emails

### DIFF
--- a/packages/shared/src/server/services/email/organizationInvitation/MembershipInvitationEmailTemplate.tsx
+++ b/packages/shared/src/server/services/email/organizationInvitation/MembershipInvitationEmailTemplate.tsx
@@ -8,7 +8,6 @@ import {
   Hr,
   Html,
   Img,
-  Link,
   Preview,
   Section,
   Tailwind,
@@ -58,12 +57,9 @@ export const MembershipInvitationTemplate = ({
             <Text className="text-sm leading-6 text-black">Hello,</Text>
             <Text className="text-sm leading-6 text-black">
               <strong>{invitedByUsername}</strong> (
-              <Link
-                href={`mailto:${invitedByUserEmail}`}
-                className="text-blue-600 no-underline"
-              >
+              <span className="text-blue-600 no-underline">
                 {invitedByUserEmail}
-              </Link>
+              </span>
               ) has invited you to join the <strong>{orgName}</strong>{" "}
               organization on
               {langfuseCloudRegion
@@ -72,6 +68,7 @@ export const MembershipInvitationTemplate = ({
               .
             </Text>
             <Section className="mb-4 mt-8 text-center">
+              {/* Note: inviteLink always refers to a root langfuse url and is not vulnerable to hyperlink injection attacks */}
               <Button
                 className="rounded bg-black px-5 py-3 text-center text-xs font-semibold text-white no-underline"
                 href={inviteLink}
@@ -84,9 +81,7 @@ export const MembershipInvitationTemplate = ({
             </Section>
             <Text className="text-sm leading-6 text-black">
               or copy and paste this URL into your browser:{" "}
-              <Link href={inviteLink} className="text-blue-600 no-underline">
-                {inviteLink}
-              </Link>
+              <span className="text-blue-600 no-underline">{inviteLink}</span>
             </Text>
             <Hr className="mx-0 my-[26px] w-full border border-solid border-[#eaeaea]" />
             <Text className="text-xs leading-6 text-[#666666]">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove hyperlinks from organization invitation emails in `MembershipInvitationEmailTemplate.tsx` to prevent hyperlink injection attacks.
> 
>   - **Security**:
>     - Remove `Link` component for `invitedByUserEmail` and `inviteLink` in `MembershipInvitationEmailTemplate.tsx`.
>     - Replace with `span` elements to prevent hyperlink injection attacks.
>     - Add comment ensuring `inviteLink` is safe from hyperlink injection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c84f745ecff264393f2b8c5ba8f5cd172ab84469. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->