### PR TITLE
chore: do not fetch metadata for trace detail initial load

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -118,8 +118,8 @@ export type GetObservationsForTraceOpts<IncludeIO extends boolean> = {
   includeIO?: IncludeIO;
 };
 
-export const getObservationsForTrace = async <ExcludeIO extends boolean>(
-  opts: GetObservationsForTraceOpts<ExcludeIO>,
+export const getObservationsForTrace = async <IncludeIO extends boolean>(
+  opts: GetObservationsForTraceOpts<IncludeIO>,
 ) => {
   const { traceId, projectId, timestamp, includeIO = false } = opts;
 
@@ -137,7 +137,7 @@ export const getObservationsForTrace = async <ExcludeIO extends boolean>(
     level,
     status_message,
     version,
-    ${includeIO ? "input, output, metadata," : ""}
+    ${includeIO === true ? "input, output, metadata," : ""}
     provided_model_name,
     internal_model_id,
     model_parameters,

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -111,12 +111,18 @@ export const upsertObservation = async (
   });
 };
 
-export const getObservationsForTrace = async (
-  traceId: string,
-  projectId: string,
-  timestamp?: Date,
-  fetchWithInputOutput: boolean = false,
+export type GetObservationsForTraceOpts<IncludeIO extends boolean> = {
+  traceId: string;
+  projectId: string;
+  timestamp?: Date;
+  includeIO?: IncludeIO;
+};
+
+export const getObservationsForTrace = async <ExcludeIO extends boolean>(
+  opts: GetObservationsForTraceOpts<ExcludeIO>,
 ) => {
+  const { traceId, projectId, timestamp, includeIO = false } = opts;
+
   const query = `
   SELECT
     id,
@@ -128,11 +134,10 @@ export const getObservationsForTrace = async (
     start_time,
     end_time,
     name,
-    metadata,
     level,
     status_message,
     version,
-    ${fetchWithInputOutput ? "input, output," : ""}
+    ${includeIO ? "input, output, metadata," : ""}
     provided_model_name,
     internal_model_id,
     model_parameters,

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -192,7 +192,7 @@ export const getObservationsForTrace = async <ExcludeIO extends boolean>(
       }
     }
 
-    const metadataValues = Object.values(observation["metadata"]);
+    const metadataValues = Object.values(observation["metadata"] ?? {});
 
     metadataValues.forEach((value) => {
       if (value && typeof value === "string") {
@@ -207,7 +207,9 @@ export const getObservationsForTrace = async <ExcludeIO extends boolean>(
     }
   }
 
-  return records.map(convertObservation);
+  return records.map((r) =>
+    convertObservation({ ...r, metadata: r.metadata ?? {} }),
+  );
 };
 
 export const getObservationForTraceIdByName = async (

--- a/web/src/__tests__/async/repositories/observation-repository.servertest.ts
+++ b/web/src/__tests__/async/repositories/observation-repository.servertest.ts
@@ -126,7 +126,11 @@ describe("Clickhouse Observations Repository Test", () => {
 
     await createObservationsCh([observation]);
 
-    const result = await getObservationsForTrace(traceId, projectId);
+    const result = await getObservationsForTrace({
+      traceId,
+      projectId,
+      includeIO: true,
+    });
     if (!result || result.length === 0) {
       throw new Error("Observation not found");
     }

--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -44,12 +44,12 @@ export default withMiddlewares({
       }
 
       const [observations, scores] = await Promise.all([
-        getObservationsForTrace(
+        getObservationsForTrace({
           traceId,
-          auth.scope.projectId,
-          trace?.timestamp,
-          true,
-        ),
+          projectId: auth.scope.projectId,
+          timestamp: trace?.timestamp,
+          includeIO: true,
+        }),
         getScoresForTraces({
           projectId: auth.scope.projectId,
           traceIds: [traceId],

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -220,11 +220,12 @@ export const traceRouter = createTRPCRouter({
     )
     .query(async ({ input, ctx }) => {
       const [observations, scores] = await Promise.all([
-        getObservationsForTrace(
-          input.traceId,
-          input.projectId,
-          input.timestamp ?? input.fromTimestamp ?? undefined,
-        ),
+        getObservationsForTrace({
+          traceId: input.traceId,
+          projectId: input.projectId,
+          timestamp: input.timestamp ?? input.fromTimestamp ?? undefined,
+          includeIO: false,
+        }),
         getScoresForTraces({
           projectId: input.projectId,
           traceIds: [input.traceId],

--- a/worker/src/__tests__/traceDeletion.test.ts
+++ b/worker/src/__tests__/traceDeletion.test.ts
@@ -60,7 +60,11 @@ describe("trace deletion", () => {
     const traces = await getTracesByIds([traceId], projectId);
     expect(traces).toHaveLength(0);
 
-    const observations = await getObservationsForTrace(traceId, projectId);
+    const observations = await getObservationsForTrace({
+      traceId,
+      projectId,
+      includeIO: true,
+    });
     expect(observations).toHaveLength(0);
 
     const scores = await getScoresForTraces({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimize `getObservationsForTrace` to conditionally fetch metadata using `includeIO` flag, reducing initial trace detail load.
> 
>   - **Behavior**:
>     - `getObservationsForTrace` in `observations.ts` now uses `includeIO` flag to conditionally fetch `input`, `output`, and `metadata`.
>     - Default `includeIO` is `false`, reducing data fetched on initial trace detail load.
>   - **Type Changes**:
>     - Introduces `GetObservationsForTraceOpts` type in `observations.ts` to encapsulate options for `getObservationsForTrace`.
>   - **Tests**:
>     - Updates `observation-repository.servertest.ts` and `traceDeletion.test.ts` to use new `getObservationsForTrace` signature.
>   - **API Changes**:
>     - Updates `traces/[traceId].ts` and `traces.ts` to use new `getObservationsForTrace` signature with `includeIO` flag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8392bc8404f3ba3268b4770ad20d0686dfdcb403. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->