### PR TITLE
fix: update navigation paths to use environment base URL (referenced prompts, open new tab of trace/observation view)

### DIFF
--- a/web/src/components/table/peek/hooks/useObservationPeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/useObservationPeekNavigation.ts
@@ -1,6 +1,7 @@
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 import { useRouter } from "next/router";
 import { type ObservationsTableRow } from "@/src/components/table/use-cases/observations";
+import { env } from "@/src/env.mjs";
 
 export const useObservationPeekNavigation = (urlPathname: string) => {
   const router = useRouter();
@@ -38,7 +39,7 @@ export const useObservationPeekNavigation = (urlPathname: string) => {
 
     if (!row) return;
 
-    const pathname = `/project/${projectId}/traces/${encodeURIComponent(row.traceId as string)}?timestamp=${timestamp}&display=${display}&observation=${peek as string}`;
+    const pathname = `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/project/${projectId}/traces/${encodeURIComponent(row.traceId as string)}?timestamp=${timestamp}&display=${display}&observation=${peek as string}`;
 
     if (openInNewTab) {
       window.open(pathname, "_blank");

--- a/web/src/components/table/peek/hooks/useTracePeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/useTracePeekNavigation.ts
@@ -1,5 +1,6 @@
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 import { useRouter } from "next/router";
+import { env } from "@/src/env.mjs";
 
 export const useTracePeekNavigation = (urlPathname: string) => {
   const router = useRouter();
@@ -34,7 +35,7 @@ export const useTracePeekNavigation = (urlPathname: string) => {
     const timestamp = params.get("timestamp");
     const display = params.get("display") ?? "details";
 
-    const pathname = `/project/${projectId}/traces/${encodeURIComponent(peek as string)}?timestamp=${timestamp}&display=${display}`;
+    const pathname = `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/project/${projectId}/traces/${encodeURIComponent(peek as string)}?timestamp=${timestamp}&display=${display}`;
 
     if (openInNewTab) {
       window.open(pathname, "_blank");

--- a/web/src/features/prompts/components/renderContentWithPromptButtons.tsx
+++ b/web/src/features/prompts/components/renderContentWithPromptButtons.tsx
@@ -1,5 +1,4 @@
 import { Badge } from "@/src/components/ui/badge";
-import 
 
 import {
   PromptDependencyRegex,
@@ -12,7 +11,7 @@ import { FileCode } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 
 const getPromptUrl = (projectId: string, tag: ParsedPromptDependencyTag) => {
-  const baseUrl = `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/project/${projectId}/prompts/`;
+  const baseUrl = `${env.NEXT_PUBLIC_BASE_PATH ?? }/project/${projectId}/prompts/`;
   if (tag.type === "version") {
     return `${baseUrl}${encodeURIComponent(tag.name)}?version=${tag.version}`;
   } else {

--- a/web/src/features/prompts/components/renderContentWithPromptButtons.tsx
+++ b/web/src/features/prompts/components/renderContentWithPromptButtons.tsx
@@ -1,15 +1,18 @@
 import { Badge } from "@/src/components/ui/badge";
+import 
 
 import {
   PromptDependencyRegex,
   type ParsedPromptDependencyTag,
 } from "@langfuse/shared";
 
+import { env } from "@/src/env.mjs";
+
 import { FileCode } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 
 const getPromptUrl = (projectId: string, tag: ParsedPromptDependencyTag) => {
-  const baseUrl = `/project/${projectId}/prompts/`;
+  const baseUrl = `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/project/${projectId}/prompts/`;
   if (tag.type === "version") {
     return `${baseUrl}${encodeURIComponent(tag.name)}?version=${tag.version}`;
   } else {

--- a/web/src/features/prompts/components/renderContentWithPromptButtons.tsx
+++ b/web/src/features/prompts/components/renderContentWithPromptButtons.tsx
@@ -11,7 +11,7 @@ import { FileCode } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 
 const getPromptUrl = (projectId: string, tag: ParsedPromptDependencyTag) => {
-  const baseUrl = `${env.NEXT_PUBLIC_BASE_PATH ?? }/project/${projectId}/prompts/`;
+  const baseUrl = `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/project/${projectId}/prompts/`;
   if (tag.type === "version") {
     return `${baseUrl}${encodeURIComponent(tag.name)}?version=${tag.version}`;
   } else {


### PR DESCRIPTION
…ed prompts

## What does this PR do?

This fixes an issue where Langfuse is hosted on a base path, referenced prompts in the prompt section redirect to `/project/${projectId}/prompts/` and returns 404, instead of `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/project/${projectId}/prompts/`
This also adds base path to the expand (open new tab) in generations+traces table peek view.

Fixes # (issue)

Adding base path to 

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix 

## Mandatory Tasks

[Reviewed] - [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes navigation path issues by including environment base URL in `useObservationPeekNavigation.ts`, `useTracePeekNavigation.ts`, and `renderContentWithPromptButtons.tsx`.
> 
>   - **Bug Fix**:
>     - Prepend `env.NEXT_PUBLIC_BASE_PATH` to navigation paths in `useObservationPeekNavigation.ts`, `useTracePeekNavigation.ts`, and `renderContentWithPromptButtons.tsx`.
>     - Fixes 404 errors when Langfuse is hosted on a base path by ensuring URLs include the base path.
>   - **Functions**:
>     - Update `expandPeek` in `useObservationPeekNavigation.ts` and `useTracePeekNavigation.ts` to use the base path.
>     - Update `getPromptUrl` in `renderContentWithPromptButtons.tsx` to include the base path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3bb5d3321dae07bb958ccf4884dbfb73a81c4965. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->