### PR TITLE
chore: increase default timeframe in custom dashboards to 7d

### DIFF
--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -102,7 +102,7 @@ export function WidgetForm({
 
   // Filter state
   const { selectedOption, dateRange, setDateRangeAndOption } =
-    useDashboardDateRange();
+    useDashboardDateRange({ defaultRelativeAggregation: "7 days" });
   const [userFilterState, setUserFilterState] = useState<FilterState>(
     initialValues.filters ?? [],
   );

--- a/web/src/hooks/useDashboardDateRange.tsx
+++ b/web/src/hooks/useDashboardDateRange.tsx
@@ -25,17 +25,22 @@ function isDashboardDateRangeAggregationOption(
   return !!dateRange && dateRange in dashboardDateRangeAggregationSettings;
 }
 
-export function useDashboardDateRange(): UseDashboardDateRangeOutput {
+export function useDashboardDateRange(
+  options: {
+    defaultRelativeAggregation?: DashboardDateRangeAggregationOption;
+  } = {},
+): UseDashboardDateRangeOutput {
   const [queryParams, setQueryParams] = useQueryParams({
     dateRange: withDefault(StringParam, "Select a date range"),
     from: StringParam,
     to: StringParam,
   });
 
+  const fallbackAggregation = options.defaultRelativeAggregation ?? "24 hours";
   const initialRangeOption: DashboardDateRangeAggregationOption =
     isDashboardDateRangeAggregationOption(queryParams.dateRange)
       ? queryParams.dateRange
-      : "24 hours";
+      : fallbackAggregation;
 
   const initialRange: DashboardDateRange | undefined =
     queryParams.dateRange !== "Select a date range" &&

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -45,7 +45,7 @@ export default function DashboardDetail() {
 
   // Filter state
   const { selectedOption, dateRange, setDateRangeAndOption } =
-    useDashboardDateRange();
+    useDashboardDateRange({ defaultRelativeAggregation: "7 days" });
   const [userFilterState, setUserFilterState] = useState<FilterState>([]);
 
   // State for handling widget deletion and addition


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default date range for custom dashboards to 7 days in `WidgetForm.tsx` and `index.tsx`.
> 
>   - **Behavior**:
>     - Change default date range in `useDashboardDateRange` to 7 days in `WidgetForm.tsx` and `index.tsx`.
>     - Default aggregation period is now 7 days instead of 24 hours.
>   - **Functions**:
>     - Update `useDashboardDateRange` to accept `defaultRelativeAggregation` option, defaulting to 7 days.
>   - **Misc**:
>     - No changes to other functionalities or components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0bedbac59659e1c6c3304ca4d10a7b4b536439fc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->