### PR TITLE
fix: increase io limit

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -89,7 +89,7 @@ const EnvSchema = z.object({
   LANGFUSE_CUSTOM_SSO_SUB_CLAIM: z.string().default("sub"),
   LANGFUSE_API_TRACE_OBSERVATIONS_SIZE_LIMIT_BYTES: z.coerce
     .number()
-    .default(10e6), // 10MB
+    .default(80e6), // 80MB
 });
 
 export const env: z.infer<typeof EnvSchema> =

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -3,6 +3,7 @@ import { env } from "../../env";
 import { NodeClickHouseClientConfigOptions } from "@clickhouse/client/dist/config";
 import { getCurrentSpan } from "../instrumentation";
 import { propagation, context } from "@opentelemetry/api";
+import { randomUUID } from "crypto";
 
 export type ClickhouseClientType = ReturnType<typeof createClient>;
 

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -3,7 +3,6 @@ import { env } from "../../env";
 import { NodeClickHouseClientConfigOptions } from "@clickhouse/client/dist/config";
 import { getCurrentSpan } from "../instrumentation";
 import { propagation, context } from "@opentelemetry/api";
-import { randomUUID } from "crypto";
 
 export type ClickhouseClientType = ReturnType<typeof createClient>;
 

--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -489,7 +489,7 @@ describe("/api/public/traces API Endpoint", () => {
     });
   });
 
-  it("should return 5XX if observations are too large when fetching single trace", async () => {
+  it.only("should return 5XX if observations are too large when fetching single trace", async () => {
     // See LFE-4882 for context
     const traceId = randomUUID();
     const trace = createTrace({
@@ -511,10 +511,10 @@ describe("/api/public/traces API Endpoint", () => {
       createObservation({
         trace_id: traceId,
         project_id: projectId,
-        input: "a".repeat(1e6),
-        output: "b".repeat(1e6),
+        input: "a".repeat(30e6),
+        output: "b".repeat(30e6),
         metadata: {
-          foo: "c".repeat(1e6),
+          foo: "c".repeat(30e6),
         },
       }),
     ]);
@@ -522,10 +522,10 @@ describe("/api/public/traces API Endpoint", () => {
       createObservation({
         trace_id: traceId,
         project_id: projectId,
-        input: "a".repeat(1e6),
-        output: "b".repeat(1e6),
+        input: "a".repeat(30e6),
+        output: "b".repeat(30e6),
         metadata: {
-          foo: "c".repeat(1e6),
+          foo: "c".repeat(30e6),
         },
       }),
     ]);

--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -489,7 +489,7 @@ describe("/api/public/traces API Endpoint", () => {
     });
   });
 
-  it.only("should return 5XX if observations are too large when fetching single trace", async () => {
+  it("should return 5XX if observations are too large when fetching single trace", async () => {
     // See LFE-4882 for context
     const traceId = randomUUID();
     const trace = createTrace({

--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -511,19 +511,21 @@ describe("/api/public/traces API Endpoint", () => {
       createObservation({
         trace_id: traceId,
         project_id: projectId,
-        input: "a".repeat(15e6),
-        output: "b".repeat(15e6),
+        input: "a".repeat(1e6),
+        output: "b".repeat(1e6),
         metadata: {
-          foo: "c".repeat(15e6),
+          foo: "c".repeat(1e6),
         },
       }),
+    ]);
+    await createObservationsCh([
       createObservation({
         trace_id: traceId,
         project_id: projectId,
-        input: "a".repeat(15e6),
-        output: "b".repeat(15e6),
+        input: "a".repeat(1e6),
+        output: "b".repeat(1e6),
         metadata: {
-          foo: "c".repeat(15e6),
+          foo: "c".repeat(1e6),
         },
       }),
     ]);
@@ -535,7 +537,7 @@ describe("/api/public/traces API Endpoint", () => {
         `/api/public/traces/${traceId}`,
       ),
     ).rejects.toThrow(
-      "Observations in trace are too large: 11.00MB exceeds limit of 10.00MB",
+      "Observations in trace are too large: 90.00MB exceeds limit of 80.00MB",
     );
   });
 

--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -511,19 +511,19 @@ describe("/api/public/traces API Endpoint", () => {
       createObservation({
         trace_id: traceId,
         project_id: projectId,
-        input: "a".repeat(30e6),
-        output: "b".repeat(30e6),
+        input: "a".repeat(15e6),
+        output: "b".repeat(15e6),
         metadata: {
-          foo: "c".repeat(30e6),
+          foo: "c".repeat(15e6),
         },
       }),
       createObservation({
         trace_id: traceId,
         project_id: projectId,
-        input: "a".repeat(30e6),
-        output: "b".repeat(30e6),
+        input: "a".repeat(15e6),
+        output: "b".repeat(15e6),
         metadata: {
-          foo: "c".repeat(30e6),
+          foo: "c".repeat(15e6),
         },
       }),
     ]);

--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -511,19 +511,19 @@ describe("/api/public/traces API Endpoint", () => {
       createObservation({
         trace_id: traceId,
         project_id: projectId,
-        input: "a".repeat(100e6),
-        output: "b".repeat(100e6),
+        input: "a".repeat(30e6),
+        output: "b".repeat(30e6),
         metadata: {
-          foo: "c".repeat(100e6),
+          foo: "c".repeat(30e6),
         },
       }),
       createObservation({
         trace_id: traceId,
         project_id: projectId,
-        input: "a".repeat(100e6),
-        output: "b".repeat(100e6),
+        input: "a".repeat(30e6),
+        output: "b".repeat(30e6),
         metadata: {
-          foo: "c".repeat(100e6),
+          foo: "c".repeat(30e6),
         },
       }),
     ]);

--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -511,19 +511,19 @@ describe("/api/public/traces API Endpoint", () => {
       createObservation({
         trace_id: traceId,
         project_id: projectId,
-        input: "a".repeat(1e6),
-        output: "b".repeat(1e6),
+        input: "a".repeat(100e6),
+        output: "b".repeat(100e6),
         metadata: {
-          foo: "c".repeat(1e6),
+          foo: "c".repeat(100e6),
         },
       }),
       createObservation({
         trace_id: traceId,
         project_id: projectId,
-        input: "a".repeat(1e6),
-        output: "b".repeat(1e6),
+        input: "a".repeat(100e6),
+        output: "b".repeat(100e6),
         metadata: {
-          foo: "c".repeat(6e6),
+          foo: "c".repeat(100e6),
         },
       }),
     ]);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Increase API trace observations size limit from 10MB to 80MB and update tests accordingly.
> 
>   - **Behavior**:
>     - Increase `LANGFUSE_API_TRACE_OBSERVATIONS_SIZE_LIMIT_BYTES` default from 10MB to 80MB in `env.ts`.
>     - Update error message in `traces-api.servertest.ts` to reflect new 80MB limit.
>   - **Tests**:
>     - Modify `createObservation` calls in `traces-api.servertest.ts` to use 30MB for `input`, `output`, and `metadata`.
>     - Adjust test case to expect error when observations exceed 80MB.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 19cc64b6ee8c32238fd5b5e63eba7aece6bbff26. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->