### PR TITLE
chore(run-scores): show only populated run-level scores

### DIFF
--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -447,6 +447,10 @@ export const getRunScoresGroupedByNameSourceType = async (
   datasetRunIds: string[],
   timestamp: Date | undefined,
 ) => {
+  if (datasetRunIds.length === 0) {
+    return [];
+  }
+
   // We mainly use queries like this to retrieve filter options.
   // Therefore, we can skip final as some inaccuracy in count is acceptable.
   const query = `

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -442,6 +442,55 @@ export const getScoresForObservations = async <
   }));
 };
 
+export const getRunScoresGroupedByNameSourceType = async (
+  projectId: string,
+  datasetRunIds: string[],
+  timestamp: Date | undefined,
+) => {
+  // We mainly use queries like this to retrieve filter options.
+  // Therefore, we can skip final as some inaccuracy in count is acceptable.
+  const query = `
+    select 
+      name,
+      source,
+      data_type
+    from scores s
+    WHERE s.project_id = {projectId: String}
+    ${timestamp ? `AND s.timestamp >= {timestamp: DateTime64(3)}` : ""}
+    AND s.dataset_run_id IN ({datasetRunIds: Array(String)})
+    GROUP BY name, source, data_type
+    ORDER BY count() desc
+    LIMIT 1000;
+  `;
+
+  const rows = await queryClickhouse<{
+    name: string;
+    source: string;
+    data_type: string;
+  }>({
+    query: query,
+    params: {
+      projectId: projectId,
+      ...(timestamp
+        ? { timestamp: convertDateToClickhouseDateTime(timestamp) }
+        : {}),
+      datasetRunIds: datasetRunIds,
+    },
+    tags: {
+      feature: "tracing",
+      type: "score",
+      kind: "list",
+      projectId,
+    },
+  });
+
+  return rows.map((row) => ({
+    name: row.name,
+    source: row.source as ScoreSourceType,
+    dataType: row.data_type as ScoreDataType,
+  }));
+};
+
 export const getScoresGroupedByNameSourceType = async (
   projectId: string,
   timestamp: Date | undefined,

--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -233,6 +233,12 @@ export function DatasetRunsTable(props: {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runs.isSuccess, runs.data]);
 
+  const runScoresKeysAndProps =
+    api.datasets.getRunLevelScoreKeysAndProps.useQuery({
+      projectId: props.projectId,
+      datasetId: props.datasetId,
+    });
+
   const { scoreColumns, scoreKeysAndProps, isColumnLoading } =
     useIndividualScoreColumns<DatasetRunRowData>({
       projectId: props.projectId,
@@ -250,6 +256,7 @@ export function DatasetRunsTable(props: {
     scoreColumnKey: "runScores",
     showAggregateViewOnly: false,
     scoreColumnPrefix: "Run-level",
+    scoreKeysAndPropsData: runScoresKeysAndProps.data,
   });
 
   const scoreIdToName = useMemo(() => {

--- a/web/src/features/scores/hooks/useIndividualScoreColumns.ts
+++ b/web/src/features/scores/hooks/useIndividualScoreColumns.ts
@@ -4,6 +4,7 @@ import { type TableRowTypesWithIndividualScoreColumns } from "@/src/features/sco
 import { constructIndividualScoreColumns } from "@/src/features/scores/components/ScoreDetailColumnHelpers";
 import { type TableDateRangeOptions } from "@/src/utils/date-range-utils";
 import { toOrderedScoresList } from "@/src/features/scores/lib/helpers";
+import { type RouterOutputs } from "@/src/utils/api";
 
 export function useIndividualScoreColumns<
   T extends TableRowTypesWithIndividualScoreColumns,
@@ -14,6 +15,7 @@ export function useIndividualScoreColumns<
   showAggregateViewOnly = false,
   scoreColumnPrefix,
   cellsLoading = false,
+  scoreKeysAndPropsData,
 }: {
   projectId: string;
   scoreColumnKey: keyof T & string;
@@ -21,6 +23,7 @@ export function useIndividualScoreColumns<
   showAggregateViewOnly?: boolean;
   scoreColumnPrefix?: "Trace" | "Generation" | "Run-level" | "Aggregated";
   cellsLoading?: boolean;
+  scoreKeysAndPropsData?: RouterOutputs["scores"]["getScoreKeysAndProps"];
 }) {
   const scoreKeysAndProps = api.scores.getScoreKeysAndProps.useQuery(
     {
@@ -44,18 +47,18 @@ export function useIndividualScoreColumns<
     },
   );
 
+  const relevantData = scoreKeysAndPropsData ?? scoreKeysAndProps.data;
+
   const scoreColumns = useMemo(() => {
     return constructIndividualScoreColumns<T>({
-      scoreColumnProps: scoreKeysAndProps.data
-        ? toOrderedScoresList(scoreKeysAndProps.data)
-        : [],
+      scoreColumnProps: relevantData ? toOrderedScoresList(relevantData) : [],
       scoreColumnKey,
       scoreColumnPrefix,
       showAggregateViewOnly,
       cellsLoading,
     });
   }, [
-    scoreKeysAndProps.data,
+    relevantData,
     scoreColumnKey,
     showAggregateViewOnly,
     scoreColumnPrefix,
@@ -64,7 +67,8 @@ export function useIndividualScoreColumns<
 
   return {
     scoreColumns,
-    scoreKeysAndProps: scoreKeysAndProps.data ?? [],
+    scoreKeysAndProps: relevantData ?? [],
+    // temporary workaround to show loading state until we have full data
     isColumnLoading: scoreKeysAndProps.isLoading,
   };
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Show only populated run-level scores by fetching and displaying relevant data in the UI.
> 
>   - **Backend**:
>     - Adds `getRunScoresGroupedByNameSourceType` in `scores.ts` to fetch run-level scores grouped by name, source, and type.
>     - Adds `getRunLevelScoreKeysAndProps` to `dataset-router.ts` to retrieve run-level score keys and properties.
>   - **Frontend**:
>     - Updates `DatasetRunsTable.tsx` to use `getRunLevelScoreKeysAndProps` for fetching run-level score data.
>     - Modifies `useIndividualScoreColumns` in `useIndividualScoreColumns.ts` to accept `scoreKeysAndPropsData` for run-level scores.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for af5d3ef45ae5abba8d86aef52c8cb93e90293e45. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->