### PR TITLE
chore: reduce title size in widget item doc hover

### DIFF
--- a/web/src/features/widgets/components/WidgetPropertySelectItem.tsx
+++ b/web/src/features/widgets/components/WidgetPropertySelectItem.tsx
@@ -35,7 +35,7 @@ export const WidgetPropertySelectItem = ({
       </HoverCardTrigger>
       <HoverCardPortal>
         <HoverCardContent hideWhenDetached align="start" side="right">
-          <div className="mb-1 font-bold">{label}</div>
+          <div className="mb-1 font-bold text-sm">{label}</div>
           {(unit || type) && (
             <div className="mb-2 flex flex-wrap gap-2 text-xs">
               {unit && (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce font size of `label` in hover card content of `WidgetPropertySelectItem` to `text-sm`.
> 
>   - **UI Change**:
>     - In `WidgetPropertySelectItem`, reduce font size of `label` in hover card content to `text-sm`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 791fc8325bb52e15c8e2471b2daa800f6a438f0d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->