### PR TITLE
chore: improve auth error message

### DIFF
--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -389,7 +389,7 @@ const signInErrors = [
   {
     code: "OAuthAccountNotLinked",
     description:
-      "Please sign in with the same provider that you used to create this account.",
+      "Please sign in with the same provider (e.g. Google, GitHub, Azure AD, etc.) that you used to create this account.",
   },
 ];
 

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -138,7 +138,7 @@ const staticProviders: Provider[] = [
       if (!dbUser) throw new Error("Invalid credentials");
       if (dbUser.password === null)
         throw new Error(
-          "Please sign in with the identity provider that is linked to your account.",
+          "Please sign in with the identity provider (e.g. Google, GitHub, Azure AD, etc.) that is linked to your account.",
         );
 
       const isValidPassword = await verifyPassword(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves OAuth account linking error messages in `sign-in.tsx` and `auth.ts` by adding provider examples.
> 
>   - **Error Message Update**:
>     - In `sign-in.tsx`, updated `OAuthAccountNotLinked` error message to include examples of providers (Google, GitHub, Azure AD).
>     - In `auth.ts`, updated error message for accounts with null passwords to include provider examples.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 12955ecc298dc1cb2b7d90c6c938730c09e6b2b6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->