### PR TITLE
feat: allow metadata filtering in dashboard builder

### DIFF
--- a/web/src/features/query/dashboardUiTableToViewMapping.ts
+++ b/web/src/features/query/dashboardUiTableToViewMapping.ts
@@ -31,6 +31,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       viewName: "sessionId",
     },
     {
+      uiTableName: "Metadata",
+      viewName: "metadata",
+    },
+    {
       uiTableName: "Release",
       viewName: "release",
     },
@@ -63,6 +67,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
     {
       uiTableName: "Session",
       viewName: "sessionId",
+    },
+    {
+      uiTableName: "Metadata",
+      viewName: "metadata",
     },
     {
       uiTableName: "Type",
@@ -119,6 +127,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       viewName: "sessionId",
     },
     {
+      uiTableName: "Metadata",
+      viewName: "metadata",
+    },
+    {
       uiTableName: "Trace Name",
       viewName: "traceName",
     },
@@ -165,6 +177,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       viewName: "sessionId",
     },
     {
+      uiTableName: "Metadata",
+      viewName: "metadata",
+    },
+    {
       uiTableName: "Trace Name",
       viewName: "traceName",
     },
@@ -199,6 +215,12 @@ const isLegacyUiTableFilter = (
         uiTableId: "observationName",
         clickhouseTableName: "observations",
         clickhouseSelect: 'o."name"',
+      },
+      {
+        uiTableName: "Metadata",
+        uiTableId: "metadata",
+        clickhouseTableName: "traces",
+        clickhouseSelect: 't."metadata"',
       },
     ])
     .some((columnDef) => columnDef.uiTableName === filter.column);

--- a/web/src/features/query/server/queryBuilder.ts
+++ b/web/src/features/query/server/queryBuilder.ts
@@ -136,7 +136,7 @@ export class QueryBuilder {
         type = "datetime";
       } else if (filter.column === "metadata") {
         clickhouseSelect = "metadata";
-        type = "json";
+        type = "stringObject";
       } else {
         throw new Error(
           `Invalid filter column ${filter.column}. Must be one of ${Object.keys(view.dimensions)} or ${view.timeDimension}`,

--- a/web/src/features/query/server/queryBuilder.ts
+++ b/web/src/features/query/server/queryBuilder.ts
@@ -134,6 +134,9 @@ export class QueryBuilder {
       } else if (filter.column === view.timeDimension) {
         clickhouseSelect = view.timeDimension;
         type = "datetime";
+      } else if (filter.column === "metadata") {
+        clickhouseSelect = "metadata";
+        type = "json";
       } else {
         throw new Error(
           `Invalid filter column ${filter.column}. Must be one of ${Object.keys(view.dimensions)} or ${view.timeDimension}`,

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -193,6 +193,12 @@ export function WidgetForm({
       internal: "internalValue",
     },
     {
+      name: "Metadata",
+      id: "metadata",
+      type: "stringObject",
+      internal: "internalValue",
+    },
+    {
       name: "Release",
       id: "release",
       type: "string",

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -159,6 +159,12 @@ export default function DashboardDetail() {
       internal: "internalValue",
     },
     {
+      name: "Metadata",
+      id: "metadata",
+      type: "stringObject",
+      internal: "internalValue",
+    },
+    {
       name: "Release",
       id: "release",
       type: "string",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add metadata filtering to dashboard builder with SQL injection protection and UI support.
> 
>   - **Behavior**:
>     - Add metadata filtering for `traces`, `scores-numeric`, and `observations` in `queryBuilder.servertest.ts`.
>     - Ensure SQL injection protection for metadata filters in `queryBuilderSQLI.servertest.ts`.
>   - **UI**:
>     - Add `Metadata` as a filter option in `WidgetForm.tsx` and `index.tsx`.
>     - Update `dashboardUiTableToViewMapping.ts` to map `Metadata` to `metadata` view.
>   - **Query Builder**:
>     - Support `metadata` column filtering in `queryBuilder.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 12df1d0c9e2c3d9cbc35a66c46300f3143d72ac3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->