### PR TITLE
feat: Add column width persistence for prompts table

### DIFF
--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -32,6 +32,7 @@ import {
   type RowSelectionState,
   type VisibilityState,
   type Row,
+  type ColumnSizingState,
 } from "@tanstack/react-table";
 import { TablePeekView } from "@/src/components/table/peek";
 import { type PeekViewProps } from "@/src/components/table/peek/hooks/usePeekView";
@@ -53,6 +54,8 @@ interface DataTableProps<TData, TValue> {
   onColumnVisibilityChange?: OnChangeFn<VisibilityState>;
   columnOrder?: ColumnOrderState;
   onColumnOrderChange?: OnChangeFn<ColumnOrderState>;
+  columnSizing?: ColumnSizingState;
+  onColumnSizingChange?: OnChangeFn<ColumnSizingState>;
   orderBy?: OrderByState;
   setOrderBy?: (s: OrderByState) => void;
   help?: { description: string; href: string };
@@ -110,6 +113,8 @@ export function DataTable<TData extends object, TValue>({
   onColumnVisibilityChange,
   columnOrder,
   onColumnOrderChange,
+  columnSizing,
+  onColumnSizingChange,
   help,
   orderBy,
   setOrderBy,
@@ -142,6 +147,7 @@ export function DataTable<TData extends object, TValue>({
     columns,
     onColumnFiltersChange: setColumnFilters,
     onColumnOrderChange: onColumnOrderChange,
+    onColumnSizingChange: onColumnSizingChange,
     getFilteredRowModel: getFilteredRowModel(),
     getCoreRowModel: getCoreRowModel(),
     manualPagination: pagination !== undefined,
@@ -170,6 +176,7 @@ export function DataTable<TData extends object, TValue>({
         ? insertArrayAfterKey(columnOrder, flattedColumnsByGroup)
         : undefined,
       rowSelection,
+      columnSizing,
     },
     manualFiltering: true,
     defaultColumn: {

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -13,11 +13,16 @@ import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState
 import { useOrderByState } from "@/src/features/orderBy/hooks/useOrderByState";
 import { promptsTableColsWithOptions } from "@/src/server/api/definitions/promptsTable";
 import { NumberParam, useQueryParams, withDefault } from "use-query-params";
-import { createColumnHelper } from "@tanstack/react-table";
+import {
+  createColumnHelper,
+  type ColumnSizingState,
+  type OnChangeFn,
+} from "@tanstack/react-table";
 import { joinTableCoreAndMetrics } from "@/src/components/table/utils/joinTableCoreAndMetrics";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { useDebounce } from "@/src/hooks/useDebounce";
 import { LocalIsoDate } from "@/src/components/LocalIsoDate";
+import useLocalStorage from "@/src/components/useLocalStorage";
 
 type PromptTableRow = {
   name: string;
@@ -228,6 +233,23 @@ export function PromptTable() {
     }),
   ] as LangfuseColumnDef<PromptTableRow>[];
 
+  const STORAGE_KEY = "prompts-table-column-sizing";
+
+  const [columnSizing, setColumnSizing] = useLocalStorage<ColumnSizingState>(
+    STORAGE_KEY,
+    {},
+  );
+
+  const handleColumnSizingChange: OnChangeFn<ColumnSizingState> = (
+    updatedSizing,
+  ) => {
+    setColumnSizing(
+      typeof updatedSizing === "function"
+        ? updatedSizing(columnSizing)
+        : updatedSizing,
+    );
+  };
+
   return (
     <>
       <DataTableToolbar
@@ -272,6 +294,8 @@ export function PromptTable() {
           onChange: setPaginationState,
           state: paginationState,
         }}
+        columnSizing={columnSizing}
+        onColumnSizingChange={handleColumnSizingChange}
       />
     </>
   );


### PR DESCRIPTION
## What does this PR do?

Implements column width persistence for prompts table using localStorage.
When users resize columns, their preferences are saved and restored on page reload.
This improves user experience by maintaining their custom layout settings.

Fixes #6483 


https://github.com/user-attachments/assets/3de1ca34-8abb-4e48-89f4-8c149ae07149


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds column width persistence to prompts table using localStorage, saving user preferences for column resizing.
> 
>   - **Behavior**:
>     - Implements column width persistence for prompts table using `localStorage` in `prompts-table.tsx`.
>     - Saves user column resizing preferences and restores them on page reload.
>   - **Components**:
>     - Adds `columnSizing` and `onColumnSizingChange` props to `DataTable` in `data-table.tsx`.
>     - Introduces `handleColumnSizingChange` function in `prompts-table.tsx` to update column sizing state.
>   - **State Management**:
>     - Utilizes `useLocalStorage` hook in `prompts-table.tsx` to store and retrieve column sizing state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bf2d7e2b0e98f6ad8070b4a7eb0492a13f1b0c5b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->