### PR TITLE
chore(table-view-presets): conditionally apply generations filter; add avatar fallback; set beta badge

### DIFF
--- a/packages/shared/src/server/services/TableViewService/TableViewService.ts
+++ b/packages/shared/src/server/services/TableViewService/TableViewService.ts
@@ -146,6 +146,7 @@ export class TableViewService {
         createdByUser: {
           select: {
             image: true,
+            name: true,
           },
         },
       },

--- a/packages/shared/src/server/services/TableViewService/types.ts
+++ b/packages/shared/src/server/services/TableViewService/types.ts
@@ -41,6 +41,7 @@ export const TableViewPresetsNamesCreatorListSchema = z.array(
     createdByUser: z
       .object({
         image: z.string().nullish(),
+        name: z.string().nullish(),
       })
       .nullish(),
   }),

--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -28,7 +28,11 @@ import {
 } from "@/src/components/ui/command";
 import { useViewMutations } from "@/src/components/table/table-view-presets/hooks/useViewMutations";
 import { cn } from "@/src/utils/tailwind";
-import { Avatar, AvatarImage } from "@/src/components/ui/avatar";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/src/components/ui/avatar";
 import {
   Dialog,
   DialogContent,
@@ -302,7 +306,20 @@ export function TableViewPresetsDrawer({
           <div className="mx-auto h-[80svh] w-full overflow-y-auto">
             <div className="sticky top-0 z-10">
               <DrawerHeader className="flex flex-row items-center justify-between rounded-sm bg-background px-3 py-2">
-                <DrawerTitle>Saved Table Views</DrawerTitle>
+                <DrawerTitle className="flex flex-row items-center gap-1">
+                  Saved Table Views{" "}
+                  <a
+                    href="https://github.com/orgs/langfuse/discussions/4657"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center"
+                    title="Saving table view presets is currently in beta. Click here to provide feedback!"
+                  >
+                    <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
+                      Beta
+                    </span>
+                  </a>
+                </DrawerTitle>
                 <DrawerClose asChild>
                   <Button variant="outline" size="icon">
                     <X className="h-4 w-4" />
@@ -495,7 +512,17 @@ export function TableViewPresetsDrawer({
                           <Avatar>
                             <AvatarImage
                               src={view.createdByUser?.image ?? undefined}
+                              alt={view.createdByUser?.name ?? "User Avatar"}
                             />
+                            <AvatarFallback className="bg-tertiary">
+                              {view.createdByUser?.name
+                                ? view.createdByUser?.name
+                                    .split(" ")
+                                    .map((word) => word[0])
+                                    .slice(0, 2)
+                                    .concat("")
+                                : null}
+                            </AvatarFallback>
                           </Avatar>
                         </div>
                       </div>

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -58,6 +58,7 @@ import { useObservationPeekState } from "@/src/components/table/peek/hooks/useOb
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
 import { useObservationPeekNavigation } from "@/src/components/table/peek/hooks/useObservationPeekNavigation";
 import { useTableViewManager } from "@/src/components/table/table-view-presets/hooks/useTableViewManager";
+import { useRouter } from "next/router";
 
 export type ObservationsTableRow = {
   // Shown by default
@@ -116,6 +117,9 @@ export default function ObservationsTable({
   modelId,
   omittedFilter = [],
 }: ObservationsTableProps) {
+  const router = useRouter();
+  const { viewId } = router.query;
+
   const [searchQuery, setSearchQuery] = useQueryParam(
     "search",
     withDefault(StringParam, null),
@@ -133,14 +137,17 @@ export default function ObservationsTable({
   );
 
   const [inputFilterState, setInputFilterState] = useQueryFilterState(
-    [
-      {
-        column: "type",
-        type: "stringOptions",
-        operator: "any of",
-        value: ["GENERATION"],
-      },
-    ],
+    // If the user loads saved table view presets, we should not apply the default type filter
+    !viewId
+      ? [
+          {
+            column: "type",
+            type: "stringOptions",
+            operator: "any of",
+            value: ["GENERATION"],
+          },
+        ]
+      : [],
     "generations",
     projectId,
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance table view presets with conditional filters, avatar fallback, and a beta badge, updating both backend and frontend components.
> 
>   - **Behavior**:
>     - Conditionally apply `type` filter in `ObservationsTable` if `viewId` is not present.
>     - Add `name` to `createdByUser` selection in `TableViewService.ts`.
>     - Add `AvatarFallback` for user avatars in `data-table-view-presets-drawer.tsx`.
>   - **UI Enhancements**:
>     - Add "Beta" badge to `DrawerTitle` in `data-table-view-presets-drawer.tsx`.
>   - **Schema and Types**:
>     - Update `TableViewPresetsNamesCreatorListSchema` to include `name` in `types.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 68266b7af845f49cdfa605f7df339106ca06af6e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->