### PR TITLE
chore(dashboard): auto-generate widget name from selected props

### DIFF
--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -46,11 +46,16 @@ import {
   LineChart,
   BarChartHorizontal,
 } from "lucide-react";
+import {
+  buildWidgetName,
+  buildWidgetDescription,
+} from "@/src/features/widgets/utils";
 
 export function WidgetForm({
   initialValues,
   projectId,
   onSave,
+  widgetId,
 }: {
   initialValues: {
     name: string;
@@ -74,12 +79,20 @@ export function WidgetForm({
     chartType: DashboardWidgetChartType;
     chartConfig: { type: DashboardWidgetChartType; row_limit?: number };
   }) => void;
+  widgetId?: string;
 }) {
   // State for form fields
   const [widgetName, setWidgetName] = useState<string>(initialValues.name);
   const [widgetDescription, setWidgetDescription] = useState<string>(
     initialValues.description,
   );
+
+  // Determine if this is an existing widget (editing mode)
+  const isExistingWidget = Boolean(widgetId);
+
+  // Disables further auto-updates once the user edits name or description
+  const [autoLocked, setAutoLocked] = useState<boolean>(isExistingWidget);
+
   const [selectedView, setSelectedView] = useState<z.infer<typeof views>>(
     initialValues.view,
   );
@@ -375,6 +388,52 @@ export function WidgetForm({
     });
   };
 
+  // Update widget name when selection changes, unless locked
+  useEffect(() => {
+    if (autoLocked) return;
+
+    const suggested = buildWidgetName({
+      aggregation: selectedAggregation,
+      measure: selectedMeasure,
+      dimension: selectedDimension,
+      view: selectedView,
+    });
+
+    if (suggested !== widgetName) {
+      setWidgetName(suggested);
+    }
+  }, [
+    autoLocked,
+    selectedAggregation,
+    selectedMeasure,
+    selectedDimension,
+    selectedView,
+  ]);
+
+  // Update widget description when selection or filters change, unless locked
+  useEffect(() => {
+    if (autoLocked) return;
+
+    const suggested = buildWidgetDescription({
+      aggregation: selectedAggregation,
+      measure: selectedMeasure,
+      dimension: selectedDimension,
+      view: selectedView,
+      filters: userFilterState,
+    });
+
+    if (suggested !== widgetDescription) {
+      setWidgetDescription(suggested);
+    }
+  }, [
+    autoLocked,
+    selectedAggregation,
+    selectedMeasure,
+    selectedDimension,
+    selectedView,
+    userFilterState,
+  ]);
+
   return (
     <div className="flex h-full gap-4">
       {/* Left column - Form */}
@@ -530,7 +589,10 @@ export function WidgetForm({
                 <Input
                   id="widget-name"
                   value={widgetName}
-                  onChange={(e) => setWidgetName(e.target.value)}
+                  onChange={(e) => {
+                    if (!autoLocked) setAutoLocked(true);
+                    setWidgetName(e.target.value);
+                  }}
                   placeholder="Enter widget name"
                 />
               </div>
@@ -541,7 +603,10 @@ export function WidgetForm({
                 <Input
                   id="widget-description"
                   value={widgetDescription}
-                  onChange={(e) => setWidgetDescription(e.target.value)}
+                  onChange={(e) => {
+                    if (!autoLocked) setAutoLocked(true);
+                    setWidgetDescription(e.target.value);
+                  }}
                   placeholder="Enter widget description"
                 />
               </div>

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -399,9 +399,7 @@ export function WidgetForm({
       view: selectedView,
     });
 
-    if (suggested !== widgetName) {
-      setWidgetName(suggested);
-    }
+    setWidgetName(suggested);
   }, [
     autoLocked,
     selectedAggregation,
@@ -422,9 +420,7 @@ export function WidgetForm({
       filters: userFilterState,
     });
 
-    if (suggested !== widgetDescription) {
-      setWidgetDescription(suggested);
-    }
+    setWidgetDescription(suggested);
   }, [
     autoLocked,
     selectedAggregation,

--- a/web/src/features/widgets/utils.ts
+++ b/web/src/features/widgets/utils.ts
@@ -1,0 +1,73 @@
+import { startCase } from "lodash";
+import { FilterState } from "@langfuse/shared";
+
+export function buildWidgetName({
+  aggregation,
+  measure,
+  dimension,
+  view,
+}: {
+  aggregation: string;
+  measure: string;
+  dimension: string;
+  view: string;
+}) {
+  const meas = startCase(measure);
+  let base: string;
+  if (measure.toLowerCase() === "count") {
+    // For count measures, ignore aggregation and only show the measure
+    base = meas;
+  } else {
+    const agg = startCase(aggregation.toLowerCase());
+    base = `${agg} ${meas}`;
+  }
+  if (dimension && dimension !== "none") {
+    base += ` by ${startCase(dimension)}`;
+  }
+  base += ` (${startCase(view)})`;
+  return base;
+}
+
+export function buildWidgetDescription({
+  aggregation,
+  measure,
+  dimension,
+  view,
+  filters,
+}: {
+  aggregation: string;
+  measure: string;
+  dimension: string;
+  view: string;
+  filters: FilterState;
+}) {
+  // Base sentence: "Shows the <agg> <measure> of <view> ..."
+  const measLabel = startCase(measure.toLowerCase());
+  const viewLabel = startCase(view);
+
+  let sentence: string;
+
+  if (measure.toLowerCase() === "count") {
+    sentence = `Shows the count of ${viewLabel}`;
+  } else {
+    const aggLabel = startCase(aggregation.toLowerCase());
+    sentence = `Shows the ${aggLabel.toLowerCase()} ${measLabel.toLowerCase()} of ${viewLabel}`;
+  }
+
+  // Dimension clause
+  if (dimension && dimension !== "none") {
+    sentence += ` by ${startCase(dimension).toLowerCase()}`;
+  }
+
+  // Filters clause
+  if (filters && filters.length > 0) {
+    if (filters.length <= 2) {
+      const cols = filters.map((f) => startCase(f.column)).join(" and ");
+      sentence += `, filtered by ${cols}`;
+    } else {
+      sentence += `, filtered by ${filters.length} conditions`;
+    }
+  }
+
+  return sentence;
+}

--- a/web/src/features/widgets/utils.ts
+++ b/web/src/features/widgets/utils.ts
@@ -1,5 +1,5 @@
 import { startCase } from "lodash";
-import { FilterState } from "@langfuse/shared";
+import { type FilterState } from "@langfuse/shared";
 
 export function buildWidgetName({
   aggregation,

--- a/web/src/pages/project/[projectId]/widgets/[widgetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/widgets/[widgetId]/index.tsx
@@ -92,6 +92,7 @@ export default function EditWidget() {
       {!isWidgetLoading && widgetData ? (
         <WidgetForm
           projectId={projectId}
+          widgetId={widgetId}
           onSave={handleUpdateWidget}
           initialValues={{
             name: widgetData.name,

--- a/web/src/pages/project/[projectId]/widgets/new.tsx
+++ b/web/src/pages/project/[projectId]/widgets/new.tsx
@@ -90,8 +90,8 @@ export default function NewWidget() {
         projectId={projectId}
         onSave={handleSaveWidget}
         initialValues={{
-          name: "Trace Chart",
-          description: "This is a new widget",
+          name: "",
+          description: "",
           view: "traces",
           dimension: "none",
           measure: "count",
@@ -99,6 +99,7 @@ export default function NewWidget() {
           filters: [],
           chartType: "LINE_TIME_SERIES",
         }}
+        widgetId={undefined}
       />
       {pendingWidgetId && (
         <SelectDashboardDialog


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Auto-generate widget names and descriptions in `WidgetForm` based on selected properties, with manual edit locking.
> 
>   - **Behavior**:
>     - Auto-generate widget name and description in `WidgetForm` based on selected properties using `buildWidgetName` and `buildWidgetDescription` from `utils.ts`.
>     - Auto-generation stops once the user manually edits the name or description.
>   - **Components**:
>     - Add `widgetId` prop to `WidgetForm` to determine if editing an existing widget.
>     - Use `useEffect` hooks in `WidgetForm` to update name and description when properties change, unless locked.
>   - **Utilities**:
>     - Add `buildWidgetName` and `buildWidgetDescription` functions in `utils.ts` to construct widget names and descriptions from properties.
>   - **Pages**:
>     - Update `index.tsx` and `new.tsx` to pass `widgetId` to `WidgetForm` and handle widget creation and editing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cb10ee4954e83878297cd3a92b985b9da9727a62. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->