### PR TITLE
chore(ui): add border to trace timeline bars to increase contrast

### DIFF
--- a/web/src/components/trace/TraceTimelineView.tsx
+++ b/web/src/components/trace/TraceTimelineView.tsx
@@ -191,7 +191,7 @@ function TreeItemInner({
               <div
                 className={cn(
                   "flex h-8 items-center justify-start rounded-sm border border-border bg-muted",
-                  itemWidth ? "" : "border border-dashed",
+                  itemWidth ? "" : "border-dashed",
                   isSelected
                     ? "ring ring-primary-accent"
                     : "group-hover:ring group-hover:ring-tertiary",

--- a/web/src/components/trace/TraceTimelineView.tsx
+++ b/web/src/components/trace/TraceTimelineView.tsx
@@ -106,7 +106,7 @@ function TreeItemInner({
           {firstTokenTimeOffset ? (
             <div
               className={cn(
-                "flex rounded-sm",
+                "flex rounded-sm border border-border",
                 isSelected
                   ? "ring ring-primary-accent"
                   : "group-hover:ring group-hover:ring-tertiary",
@@ -190,7 +190,7 @@ function TreeItemInner({
             >
               <div
                 className={cn(
-                  "flex h-8 items-center justify-start rounded-sm bg-muted",
+                  "flex h-8 items-center justify-start rounded-sm border border-border bg-muted",
                   itemWidth ? "" : "border border-dashed",
                   isSelected
                     ? "ring ring-primary-accent"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add border to trace timeline bars in `TreeItemInner` in `TraceTimelineView.tsx` for increased contrast.
> 
>   - **UI Changes**:
>     - Add border to trace timeline bars in `TreeItemInner` in `TraceTimelineView.tsx` for increased contrast.
>     - Applies to both `firstTokenTimeOffset` and non-`firstTokenTimeOffset` cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8c7475ef5310f9b87c91f972b9e1360141fdf770. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->