### PR TITLE
fix(tables-ui): truncate name columns in traces and observations table

### DIFF
--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -335,6 +335,14 @@ export default function ObservationsTable({
       header: "Name",
       size: 150,
       enableSorting: true,
+      cell: ({ row }) => {
+        const value: ObservationsTableRow["name"] = row.getValue("name");
+        return value ? (
+          <span className="truncate" title={value}>
+            {value}
+          </span>
+        ) : undefined;
+      },
     },
     {
       accessorKey: "input",

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -457,6 +457,14 @@ export default function TracesTable({
       size: 150,
       enableHiding: true,
       enableSorting: true,
+      cell: ({ row }) => {
+        const value: TracesTableRow["name"] = row.getValue("name");
+        return value ? (
+          <span className="truncate" title={value}>
+            {value}
+          </span>
+        ) : undefined;
+      },
     },
     {
       accessorKey: "input",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Truncate long names in `name` columns of `ObservationsTable` and `TracesTable`, showing full names on hover.
> 
>   - **UI Changes**:
>     - In `observations.tsx`, the `name` column now truncates long names and shows the full name on hover using a `span` with `className="truncate"`.
>     - In `traces.tsx`, the `name` column is updated similarly to truncate long names and display the full name on hover.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 49460c990fc7bca79364e1cfb444e24001e90ea2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->