### PR TITLE
feat(evaluation): allow filtering by log status

### DIFF
--- a/packages/shared/src/tableDefinitions/types.ts
+++ b/packages/shared/src/tableDefinitions/types.ts
@@ -75,6 +75,7 @@ export const tableNames = [
   "prompts",
   "users",
   "job_configurations",
+  "job_executions",
   "dataset_items",
 ] as const;
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -35,4 +35,5 @@ export type TableName =
   | "dashboard"
   | "widgets"
   | "users"
-  | "eval_configs";
+  | "eval_configs"
+  | "job_executions";

--- a/web/src/ee/features/evals/components/eval-log.tsx
+++ b/web/src/ee/features/evals/components/eval-log.tsx
@@ -7,6 +7,8 @@ import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { IOTableCell } from "@/src/components/ui/CodeJsonViewer";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
+import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
+import { evalExecutionsFilterCols } from "@/src/server/api/definitions/evalExecutionsTable";
 import { type RouterOutputs, api } from "@/src/utils/api";
 import { type Prisma } from "@langfuse/shared";
 import { createColumnHelper } from "@tanstack/react-table";
@@ -38,9 +40,17 @@ export default function EvalLogTable({
     pageIndex: withDefault(NumberParam, 0),
     pageSize: withDefault(NumberParam, 50),
   });
+
+  const [filterState, setFilterState] = useQueryFilterState(
+    [],
+    "job_executions",
+    projectId,
+  );
+
   const logs = api.evals.getLogs.useQuery({
     page: paginationState.pageIndex,
     limit: paginationState.pageSize,
+    filter: filterState,
     jobConfigurationId,
     projectId,
   });
@@ -191,6 +201,9 @@ export default function EvalLogTable({
         setColumnOrder={setColumnOrder}
         rowHeight={rowHeight}
         setRowHeight={setRowHeight}
+        filterState={filterState}
+        setFilterState={setFilterState}
+        filterColumnDefinition={evalExecutionsFilterCols}
       />
       <DataTable
         columns={columns}

--- a/web/src/features/filters/hooks/useFilterState.ts
+++ b/web/src/features/filters/hooks/useFilterState.ts
@@ -17,6 +17,7 @@ import { promptsTableCols } from "@/src/server/api/definitions/promptsTable";
 import { usersTableCols } from "@/src/server/api/definitions/usersTable";
 import useSessionStorage from "@/src/components/useSessionStorage";
 import { evalConfigFilterColumns } from "@/src/server/api/definitions/evalConfigsTable";
+import { evalExecutionsFilterCols } from "@/src/server/api/definitions/evalExecutionsTable";
 
 const DEBUG_QUERY_STATE = false;
 
@@ -139,6 +140,7 @@ const tableCols = {
   prompts: promptsTableCols,
   users: usersTableCols,
   eval_configs: evalConfigFilterColumns,
+  job_executions: evalExecutionsFilterCols,
   widgets: [
     { id: "environment", name: "Environment" },
     { id: "traceName", name: "Trace Name" },

--- a/web/src/server/api/definitions/evalExecutionsTable.ts
+++ b/web/src/server/api/definitions/evalExecutionsTable.ts
@@ -1,0 +1,13 @@
+import { type ColumnDefinition, JobExecutionStatus } from "@langfuse/shared";
+
+export const evalExecutionsFilterCols: ColumnDefinition[] = [
+  {
+    name: "Status",
+    id: "status",
+    type: "stringOptions",
+    internal: 'je."status"::text',
+    options: Object.values(JobExecutionStatus)
+      .filter((value) => value !== JobExecutionStatus.CANCELLED)
+      .map((value) => ({ value })),
+  },
+];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add filtering by job execution status to evaluation logs, updating types, hooks, and API routes.
> 
>   - **Behavior**:
>     - Add filtering by `job_executions` status in `eval-log.tsx` using `useQueryFilterState`.
>     - Update `getLogs` in `router.ts` to handle `filter` input and apply SQL filtering.
>   - **Types**:
>     - Add `job_executions` to `TableName` in `types.ts`.
>     - Add `job_executions` to `tableNames` in `types.ts`.
>   - **Filter Definitions**:
>     - Add `evalExecutionsFilterCols` in `evalExecutionsTable.ts` for status filtering.
>     - Update `useFilterState.ts` to include `job_executions` in `tableCols`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f863eb76cff19e9ff3c27c0df836627b9fd14a96. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->