### PR TITLE
fix(llm-tool-dialog): do not propagate textarea keystrokes up

### DIFF
--- a/web/src/ee/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
+++ b/web/src/ee/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
@@ -187,6 +187,9 @@ export const CreateOrEditLLMSchemaDialog: React.FC<
                         placeholder="Describe the schema"
                         className="max-h-[120px] focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 focus-visible:ring-offset-0"
                         {...field}
+                        onKeyDown={(e) => {
+                          e.stopPropagation();
+                        }}
                       />
                     </FormControl>
                     <FormMessage />

--- a/web/src/ee/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
+++ b/web/src/ee/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
@@ -196,6 +196,9 @@ export const CreateOrEditLLMToolDialog: React.FC<CreateOrEditLLMToolDialog> = (
                         placeholder="Describe the tool's purpose and usage"
                         className="max-h-[120px] focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 focus-visible:ring-offset-0"
                         {...field}
+                        onKeyDown={(e) => {
+                          e.stopPropagation();
+                        }}
                       />
                     </FormControl>
                     <FormMessage />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes input field navigation issue by stopping keydown event propagation in `CreateOrEditLLMSchemaDialog` and `CreateOrEditLLMToolDialog`.
> 
>   - **Behavior**:
>     - Fixes input field navigation issue by adding `onKeyDown` event handler to stop event propagation in `Textarea` components.
>     - Applied in `CreateOrEditLLMSchemaDialog` and `CreateOrEditLLMToolDialog` components.
>   - **Components**:
>     - `CreateOrEditLLMSchemaDialog`: Stops keydown event propagation in the description `Textarea`.
>     - `CreateOrEditLLMToolDialog`: Stops keydown event propagation in the description `Textarea`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 35a826af81cb8e5baed275e35f0a60f563911258. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->