### PR TITLE
feat: add new metrics api endpoint

### DIFF
--- a/fern/apis/server/definition/metrics.yml
+++ b/fern/apis/server/definition/metrics.yml
@@ -6,6 +6,54 @@ service:
   auth: true
   base-path: /api/public
   endpoints:
+    metrics:
+      docs: Get metrics from the Langfuse project using a query object
+      method: GET
+      path: /metrics
+      request:
+        name: GetMetricsRequest
+        query-parameters:
+          query:
+            type: string
+            docs: |
+              JSON string containing the query parameters with the following structure:
+              ```json
+              {
+                "view": string,           // Required. One of "traces", "observations", "scores-numeric", "scores-categorical"
+                "dimensions": [           // Optional. Default: []
+                  {
+                    "field": string       // Field to group by, e.g. "name", "userId", "sessionId"
+                  }
+                ],
+                "metrics": [              // Required. At least one metric must be provided
+                  {
+                    "measure": string,    // What to measure, e.g. "count", "latency", "value"
+                    "aggregation": string // How to aggregate, e.g. "count", "sum", "avg", "p95"
+                  }
+                ],
+                "filters": [              // Optional. Default: []
+                  {
+                    "column": string,     // Column to filter on
+                    "operator": string,   // Operator, e.g. "=", ">", "<", "contains"
+                    "value": any,         // Value to compare against
+                    "type": string,       // Data type, e.g. "string", "number", "stringObject"
+                    "key": string         // Required only when filtering on metadata
+                  }
+                ],
+                "timeDimension": {        // Optional. Default: null. If provided, results will be grouped by time
+                  "granularity": string   // One of "minute", "hour", "day", "week", "month", "year", "auto"
+                },
+                "fromTimestamp": string,  // Required. ISO datetime string for start of time range
+                "toTimestamp": string,    // Required. ISO datetime string for end of time range
+                "orderBy": [              // Optional. Default: null
+                  {
+                    "field": string,      // Field to order by
+                    "direction": string   // "asc" or "desc"
+                  }
+                ]
+              }
+              ```
+      response: MetricsResponse
     daily:
       docs: Get daily metrics of the Langfuse project
       method: GET
@@ -41,6 +89,13 @@ service:
             docs: Optional filter to only include traces and observations before a certain datetime (ISO 8601)
       response: DailyMetrics
 types:
+  MetricsResponse:
+    properties:
+      data:
+        type: list<map<string, unknown>>
+        docs: |
+          The metrics data. Each item in the list contains the metric values and dimensions requested in the query.
+          Format varies based on the query parameters.
   DailyMetrics:
     properties:
       data:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -1692,6 +1692,94 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/MembershipRequest'
+  /api/public/metrics:
+    get:
+      description: Get metrics from the Langfuse project using a query object
+      operationId: metrics_metrics
+      tags:
+        - Metrics
+      parameters:
+        - name: query
+          in: query
+          description: >-
+            JSON string containing the query parameters with the following
+            structure:
+
+            ```json
+
+            {
+              "view": string,           // Required. One of "traces", "observations", "scores-numeric", "scores-categorical"
+              "dimensions": [           // Optional. Default: []
+                {
+                  "field": string       // Field to group by, e.g. "name", "userId", "sessionId"
+                }
+              ],
+              "metrics": [              // Required. At least one metric must be provided
+                {
+                  "measure": string,    // What to measure, e.g. "count", "latency", "value"
+                  "aggregation": string // How to aggregate, e.g. "count", "sum", "avg", "p95"
+                }
+              ],
+              "filters": [              // Optional. Default: []
+                {
+                  "column": string,     // Column to filter on
+                  "operator": string,   // Operator, e.g. "=", ">", "<", "contains"
+                  "value": any,         // Value to compare against
+                  "type": string,       // Data type, e.g. "string", "number", "stringObject"
+                  "key": string         // Required only when filtering on metadata
+                }
+              ],
+              "timeDimension": {        // Optional. Default: null. If provided, results will be grouped by time
+                "granularity": string   // One of "minute", "hour", "day", "week", "month", "year", "auto"
+              },
+              "fromTimestamp": string,  // Required. ISO datetime string for start of time range
+              "toTimestamp": string,    // Required. ISO datetime string for end of time range
+              "orderBy": [              // Optional. Default: null
+                {
+                  "field": string,      // Field to order by
+                  "direction": string   // "asc" or "desc"
+                }
+              ]
+            }
+
+            ```
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricsResponse'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
   /api/public/metrics/daily:
     get:
       description: Get daily metrics of the Langfuse project
@@ -6266,6 +6354,22 @@ components:
             $ref: '#/components/schemas/MembershipResponse'
       required:
         - memberships
+    MetricsResponse:
+      title: MetricsResponse
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+          description: >-
+            The metrics data. Each item in the list contains the metric values
+            and dimensions requested in the query.
+
+            Format varies based on the query parameters.
+      required:
+        - data
     DailyMetrics:
       title: DailyMetrics
       type: object

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -1343,6 +1343,37 @@
       "item": [
         {
           "_type": "endpoint",
+          "name": "Metrics",
+          "request": {
+            "description": "Get metrics from the Langfuse project using a query object",
+            "url": {
+              "raw": "{{baseUrl}}/api/public/metrics?query=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "public",
+                "metrics"
+              ],
+              "query": [
+                {
+                  "key": "query",
+                  "value": "",
+                  "description": "JSON string containing the query parameters with the following structure:\n```json\n{\n  \"view\": string,           // Required. One of \"traces\", \"observations\", \"scores-numeric\", \"scores-categorical\"\n  \"dimensions\": [           // Optional. Default: []\n    {\n      \"field\": string       // Field to group by, e.g. \"name\", \"userId\", \"sessionId\"\n    }\n  ],\n  \"metrics\": [              // Required. At least one metric must be provided\n    {\n      \"measure\": string,    // What to measure, e.g. \"count\", \"latency\", \"value\"\n      \"aggregation\": string // How to aggregate, e.g. \"count\", \"sum\", \"avg\", \"p95\"\n    }\n  ],\n  \"filters\": [              // Optional. Default: []\n    {\n      \"column\": string,     // Column to filter on\n      \"operator\": string,   // Operator, e.g. \"=\", \">\", \"<\", \"contains\"\n      \"value\": any,         // Value to compare against\n      \"type\": string,       // Data type, e.g. \"string\", \"number\", \"stringObject\"\n      \"key\": string         // Required only when filtering on metadata\n    }\n  ],\n  \"timeDimension\": {        // Optional. Default: null. If provided, results will be grouped by time\n    \"granularity\": string   // One of \"minute\", \"hour\", \"day\", \"week\", \"month\", \"year\", \"auto\"\n  },\n  \"fromTimestamp\": string,  // Required. ISO datetime string for start of time range\n  \"toTimestamp\": string,    // Required. ISO datetime string for end of time range\n  \"orderBy\": [              // Optional. Default: null\n    {\n      \"field\": string,      // Field to order by\n      \"direction\": string   // \"asc\" or \"desc\"\n    }\n  ]\n}\n```"
+                }
+              ],
+              "variable": []
+            },
+            "header": [],
+            "method": "GET",
+            "auth": null,
+            "body": null
+          },
+          "response": []
+        },
+        {
+          "_type": "endpoint",
           "name": "Daily",
           "request": {
             "description": "Get daily metrics of the Langfuse project",

--- a/web/src/__tests__/async/metrics-api.servertest.ts
+++ b/web/src/__tests__/async/metrics-api.servertest.ts
@@ -1,0 +1,288 @@
+import { randomUUID } from "crypto";
+import {
+  makeZodVerifiedAPICall,
+  makeZodVerifiedAPICallSilent,
+  makeAPICall,
+} from "@/src/__tests__/test-utils";
+import { GetMetricsV1Response } from "@/src/features/public-api/types/metrics";
+import { createBasicAuthHeader } from "@langfuse/shared/src/server";
+import { type QueryType } from "@/src/features/query/types";
+import {
+  createTrace,
+  createObservation,
+  createTracesCh,
+  createObservationsCh,
+} from "@langfuse/shared/src/server";
+
+describe("/api/public/metrics API Endpoint", () => {
+  // Test setup variables
+  const testTraces: Array<{
+    id: string;
+    name: string;
+    timestamp: Date;
+    metadata?: Record<string, any>;
+  }> = [];
+  const testMetadataValue = randomUUID();
+
+  // Current time for traces
+  const now = new Date();
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  // Set up test data before running tests
+  beforeAll(async () => {
+    // Create test traces with different names
+    const trace1Id = randomUUID();
+    const trace2Id = randomUUID();
+    const trace3Id = randomUUID();
+
+    // Create traces with different names and timestamps
+    testTraces.push(
+      {
+        id: trace1Id,
+        name: "trace-test-1",
+        timestamp: now,
+        metadata: { test: testMetadataValue },
+      },
+      {
+        id: trace2Id,
+        name: "trace-test-2",
+        timestamp: yesterday,
+        metadata: { test: testMetadataValue },
+      },
+      {
+        id: trace3Id,
+        name: "trace-test-3",
+        timestamp: yesterday,
+        metadata: { test: testMetadataValue },
+      },
+    );
+
+    // Insert traces into database
+    await createTracesCh(
+      testTraces.map((trace) =>
+        createTrace({
+          id: trace.id,
+          name: trace.name,
+          timestamp: trace.timestamp.getTime(),
+          metadata: trace.metadata || {},
+        }),
+      ),
+    );
+
+    // Create observations for trace1
+    const trace1Observations = [];
+    for (let i = 0; i < 3; i++) {
+      trace1Observations.push(
+        createObservation({
+          id: randomUUID(),
+          trace_id: trace1Id,
+          name: `observation-${i}`,
+          start_time: now.getTime(),
+          metadata: { test: testMetadataValue },
+        }),
+      );
+    }
+
+    // Create observations for trace2
+    const trace2Observations = [];
+    for (let i = 0; i < 2; i++) {
+      trace2Observations.push(
+        createObservation({
+          id: randomUUID(),
+          trace_id: trace2Id,
+          name: `observation-${i}`,
+          start_time: yesterday.getTime(),
+          metadata: { test: testMetadataValue },
+        }),
+      );
+    }
+    await createObservationsCh([...trace1Observations, ...trace2Observations]);
+  });
+
+  it.each([
+    [
+      "simple trace query",
+      {
+        view: "traces",
+        dimensions: [{ field: "name" }],
+        metrics: [{ measure: "count", aggregation: "count" }],
+        filters: [
+          {
+            column: "metadata",
+            operator: "contains",
+            key: "test",
+            value: testMetadataValue,
+            type: "stringObject",
+          },
+        ],
+        timeDimension: null,
+        fromTimestamp: yesterday.toISOString(),
+        toTimestamp: now.toISOString(),
+        orderBy: null,
+      } as QueryType,
+      // Expected result structure (data will be dummy)
+      {
+        dataLength: 3,
+        expectedMetrics: ["count_count"],
+        expectedDimensions: ["name"],
+      },
+    ],
+    [
+      "query with time dimension",
+      {
+        view: "traces",
+        dimensions: [{ field: "name" }],
+        metrics: [{ measure: "count", aggregation: "count" }],
+        filters: [
+          {
+            column: "metadata",
+            operator: "contains",
+            key: "test",
+            value: testMetadataValue,
+            type: "stringObject",
+          },
+        ],
+        timeDimension: {
+          granularity: "day",
+        },
+        fromTimestamp: yesterday.toISOString(),
+        toTimestamp: now.toISOString(),
+        orderBy: null,
+      } as QueryType,
+      // Expected result structure
+      {
+        dataLength: 3,
+        expectedMetrics: ["count_count"],
+        expectedDimensions: ["time_dimension", "name"],
+      },
+    ],
+    [
+      "observations query with multiple metrics",
+      {
+        view: "observations",
+        dimensions: [{ field: "name" }],
+        metrics: [
+          { measure: "count", aggregation: "count" },
+          { measure: "latency", aggregation: "p95" },
+        ],
+        filters: [
+          {
+            column: "metadata",
+            operator: "contains",
+            key: "test",
+            value: testMetadataValue,
+            type: "stringObject",
+          },
+        ],
+        timeDimension: null,
+        fromTimestamp: yesterday.toISOString(),
+        toTimestamp: now.toISOString(),
+        orderBy: null,
+      } as QueryType,
+      // Expected result structure
+      {
+        dataLength: 5,
+        expectedMetrics: ["dummy_metric"],
+      },
+    ],
+  ])(
+    "should accept complex query formats and return expected results: %s",
+    async (
+      _name: string,
+      queryObject: QueryType,
+      expectedResult: { dataLength: number; expectedMetrics: string[] },
+    ) => {
+      // Add pagination parameters needed for the API
+      const fullQuery = {
+        ...queryObject,
+        page: 1,
+        limit: 10,
+      };
+
+      // Make the API call
+      const response = await makeZodVerifiedAPICall(
+        GetMetricsV1Response,
+        "GET",
+        `/api/public/metrics?query=${encodeURIComponent(JSON.stringify(fullQuery))}`,
+      );
+
+      // Validate response format
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body.data)).toBe(true);
+
+      // Validate response matches expected structure
+      expect(response.body.data).toHaveLength(expectedResult.dataLength);
+
+      // Check pagination metadata is present
+      expect(response.body.meta).toHaveProperty("page");
+      expect(response.body.meta).toHaveProperty("limit");
+      expect(response.body.meta).toHaveProperty("totalItems");
+      expect(response.body.meta).toHaveProperty("totalPages");
+    },
+  );
+
+  it("should return 401 with invalid authentication", async () => {
+    const now = new Date();
+    const yesterday = new Date(now);
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    // Create the query object
+    const query = {
+      view: "traces",
+      metrics: [
+        {
+          measure: "totalCount",
+          aggregation: "count",
+        },
+      ],
+      fromTimestamp: yesterday.toISOString(),
+      toTimestamp: now.toISOString(),
+      page: 1,
+      limit: 10,
+    };
+
+    const invalidAuth = createBasicAuthHeader(
+      "invalid-project-key",
+      "invalid-secret-key",
+    );
+
+    const { status } = await makeAPICall(
+      "GET",
+      `/api/public/metrics?query=${encodeURIComponent(JSON.stringify(query))}`,
+      undefined,
+      invalidAuth,
+    );
+
+    expect(status).toBe(401);
+  });
+
+  it("should return 400 for invalid query parameters", async () => {
+    // Test missing required parameters by sending an invalid JSON string
+    const { status } = await makeZodVerifiedAPICallSilent(
+      GetMetricsV1Response,
+      "GET",
+      `/api/public/metrics?query=invalid-json-string`,
+      undefined,
+    );
+
+    expect(status).toBe(400);
+  });
+
+  it("should return 400 for incomplete query object", async () => {
+    // Missing required fields in the query object
+    const incompleteQuery = {
+      view: "traces",
+      // Missing metrics, fromTimestamp, toTimestamp
+    };
+
+    const { status } = await makeZodVerifiedAPICallSilent(
+      GetMetricsV1Response,
+      "GET",
+      `/api/public/metrics?query=${encodeURIComponent(JSON.stringify(incompleteQuery))}`,
+      undefined,
+    );
+
+    expect(status).toBe(400);
+  });
+});

--- a/web/src/features/public-api/types/metrics.ts
+++ b/web/src/features/public-api/types/metrics.ts
@@ -26,7 +26,9 @@ export const MetricsQueryObject = z
       .object({
         granularity: granularities,
       })
-      .nullable(),
+      .nullable()
+      .optional()
+      .default(null),
     fromTimestamp: z.string().datetime({ offset: true }),
     toTimestamp: z.string().datetime({ offset: true }),
     orderBy: z
@@ -36,7 +38,9 @@ export const MetricsQueryObject = z
           direction: z.enum(["asc", "desc"]),
         }),
       )
-      .nullable(),
+      .nullable()
+      .optional()
+      .default(null),
   })
   .refine(
     (query) =>

--- a/web/src/features/public-api/types/metrics.ts
+++ b/web/src/features/public-api/types/metrics.ts
@@ -1,13 +1,77 @@
 import {
+  InvalidRequestError,
   paginationMetaResponseZod,
   publicApiPaginationZod,
+  singleFilter,
 } from "@langfuse/shared";
 import { stringDateTime } from "@langfuse/shared/src/server";
 import { z } from "zod";
+import { dimension, granularities, metric, views } from "@/src/features/query";
+
+/**
+ * Query Object Structure
+ */
+export const MetricsQueryObject = z
+  .object({
+    // Pagination parameters
+    page: z.number().min(1).default(1),
+    limit: z.number().min(1).max(100).default(10),
+
+    // QueryType structure
+    view: views,
+    dimensions: z.array(dimension).optional().default([]),
+    metrics: z.array(metric),
+    filters: z.array(singleFilter).optional().default([]),
+    timeDimension: z
+      .object({
+        granularity: granularities,
+      })
+      .nullable()
+      .optional(),
+    fromTimestamp: z.string().datetime({ offset: true }),
+    toTimestamp: z.string().datetime({ offset: true }),
+    orderBy: z
+      .array(
+        z.object({
+          field: z.string(),
+          direction: z.enum(["asc", "desc"]),
+        }),
+      )
+      .nullable()
+      .optional(),
+  })
+  .refine(
+    (query) =>
+      // Ensure fromTimestamp is before toTimestamp
+      new Date(query.fromTimestamp).getTime() <
+      new Date(query.toTimestamp).getTime(),
+    {
+      message: "fromTimestamp must be before toTimestamp",
+    },
+  );
 
 /**
  * Endpoints
  */
+
+// GET /api/public/metrics
+export const GetMetricsV1Query = z.object({
+  query: z
+    .string()
+    .transform((str) => {
+      try {
+        return JSON.parse(str);
+      } catch (e) {
+        throw new InvalidRequestError("Invalid JSON in query parameter");
+      }
+    })
+    .pipe(MetricsQueryObject),
+});
+
+export const GetMetricsV1Response = z.object({
+  data: z.array(z.record(z.unknown())),
+  meta: paginationMetaResponseZod,
+});
 
 // Get /metrics/daily
 export const GetMetricsDailyV1Query = z.object({

--- a/web/src/features/public-api/types/metrics.ts
+++ b/web/src/features/public-api/types/metrics.ts
@@ -14,8 +14,8 @@ import { dimension, granularities, metric, views } from "@/src/features/query";
 export const MetricsQueryObject = z
   .object({
     // Pagination parameters
-    page: z.number().min(1).default(1),
-    limit: z.number().min(1).max(100).default(10),
+    // page: z.number().min(1).default(1),
+    // limit: z.number().min(1).max(100).default(10),
 
     // QueryType structure
     view: views,
@@ -26,8 +26,7 @@ export const MetricsQueryObject = z
       .object({
         granularity: granularities,
       })
-      .nullable()
-      .optional(),
+      .nullable(),
     fromTimestamp: z.string().datetime({ offset: true }),
     toTimestamp: z.string().datetime({ offset: true }),
     orderBy: z
@@ -37,8 +36,7 @@ export const MetricsQueryObject = z
           direction: z.enum(["asc", "desc"]),
         }),
       )
-      .nullable()
-      .optional(),
+      .nullable(),
   })
   .refine(
     (query) =>
@@ -70,7 +68,7 @@ export const GetMetricsV1Query = z.object({
 
 export const GetMetricsV1Response = z.object({
   data: z.array(z.record(z.unknown())),
-  meta: paginationMetaResponseZod,
+  // meta: paginationMetaResponseZod,
 });
 
 // Get /metrics/daily

--- a/web/src/pages/api/public/metrics/index.ts
+++ b/web/src/pages/api/public/metrics/index.ts
@@ -1,0 +1,51 @@
+import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
+import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
+import { logger } from "@langfuse/shared/src/server";
+import {
+  GetMetricsV1Query,
+  GetMetricsV1Response,
+} from "@/src/features/public-api/types/metrics";
+
+export default withMiddlewares({
+  GET: createAuthedProjectAPIRoute({
+    name: "Get Metrics",
+    rateLimitResource: "public-api-metrics",
+    querySchema: GetMetricsV1Query,
+    responseSchema: GetMetricsV1Response,
+    fn: async ({ query, auth }) => {
+      try {
+        // Extract the parsed query object
+        const queryParams = query.query;
+
+        // Log the received query for debugging
+        logger.info("Received metrics query", {
+          query: queryParams,
+          projectId: auth.scope.projectId,
+        });
+
+        // This is a dummy implementation as requested
+        // In the future, this would call the actual query execution logic
+
+        // Return dummy data for now
+        return {
+          data: [
+            {
+              metric: "dummy_metric",
+              value: 42,
+              timestamp: new Date().toISOString(),
+            },
+          ],
+          meta: {
+            page: queryParams.page,
+            limit: queryParams.limit,
+            totalItems: 1,
+            totalPages: 1,
+          },
+        };
+      } catch (error) {
+        logger.error("Error in metrics API", { error, query });
+        throw error;
+      }
+    },
+  }),
+});


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces a new `GET /api/public/metrics` endpoint to fetch metrics with query validation, response structure, and comprehensive testing.
> 
>   - **API Endpoint**:
>     - Adds `GET /api/public/metrics` endpoint in `metrics.yml` and `index.ts` to fetch metrics using a query object.
>     - Supports query parameters like `view`, `dimensions`, `metrics`, `filters`, `timeDimension`, `fromTimestamp`, `toTimestamp`, and `orderBy`.
>   - **Schema and Types**:
>     - Defines `MetricsQueryObject` and `GetMetricsV1Query` in `metrics.ts` for query validation.
>     - Defines `MetricsResponse` and `GetMetricsV1Response` for response structure.
>   - **Testing**:
>     - Adds `metrics-api.servertest.ts` with tests for valid queries, invalid authentication, and invalid query parameters.
>     - Tests cover scenarios like simple trace queries, queries with time dimensions, and multiple metrics.
>   - **Documentation**:
>     - Updates `openapi.yml` and `postman/collection.json` to include the new metrics endpoint.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 255ec80012d397fe657ad1d71d1d10b7b2a940e0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->