### PR TITLE
fix: fix json limits and scope to single bodies only

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -171,37 +171,6 @@ export const getObservationsForTrace = async (
     },
   });
 
-  // Large number of observations in trace with large input / output / metadata will lead to
-  // high CPU and memory consumption in the convertObservation step, where parsing occurs
-  // Thus, limit the size of the payload to 5MB, follows NextJS response size limitation:
-  // https://nextjs.org/docs/messages/api-routes-response-size-limit
-  // See also LFE-4882 for more details
-  let payloadSize = 0;
-
-  for (const observation of records) {
-    for (const key of ["input", "output"] as const) {
-      const value = observation[key];
-
-      if (value && typeof value === "string") {
-        payloadSize += value.length;
-      }
-    }
-
-    const metadataValues = Object.values(observation["metadata"]);
-
-    metadataValues.forEach((value) => {
-      if (value && typeof value === "string") {
-        payloadSize += value.length;
-      }
-    });
-
-    if (payloadSize >= env.LANGFUSE_API_TRACE_OBSERVATIONS_SIZE_LIMIT_BYTES) {
-      const errorMessage = `Observations in trace are too large: ${(payloadSize / 1e6).toFixed(2)}MB exceeds limit of ${(env.LANGFUSE_API_TRACE_OBSERVATIONS_SIZE_LIMIT_BYTES / 1e6).toFixed(2)}MB`;
-
-      throw new Error(errorMessage);
-    }
-  }
-
   return records.map(convertObservation);
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Centralizes JSON size validation in `json.ts` and removes it from `observations.ts`, ensuring payloads are within limits before parsing.
> 
>   - **Behavior**:
>     - Removed JSON size validation logic from `getObservationsForTrace` in `observations.ts`.
>     - Added `assertJsonSize` function in `json.ts` to validate JSON size before parsing.
>     - `parseJsonPrioritised` in `json.ts` now calls `assertJsonSize` to ensure JSON payloads do not exceed size limits.
>   - **Logging**:
>     - Logs an error if JSON size exceeds the limit in `assertJsonSize` in `json.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3c2a9a5b9ac039b879bfd2dfada1f5c4725d1222. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->