### PR TITLE
fix(session-ui): handling mine type as enum string equivalent

### DIFF
--- a/web/src/components/ui/LangfuseMediaView.tsx
+++ b/web/src/components/ui/LangfuseMediaView.tsx
@@ -106,9 +106,11 @@ function FileViewer({
 }) {
   if (!src) return null;
 
+  const mimeType = String(contentType);
+
   const fileName = src.split("/").pop()?.split("?")[0] || "";
-  const fileType = contentType.split("/")[0];
-  const fileExtension = contentType.split("/")[1].toUpperCase();
+  const fileType = mimeType.split("/")[0];
+  const fileExtension = mimeType.split("/")[1]?.toUpperCase() || "FILE";
 
   const openInNewTab = () => {
     window.open(src, "_blank", "noopener,noreferrer");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Convert `contentType` to string and handle undefined values in `LangfuseMediaView.tsx` to prevent crashes.
> 
>   - **Behavior**:
>     - Convert `contentType` to string in `FileViewer` to handle undefined values.
>     - Default `fileExtension` to "FILE" if `contentType` is undefined in `LangfuseMediaView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 11e20a8ca0ab14bf672cfae649f77c5c9073a801. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->