### PR TITLE
feat(dashboard): add newly created widget to dashboard on save

### DIFF
--- a/web/src/features/widgets/components/SelectWidgetDialog.tsx
+++ b/web/src/features/widgets/components/SelectWidgetDialog.tsx
@@ -35,6 +35,7 @@ interface SelectWidgetDialogProps {
   onOpenChange: (open: boolean) => void;
   projectId: string;
   onSelectWidget: (widget: WidgetItem) => void;
+  dashboardId: string;
 }
 
 export function SelectWidgetDialog({
@@ -42,6 +43,7 @@ export function SelectWidgetDialog({
   onOpenChange,
   projectId,
   onSelectWidget,
+  dashboardId,
 }: SelectWidgetDialogProps) {
   const router = useRouter();
   const [selectedWidgetId, setSelectedWidgetId] = useState<string | null>(null);
@@ -61,7 +63,7 @@ export function SelectWidgetDialog({
   );
 
   const handleNavigateToNewWidget = () => {
-    router.push(`/project/${projectId}/widgets/new`);
+    router.push(`/project/${projectId}/widgets/new?dashboardId=${dashboardId}`);
   };
 
   const handleAddWidget = () => {

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -31,9 +31,10 @@ interface WidgetPlacement {
 
 export default function DashboardDetail() {
   const router = useRouter();
-  const { projectId, dashboardId } = router.query as {
+  const { projectId, dashboardId, addWidgetId } = router.query as {
     projectId: string;
     dashboardId: string;
+    addWidgetId?: string;
   };
 
   const hasCUDAccess = useHasProjectAccess({
@@ -71,6 +72,53 @@ export default function DashboardDetail() {
         showErrorToast("Error updating dashboard", error.message);
       },
     });
+
+  // Helper function to add a widget to the dashboard
+  const addWidgetToDashboard = (widget: WidgetItem) => {
+    if (!localDashboardDefinition) return;
+    if (
+      localDashboardDefinition.widgets.some((w) => w.widgetId === widget.id)
+    ) {
+      showErrorToast(
+        "Widget already exists",
+        "The widget you are trying to add already exists on the dashboard.",
+        "WARNING",
+      );
+      return;
+    }
+
+    // Find the maximum y position to place the new widget at the bottom
+    const maxY =
+      localDashboardDefinition.widgets.length > 0
+        ? Math.max(
+            ...localDashboardDefinition.widgets.map((w) => w.y + w.y_size),
+          )
+        : 0;
+
+    // Create a new widget placement
+    const newWidgetPlacement: WidgetPlacement = {
+      id: uuidv4(),
+      widgetId: widget.id,
+      x: 0, // Start at left
+      y: maxY, // Place below existing widgets
+      x_size: 6, // Default size (half of 12-column grid)
+      y_size: 2, // Default height of 2 rows
+      type: "widget",
+    };
+
+    // Add the widget to the local dashboard definition
+    setLocalDashboardDefinition({
+      ...localDashboardDefinition,
+      widgets: [...localDashboardDefinition.widgets, newWidgetPlacement],
+    });
+
+    setHasUnsavedChanges(true);
+
+    showSuccessToast({
+      title: "Widget added",
+      description: `"${widget.name}" has been added to the dashboard. Click Save to apply changes.`,
+    });
+  };
 
   const traceFilterOptions = api.traces.filterOptions.useQuery(
     {
@@ -186,11 +234,37 @@ export default function DashboardDetail() {
     },
   );
 
+  // Fetch widget data if addWidgetId is present
+  const widgetToAdd = api.dashboardWidgets.get.useQuery(
+    { projectId, widgetId: addWidgetId || "" },
+    {
+      enabled: Boolean(projectId) && Boolean(addWidgetId),
+    },
+  );
+
   useEffect(() => {
     if (dashboard.data && !localDashboardDefinition) {
       setLocalDashboardDefinition(dashboard.data.definition);
     }
   }, [dashboard.data, localDashboardDefinition]);
+
+  useEffect(() => {
+    if (widgetToAdd.data && addWidgetId) {
+      addWidgetToDashboard(widgetToAdd.data);
+      // Remove the addWidgetId query parameter
+      router.push({
+        pathname: router.pathname,
+        query: { projectId, dashboardId },
+      });
+    }
+  }, [
+    widgetToAdd.data,
+    addWidgetId,
+    localDashboardDefinition,
+    projectId,
+    dashboardId,
+    router,
+  ]);
 
   // Handle deleting a widget
   const handleDeleteWidget = (tileId: string) => {
@@ -215,39 +289,7 @@ export default function DashboardDetail() {
 
   // Handle widget selection from dialog
   const handleSelectWidget = (widget: WidgetItem) => {
-    if (localDashboardDefinition) {
-      // Find the maximum y position to place the new widget at the bottom
-      const maxY =
-        localDashboardDefinition.widgets.length > 0
-          ? Math.max(
-              ...localDashboardDefinition.widgets.map((w) => w.y + w.y_size),
-            )
-          : 0;
-
-      // Create a new widget placement
-      const newWidgetPlacement: WidgetPlacement = {
-        id: uuidv4(),
-        widgetId: widget.id,
-        x: 0, // Start at left
-        y: maxY, // Place below existing widgets
-        x_size: 6, // Default size (half of 12-column grid)
-        y_size: 2, // Default height of 2 rows
-        type: "widget",
-      };
-
-      // Add the widget to the local dashboard definition
-      setLocalDashboardDefinition({
-        ...localDashboardDefinition,
-        widgets: [...localDashboardDefinition.widgets, newWidgetPlacement],
-      });
-
-      setHasUnsavedChanges(true);
-
-      showSuccessToast({
-        title: "Widget added",
-        description: `"${widget.name}" has been added to the dashboard. Click Save to apply changes.`,
-      });
-    }
+    addWidgetToDashboard(widget);
   };
 
   // Handle saving the dashboard
@@ -268,6 +310,7 @@ export default function DashboardDetail() {
         onOpenChange={setIsWidgetDialogOpen}
         projectId={projectId}
         onSelectWidget={handleSelectWidget}
+        dashboardId={dashboardId}
       />
 
       <Page

--- a/web/src/pages/project/[projectId]/widgets/new.tsx
+++ b/web/src/pages/project/[projectId]/widgets/new.tsx
@@ -13,17 +13,28 @@ import { type z } from "zod";
 
 export default function NewWidget() {
   const router = useRouter();
-  const { projectId } = router.query as { projectId: string };
+  const { projectId, dashboardId } = router.query as {
+    projectId: string;
+    dashboardId?: string;
+  };
 
   // Save widget mutation
   const createWidgetMutation = api.dashboardWidgets.create.useMutation({
-    onSuccess: () => {
+    onSuccess: (data) => {
       showSuccessToast({
         title: "Widget created successfully",
         description: "Your widget has been created.",
       });
-      // Navigate back to widgets list
-      void router.push(`/project/${projectId}/widgets`);
+
+      // If dashboardId is provided, redirect back to the dashboard with the new widget ID
+      if (dashboardId) {
+        void router.push(
+          `/project/${projectId}/dashboards/${dashboardId}?addWidgetId=${data.widget.id}`,
+        );
+      } else {
+        // Otherwise, navigate to widgets list
+        void router.push(`/project/${projectId}/widgets`);
+      }
     },
     onError: (error) => {
       showErrorToast("Failed to save widget", error.message);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Automatically add newly created widget to dashboard on save if `dashboardId` is provided, updating dashboard state accordingly.
> 
>   - **Behavior**:
>     - Automatically adds newly created widget to dashboard if `dashboardId` is provided in `new.tsx`.
>     - Updates dashboard state in `index.tsx` to include new widget and remove `addWidgetId` from query.
>   - **Functions**:
>     - Adds `addWidgetToDashboard` in `index.tsx` to handle widget placement logic.
>     - Modifies `handleNavigateToNewWidget` in `SelectWidgetDialog.tsx` to include `dashboardId` in URL.
>   - **Misc**:
>     - Refactors widget addition logic in `index.tsx` to use `addWidgetToDashboard`.
>     - Adds `dashboardId` prop to `SelectWidgetDialog` in `index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9c8ca097c3b00a4adfc0c661ff5fa1b56fd6ec0b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->