### PR TITLE
fix: persist changes in evals template edit on tab change

### DIFF
--- a/web/src/ee/features/evals/components/template-form.tsx
+++ b/web/src/ee/features/evals/components/template-form.tsx
@@ -237,7 +237,6 @@ export const InnerEvalTemplateForm = (props: {
     resolver: zodResolver(formSchema),
     disabled: !props.isEditing,
     defaultValues: {
-      // when updating, the name has to remain the same and should not be updated
       name:
         props.existingEvalTemplateName ?? props.preFilledFormValues?.name ?? "",
       prompt: props.preFilledFormValues?.prompt ?? undefined,
@@ -250,24 +249,6 @@ export const InnerEvalTemplateForm = (props: {
         : undefined,
     },
   });
-
-  // reset the form if the input template changes
-  useEffect(() => {
-    if (props.preFilledFormValues) {
-      form.reset({
-        // taking the existing template over the pre-filled value.
-        // Existing is for editing, pre-filled is for creating off a template
-        name: props.existingEvalTemplateName ?? props.preFilledFormValues.name,
-        prompt: props.preFilledFormValues.prompt,
-        variables: props.preFilledFormValues.vars,
-        outputReasoning: OutputSchema.parse(
-          props.preFilledFormValues.outputSchema,
-        ).reasoning,
-        outputScore: OutputSchema.parse(props.preFilledFormValues.outputSchema)
-          .score,
-      });
-    }
-  }, [props.preFilledFormValues, form, props.existingEvalTemplateName]);
 
   const extractedVariables = form.watch("prompt")
     ? extractVariables(form.watch("prompt")).filter(getIsCharOrUnderscore)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Removes form reset logic in `InnerEvalTemplateForm` to persist changes on tab switch.
> 
>   - **Behavior**:
>     - Removes `useEffect` in `InnerEvalTemplateForm` that reset the form on `preFilledFormValues` change, ensuring changes persist on tab switch.
>   - **Misc**:
>     - Removes comment about name update restriction in `InnerEvalTemplateForm`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b12b139f712d9a415dc864dccf539c7a91ebb12a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->