### PR TITLE
perf: drop unused observation_media index

### DIFF
--- a/packages/shared/prisma/migrations/20250522140357_remove_obsolete_observation_media_index/migration.sql
+++ b/packages/shared/prisma/migrations/20250522140357_remove_obsolete_observation_media_index/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX CONCURRENTLY IF EXISTS "observation_media_project_id_observation_id_idx";

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -1032,7 +1032,6 @@ model ObservationMedia {
   field         String   @map("field")
 
   @@unique([projectId, traceId, observationId, mediaId, field])
-  @@index([projectId, observationId])
   @@index([projectId, mediaId])
   @@map("observation_media")
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove unused `observation_media_project_id_observation_id_idx` index from `ObservationMedia` model and database.
> 
>   - **Database Migration**:
>     - Adds `20250522140357_remove_obsolete_observation_media_index/migration.sql` to drop `observation_media_project_id_observation_id_idx` index.
>   - **Prisma Schema**:
>     - Removes `@@index([projectId, observationId])` from `ObservationMedia` model in `schema.prisma`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9889e3e4352c4b0efd7659b309a97fd7169b92dd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->