### PR TITLE
docs: add note that docker ENTRYPOINT is covered by semver

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -149,6 +149,8 @@ USER nextjs
 # Default port to 3000
 ENV PORT 3000
 
+# Docker ENTRYPOINT (dumb-init) is covered by semantic versioning, not the entrypoint.sh itself
+# Reasoning: ENTRYPOINT is overridden by some self-hosted deployments, thus changing this is breaking
 ENTRYPOINT ["dumb-init", "--", "./web/entrypoint.sh"]
 
 # startup command - use dd-trace if NEXT_PUBLIC_LANGFUSE_CLOUD_REGION is configured

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -73,6 +73,8 @@ RUN chmod +x ./worker/entrypoint.sh
 EXPOSE 3030
 ENV PORT=3030
 
+# Docker ENTRYPOINT (dumb-init) is covered by semantic versioning, not the entrypoint.sh itself
+# Reasoning: ENTRYPOINT is overridden by some self-hosted deployments, thus changing this is breaking
 ENTRYPOINT ["dumb-init", "--", "./worker/entrypoint.sh"]
 
 # startup command


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add comments to `web/Dockerfile` and `worker/Dockerfile` clarifying Docker `ENTRYPOINT` is semver-covered, not `entrypoint.sh`.
> 
>   - **Documentation**:
>     - Add comments in `web/Dockerfile` and `worker/Dockerfile` clarifying that Docker `ENTRYPOINT` is covered by semantic versioning, not `entrypoint.sh`.
>     - Reason: `ENTRYPOINT` is overridden by some self-hosted deployments, making changes breaking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 53afc1532ca9a76f5ee2dc85a5a77ba1f4814c7e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->