### PR TITLE
fix: prompt variables of SQL Semantic Equivalence evaluator

### DIFF
--- a/worker/src/constants/managed-evaluators.json
+++ b/worker/src/constants/managed-evaluators.json
@@ -202,7 +202,7 @@
   {
     "id": "cmal6wart010lynrdtpv6olai",
     "created_at": "2025-05-20T18:16:12.000Z",
-    "updated_at": "2025-05-20T18:16:12.000Z",
+    "updated_at": "2025-05-25T18:16:12.000Z",
     "name": "SQL Semantic Equivalence",
     "partner": "ragas",
     "version": 1,
@@ -210,7 +210,7 @@
       "score": "Score between 0 and 1 based on the equivalence of the two SQL queries",
       "reasoning": "One sentence reasoning for the score"
     },
-    "prompt": "Explain and compare two SQL queries (Q1 and Q2) based on the provided database schema. First, explain each query, then determine if they have significant logical differences.\nDatabase Schema: {{database_schema}}\nQ1: {{q1}}\nQ2: {{q2}}"
+    "prompt": "Explain and compare two SQL queries (Q1 and Q2) based on the provided database schema. First, explain each query, then determine if they have significant logical differences.\nDatabase Schema: {{database_schema}}\nQ1: {{question_one}}\nQ2: {{question_two}}"
   },
   {
     "id": "cmal6wart010lynrdtpv6olaj",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updated prompt variables in SQL Semantic Equivalence evaluator for clarity in `managed-evaluators.json`.
> 
>   - **Prompt Variables**:
>     - In `managed-evaluators.json`, updated SQL Semantic Equivalence evaluator prompt variables from `{{q1}}` and `{{q2}}` to `{{question_one}}` and `{{question_two}}` for clarity.
>   - **Metadata**:
>     - Updated `updated_at` timestamp for SQL Semantic Equivalence evaluator entry.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 24fcf97503f667ba30134d3104b6e443647fd0f4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->