### PR TITLE
fix: dynamically calc max value for home line charts

### DIFF
--- a/web/src/features/dashboard/components/BaseTimeSeriesChart.tsx
+++ b/web/src/features/dashboard/components/BaseTimeSeriesChart.tsx
@@ -7,6 +7,7 @@ import {
   dashboardDateRangeAggregationSettings,
   type DashboardDateRangeAggregationOption,
 } from "@/src/utils/date-range-utils";
+import { useMemo } from "react";
 
 export type TimeSeriesChartDataPoint = {
   ts: number;
@@ -78,7 +79,7 @@ export function BaseTimeSeriesChart(props: {
   const colors = getColorsForCategories(Array.from(labels));
 
   // Calculate dynamic maxValue based on the maximum value in the data plus 10%
-  const calculateMaxValue = (): number | undefined => {
+  const dynamicMaxValue = useMemo(() => {
     if (props.data.length === 0) return undefined;
 
     const maxValue = Math.max(
@@ -96,9 +97,7 @@ export function BaseTimeSeriesChart(props: {
 
     // Round up to the next multiple of roundTo
     return Math.ceil(bufferedValue / roundTo) * roundTo;
-  };
-
-  const dynamicMaxValue = calculateMaxValue();
+  }, [props.data]);
 
   return (
     <ChartComponent

--- a/web/src/features/dashboard/components/BaseTimeSeriesChart.tsx
+++ b/web/src/features/dashboard/components/BaseTimeSeriesChart.tsx
@@ -77,6 +77,29 @@ export function BaseTimeSeriesChart(props: {
   );
   const colors = getColorsForCategories(Array.from(labels));
 
+  // Calculate dynamic maxValue based on the maximum value in the data plus 10%
+  const calculateMaxValue = (): number | undefined => {
+    if (props.data.length === 0) return undefined;
+
+    const maxValue = Math.max(
+      ...props.data.flatMap((point) => point.values.map((v) => v.value ?? 0)),
+    );
+
+    if (maxValue <= 0) return undefined;
+
+    // Add 10% buffer
+    const bufferedValue = maxValue * 1.1;
+
+    // Get order of magnitude and rounding goal
+    const magnitude = Math.floor(Math.log10(bufferedValue));
+    const roundTo = Math.max(1, Math.pow(10, magnitude) / 5);
+
+    // Round up to the next multiple of roundTo
+    return Math.ceil(bufferedValue / roundTo) * roundTo;
+  };
+
+  const dynamicMaxValue = calculateMaxValue();
+
   return (
     <ChartComponent
       className={cn("mt-4", props.className)}
@@ -92,6 +115,7 @@ export function BaseTimeSeriesChart(props: {
       onValueChange={() => {}}
       enableLegendSlider={true}
       customTooltip={TooltipComponent}
+      maxValue={dynamicMaxValue}
     />
   );
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Dynamically calculates `maxValue` for line charts in `BaseTimeSeriesChart` with a 10% buffer and significant figure rounding.
> 
>   - **Behavior**:
>     - Dynamically calculates `maxValue` for line charts in `BaseTimeSeriesChart` using `useMemo`.
>     - Adds 10% buffer to the maximum data value and rounds to a significant figure.
>     - Handles empty data by returning `undefined` for `maxValue`.
>   - **Components**:
>     - Updates `BaseTimeSeriesChart` to use `dynamicMaxValue` for `maxValue` prop in `ChartComponent`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4b74c6400319e9f8c45a7dd438b5fd47c432c55a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->