### PR TITLE
chore: reduce amount of ingested dd spans

### DIFF
--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -13,7 +13,6 @@ import { getClickhouseEntityType } from "../clickhouse/schemaUtils";
 import {
   getCurrentSpan,
   instrumentAsync,
-  instrumentSync,
   recordDistribution,
   recordIncrement,
   traceException,
@@ -117,19 +116,7 @@ export const processEventBatch = async (
 
   const batch: z.infer<typeof ingestionEvent>[] = input
     .flatMap((event) => {
-      const parsed = instrumentSync(
-        { name: "ingestion-zod-parse-individual-event" },
-        (span) => {
-          const parsedBody = ingestionEvent.safeParse(event);
-          if (parsedBody.data?.id !== undefined) {
-            span.setAttribute(
-              "langfuse.ingestion.entity.id",
-              parsedBody.data.id,
-            );
-          }
-          return parsedBody;
-        },
-      );
+      const parsed = ingestionEvent.safeParse(event);
       if (!parsed.success) {
         validationErrors.push({
           id:

--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -15,7 +15,7 @@ import {
   BaseError,
   UnauthorizedError,
 } from "@langfuse/shared";
-import { instrumentSync, processEventBatch } from "@langfuse/shared/src/server";
+import { processEventBatch } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
 import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";

--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -105,10 +105,7 @@ export default async function handler(
       metadata: jsonSchema.nullish(),
     });
 
-    const parsedSchema = instrumentSync(
-      { name: "ingestion-zod-parse-unknown-batch-event" },
-      () => batchType.safeParse(req.body),
-    );
+    const parsedSchema = batchType.safeParse(req.body);
 
     if (!parsedSchema.success) {
       logger.info("Invalid request data", parsedSchema.error);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove `instrumentSync` calls from `processEventBatch.ts` and `ingestion.ts` to reduce ingested spans and simplify event parsing.
> 
>   - **Behavior**:
>     - Removed `instrumentSync` calls from `processEventBatch` in `processEventBatch.ts` and `handler` in `ingestion.ts`.
>     - Simplifies event parsing by directly using `safeParse` without instrumentation.
>   - **Imports**:
>     - Removed `instrumentSync` import from `processEventBatch.ts` and `ingestion.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fd0fad44a325c2aea1db27c5a111cf82c0621725. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->