### PR TITLE
fix(ui) langgraph agent graph

### DIFF
--- a/web/src/features/trace-graph-view/components/TraceGraphView.tsx
+++ b/web/src/features/trace-graph-view/components/TraceGraphView.tsx
@@ -88,9 +88,20 @@ function parseGraph(params: {
   const nodeToParentObservationMap = new Map<string, string>();
 
   observations?.forEach((o) => {
-    const parsedMetadata = LanggraphMetadataSchema.safeParse(
-      o.metadata ? JSON.parse(o.metadata) : undefined,
-    );
+    // Metadata is returned stringified by API, parse it first
+    let jsonParsedMetadata = o.metadata;
+
+    try {
+      jsonParsedMetadata =
+        o.metadata && typeof o.metadata === "string"
+          ? JSON.parse(o.metadata)
+          : o.metadata;
+    } catch {
+      return;
+    }
+
+    const parsedMetadata =
+      LanggraphMetadataSchema.safeParse(jsonParsedMetadata);
 
     if (!parsedMetadata.success) return;
 

--- a/web/src/features/trace-graph-view/components/TraceGraphView.tsx
+++ b/web/src/features/trace-graph-view/components/TraceGraphView.tsx
@@ -42,9 +42,11 @@ export const TraceGraphView: React.FC<TraceGraphViewProps> = (props) => {
     );
     const nodeName =
       currentObservation &&
-      LanggraphMetadataSchema.safeParse(currentObservation.metadata).data?.[
-        LANGGRAPH_NODE_TAG
-      ];
+      LanggraphMetadataSchema.safeParse(
+        currentObservation.metadata
+          ? JSON.parse(currentObservation.metadata)
+          : undefined,
+      ).data?.[LANGGRAPH_NODE_TAG];
 
     setSelectedNodeName(nodeName ?? null);
   }, [currentObservationId, observations]);
@@ -86,7 +88,9 @@ function parseGraph(params: {
   const nodeToParentObservationMap = new Map<string, string>();
 
   observations?.forEach((o) => {
-    const parsedMetadata = LanggraphMetadataSchema.safeParse(o.metadata);
+    const parsedMetadata = LanggraphMetadataSchema.safeParse(
+      o.metadata ? JSON.parse(o.metadata) : undefined,
+    );
 
     if (!parsedMetadata.success) return;
 
@@ -101,7 +105,7 @@ function parseGraph(params: {
         (obs) => obs.id === o.parentObservationId,
       );
       const parsedParentMetadata = LanggraphMetadataSchema.safeParse(
-        parent?.metadata,
+        parent?.metadata ? JSON.parse(parent.metadata) : undefined,
       );
 
       if (parent && !parsedParentMetadata.success) {

--- a/web/src/features/trace-graph-view/utils/isLanggraphTrace.ts
+++ b/web/src/features/trace-graph-view/utils/isLanggraphTrace.ts
@@ -4,10 +4,18 @@ import { LanggraphMetadataSchema } from "../types";
 export const isLanggraphTrace = (
   observations: ObservationReturnTypeWithMetadata[],
 ) => {
-  return observations.some(
-    (o) =>
-      LanggraphMetadataSchema.safeParse(
-        o.metadata ? JSON.parse(o.metadata) : undefined,
-      ).success,
-  );
+  return observations.some((o) => {
+    let jsonParsedMetadata = o.metadata;
+
+    try {
+      jsonParsedMetadata =
+        o.metadata && typeof o.metadata === "string"
+          ? JSON.parse(o.metadata)
+          : o.metadata;
+    } catch {
+      return false;
+    }
+
+    return LanggraphMetadataSchema.safeParse(jsonParsedMetadata).success;
+  });
 };

--- a/web/src/features/trace-graph-view/utils/isLanggraphTrace.ts
+++ b/web/src/features/trace-graph-view/utils/isLanggraphTrace.ts
@@ -5,6 +5,9 @@ export const isLanggraphTrace = (
   observations: ObservationReturnTypeWithMetadata[],
 ) => {
   return observations.some(
-    (o) => LanggraphMetadataSchema.safeParse(o.metadata).success,
+    (o) =>
+      LanggraphMetadataSchema.safeParse(
+        o.metadata ? JSON.parse(o.metadata) : undefined,
+      ).success,
   );
 };

--- a/web/src/features/trace-graph-view/utils/isLanggraphTrace.ts
+++ b/web/src/features/trace-graph-view/utils/isLanggraphTrace.ts
@@ -5,17 +5,6 @@ export const isLanggraphTrace = (
   observations: ObservationReturnTypeWithMetadata[],
 ) => {
   return observations.some((o) => {
-    let jsonParsedMetadata = o.metadata;
-
-    try {
-      jsonParsedMetadata =
-        o.metadata && typeof o.metadata === "string"
-          ? JSON.parse(o.metadata)
-          : o.metadata;
-    } catch {
-      return false;
-    }
-
-    return LanggraphMetadataSchema.safeParse(jsonParsedMetadata).success;
+    return LanggraphMetadataSchema.safeParse(o.metadata).success;
   });
 };

--- a/web/src/features/trace-graph-view/utils/isLanggraphTrace.ts
+++ b/web/src/features/trace-graph-view/utils/isLanggraphTrace.ts
@@ -4,7 +4,7 @@ import { LanggraphMetadataSchema } from "../types";
 export const isLanggraphTrace = (
   observations: ObservationReturnTypeWithMetadata[],
 ) => {
-  return observations.some((o) => {
-    return LanggraphMetadataSchema.safeParse(o.metadata).success;
-  });
+  return observations.some(
+    (o) => LanggraphMetadataSchema.safeParse(o.metadata).success,
+  );
 };


### PR DESCRIPTION
LangGraph traces seems to have not been recognized correctly anymore. This PR fixes this.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes metadata parsing in `TraceGraphView` to correctly handle LangGraph traces by converting string metadata to objects.
> 
>   - **Behavior**:
>     - Fixes metadata parsing in `TraceGraphView` by converting string metadata to objects using `JSON.parse()`.
>     - Handles parsing errors by returning the original observation if parsing fails.
>   - **Functions**:
>     - Updates `TraceGraphView` to map `rawObservations` to `observations` with parsed metadata.
>     - Modifies `parseGraph()` to utilize `LanggraphMetadataSchema.safeParse()` for metadata validation.
>   - **Misc**:
>     - No changes to the structure or logic of the graph rendering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7b19062486bc46358b0b4ae2721865602d81deb1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->