### PR TITLE
feat(cost-tracking+llm-keys): add claude 4 sonnet and opus

### DIFF
--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -303,6 +303,8 @@ export type OpenAIModel = (typeof openAIModels)[number];
 // NOTE: Update docs page when changing this! https://langfuse.com/docs/playground#openai-playground--anthropic-playground
 // WARNING: The first entry in the array is chosen as the default model to add LLM API keys
 export const anthropicModels = [
+  "claude-sonnet-4-20250514",
+  "claude-opus-4-20250514",
   "claude-3-7-sonnet-20250219",
   "claude-3-5-sonnet-20241022",
   "claude-3-5-sonnet-20240620",

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1732,5 +1732,62 @@
       "tokensPerMessage": 3
     },
     "tokenizer_id": "openai"
+  },
+  {
+    "id": "cmazmkzlm00000djp1e1qe4k4",
+    "model_name": "claude-sonnet-4-20250514",
+    "match_pattern": "(?i)^(claude-sonnet-4-20250514|anthropic\\.claude-sonnet-4-20250514-v1:0|claude-sonnet-4-V1@20250514)$",
+    "created_at": "2025-05-22T17:09:02.131Z",
+    "updated_at": "2025-05-22T17:09:02.131Z",
+    "prices": {
+      "input": 3e-6,
+      "input_tokens": 3e-6,
+      "output": 15e-6,
+      "output_tokens": 15e-6,
+      "cache_creation_input_tokens": 3.75e-6,
+      "input_cache_creation": 3.75e-6,
+      "cache_read_input_tokens": 0.3e-6,
+      "input_cache_read": 0.3e-6
+    },
+    "tokenizer_config": null,
+    "tokenizer_id": "claude"
+  },
+  {
+    "id": "cmazmlbnv00010djpazed91va",
+    "model_name": "claude-sonnet-4-latest",
+    "match_pattern": "(?i)^(claude-sonnet-4-latest)$",
+    "created_at": "2025-05-22T17:09:02.131Z",
+    "updated_at": "2025-05-22T17:09:02.131Z",
+    "prices": {
+      "input": 3e-6,
+      "input_tokens": 3e-6,
+      "output": 15e-6,
+      "output_tokens": 15e-6,
+      "cache_creation_input_tokens": 3.75e-6,
+      "input_cache_creation": 3.75e-6,
+      "cache_read_input_tokens": 0.3e-6,
+      "input_cache_read": 0.3e-6
+    },
+    "tokenizer_config": null,
+    "tokenizer_id": "claude"
+  },
+  {
+    "id": "cmazmlm2p00020djpa9s64jw5",
+    "model_name": "claude-opus-4-20250514",
+    "match_pattern": "(?i)^(claude-opus-4-20250514|anthropic\\.claude-opus-4-20250514-v1:0|claude-opus-4@20250514)$",
+    "created_at": "2025-05-22T17:09:02.131Z",
+    "updated_at": "2025-05-22T17:09:02.131Z",
+    "prices": {
+      "input": 15e-6,
+      "input_tokens": 15e-6,
+      "output": 75e-6,
+      "output_tokens": 75e-6,
+      "cache_creation_input_tokens": 18.75e-6,
+      "input_cache_creation": 18.75e-6,
+      "cache_read_input_tokens": 1.5e-6,
+      "input_cache_read": 1.5e-6
+    },
+    "tokenizer_config": null,
+    "tokenizer_id": "claude"
   }
 ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `claude-sonnet-4-20250514` and `claude-opus-4-20250514` models to `anthropicModels` and update pricing in `default-model-prices.json`.
> 
>   - **Models**:
>     - Add `claude-sonnet-4-20250514` and `claude-opus-4-20250514` to `anthropicModels` in `types.ts`.
>     - Update `default-model-prices.json` with pricing for `claude-sonnet-4-20250514`, `claude-sonnet-4-latest`, and `claude-opus-4-20250514`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c3a03fd028ec046959e63e9cd28ccf230048de80. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->