### PR TITLE
perf: also add trace_id to observations search

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -285,12 +285,14 @@ export const getObservationById = async ({
   fetchWithInputOutput = false,
   startTime,
   type,
+  traceId,
 }: {
   id: string;
   projectId: string;
   fetchWithInputOutput?: boolean;
   startTime?: Date;
   type?: ObservationType;
+  traceId?: string;
 }) => {
   const records = await getObservationByIdInternal({
     id,
@@ -298,6 +300,7 @@ export const getObservationById = async ({
     fetchWithInputOutput,
     startTime,
     type,
+    traceId,
   });
   const mapped = records.map(convertObservation);
 
@@ -369,12 +372,14 @@ const getObservationByIdInternal = async ({
   fetchWithInputOutput = false,
   startTime,
   type,
+  traceId,
 }: {
   id: string;
   projectId: string;
   fetchWithInputOutput?: boolean;
   startTime?: Date;
   type?: ObservationType;
+  traceId?: string;
 }) => {
   const query = `
   SELECT
@@ -412,6 +417,7 @@ const getObservationByIdInternal = async ({
   AND project_id = {projectId: String}
   ${startTime ? `AND toDate(start_time) = toDate({startTime: DateTime64(3)})` : ""}
   ${type ? `AND type = {type: String}` : ""}
+  ${traceId ? `AND trace_id = {traceId: String}` : ""}
   ORDER BY event_ts desc
   LIMIT 1 by id, project_id`;
   return await queryClickhouse<ObservationRecordReadType>({

--- a/web/src/server/api/routers/observations.ts
+++ b/web/src/server/api/routers/observations.ts
@@ -23,6 +23,7 @@ export const observationsRouter = createTRPCRouter({
           id: input.observationId,
           projectId: input.projectId,
           fetchWithInputOutput: true,
+          traceId: input.traceId,
           startTime: input.startTime ?? undefined,
         });
         if (!obs) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `traceId` parameter to `getObservationById` for filtering observations by trace ID, updating related API and SQL query.
> 
>   - **Behavior**:
>     - Adds `traceId` parameter to `getObservationById` and `getObservationByIdInternal` in `observations.ts` to filter observations by `trace_id`.
>     - Updates SQL query in `getObservationByIdInternal` to include `trace_id` condition.
>   - **API**:
>     - Updates `observationsRouter` in `routers/observations.ts` to pass `traceId` to `getObservationById`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4aa5e76a027d3ec0cd74e80505a43d5f09ec2804. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->