### PR TITLE
fix(ui-tool-calls): handle parsing errors gracefully

### DIFF
--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -71,7 +71,13 @@ export const OpenAIToolCallSchema = z.object({
       z.record(z.string(), z.unknown()),
       z
         .string()
-        .transform((v) => JSON.parse(v))
+        .transform((v) => {
+          try {
+            return JSON.parse(v);
+          } catch {
+            return v;
+          }
+        })
         .pipe(z.record(z.string(), z.unknown())),
     ]),
   }),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add error handling for JSON parsing in `OpenAIToolCallSchema` in `types.ts`.
> 
>   - **Behavior**:
>     - In `OpenAIToolCallSchema` in `types.ts`, added try-catch to handle JSON parsing errors in `transform()` function.
>     - If JSON parsing fails, returns the original string instead of throwing an error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for aa6c043c558ca26e6e74906b856d8f266ecd9ddc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->