### PR TITLE
style(observations): correctly display costs as sums

### DIFF
--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -244,7 +244,7 @@ export const ObservationPreview = ({
                       </Badge>
                     </BreakdownTooltip>
                   ) : undefined}
-                  {totalCost && totalCost !== thisCost ? (
+                  {totalCost && (!thisCost || !totalCost.equals(thisCost)) ? (
                     <Badge variant="tertiary">
                       ∑ {usdFormatter(totalCost.toNumber())}
                     </Badge>

--- a/web/src/components/trace/ObservationTree.tsx
+++ b/web/src/components/trace/ObservationTree.tsx
@@ -190,12 +190,18 @@ const ObservationTreeTraceNode = (props: {
           {props.showMetrics && (
             <div className="flex gap-2">
               {props.trace.latency ? (
-                <span className="text-xs text-muted-foreground">
+                <span
+                  className="text-xs text-muted-foreground"
+                  title="Aggregated duration of all observations"
+                >
                   {formatIntervalSeconds(props.trace.latency)}
                 </span>
               ) : null}
               {props.totalCost ? (
-                <span className="text-xs text-muted-foreground">
+                <span
+                  className="text-xs text-muted-foreground"
+                  title="Aggregated cost of all observations"
+                >
                   {usdFormatter(props.totalCost.toNumber())}
                 </span>
               ) : null}
@@ -424,6 +430,11 @@ const ObservationTreeNodeCard = ({
                 <div className="flex w-full flex-wrap gap-2">
                   {duration ? (
                     <span
+                      title={
+                        observation.children.length > 0
+                          ? "Aggregated duration of all child observations"
+                          : undefined
+                      }
                       className={cn(
                         "text-xs text-muted-foreground",
                         parentTotalDuration &&
@@ -447,6 +458,11 @@ const ObservationTreeNodeCard = ({
                   ) : null}
                   {totalCost ? (
                     <span
+                      title={
+                        observation.children.length > 0
+                          ? "Aggregated cost of all child observations"
+                          : undefined
+                      }
                       className={cn(
                         "text-xs text-muted-foreground",
                         parentTotalCost &&
@@ -457,6 +473,7 @@ const ObservationTreeNodeCard = ({
                           }),
                       )}
                     >
+                      {observation.children.length > 0 ? "∑ " : ""}
                       {usdFormatter(totalCost.toNumber())}
                     </span>
                   ) : null}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve cost display in `ObservationPreview.tsx` and `ObservationTree.tsx` by showing sums and adding tooltips for clarity.
> 
>   - **Behavior**:
>     - In `ObservationPreview.tsx`, update cost display logic to show sums when `totalCost` is not equal to `thisCost`.
>     - In `ObservationTree.tsx`, add titles to cost and duration spans to indicate aggregation of child observations.
>   - **UI Enhancements**:
>     - Add tooltips in `ObservationTree.tsx` to clarify aggregated cost and duration.
>     - Prefix aggregated costs with '∑' in `ObservationTreeNodeCard` and `ObservationTreeTraceNode`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 13971c916b3854c50c75aad755077d4f1964cb8f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->