### PR TITLE
chore: do not alert on missing api keys

### DIFF
--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -143,6 +143,12 @@ export const evalJobExecutorQueueProcessor = async (
     // do not log expected errors (api failures + missing api keys not provided by the user)
     if (
       (e instanceof BaseError && e.message.includes("API key for provider")) || // api key not provided
+      (e instanceof BaseError &&
+        e.message.includes("No API key found for provider")) || // api key not provided
+      (e instanceof BaseError &&
+        e.message.includes(
+          "`No default model or custom model found for project",
+        )) || // api key not provided
       (e instanceof ApiError && e.httpCode >= 400 && e.httpCode < 500) || // do not error and retry on 4xx errors. They are visible to the user in the UI but do not alert us.
       (e instanceof ApiError && e.message.includes("TypeError")) || // Zod parsing the response failed. User should update prompt to consistently return expected output structure.
       (e instanceof ApiError &&


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `evalQueue.ts`, updated `evalJobExecutorQueueProcessor` to not alert on specific missing API key errors.
> 
>   - **Error Handling**:
>     - In `evalJobExecutorQueueProcessor`, added conditions to not alert on errors with messages "No API key found for provider" and "`No default model or custom model found for project".
>     - These errors are treated as expected and do not trigger alerts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6ba8bb423a53662d56938c99e933950077785feb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->