### PR TITLE
feat(dashboard): add documentation hovers onto widget properties

### DIFF
--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -10,89 +10,115 @@ import {
 
 export const traceView: ViewDeclarationType = {
   name: "traces",
+  description:
+    "Traces represent a group of observations and typically represent a single request or operation.",
   dimensions: {
     id: {
       sql: "id",
       type: "string",
+      description: "Unique identifier of the trace.",
     },
     name: {
       sql: "name",
       type: "string",
+      description:
+        "Name assigned to the trace (often the endpoint or operation).",
     },
     tags: {
       sql: "tags",
       type: "string[]",
+      description: "User-defined tags associated with the trace.",
     },
     userId: {
       sql: "user_id",
       alias: "userId",
       type: "string",
+      description: "Identifier of the user triggering the trace.",
     },
     sessionId: {
       sql: "session_id",
       alias: "sessionId",
       type: "string",
+      description: "Identifier of the session triggering the trace.",
     },
     release: {
       sql: "release",
       type: "string",
+      description: "Release version of the trace.",
     },
     version: {
       sql: "version",
       type: "string",
+      description: "Version of the trace.",
     },
     environment: {
       sql: "environment",
       type: "string",
+      description: "Deployment environment (e.g., production, staging).",
     },
     observationName: {
       sql: "name",
       alias: "observationName",
       type: "string",
       relationTable: "observations",
+      description: "Name of the observation.",
     },
     scoreName: {
       sql: "name",
       alias: "scoreName",
       type: "string",
       relationTable: "scores",
+      description: "Name of the score.",
     },
   },
   measures: {
     count: {
       sql: "count(*)",
       alias: "count",
-      type: "count",
+      type: "integer",
+      description: "Total number of traces.",
+      unit: "traces",
     },
     observationsCount: {
       sql: "uniq(observations.id)",
       alias: "observationsCount",
-      type: "count",
+      type: "integer",
       relationTable: "observations",
+      description: "Unique observations linked to the trace.",
+      unit: "observations",
     },
     scoresCount: {
       sql: "uniq(scores.id)",
       alias: "scoresCount",
-      type: "count",
+      type: "integer",
       relationTable: "scores",
+      description: "Unique scores attached to the trace.",
+      unit: "scores",
     },
     latency: {
       sql: "date_diff('millisecond', min(observations.start_time), max(observations.end_time))",
       alias: "latency",
-      type: "number",
+      type: "integer",
       relationTable: "observations",
+      description:
+        "Elapsed time between the first and last observation inside the trace.",
+      unit: "millisecond",
     },
     totalTokens: {
       sql: "sumMap(observations.usage_details)['total']",
       alias: "totalTokens",
-      type: "sum",
+      type: "integer",
       relationTable: "observations",
+      description: "Sum of tokens consumed by all observations in the trace.",
+      unit: "tokens",
     },
     totalCost: {
       sql: "sum(observations.total_cost)",
       alias: "totalCost",
-      type: "sum",
+      type: "decimal",
       relationTable: "observations",
+      description: "Total cost accumulated across observations in the trace.",
+      unit: "USD",
     },
   },
   tableRelations: {
@@ -116,127 +142,161 @@ export const traceView: ViewDeclarationType = {
 
 export const observationsView: ViewDeclarationType = {
   name: "observations",
+  description:
+    "Observations represent individual requests or operations within a trace. They are grouped into Spans, Generations, and Events.",
   dimensions: {
     id: {
       sql: "id",
       type: "string",
+      description: "Unique identifier for the observation.",
     },
     traceId: {
       sql: "trace_id",
       alias: "traceId",
       type: "string",
+      description: "Identifier linking the observation to its parent trace.",
     },
     traceName: {
       sql: "name",
       alias: "traceName",
       type: "string",
       relationTable: "traces",
+      description: "Name of the parent trace.",
     },
     environment: {
       sql: "environment",
       type: "string",
+      description: "Deployment environment (e.g., production, staging).",
     },
     parentObservationId: {
       sql: "parent_observation_id",
       alias: "parentObservationId",
       type: "string",
+      description:
+        "Identifier of the parent observation. Empty for the root span.",
     },
     type: {
       sql: "type",
       type: "string",
+      description:
+        "Type of the observation. Can be a SPAN, GENERATION, or EVENT.",
     },
     name: {
       sql: "name",
       type: "string",
+      description: "Name of the observation.",
     },
     level: {
       sql: "level",
       type: "string",
+      description: "Logging level of the observation.",
     },
     version: {
       sql: "version",
       type: "string",
+      description: "Version of the observation.",
     },
     tags: {
       sql: "tags",
       type: "string[]",
       relationTable: "traces",
+      description: "User-defined tags associated with the trace.",
     },
     providedModelName: {
       sql: "provided_model_name",
       alias: "providedModelName",
       type: "string",
+      description: "Name of the model used for the observation.",
     },
     promptName: {
       sql: "prompt_name",
       alias: "promptName",
       type: "string",
+      description: "Name of the prompt used for the observation.",
     },
     promptVersion: {
       sql: "prompt_version",
       alias: "promptVersion",
       type: "string",
+      description: "Version of the prompt used for the observation.",
     },
     userId: {
       sql: "user_id",
       alias: "userId",
       type: "string",
       relationTable: "traces",
+      description: "Identifier of the user triggering the observation.",
     },
     sessionId: {
       sql: "session_id",
       alias: "sessionId",
       type: "string",
       relationTable: "traces",
+      description: "Identifier of the session triggering the observation.",
     },
     traceRelease: {
       sql: "release",
       type: "string",
       relationTable: "traces",
+      description: "Release version of the parent trace.",
     },
     traceVersion: {
       sql: "version",
       type: "string",
       relationTable: "traces",
+      description: "Version of the parent trace.",
     },
     scoreName: {
       sql: "name",
       alias: "scoreName",
       type: "string",
       relationTable: "scores",
+      description: "Name of the score.",
     },
   },
   measures: {
     count: {
       sql: "count(*)",
       alias: "count",
-      type: "count",
+      type: "integer",
+      description: "Total number of observations.",
+      unit: "observations",
     },
     latency: {
       sql: "date_diff('millisecond', any(observations.start_time), any(observations.end_time))",
       alias: "latency",
-      type: "number",
+      type: "integer",
+      description: "Latency of an individual observation.",
+      unit: "ms",
     },
     totalTokens: {
       sql: "sumMap(usage_details)['total']",
       alias: "totalTokens",
-      type: "sum",
+      type: "integer",
+      description: "Sum of tokens consumed by the observation.",
+      unit: "tokens",
     },
     totalCost: {
       sql: "sum(total_cost)",
       alias: "totalCost",
-      type: "sum",
+      type: "decimal",
+      description: "Total cost accumulated by the observation.",
+      unit: "USD",
     },
     timeToFirstToken: {
       sql: "date_diff('millisecond', any(observations.start_time), any(observations.completion_start_time))",
       alias: "timeToFirstToken",
-      type: "number",
+      type: "integer",
+      description: "Time to first token for the observation.",
+      unit: "ms",
     },
     countScores: {
       sql: "uniq(scores.id)",
       alias: "countScores",
-      type: "count",
+      type: "integer",
       relationTable: "scores",
+      description: "Unique scores attached to the observation.",
+      unit: "scores",
     },
   },
   tableRelations: {
@@ -262,100 +322,121 @@ const scoreBaseDimensions: DimensionsDeclarationType = {
   id: {
     sql: "id",
     type: "string",
+    description: "Unique identifier of the score entry.",
   },
   environment: {
     sql: "environment",
     type: "string",
+    description: "Deployment environment (e.g., production, staging).",
   },
   name: {
     sql: "name",
     type: "string",
+    description: "Name of the score (e.g., accuracy, toxicity).",
   },
   source: {
     sql: "source",
     type: "string",
+    description: "Origin of the score. Can be API, ANNOTATION, or EVAL.",
   },
   dataType: {
     sql: "data_type",
     alias: "dataType",
     type: "string",
+    description:
+      "Internal data type of the score (NUMERIC, BOOLEAN, CATEGORICAL).",
   },
   traceId: {
     sql: "trace_id",
     alias: "traceId",
     type: "string",
+    description: "Identifier of the parent trace.",
   },
   traceName: {
     sql: "name",
     alias: "traceName",
     type: "string",
     relationTable: "traces",
+    description: "Name of the parent trace.",
   },
   tags: {
     sql: "tags",
     type: "string[]",
     relationTable: "traces",
+    description: "User-defined tags associated with the trace.",
   },
   userId: {
     sql: "user_id",
     alias: "userId",
     type: "string",
     relationTable: "traces",
+    description: "Identifier of the user triggering the trace.",
   },
   sessionId: {
     sql: "session_id",
     alias: "sessionId",
     type: "string",
     relationTable: "traces",
+    description: "Identifier of the session triggering the trace.",
   },
   traceRelease: {
     sql: "release",
     type: "string",
     relationTable: "traces",
+    description: "Release version of the parent trace.",
   },
   traceVersion: {
     sql: "version",
     type: "string",
     relationTable: "traces",
+    description: "Version of the parent trace.",
   },
   observationId: {
     sql: "observation_id",
     alias: "observationId",
     type: "string",
+    description: "Identifier of the observation associated with the score.",
   },
   observationName: {
     sql: "name",
     alias: "observationName",
     type: "string",
     relationTable: "observations",
+    description: "Name of the observation associated with the score.",
   },
   observationModelName: {
     sql: "provided_model_name",
     alias: "observationModelName",
     type: "string",
     relationTable: "observations",
+    description: "Name of the model used for the observation.",
   },
   observationPromptName: {
     sql: "prompt_name",
     alias: "observationPromptName",
     type: "string",
     relationTable: "observations",
+    description: "Name of the prompt used for the observation.",
   },
   observationPromptVersion: {
     sql: "prompt_version",
     alias: "observationPromptVersion",
     type: "string",
     relationTable: "observations",
+    description: "Version of the prompt used for the observation.",
   },
   configId: {
     sql: "config_id",
     alias: "configId",
     type: "string",
+    description: "Identifier of the config associated with the score.",
   },
 };
 
 export const scoresNumericView: ViewDeclarationType = {
   name: "scores_numeric",
+  description:
+    "Scores are flexible objects that are used for evaluations. This view contains numeric scores.",
   dimensions: {
     ...scoreBaseDimensions,
   },
@@ -363,12 +444,15 @@ export const scoresNumericView: ViewDeclarationType = {
     count: {
       sql: "count(*)",
       alias: "count",
-      type: "count",
+      type: "integer",
+      description: "Total number of scores.",
+      unit: "scores",
     },
     value: {
       sql: "any(value)",
       alias: "value",
       type: "number",
+      description: "Value of the score.",
     },
   },
   tableRelations: {
@@ -400,19 +484,24 @@ export const scoresNumericView: ViewDeclarationType = {
 
 export const scoresCategoricalView: ViewDeclarationType = {
   name: "scores_categorical",
+  description:
+    "Scores are flexible objects that are used for evaluations. This view contains categorical scores.",
   dimensions: {
     ...scoreBaseDimensions,
     stringValue: {
       sql: "string_value",
       alias: "stringValue",
       type: "string",
+      description: "Value of the score.",
     },
   },
   measures: {
     count: {
       sql: "count(*)",
       alias: "count",
-      type: "count",
+      type: "integer",
+      description: "Total number of scores.",
+      unit: "scores",
     },
   },
   tableRelations: {

--- a/web/src/features/query/server/queryBuilder.ts
+++ b/web/src/features/query/server/queryBuilder.ts
@@ -120,7 +120,7 @@ export class QueryBuilder {
       if (filter.column in view.dimensions) {
         const dimension = view.dimensions[filter.column];
         clickhouseSelect = dimension.sql;
-        type = dimension.type;
+        type = "string";
         if (dimension.relationTable) {
           clickhouseTableName = dimension.relationTable;
         }

--- a/web/src/features/query/types.ts
+++ b/web/src/features/query/types.ts
@@ -8,22 +8,27 @@ export type DimensionsDeclarationType = z.infer<
 
 export const viewDeclaration = z.object({
   name: z.string(),
+  description: z.string(),
   // This is the basic statement that we query from. Usually, this should be the view_name + FINAL or a more complex subquery.
   baseCte: z.string(),
   dimensions: z.record(
     z.object({
       sql: z.string(),
       alias: z.string().optional(),
-      type: z.enum(["string", "number", "bool", "string[]"]),
       relationTable: z.string().optional(),
+      description: z.string().optional(),
+      type: z.string().optional(),
+      unit: z.string().optional(),
     }),
   ),
   measures: z.record(
     z.object({
       sql: z.string(),
       alias: z.string().optional(),
-      type: z.enum(["count", "sum", "number"]),
       relationTable: z.string().optional(),
+      description: z.string().optional(),
+      type: z.string().optional(),
+      unit: z.string().optional(),
     }),
   ),
   tableRelations: z.record(

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -22,6 +22,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/src/components/ui/select";
+import { WidgetPropertySelectItem } from "@/src/features/widgets/components/WidgetPropertySelectItem";
 import { Label } from "@/src/components/ui/label";
 import { viewDeclarations } from "@/src/features/query/dataModel";
 import { type z } from "zod";
@@ -409,9 +410,12 @@ export function WidgetForm({
                   </SelectTrigger>
                   <SelectContent>
                     {views.options.map((view) => (
-                      <SelectItem key={view} value={view}>
-                        {startCase(view)}
-                      </SelectItem>
+                      <WidgetPropertySelectItem
+                        key={view}
+                        value={view}
+                        label={startCase(view)}
+                        description={viewDeclarations[view].description}
+                      />
                     ))}
                   </SelectContent>
                 </Select>
@@ -428,11 +432,22 @@ export function WidgetForm({
                     <SelectValue placeholder="Select metrics" />
                   </SelectTrigger>
                   <SelectContent>
-                    {availableMetrics.map((metric) => (
-                      <SelectItem key={metric.value} value={metric.value}>
-                        {metric.label}
-                      </SelectItem>
-                    ))}
+                    {availableMetrics.map((metric) => {
+                      const meta =
+                        viewDeclarations[selectedView]?.measures?.[
+                          metric.value
+                        ];
+                      return (
+                        <WidgetPropertySelectItem
+                          key={metric.value}
+                          value={metric.value}
+                          label={metric.label}
+                          description={meta?.description}
+                          unit={meta?.unit}
+                          type={meta?.type}
+                        />
+                      );
+                    })}
                   </SelectContent>
                 </Select>
                 {selectedMeasure !== "count" && (
@@ -484,11 +499,22 @@ export function WidgetForm({
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="none">None</SelectItem>
-                    {availableDimensions.map((dimension) => (
-                      <SelectItem key={dimension.value} value={dimension.value}>
-                        {dimension.label}
-                      </SelectItem>
-                    ))}
+                    {availableDimensions.map((dimension) => {
+                      const meta =
+                        viewDeclarations[selectedView]?.dimensions?.[
+                          dimension.value
+                        ];
+                      return (
+                        <WidgetPropertySelectItem
+                          key={dimension.value}
+                          value={dimension.value}
+                          label={dimension.label}
+                          description={meta?.description}
+                          unit={meta?.unit}
+                          type={meta?.type}
+                        />
+                      );
+                    })}
                   </SelectContent>
                 </Select>
               </div>

--- a/web/src/features/widgets/components/WidgetPropertySelectItem.tsx
+++ b/web/src/features/widgets/components/WidgetPropertySelectItem.tsx
@@ -1,0 +1,58 @@
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/src/components/ui/hover-card";
+import { HoverCardPortal } from "@radix-ui/react-hover-card";
+import { SelectItem } from "@/src/components/ui/select";
+import * as React from "react";
+
+/**
+ * Generic SelectItem with a hover-card that shows documentation for a widget property
+ * (view, metric, dimension).
+ */
+export const WidgetPropertySelectItem = ({
+  value,
+  label,
+  description,
+  unit,
+  type,
+  className,
+}: {
+  value: string;
+  label: string;
+  description?: string;
+  unit?: string;
+  type?: string;
+  className?: string;
+}) => {
+  return (
+    <HoverCard openDelay={100} closeDelay={50}>
+      <HoverCardTrigger asChild>
+        <SelectItem value={value} className={className ?? "max-w-56"}>
+          {label}
+        </SelectItem>
+      </HoverCardTrigger>
+      <HoverCardPortal>
+        <HoverCardContent hideWhenDetached align="start" side="right">
+          <div className="mb-1 font-bold">{label}</div>
+          {(unit || type) && (
+            <div className="mb-2 flex flex-wrap gap-2 text-xs">
+              {unit && (
+                <span className="rounded bg-muted px-1.5 py-0.5 text-muted-foreground">
+                  Unit: {unit}
+                </span>
+              )}
+              {type && (
+                <span className="rounded bg-muted px-1.5 py-0.5 text-muted-foreground">
+                  Type: {type}
+                </span>
+              )}
+            </div>
+          )}
+          {description && <p className="text-xs leading-snug">{description}</p>}
+        </HoverCardContent>
+      </HoverCardPortal>
+    </HoverCard>
+  );
+};

--- a/web/src/features/widgets/components/WidgetPropertySelectItem.tsx
+++ b/web/src/features/widgets/components/WidgetPropertySelectItem.tsx
@@ -27,7 +27,7 @@ export const WidgetPropertySelectItem = ({
   className?: string;
 }) => {
   return (
-    <HoverCard openDelay={100} closeDelay={50}>
+    <HoverCard openDelay={0} closeDelay={0}>
       <HoverCardTrigger asChild>
         <SelectItem value={value} className={className ?? "max-w-56"}>
           {label}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds hover documentation to widget properties in the dashboard, displaying descriptions, types, and units for views, metrics, and dimensions.
> 
>   - **Behavior**:
>     - Adds hover documentation to widget properties (views, metrics, dimensions) in `WidgetForm.tsx` using `WidgetPropertySelectItem`.
>     - Displays descriptions, types, and units for each property.
>   - **Components**:
>     - Introduces `WidgetPropertySelectItem` in `WidgetPropertySelectItem.tsx` for displaying hover cards with property details.
>     - Updates `WidgetForm.tsx` to use `WidgetPropertySelectItem` for view, metric, and dimension selections.
>   - **Data Model**:
>     - Adds `description`, `type`, and `unit` fields to dimensions and measures in `dataModel.ts` and `types.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3a90f4e9ce7f1d91c8f0958483546b33a6dc562c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->