### PR TITLE
fix: fix traceid filter for observations by id clickhouse query

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -428,6 +428,7 @@ const getObservationByIdInternal = async ({
       ...(startTime
         ? { startTime: convertDateToClickhouseDateTime(startTime) }
         : {}),
+      ...(traceId ? { traceId } : {}),
     },
     tags: {
       feature: "tracing",

--- a/web/src/__tests__/async/repositories/observation-repository.servertest.ts
+++ b/web/src/__tests__/async/repositories/observation-repository.servertest.ts
@@ -69,50 +69,78 @@ describe("Clickhouse Observations Repository Test", () => {
       fetchWithInputOutput: true,
     });
 
-    it("should return an observation if exists by traceId", async () => {
-      const observationId = v4();
-      const traceId = v4();
-  
-      const observation = createObservation({
-        id: observationId,
-        trace_id: traceId,
-        project_id: projectId,
-        type: "sample_type",
-        metadata: {},
-        provided_usage_details: { input: 1234, output: 5678, total: 6912 },
-        provided_cost_details: { input: 100, output: 200, total: 300 },
-        usage_details: { input: 1234, output: 5678, total: 6912 },
-        cost_details: { input: 100, output: 200, total: 300 },
-        is_deleted: 0,
-        created_at: Date.now(),
-        updated_at: Date.now(),
-        start_time: Date.now(),
-        event_ts: Date.now(),
-        name: "sample_name",
-        level: "sample_level",
-        status_message: "sample_status",
-        version: "1.0",
-        input: "sample_input",
-        output: "sample_output",
-        provided_model_name: "sample_model",
-        internal_model_id: "sample_internal_model_id",
-        model_parameters: '{"something":"sample_param"}',
-        total_cost: 300,
-        prompt_id: "sample_prompt_id",
-        prompt_name: "sample_prompt_name",
-        prompt_version: 1,
-        end_time: Date.now(),
-        completion_start_time: Date.now(),
-      });
-  
-      await createObservationsCh([observation]);
-  
-      const result = await getObservationById({
-        id: observationId,
-        projectId,
-        traceId,
-        fetchWithInputOutput: true,
-      });
+    expect(result.id).toEqual(observation.id);
+    expect(result.traceId).toEqual(observation.trace_id);
+    expect(result.projectId).toEqual(observation.project_id);
+    expect(result.type).toEqual(observation.type);
+
+    expect(result.metadata).toEqual(observation.metadata);
+    expect(result.createdAt).toEqual(new Date(observation.created_at));
+    expect(result.updatedAt).toEqual(new Date(observation.updated_at));
+    expect(result.startTime).toEqual(new Date(observation.start_time));
+    expect(result.name).toEqual(observation.name);
+    expect(result.level).toEqual(observation.level);
+    expect(result.statusMessage).toEqual(observation.status_message);
+    expect(result.version).toEqual(observation.version);
+    expect(result.input).toEqual(observation.input);
+    expect(result.output).toEqual(observation.output);
+    expect(result.internalModelId).toEqual(observation.internal_model_id);
+    expect(result.modelParameters).toEqual({ something: "sample_param" });
+    expect(result.promptId).toEqual(observation.prompt_id);
+    expect(result.endTime).toEqual(new Date(observation.end_time!));
+    expect(result.completionStartTime).toEqual(
+      new Date(observation.completion_start_time!),
+    );
+    expect(result.totalCost).toEqual(observation.total_cost!);
+    expect(result.inputUsage).toEqual(1234);
+    expect(result.outputUsage).toEqual(5678);
+    expect(result.totalUsage).toEqual(6912);
+  });
+
+  it("should return an observation if exists by traceId", async () => {
+    const observationId = v4();
+    const traceId = v4();
+
+    const observation = createObservation({
+      id: observationId,
+      trace_id: traceId,
+      project_id: projectId,
+      type: "sample_type",
+      metadata: {},
+      provided_usage_details: { input: 1234, output: 5678, total: 6912 },
+      provided_cost_details: { input: 100, output: 200, total: 300 },
+      usage_details: { input: 1234, output: 5678, total: 6912 },
+      cost_details: { input: 100, output: 200, total: 300 },
+      is_deleted: 0,
+      created_at: Date.now(),
+      updated_at: Date.now(),
+      start_time: Date.now(),
+      event_ts: Date.now(),
+      name: "sample_name",
+      level: "sample_level",
+      status_message: "sample_status",
+      version: "1.0",
+      input: "sample_input",
+      output: "sample_output",
+      provided_model_name: "sample_model",
+      internal_model_id: "sample_internal_model_id",
+      model_parameters: '{"something":"sample_param"}',
+      total_cost: 300,
+      prompt_id: "sample_prompt_id",
+      prompt_name: "sample_prompt_name",
+      prompt_version: 1,
+      end_time: Date.now(),
+      completion_start_time: Date.now(),
+    });
+
+    await createObservationsCh([observation]);
+
+    const result = await getObservationById({
+      id: observationId,
+      projectId,
+      traceId,
+      fetchWithInputOutput: true,
+    });
     if (!result) {
       throw new Error("Observation not found");
     }

--- a/web/src/__tests__/async/repositories/observation-repository.servertest.ts
+++ b/web/src/__tests__/async/repositories/observation-repository.servertest.ts
@@ -68,6 +68,51 @@ describe("Clickhouse Observations Repository Test", () => {
       projectId,
       fetchWithInputOutput: true,
     });
+
+    it("should return an observation if exists by traceId", async () => {
+      const observationId = v4();
+      const traceId = v4();
+  
+      const observation = createObservation({
+        id: observationId,
+        trace_id: traceId,
+        project_id: projectId,
+        type: "sample_type",
+        metadata: {},
+        provided_usage_details: { input: 1234, output: 5678, total: 6912 },
+        provided_cost_details: { input: 100, output: 200, total: 300 },
+        usage_details: { input: 1234, output: 5678, total: 6912 },
+        cost_details: { input: 100, output: 200, total: 300 },
+        is_deleted: 0,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+        start_time: Date.now(),
+        event_ts: Date.now(),
+        name: "sample_name",
+        level: "sample_level",
+        status_message: "sample_status",
+        version: "1.0",
+        input: "sample_input",
+        output: "sample_output",
+        provided_model_name: "sample_model",
+        internal_model_id: "sample_internal_model_id",
+        model_parameters: '{"something":"sample_param"}',
+        total_cost: 300,
+        prompt_id: "sample_prompt_id",
+        prompt_name: "sample_prompt_name",
+        prompt_version: 1,
+        end_time: Date.now(),
+        completion_start_time: Date.now(),
+      });
+  
+      await createObservationsCh([observation]);
+  
+      const result = await getObservationById({
+        id: observationId,
+        projectId,
+        traceId,
+        fetchWithInputOutput: true,
+      });
     if (!result) {
       throw new Error("Observation not found");
     }
@@ -75,27 +120,6 @@ describe("Clickhouse Observations Repository Test", () => {
     expect(result.traceId).toEqual(observation.trace_id);
     expect(result.projectId).toEqual(observation.project_id);
     expect(result.type).toEqual(observation.type);
-    expect(result.metadata).toEqual(observation.metadata);
-    expect(result.createdAt).toEqual(new Date(observation.created_at));
-    expect(result.updatedAt).toEqual(new Date(observation.updated_at));
-    expect(result.startTime).toEqual(new Date(observation.start_time));
-    expect(result.name).toEqual(observation.name);
-    expect(result.level).toEqual(observation.level);
-    expect(result.statusMessage).toEqual(observation.status_message);
-    expect(result.version).toEqual(observation.version);
-    expect(result.input).toEqual(observation.input);
-    expect(result.output).toEqual(observation.output);
-    expect(result.internalModelId).toEqual(observation.internal_model_id);
-    expect(result.modelParameters).toEqual({ something: "sample_param" });
-    expect(result.promptId).toEqual(observation.prompt_id);
-    expect(result.endTime).toEqual(new Date(observation.end_time!));
-    expect(result.completionStartTime).toEqual(
-      new Date(observation.completion_start_time!),
-    );
-    expect(result.totalCost).toEqual(observation.total_cost!);
-    expect(result.inputUsage).toEqual(1234);
-    expect(result.outputUsage).toEqual(5678);
-    expect(result.totalUsage).toEqual(6912);
   });
   it("should return an observation view", async () => {
     const observationId = v4();

--- a/web/src/__tests__/async/repositories/observation-repository.servertest.ts
+++ b/web/src/__tests__/async/repositories/observation-repository.servertest.ts
@@ -69,6 +69,10 @@ describe("Clickhouse Observations Repository Test", () => {
       fetchWithInputOutput: true,
     });
 
+    if (!result) {
+      throw new Error("Observation not found");
+    }
+
     expect(result.id).toEqual(observation.id);
     expect(result.traceId).toEqual(observation.trace_id);
     expect(result.projectId).toEqual(observation.project_id);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes `getObservationByIdInternal` to include `traceId` in query parameters and adds a test for this behavior.
> 
>   - **Behavior**:
>     - Fixes `getObservationByIdInternal` in `observations.ts` to include `traceId` in query parameters for filtering observations by `traceId`.
>   - **Tests**:
>     - Adds test case in `observation-repository.servertest.ts` to verify observation retrieval by `traceId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1c670f5887c24b0f0de1a628811826e61da8714c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->