### PR TITLE
feat(dashboard): add new widget to dashboard on save

### DIFF
--- a/web/src/features/dashboard/components/SelectDashboardDialog.tsx
+++ b/web/src/features/dashboard/components/SelectDashboardDialog.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { useRouter } from "next/router";
 import { api } from "@/src/utils/api";
 import {
   Dialog,
@@ -22,7 +21,6 @@ export interface SelectDashboardDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   projectId: string;
-  widgetId: string;
   onSelectDashboard: (dashboardId: string) => void;
   onSkip: () => void;
 }
@@ -37,7 +35,6 @@ export function SelectDashboardDialog({
   const [selectedDashboardId, setSelectedDashboardId] = useState<string | null>(
     null,
   );
-  const router = useRouter();
 
   const dashboards = api.dashboard.allDashboards.useQuery(
     {

--- a/web/src/features/dashboard/components/SelectDashboardDialog.tsx
+++ b/web/src/features/dashboard/components/SelectDashboardDialog.tsx
@@ -1,0 +1,128 @@
+import React, { useState } from "react";
+import { useRouter } from "next/router";
+import { api } from "@/src/utils/api";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/src/components/ui/dialog";
+import { Button } from "@/src/components/ui/button";
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from "@/src/components/ui/table";
+
+export interface SelectDashboardDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  widgetId: string;
+  onSelectDashboard: (dashboardId: string) => void;
+  onSkip: () => void;
+}
+
+export function SelectDashboardDialog({
+  open,
+  onOpenChange,
+  projectId,
+  onSelectDashboard,
+  onSkip,
+}: SelectDashboardDialogProps) {
+  const [selectedDashboardId, setSelectedDashboardId] = useState<string | null>(
+    null,
+  );
+  const router = useRouter();
+
+  const dashboards = api.dashboard.allDashboards.useQuery(
+    {
+      projectId,
+      orderBy: {
+        column: "updatedAt",
+        order: "DESC",
+      },
+    },
+    {
+      enabled: Boolean(projectId) && open,
+    },
+  );
+
+  const handleAdd = () => {
+    if (selectedDashboardId) {
+      onSelectDashboard(selectedDashboardId);
+      onOpenChange(false);
+    }
+  };
+
+  const handleSkip = () => {
+    onSkip();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[800px]">
+        <DialogHeader>
+          <DialogTitle>Select dashboard to add widget to</DialogTitle>
+        </DialogHeader>
+
+        <div className="mt-4 max-h-[400px] overflow-y-auto">
+          {dashboards.isLoading ? (
+            <div className="py-8 text-center">Loading dashboards...</div>
+          ) : dashboards.isError ? (
+            <div className="py-8 text-center text-destructive">
+              Error: {dashboards.error.message}
+            </div>
+          ) : dashboards.data?.dashboards.length === 0 ? (
+            <div className="py-8 text-center text-muted-foreground">
+              No dashboards found.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Description</TableHead>
+                  <TableHead>Updated</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {dashboards.data?.dashboards.map((d) => (
+                  <TableRow
+                    key={d.id}
+                    onClick={() => setSelectedDashboardId(d.id)}
+                    className={`cursor-pointer hover:bg-muted ${
+                      selectedDashboardId === d.id ? "bg-muted" : ""
+                    }`}
+                  >
+                    <TableCell className="font-medium">{d.name}</TableCell>
+                    <TableCell className="max-w-[200px] truncate">
+                      {d.description}
+                    </TableCell>
+                    <TableCell>
+                      {new Date(d.updatedAt).toLocaleString()}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </div>
+
+        <DialogFooter className="mt-4 flex justify-between">
+          <Button variant="outline" onClick={handleSkip}>
+            Skip
+          </Button>
+          <Button onClick={handleAdd} disabled={!selectedDashboardId}>
+            Add to Dashboard
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/pages/project/[projectId]/widgets/new.tsx
+++ b/web/src/pages/project/[projectId]/widgets/new.tsx
@@ -10,6 +10,8 @@ import {
   type metricAggregations,
 } from "@/src/features/query/types";
 import { type z } from "zod";
+import { SelectDashboardDialog } from "@/src/features/dashboard/components/SelectDashboardDialog";
+import { useState } from "react";
 
 export default function NewWidget() {
   const router = useRouter();
@@ -18,7 +20,6 @@ export default function NewWidget() {
     dashboardId?: string;
   };
 
-  // Save widget mutation
   const createWidgetMutation = api.dashboardWidgets.create.useMutation({
     onSuccess: (data) => {
       showSuccessToast({
@@ -26,14 +27,13 @@ export default function NewWidget() {
         description: "Your widget has been created.",
       });
 
-      // If dashboardId is provided, redirect back to the dashboard with the new widget ID
       if (dashboardId) {
         void router.push(
           `/project/${projectId}/dashboards/${dashboardId}?addWidgetId=${data.widget.id}`,
         );
       } else {
-        // Otherwise, navigate to widgets list
-        void router.push(`/project/${projectId}/widgets`);
+        setPendingWidgetId(data.widget.id); // store for dialog
+        setDashboardDialogOpen(true);
       }
     },
     onError: (error) => {
@@ -41,7 +41,6 @@ export default function NewWidget() {
     },
   });
 
-  // Handle save widget
   const handleSaveWidget = (widgetData: {
     name: string;
     description: string;
@@ -74,6 +73,9 @@ export default function NewWidget() {
     });
   };
 
+  const [dashboardDialogOpen, setDashboardDialogOpen] = useState(false);
+  const [pendingWidgetId, setPendingWidgetId] = useState<string | null>(null);
+
   return (
     <Page
       withPadding
@@ -98,6 +100,22 @@ export default function NewWidget() {
           chartType: "LINE_TIME_SERIES",
         }}
       />
+      {pendingWidgetId && (
+        <SelectDashboardDialog
+          open={dashboardDialogOpen}
+          onOpenChange={setDashboardDialogOpen}
+          projectId={projectId}
+          widgetId={pendingWidgetId}
+          onSelectDashboard={(dashboardId) => {
+            router.push(
+              `/project/${projectId}/dashboards/${dashboardId}?addWidgetId=${pendingWidgetId}`,
+            );
+          }}
+          onSkip={() => {
+            router.push(`/project/${projectId}/widgets`);
+          }}
+        />
+      )}
     </Page>
   );
 }

--- a/web/src/pages/project/[projectId]/widgets/new.tsx
+++ b/web/src/pages/project/[projectId]/widgets/new.tsx
@@ -105,7 +105,6 @@ export default function NewWidget() {
           open={dashboardDialogOpen}
           onOpenChange={setDashboardDialogOpen}
           projectId={projectId}
-          widgetId={pendingWidgetId}
           onSelectDashboard={(dashboardId) => {
             router.push(
               `/project/${projectId}/dashboards/${dashboardId}?addWidgetId=${pendingWidgetId}`,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `SelectDashboardDialog` to allow selecting a dashboard for a new widget on save, integrated into the widget creation process.
> 
>   - **Feature**:
>     - Adds `SelectDashboardDialog` component in `SelectDashboardDialog.tsx` to allow users to select a dashboard to add a widget to.
>     - Integrates `SelectDashboardDialog` in `new.tsx` to prompt users to select a dashboard after widget creation if no `dashboardId` is provided.
>   - **Behavior**:
>     - On widget creation success, if `dashboardId` is not provided, opens `SelectDashboardDialog` to select a dashboard or skip.
>     - Handles loading, error, and empty states for dashboard selection.
>   - **State Management**:
>     - Uses `useState` to manage `dashboardDialogOpen` and `pendingWidgetId` in `new.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6187dafad502e1db88d11980039ff5577bd0c34d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->