### PR TITLE
fix(ui-graph-view): fix metadata parsing in isLanggraphTrace

### DIFF
--- a/web/src/features/trace-graph-view/utils/isLanggraphTrace.ts
+++ b/web/src/features/trace-graph-view/utils/isLanggraphTrace.ts
@@ -4,7 +4,15 @@ import { LanggraphMetadataSchema } from "../types";
 export const isLanggraphTrace = (
   observations: ObservationReturnTypeWithMetadata[],
 ) => {
-  return observations.some(
-    (o) => LanggraphMetadataSchema.safeParse(o.metadata).success,
-  );
+  return observations.some((o) => {
+    let metadata = o.metadata;
+
+    if (metadata && typeof metadata == "string") {
+      try {
+        metadata = JSON.parse(metadata);
+      } catch {}
+    }
+
+    return LanggraphMetadataSchema.safeParse(metadata).success;
+  });
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes metadata parsing in `isLanggraphTrace` by adding logic to parse string metadata before validation.
> 
>   - **Behavior**:
>     - Fixes metadata parsing in `isLanggraphTrace` in `isLanggraphTrace.ts`.
>     - Adds logic to parse `metadata` if it is a string before schema validation.
>     - Handles JSON parsing errors silently.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 09954a8146d01bf9ee072ec2a8c69abf4e945752. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->