### PR TITLE
chore(ui): increase contrast ratio of annotation selection

### DIFF
--- a/web/src/components/ui/toggle.tsx
+++ b/web/src/components/ui/toggle.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/src/utils/tailwind";
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",
+  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground",
   {
     variants: {
       variant: {

--- a/web/src/features/scores/components/AnnotateDrawerContent.tsx
+++ b/web/src/features/scores/components/AnnotateDrawerContent.tsx
@@ -896,7 +896,7 @@ export function AnnotateDrawerContent<Target extends ScoreTarget>({
                                             >
                                               {category.label}
                                             </span>
-                                            <span className="text-primary/60">{`(${category.value})`}</span>
+                                            <span>{`(${category.value})`}</span>
                                           </ToggleGroupItem>
                                         ),
                                       )}


### PR DESCRIPTION
Fixes langfuse/langfuse#6720
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase UI contrast for annotation selection by updating CSS classes in `toggle.tsx` and `AnnotateDrawerContent.tsx`.
> 
>   - **UI Contrast**:
>     - In `toggle.tsx`, change `data-[state=on]:bg-accent` to `data-[state=on]:bg-primary` and `data-[state=on]:text-accent-foreground` to `data-[state=on]:text-primary-foreground` to increase contrast.
>     - In `AnnotateDrawerContent.tsx`, remove `text-primary/60` class from category value span to improve text visibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 47026c6acda7c778d6192cb00a629360cdce8056. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->