### PR TITLE
chore: show full user email on hover

### DIFF
--- a/web/src/components/nav/nav-user.tsx
+++ b/web/src/components/nav/nav-user.tsx
@@ -65,7 +65,9 @@ export function NavUser({ user, items }: UserNavigationProps) {
               </Avatar>
               <div className="grid flex-1 text-left text-sm leading-tight">
                 <span className="truncate font-semibold">{user.name}</span>
-                <span className="truncate text-xs">{user.email}</span>
+                <span className="truncate text-xs" title={user.email}>
+                  {user.email}
+                </span>
               </div>
               <ChevronsUpDown className="ml-auto size-4" />
             </SidebarMenuButton>
@@ -86,7 +88,9 @@ export function NavUser({ user, items }: UserNavigationProps) {
                 </Avatar>
                 <div className="grid flex-1 text-left text-sm leading-tight">
                   <span className="truncate font-semibold">{user.name}</span>
-                  <span className="truncate text-xs">{user.email}</span>
+                  <span className="truncate text-xs" title={user.email}>
+                    {user.email}
+                  </span>
                 </div>
               </div>
             </DropdownMenuLabel>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `title` attribute to display full user email on hover in `NavUser` component.
> 
>   - **Behavior**:
>     - Adds `title` attribute to `user.email` spans in `NavUser` component to show full email on hover.
>     - Affects both the sidebar menu button and dropdown menu label.
>   - **Files**:
>     - Changes in `nav-user.tsx` to implement the hover feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c91ef7848c44665ac648e80a9c06bf69c479033e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->