### PR TITLE
chore(table-views): handle nullish avatar

### DIFF
--- a/packages/shared/src/server/services/TableViewService/types.ts
+++ b/packages/shared/src/server/services/TableViewService/types.ts
@@ -38,9 +38,11 @@ export const TableViewPresetsNamesCreatorListSchema = z.array(
     id: z.string(),
     name: z.string(),
     createdBy: z.string(),
-    createdByUser: z.object({
-      image: z.string(),
-    }),
+    createdByUser: z
+      .object({
+        image: z.string().nullish(),
+      })
+      .nullish(),
   }),
 );
 

--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -493,7 +493,9 @@ export function TableViewPresetsDrawer({
                         </DropdownMenu>
                         <div className="flex items-center text-xs text-muted-foreground">
                           <Avatar>
-                            <AvatarImage src={view.createdByUser.image} />
+                            <AvatarImage
+                              src={view.createdByUser?.image ?? undefined}
+                            />
                           </Avatar>
                         </div>
                       </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Handle nullish avatar images in table view presets by updating schema and component rendering logic.
> 
>   - **Schema Update**:
>     - In `types.ts`, `createdByUser.image` is now `z.string().nullish()` and `createdByUser` is `z.object(...).nullish()`.
>   - **Component Update**:
>     - In `data-table-view-presets-drawer.tsx`, `AvatarImage` now uses `view.createdByUser?.image ?? undefined` to handle nullish values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 97a3651554369a6080801395440e75faa54d4e34. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->