### PR TITLE
feat(dashboards): add support for cloning existing dashboards

### DIFF
--- a/packages/shared/src/server/services/DashboardService/DashboardService.ts
+++ b/packages/shared/src/server/services/DashboardService/DashboardService.ts
@@ -115,6 +115,31 @@ export class DashboardService {
   }
 
   /**
+   * Updates a dashboard's name and description.
+   */
+  public static async updateDashboard(
+    dashboardId: string,
+    projectId: string,
+    name: string,
+    description: string,
+    userId?: string,
+  ): Promise<DashboardDomain> {
+    const updatedDashboard = await prisma.dashboard.update({
+      where: {
+        id: dashboardId,
+        projectId,
+      },
+      data: {
+        name,
+        description,
+        updatedBy: userId,
+      },
+    });
+
+    return DashboardDomainSchema.parse(updatedDashboard);
+  }
+
+  /**
    * Gets a dashboard by ID.
    */
   public static async getDashboard(

--- a/web/src/components/deleteButton.tsx
+++ b/web/src/components/deleteButton.tsx
@@ -276,6 +276,9 @@ export function DeleteDashboardButton(props: DeleteButtonProps) {
       captureDeleteOpen={(capture) =>
         capture("dashboard:delete_dashboard_form_open")
       }
+      captureDeleteSuccess={(capture) =>
+        capture("dashboard:delete_dashboard_button_click")
+      }
       entityToDeleteName="dashboard"
       executeDeleteMutation={executeDeleteMutation}
       isDeleteMutationLoading={dashboardMutation.isLoading}

--- a/web/src/components/deleteButton.tsx
+++ b/web/src/components/deleteButton.tsx
@@ -243,6 +243,49 @@ export function DeleteDatasetButton(props: DeleteButtonProps) {
   );
 }
 
+export function DeleteDashboardButton(props: DeleteButtonProps) {
+  const utils = api.useUtils();
+  const {
+    itemId,
+    projectId,
+    scope = "dashboards:CUD",
+    invalidateFunc = () => void utils.dashboard.invalidate(),
+  } = props;
+  const dashboardMutation = api.dashboard.delete.useMutation();
+  const executeDeleteMutation = async (onSuccess: () => void) => {
+    try {
+      await dashboardMutation.mutateAsync({
+        dashboardId: itemId,
+        projectId,
+      });
+    } catch (error) {
+      return Promise.reject(error);
+    }
+    showSuccessToast({
+      title: "Dashboard deleted",
+      description: "The dashboard has been deleted successfully",
+    });
+    onSuccess();
+  };
+
+  return (
+    <DeleteButton
+      {...props}
+      scope={scope}
+      invalidateFunc={invalidateFunc}
+      captureDeleteOpen={(capture) =>
+        capture("dashboard:delete_dashboard_form_open")
+      }
+      captureDeleteSuccess={(capture) =>
+        capture("dashboard:delete_dashboard_form_open")
+      }
+      entityToDeleteName="dashboard"
+      executeDeleteMutation={executeDeleteMutation}
+      isDeleteMutationLoading={dashboardMutation.isLoading}
+    />
+  );
+}
+
 export function DeleteEvaluatorButton(props: DeleteButtonProps) {
   const utils = api.useUtils();
   const {

--- a/web/src/components/deleteButton.tsx
+++ b/web/src/components/deleteButton.tsx
@@ -276,9 +276,6 @@ export function DeleteDashboardButton(props: DeleteButtonProps) {
       captureDeleteOpen={(capture) =>
         capture("dashboard:delete_dashboard_form_open")
       }
-      captureDeleteSuccess={(capture) =>
-        capture("dashboard:delete_dashboard_form_open")
-      }
       entityToDeleteName="dashboard"
       executeDeleteMutation={executeDeleteMutation}
       isDeleteMutationLoading={dashboardMutation.isLoading}

--- a/web/src/features/dashboard/components/DashboardTable.tsx
+++ b/web/src/features/dashboard/components/DashboardTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 import { useOrderByState } from "@/src/features/orderBy/hooks/useOrderByState";
 import { NumberParam, useQueryParams, withDefault } from "use-query-params";
@@ -11,7 +11,7 @@ import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
 import { Button } from "@/src/components/ui/button";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
-import { Copy } from "lucide-react";
+import { Copy, Edit } from "lucide-react";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
@@ -23,6 +23,7 @@ import {
   DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
 import { DeleteDashboardButton } from "@/src/components/deleteButton";
+import { EditDashboardDialog } from "@/src/features/dashboard/components/EditDashboardDialog";
 
 type DashboardTableRow = {
   id: string;
@@ -79,6 +80,44 @@ function CloneDashboardButton({
       <Copy className="mr-2 h-4 w-4" />
       Clone
     </Button>
+  );
+}
+
+function EditDashboardButton({
+  dashboardId,
+  projectId,
+  dashboardName,
+  dashboardDescription,
+}: {
+  dashboardId: string;
+  projectId: string;
+  dashboardName: string;
+  dashboardDescription: string;
+}) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const hasAccess = useHasProjectAccess({ projectId, scope: "dashboards:CUD" });
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="default"
+        disabled={!hasAccess}
+        onClick={() => setIsDialogOpen(true)}
+      >
+        <Edit className="mr-2 h-4 w-4" />
+        Edit
+      </Button>
+
+      <EditDashboardDialog
+        open={isDialogOpen}
+        onOpenChange={setIsDialogOpen}
+        projectId={projectId}
+        dashboardId={dashboardId}
+        initialName={dashboardName}
+        initialDescription={dashboardDescription}
+      />
+    </>
   );
 }
 
@@ -173,6 +212,8 @@ export function DashboardTable() {
       size: 70,
       cell: (row) => {
         const id = row.row.original.id;
+        const name = row.row.original.name;
+        const description = row.row.original.description;
         return (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -181,6 +222,14 @@ export function DashboardTable() {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent className="flex flex-col [&>*]:w-full [&>*]:justify-start">
+              <DropdownMenuItem asChild>
+                <EditDashboardButton
+                  dashboardId={id}
+                  projectId={projectId}
+                  dashboardName={name}
+                  dashboardDescription={description}
+                />
+              </DropdownMenuItem>
               <DropdownMenuItem asChild>
                 <CloneDashboardButton dashboardId={id} projectId={projectId} />
               </DropdownMenuItem>

--- a/web/src/features/dashboard/components/EditDashboardDialog.tsx
+++ b/web/src/features/dashboard/components/EditDashboardDialog.tsx
@@ -11,7 +11,6 @@ import { Button } from "@/src/components/ui/button";
 import { Input } from "@/src/components/ui/input";
 import { Label } from "@/src/components/ui/label";
 import { Textarea } from "@/src/components/ui/textarea";
-import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 

--- a/web/src/features/dashboard/components/EditDashboardDialog.tsx
+++ b/web/src/features/dashboard/components/EditDashboardDialog.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from "react";
+import { api } from "@/src/utils/api";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/src/components/ui/dialog";
+import { Button } from "@/src/components/ui/button";
+import { Input } from "@/src/components/ui/input";
+import { Label } from "@/src/components/ui/label";
+import { Textarea } from "@/src/components/ui/textarea";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+
+interface EditDashboardDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  dashboardId: string;
+  initialName: string;
+  initialDescription: string;
+}
+
+export function EditDashboardDialog({
+  open,
+  onOpenChange,
+  projectId,
+  dashboardId,
+  initialName,
+  initialDescription,
+}: EditDashboardDialogProps) {
+  const [name, setName] = useState(initialName);
+  const [description, setDescription] = useState(initialDescription);
+  const utils = api.useUtils();
+
+  const updateDashboard = api.dashboard.updateDashboardMetadata.useMutation({
+    onSuccess: () => {
+      void utils.dashboard.invalidate();
+      showSuccessToast({
+        title: "Dashboard updated",
+        description: "The dashboard has been updated successfully",
+      });
+      onOpenChange(false);
+    },
+    onError: (e) => {
+      showErrorToast("Failed to update dashboard", e.message);
+    },
+  });
+
+  const handleSave = () => {
+    if (!name.trim()) {
+      showErrorToast("Validation error", "Dashboard name is required");
+      return;
+    }
+
+    updateDashboard.mutate({
+      projectId,
+      dashboardId,
+      name: name.trim(),
+      description: description.trim(),
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Edit Dashboard</DialogTitle>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Dashboard name"
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="description">Description</Label>
+            <Textarea
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Dashboard description"
+              rows={3}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <div className="flex gap-2">
+            <Button
+              onClick={() => onOpenChange(false)}
+              variant="outline"
+              type="button"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSave}
+              type="button"
+              loading={updateDashboard.isLoading}
+            >
+              Save Changes
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/features/dashboard/server/dashboard-router.ts
+++ b/web/src/features/dashboard/server/dashboard-router.ts
@@ -49,6 +49,14 @@ const UpdateDashboardDefinitionInput = z.object({
   definition: DashboardDefinitionSchema,
 });
 
+// Update dashboard input schema
+const UpdateDashboardInput = z.object({
+  projectId: z.string(),
+  dashboardId: z.string(),
+  name: z.string().min(1, "Dashboard name is required"),
+  description: z.string(),
+});
+
 // Create dashboard input schema
 const CreateDashboardInput = z.object({
   projectId: z.string(),
@@ -222,6 +230,26 @@ export const dashboardRouter = createTRPCRouter({
         input.dashboardId,
         input.projectId,
         input.definition,
+        ctx.session.user.id,
+      );
+
+      return dashboard;
+    }),
+
+  updateDashboardMetadata: protectedProjectProcedure
+    .input(UpdateDashboardInput)
+    .mutation(async ({ ctx, input }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "dashboards:CUD",
+      });
+
+      const dashboard = await DashboardService.updateDashboard(
+        input.dashboardId,
+        input.projectId,
+        input.name,
+        input.description,
         ctx.session.user.id,
       );
 

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -104,6 +104,7 @@ const events = {
     "save_to_prompt_version_button_click",
   ],
   dashboard: [
+    "clone_dashboard",
     "chart_tab_switch",
     "date_range_changed",
     "new_widget_form_open",

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -111,6 +111,7 @@ const events = {
     "new_dashboard_form_open",
     "delete_widget_form_open",
     "delete_dashboard_form_open",
+    "delete_dashboard_button_click",
   ],
   datasets: [
     "delete_form_open",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for cloning and editing dashboards, including UI components and analytics tracking.
> 
>   - **Features**:
>     - Add `cloneDashboard` mutation in `dashboard-router.ts` to clone dashboards.
>     - Add `updateDashboardMetadata` mutation in `dashboard-router.ts` to update dashboard name and description.
>     - Implement `CloneDashboardButton` and `EditDashboardButton` in `DashboardTable.tsx` for UI interactions.
>   - **UI Components**:
>     - Add `EditDashboardDialog` in `EditDashboardDialog.tsx` for editing dashboard details.
>     - Add `DeleteDashboardButton` in `deleteButton.tsx` for deleting dashboards.
>   - **Analytics**:
>     - Track `clone_dashboard` and `delete_dashboard_button_click` events in `usePostHogClientCapture.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0c05528cd6881a24e7950abd171996e8c5f7caee. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->