### PR TITLE
feat(scores): add link to session on session scores table

### DIFF
--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -683,6 +683,7 @@ const getScoresUiGeneric = async <T>(props: {
         s.comment,
         ${excludeMetadata ? "" : "s.metadata,"}
         s.trace_id,
+        s.session_id,
         s.observation_id,
         s.author_user_id,
         t.user_id,

--- a/packages/shared/src/tableDefinitions/mapScoresTable.ts
+++ b/packages/shared/src/tableDefinitions/mapScoresTable.ts
@@ -32,6 +32,12 @@ export const scoresTableUiColumnDefinitions: UiColumnMappings = [
     clickhouseSelect: "observation_id",
   },
   {
+    uiTableName: "Session ID",
+    uiTableId: "sessionId",
+    clickhouseTableName: "scores",
+    clickhouseSelect: "session_id",
+  },
+  {
     uiTableName: "Name",
     uiTableId: "name",
     clickhouseTableName: "scores",

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -44,10 +44,12 @@ import type { RowSelectionState } from "@tanstack/react-table";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import { useSelectAll } from "@/src/features/table/hooks/useSelectAll";
 import { TableSelectionManager } from "@/src/features/table/components/TableSelectionManager";
+import TableId from "@/src/components/table/table-id";
 
 export type ScoresTableRow = {
   id: string;
   traceId?: string;
+  sessionId?: string;
   timestamp: Date;
   source: string;
   name: string;
@@ -258,6 +260,32 @@ export default function ScoresTable({
       enableSorting: false,
       defaultHidden: true,
       enableHiding: true,
+      cell: ({ row }) => {
+        const value = row.getValue("id");
+        return typeof value === "string" ? (
+          <TableId value={value} />
+        ) : undefined;
+      },
+    },
+    {
+      accessorKey: "traceName",
+      header: "Trace Name",
+      id: "traceName",
+      enableHiding: true,
+      enableSorting: true,
+      size: 150,
+      cell: ({ row }) => {
+        const value = row.getValue("traceName") as ScoresTableRow["traceName"];
+        const filter = encodeURIComponent(
+          `name;stringOptions;;any of;${value}`,
+        );
+        return value ? (
+          <TableLink
+            path={`/project/${projectId}/traces?filter=${value ? filter : ""}`}
+            value={value}
+          />
+        ) : undefined;
+      },
     },
     {
       accessorKey: "traceId",
@@ -298,20 +326,17 @@ export default function ScoresTable({
       },
     },
     {
-      accessorKey: "traceName",
-      header: "Trace Name",
-      id: "traceName",
+      accessorKey: "sessionId",
+      header: "Session",
+      id: "sessionId",
       enableHiding: true,
       enableSorting: true,
-      size: 150,
+      size: 100,
       cell: ({ row }) => {
-        const value = row.getValue("traceName") as ScoresTableRow["traceName"];
-        const filter = encodeURIComponent(
-          `name;stringOptions;;any of;${value}`,
-        );
-        return value ? (
+        const value = row.getValue("sessionId");
+        return typeof value === "string" ? (
           <TableLink
-            path={`/project/${projectId}/traces?filter=${value ? filter : ""}`}
+            path={`/project/${projectId}/sessions/${encodeURIComponent(value)}`}
             value={value}
           />
         ) : undefined;
@@ -564,6 +589,7 @@ export default function ScoresTable({
       },
       comment: score.comment ?? undefined,
       observationId: score.observationId ?? undefined,
+      sessionId: score.sessionId ?? undefined,
       traceId: score.traceId ?? undefined,
       traceName: score.traceName ?? undefined,
       userId: score.traceUserId ?? undefined,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add session ID links to session scores table, updating data retrieval and UI components.
> 
>   - **Behavior**:
>     - Adds `session_id` to `getScoresUiGeneric` in `scores.ts` for session score data retrieval.
>     - Adds session link in `ScoresTable` in `scores.tsx`, linking session IDs to session paths.
>   - **UI**:
>     - Adds `Session ID` column to `scoresTableUiColumnDefinitions` in `mapScoresTable.ts`.
>     - Updates `ScoresTableRow` type in `scores.tsx` to include `sessionId`.
>   - **Misc**:
>     - Adjusts column definitions and cell rendering in `scores.tsx` to support session links.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 546b94d6aaeb5601cb0bf5a879b705a4890f0ceb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->