### PR TITLE
fix(dashboard): avoid invalid filter name on view switches

### DIFF
--- a/web/src/features/query/server/queryBuilder.ts
+++ b/web/src/features/query/server/queryBuilder.ts
@@ -138,6 +138,12 @@ export class QueryBuilder {
       } else if (filter.column === "metadata") {
         clickhouseSelect = "metadata";
         type = "stringObject";
+      } else if (filter.column.endsWith("Name")) {
+        // Sometimes, the filter does not update correctly and sends us scoreName instead of name for scores, etc.
+        // If this happens, none of the conditions above apply, and we use this fallback to avoid raising an error.
+        // As this is hard to catch, we include this workaround. (LFE-4838).
+        clickhouseSelect = "name";
+        type = "string";
       } else {
         throw new InvalidRequestError(
           `Invalid filter column ${filter.column}. Must be one of ${Object.keys(view.dimensions)} or ${view.timeDimension}`,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds fallback logic in `queryBuilder.ts` to handle incorrect filter names ending with "Name", ensuring queries do not raise errors, with tests in `queryBuilder.servertest.ts`.
> 
>   - **Behavior**:
>     - Adds fallback logic in `mapFilters()` in `queryBuilder.ts` to handle filter columns ending with "Name" by mapping them to "name".
>     - Ensures queries with incorrect filter names (e.g., "scoreName") do not raise errors.
>   - **Tests**:
>     - Adds test case in `queryBuilder.servertest.ts` to verify fallback handling for "scoreName" filter in "scores-numeric" view.
>     - Confirms that the query correctly filters by "name" and returns expected results.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 022d02fa3073fa099a4945a000c9d42f7d478bcd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->