### PR TITLE
chore: add metrics to measure by-id recency

### DIFF
--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -30,6 +30,7 @@ import { env } from "../../env";
 import { _handleGetScoreById, _handleGetScoresByIds } from "./scores-utils";
 import { parseMetadataCHRecordToDomain } from "../utils/metadata_conversion";
 import { ClickHouseClientConfigOptions } from "@clickhouse/client";
+import { recordDistribution } from "../instrumentation";
 
 export const searchExistingAnnotationScore = async (
   projectId: string,
@@ -347,6 +348,14 @@ export const getScoresForTraces = async <
       ...row,
       metadata: excludeMetadata ? {} : row.metadata,
     });
+
+    recordDistribution(
+      "langfuse.query_by_id_age",
+      new Date().getTime() - score.timestamp.getTime(),
+      {
+        table: "scores",
+      },
+    );
 
     if (includeHasMetadata) {
       Object.assign(score, { hasMetadata: !!row.has_metadata });

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -225,6 +225,13 @@ export const traceRouter = createTRPCRouter({
       }),
     )
     .query(async ({ input, ctx }) => {
+      if (!ctx.trace) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Trace not found",
+        });
+      }
+
       const [observations, scores] = await Promise.all([
         getObservationsForTrace({
           traceId: input.traceId,
@@ -238,13 +245,6 @@ export const traceRouter = createTRPCRouter({
           timestamp: input.timestamp ?? input.fromTimestamp ?? undefined,
         }),
       ]);
-
-      if (!ctx.trace) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Trace not found",
-        });
-      }
 
       const validatedScores = filterAndValidateDbScoreList({
         scores,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add recency metrics logging for observations, scores, and traces by integrating `recordDistribution` calls in key functions.
> 
>   - **Metrics**:
>     - Add `recordDistribution` calls to log recency metrics for observations in `getObservationsForTrace` and `getObservationById` in `observations.ts`.
>     - Add `recordDistribution` calls for scores in `getScoresForTraces` in `scores.ts`.
>     - Add `recordDistribution` calls for traces in `getTracesBySessionId` and `getTraceById` in `traces.ts`.
>   - **Error Handling**:
>     - Move trace not found error in `traceRouter` in `traces.ts` to occur before fetching observations and scores.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 62b9f0c793054f3557ce591d9d1a70b24b43c747. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->