### PR TITLE
feat: add totalTokens and totalCost to dashboard builder

### DIFF
--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -82,6 +82,18 @@ export const traceView: ViewDeclarationType = {
       type: "number",
       relationTable: "observations",
     },
+    totalTokens: {
+      sql: "sumMap(observations.usage_details)['total']",
+      alias: "totalTokens",
+      type: "sum",
+      relationTable: "observations",
+    },
+    totalCost: {
+      sql: "sum(observations.total_cost)",
+      alias: "totalCost",
+      type: "sum",
+      relationTable: "observations",
+    },
   },
   tableRelations: {
     observations: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `totalTokens` and `totalCost` measures to `traceView` in `dataModel.ts` for enhanced dashboard metrics.
> 
>   - **Measures**:
>     - Add `totalTokens` to `traceView` in `dataModel.ts` using `sumMap(observations.usage_details)['total']`.
>     - Add `totalCost` to `traceView` in `dataModel.ts` using `sum(observations.total_cost)`.
>   - **Relations**:
>     - Both measures relate to the `observations` table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ff00f9fec3eeadd24ea2b29a16ff53d09af7d97a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->