### PR TITLE
fix(otel): avoid logging model name as model param

### DIFF
--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -364,7 +364,10 @@ const extractModelParameters = (
   );
   return modelParameters.reduce((acc: any, key) => {
     const modelParamKey = key.replace("gen_ai.request.", "");
-    acc[modelParamKey] = attributes[key];
+    // avoid double-reporting the model name, already included in native model attribute
+    if (modelParamKey !== "model") {
+      acc[modelParamKey] = attributes[key];
+    }
     return acc;
   }, {});
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes double-reporting of model name in `extractModelParameters` in `index.ts` by excluding `model` key if already present.
> 
>   - **Behavior**:
>     - In `extractModelParameters` in `index.ts`, avoid adding `model` key to `acc` if it already exists in native model attribute.
>   - **Misc**:
>     - Add comment explaining the reason for excluding `model` key in `extractModelParameters`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f8aec5b536677dd1d27f3b71b1043a92c5f21ad1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->