### PR TITLE
perf: add mediaId index to efficiently delete media items

### DIFF
--- a/packages/shared/prisma/migrations/20250519073249_add_trace_media_media_id_index/migration.sql
+++ b/packages/shared/prisma/migrations/20250519073249_add_trace_media_media_id_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY "trace_media_project_id_media_id_idx" ON "trace_media"("project_id", "media_id");

--- a/packages/shared/prisma/migrations/20250519073249_add_trace_media_media_id_index/migration.sql
+++ b/packages/shared/prisma/migrations/20250519073249_add_trace_media_media_id_index/migration.sql
@@ -1,2 +1,2 @@
 -- CreateIndex
-CREATE INDEX CONCURRENTLY "trace_media_project_id_media_id_idx" ON "trace_media"("project_id", "media_id");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "trace_media_project_id_media_id_idx" ON "trace_media"("project_id", "media_id");

--- a/packages/shared/prisma/migrations/20250519073327_add_observation_media_media_id_index/migration.sql
+++ b/packages/shared/prisma/migrations/20250519073327_add_observation_media_media_id_index/migration.sql
@@ -1,2 +1,2 @@
 -- CreateIndex
-CREATE INDEX CONCURRENTLY "observation_media_project_id_media_id_idx" ON "observation_media"("project_id", "media_id");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "observation_media_project_id_media_id_idx" ON "observation_media"("project_id", "media_id");

--- a/packages/shared/prisma/migrations/20250519073327_add_observation_media_media_id_index/migration.sql
+++ b/packages/shared/prisma/migrations/20250519073327_add_observation_media_media_id_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY "observation_media_project_id_media_id_idx" ON "observation_media"("project_id", "media_id");

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -1014,6 +1014,7 @@ model TraceMedia {
   field     String   @map("field")
 
   @@unique([projectId, traceId, mediaId, field])
+  @@index([projectId, mediaId])
   @@map("trace_media")
 }
 
@@ -1031,6 +1032,7 @@ model ObservationMedia {
 
   @@unique([projectId, traceId, observationId, mediaId, field])
   @@index([projectId, observationId])
+  @@index([projectId, mediaId])
   @@map("observation_media")
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add indexes to `trace_media` and `observation_media` tables to improve media item deletion performance.
> 
>   - **Indexes**:
>     - Add `trace_media_project_id_media_id_idx` index on `trace_media` table for `project_id` and `media_id` in `20250519073249_add_trace_media_media_id_index/migration.sql`.
>     - Add `observation_media_project_id_media_id_idx` index on `observation_media` table for `project_id` and `media_id` in `20250519073327_add_observation_media_media_id_index/migration.sql`.
>   - **Schema**:
>     - Update `TraceMedia` model in `schema.prisma` to include `@@index([projectId, mediaId])`.
>     - Update `ObservationMedia` model in `schema.prisma` to include `@@index([projectId, mediaId])`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5e8455afa1973e1bc1f51612d0b9e1a2d4013126. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->