### PR TITLE
feat: add otel attribute parsing for google adk

### DIFF
--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -153,6 +153,16 @@ const extractInputAndOutput = (
     return { input: eventInput || input, output: eventOutput || output };
   }
 
+  // Google Vertex AI Agent-Developer-Kit (ADK)
+  input = attributes["gcp.vertex.agent.llm_request"];
+  output = attributes["gcp.vertex.agent.llm_response"];
+  if (input || output) {
+    return {
+      input: input,
+      output: output,
+    };
+  }
+
   // Logfire uses `prompt` and `all_messages_events` property on spans
   input = attributes["prompt"];
   output = attributes["all_messages_events"];


### PR DESCRIPTION
Imrpove parsing for ADK

Example trace created previously: https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/b5202f806c540a61b64c25462fb72595?observation=fc46f962ef879eaa
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `extractInputAndOutput` in `index.ts` to parse Google Vertex AI ADK attributes for input and output.
> 
>   - **Behavior**:
>     - Enhance `extractInputAndOutput` in `index.ts` to parse Google Vertex AI ADK attributes `gcp.vertex.agent.llm_request` and `gcp.vertex.agent.llm_response`.
>     - Returns parsed `input` and `output` if ADK attributes are present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a7a57a512c7cda7ea856a3740346a6aa83b6f3f2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->