### PR TITLE
 perf(otel): do not pass deep parsed metadata

### DIFF
--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -631,6 +631,13 @@ export const convertOtelSpanToIngestionEvent = (
         !parentObservationId ||
         String(attributes[LangfuseOtelSpanAttributes.AS_ROOT]) === "true";
 
+      const spanAttributesInMetadata = Object.fromEntries(
+        Object.entries(attributes).map(([key, value]) => [
+          key,
+          typeof value === "string" ? value : JSON.stringify(value),
+        ]),
+      );
+
       const hasTraceUpdates = [
         LangfuseOtelSpanAttributes.TRACE_NAME,
         LangfuseOtelSpanAttributes.TRACE_INPUT,
@@ -653,7 +660,9 @@ export const convertOtelSpanToIngestionEvent = (
           metadata: {
             ...resourceAttributeMetadata,
             ...extractMetadata(attributes, "trace"),
-            ...(isLangfuseSDKSpans ? {} : { attributes }),
+            ...(isLangfuseSDKSpans
+              ? {}
+              : { attributes: spanAttributesInMetadata }),
             resourceAttributes,
             scope: { ...(scopeSpan.scope || {}), attributes: scopeAttributes },
           },
@@ -702,7 +711,9 @@ export const convertOtelSpanToIngestionEvent = (
         metadata: {
           ...resourceAttributeMetadata,
           ...spanAttributeMetadata,
-          ...(isLangfuseSDKSpans ? {} : { attributes }),
+          ...(isLangfuseSDKSpans
+            ? {}
+            : { attributes: spanAttributesInMetadata }),
           resourceAttributes,
           scope: { ...scopeSpan.scope, attributes: scopeAttributes },
         },

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -94,7 +94,7 @@ export default withMiddlewares({
           convertOtelSpanToIngestionEvent(span, auth.scope.publicKey),
       );
       // We set a delay of 0 for OTel, as we never expect updates.
-      return processEventBatch(events, auth, 0, false);
+      return processEventBatch(events, auth, 0);
     },
   }),
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reverts optional batch validation in `processEventBatch`, ensuring consistent event validation and metadata handling.
> 
>   - **Behavior**:
>     - Reverts optional batch validation in `processEventBatch` in `processEventBatch.ts`, removing `validateBatch` parameter.
>     - Always validates events using `ingestionEvent.safeParse()`.
>   - **Metadata Handling**:
>     - In `index.ts`, ensures `attributes` are always converted to strings in `spanAttributesInMetadata`.
>   - **API Changes**:
>     - Updates `index.ts` to call `processEventBatch` without `validateBatch` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fc084fe65bd836d610cc9f5a4da5e14a93d7e8be. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->