### PR TITLE
fix(otel): set trace name only if root span or attr provided

### DIFF
--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -656,7 +656,7 @@ export const convertOtelSpanToIngestionEvent = (
           timestamp: startTimeISO,
           name:
             attributes[LangfuseOtelSpanAttributes.TRACE_NAME] ??
-            extractName(span.name, attributes),
+            (is_root_span ? extractName(span.name, attributes) : undefined),
           metadata: {
             ...resourceAttributeMetadata,
             ...extractMetadata(attributes, "trace"),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes trace name setting in `convertOtelSpanToIngestionEvent` to only apply for root spans or when a specific attribute is provided.
> 
>   - **Behavior**:
>     - In `convertOtelSpanToIngestionEvent` in `index.ts`, set trace name only if `is_root_span` is true or `LangfuseOtelSpanAttributes.TRACE_NAME` attribute is provided.
>     - Prevents setting trace name for non-root spans without the specific attribute.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 74597de9aad22441be3db707c48d9c876a1f7156. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->