### PR TITLE
perf: increase socket lifetime and connections for clickhouse client

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -38,6 +38,8 @@ const EnvSchema = z.object({
   CLICKHOUSE_DB: z.string().default("default"),
   CLICKHOUSE_USER: z.string(),
   CLICKHOUSE_PASSWORD: z.string(),
+  CLICKHOUSE_KEEP_ALIVE_IDLE_SOCKET_TTL: z.coerce.number().int().default(9000),
+  CLICKHOUSE_MAX_OPEN_CONNECTIONS: z.coerce.number().int().default(25),
 
   LANGFUSE_INGESTION_QUEUE_DELAY_MS: z.coerce
     .number()

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -83,6 +83,10 @@ export class ClickHouseClientManager {
         password: env.CLICKHOUSE_PASSWORD,
         database: env.CLICKHOUSE_DB,
         http_headers: headers,
+        keep_alive: {
+          idle_socket_ttl: env.CLICKHOUSE_KEEP_ALIVE_IDLE_SOCKET_TTL,
+        },
+        max_open_connections: env.CLICKHOUSE_MAX_OPEN_CONNECTIONS,
         clickhouse_settings: {
           ...cloudOptions,
           ...opts.clickhouse_settings,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add environment variables for ClickHouse client socket TTL and max connections, and update client configuration to use them.
> 
>   - **Environment Variables**:
>     - Added `CLICKHOUSE_KEEP_ALIVE_IDLE_SOCKET_TTL` and `CLICKHOUSE_MAX_OPEN_CONNECTIONS` to `env.ts` with default values 9000 and 25, respectively.
>   - **ClickHouse Client**:
>     - Updated `getClient()` in `client.ts` to use `CLICKHOUSE_KEEP_ALIVE_IDLE_SOCKET_TTL` and `CLICKHOUSE_MAX_OPEN_CONNECTIONS` for `keep_alive` and `max_open_connections` settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2c09b659c97919fbcccaafa8369f0e9b246cf661. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->