### PR TITLE
chore: ensure eval config modal closes after successful delete

### DIFF
--- a/web/src/components/deleteButton.tsx
+++ b/web/src/components/deleteButton.tsx
@@ -311,12 +311,13 @@ export function DeleteEvalConfigButton(props: DeleteButtonProps) {
     },
   });
 
-  const executeDeleteMutation = async () => {
+  const executeDeleteMutation = async (onSuccess: () => void) => {
     try {
       await evaluatorMutation.mutateAsync({
         evalConfigId: itemId,
         projectId,
       });
+      onSuccess();
     } catch (error) {
       return Promise.reject(error);
     }

--- a/web/src/components/deleteButton.tsx
+++ b/web/src/components/deleteButton.tsx
@@ -292,7 +292,7 @@ export function DeleteDashboardButton(props: DeleteButtonProps) {
   );
 }
 
-export function DeleteEvaluatorButton(props: DeleteButtonProps) {
+export function DeleteEvalConfigButton(props: DeleteButtonProps) {
   const utils = api.useUtils();
   const {
     itemId,
@@ -300,8 +300,18 @@ export function DeleteEvaluatorButton(props: DeleteButtonProps) {
     scope = "evalJob:CUD",
     invalidateFunc = () => void utils.evals.invalidate(),
   } = props;
-  const evaluatorMutation = api.evals.deleteEvalJob.useMutation();
-  const executeDeleteMutation = async (onSuccess: () => void) => {
+
+  const evaluatorMutation = api.evals.deleteEvalJob.useMutation({
+    onSuccess: () => {
+      showSuccessToast({
+        title: "Running evaluator deleted",
+        description: "The running evaluator has been deleted successfully",
+      });
+      void utils.evals.invalidate();
+    },
+  });
+
+  const executeDeleteMutation = async () => {
     try {
       await evaluatorMutation.mutateAsync({
         evalConfigId: itemId,
@@ -310,11 +320,12 @@ export function DeleteEvaluatorButton(props: DeleteButtonProps) {
     } catch (error) {
       return Promise.reject(error);
     }
-    onSuccess();
   };
+
   const hasModelBasedEvaluationEntitlement = useHasEntitlement(
     "model-based-evaluations",
   );
+
   return (
     <DeleteButton
       {...props}
@@ -322,15 +333,15 @@ export function DeleteEvaluatorButton(props: DeleteButtonProps) {
       invalidateFunc={invalidateFunc}
       captureDeleteOpen={(capture, isTableAction) =>
         capture("eval_config:delete_form_open", {
-          source: isTableAction ? "table-single-row" : "evaluator",
+          source: isTableAction ? "table-single-row" : "eval config detail",
         })
       }
       captureDeleteSuccess={(capture, isTableAction) =>
         capture("eval_config:delete_evaluator_button_click", {
-          source: isTableAction ? "table-single-row" : "evaluator",
+          source: isTableAction ? "table-single-row" : "eval config detail",
         })
       }
-      entityToDeleteName="evaluator"
+      entityToDeleteName="running evaluator"
       executeDeleteMutation={executeDeleteMutation}
       isDeleteMutationLoading={evaluatorMutation.isLoading}
       enabled={hasModelBasedEvaluationEntitlement}

--- a/web/src/ee/features/evals/components/evaluator-table.tsx
+++ b/web/src/ee/features/evals/components/evaluator-table.tsx
@@ -38,7 +38,7 @@ import { showSuccessToast } from "@/src/features/notifications/showSuccessToast"
 import { Dialog, DialogContent, DialogTitle } from "@/src/components/ui/dialog";
 import { EvaluatorForm } from "@/src/ee/features/evals/components/evaluator-form";
 import { useRouter } from "next/router";
-import { DeleteEvaluatorButton } from "@/src/components/deleteButton";
+import { DeleteEvalConfigButton } from "@/src/components/deleteButton";
 import { evalConfigFilterColumns } from "@/src/server/api/definitions/evalConfigsTable";
 import { RAGAS_TEMPLATE_PREFIX } from "@/src/ee/features/evals/types";
 import { MaintainerTooltip } from "@/src/ee/features/evals/components/maintainer-tooltip";
@@ -292,7 +292,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
                 Edit
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
-                <DeleteEvaluatorButton
+                <DeleteEvalConfigButton
                   aria-label="delete"
                   itemId={id}
                   projectId={projectId}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Ensure `DeleteEvalConfigButton` closes modal after successful deletion and rename for clarity.
> 
>   - **Behavior**:
>     - `DeleteEvalConfigButton` now closes the modal after successful deletion by calling `onSuccess()` in `deleteButton.tsx`.
>     - Shows a success toast upon successful deletion in `deleteButton.tsx`.
>   - **Renames**:
>     - `DeleteEvaluatorButton` to `DeleteEvalConfigButton`.
>   - **Usage**:
>     - Updated usage in `evaluator-table.tsx` to use `DeleteEvalConfigButton`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5c792234b5a5ce2d06fb46a68b10474a423ac035. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->