### PR TITLE
feat: otel span mapping for pipecat traces

### DIFF
--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -271,6 +271,12 @@ const extractInputAndOutput = (
     };
   }
 
+  // Pipecat uses messages attribute
+  input = attributes["messages"];
+  if (input) {
+    return { input, output: null };
+  }
+
   return { input: null, output: null };
 };
 
@@ -469,7 +475,11 @@ const extractUsageDetails = (
   const usageDetails = Object.keys(attributes).filter(
     (key) =>
       (key.startsWith("gen_ai.usage.") && key !== "gen_ai.usage.cost") ||
-      key.startsWith("llm.token_count"),
+      key.startsWith("llm.token_count") ||
+      // pipecat logs usage metrics using llm.* attributes
+      key === "llm.prompt_tokens" ||
+      key === "llm.completion_tokens" ||
+      key === "llm.total_tokens",
   );
 
   const usageDetailKeyMapping: Record<string, string> = {
@@ -485,7 +495,8 @@ const extractUsageDetails = (
   return usageDetails.reduce((acc: any, key) => {
     const usageDetailKey = key
       .replace("gen_ai.usage.", "")
-      .replace("llm.token_count.", "");
+      .replace("llm.token_count.", "")
+      .replace("llm.", "");
     const mappedUsageDetailKey =
       usageDetailKeyMapping[usageDetailKey] ?? usageDetailKey;
     // Cast the respective key to a number


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for Pipecat traces by extracting input from `messages` attribute and usage metrics from `llm.*` attributes in `index.ts`.
> 
>   - **Behavior**:
>     - In `extractInputAndOutput()`, added logic to handle Pipecat traces by checking for `messages` attribute and returning it as input.
>     - In `extractUsageDetails()`, added handling for Pipecat usage metrics by checking for `llm.prompt_tokens`, `llm.completion_tokens`, and `llm.total_tokens` attributes.
>   - **Misc**:
>     - Updated key replacement logic in `extractUsageDetails()` to include `llm.` prefix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 15b81899cc3b4d68c4e16b28b3020cf81fb41b81. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->