### PR TITLE
fix(ui-jump-to-playground): look up llm api keys when model parsing

### DIFF
--- a/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -96,7 +96,7 @@ export const JumpToPlaygroundButton: React.FC<JumpToPlaygroundButtonProps> = (
     } else if (props.source === "generation") {
       setCapturedState(parseGeneration(props.generation, modelToProviderMap));
     }
-  }, [props]);
+  }, [props, modelToProviderMap]);
 
   useEffect(() => {
     if (capturedState) {

--- a/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -1,5 +1,5 @@
 import { Terminal } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { useRouter } from "next/router";
 import { z } from "zod";
 
@@ -29,6 +29,7 @@ import {
   OpenAIResponseFormatSchema,
 } from "@langfuse/shared";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
+import { api } from "@/src/utils/api";
 import { cn } from "@/src/utils/tailwind";
 
 type JumpToPlaygroundButtonProps = (
@@ -62,11 +63,38 @@ export const JumpToPlaygroundButton: React.FC<JumpToPlaygroundButtonProps> = (
   const [isAvailable, setIsAvailable] = useState<boolean>(false);
   const isEntitled = useHasEntitlement("playground");
 
+  const apiKeys = api.llmApiKey.all.useQuery(
+    {
+      projectId: projectId as string,
+    },
+    { enabled: Boolean(projectId) },
+  );
+
+  const modelToProviderMap = useMemo(() => {
+    const modelToProviderMap: Record<string, string> = {};
+
+    (apiKeys.data?.data ?? []).forEach((apiKey) => {
+      const { provider, customModels, withDefaultModels, adapter } = apiKey;
+      // add default models if enabled
+      if (withDefaultModels) {
+        (playgroundSupportedModels[adapter] ?? []).forEach((model) => {
+          modelToProviderMap[model] = provider;
+        });
+      }
+
+      // add custom models if set
+      customModels.forEach((customModel) => {
+        modelToProviderMap[customModel] = provider;
+      });
+    });
+    return modelToProviderMap;
+  }, [apiKeys.data]);
+
   useEffect(() => {
     if (props.source === "prompt") {
       setCapturedState(parsePrompt(props.prompt));
     } else if (props.source === "generation") {
-      setCapturedState(parseGeneration(props.generation));
+      setCapturedState(parseGeneration(props.generation, modelToProviderMap));
     }
   }, [props]);
 
@@ -231,10 +259,11 @@ const parseGeneration = (
     output: string | null;
     metadata: string | null;
   },
+  modelToProviderMap: Record<string, string>,
 ): PlaygroundCache => {
   if (generation.type !== "GENERATION") return null;
 
-  const modelParams = parseModelParams(generation);
+  const modelParams = parseModelParams(generation, modelToProviderMap);
   const tools = parseTools(generation);
   const structuredOutputSchema = parseStructuredOutputSchema(generation);
 
@@ -311,6 +340,7 @@ const parseGeneration = (
 
 function parseModelParams(
   generation: Omit<Observation, "input" | "output" | "metadata">,
+  modelToProviderMap: Record<string, string>,
 ):
   | (Partial<UIModelParams> & Pick<UIModelParams, "provider" | "model">)
   | undefined {
@@ -320,10 +350,7 @@ function parseModelParams(
     | undefined = undefined;
 
   if (generationModel) {
-    const provider = Object.entries(playgroundSupportedModels).find(
-      ([_, models]) =>
-        generationModel ? models.some((m) => m === generationModel) : false,
-    )?.[0];
+    const provider = modelToProviderMap[generationModel];
 
     if (!provider) return;
 

--- a/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -71,23 +71,23 @@ export const JumpToPlaygroundButton: React.FC<JumpToPlaygroundButtonProps> = (
   );
 
   const modelToProviderMap = useMemo(() => {
-    const modelToProviderMap: Record<string, string> = {};
+    const modelProviderMap: Record<string, string> = {};
 
     (apiKeys.data?.data ?? []).forEach((apiKey) => {
       const { provider, customModels, withDefaultModels, adapter } = apiKey;
       // add default models if enabled
       if (withDefaultModels) {
         (playgroundSupportedModels[adapter] ?? []).forEach((model) => {
-          modelToProviderMap[model] = provider;
+          modelProviderMap[model] = provider;
         });
       }
 
       // add custom models if set
       customModels.forEach((customModel) => {
-        modelToProviderMap[customModel] = provider;
+        modelProviderMap[customModel] = provider;
       });
     });
-    return modelToProviderMap;
+    return modelProviderMap;
   }, [apiKeys.data]);
 
   useEffect(() => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `JumpToPlaygroundButton.tsx` to query LLM API keys for model-provider mapping during model parsing.
> 
>   - **Behavior**:
>     - `JumpToPlaygroundButton.tsx` now queries LLM API keys using `api.llmApiKey.all.useQuery` to map models to providers.
>     - `parseGeneration` function updated to use `modelToProviderMap` for associating models with providers.
>   - **Functions**:
>     - `parseModelParams` updated to use `modelToProviderMap` for determining the provider of a model.
>     - `useMemo` used to create `modelToProviderMap` from API keys data.
>   - **Imports**:
>     - Added `useMemo` and `api` imports in `JumpToPlaygroundButton.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bd73c8e41fc564f36a5d8cb1ed916ccdc2be2429. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->