### PR TITLE
feat: allow AWS S3 SSE configuration for S3 interactions

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -65,7 +65,7 @@ const EnvSchema = z.object({
   LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: z
     .enum(["true", "false"])
     .default("false"),
-  LANGFUSE_S3_EVENT_UPLOAD_SSE: z.string().optional(),
+  LANGFUSE_S3_EVENT_UPLOAD_SSE: z.enum(["AES256", "aws:kms"]).optional(),
   LANGFUSE_S3_EVENT_UPLOAD_SSE_KMS_KEY_ID: z.string().optional(),
   LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: z.string().optional(),
   LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: z.string().default(""),

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -65,6 +65,8 @@ const EnvSchema = z.object({
   LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: z
     .enum(["true", "false"])
     .default("false"),
+  LANGFUSE_S3_EVENT_UPLOAD_SSE: z.string().optional(),
+  LANGFUSE_S3_EVENT_UPLOAD_SSE_KMS_KEY_ID: z.string().optional(),
   LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: z.string().optional(),
   LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: z.string().default(""),
   LANGFUSE_S3_MEDIA_UPLOAD_REGION: z.string().optional(),
@@ -74,6 +76,8 @@ const EnvSchema = z.object({
   LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: z
     .enum(["true", "false"])
     .default("false"),
+  LANGFUSE_S3_MEDIA_UPLOAD_SSE: z.string().optional(),
+  LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID: z.string().optional(),
   LANGFUSE_USE_AZURE_BLOB: z.enum(["true", "false"]).default("false"),
   LANGFUSE_USE_GOOGLE_CLOUD_STORAGE: z.enum(["true", "false"]).default("false"),
   LANGFUSE_GOOGLE_CLOUD_STORAGE_CREDENTIALS: z.string().optional(),
@@ -82,6 +86,8 @@ const EnvSchema = z.object({
   LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED: z
     .enum(["true", "false"])
     .default("false"),
+  LANGFUSE_S3_CORE_DATA_EXPORT_SSE: z.string().optional(),
+  LANGFUSE_S3_CORE_DATA_EXPORT_SSE_KMS_KEY_ID: z.string().optional(),
   LANGFUSE_POSTGRES_METERING_DATA_EXPORT_IS_ENABLED: z
     .enum(["true", "false"])
     .default("false"),

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -76,7 +76,7 @@ const EnvSchema = z.object({
   LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: z
     .enum(["true", "false"])
     .default("false"),
-  LANGFUSE_S3_MEDIA_UPLOAD_SSE: z.string().optional(),
+  LANGFUSE_S3_MEDIA_UPLOAD_SSE: z.enum(["AES256", "aws:kms"]).optional(),
   LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID: z.string().optional(),
   LANGFUSE_USE_AZURE_BLOB: z.enum(["true", "false"]).default("false"),
   LANGFUSE_USE_GOOGLE_CLOUD_STORAGE: z.enum(["true", "false"]).default("false"),
@@ -86,7 +86,7 @@ const EnvSchema = z.object({
   LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED: z
     .enum(["true", "false"])
     .default("false"),
-  LANGFUSE_S3_CORE_DATA_EXPORT_SSE: z.string().optional(),
+  LANGFUSE_S3_CORE_DATA_EXPORT_SSE: z.enum(["AES256", "aws:kms"]).optional(),
   LANGFUSE_S3_CORE_DATA_EXPORT_SSE_KMS_KEY_ID: z.string().optional(),
   LANGFUSE_POSTGRES_METERING_DATA_EXPORT_IS_ENABLED: z
     .enum(["true", "false"])

--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -38,6 +38,8 @@ const getS3StorageServiceClient = (bucketName: string): StorageService => {
       endpoint: env.LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT,
       region: env.LANGFUSE_S3_EVENT_UPLOAD_REGION,
       forcePathStyle: env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+      awsSse: env.LANGFUSE_S3_EVENT_UPLOAD_SSE,
+      awsSseKmsKeyId: env.LANGFUSE_S3_EVENT_UPLOAD_SSE_KMS_KEY_ID,
     });
   }
   return s3StorageServiceClient;

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -25,6 +25,8 @@ const getS3StorageServiceClient = (bucketName: string): StorageService => {
       endpoint: env.LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT,
       region: env.LANGFUSE_S3_EVENT_UPLOAD_REGION,
       forcePathStyle: env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+      awsSse: env.LANGFUSE_S3_EVENT_UPLOAD_SSE,
+      awsSseKmsKeyId: env.LANGFUSE_S3_EVENT_UPLOAD_SSE_KMS_KEY_ID,
     });
   }
   return s3StorageServiceClient;

--- a/packages/shared/src/server/s3/index.ts
+++ b/packages/shared/src/server/s3/index.ts
@@ -16,6 +16,8 @@ export const getS3MediaStorageClient = (bucketName: string): StorageService => {
       endpoint: env.LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT,
       region: env.LANGFUSE_S3_MEDIA_UPLOAD_REGION,
       forcePathStyle: env.LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE === "true",
+      awsSse: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE,
+      awsSseKmsKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID,
     });
   }
   return s3MediaStorageClient;
@@ -30,6 +32,8 @@ export const getS3EventStorageClient = (bucketName: string): StorageService => {
       endpoint: env.LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT,
       region: env.LANGFUSE_S3_EVENT_UPLOAD_REGION,
       forcePathStyle: env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+      awsSse: env.LANGFUSE_S3_EVENT_UPLOAD_SSE,
+      awsSseKmsKeyId: env.LANGFUSE_S3_EVENT_UPLOAD_SSE_KMS_KEY_ID,
     });
   }
   return s3EventStorageClient;

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -4,6 +4,7 @@ import {
   GetObjectCommand,
   ListObjectsV2Command,
   PutObjectCommand,
+  PutObjectCommandInput,
   S3Client,
 } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
@@ -65,6 +66,8 @@ export class StorageServiceFactory {
    * @param params.useAzureBlob - Use Azure Blob Storage instead of S3
    * @param params.useGoogleCloudStorage - Use Google Cloud Storage instead of S3
    * @param params.googleCloudCredentials - Google Cloud Storage credentials JSON string or path to credentials file
+   * @param params.awsSse - Server-side encryption method (e.g., "aws:kms")
+   * @param params.awsSseKmsKeyId - SSE KMS Key ID when using KMS encryption
    */
   public static getInstance(params: {
     accessKeyId: string | undefined;
@@ -77,6 +80,8 @@ export class StorageServiceFactory {
     useAzureBlob?: boolean;
     useGoogleCloudStorage?: boolean;
     googleCloudCredentials?: string;
+    awsSse: string | undefined;
+    awsSseKmsKeyId: string | undefined;
   }): StorageService {
     if (params.useAzureBlob || env.LANGFUSE_USE_AZURE_BLOB === "true") {
       return new AzureBlobStorageService(params);
@@ -364,6 +369,8 @@ class S3StorageService implements StorageService {
   private client: S3Client;
   private signedUrlClient: S3Client;
   private bucketName: string;
+  private awsSse: string | undefined;
+  private awsSseKmsKeyId: string | undefined;
 
   constructor(params: {
     accessKeyId: string | undefined;
@@ -373,6 +380,8 @@ class S3StorageService implements StorageService {
     externalEndpoint?: string | undefined;
     region: string | undefined;
     forcePathStyle: boolean;
+    awsSse: string | undefined;
+    awsSseKmsKeyId: string | undefined;
   }) {
     // Use accessKeyId and secretAccessKey if provided or fallback to default credentials
     const { accessKeyId, secretAccessKey } = params;
@@ -415,6 +424,18 @@ class S3StorageService implements StorageService {
       : this.client;
 
     this.bucketName = params.bucketName;
+    this.awsSse = params.awsSse;
+    this.awsSseKmsKeyId = params.awsSseKmsKeyId;
+  }
+
+  private addSSEToParams<T>(params: Record<string, unknown>): T {
+    if (this.awsSse) {
+      params.ServerSideEncryption = this.awsSse;
+      if (this.awsSse === "aws:kms" && this.awsSseKmsKeyId) {
+        params.SSEKMSKeyId = this.awsSseKmsKeyId;
+      }
+    }
+    return params as T;
   }
 
   public async uploadFile({
@@ -426,12 +447,12 @@ class S3StorageService implements StorageService {
     try {
       await new Upload({
         client: this.client,
-        params: {
+        params: this.addSSEToParams<PutObjectCommandInput>({
           Bucket: this.bucketName,
           Key: fileName,
           Body: data,
           ContentType: fileType,
-        },
+        }),
       }).done();
 
       const signedUrl = await this.getSignedUrl(fileName, expiresInSeconds);
@@ -444,12 +465,14 @@ class S3StorageService implements StorageService {
   }
 
   public async uploadJson(path: string, body: Record<string, unknown>[]) {
-    const putCommand = new PutObjectCommand({
-      Bucket: this.bucketName,
-      Key: path,
-      Body: JSON.stringify(body),
-      ContentType: "application/json",
-    });
+    const putCommand = new PutObjectCommand(
+      this.addSSEToParams({
+        Bucket: this.bucketName,
+        Key: path,
+        Body: JSON.stringify(body),
+        ContentType: "application/json",
+      }),
+    );
 
     try {
       await this.client.send(putCommand);
@@ -573,13 +596,15 @@ class S3StorageService implements StorageService {
 
     return getSignedUrl(
       this.signedUrlClient,
-      new PutObjectCommand({
-        Bucket: this.bucketName,
-        Key: path,
-        ContentType: contentType,
-        ChecksumSHA256: sha256Hash,
-        ContentLength: contentLength,
-      }),
+      new PutObjectCommand(
+        this.addSSEToParams({
+          Bucket: this.bucketName,
+          Key: path,
+          ContentType: contentType,
+          ChecksumSHA256: sha256Hash,
+          ContentLength: contentLength,
+        }),
+      ),
       {
         expiresIn: ttlSeconds,
         signableHeaders: new Set(["content-type", "content-length"]),

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -235,7 +235,7 @@ export const env = createEnv({
       .number()
       .nonnegative()
       .default(3600),
-    LANGFUSE_S3_MEDIA_UPLOAD_SSE: z.string().optional(),
+    LANGFUSE_S3_MEDIA_UPLOAD_SSE: z.enum(["AES256", "aws:kms"]).optional(),
     LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID: z.string().optional(),
 
     LANGFUSE_ALLOWED_ORGANIZATION_CREATORS: z

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -158,21 +158,6 @@ export const env = createEnv({
     EMAIL_FROM_ADDRESS: z.string().optional(),
     SMTP_CONNECTION_URL: z.string().optional(),
 
-    // S3 Batch Export
-    LANGFUSE_S3_BATCH_EXPORT_ENABLED: z
-      .enum(["true", "false"])
-      .default("false"),
-    LANGFUSE_S3_BATCH_EXPORT_BUCKET: z.string().optional(),
-    LANGFUSE_S3_BATCH_EXPORT_PREFIX: z.string().default(""),
-    LANGFUSE_S3_BATCH_EXPORT_REGION: z.string().optional(),
-    LANGFUSE_S3_BATCH_EXPORT_ENDPOINT: z.string().optional(),
-    LANGFUSE_S3_BATCH_EXPORT_EXTERNAL_ENDPOINT: z.string().optional(),
-    LANGFUSE_S3_BATCH_EXPORT_ACCESS_KEY_ID: z.string().optional(),
-    LANGFUSE_S3_BATCH_EXPORT_SECRET_ACCESS_KEY: z.string().optional(),
-    LANGFUSE_S3_BATCH_EXPORT_FORCE_PATH_STYLE: z
-      .enum(["true", "false"])
-      .default("false"),
-
     TURNSTILE_SECRET_KEY: z.string().optional(),
 
     // Otel
@@ -250,6 +235,8 @@ export const env = createEnv({
       .number()
       .nonnegative()
       .default(3600),
+    LANGFUSE_S3_MEDIA_UPLOAD_SSE: z.string().optional(),
+    LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID: z.string().optional(),
 
     LANGFUSE_ALLOWED_ORGANIZATION_CREATORS: z
       .string()
@@ -458,26 +445,6 @@ export const env = createEnv({
     OTEL_SERVICE_NAME: process.env.OTEL_SERVICE_NAME,
     OTEL_TRACE_SAMPLING_RATIO: process.env.OTEL_TRACE_SAMPLING_RATIO,
 
-    // S3 Batch Export
-    LANGFUSE_S3_BATCH_EXPORT_ENABLED:
-      process.env.LANGFUSE_S3_BATCH_EXPORT_ENABLED,
-    LANGFUSE_S3_BATCH_EXPORT_BUCKET:
-      process.env.LANGFUSE_S3_BATCH_EXPORT_BUCKET,
-    LANGFUSE_S3_BATCH_EXPORT_PREFIX:
-      process.env.LANGFUSE_S3_BATCH_EXPORT_PREFIX,
-    LANGFUSE_S3_BATCH_EXPORT_REGION:
-      process.env.LANGFUSE_S3_BATCH_EXPORT_REGION,
-    LANGFUSE_S3_BATCH_EXPORT_ENDPOINT:
-      process.env.LANGFUSE_S3_BATCH_EXPORT_ENDPOINT,
-    LANGFUSE_S3_BATCH_EXPORT_EXTERNAL_ENDPOINT:
-      process.env.LANGFUSE_S3_BATCH_EXPORT_EXTERNAL_ENDPOINT,
-    LANGFUSE_S3_BATCH_EXPORT_ACCESS_KEY_ID:
-      process.env.LANGFUSE_S3_BATCH_EXPORT_ACCESS_KEY_ID,
-    LANGFUSE_S3_BATCH_EXPORT_SECRET_ACCESS_KEY:
-      process.env.LANGFUSE_S3_BATCH_EXPORT_SECRET_ACCESS_KEY,
-    LANGFUSE_S3_BATCH_EXPORT_FORCE_PATH_STYLE:
-      process.env.LANGFUSE_S3_BATCH_EXPORT_FORCE_PATH_STYLE,
-
     // S3 media upload
     LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH:
       process.env.LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH,
@@ -497,6 +464,9 @@ export const env = createEnv({
       process.env.LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE,
     LANGFUSE_S3_MEDIA_DOWNLOAD_URL_EXPIRY_SECONDS:
       process.env.LANGFUSE_S3_MEDIA_DOWNLOAD_URL_EXPIRY_SECONDS,
+    LANGFUSE_S3_MEDIA_UPLOAD_SSE: process.env.LANGFUSE_S3_MEDIA_UPLOAD_SSE,
+    LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID:
+      process.env.LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID,
     // Worker
     TURNSTILE_SECRET_KEY: process.env.TURNSTILE_SECRET_KEY,
     NEXT_PUBLIC_TURNSTILE_SITE_KEY: process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY,

--- a/web/src/features/media/server/getMediaStorageClient.ts
+++ b/web/src/features/media/server/getMediaStorageClient.ts
@@ -17,6 +17,8 @@ export const getMediaStorageServiceClient = (
       endpoint: env.LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT,
       region: env.LANGFUSE_S3_MEDIA_UPLOAD_REGION,
       forcePathStyle: env.LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE === "true",
+      awsSse: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE,
+      awsSseKmsKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID,
     });
   }
   return s3StorageServiceClient;

--- a/worker/src/ee/evaluation/evalService.ts
+++ b/worker/src/ee/evaluation/evalService.ts
@@ -61,6 +61,8 @@ const getS3StorageServiceClient = (bucketName: string): StorageService => {
       endpoint: env.LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT,
       region: env.LANGFUSE_S3_EVENT_UPLOAD_REGION,
       forcePathStyle: env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+      awsSse: env.LANGFUSE_S3_EVENT_UPLOAD_SSE,
+      awsSseKmsKeyId: env.LANGFUSE_S3_EVENT_UPLOAD_SSE_KMS_KEY_ID,
     });
   }
   return s3StorageServiceClient;

--- a/worker/src/ee/integrations/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/ee/integrations/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -62,6 +62,7 @@ const processBlobStorageExport = async (config: {
   );
 
   // Initialize the storage service
+  // KMS SSE is not supported for this integration.
   const storageService: StorageService = StorageServiceFactory.getInstance({
     accessKeyId: config.accessKeyId,
     secretAccessKey: config.secretAccessKey,
@@ -69,6 +70,8 @@ const processBlobStorageExport = async (config: {
     endpoint: config.endpoint ?? undefined,
     region: config.region,
     forcePathStyle: config.forcePathStyle ?? false,
+    awsSse: undefined,
+    awsSseKmsKeyId: undefined,
     useAzureBlob: config.type === BlobStorageIntegrationType.AZURE_BLOB_STORAGE,
   });
 

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -28,7 +28,7 @@ const EnvSchema = z.object({
   LANGFUSE_S3_BATCH_EXPORT_FORCE_PATH_STYLE: z
     .enum(["true", "false"])
     .default("false"),
-  LANGFUSE_S3_BATCH_EXPORT_SSE: z.string().optional(),
+  LANGFUSE_S3_BATCH_EXPORT_SSE: z.enum(["AES256", "aws:kms"]).optional(),
   LANGFUSE_S3_BATCH_EXPORT_SSE_KMS_KEY_ID: z.string().optional(),
 
   LANGFUSE_S3_EVENT_UPLOAD_BUCKET: z.string({
@@ -42,7 +42,7 @@ const EnvSchema = z.object({
   LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: z
     .enum(["true", "false"])
     .default("false"),
-  LANGFUSE_S3_EVENT_UPLOAD_SSE: z.string().optional(),
+  LANGFUSE_S3_EVENT_UPLOAD_SSE: z.enum(["AES256", "aws:kms"]).optional(),
   LANGFUSE_S3_EVENT_UPLOAD_SSE_KMS_KEY_ID: z.string().optional(),
 
   BATCH_EXPORT_PAGE_SIZE: z.coerce.number().positive().default(500),
@@ -211,7 +211,7 @@ const EnvSchema = z.object({
   LANGFUSE_S3_CORE_DATA_UPLOAD_FORCE_PATH_STYLE: z
     .enum(["true", "false"])
     .default("false"),
-  LANGFUSE_S3_CORE_DATA_UPLOAD_SSE: z.string().optional(),
+  LANGFUSE_S3_CORE_DATA_UPLOAD_SSE: z.enum(["AES256", "aws:kms"]).optional(),
   LANGFUSE_S3_CORE_DATA_UPLOAD_SSE_KMS_KEY_ID: z.string().optional(),
 
   // Media upload
@@ -224,7 +224,7 @@ const EnvSchema = z.object({
   LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: z
     .enum(["true", "false"])
     .default("false"),
-  LANGFUSE_S3_MEDIA_UPLOAD_SSE: z.string().optional(),
+  LANGFUSE_S3_MEDIA_UPLOAD_SSE: z.enum(["AES256", "aws:kms"]).optional(),
   LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID: z.string().optional(),
 
   // Metering data Postgres export - Langfuse Cloud

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -28,6 +28,8 @@ const EnvSchema = z.object({
   LANGFUSE_S3_BATCH_EXPORT_FORCE_PATH_STYLE: z
     .enum(["true", "false"])
     .default("false"),
+  LANGFUSE_S3_BATCH_EXPORT_SSE: z.string().optional(),
+  LANGFUSE_S3_BATCH_EXPORT_SSE_KMS_KEY_ID: z.string().optional(),
 
   LANGFUSE_S3_EVENT_UPLOAD_BUCKET: z.string({
     required_error: "Langfuse requires a bucket name for S3 Event Uploads.",
@@ -40,6 +42,8 @@ const EnvSchema = z.object({
   LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: z
     .enum(["true", "false"])
     .default("false"),
+  LANGFUSE_S3_EVENT_UPLOAD_SSE: z.string().optional(),
+  LANGFUSE_S3_EVENT_UPLOAD_SSE_KMS_KEY_ID: z.string().optional(),
 
   BATCH_EXPORT_PAGE_SIZE: z.coerce.number().positive().default(500),
   BATCH_EXPORT_ROW_LIMIT: z.coerce.number().positive().default(1_500_000),
@@ -207,6 +211,8 @@ const EnvSchema = z.object({
   LANGFUSE_S3_CORE_DATA_UPLOAD_FORCE_PATH_STYLE: z
     .enum(["true", "false"])
     .default("false"),
+  LANGFUSE_S3_CORE_DATA_UPLOAD_SSE: z.string().optional(),
+  LANGFUSE_S3_CORE_DATA_UPLOAD_SSE_KMS_KEY_ID: z.string().optional(),
 
   // Media upload
   LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: z.string().optional(),
@@ -218,6 +224,8 @@ const EnvSchema = z.object({
   LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: z
     .enum(["true", "false"])
     .default("false"),
+  LANGFUSE_S3_MEDIA_UPLOAD_SSE: z.string().optional(),
+  LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID: z.string().optional(),
 
   // Metering data Postgres export - Langfuse Cloud
   LANGFUSE_POSTGRES_METERING_DATA_EXPORT_IS_ENABLED: z

--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -116,6 +116,8 @@ export const handleBatchExportJob = async (
     externalEndpoint: env.LANGFUSE_S3_BATCH_EXPORT_EXTERNAL_ENDPOINT,
     region: env.LANGFUSE_S3_BATCH_EXPORT_REGION,
     forcePathStyle: env.LANGFUSE_S3_BATCH_EXPORT_FORCE_PATH_STYLE === "true",
+    awsSse: env.LANGFUSE_S3_BATCH_EXPORT_SSE,
+    awsSseKmsKeyId: env.LANGFUSE_S3_BATCH_EXPORT_SSE_KMS_KEY_ID,
   }).uploadFile({
     fileName,
     fileType:

--- a/worker/src/features/traces/processClickhouseTraceDelete.ts
+++ b/worker/src/features/traces/processClickhouseTraceDelete.ts
@@ -22,6 +22,8 @@ const getS3MediaStorageClient = (bucketName: string): StorageService => {
       endpoint: env.LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT,
       region: env.LANGFUSE_S3_MEDIA_UPLOAD_REGION,
       forcePathStyle: env.LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE === "true",
+      awsSse: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE,
+      awsSseKmsKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID,
     });
   }
   return s3MediaStorageClient;

--- a/worker/src/queues/coreDataS3ExportQueue.ts
+++ b/worker/src/queues/coreDataS3ExportQueue.ts
@@ -19,6 +19,8 @@ const getS3StorageServiceClient = (bucketName: string): StorageService => {
       region: env.LANGFUSE_S3_CORE_DATA_UPLOAD_REGION,
       forcePathStyle:
         env.LANGFUSE_S3_CORE_DATA_UPLOAD_FORCE_PATH_STYLE === "true",
+      awsSse: env.LANGFUSE_S3_CORE_DATA_UPLOAD_SSE,
+      awsSseKmsKeyId: env.LANGFUSE_S3_CORE_DATA_UPLOAD_SSE_KMS_KEY_ID,
     });
   }
   return s3StorageServiceClient;

--- a/worker/src/queues/projectDelete.ts
+++ b/worker/src/queues/projectDelete.ts
@@ -26,6 +26,8 @@ const getS3MediaStorageClient = (bucketName: string): StorageService => {
       endpoint: env.LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT,
       region: env.LANGFUSE_S3_MEDIA_UPLOAD_REGION,
       forcePathStyle: env.LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE === "true",
+      awsSse: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE,
+      awsSseKmsKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID,
     });
   }
   return s3MediaStorageClient;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> This PR adds AWS S3 server-side encryption (SSE) configuration options for various S3 interactions, allowing data encryption using AES256 or AWS KMS methods.
> 
>   - **Environment Variables**:
>     - Added `LANGFUSE_S3_*_SSE` and `LANGFUSE_S3_*_SSE_KMS_KEY_ID` for event, media, core data, and batch exports in `env.ts` and `env.mjs`.
>   - **Storage Service**:
>     - Updated `StorageServiceFactory.getInstance()` to accept `awsSse` and `awsSseKmsKeyId` parameters in `StorageService.ts`.
>     - Modified `S3StorageService` to include SSE parameters in `uploadFile()`, `uploadJson()`, and `getSignedUploadUrl()`.
>   - **S3 Client Initialization**:
>     - Updated `getS3StorageServiceClient()` and `getS3MediaStorageClient()` functions in `processEventBatch.ts`, `clickhouse.ts`, `index.ts`, `getMediaStorageClient.ts`, `evalService.ts`, `processClickhouseTraceDelete.ts`, `coreDataS3ExportQueue.ts`, and `projectDelete.ts` to include SSE configurations.
>   - **Batch and Core Data Exports**:
>     - Added SSE support in `handleBatchExportJob.ts` and `coreDataS3ExportQueue.ts` for batch and core data exports.
>   - **Blob Storage Integration**:
>     - Noted that KMS SSE is not supported in `handleBlobStorageIntegrationProjectJob.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5b5b8ba9c6fe5d6a333cbdc3c4df404c417f6270. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->