### PR TITLE
fix(dashboard): render localized time strings for LineCharts

### DIFF
--- a/web/src/features/widgets/chart-library/Chart.tsx
+++ b/web/src/features/widgets/chart-library/Chart.tsx
@@ -22,20 +22,35 @@ export const Chart = ({
   const [forceRender, setForceRender] = useState(false);
   const shouldWarn = data.length > 2000 && !forceRender;
 
+  const renderedData = data.map((item) => {
+    return {
+      ...item,
+      time_dimension: item.time_dimension
+        ? new Date(item.time_dimension).toLocaleTimeString("en-US", {
+            year: "2-digit",
+            month: "numeric",
+            day: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+          })
+        : undefined,
+    };
+  });
+
   const renderChart = () => {
     switch (chartType) {
       case "LINE_TIME_SERIES":
-        return <LineChartTimeSeries data={data} />;
+        return <LineChartTimeSeries data={renderedData} />;
       case "BAR_TIME_SERIES":
-        return <VerticalBarChartTimeSeries data={data} />;
+        return <VerticalBarChartTimeSeries data={renderedData} />;
       case "HORIZONTAL_BAR":
-        return <HorizontalBarChart data={data.slice(0, rowLimit)} />;
+        return <HorizontalBarChart data={renderedData.slice(0, rowLimit)} />;
       case "VERTICAL_BAR":
-        return <VerticalBarChart data={data.slice(0, rowLimit)} />;
+        return <VerticalBarChart data={renderedData.slice(0, rowLimit)} />;
       case "PIE":
-        return <PieChart data={data.slice(0, rowLimit)} />;
+        return <PieChart data={renderedData.slice(0, rowLimit)} />;
       default:
-        return <HorizontalBarChart data={data.slice(0, rowLimit)} />;
+        return <HorizontalBarChart data={renderedData.slice(0, rowLimit)} />;
     }
   };
 

--- a/web/src/features/widgets/chart-library/Chart.tsx
+++ b/web/src/features/widgets/chart-library/Chart.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import { type DataPoint } from "@/src/features/widgets/chart-library/chart-props";
 import { CardContent } from "@/src/components/ui/card";
 import LineChartTimeSeries from "@/src/features/widgets/chart-library/LineChartTimeSeries";
@@ -22,20 +22,22 @@ export const Chart = ({
   const [forceRender, setForceRender] = useState(false);
   const shouldWarn = data.length > 2000 && !forceRender;
 
-  const renderedData = data.map((item) => {
-    return {
-      ...item,
-      time_dimension: item.time_dimension
-        ? new Date(item.time_dimension).toLocaleTimeString("en-US", {
-            year: "2-digit",
-            month: "numeric",
-            day: "numeric",
-            hour: "2-digit",
-            minute: "2-digit",
-          })
-        : undefined,
-    };
-  });
+  const renderedData = useMemo(() => {
+    return data.map((item) => {
+      return {
+        ...item,
+        time_dimension: item.time_dimension
+          ? new Date(item.time_dimension).toLocaleTimeString("en-US", {
+              year: "2-digit",
+              month: "numeric",
+              day: "numeric",
+              hour: "2-digit",
+              minute: "2-digit",
+            })
+          : undefined,
+      };
+    });
+  }, [data]);
 
   const renderChart = () => {
     switch (chartType) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Localizes `time_dimension` in `Chart.tsx` using `useMemo` for optimized rendering of time strings in charts.
> 
>   - **Behavior**:
>     - Localizes `time_dimension` in `Chart.tsx` using `useMemo` to format as a localized time string.
>     - Affects `LineChartTimeSeries`, `VerticalBarChartTimeSeries`, `HorizontalBarChart`, `VerticalBarChart`, and `PieChart` by passing `renderedData` instead of `data`.
>   - **Performance**:
>     - Uses `useMemo` to optimize rendering by memoizing the transformation of `data` to `renderedData`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0e49b458d6310d67a2c0f333b6d1bb870384029c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->