### PR TITLE
fix: use quorum writes for temporary dataset tables

### DIFF
--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -169,6 +169,8 @@ export const insertPostgresDatasetRunsIntoClickhouse = async (
     format: "JSONEachRow",
     clickhouse_settings: {
       log_comment: JSON.stringify({ feature: "dataset", projectId }),
+      insert_quorum_parallel: 0,
+      insert_quorum: "auto",
     },
   });
 };
@@ -190,7 +192,6 @@ export const createTempTableInClickhouse = async (tableName: string) => {
   await commandClickhouse({
     query,
     params: { tableName },
-
     tags: { feature: "dataset" },
   });
 };
@@ -202,7 +203,6 @@ export const deleteTempTableInClickhouse = async (tableName: string) => {
   await commandClickhouse({
     query,
     params: { tableName },
-
     tags: { feature: "dataset" },
   });
 };
@@ -260,7 +260,6 @@ const getTraceScoresFromTempTable = async (
       AND tmp.dataset_id = {datasetId: String}
       ORDER BY s.event_ts DESC
       LIMIT 1 BY s.id, s.project_id, tmp.run_id
-      SETTINGS select_sequential_consistency = 1;
   `;
 
   const rows = await queryClickhouse<
@@ -275,7 +274,11 @@ const getTraceScoresFromTempTable = async (
       projectId: input.projectId,
       datasetId: input.datasetId,
     },
-
+    clickhouseConfigs: {
+      clickhouse_settings: {
+        select_sequential_consistency: "1",
+      },
+    },
     tags: { feature: "dataset", projectId: input.projectId },
   });
 
@@ -328,7 +331,11 @@ const getObservationLatencyAndCostForDataset = async (
       projectId: input.projectId,
       datasetId: input.datasetId,
     },
-
+    clickhouseConfigs: {
+      clickhouse_settings: {
+        select_sequential_consistency: "1",
+      },
+    },
     tags: { feature: "dataset", projectId: input.projectId ?? "" },
   });
 
@@ -377,7 +384,11 @@ const getTraceLatencyAndCostForDataset = async (
       projectId: input.projectId,
       datasetId: input.datasetId,
     },
-
+    clickhouseConfigs: {
+      clickhouse_settings: {
+        select_sequential_consistency: "1",
+      },
+    },
     tags: { feature: "dataset", projectId: input.projectId ?? "" },
   });
 


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/5919
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use quorum writes and sequential consistency reads for temporary dataset tables in Clickhouse operations.
> 
>   - **Behavior**:
>     - Use quorum writes for temporary dataset tables by setting `insert_quorum_parallel: 0` and `insert_quorum: "auto"` in `insertPostgresDatasetRunsIntoClickhouse()`.
>     - Ensure sequential consistency reads by setting `select_sequential_consistency: "1"` in `getTraceScoresFromTempTable()`, `getObservationLatencyAndCostForDataset()`, and `getTraceLatencyAndCostForDataset()`.
>   - **Misc**:
>     - Remove redundant semicolons in `createTempTableInClickhouse()` and `deleteTempTableInClickhouse()` functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b1ba0247dc7765148a4a4ba3be433898385af5c0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->