### PR TITLE
fix(ui): hover state color of chat message types

### DIFF
--- a/web/src/components/ChatMessages/ChatMessageComponent.tsx
+++ b/web/src/components/ChatMessages/ChatMessageComponent.tsx
@@ -237,7 +237,7 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
               onClick={toggleRole}
               type="button"
               variant="ghost"
-              className="h-6 w-full px-1 py-0 text-[10px] font-semibold text-gray-500 hover:bg-gray-50"
+              className="h-6 w-full px-1 py-0 text-[10px] font-semibold text-muted-foreground hover:bg-accent hover:text-accent-foreground"
             >
               {capitalize(message.role)}
             </Button>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update hover state colors for chat message types in `ChatMessageComponent.tsx`.
> 
>   - **UI Update**:
>     - In `ChatMessageComponent.tsx`, updated the `className` for the `Button` component to change hover state colors.
>     - Hover background color changed to `hover:bg-accent` and text color to `hover:text-accent-foreground`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ae48e92e3decec58b76ba9a67cb69ffde1f2f054. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->