### PR TITLE
chore(dashboard): show description on hover in selection tables

### DIFF
--- a/web/src/features/dashboard/components/SelectDashboardDialog.tsx
+++ b/web/src/features/dashboard/components/SelectDashboardDialog.tsx
@@ -98,7 +98,7 @@ export function SelectDashboardDialog({
                     }`}
                   >
                     <TableCell className="font-medium">{d.name}</TableCell>
-                    <TableCell className="max-w-[200px] truncate">
+                    <TableCell className="truncate" title={d.description}>
                       {d.description}
                     </TableCell>
                     <TableCell>

--- a/web/src/features/widgets/components/SelectWidgetDialog.tsx
+++ b/web/src/features/widgets/components/SelectWidgetDialog.tsx
@@ -116,7 +116,7 @@ export function SelectWidgetDialog({
                     }`}
                   >
                     <TableCell className="font-medium">{widget.name}</TableCell>
-                    <TableCell className="max-w-[200px] truncate">
+                    <TableCell className="truncate" title={widget.description}>
                       {widget.description}
                     </TableCell>
                     <TableCell>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add tooltip to show full description on hover in `SelectDashboardDialog.tsx` and `SelectWidgetDialog.tsx`.
> 
>   - **UI Enhancement**:
>     - In `SelectDashboardDialog.tsx`, added `title` attribute to `TableCell` for dashboard descriptions to show full text on hover.
>     - In `SelectWidgetDialog.tsx`, added `title` attribute to `TableCell` for widget descriptions to show full text on hover.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for afb8010ab2b0734083732df335e46255b8ac6408. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->