### PR TITLE
perf: clickhouse prop table experiment

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -105,6 +105,10 @@ const EnvSchema = z.object({
     .number()
     .default(80e6), // 80MB
   LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS: z.coerce.number().default(240_000), // 4 minutes
+
+  LANGFUSE_CLICKHOUSE_TABLE_EXPERIMENT_MODE: z
+    .enum(["off", "control", "experiment", "compare"])
+    .default("off"),
 });
 
 export const env: z.infer<typeof EnvSchema> =

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -517,11 +517,13 @@ export const getTracesGroupedByUsers = async (
     const query = `
         SELECT 
           tp.value AS user,
-          count()  AS count
-        FROM trace_properties tp
-          LEFT JOIN traces t ON t.id = tp.trace_id AND t.project_id = tp.project_id
+          uniq(o.trace_id)  AS count
+        FROM observations o
+        LEFT JOIN trace_properties tp
+        ON o.trace_id = tp.trace_id
+        AND o.project_id = tp.project_id
         WHERE tp.project_id = {projectId:String}
-          AND tp.property = 'user_id'
+        AND tp.property = 'user_id'
           ${tracesFilterRes?.query ? `AND ${tracesFilterRes.query}` : ""}
           ${search.query}
         GROUP BY user

--- a/packages/shared/src/server/utils/clickhouseExperiment.ts
+++ b/packages/shared/src/server/utils/clickhouseExperiment.ts
@@ -1,0 +1,64 @@
+import { env } from "../../env";
+import { recordDistribution } from "../instrumentation";
+import { logger } from "../logger";
+
+/**
+ * Wrapper to run ClickHouse control vs. experimental queries and optionally compare them.
+ *
+ * Modes (env CLICKHOUSE_EXPERIMENT_MODE):
+ *   off        – run control only (default)
+ *   control    – run control only (explicit)
+ *   experiment – run experiment only
+ *   compare    – run both, emit latency metrics + diff log, return control result
+ */
+export async function runCHExperiment<T>(
+  label: string,
+  control: () => Promise<T>,
+  experiment: () => Promise<T>,
+): Promise<T> {
+  const mode = env.LANGFUSE_CLICKHOUSE_TABLE_EXPERIMENT_MODE;
+  const run = async (fn: () => Promise<T>) => {
+    const start = Date.now();
+    try {
+      const res = await fn();
+      return { res, ms: Date.now() - start, err: undefined as unknown };
+    } catch (err) {
+      return { res: undefined as unknown as T, ms: Date.now() - start, err };
+    }
+  };
+
+  switch (mode) {
+    case "control": {
+      return control();
+    }
+    case "experiment": {
+      return experiment();
+    }
+    case "compare": {
+      const [c, e] = await Promise.all([run(control), run(experiment)]);
+
+      // latency metrics
+      recordDistribution(`ch_exp.${label}.control_ms`, c.ms);
+      recordDistribution(`ch_exp.${label}.experiment_ms`, e.ms);
+
+      // diff check
+      const equal = JSON.stringify(c.res) === JSON.stringify(e.res);
+
+      if (!equal || c.err || e.err) {
+        logger.warn("ClickHouse experiment mismatch", {
+          label,
+          equal,
+          controlErr: c.err,
+          experimentErr: e.err,
+        });
+      }
+
+      // prefer returning control result to keep behaviour unchanged
+      return c.res ?? e.res;
+    }
+    case "off":
+    default: {
+      return control();
+    }
+  }
+}

--- a/packages/shared/src/server/utils/clickhouseExperiment.ts
+++ b/packages/shared/src/server/utils/clickhouseExperiment.ts
@@ -57,6 +57,13 @@ export async function runCHExperiment<T>(
         });
       }
 
+      logger.info("Clickhouse experiment result", {
+        label,
+        equal,
+        control_ms: c.ms,
+        experiment_ms: e.ms,
+      });
+
       // raise control error if any
       if (c.err) {
         throw c.err;

--- a/packages/shared/src/server/utils/clickhouseExperiment.ts
+++ b/packages/shared/src/server/utils/clickhouseExperiment.ts
@@ -38,8 +38,12 @@ export async function runCHExperiment<T>(
       const [c, e] = await Promise.all([run(control), run(experiment)]);
 
       // latency metrics
-      recordDistribution(`ch_exp.${label}.control_ms`, c.ms);
-      recordDistribution(`ch_exp.${label}.experiment_ms`, e.ms);
+      recordDistribution(`langfuse.ch_exp.${label}_ms`, c.ms, {
+        type: "control",
+      });
+      recordDistribution(`langfuse.ch_exp.${label}_ms`, e.ms, {
+        type: "experiment",
+      });
 
       // diff check
       const equal = JSON.stringify(c.res) === JSON.stringify(e.res);
@@ -53,8 +57,12 @@ export async function runCHExperiment<T>(
         });
       }
 
+      // raise control error if any
+      if (c.err) {
+        throw c.err;
+      }
       // prefer returning control result to keep behaviour unchanged
-      return c.res ?? e.res;
+      return c.res;
     }
     case "off":
     default: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces ClickHouse table experiment modes in `getTracesGroupedByUsers` using `runCHExperiment` for control and experimental query execution.
> 
>   - **Behavior**:
>     - Adds `LANGFUSE_CLICKHOUSE_TABLE_EXPERIMENT_MODE` to `env.ts` with modes: `off`, `control`, `experiment`, `compare`.
>     - Implements `runCHExperiment` in `clickhouseExperiment.ts` to handle experiment logic.
>     - Updates `getTracesGroupedByUsers` in `traces.ts` to use `runCHExperiment` for control and experimental query execution.
>   - **Misc**:
>     - Logs latency metrics and differences in results when in `compare` mode.
>     - Default behavior remains unchanged when mode is `off` or `control`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 36ae4868a3f7438c21360bef9a183ea297fb0825. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->