### PR TITLE
feat(otel): add support for observations of type 'event'

### DIFF
--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -762,9 +762,16 @@ export const convertOtelSpanToIngestionEvent = (
         ("openinference.span.kind" in attributes &&
           attributes["openinference.span.kind"] === "LLM");
 
+      const isEvent =
+        attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] === "event";
+
       events.push({
         id: randomUUID(),
-        type: isGeneration ? "generation-create" : "span-create",
+        type: isGeneration
+          ? "generation-create"
+          : isEvent
+            ? "event-create"
+            : "span-create",
         timestamp: new Date().toISOString(),
         body: observation,
       });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for 'event' observation type in `convertOtelSpanToIngestionEvent` function in `index.ts`.
> 
>   - **Behavior**:
>     - Adds support for 'event' observation type in `convertOtelSpanToIngestionEvent` in `index.ts`.
>     - Checks if `attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE]` is 'event' and sets event type to 'event-create'.
>   - **Misc**:
>     - No changes to existing functionality for 'generation' or 'span' types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 88059f0da5c4892c63022c3c069db6440d852770. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->