### PR TITLE
perf: skip zod validation for otel event batches

### DIFF
--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -77,11 +77,13 @@ const getDelay = (delay: number | null) => {
  * @param input - Batch of IngestionEventType. Will validate the types first thing and return errors if they are invalid.
  * @param authCheck - AuthHeaderValidVerificationResult
  * @param delay - (Optional) Delay in ms to wait before processing events in the batch.
+ * @param validateBatch - (Optional) Options to control validation.
  */
 export const processEventBatch = async (
   input: unknown[],
   authCheck: AuthHeaderValidVerificationResult,
   delay: number | null = null,
+  validateBatch: boolean = true,
 ): Promise<{
   successes: { id: string; status: number }[];
   errors: {
@@ -116,27 +118,36 @@ export const processEventBatch = async (
 
   const batch: z.infer<typeof ingestionEvent>[] = input
     .flatMap((event) => {
-      const parsed = ingestionEvent.safeParse(event);
-      if (!parsed.success) {
-        validationErrors.push({
-          id:
-            typeof event === "object" && event && "id" in event
-              ? typeof event.id === "string"
-                ? event.id
-                : "unknown"
-              : "unknown",
-          error: new InvalidRequestError(parsed.error.message),
-        });
-        return [];
+      let eventData: z.infer<typeof ingestionEvent> | null = null;
+
+      if (validateBatch) {
+        const parsed = ingestionEvent.safeParse(event);
+        if (!parsed.success) {
+          validationErrors.push({
+            id:
+              typeof event === "object" && event && "id" in event
+                ? typeof (event as any).id === "string"
+                  ? (event as any).id
+                  : "unknown"
+                : "unknown",
+            error: new InvalidRequestError(parsed.error.message),
+          });
+          return [];
+        }
+        eventData = parsed.data;
+      } else {
+        // Skip validation – assume input already conforms
+        eventData = event as z.infer<typeof ingestionEvent>;
       }
-      if (!isAuthorized(parsed.data, authCheck)) {
+
+      if (!isAuthorized(eventData, authCheck)) {
         authenticationErrors.push({
-          id: parsed.data.id,
+          id: eventData.id,
           error: new UnauthorizedError("Access Scope Denied"),
         });
         return [];
       }
-      return [parsed.data];
+      return [eventData];
     })
     .flatMap((event) => {
       if (event.type === eventTypes.SDK_LOG) {

--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -126,8 +126,8 @@ export const processEventBatch = async (
           validationErrors.push({
             id:
               typeof event === "object" && event && "id" in event
-                ? typeof (event as any).id === "string"
-                  ? (event as any).id
+                ? typeof event.id === "string"
+                  ? event.id
                   : "unknown"
                 : "unknown",
             error: new InvalidRequestError(parsed.error.message),

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -93,7 +93,7 @@ export default withMiddlewares({
         convertOtelSpanToIngestionEvent,
       );
       // We set a delay of 0 for OTel, as we never expect updates.
-      return processEventBatch(events, auth, 0);
+      return processEventBatch(events, auth, 0, false);
     },
   }),
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds option to skip Zod validation for OTel event batches in `processEventBatch` for performance improvement.
> 
>   - **Behavior**:
>     - Adds `validateBatch` parameter to `processEventBatch` in `processEventBatch.ts` to control validation.
>     - Skips Zod validation for OTel event batches by setting `validateBatch` to `false` in `index.ts`.
>   - **Functions**:
>     - Modifies `processEventBatch` to conditionally parse events based on `validateBatch` flag.
>     - Updates `processEventBatch` call in OTel traces API endpoint in `index.ts` to disable validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 09845ea59a7049296e35b138835bbc1429dcbf32. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->