### PR TITLE
chore: lw3-3 product hunt notification

### DIFF
--- a/web/src/components/nav/sidebar-notifications.tsx
+++ b/web/src/components/nav/sidebar-notifications.tsx
@@ -11,6 +11,9 @@ import { X } from "lucide-react";
 import useLocalStorage from "../useLocalStorage";
 import Link from "next/link";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import ProductHuntBadgeLight from "../images/product_hunt_badge_light.svg";
+import ProductHuntBadgeDark from "../images/product_hunt_badge_dark.svg";
+import Image from "next/image";
 
 const NOTIFICATION_TTL_MS = 14 * 24 * 60 * 60 * 1000; // two weeks
 
@@ -26,6 +29,36 @@ type SidebarNotification = {
 };
 
 const notifications: SidebarNotification[] = [
+  {
+    id: "lw3-3-producthunt",
+    title: "Launch Week #3: Day 3",
+    description: (
+      <span>
+        We are launching <strong>Custom Dashboards</strong> on Product Hunt
+        today.
+        <br />
+        Support the launch to help grow the community!
+      </span>
+    ),
+    link: "https://langfuse.com/ph",
+    linkTitle: "Product Hunt",
+    linkContent: (
+      <>
+        <Image
+          src={ProductHuntBadgeDark}
+          alt="Product Hunt"
+          width={160}
+          className="mt-1 hidden dark:block"
+        />
+        <Image
+          src={ProductHuntBadgeLight}
+          alt="Product Hunt"
+          width={160}
+          className="mt-1 dark:hidden"
+        />
+      </>
+    ),
+  },
   {
     id: "lw3-2",
     title: "Launch Week #3: Day 2",

--- a/web/src/components/nav/sidebar-notifications.tsx
+++ b/web/src/components/nav/sidebar-notifications.tsx
@@ -32,6 +32,7 @@ const notifications: SidebarNotification[] = [
   {
     id: "lw3-3-producthunt",
     title: "Launch Week #3: Day 3",
+    createdAt: "2025-05-21",
     description: (
       <span>
         We are launching <strong>Custom Dashboards</strong> on Product Hunt

--- a/web/src/components/nav/sidebar-notifications.tsx
+++ b/web/src/components/nav/sidebar-notifications.tsx
@@ -112,18 +112,13 @@ export function SidebarNotifications() {
 
   // Find the oldest non-dismissed notification on mount or when dismissed list changes
   useEffect(() => {
-    const lastAvailableIndex = notifications
-      .slice()
-      .reverse()
-      .findIndex(
-        (notif) =>
-          !dismissedNotifications.includes(notif.id) && !isExpired(notif),
-      );
+    const firstAvailableIndex = notifications.findIndex(
+      (notif) =>
+        !dismissedNotifications.includes(notif.id) && !isExpired(notif),
+    );
 
     setCurrentNotificationIndex(
-      lastAvailableIndex === -1
-        ? null
-        : notifications.length - 1 - lastAvailableIndex,
+      firstAvailableIndex === -1 ? null : firstAvailableIndex,
     );
   }, [dismissedNotifications]);
 


### PR DESCRIPTION
To go live 21.05.2025 – 10am CEST
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a new Product Hunt notification and changes notification display logic in `sidebar-notifications.tsx`.
> 
>   - **Behavior**:
>     - Adds a new notification for "Launch Week #3: Day 3" with Product Hunt badges in `sidebar-notifications.tsx`.
>     - Changes logic to display the first available notification instead of the last in `useEffect` in `SidebarNotifications`.
>   - **Assets**:
>     - Adds `ProductHuntBadgeLight` and `ProductHuntBadgeDark` SVGs for light and dark themes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 18015fb0868595345594293138bdc45b34717703. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->