### PR TITLE
fix: fail gracefully for batch actions in case eval config does not exist

### DIFF
--- a/worker/src/features/batchAction/handleBatchActionJob.ts
+++ b/worker/src/features/batchAction/handleBatchActionJob.ts
@@ -184,7 +184,10 @@ export const handleBatchActionJob = async (
     });
 
     if (!config) {
-      throw new Error("Eval config not found");
+      logger.error(
+        `Eval config ${configId} not found for project ${projectId}`,
+      );
+      return;
     }
 
     const dbReadStream = await getDatabaseReadStream({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Handle missing eval config gracefully in `handleBatchActionJob` by logging error and returning, with test added to verify behavior.
> 
>   - **Behavior**:
>     - In `handleBatchActionJob`, if eval config does not exist, log error and return instead of throwing an error.
>     - Affects `eval-create` action in batch processing.
>   - **Tests**:
>     - Add test in `batchAction.test.ts` to verify no evals are created if config is missing.
>     - Ensures graceful handling of missing config scenario.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2658c0aad11e667b8ac24d63ce79a401ad3ff064. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->