### PR TITLE
chore: ignore HEAD request for auth api endpoints

### DIFF
--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -3,6 +3,11 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import NextAuth from "next-auth";
 
 export default async function auth(req: NextApiRequest, res: NextApiResponse) {
+  // Workaround for corporate email link checkers (e.g., Outlook SafeLink)
+  // https://next-auth.js.org/tutorials/avoid-corporate-link-checking-email-provider
+  if (req.method === "HEAD") {
+    return res.status(200).end();
+  }
   // Do whatever you want here, before the request is passed down to `NextAuth`
   const authOptions = await getAuthOptions();
   // https://github.com/nextauthjs/next-auth/issues/2408#issuecomment-1382629234


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add handling for `HEAD` requests in `auth()` in `[...nextauth].ts` to return 200 status for corporate email link checkers.
> 
>   - **Behavior**:
>     - In `auth()` in `[...nextauth].ts`, add handling for `HEAD` requests to return a 200 status immediately.
>     - This change is a workaround for corporate email link checkers like Outlook SafeLink.
>   - **Misc**:
>     - No changes to existing authentication logic or headers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fc7074215624a3060875a2e3f76ec166e3cfd4d5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->