### PR TITLE
fix: do not wrap traces toolbar

### DIFF
--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -136,7 +136,7 @@ export function DataTableToolbar<TData, TValue>({
     <div className={cn("grid h-fit w-full gap-0 px-2", className)}>
       <div className="my-2 flex flex-wrap items-center gap-2 @container">
         {searchConfig && (
-          <div className="flex min-w-0 flex-shrink-0 items-stretch">
+          <div className="flex min-w-0 max-w-64 flex-shrink-0 items-stretch">
             <div
               className={cn(
                 "flex h-8 flex-1 items-center border border-input bg-background pl-2",

--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -136,7 +136,7 @@ export function DataTableToolbar<TData, TValue>({
     <div className={cn("grid h-fit w-full gap-0 px-2", className)}>
       <div className="my-2 flex flex-wrap items-center gap-2 @container">
         {searchConfig && (
-          <div className="flex w-full max-w-sm items-stretch">
+          <div className="flex min-w-0 flex-shrink-0 items-stretch">
             <div
               className={cn(
                 "flex h-8 flex-1 items-center border border-input bg-background pl-2",
@@ -180,7 +180,7 @@ export function DataTableToolbar<TData, TValue>({
                   <Button
                     variant="outline"
                     size="default"
-                    className="flex w-auto min-w-[130px] items-center justify-between gap-1 rounded-l-none border-l-0"
+                    className="flex w-auto items-center justify-between gap-1 rounded-l-none border-l-0"
                   >
                     <span className="flex items-center gap-1">
                       {searchConfig.tableAllowsFullTextSearch &&


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adjust CSS in `data-table-toolbar.tsx` to prevent toolbar wrapping by modifying flex properties and width constraints.
> 
>   - **CSS Adjustments**:
>     - Change `className` of search container from `"flex w-full max-w-sm items-stretch"` to `"flex min-w-0 max-w-64 flex-shrink-0 items-stretch"` in `data-table-toolbar.tsx`.
>     - Remove `min-w-[130px]` from `Button` class in `data-table-toolbar.tsx` to prevent wrapping.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 547e01afe2f189e633ba91ba187f7ad6f6662988. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->