### PR TITLE
feat(dashboards): add langfuse managed read-only dashboard support

### DIFF
--- a/packages/shared/src/server/services/DashboardService/DashboardService.ts
+++ b/packages/shared/src/server/services/DashboardService/DashboardService.ts
@@ -30,7 +30,10 @@ export class DashboardService {
     const [dashboards, totalCount] = await Promise.all([
       prisma.dashboard.findMany({
         where: {
-          projectId,
+          OR: [
+            { projectId },
+            { projectId: null },
+          ],
         },
         orderBy: orderBy
           ? [{ [orderBy.column]: orderBy.order.toLowerCase() }]
@@ -40,13 +43,19 @@ export class DashboardService {
       }),
       prisma.dashboard.count({
         where: {
-          projectId,
+          OR: [
+            { projectId },
+            { projectId: null },
+          ],
         },
       }),
     ]);
 
     const domainDashboards = dashboards.map((dashboard) =>
-      DashboardDomainSchema.parse(dashboard),
+      DashboardDomainSchema.parse({
+        ...dashboard,
+        owner: dashboard.projectId ? "PROJECT" : "LANGFUSE",
+      }),
     );
 
     return {
@@ -78,7 +87,10 @@ export class DashboardService {
       },
     });
 
-    return DashboardDomainSchema.parse(newDashboard);
+    return DashboardDomainSchema.parse({
+      ...newDashboard,
+      owner: newDashboard.projectId ? "PROJECT" : "LANGFUSE",
+    });
   }
 
   /**
@@ -111,7 +123,10 @@ export class DashboardService {
       },
     });
 
-    return DashboardDomainSchema.parse(updatedDashboard);
+    return DashboardDomainSchema.parse({
+      ...updatedDashboard,
+      owner: updatedDashboard.projectId ? "PROJECT" : "LANGFUSE",
+    });
   }
 
   /**
@@ -136,7 +151,10 @@ export class DashboardService {
       },
     });
 
-    return DashboardDomainSchema.parse(updatedDashboard);
+    return DashboardDomainSchema.parse({
+      ...updatedDashboard,
+      owner: updatedDashboard.projectId ? "PROJECT" : "LANGFUSE",
+    });
   }
 
   /**
@@ -149,7 +167,10 @@ export class DashboardService {
     const dashboard = await prisma.dashboard.findFirst({
       where: {
         id: dashboardId,
-        projectId,
+        OR: [
+          { projectId },
+          { projectId: null },
+        ],
       },
     });
 
@@ -157,7 +178,10 @@ export class DashboardService {
       return null;
     }
 
-    return DashboardDomainSchema.parse(dashboard);
+    return DashboardDomainSchema.parse({
+      ...dashboard,
+      owner: dashboard.projectId ? "PROJECT" : "LANGFUSE",
+    });
   }
 
   /**
@@ -192,7 +216,10 @@ export class DashboardService {
     const [widgets, totalCount] = await Promise.all([
       prisma.dashboardWidget.findMany({
         where: {
-          projectId,
+          OR: [
+            { projectId },
+            { projectId: null },
+          ],
         },
         orderBy: orderBy
           ? [{ [orderBy.column]: orderBy.order.toLowerCase() }]
@@ -202,13 +229,19 @@ export class DashboardService {
       }),
       prisma.dashboardWidget.count({
         where: {
-          projectId,
+          OR: [
+            { projectId },
+            { projectId: null },
+          ],
         },
       }),
     ]);
 
     const domainWidgets = widgets.map((widget) =>
-      WidgetDomainSchema.parse(widget),
+      WidgetDomainSchema.parse({
+        ...widget,
+        owner: widget.projectId ? "PROJECT" : "LANGFUSE",
+      }),
     );
 
     return {
@@ -241,7 +274,10 @@ export class DashboardService {
       },
     });
 
-    return WidgetDomainSchema.parse(newWidget);
+    return WidgetDomainSchema.parse({
+      ...newWidget,
+      owner: newWidget.projectId ? "PROJECT" : "LANGFUSE",
+    });
   }
 
   /**
@@ -254,7 +290,10 @@ export class DashboardService {
     const widget = await prisma.dashboardWidget.findFirst({
       where: {
         id: widgetId,
-        projectId,
+        OR: [
+          { projectId },
+          { projectId: null },
+        ],
       },
     });
 
@@ -262,7 +301,10 @@ export class DashboardService {
       return null;
     }
 
-    return WidgetDomainSchema.parse(widget);
+    return WidgetDomainSchema.parse({
+      ...widget,
+      owner: widget.projectId ? "PROJECT" : "LANGFUSE",
+    });
   }
 
   /**
@@ -293,20 +335,8 @@ export class DashboardService {
     });
 
     return WidgetDomainSchema.parse({
-      id: widgetId,
-      projectId,
-      createdAt: updatedWidget.createdAt,
-      updatedAt: updatedWidget.updatedAt,
-      createdBy: updatedWidget.createdBy,
-      updatedBy: updatedWidget.updatedBy,
-      name: updatedWidget.name,
-      description: updatedWidget.description,
-      view: updatedWidget.view,
-      dimensions: updatedWidget.dimensions as WidgetDomain["dimensions"],
-      metrics: updatedWidget.metrics as WidgetDomain["metrics"],
-      filters: updatedWidget.filters as WidgetDomain["filters"],
-      chartType: updatedWidget.chartType,
-      chartConfig: updatedWidget.chartConfig as WidgetDomain["chartConfig"],
+      ...updatedWidget,
+      owner: updatedWidget.projectId ? "PROJECT" : "LANGFUSE",
     });
   }
 

--- a/packages/shared/src/server/services/DashboardService/DashboardService.ts
+++ b/packages/shared/src/server/services/DashboardService/DashboardService.ts
@@ -207,7 +207,7 @@ export class DashboardService {
     const [widgets, totalCount] = await Promise.all([
       prisma.dashboardWidget.findMany({
         where: {
-          OR: [{ projectId }, { projectId: null }],
+          projectId,
         },
         orderBy: orderBy
           ? [{ [orderBy.column]: orderBy.order.toLowerCase() }]
@@ -217,7 +217,7 @@ export class DashboardService {
       }),
       prisma.dashboardWidget.count({
         where: {
-          OR: [{ projectId }, { projectId: null }],
+          projectId,
         },
       }),
     ]);
@@ -266,7 +266,7 @@ export class DashboardService {
   }
 
   /**
-   * Gets a dashboard widget by ID.
+   * Gets a dashboard widget by ID. Look either in the current project or in the Langfuse managed widgets.
    */
   public static async getWidget(
     widgetId: string,

--- a/packages/shared/src/server/services/DashboardService/DashboardService.ts
+++ b/packages/shared/src/server/services/DashboardService/DashboardService.ts
@@ -30,10 +30,7 @@ export class DashboardService {
     const [dashboards, totalCount] = await Promise.all([
       prisma.dashboard.findMany({
         where: {
-          OR: [
-            { projectId },
-            { projectId: null },
-          ],
+          OR: [{ projectId }, { projectId: null }],
         },
         orderBy: orderBy
           ? [{ [orderBy.column]: orderBy.order.toLowerCase() }]
@@ -43,10 +40,7 @@ export class DashboardService {
       }),
       prisma.dashboard.count({
         where: {
-          OR: [
-            { projectId },
-            { projectId: null },
-          ],
+          OR: [{ projectId }, { projectId: null }],
         },
       }),
     ]);
@@ -167,10 +161,7 @@ export class DashboardService {
     const dashboard = await prisma.dashboard.findFirst({
       where: {
         id: dashboardId,
-        OR: [
-          { projectId },
-          { projectId: null },
-        ],
+        OR: [{ projectId }, { projectId: null }],
       },
     });
 
@@ -216,10 +207,7 @@ export class DashboardService {
     const [widgets, totalCount] = await Promise.all([
       prisma.dashboardWidget.findMany({
         where: {
-          OR: [
-            { projectId },
-            { projectId: null },
-          ],
+          OR: [{ projectId }, { projectId: null }],
         },
         orderBy: orderBy
           ? [{ [orderBy.column]: orderBy.order.toLowerCase() }]
@@ -229,10 +217,7 @@ export class DashboardService {
       }),
       prisma.dashboardWidget.count({
         where: {
-          OR: [
-            { projectId },
-            { projectId: null },
-          ],
+          OR: [{ projectId }, { projectId: null }],
         },
       }),
     ]);
@@ -290,10 +275,7 @@ export class DashboardService {
     const widget = await prisma.dashboardWidget.findFirst({
       where: {
         id: widgetId,
-        OR: [
-          { projectId },
-          { projectId: null },
-        ],
+        OR: [{ projectId }, { projectId: null }],
       },
     });
 

--- a/packages/shared/src/server/services/DashboardService/types.ts
+++ b/packages/shared/src/server/services/DashboardService/types.ts
@@ -62,6 +62,8 @@ export const DashboardDefinitionSchema = z.object({
   widgets: z.array(DashboardDefinitionWidgetSchema),
 });
 
+export const OwnerEnum = z.enum(["PROJECT", "LANGFUSE"]);
+
 // Define the dashboard domain object
 export const DashboardDomainSchema = z.object({
   id: z.string(),
@@ -73,6 +75,7 @@ export const DashboardDomainSchema = z.object({
   name: z.string(),
   description: z.string(),
   definition: DashboardDefinitionSchema,
+  owner: OwnerEnum,
 });
 
 // Define the dashboard list response
@@ -97,6 +100,7 @@ export const WidgetDomainSchema = z.object({
   filters: z.array(singleFilter),
   chartType: z.nativeEnum(DashboardWidgetChartType),
   chartConfig: ChartConfigSchema,
+  owner: OwnerEnum,
 });
 
 // Define create widget input schema
@@ -123,3 +127,4 @@ export type DashboardListResponse = z.infer<typeof DashboardListResponseSchema>;
 export type WidgetDomain = z.infer<typeof WidgetDomainSchema>;
 export type CreateWidgetInput = z.infer<typeof CreateWidgetInputSchema>;
 export type WidgetListResponse = z.infer<typeof WidgetListResponseSchema>;
+export type Owner = z.infer<typeof OwnerEnum>;

--- a/packages/shared/src/server/services/DashboardService/types.ts
+++ b/packages/shared/src/server/services/DashboardService/types.ts
@@ -127,4 +127,3 @@ export type DashboardListResponse = z.infer<typeof DashboardListResponseSchema>;
 export type WidgetDomain = z.infer<typeof WidgetDomainSchema>;
 export type CreateWidgetInput = z.infer<typeof CreateWidgetInputSchema>;
 export type WidgetListResponse = z.infer<typeof WidgetListResponseSchema>;
-export type Owner = z.infer<typeof OwnerEnum>;

--- a/web/src/features/dashboard/components/DashboardTable.tsx
+++ b/web/src/features/dashboard/components/DashboardTable.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/src/components/ui/dropdown-menu";
 import { DeleteDashboardButton } from "@/src/components/deleteButton";
 import { EditDashboardDialog } from "@/src/features/dashboard/components/EditDashboardDialog";
+import { User as UserIcon } from "lucide-react";
 
 type DashboardTableRow = {
   id: string;
@@ -31,6 +32,7 @@ type DashboardTableRow = {
   description: string;
   createdAt: Date;
   updatedAt: Date;
+  owner: "PROJECT" | "LANGFUSE";
 };
 
 function CloneDashboardButton({
@@ -186,6 +188,25 @@ export function DashboardTable() {
         return row.getValue();
       },
     }),
+    columnHelper.display({
+      id: "ownerTag",
+      header: "Owner",
+      size: 80,
+      cell: (row) => {
+        return row.row.original.owner === "LANGFUSE" ? (
+          <span className="flex gap-1 px-2 py-0.5 text-xs">
+            <span role="img" aria-label="Langfuse">
+              🪢
+            </span>
+            Langfuse
+          </span>
+        ) : (
+          <span className="flex gap-1 px-2 py-0.5 text-xs">
+            <UserIcon className="h-3 w-3" /> User
+          </span>
+        );
+      },
+    }),
     columnHelper.accessor("createdAt", {
       header: "Created At",
       id: "createdAt",
@@ -214,6 +235,7 @@ export function DashboardTable() {
         const id = row.row.original.id;
         const name = row.row.original.name;
         const description = row.row.original.description;
+        const owner = row.row.original.owner;
         return (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -222,24 +244,28 @@ export function DashboardTable() {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent className="flex flex-col [&>*]:w-full [&>*]:justify-start">
-              <DropdownMenuItem asChild>
-                <EditDashboardButton
-                  dashboardId={id}
-                  projectId={projectId}
-                  dashboardName={name}
-                  dashboardDescription={description}
-                />
-              </DropdownMenuItem>
+              {owner === "PROJECT" && (
+                <DropdownMenuItem asChild>
+                  <EditDashboardButton
+                    dashboardId={id}
+                    projectId={projectId}
+                    dashboardName={name}
+                    dashboardDescription={description}
+                  />
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem asChild>
                 <CloneDashboardButton dashboardId={id} projectId={projectId} />
               </DropdownMenuItem>
-              <DropdownMenuItem asChild>
-                <DeleteDashboardButton
-                  itemId={id}
-                  projectId={projectId}
-                  isTableAction
-                />
-              </DropdownMenuItem>
+              {owner === "PROJECT" && (
+                <DropdownMenuItem asChild>
+                  <DeleteDashboardButton
+                    itemId={id}
+                    projectId={projectId}
+                    isTableAction
+                  />
+                </DropdownMenuItem>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         );

--- a/web/src/features/dashboard/components/DashboardTable.tsx
+++ b/web/src/features/dashboard/components/DashboardTable.tsx
@@ -25,6 +25,7 @@ import {
 import { DeleteDashboardButton } from "@/src/components/deleteButton";
 import { EditDashboardDialog } from "@/src/features/dashboard/components/EditDashboardDialog";
 import { User as UserIcon } from "lucide-react";
+import { useRouter } from "next/router";
 
 type DashboardTableRow = {
   id: string;
@@ -126,6 +127,7 @@ function EditDashboardButton({
 export function DashboardTable() {
   const projectId = useProjectIdFromURL() as string;
   const { setDetailPageList } = useDetailPageLists();
+  const router = useRouter();
 
   const [orderByState, setOrderByState] = useOrderByState({
     column: "updatedAt",
@@ -237,37 +239,39 @@ export function DashboardTable() {
         const description = row.row.original.description;
         const owner = row.row.original.owner;
         return (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost">
-                <MoreVertical className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent className="flex flex-col [&>*]:w-full [&>*]:justify-start">
-              {owner === "PROJECT" && (
+          <div onClick={(e) => e.stopPropagation()}>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost">
+                  <MoreVertical className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="flex flex-col [&>*]:w-full [&>*]:justify-start">
+                {owner === "PROJECT" && (
+                  <DropdownMenuItem asChild>
+                    <EditDashboardButton
+                      dashboardId={id}
+                      projectId={projectId}
+                      dashboardName={name}
+                      dashboardDescription={description}
+                    />
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem asChild>
-                  <EditDashboardButton
-                    dashboardId={id}
-                    projectId={projectId}
-                    dashboardName={name}
-                    dashboardDescription={description}
-                  />
+                  <CloneDashboardButton dashboardId={id} projectId={projectId} />
                 </DropdownMenuItem>
-              )}
-              <DropdownMenuItem asChild>
-                <CloneDashboardButton dashboardId={id} projectId={projectId} />
-              </DropdownMenuItem>
-              {owner === "PROJECT" && (
-                <DropdownMenuItem asChild>
-                  <DeleteDashboardButton
-                    itemId={id}
-                    projectId={projectId}
-                    isTableAction
-                  />
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
+                {owner === "PROJECT" && (
+                  <DropdownMenuItem asChild>
+                    <DeleteDashboardButton
+                      itemId={id}
+                      projectId={projectId}
+                      isTableAction
+                    />
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         );
       },
     }),
@@ -297,6 +301,11 @@ export function DashboardTable() {
         totalCount: dashboards.data?.totalCount ?? null,
         onChange: setPaginationState,
         state: paginationState,
+      }}
+      onRowClick={(row) => {
+        router.push(
+          `/project/${projectId}/dashboards/${encodeURIComponent(row.id)}`,
+        );
       }}
     />
   );

--- a/web/src/features/dashboard/components/DashboardTable.tsx
+++ b/web/src/features/dashboard/components/DashboardTable.tsx
@@ -202,7 +202,7 @@ export function DashboardTable() {
           </span>
         ) : (
           <span className="flex gap-1 px-2 py-0.5 text-xs">
-            <UserIcon className="h-3 w-3" /> User
+            <UserIcon className="h-3 w-3" /> Project
           </span>
         );
       },

--- a/web/src/features/dashboard/components/SelectDashboardDialog.tsx
+++ b/web/src/features/dashboard/components/SelectDashboardDialog.tsx
@@ -89,23 +89,25 @@ export function SelectDashboardDialog({
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {dashboards.data?.dashboards.map((d) => (
-                  <TableRow
-                    key={d.id}
-                    onClick={() => setSelectedDashboardId(d.id)}
-                    className={`cursor-pointer hover:bg-muted ${
-                      selectedDashboardId === d.id ? "bg-muted" : ""
-                    }`}
-                  >
-                    <TableCell className="font-medium">{d.name}</TableCell>
-                    <TableCell className="max-w-[200px] truncate">
-                      {d.description}
-                    </TableCell>
-                    <TableCell>
-                      {new Date(d.updatedAt).toLocaleString()}
-                    </TableCell>
-                  </TableRow>
-                ))}
+                {dashboards.data?.dashboards
+                  .filter((d) => d.owner === "PROJECT")
+                  .map((d) => (
+                    <TableRow
+                      key={d.id}
+                      onClick={() => setSelectedDashboardId(d.id)}
+                      className={`cursor-pointer hover:bg-muted ${
+                        selectedDashboardId === d.id ? "bg-muted" : ""
+                      }`}
+                    >
+                      <TableCell className="font-medium">{d.name}</TableCell>
+                      <TableCell className="max-w-[200px] truncate">
+                        {d.description}
+                      </TableCell>
+                      <TableCell>
+                        {new Date(d.updatedAt).toLocaleString()}
+                      </TableCell>
+                    </TableRow>
+                  ))}
               </TableBody>
             </Table>
           )}

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -13,6 +13,7 @@ import { PencilIcon, TrashIcon, CopyIcon } from "lucide-react";
 import { useRouter } from "next/router";
 import { startCase } from "lodash";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 
 interface WidgetPlacement {
   id: string;
@@ -145,6 +146,9 @@ export function DashboardWidget({
           `/project/${projectId}/widgets/${data.widgetId}?dashboardId=${dashboardId}`,
         );
       });
+    },
+    onError: (e) => {
+      showErrorToast("Failed to clone widget", e.message);
     },
   });
   const handleCopy = () => {

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -11,7 +11,6 @@ import { type FilterState } from "@langfuse/shared";
 import { isTimeSeriesChart } from "@/src/features/widgets/chart-library/utils";
 import { PencilIcon, TrashIcon } from "lucide-react";
 import { useRouter } from "next/router";
-import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { startCase } from "lodash";
 
 interface WidgetPlacement {
@@ -35,12 +34,14 @@ export function DashboardWidget({
   dateRange,
   filterState,
   onDeleteWidget,
+  canEdit,
 }: {
   projectId: string;
   placement: WidgetPlacement;
   dateRange: { from: Date; to: Date } | undefined;
   filterState: FilterState;
   onDeleteWidget: (tileId: string) => void;
+  canEdit: boolean;
 }) {
   const router = useRouter();
   const widget = api.dashboardWidgets.get.useQuery(
@@ -52,11 +53,6 @@ export function DashboardWidget({
       enabled: Boolean(projectId),
     },
   );
-
-  const hasCUDAccess = useHasProjectAccess({
-    projectId,
-    scope: "dashboards:CUD",
-  });
 
   const fromTimestamp = dateRange
     ? dateRange.from
@@ -165,24 +161,24 @@ export function DashboardWidget({
     >
       <div className="mb-2 flex items-center justify-between">
         <span className="font-medium">{widget.data.name}</span>
-        <div className="flex space-x-2">
-          <button
-            onClick={handleEdit}
-            className="hidden text-muted-foreground hover:text-foreground group-hover:block"
-            aria-label="Edit widget"
-            disabled={!hasCUDAccess}
-          >
-            <PencilIcon size={16} />
-          </button>
-          <button
-            onClick={handleDelete}
-            className="hidden text-muted-foreground hover:text-destructive group-hover:block"
-            aria-label="Delete widget"
-            disabled={!hasCUDAccess}
-          >
-            <TrashIcon size={16} />
-          </button>
-        </div>
+        {canEdit && (
+          <div className="flex space-x-2">
+            <button
+              onClick={handleEdit}
+              className="hidden text-muted-foreground hover:text-foreground group-hover:block"
+              aria-label="Edit widget"
+            >
+              <PencilIcon size={16} />
+            </button>
+            <button
+              onClick={handleDelete}
+              className="hidden text-muted-foreground hover:text-destructive group-hover:block"
+              aria-label="Delete widget"
+            >
+              <TrashIcon size={16} />
+            </button>
+          </div>
+        )}
       </div>
       <div className="mb-4 text-sm text-muted-foreground">
         {widget.data.description}

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -35,14 +35,14 @@ export function DashboardWidget({
   dateRange,
   filterState,
   onDeleteWidget,
-  owner,
+  dashboardOwner,
 }: {
   projectId: string;
   placement: WidgetPlacement;
   dateRange: { from: Date; to: Date } | undefined;
   filterState: FilterState;
   onDeleteWidget: (tileId: string) => void;
-  owner: "LANGFUSE" | "PROJECT";
+  dashboardOwner: "LANGFUSE" | "PROJECT";
 }) {
   const router = useRouter();
   const widget = api.dashboardWidgets.get.useQuery(
@@ -56,7 +56,7 @@ export function DashboardWidget({
   );
   const hasCUDAccess =
     useHasProjectAccess({ projectId, scope: "dashboards:CUD" }) &&
-    owner !== "LANGFUSE";
+    dashboardOwner !== "LANGFUSE";
 
   const fromTimestamp = dateRange
     ? dateRange.from

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -191,7 +191,12 @@ export function DashboardWidget({
       className={`${getGridClasses(placement)} group flex flex-col overflow-hidden rounded-lg border bg-background p-4`}
     >
       <div className="mb-2 flex items-center justify-between">
-        <span className="font-medium">{widget.data.name}</span>
+        <span className="font-medium">
+          {widget.data.name}{" "}
+          {dashboardOwner === "PROJECT" && widget.data.owner === "LANGFUSE"
+            ? " ( 🪢 )"
+            : null}
+        </span>
         {hasCUDAccess && (
           <div className="flex space-x-2">
             {widget.data.owner === "PROJECT" ? (

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -13,7 +13,6 @@ import { PencilIcon, TrashIcon, CopyIcon } from "lucide-react";
 import { useRouter } from "next/router";
 import { startCase } from "lodash";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
-import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 
 interface WidgetPlacement {
   id: string;

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -12,6 +12,7 @@ import { isTimeSeriesChart } from "@/src/features/widgets/chart-library/utils";
 import { PencilIcon, TrashIcon } from "lucide-react";
 import { useRouter } from "next/router";
 import { startCase } from "lodash";
+import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 
 interface WidgetPlacement {
   id: string;
@@ -34,14 +35,14 @@ export function DashboardWidget({
   dateRange,
   filterState,
   onDeleteWidget,
-  canEdit,
+  owner,
 }: {
   projectId: string;
   placement: WidgetPlacement;
   dateRange: { from: Date; to: Date } | undefined;
   filterState: FilterState;
   onDeleteWidget: (tileId: string) => void;
-  canEdit: boolean;
+  owner: "LANGFUSE" | "PROJECT";
 }) {
   const router = useRouter();
   const widget = api.dashboardWidgets.get.useQuery(
@@ -53,6 +54,9 @@ export function DashboardWidget({
       enabled: Boolean(projectId),
     },
   );
+  const hasCUDAccess =
+    useHasProjectAccess({ projectId, scope: "dashboards:CUD" }) &&
+    owner !== "LANGFUSE";
 
   const fromTimestamp = dateRange
     ? dateRange.from
@@ -161,7 +165,7 @@ export function DashboardWidget({
     >
       <div className="mb-2 flex items-center justify-between">
         <span className="font-medium">{widget.data.name}</span>
-        {canEdit && (
+        {hasCUDAccess && (
           <div className="flex space-x-2">
             <button
               onClick={handleEdit}

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -32,6 +32,7 @@ const getGridClasses = (widget: WidgetPlacement) => {
 
 export function DashboardWidget({
   projectId,
+  dashboardId,
   placement,
   dateRange,
   filterState,
@@ -39,6 +40,7 @@ export function DashboardWidget({
   dashboardOwner,
 }: {
   projectId: string;
+  dashboardId: string;
   placement: WidgetPlacement;
   dateRange: { from: Date; to: Date } | undefined;
   filterState: FilterState;
@@ -46,6 +48,7 @@ export function DashboardWidget({
   dashboardOwner: "LANGFUSE" | "PROJECT";
 }) {
   const router = useRouter();
+  const utils = api.useUtils();
   const widget = api.dashboardWidgets.get.useQuery(
     {
       widgetId: placement.widgetId,
@@ -131,12 +134,18 @@ export function DashboardWidget({
   }, [queryResult.data, widget.data]);
 
   const handleEdit = () => {
-    router.push(`/project/${projectId}/widgets/${placement.widgetId}`);
+    router.push(
+      `/project/${projectId}/widgets/${placement.widgetId}?dashboardId=${dashboardId}`,
+    );
   };
 
   const copyMutation = api.dashboardWidgets.copyToProject.useMutation({
     onSuccess: (data) => {
-      router.push(`/project/${projectId}/widgets/${data.widgetId}`);
+      utils.dashboard.getDashboard.invalidate().then(() => {
+        router.push(
+          `/project/${projectId}/widgets/${data.widgetId}?dashboardId=${dashboardId}`,
+        );
+      });
     },
   });
   const handleCopy = () => {

--- a/web/src/features/widgets/components/WidgetTable.tsx
+++ b/web/src/features/widgets/components/WidgetTable.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/src/components/ui/popover";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import { useRouter } from "next/router";
 
 type WidgetTableRow = {
   id: string;
@@ -108,6 +109,7 @@ export function DeleteWidget({
 export function DashboardWidgetTable() {
   const projectId = useProjectIdFromURL();
   const { setDetailPageList } = useDetailPageLists();
+  const router = useRouter();
 
   const [orderByState, setOrderByState] = useOrderByState({
     column: "updatedAt",
@@ -227,7 +229,11 @@ export function DashboardWidgetTable() {
       size: 70,
       cell: (row) => {
         const id = row.row.original.id;
-        return <DeleteWidget widgetId={id} owner={row.row.original.owner} />;
+        return (
+          <div onClick={(e) => e.stopPropagation()}>
+            <DeleteWidget widgetId={id} owner={row.row.original.owner} />
+          </div>
+        );
       },
     }),
   ] as LangfuseColumnDef<WidgetTableRow>[];
@@ -256,6 +262,11 @@ export function DashboardWidgetTable() {
         totalCount: widgets.data?.totalCount ?? null,
         onChange: setPaginationState,
         state: paginationState,
+      }}
+      onRowClick={(row) => {
+        router.push(
+          `/project/${projectId}/widgets/${encodeURIComponent(row.id)}`,
+        );
       }}
     />
   );

--- a/web/src/features/widgets/components/WidgetTable.tsx
+++ b/web/src/features/widgets/components/WidgetTable.tsx
@@ -30,13 +30,22 @@ type WidgetTableRow = {
   chartType: string;
   createdAt: Date;
   updatedAt: Date;
+  owner: "PROJECT" | "LANGFUSE";
 };
 
-export function DeleteWidget({ widgetId }: { widgetId: string }) {
+export function DeleteWidget({
+  widgetId,
+  owner,
+}: {
+  widgetId: string;
+  owner: "PROJECT" | "LANGFUSE";
+}) {
   const projectId = useProjectIdFromURL();
   const utils = api.useUtils();
   const [isOpen, setIsOpen] = useState(false);
-  const hasAccess = useHasProjectAccess({ projectId, scope: "dashboards:CUD" });
+  const hasAccess =
+    useHasProjectAccess({ projectId, scope: "dashboards:CUD" }) &&
+    owner !== "LANGFUSE";
   const capture = usePostHogClientCapture();
 
   const mutDeleteWidget = api.dashboardWidgets.delete.useMutation({
@@ -218,7 +227,7 @@ export function DashboardWidgetTable() {
       size: 70,
       cell: (row) => {
         const id = row.row.original.id;
-        return <DeleteWidget widgetId={id} />;
+        return <DeleteWidget widgetId={id} owner={row.row.original.owner} />;
       },
     }),
   ] as LangfuseColumnDef<WidgetTableRow>[];

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -370,7 +370,7 @@ export default function DashboardDetail() {
                 dateRange={dateRange}
                 filterState={userFilterState}
                 onDeleteWidget={handleDeleteWidget}
-                owner={dashboard.data?.owner}
+                dashboardOwner={dashboard.data?.owner}
               />
             ))}
           </div>

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -365,6 +365,7 @@ export default function DashboardDetail() {
             {localDashboardDefinition.widgets.map((widgetPlacement) => (
               <DashboardWidget
                 key={widgetPlacement.id}
+                dashboardId={dashboardId}
                 projectId={projectId}
                 placement={widgetPlacement}
                 dateRange={dateRange}

--- a/web/src/pages/project/[projectId]/widgets/[widgetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/widgets/[widgetId]/index.tsx
@@ -10,9 +10,10 @@ import { type z } from "zod";
 
 export default function EditWidget() {
   const router = useRouter();
-  const { projectId, widgetId } = router.query as {
+  const { projectId, widgetId, dashboardId } = router.query as {
     projectId: string;
     widgetId: string;
+    dashboardId?: string;
   };
 
   // Fetch the widget details
@@ -34,8 +35,14 @@ export default function EditWidget() {
         title: "Widget updated successfully",
         description: "Your widget has been updated.",
       });
-      // Navigate back to widgets list
-      void router.push(`/project/${projectId}/widgets`);
+      // Navigate back to dashboard if provided else widgets list
+      if (dashboardId) {
+        void router.push(
+          `/project/${projectId}/dashboards/${dashboardId}?addWidgetId=${widgetId}`,
+        );
+      } else {
+        void router.push(`/project/${projectId}/widgets`);
+      }
     },
     onError: (error) => {
       showErrorToast("Failed to update widget", error.message);

--- a/web/src/server/api/routers/dashboardWidgets.ts
+++ b/web/src/server/api/routers/dashboardWidgets.ts
@@ -175,6 +175,33 @@ export const dashboardWidgetRouter = createTRPCRouter({
       };
     }),
 
+  copyToProject: protectedProjectProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        widgetId: z.string(),
+        dashboardId: z.string(),
+        placementId: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "dashboards:CUD",
+      });
+
+      const newWidgetId = await DashboardService.copyWidgetToProject({
+        sourceWidgetId: input.widgetId,
+        projectId: input.projectId,
+        dashboardId: input.dashboardId,
+        placementId: input.placementId,
+        userId: ctx.session.user?.id,
+      });
+
+      return { widgetId: newWidgetId };
+    }),
+
   // Define delete widget input schema
   delete: protectedProjectProcedure
     .input(

--- a/web/src/server/api/routers/dashboardWidgets.ts
+++ b/web/src/server/api/routers/dashboardWidgets.ts
@@ -139,6 +139,7 @@ export const dashboardWidgetRouter = createTRPCRouter({
       return {
         ...widget,
         view: reverseViewMapping[widget.view],
+        owner: widget.owner,
       };
     }),
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds support for Langfuse-managed read-only dashboards and widgets, including widget duplication to projects and UI updates for ownership handling.
> 
>   - **Behavior**:
>     - Adds support for Langfuse-managed read-only dashboards and widgets in `DashboardService.ts`.
>     - Introduces `copyWidgetToProject` method in `DashboardService.ts` to duplicate Langfuse widgets into projects.
>     - Updates `getDashboard`, `listDashboards`, `createDashboard`, `updateDashboardDefinition`, `updateDashboard`, `getWidget`, `listWidgets`, `createWidget`, `updateWidget` to handle `owner` field.
>   - **Models**:
>     - Adds `OwnerEnum` to `types.ts` to distinguish between `PROJECT` and `LANGFUSE` ownership.
>     - Updates `DashboardDomainSchema` and `WidgetDomainSchema` in `types.ts` to include `owner` field.
>   - **UI Components**:
>     - Updates `DashboardTable.tsx`, `SelectDashboardDialog.tsx`, `DashboardWidget.tsx`, `WidgetTable.tsx` to display ownership and handle actions based on ownership.
>     - Adds clone functionality to dashboards and widgets in `DashboardTable.tsx` and `DashboardWidget.tsx`.
>     - Modifies `DashboardDetail.tsx` to handle widget addition and cloning based on ownership.
>     - Updates `EditWidget.tsx` to redirect appropriately after widget updates.
>   - **API**:
>     - Adds `copyToProject` mutation in `dashboardWidgets.ts` to support widget duplication.
>     - Updates `dashboardWidgets.ts` to handle ownership in widget operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2cda2d986a8272190768e107b3bf19f918487e11. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->