### PR TITLE
fix(dashboards): update resize migration to handle empty widget list correctly

### DIFF
--- a/packages/shared/prisma/migrations/20250519145128_resize_dashboard_y_axis_components/migration.sql
+++ b/packages/shared/prisma/migrations/20250519145128_resize_dashboard_y_axis_components/migration.sql
@@ -2,7 +2,9 @@
 WITH updated AS (
     SELECT
         id,
-        jsonb_set(
+        CASE
+            WHEN jsonb_array_length(definition->'widgets') = 0 THEN definition
+            ELSE jsonb_set(
                 definition,                             -- original JSON
                 '{widgets}',                            -- path to replace
                 (
@@ -21,9 +23,9 @@ WITH updated AS (
                     FROM jsonb_array_elements(definition->'widgets') AS widget
                 ),
                 true                                    -- create path if absent
-        ) AS new_def
+            )
+        END AS new_def
     FROM dashboards
-    WHERE definition ? 'widgets'                -- only rows that have widgets
 )
 UPDATE dashboards d
 SET    definition = u.new_def


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates SQL migration to correctly handle empty 'widgets' array in dashboards definition.
> 
>   - **Behavior**:
>     - Updates `migration.sql` to handle empty 'widgets' array in `dashboards.definition`.
>     - Uses `CASE` to check `jsonb_array_length(definition->'widgets')` and bypass `jsonb_set` if empty.
>   - **SQL Logic**:
>     - Retains original `definition` if 'widgets' array is empty.
>     - Applies `jsonb_set` to triple `y` and `y_size` values if 'widgets' array is not empty.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 64c5b5d9e4a16ce16b694d16eccbc9885b93a746. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->