### PR TITLE
fix(auth): add domain check for multi-tenant sso providers

### DIFF
--- a/web/src/ee/features/multi-tenant-sso/utils.ts
+++ b/web/src/ee/features/multi-tenant-sso/utils.ts
@@ -242,3 +242,30 @@ const getAuthProviderIdForSsoConfig = (
   if (!dbSsoConfig.authConfig) return dbSsoConfig.authProvider;
   return `${dbSsoConfig.domain}.${dbSsoConfig.authProvider}`;
 };
+
+export const findMultiTenantSsoConfig = async ({
+  providerId,
+}: {
+  providerId: string;
+}): Promise<
+  | {
+      isMultiTenantSsoProvider: true;
+      domain: string;
+    }
+  | {
+      isMultiTenantSsoProvider: false;
+      domain: null;
+    }
+> => {
+  const allConfigs = await getSsoConfigs();
+
+  const config = allConfigs.find(
+    (c) => getAuthProviderIdForSsoConfig(c) === providerId,
+  );
+
+  if (config) {
+    return { isMultiTenantSsoProvider: true, domain: config.domain };
+  } else {
+    return { isMultiTenantSsoProvider: false, domain: null };
+  }
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add domain validation for multi-tenant SSO providers to ensure correct domain association in `auth.ts`.
> 
>   - **Behavior**:
>     - Adds domain check for multi-tenant SSO providers in `getAuthOptions()` in `auth.ts`.
>     - Throws error if SSO provider is used for a non-associated domain.
>   - **Functions**:
>     - Adds `findMultiTenantSsoConfig` in `utils.ts` to find SSO config by `providerId`.
>     - Updates `signIn` callback in `auth.ts` to use `findMultiTenantSsoConfig` for domain validation.
>   - **Misc**:
>     - Renames `domain` to `userDomain` in `auth.ts` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5d56dc1082cb572e703cf5343e3de437b2d5f592. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->