### PR TITLE
fix(ui): peek view header should stay single line on mobile screens

### DIFF
--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -123,11 +123,11 @@ export function TablePeekView<TData>({
         side="right"
         className="flex max-h-full min-h-0 min-w-[60vw] flex-col gap-0 overflow-hidden rounded-l-xl p-0"
       >
-        <SheetHeader className="flex min-h-12 flex-row justify-between rounded-t-xl bg-header px-2">
-          <SheetTitle className="!mt-0 ml-2 flex flex-row items-center gap-2">
+        <SheetHeader className="flex min-h-12 flex-row flex-nowrap items-center justify-between rounded-t-xl bg-header px-2">
+          <SheetTitle className="!mt-0 ml-2 flex min-w-0 flex-row items-center gap-2">
             <ItemBadge type={itemType} showLabel />
             <span
-              className="text-sm font-medium focus:outline-none"
+              className="truncate text-sm font-medium focus:outline-none"
               tabIndex={0}
             >
               {customTitlePrefix
@@ -137,7 +137,7 @@ export function TablePeekView<TData>({
           </SheetTitle>
           <div
             className={cn(
-              "!mt-0 flex flex-row items-center gap-2",
+              "!mt-0 flex flex-shrink-0 flex-row items-center gap-2",
               !canExpand && "mr-8",
             )}
           >


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `peek.tsx` header to remain single-line on mobile by adjusting CSS classes for `SheetHeader` and `SheetTitle`.
> 
>   - **UI Fixes**:
>     - In `peek.tsx`, updated `SheetHeader` to use `flex-nowrap` and `items-center` to keep the header single-line on mobile.
>     - Updated `SheetTitle` to include `min-w-0` and `truncate` for text overflow handling.
>     - Adjusted class for the div containing buttons to `flex-shrink-0` to prevent shrinking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a25d13c9d35c87530d140ef09c1e42561e924109. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->