### PR TITLE
fix: remove extra decode in path for v2 dataset fetch

### DIFF
--- a/web/src/__tests__/async/datasets-api.servertest.ts
+++ b/web/src/__tests__/async/datasets-api.servertest.ts
@@ -22,6 +22,7 @@ import {
   DeleteDatasetItemV1Response,
   DeleteDatasetRunV1Response,
   GetDatasetRunItemsV1Response,
+  PostDatasetsV2Body,
 } from "@/src/features/public-api/types/datasets";
 import { v4 as uuidv4 } from "uuid";
 import {
@@ -312,6 +313,29 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     );
 
     expect(response.status).toBe(404);
+  });
+
+  it("should support datasets with special characters in the name", async () => {
+    const name = "Special Characters !@#$%^&";
+    const createRes = await makeZodVerifiedAPICall(
+      PostDatasetsV2Body,
+      "POST",
+      "/api/public/v2/datasets",
+      {
+        name: name,
+      },
+      auth,
+    );
+    expect(createRes.status).toBe(200);
+
+    const getRes = await makeZodVerifiedAPICall(
+      GetDatasetV2Response,
+      "GET",
+      `/api/public/v2/datasets/${encodeURIComponent(name)}`,
+      undefined,
+      auth,
+    );
+    expect(getRes.status).toBe(200);
   });
 
   it("GET datasets (v1 & v2)", async () => {

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -113,7 +113,7 @@ export const GetDatasetsV2Response = z
 
 // GET /v2/datasets/{datasetName}
 export const GetDatasetV2Query = z.object({
-  datasetName: queryStringZod,
+  datasetName: z.string(),
 });
 export const GetDatasetV2Response = APIDataset.strict();
 


### PR DESCRIPTION
## What does this PR do?

When making a call to the datasets endpoint like this:
```
GET '/api/public/v2/datasets/Special%20Characters%20!%40%23%24%25%5E%26'
```
```json
{
  "message": "Internal Server Error",
  "error": "URI malformed"
}
```

The issue is that nextjs is already decoding the uri path, so when zod decodes it again, you get the `URI malformed` error.  you can see this same result if you run this snippet:

```node
decodeURIComponent(decodeURIComponent('%25'))
```
This is because `%25` decodes to `%` which will cause the error on the second pass.


Fixes #5962 

Remove `decodeURIComponent` in the zod schema.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix double URI decoding error in dataset names by removing redundant `decodeURIComponent` in `datasets.ts`.
> 
>   - **Bug Fix**:
>     - Remove `decodeURIComponent` from `GetDatasetV2Query` in `datasets.ts` to prevent double decoding errors.
>   - **Tests**:
>     - Add test in `datasets-api.servertest.ts` to verify handling of dataset names with special characters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 01bb8ee369e11769380cf0204765204f2256ce39. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->