### PR TITLE
fix: Increase memory usage for deploy

### DIFF
--- a/.github/workflows/_deploy_ecs_service.yml
+++ b/.github/workflows/_deploy_ecs_service.yml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
       - name: Get app name
         uses: winterjung/split@v2
         id: split

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -85,7 +85,7 @@ ENV NEXT_MANUAL_SIG_HANDLE true
 # set the CI flag to true to get CI specific logs
 ENV CI true
 
-RUN NODE_OPTIONS='--max-old-space-size=4096' turbo run build --filter=web...
+RUN NODE_OPTIONS='--max-old-space-size=8192' turbo run build --filter=web...
 
 # Production image, copy all the files and run next
 FROM --platform=${TARGETPLATFORM:-linux/amd64} base AS runner


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase memory usage for deployment by setting 10GB swap space and doubling Node.js memory limit in Dockerfile.
> 
>   - **GitHub Workflow**:
>     - Adds a step to set swap space to 10GB in `_deploy_ecs_service.yml` using `pierotofy/set-swap-space@master`.
>   - **Dockerfile**:
>     - Increases `NODE_OPTIONS` `--max-old-space-size` from 4096 to 8192 in `web/Dockerfile` to allow more memory usage during the build process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ae215ced18913047436d2486ed9000369484f1e7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->