### PR TITLE
fix(dashboard): map traceRelease and traceVersion correctly on breakdown

### DIFF
--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -191,11 +191,13 @@ export const observationsView: ViewDeclarationType = {
     },
     traceRelease: {
       sql: "release",
+      alias: "traceRelease",
       type: "string",
       relationTable: "traces",
     },
     traceVersion: {
       sql: "version",
+      alias: "traceVersion",
       type: "string",
       relationTable: "traces",
     },
@@ -310,11 +312,13 @@ const scoreBaseDimensions: DimensionsDeclarationType = {
   },
   traceRelease: {
     sql: "release",
+    alias: "traceRelease",
     type: "string",
     relationTable: "traces",
   },
   traceVersion: {
     sql: "version",
+    alias: "traceVersion",
     type: "string",
     relationTable: "traces",
   },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add aliases `traceRelease` and `traceVersion` to ensure correct mapping in `observationsView` and `scoreBaseDimensions`.
> 
>   - **Data Model Changes**:
>     - Add alias `traceRelease` for `release` in `observationsView` and `scoreBaseDimensions`.
>     - Add alias `traceVersion` for `version` in `observationsView` and `scoreBaseDimensions`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 56a725b44019b70c5fa699074a13366e53eaa19c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->