### PR TITLE
chore: change logging pattern around redis retries

### DIFF
--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -1,5 +1,5 @@
 import Redis, { RedisOptions } from "ioredis";
-import fs from 'fs';
+import fs from "fs";
 import { env } from "../../env";
 import { logger } from "../logger";
 
@@ -10,8 +10,11 @@ const defaultRedisOptions: Partial<RedisOptions> = {
 
 export const redisQueueRetryOptions: Partial<RedisOptions> = {
   retryStrategy: (times: number) => {
+    if (times >= 5) {
+      // A few retries are expected and no cause for action.
+      logger.warn(`Connection to redis lost. Retry attempt: ${times}`);
+    }
     // Retries forever. Waits at least 1s and at most 20s between retries.
-    logger.warn(`Connection to redis lost. Retry attempt: ${times}`);
     return Math.max(Math.min(Math.exp(times), 20000), 1000);
   },
   reconnectOnError: (err) => {
@@ -29,9 +32,15 @@ export const createNewRedisInstance = (
   const tlsOptions = tlsEnabled
     ? {
         tls: {
-          ca: env.REDIS_TLS_CA_PATH ? fs.readFileSync(env.REDIS_TLS_CA_PATH) : undefined,
-          cert: env.REDIS_TLS_CERT_PATH ? fs.readFileSync(env.REDIS_TLS_CERT_PATH) : undefined,
-          key: env.REDIS_TLS_KEY_PATH ? fs.readFileSync(env.REDIS_TLS_KEY_PATH) : undefined,
+          ca: env.REDIS_TLS_CA_PATH
+            ? fs.readFileSync(env.REDIS_TLS_CA_PATH)
+            : undefined,
+          cert: env.REDIS_TLS_CERT_PATH
+            ? fs.readFileSync(env.REDIS_TLS_CERT_PATH)
+            : undefined,
+          key: env.REDIS_TLS_KEY_PATH
+            ? fs.readFileSync(env.REDIS_TLS_KEY_PATH)
+            : undefined,
         },
       }
     : {};


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/6344

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change logging in `redisQueueRetryOptions` to log only after 5 retries and improve code formatting in `redis.ts`.
> 
>   - **Behavior**:
>     - Modify `retryStrategy` in `redisQueueRetryOptions` to log a warning only after 5 retry attempts instead of every attempt.
>   - **Formatting**:
>     - Change single quotes to double quotes in `import fs` statement in `redis.ts`.
>     - Reformat `tlsOptions` object for better readability in `createNewRedisInstance()` in `redis.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0f1bd8a391d9611a6d9e34d29bdb766cac38b9a1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->