### PR TITLE
feat(datasets): support `GET` dataset-run-items

### DIFF
--- a/fern/apis/server/definition/dataset-run-items.yml
+++ b/fern/apis/server/definition/dataset-run-items.yml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
 imports:
   commons: ./commons.yml
+  pagination: ./utils/pagination.yml
 service:
   auth: true
   base-path: /api/public
@@ -11,6 +12,23 @@ service:
       path: /dataset-run-items
       request: CreateDatasetRunItemRequest
       response: commons.DatasetRunItem
+    list:
+      method: GET
+      docs: List dataset run items
+      path: /dataset-run-items
+      request:
+        name: ListDatasetRunItemsRequest
+        query-parameters:
+          datasetId: string
+          runName: string
+          page:
+            type: optional<integer>
+            docs: page number, starts at 1
+          limit:
+            type: optional<integer>
+            docs: limit of items per page
+          response: PaginatedDatasetRunItems
+
 types:
   CreateDatasetRunItemRequest:
     properties:
@@ -26,3 +44,7 @@ types:
       traceId:
         type: optional<string>
         docs: traceId should always be provided. For compatibility with older SDK versions it can also be inferred from the provided observationId.
+  PaginatedDatasetRunItems:
+    properties:
+      data: list<commons.DatasetRunItem>
+      meta: pagination.MetaResponse

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -845,6 +845,71 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateDatasetRunItemRequest'
+    get:
+      description: List dataset run items
+      operationId: datasetRunItems_list
+      tags:
+        - DatasetRunItems
+      parameters:
+        - name: datasetId
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: runName
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: page number, starts at 1
+          required: false
+          schema:
+            type: integer
+            nullable: true
+        - name: limit
+          in: query
+          description: limit of items per page
+          required: false
+          schema:
+            type: integer
+            nullable: true
+        - name: response
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/PaginatedDatasetRunItems'
+      responses:
+        '204':
+          description: ''
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
   /api/public/v2/datasets:
     get:
       description: Get all datasets
@@ -5351,6 +5416,19 @@ components:
       required:
         - runName
         - datasetItemId
+    PaginatedDatasetRunItems:
+      title: PaginatedDatasetRunItems
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/DatasetRunItem'
+        meta:
+          $ref: '#/components/schemas/utilsMetaResponse'
+      required:
+        - data
+        - meta
     PaginatedDatasets:
       title: PaginatedDatasets
       type: object

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -642,6 +642,57 @@
             }
           },
           "response": []
+        },
+        {
+          "_type": "endpoint",
+          "name": "List",
+          "request": {
+            "description": "List dataset run items",
+            "url": {
+              "raw": "{{baseUrl}}/api/public/dataset-run-items?datasetId=&runName=&page=&limit=&response=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "public",
+                "dataset-run-items"
+              ],
+              "query": [
+                {
+                  "key": "datasetId",
+                  "value": "",
+                  "description": null
+                },
+                {
+                  "key": "runName",
+                  "value": "",
+                  "description": null
+                },
+                {
+                  "key": "page",
+                  "value": "",
+                  "description": "page number, starts at 1"
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "limit of items per page"
+                },
+                {
+                  "key": "response",
+                  "value": "",
+                  "description": null
+                }
+              ],
+              "variable": []
+            },
+            "header": [],
+            "method": "GET",
+            "auth": null,
+            "body": null
+          },
+          "response": []
         }
       ]
     },

--- a/web/src/__tests__/async/datasets-api.servertest.ts
+++ b/web/src/__tests__/async/datasets-api.servertest.ts
@@ -1421,7 +1421,6 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
 
     // Create 10 run items
     for (let i = 0; i < 10; i++) {
-      const runItemId = `run-item-${i}-${v4()}`;
       await makeZodVerifiedAPICall(
         PostDatasetRunItemsV1Response,
         "POST",

--- a/web/src/__tests__/async/datasets-api.servertest.ts
+++ b/web/src/__tests__/async/datasets-api.servertest.ts
@@ -21,6 +21,7 @@ import {
   PostDatasetsV2Response,
   DeleteDatasetItemV1Response,
   DeleteDatasetRunV1Response,
+  GetDatasetRunItemsV1Response,
 } from "@/src/features/public-api/types/datasets";
 import { v4 as uuidv4 } from "uuid";
 import {
@@ -1367,5 +1368,119 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
       },
     });
     expect(dbRunItemAfterDelete).toBeNull();
+  });
+
+  it("should properly paginate and filter dataset run items", async () => {
+    // Create a dataset
+    const datasetName = `pagination-test-${v4()}`;
+    const dataset = await makeZodVerifiedAPICall(
+      PostDatasetsV1Response,
+      "POST",
+      "/api/public/datasets",
+      {
+        name: datasetName,
+      },
+      auth,
+    );
+
+    // Create 10 dataset items with different inputs
+    const itemIds = [];
+    for (let i = 0; i < 10; i++) {
+      const itemId = `item-${i}-${v4()}`;
+      itemIds.push(itemId);
+
+      await makeZodVerifiedAPICall(
+        PostDatasetItemsV1Response,
+        "POST",
+        "/api/public/dataset-items",
+        {
+          datasetName: datasetName,
+          id: itemId,
+          input: { value: `test-value-${i}` },
+          metadata: { index: i },
+          // Add sourceObservationId to odd numbered items
+          sourceTraceId: v4(),
+          sourceObservationId: i % 2 === 1 ? v4() : undefined,
+          datasetId: dataset.body.id,
+        },
+        auth,
+      );
+    }
+
+    // Create a run
+    const runName = `run-${v4()}`;
+    await prisma.datasetRuns.create({
+      data: {
+        id: v4(),
+        datasetId: dataset.body.id,
+        name: runName,
+        metadata: {},
+        projectId: dataset.body.projectId,
+      },
+    });
+
+    // Create 10 run items
+    for (let i = 0; i < 10; i++) {
+      const runItemId = `run-item-${i}-${v4()}`;
+      await makeZodVerifiedAPICall(
+        PostDatasetRunItemsV1Response,
+        "POST",
+        "/api/public/dataset-run-items",
+        {
+          runName,
+          datasetItemId: itemIds[i],
+          traceId: v4(),
+          metadata: { index: i },
+        },
+        auth,
+      );
+    }
+
+    // Test basic pagination with limit
+    const pageSize = 3;
+    const page1 = await makeZodVerifiedAPICall(
+      GetDatasetRunItemsV1Response,
+      "GET",
+      `/api/public/dataset-run-items?datasetId=${dataset.body.id}&runName=${encodeURIComponent(runName)}&limit=${pageSize}&page=1`,
+      undefined,
+      auth,
+    );
+
+    expect(page1.status).toBe(200);
+    expect(page1.body.data.length).toBe(pageSize);
+    expect(page1.body.meta).toMatchObject({
+      totalItems: 10,
+      limit: pageSize,
+      page: 1,
+      totalPages: Math.ceil(10 / pageSize),
+    });
+
+    // Test second page
+    const page2 = await makeZodVerifiedAPICall(
+      GetDatasetRunItemsV1Response,
+      "GET",
+      `/api/public/dataset-run-items?datasetId=${dataset.body.id}&runName=${encodeURIComponent(runName)}&limit=${pageSize}&page=2`,
+      undefined,
+      auth,
+    );
+
+    expect(page2.status).toBe(200);
+    expect(page2.body.data.length).toBe(pageSize);
+    // Check that we got different items on different pages
+    const page1Ids = page1.body.data.map((item) => item.id);
+    const page2Ids = page2.body.data.map((item) => item.id);
+    page2Ids.forEach((id) => {
+      expect(page1Ids).not.toContain(id);
+    });
+
+    // Test non-existent dataset name
+    const nonExistent = await makeAPICall(
+      "GET",
+      `/api/public/dataset-run-items?datasetId=${v4()}&runName=does-not-exist`,
+      undefined,
+      auth,
+    );
+
+    expect(nonExistent.status).toBe(404);
   });
 });

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -198,6 +198,19 @@ export const PostDatasetRunItemsV1Body = z
   });
 export const PostDatasetRunItemsV1Response = APIDatasetRunItem.strict();
 
+// GET /dataset-run-items
+export const GetDatasetRunItemsV1Query = z.object({
+  datasetId: z.string(),
+  runName: z.string(),
+  ...publicApiPaginationZod,
+});
+export const GetDatasetRunItemsV1Response = z
+  .object({
+    data: z.array(APIDatasetRunItem),
+    meta: paginationMetaResponseZod,
+  })
+  .strict();
+
 /**
  * Deprecated endpoints replaced with v2, available for backward compatibility
  */

--- a/web/src/pages/api/public/dataset-run-items.ts
+++ b/web/src/pages/api/public/dataset-run-items.ts
@@ -2,6 +2,8 @@ import { prisma } from "@langfuse/shared/src/db";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import {
+  GetDatasetRunItemsV1Query,
+  GetDatasetRunItemsV1Response,
   PostDatasetRunItemsV1Body,
   PostDatasetRunItemsV1Response,
   transformDbDatasetRunItemToAPIDatasetRunItem,
@@ -115,6 +117,76 @@ export default withMiddlewares({
         ...runItem,
         datasetRunName: run.name,
       });
+    },
+  }),
+  GET: createAuthedProjectAPIRoute({
+    name: "Get Dataset Run Items",
+    querySchema: GetDatasetRunItemsV1Query,
+    responseSchema: GetDatasetRunItemsV1Response,
+    fn: async ({ query, auth }) => {
+      const { datasetId, runName, ...pagination } = query;
+
+      /**************
+       * VALIDATION *
+       **************/
+
+      const datasetRun = await prisma.datasetRuns.findUnique({
+        where: {
+          datasetId_projectId_name: {
+            datasetId,
+            name: runName,
+            projectId: auth.scope.projectId,
+          },
+        },
+        select: {
+          id: true,
+          name: true,
+        },
+      });
+
+      if (!datasetRun) {
+        throw new LangfuseNotFoundError(
+          "Dataset run not found for the given project and dataset id",
+        );
+      }
+
+      const datasetRunItems = await prisma.datasetRunItems.findMany({
+        where: {
+          datasetRunId: datasetRun.id,
+          projectId: auth.scope.projectId,
+        },
+        orderBy: {
+          createdAt: "desc",
+        },
+        take: pagination.limit,
+        skip: (pagination.page - 1) * pagination.limit,
+      });
+
+      const totalItems = await prisma.datasetRunItems.count({
+        where: {
+          datasetRunId: datasetRun.id,
+          projectId: auth.scope.projectId,
+        },
+      });
+
+      /**************
+       * RESPONSE *
+       **************/
+
+      return {
+        data: datasetRunItems.map((runItem) =>
+          transformDbDatasetRunItemToAPIDatasetRunItem({
+            ...runItem,
+            datasetRunName: datasetRun.name,
+          }),
+        ),
+        meta: {
+          page: pagination.page,
+          limit: pagination.limit,
+          totalItems,
+          totalPages: Math.ceil(totalItems / pagination.limit),
+        },
+      };
     },
   }),
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `GET /dataset-run-items` endpoint to list dataset run items with pagination and filtering, including tests and documentation updates.
> 
>   - **Endpoints**:
>     - Add `GET /dataset-run-items` endpoint in `dataset-run-items.ts` to list dataset run items with pagination and filtering by `datasetId` and `runName`.
>   - **Schemas**:
>     - Add `GetDatasetRunItemsV1Query` and `GetDatasetRunItemsV1Response` in `datasets.ts` for request and response validation.
>   - **Tests**:
>     - Add test for pagination and filtering of dataset run items in `datasets-api.servertest.ts`.
>   - **Documentation**:
>     - Update `openapi.yml` and `collection.json` to include the new `GET /dataset-run-items` endpoint.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 36a91b89ccc050a85755362f5bff1b6adc5385d4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->