### PR TITLE
chore: add analytic views in ClickHouse

### DIFF
--- a/packages/shared/clickhouse/migrations/clustered/0019_analytics_traces.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0019_analytics_traces.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS analytics_traces ON CLUSTER default;

--- a/packages/shared/clickhouse/migrations/clustered/0019_analytics_traces.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0019_analytics_traces.up.sql
@@ -1,0 +1,13 @@
+CREATE VIEW analytics_traces ON CLUSTER default AS
+SELECT
+    project_id,
+    toStartOfHour(timestamp) AS hour,
+    uniq(id) AS countTraces,
+    max(user_id IS NOT NULL) AS hasUsers,
+    max(session_id IS NOT NULL) AS hasSessions,
+    max(if(environment != 'default', 1, 0)) AS hasEnvironments
+FROM
+    traces
+GROUP BY
+    project_id,
+    hour;

--- a/packages/shared/clickhouse/migrations/clustered/0019_analytics_traces.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0019_analytics_traces.up.sql
@@ -5,7 +5,8 @@ SELECT
     uniq(id) AS countTraces,
     max(user_id IS NOT NULL) AS hasUsers,
     max(session_id IS NOT NULL) AS hasSessions,
-    max(if(environment != 'default', 1, 0)) AS hasEnvironments
+    max(if(environment != 'default', 1, 0)) AS hasEnvironments,
+    max(length(tags) > 0) AS hasTags
 FROM
     traces
 GROUP BY

--- a/packages/shared/clickhouse/migrations/clustered/0019_analytics_traces.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0019_analytics_traces.up.sql
@@ -9,6 +9,7 @@ SELECT
     max(length(tags) > 0) AS hasTags
 FROM
     traces
+WHERE toStartOfHour(timestamp) <= toStartOfHour(subtractHours(now(), 1))
 GROUP BY
     project_id,
     hour;

--- a/packages/shared/clickhouse/migrations/clustered/0020_analytics_observations.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0020_analytics_observations.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS analytics_observations ON CLUSTER default;

--- a/packages/shared/clickhouse/migrations/clustered/0020_analytics_observations.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0020_analytics_observations.up.sql
@@ -1,6 +1,7 @@
 CREATE VIEW analytics_observations ON CLUSTER default AS
 SELECT
     project_id,
+    type,
     toStartOfHour(start_time) AS hour,
     uniq(id) AS countObservations,
     max(level != 'DEFAULT') AS hasLevel,
@@ -10,6 +11,8 @@ SELECT
     max(prompt_name IS NOT NULL) AS hasPromptName
 FROM
     observations
+WHERE toStartOfHour(start_time) <= toStartOfHour(subtractHours(now(), 1))
 GROUP BY
     project_id,
+    type,
     hour;

--- a/packages/shared/clickhouse/migrations/clustered/0020_analytics_observations.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0020_analytics_observations.up.sql
@@ -1,0 +1,15 @@
+CREATE VIEW analytics_observations ON CLUSTER default AS
+SELECT
+    project_id,
+    toStartOfHour(start_time) AS hour,
+    uniq(id) AS countObservations,
+    max(level != 'DEFAULT') AS hasLevel,
+    max(provided_model_name IS NOT NULL) AS hasProvidedModelName,
+    max(length(provided_usage_details) > 0) AS hasProvidedUsageDetails,
+    max(length(provided_cost_details) > 0) AS hasProvidedCostDetails,
+    max(prompt_name IS NOT NULL) AS hasPromptName
+FROM
+    observations
+GROUP BY
+    project_id,
+    hour;

--- a/packages/shared/clickhouse/migrations/clustered/0021_analytics_scores.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0021_analytics_scores.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS analytics_scores ON CLUSTER default;

--- a/packages/shared/clickhouse/migrations/clustered/0021_analytics_scores.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0021_analytics_scores.up.sql
@@ -1,0 +1,13 @@
+CREATE VIEW analytics_scores ON CLUSTER default AS
+SELECT
+    project_id,
+    toStartOfHour(timestamp) AS hour,
+    uniq(id) AS countScores,
+    max(source = 'ANNOTATION') AS hasAnnotation,
+    max(source = 'API') AS hasApi,
+    max(source = 'EVAL') AS hasEval
+FROM
+    scores
+GROUP BY
+    project_id,
+    hour;

--- a/packages/shared/clickhouse/migrations/clustered/0021_analytics_scores.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0021_analytics_scores.up.sql
@@ -15,6 +15,7 @@ SELECT
     max(comment IS NOT NULL) AS hasComment
 FROM
     scores
+WHERE toStartOfHour(timestamp) <= toStartOfHour(subtractHours(now(), 1))
 GROUP BY
     project_id,
     hour;

--- a/packages/shared/clickhouse/migrations/clustered/0021_analytics_scores.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0021_analytics_scores.up.sql
@@ -5,7 +5,14 @@ SELECT
     uniq(id) AS countScores,
     max(source = 'ANNOTATION') AS hasAnnotation,
     max(source = 'API') AS hasApi,
-    max(source = 'EVAL') AS hasEval
+    max(source = 'EVAL') AS hasEval,
+    max(observation_id IS NOT NULL) AS hasObservationScore,
+    max(session_id IS NOT NULL) AS hasSessionScore,
+    max(dataset_run_id IS NOT NULL) AS hasDatasetRunScore,
+    max(data_type = 'BOOLEAN') AS hasBoolScore,
+    max(data_type = 'NUMERIC') AS hasNumericScore,
+    max(data_type = 'CATEGORICAL') AS hasCategoricalScore,
+    max(comment IS NOT NULL) AS hasComment
 FROM
     scores
 GROUP BY

--- a/packages/shared/clickhouse/migrations/unclustered/0019_analytics_traces.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0019_analytics_traces.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS analytics_traces;

--- a/packages/shared/clickhouse/migrations/unclustered/0019_analytics_traces.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0019_analytics_traces.up.sql
@@ -1,0 +1,13 @@
+CREATE VIEW analytics_traces AS
+SELECT
+    project_id,
+    toStartOfHour(timestamp) AS hour,
+    uniq(id) AS countTraces,
+    max(user_id IS NOT NULL) AS hasUsers,
+    max(session_id IS NOT NULL) AS hasSessions,
+    max(if(environment != 'default', 1, 0)) AS hasEnvironments
+FROM
+    traces
+GROUP BY
+    project_id,
+    hour;

--- a/packages/shared/clickhouse/migrations/unclustered/0019_analytics_traces.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0019_analytics_traces.up.sql
@@ -5,7 +5,8 @@ SELECT
     uniq(id) AS countTraces,
     max(user_id IS NOT NULL) AS hasUsers,
     max(session_id IS NOT NULL) AS hasSessions,
-    max(if(environment != 'default', 1, 0)) AS hasEnvironments
+    max(if(environment != 'default', 1, 0)) AS hasEnvironments,
+    max(length(tags) > 0) AS hasTags
 FROM
     traces
 GROUP BY

--- a/packages/shared/clickhouse/migrations/unclustered/0019_analytics_traces.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0019_analytics_traces.up.sql
@@ -9,6 +9,7 @@ SELECT
     max(length(tags) > 0) AS hasTags
 FROM
     traces
+WHERE toStartOfHour(timestamp) <= toStartOfHour(subtractHours(now(), 1))
 GROUP BY
     project_id,
     hour;

--- a/packages/shared/clickhouse/migrations/unclustered/0020_analytics_observations.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0020_analytics_observations.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS analytics_observations;

--- a/packages/shared/clickhouse/migrations/unclustered/0020_analytics_observations.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0020_analytics_observations.up.sql
@@ -1,6 +1,7 @@
 CREATE VIEW analytics_observations AS
 SELECT
     project_id,
+    type,
     toStartOfHour(start_time) AS hour,
     uniq(id) AS countObservations,
     max(level != 'DEFAULT') AS hasLevel,
@@ -10,6 +11,8 @@ SELECT
     max(prompt_name IS NOT NULL) AS hasPromptName
 FROM
     observations
+WHERE toStartOfHour(start_time) <= toStartOfHour(subtractHours(now(), 1))
 GROUP BY
     project_id,
+    type,
     hour;

--- a/packages/shared/clickhouse/migrations/unclustered/0020_analytics_observations.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0020_analytics_observations.up.sql
@@ -1,0 +1,15 @@
+CREATE VIEW analytics_observations AS
+SELECT
+    project_id,
+    toStartOfHour(start_time) AS hour,
+    uniq(id) AS countObservations,
+    max(level != 'DEFAULT') AS hasLevel,
+    max(provided_model_name IS NOT NULL) AS hasProvidedModelName,
+    max(length(provided_usage_details) > 0) AS hasProvidedUsageDetails,
+    max(length(provided_cost_details) > 0) AS hasProvidedCostDetails,
+    max(prompt_name IS NOT NULL) AS hasPromptName
+FROM
+    observations
+GROUP BY
+    project_id,
+    hour;

--- a/packages/shared/clickhouse/migrations/unclustered/0021_analytics_scores.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0021_analytics_scores.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS analytics_scores;

--- a/packages/shared/clickhouse/migrations/unclustered/0021_analytics_scores.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0021_analytics_scores.up.sql
@@ -15,6 +15,7 @@ SELECT
     max(comment IS NOT NULL) AS hasComment
 FROM
     scores
+WHERE toStartOfHour(timestamp) <= toStartOfHour(subtractHours(now(), 1))
 GROUP BY
     project_id,
     hour;

--- a/packages/shared/clickhouse/migrations/unclustered/0021_analytics_scores.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0021_analytics_scores.up.sql
@@ -1,0 +1,13 @@
+CREATE VIEW analytics_scores AS
+SELECT
+    project_id,
+    toStartOfHour(timestamp) AS hour,
+    uniq(id) AS countScores,
+    max(source = 'ANNOTATION') AS hasAnnotation,
+    max(source = 'API') AS hasApi,
+    max(source = 'EVAL') AS hasEval
+FROM
+    scores
+GROUP BY
+    project_id,
+    hour;

--- a/packages/shared/clickhouse/migrations/unclustered/0021_analytics_scores.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0021_analytics_scores.up.sql
@@ -5,7 +5,14 @@ SELECT
     uniq(id) AS countScores,
     max(source = 'ANNOTATION') AS hasAnnotation,
     max(source = 'API') AS hasApi,
-    max(source = 'EVAL') AS hasEval
+    max(source = 'EVAL') AS hasEval,
+    max(observation_id IS NOT NULL) AS hasObservationScore,
+    max(session_id IS NOT NULL) AS hasSessionScore,
+    max(dataset_run_id IS NOT NULL) AS hasDatasetRunScore,
+    max(data_type = 'BOOLEAN') AS hasBoolScore,
+    max(data_type = 'NUMERIC') AS hasNumericScore,
+    max(data_type = 'CATEGORICAL') AS hasCategoricalScore,
+    max(comment IS NOT NULL) AS hasComment
 FROM
     scores
 GROUP BY


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add analytic views in ClickHouse for traces, observations, and scores with corresponding up and down migrations for clustered and unclustered setups.
> 
>   - **Clustered Views**:
>     - Adds `analytics_traces` view in `0019_analytics_traces.up.sql` to aggregate trace data by project and hour.
>     - Adds `analytics_observations` view in `0020_analytics_observations.up.sql` to aggregate observation data by project, type, and hour.
>     - Adds `analytics_scores` view in `0021_analytics_scores.up.sql` to aggregate score data by project and hour.
>   - **Unclustered Views**:
>     - Adds `analytics_traces` view in `0019_analytics_traces.up.sql` to aggregate trace data by project and hour.
>     - Adds `analytics_observations` view in `0020_analytics_observations.up.sql` to aggregate observation data by project, type, and hour.
>     - Adds `analytics_scores` view in `0021_analytics_scores.up.sql` to aggregate score data by project and hour.
>   - **Down Migrations**:
>     - Adds down migration files to drop `analytics_traces`, `analytics_observations`, and `analytics_scores` views for both clustered and unclustered setups.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 94586862248094161550222fe6c1901389a84e99. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->