### PR TITLE
feat(auth): switch to OTP based password reset instead of magic link

### DIFF
--- a/packages/shared/src/server/services/email/passwordReset/sendResetPasswordVerificationRequest.tsx
+++ b/packages/shared/src/server/services/email/passwordReset/sendResetPasswordVerificationRequest.tsx
@@ -5,7 +5,6 @@
 import * as React from "react";
 import {
   Body,
-  Button,
   Container,
   Head,
   Heading,
@@ -21,11 +20,11 @@ import { render } from "@react-email/render";
 import { type SendVerificationRequestParams } from "next-auth/providers/email";
 
 interface ResetPasswordTemplateProps {
-  url: string;
+  token: string;
 }
 
-const ResetPasswordTemplate = ({ url }: ResetPasswordTemplateProps) => {
-  const previewText = "Reset your Langfuse password";
+const ResetPasswordTemplate = ({ token }: ResetPasswordTemplateProps) => {
+  const previewText = "Your Langfuse reset code";
   return (
     <Html>
       <Head />
@@ -48,17 +47,14 @@ const ResetPasswordTemplate = ({ url }: ResetPasswordTemplateProps) => {
               It happens to the best of us.
             </Heading>
             <Section className="mb-8 mt-8 text-center">
-              <Button
-                className="rounded bg-black px-5 py-3 text-center text-xs font-semibold text-white no-underline"
-                href={url}
-              >
-                Reset your password
-              </Button>
+              <Text className="text-center text-sm font-semibold">
+                Your one time passcode:
+              </Text>
+              <Heading className="text-3xl mt-2">{token}</Heading>
             </Section>
             <Text className="text-center text-xs leading-6 text-[#666666]">
-              The link is valid for 10 minutes. If you do not want to change
-              your password or didn&apos;t request a reset, you can ignore and
-              delete this email.
+              This code is valid for 3 minutes. If you did not request a reset,
+              you can ignore this email.
             </Text>
           </Container>
         </Body>
@@ -68,16 +64,16 @@ const ResetPasswordTemplate = ({ url }: ResetPasswordTemplateProps) => {
 };
 
 export async function sendResetPasswordVerificationRequest(
-  params: SendVerificationRequestParams
+  params: SendVerificationRequestParams,
 ) {
-  const { identifier, url, provider } = params;
+  const { identifier, token, provider } = params as SendVerificationRequestParams & { token: string };
   const transport = createTransport(provider.server);
-  const htmlTemplate = render(<ResetPasswordTemplate url={url} />);
+  const htmlTemplate = render(<ResetPasswordTemplate token={token} />);
   const result = await transport.sendMail({
     to: identifier,
     from: provider.from,
-    subject: `Forgot your password?`,
-    text: `To reset your Langfuse password, please confirm your email:\n${url}\n\nThe link is valid for 10 minutes. If you do not want to change your password or didn't request a reset, you can ignore and delete this email.`,
+    subject: `Your Langfuse password reset code`,
+    text: `Use the following code to reset your Langfuse password: ${token}\n\nThis code will expire in 3 minutes. If you did not request a reset, you can ignore this email.`,
     html: htmlTemplate,
   });
   const failed = result.rejected.concat(result.pending).filter(Boolean);

--- a/web/src/features/auth-credentials/components/ResetPasswordButton.tsx
+++ b/web/src/features/auth-credentials/components/ResetPasswordButton.tsx
@@ -67,7 +67,6 @@ export function RequestResetPasswordEmailButton({
         `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/auth/reset-password`,
       );
       const url = `/api/auth/callback/email?email=${formattedEmail}&token=${formattedCode}&callbackUrl=${callback}`;
-      console.log("url", url);
       window.location.href = url;
     } catch (error) {
       console.error("Error verifying code:", error);

--- a/web/src/features/auth-credentials/components/ResetPasswordButton.tsx
+++ b/web/src/features/auth-credentials/components/ResetPasswordButton.tsx
@@ -2,7 +2,6 @@ import { signIn, useSession } from "next-auth/react";
 import { Button } from "@/src/components/ui/button";
 import { Input } from "@/src/components/ui/input";
 import { useEffect, useState } from "react";
-import { useRouter } from "next/router";
 import { z } from "zod";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { env } from "@/src/env.mjs";
@@ -22,7 +21,6 @@ export function RequestResetPasswordEmailButton({
   const [isValidEmail, setIsValidEmail] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const session = useSession();
-  const router = useRouter();
   const capture = usePostHogClientCapture();
 
   useEffect(() => {
@@ -82,8 +80,8 @@ export function RequestResetPasswordEmailButton({
   return (
     <>
       {isEmailSent ? (
-        <div className="flex flex-col space-y-2">
-          <label htmlFor="otp-code" className="text-sm font-medium">
+        <div>
+          <label htmlFor="otp-code" className="mb-2 block text-sm font-medium">
             Check your inbox for the code
           </label>
           <Input
@@ -94,7 +92,7 @@ export function RequestResetPasswordEmailButton({
             value={code}
             onChange={(e) => setCode(e.target.value)}
             placeholder="One time passcode"
-            className="w-full"
+            className="mb-8 w-full"
           />
           <Button
             onClick={handleVerify}

--- a/web/src/features/auth-credentials/components/ResetPasswordButton.tsx
+++ b/web/src/features/auth-credentials/components/ResetPasswordButton.tsx
@@ -58,8 +58,7 @@ export function RequestResetPasswordEmailButton({
     }
   };
 
-  const handleVerify = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const handleVerify = async (_e: React.MouseEvent<HTMLButtonElement>) => {
     if (!code) return;
     setIsLoading(true);
     setErrorMessage(null);
@@ -70,12 +69,8 @@ export function RequestResetPasswordEmailButton({
         `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/auth/reset-password`,
       );
       const url = `/api/auth/callback/email?email=${formattedEmail}&token=${formattedCode}&callbackUrl=${callback}`;
-      const res = await fetch(url);
-      if (res.url.includes("/auth/reset-password")) {
-        router.reload();
-      } else {
-        setErrorMessage("Invalid code. Please try again.");
-      }
+      console.log("url", url);
+      window.location.href = url;
     } catch (error) {
       console.error("Error verifying code:", error);
       setErrorMessage("An unexpected error occurred. Please try again.");
@@ -87,9 +82,12 @@ export function RequestResetPasswordEmailButton({
   return (
     <>
       {isEmailSent ? (
-        <form onSubmit={handleVerify} className="flex flex-col space-y-2">
-          <span className="text-sm text-center">Check your inbox for the code</span>
+        <div className="flex flex-col space-y-2">
+          <label htmlFor="otp-code" className="text-sm font-medium">
+            Check your inbox for the code
+          </label>
           <Input
+            id="otp-code"
             type="number"
             minLength={6}
             maxLength={6}
@@ -99,7 +97,7 @@ export function RequestResetPasswordEmailButton({
             className="w-full"
           />
           <Button
-            type="submit"
+            onClick={handleVerify}
             className={className}
             loading={isLoading}
             disabled={!code || code.length !== 6}
@@ -107,7 +105,7 @@ export function RequestResetPasswordEmailButton({
           >
             Verify code
           </Button>
-        </form>
+        </div>
       ) : (
         <Button
           onClick={handleResetPassword}

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -172,15 +172,11 @@ if (env.SMTP_CONNECTION_URL && env.EMAIL_FROM_ADDRESS) {
       from: env.EMAIL_FROM_ADDRESS,
       maxAge: 3 * 60, // 3 minutes
       async generateVerificationToken() {
-        return generateOtp().toString();
+        return randomInt(100000, 1000000).toString();
       },
       sendVerificationRequest: sendResetPasswordVerificationRequest,
     }),
   );
-}
-
-function generateOtp() {
-  return randomInt(100000, 1000000);
 }
 
 if (

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -180,7 +180,7 @@ if (env.SMTP_CONNECTION_URL && env.EMAIL_FROM_ADDRESS) {
 }
 
 function generateOtp() {
-  return randomInt(100000, 999999);
+  return randomInt(100000, 1000000);
 }
 
 if (

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -24,6 +24,7 @@ import GitHubProvider from "next-auth/providers/github";
 import GitLabProvider from "next-auth/providers/gitlab";
 import OktaProvider from "next-auth/providers/okta";
 import EmailProvider from "next-auth/providers/email";
+import { randomInt } from "crypto";
 import Auth0Provider from "next-auth/providers/auth0";
 import CognitoProvider from "next-auth/providers/cognito";
 import AzureADProvider from "next-auth/providers/azure-ad";
@@ -169,10 +170,17 @@ if (env.SMTP_CONNECTION_URL && env.EMAIL_FROM_ADDRESS) {
     EmailProvider({
       server: env.SMTP_CONNECTION_URL,
       from: env.EMAIL_FROM_ADDRESS,
-      maxAge: 60 * 10, // 10 minutes
+      maxAge: 3 * 60, // 3 minutes
+      async generateVerificationToken() {
+        return generateOtp().toString();
+      },
       sendVerificationRequest: sendResetPasswordVerificationRequest,
     }),
   );
+}
+
+function generateOtp() {
+  return randomInt(100000, 999999);
 }
 
 if (


### PR DESCRIPTION
## Summary
- use OTP tokens for password reset emails
- update ResetPasswordButton with OTP input flow
- shorten verification window and generate numeric tokens

## Testing
- `pnpm --filter web lint`
- `pnpm --filter @langfuse/shared lint`
- `pnpm --filter web test` *(fails: Cannot find module '@langfuse/shared/src/db')*
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Switch password reset from magic link to OTP, updating email templates, UI components, and auth configuration for OTP handling.
> 
>   - **Behavior**:
>     - Switch from magic link to OTP for password reset in `sendResetPasswordVerificationRequest.tsx`.
>     - OTP is a 6-digit numeric code, valid for 3 minutes.
>     - Update email subject and body to reflect OTP usage.
>   - **UI Changes**:
>     - Update `ResetPasswordButton.tsx` to include OTP input and verification flow.
>     - Add input field for OTP and verify button.
>   - **Auth Configuration**:
>     - Modify `auth.ts` to generate 6-digit OTP using `randomInt` from `crypto`.
>     - Set OTP expiration to 3 minutes in `EmailProvider`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a9842f068be224e1e1e9de2029f69fbf62bb33d6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->