### PR TITLE
chore: parameterize clickhouse deletion timeouts

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -90,6 +90,7 @@ const EnvSchema = z.object({
   LANGFUSE_API_TRACE_OBSERVATIONS_SIZE_LIMIT_BYTES: z.coerce
     .number()
     .default(80e6), // 80MB
+  LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS: z.coerce.number().default(240_000), // 4 minutes
 });
 
 export const env: z.infer<typeof EnvSchema> =

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -76,6 +76,10 @@ export class ClickHouseClientManager {
         cloudOptions.input_format_json_throw_on_bad_escape_sequence = 0;
       }
 
+      const langfuseDefaultSettings = {
+        lightweight_deletes_sync: 1,
+      };
+
       const client = createClient({
         ...opts,
         url: env.CLICKHOUSE_URL,
@@ -85,6 +89,7 @@ export class ClickHouseClientManager {
         http_headers: headers,
         clickhouse_settings: {
           ...cloudOptions,
+          ...langfuseDefaultSettings,
           ...opts.clickhouse_settings,
           async_insert: 1,
           wait_for_async_insert: 1, // if disabled, we won't get errors from clickhouse

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -76,10 +76,6 @@ export class ClickHouseClientManager {
         cloudOptions.input_format_json_throw_on_bad_escape_sequence = 0;
       }
 
-      const langfuseDefaultSettings = {
-        lightweight_deletes_sync: 1,
-      };
-
       const client = createClient({
         ...opts,
         url: env.CLICKHOUSE_URL,
@@ -89,7 +85,6 @@ export class ClickHouseClientManager {
         http_headers: headers,
         clickhouse_settings: {
           ...cloudOptions,
-          ...langfuseDefaultSettings,
           ...opts.clickhouse_settings,
           async_insert: 1,
           wait_for_async_insert: 1, // if disabled, we won't get errors from clickhouse

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1039,7 +1039,7 @@ export const deleteObservationsByTraceIds = async (
       traceIds,
     },
     clickhouseConfigs: {
-      request_timeout: 120_000, // 2 minutes
+      request_timeout: env.LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS,
     },
     tags: {
       feature: "tracing",
@@ -1061,7 +1061,7 @@ export const deleteObservationsByProjectId = async (projectId: string) => {
       projectId,
     },
     clickhouseConfigs: {
-      request_timeout: 120_000, // 2 minutes
+      request_timeout: env.LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS,
     },
     tags: {
       feature: "tracing",
@@ -1088,7 +1088,7 @@ export const deleteObservationsOlderThanDays = async (
       cutoffDate: convertDateToClickhouseDateTime(beforeDate),
     },
     clickhouseConfigs: {
-      request_timeout: 120_000, // 2 minutes
+      request_timeout: env.LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS,
     },
     tags: {
       feature: "tracing",

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -922,6 +922,9 @@ export const deleteScores = async (projectId: string, scoreIds: string[]) => {
       projectId,
       scoreIds,
     },
+    clickhouseConfigs: {
+      request_timeout: env.LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS,
+    },
     tags: {
       feature: "tracing",
       type: "score",
@@ -969,7 +972,7 @@ export const deleteScoresByProjectId = async (projectId: string) => {
       projectId,
     },
     clickhouseConfigs: {
-      request_timeout: 120_000, // 2 minutes
+      request_timeout: env.LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS,
     },
     tags: {
       feature: "tracing",
@@ -996,7 +999,7 @@ export const deleteScoresOlderThanDays = async (
       cutoffDate: convertDateToClickhouseDateTime(beforeDate),
     },
     clickhouseConfigs: {
-      request_timeout: 120_000, // 2 minutes
+      request_timeout: env.LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS,
     },
     tags: {
       feature: "tracing",

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -570,7 +570,7 @@ export const deleteTraces = async (projectId: string, traceIds: string[]) => {
       traceIds,
     },
     clickhouseConfigs: {
-      request_timeout: 120_000, // 2 minutes
+      request_timeout: env.LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS,
     },
     tags: {
       feature: "tracing",
@@ -597,7 +597,7 @@ export const deleteTracesOlderThanDays = async (
       cutoffDate: convertDateToClickhouseDateTime(beforeDate),
     },
     clickhouseConfigs: {
-      request_timeout: 120_000, // 2 minutes
+      request_timeout: env.LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS,
     },
     tags: {
       feature: "tracing",
@@ -619,7 +619,7 @@ export const deleteTracesByProjectId = async (projectId: string) => {
       projectId,
     },
     clickhouseConfigs: {
-      request_timeout: 120_000, // 2 minutes
+      request_timeout: env.LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS,
     },
     tags: {
       feature: "tracing",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Parameterizes Clickhouse deletion timeouts using a new environment variable `LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS` across multiple repository functions.
> 
>   - **Environment Variable**:
>     - Adds `LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS` to `env.ts` with a default of 240,000 ms (4 minutes).
>   - **Repositories**:
>     - Updates `deleteObservationsByTraceIds`, `deleteObservationsByProjectId`, and `deleteObservationsOlderThanDays` in `observations.ts` to use `LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS`.
>     - Updates `deleteScores`, `deleteScoresByProjectId`, and `deleteScoresOlderThanDays` in `scores.ts` to use `LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS`.
>     - Updates `deleteTraces`, `deleteTracesByProjectId`, and `deleteTracesOlderThanDays` in `traces.ts` to use `LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3a9e6c913fff001d3493c84ad37bbc1c19ef9dbf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->