### PR TITLE
fix(scores): conditionally render metadata in score badges

### DIFF
--- a/web/src/components/grouped-score-badge.tsx
+++ b/web/src/components/grouped-score-badge.tsx
@@ -22,6 +22,19 @@ const partitionScores = <T extends APIScoreV2 | LastUserScore>(
   return { visibleScores, hiddenScores };
 };
 
+const hasMetadata = (score: APIScoreV2 | LastUserScore) => {
+  if (!score.metadata) return false;
+  try {
+    const metadata =
+      typeof score.metadata === "string"
+        ? JSON.parse(score.metadata)
+        : score.metadata;
+    return Object.keys(metadata).length > 0;
+  } catch {
+    return false;
+  }
+};
+
 const ScoreGroupBadge = <T extends APIScoreV2 | LastUserScore>({
   name,
   scores,
@@ -55,7 +68,7 @@ const ScoreGroupBadge = <T extends APIScoreV2 | LastUserScore>({
                 </HoverCardContent>
               </HoverCard>
             )}
-            {s.metadata && Object.keys(s.metadata).length > 0 && (
+            {hasMetadata(s) && (
               <HoverCard>
                 <HoverCardTrigger className="inline-block">
                   <BracesIcon className="mb-[0.0625rem] !size-3" />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `hasMetadata` function to conditionally render metadata in `ScoreGroupBadge` in `grouped-score-badge.tsx`.
> 
>   - **Behavior**:
>     - Adds `hasMetadata` function to check for valid metadata in `grouped-score-badge.tsx`.
>     - Updates `ScoreGroupBadge` to use `hasMetadata` for conditional rendering of metadata.
>   - **Functions**:
>     - `hasMetadata` checks if `score.metadata` exists and is a non-empty object or valid JSON string.
>     - Replaces direct metadata check with `hasMetadata` in `ScoreGroupBadge`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c41083a868cd939845438c06b97ea4c763a194d8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->