### PR TITLE
fix(auth): only apply login domain enforcement to multi-tenant sso

### DIFF
--- a/web/src/ee/features/multi-tenant-sso/utils.ts
+++ b/web/src/ee/features/multi-tenant-sso/utils.ts
@@ -259,9 +259,9 @@ export const findMultiTenantSsoConfig = async ({
 > => {
   const allConfigs = await getSsoConfigs();
 
-  const config = allConfigs.find(
-    (c) => getAuthProviderIdForSsoConfig(c) === providerId,
-  );
+  const config = allConfigs
+    .filter((config) => Boolean(config.authConfig)) // exclude all that don't use custom credentials (enforcement of social login)
+    .find((c) => getAuthProviderIdForSsoConfig(c) === providerId);
 
   if (config) {
     return { isMultiTenantSsoProvider: true, domain: config.domain };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `findMultiTenantSsoConfig` in `utils.ts` to enforce login domain only for multi-tenant SSO with custom credentials.
> 
>   - **Behavior**:
>     - In `findMultiTenantSsoConfig` in `utils.ts`, filter SSO configurations to exclude those without custom credentials, ensuring login domain enforcement applies only to multi-tenant SSO.
>   - **Misc**:
>     - No changes to other functions or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 41d5cebd241e8994bd921c93abc9f2f09f9d2ae0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->