### PR TITLE
chore: reduce minimum project retention to 3 days

### DIFF
--- a/fern/apis/server/definition/projects.yml
+++ b/fern/apis/server/definition/projects.yml
@@ -26,7 +26,7 @@ service:
               docs: Optional metadata for the project
             retention:
               type: integer
-              docs: Number of days to retain data. Must be 0 or at least 7 days. Requires data-retention entitlement for non-zero values. Optional.
+              docs: Number of days to retain data. Must be 0 or at least 3 days. Requires data-retention entitlement for non-zero values. Optional.
       response: Project
     
     update:
@@ -45,7 +45,7 @@ service:
               docs: Optional metadata for the project
             retention:
               type: integer
-              docs: Number of days to retain data. Must be 0 or at least 7 days. Requires data-retention entitlement for non-zero values. Optional.
+              docs: Number of days to retain data. Must be 0 or at least 3 days. Requires data-retention entitlement for non-zero values. Optional.
       response: Project
     
     delete:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -2308,7 +2308,7 @@ paths:
                 retention:
                   type: integer
                   description: >-
-                    Number of days to retain data. Must be 0 or at least 7 days.
+                    Number of days to retain data. Must be 0 or at least 3 days.
                     Requires data-retention entitlement for non-zero values.
                     Optional.
               required:
@@ -2377,7 +2377,7 @@ paths:
                 retention:
                   type: integer
                   description: >-
-                    Number of days to retain data. Must be 0 or at least 7 days.
+                    Number of days to retain data. Must be 0 or at least 3 days.
                     Requires data-retention entitlement for non-zero values.
                     Optional.
               required:

--- a/web/src/__tests__/async/projects-api.servertest.ts
+++ b/web/src/__tests__/async/projects-api.servertest.ts
@@ -239,13 +239,13 @@ describe("Projects API", () => {
     it("should validate retention days", async () => {
       const uniqueProjectName = `Test Project ${randomUUID().substring(0, 8)}`;
 
-      // Test with invalid retention days (less than 7 and not 0)
+      // Test with invalid retention days (less than 3 and not 0)
       const invalidResult = await makeAPICall(
         "POST",
         "/api/public/projects",
         {
           name: uniqueProjectName,
-          retention: 5, // Invalid: less than 7 and not 0
+          retention: 2, // Invalid: less than 3 and not 0
         },
         createBasicAuthHeader(orgApiKey, orgSecretKey),
       );
@@ -390,13 +390,13 @@ describe("Projects API", () => {
     });
 
     it("should validate retention days on update", async () => {
-      // Test with invalid retention days (less than 7 and not 0)
+      // Test with invalid retention days (less than 3 and not 0)
       const invalidResult = await makeAPICall(
         "PUT",
         `/api/public/projects/${testProjectId}`,
         {
           name: "Updated Project Name",
-          retention: 5, // Invalid: less than 7 and not 0
+          retention: 2, // Invalid: less than 3 and not 0
         },
         createBasicAuthHeader(orgApiKey, orgSecretKey),
       );

--- a/web/src/ee/features/admin-api/public/projects/createProject.ts
+++ b/web/src/ee/features/admin-api/public/projects/createProject.ts
@@ -39,7 +39,7 @@ export async function handleCreateProject(
         projectRetentionSchema.parse({ retention });
       } catch (error) {
         return res.status(400).json({
-          message: "Invalid retention value. Must be 0 or at least 7 days.",
+          message: "Invalid retention value. Must be 0 or at least 3 days.",
         });
       }
 

--- a/web/src/ee/features/admin-api/public/projects/projectById/index.ts
+++ b/web/src/ee/features/admin-api/public/projects/projectById/index.ts
@@ -47,7 +47,7 @@ export async function handleUpdateProject(
         projectRetentionSchema.parse({ retention });
       } catch (error) {
         return res.status(400).json({
-          message: "Invalid retention value. Must be 0 or at least 7 days.",
+          message: "Invalid retention value. Must be 0 or at least 3 days.",
         });
       }
 

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -276,7 +276,7 @@ export const env = createEnv({
     LANGFUSE_INIT_ORG_CLOUD_PLAN: z.string().optional(), // for use in CI
     LANGFUSE_INIT_PROJECT_ID: z.string().optional(),
     LANGFUSE_INIT_PROJECT_NAME: z.string().optional(),
-    LANGFUSE_INIT_PROJECT_RETENTION: z.number().int().gte(7).optional(),
+    LANGFUSE_INIT_PROJECT_RETENTION: z.number().int().gte(3).optional(),
     LANGFUSE_INIT_PROJECT_PUBLIC_KEY: z.string().optional(),
     LANGFUSE_INIT_PROJECT_SECRET_KEY: z.string().optional(),
     LANGFUSE_INIT_USER_EMAIL: z
@@ -529,8 +529,10 @@ export const env = createEnv({
       process.env.LANGFUSE_UI_DEFAULT_BASE_URL_ANTHROPIC,
     LANGFUSE_UI_DEFAULT_BASE_URL_AZURE:
       process.env.LANGFUSE_UI_DEFAULT_BASE_URL_AZURE,
-    LANGFUSE_UI_VISIBLE_PRODUCT_MODULES: process.env.LANGFUSE_UI_VISIBLE_PRODUCT_MODULES,
-    LANGFUSE_UI_HIDDEN_PRODUCT_MODULES: process.env.LANGFUSE_UI_HIDDEN_PRODUCT_MODULES,
+    LANGFUSE_UI_VISIBLE_PRODUCT_MODULES:
+      process.env.LANGFUSE_UI_VISIBLE_PRODUCT_MODULES,
+    LANGFUSE_UI_HIDDEN_PRODUCT_MODULES:
+      process.env.LANGFUSE_UI_HIDDEN_PRODUCT_MODULES,
     // EE License
     LANGFUSE_EE_LICENSE_KEY: process.env.LANGFUSE_EE_LICENSE_KEY,
     ADMIN_API_KEY: process.env.ADMIN_API_KEY,

--- a/web/src/features/auth/lib/projectRetentionSchema.ts
+++ b/web/src/features/auth/lib/projectRetentionSchema.ts
@@ -4,7 +4,7 @@ export const projectRetentionSchema = z.object({
   retention: z.coerce
     .number()
     .int("Must be an integer")
-    .refine((value) => value === 0 || value >= 7, {
-      message: "Value must be 0 or at least 7 days",
+    .refine((value) => value === 0 || value >= 3, {
+      message: "Value must be 0 or at least 3 days",
     }),
 });

--- a/web/src/features/projects/components/ConfigureRetention.tsx
+++ b/web/src/features/projects/components/ConfigureRetention.tsx
@@ -66,7 +66,7 @@ export default function ConfigureRetention() {
       <Card className="mb-4 p-3">
         <p className="mb-4 text-sm text-primary">
           Data retention automatically deletes events older than the specified
-          number of days. The value must be an integer larger than 7. Set to 0
+          number of days. The value must be an integer larger than 3. Set to 0
           to retain data indefinitely. The deletion happens asynchronously, i.e.
           event may be available for a while after they expired.
         </p>

--- a/web/src/features/projects/components/ConfigureRetention.tsx
+++ b/web/src/features/projects/components/ConfigureRetention.tsx
@@ -66,7 +66,7 @@ export default function ConfigureRetention() {
       <Card className="mb-4 p-3">
         <p className="mb-4 text-sm text-primary">
           Data retention automatically deletes events older than the specified
-          number of days. The value must be an integer larger than 3. Set to 0
+          number of days. The value must be 0 or at least 3 days. Set to 0
           to retain data indefinitely. The deletion happens asynchronously, i.e.
           event may be available for a while after they expired.
         </p>

--- a/web/src/features/projects/server/projectsRouter.ts
+++ b/web/src/features/projects/server/projectsRouter.ts
@@ -106,7 +106,7 @@ export const projectsRouter = createTRPCRouter({
     .input(
       z.object({
         projectId: z.string(),
-        retention: z.number().int().gte(7).nullable(),
+        retention: z.number().int().gte(3).nullable(),
       }),
     )
     .mutation(async ({ input, ctx }) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reduce minimum project retention period from 7 days to 3 days across API, validation, and tests.
> 
>   - **Behavior**:
>     - Minimum project retention period reduced from 7 days to 3 days in `projects.yml` and `openapi.yml`.
>     - Updated validation in `projectRetentionSchema` to enforce new minimum of 3 days.
>     - Adjusted error messages in `createProject.ts` and `projectById/index.ts` to reflect new minimum.
>   - **Tests**:
>     - Updated test cases in `projects-api.servertest.ts` to validate against new minimum retention period of 3 days.
>   - **Environment**:
>     - Updated `LANGFUSE_INIT_PROJECT_RETENTION` in `env.mjs` to require a minimum of 3 days.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7ff122654c445db4aa837bbc4aab83e728af4843. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->