### PR TITLE
feat(ui): implement optional sidebar notification expiry

### DIFF
--- a/web/src/components/nav/sidebar-notifications.tsx
+++ b/web/src/components/nav/sidebar-notifications.tsx
@@ -12,10 +12,13 @@ import useLocalStorage from "../useLocalStorage";
 import Link from "next/link";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
+const NOTIFICATION_TTL_MS = 14 * 24 * 60 * 60 * 1000; // two weeks
+
 type SidebarNotification = {
   id: string; // Add unique ID for each notification
   title: string;
   description: React.ReactNode;
+  createdAt?: string;
   link?: string;
   // defaults to "Learn more" if no linkContent and no linkTitle
   linkTitle?: string;
@@ -30,6 +33,7 @@ const notifications: SidebarNotification[] = [
       "New full text search for trace and observation input/output.",
     link: "https://langfuse.com/blog/2025-05-19-launch-week-3",
     linkTitle: "Learn more",
+    createdAt: "2025-05-19",
   },
   {
     id: "github-star",
@@ -59,12 +63,21 @@ export function SidebarNotifications() {
     string[]
   >(STORAGE_KEY, []);
 
+  const isExpired = (notif: SidebarNotification) => {
+    if (!notif.createdAt) return false;
+    const created = new Date(notif.createdAt).getTime();
+    return Date.now() > created + NOTIFICATION_TTL_MS;
+  };
+
   // Find the oldest non-dismissed notification on mount or when dismissed list changes
   useEffect(() => {
     const lastAvailableIndex = notifications
       .slice()
       .reverse()
-      .findIndex((notif) => !dismissedNotifications.includes(notif.id));
+      .findIndex(
+        (notif) =>
+          !dismissedNotifications.includes(notif.id) && !isExpired(notif),
+      );
 
     setCurrentNotificationIndex(
       lastAvailableIndex === -1

--- a/web/src/components/nav/sidebar-notifications.tsx
+++ b/web/src/components/nav/sidebar-notifications.tsx
@@ -18,7 +18,7 @@ type SidebarNotification = {
   id: string; // Add unique ID for each notification
   title: string;
   description: React.ReactNode;
-  createdAt?: string; // optional, used to expire the notication
+  createdAt?: string; // optional, used to expire the notification
   link?: string;
   // defaults to "Learn more" if no linkContent and no linkTitle
   linkTitle?: string;

--- a/web/src/components/nav/sidebar-notifications.tsx
+++ b/web/src/components/nav/sidebar-notifications.tsx
@@ -18,7 +18,7 @@ type SidebarNotification = {
   id: string; // Add unique ID for each notification
   title: string;
   description: React.ReactNode;
-  createdAt?: string;
+  createdAt?: string; // optional, used to expire the notication
   link?: string;
   // defaults to "Learn more" if no linkContent and no linkTitle
   linkTitle?: string;


### PR DESCRIPTION
## Summary
- add createdAt metadata to sidebar notifications
- hide sidebar notifications after two weeks

## Testing
- `pnpm run lint`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add expiration to sidebar notifications, hiding them after two weeks based on `createdAt` metadata.
> 
>   - **Behavior**:
>     - Add `createdAt` metadata to `SidebarNotification` type in `sidebar-notifications.tsx`.
>     - Hide notifications older than two weeks using `isExpired()` function in `SidebarNotifications`.
>   - **Constants**:
>     - Define `NOTIFICATION_TTL_MS` as two weeks in milliseconds in `sidebar-notifications.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 279c96e905b2926153a94d18802b28a324796d73. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->