### PR TITLE
fix(playground): update tools and schemas if name already exists

### DIFF
--- a/web/src/ee/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
+++ b/web/src/ee/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
@@ -91,7 +91,7 @@ export const CreateOrEditLLMSchemaDialog: React.FC<
         schema: JSON.stringify(existingLlmSchema.schema, null, 2),
       });
     }
-  }, [existingLlmSchema, form]);
+  }, [existingLlmSchema, form, props.defaultValues]);
 
   async function onSubmit(values: FormValues) {
     let result;

--- a/web/src/ee/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
+++ b/web/src/ee/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
@@ -84,7 +84,7 @@ export const CreateOrEditLLMSchemaDialog: React.FC<
 
   // Populate form when in edit mode
   useEffect(() => {
-    if (existingLlmSchema) {
+    if (existingLlmSchema && !props.defaultValues) {
       form.reset({
         name: existingLlmSchema.name,
         description: existingLlmSchema.description,

--- a/web/src/ee/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
+++ b/web/src/ee/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
@@ -84,7 +84,7 @@ export const CreateOrEditLLMToolDialog: React.FC<CreateOrEditLLMToolDialog> = (
 
   // Populate form when in edit mode
   useEffect(() => {
-    if (existingLlmTool) {
+    if (existingLlmTool && !props.defaultValues) {
       form.reset({
         name: existingLlmTool.name,
         description: existingLlmTool.description,

--- a/web/src/ee/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
+++ b/web/src/ee/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
@@ -91,7 +91,7 @@ export const CreateOrEditLLMToolDialog: React.FC<CreateOrEditLLMToolDialog> = (
         parameters: JSON.stringify(existingLlmTool.parameters, null, 2),
       });
     }
-  }, [existingLlmTool, form]);
+  }, [existingLlmTool, form, props.defaultValues]);
 
   async function onSubmit(values: FormValues) {
     let result;

--- a/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -431,7 +431,13 @@ function parseStructuredOutputSchema(
   },
 ): PlaygroundSchema | null {
   try {
-    const metadata = generation.metadata;
+    let metadata = generation.metadata;
+
+    try {
+      if (typeof metadata === "string") {
+        metadata = JSON.parse(metadata);
+      }
+    } catch {}
 
     if (
       typeof metadata === "object" &&

--- a/web/src/ee/features/playground/page/components/PlaygroundTools/index.tsx
+++ b/web/src/ee/features/playground/page/components/PlaygroundTools/index.tsx
@@ -42,7 +42,13 @@ export const PlaygroundTools = () => {
 
   const isToolSaved = useCallback(
     (tool: PlaygroundTool) => {
-      return savedTools.some((savedTool) => savedTool.id === tool.id);
+      return savedTools.some(
+        (savedTool) =>
+          savedTool.id === tool.id &&
+          savedTool.description === tool.description &&
+          JSON.stringify(savedTool.parameters) ===
+            JSON.stringify(tool.parameters),
+      );
     },
     [savedTools],
   );
@@ -51,11 +57,7 @@ export const PlaygroundTools = () => {
     tools.forEach((tool, index) => {
       if (!tool.existingLlmTool) {
         const matchingSavedTool = savedTools.find(
-          (savedTool) =>
-            savedTool.name === tool.name &&
-            savedTool.description === tool.description &&
-            JSON.stringify(savedTool.parameters) ===
-              JSON.stringify(tool.parameters),
+          (savedTool) => savedTool.name === tool.name,
         );
 
         if (matchingSavedTool) {

--- a/web/src/ee/features/playground/page/components/StructuredOutputSchemaSection.tsx
+++ b/web/src/ee/features/playground/page/components/StructuredOutputSchemaSection.tsx
@@ -42,7 +42,12 @@ export const StructuredOutputSchemaSection = () => {
 
   const isSchemaSaved = useCallback(
     (schema: PlaygroundSchema) => {
-      return savedSchemas.some((savedSchema) => savedSchema.id === schema.id);
+      return savedSchemas.some(
+        (savedSchema) =>
+          savedSchema.id === schema.id &&
+          savedSchema.description === schema.description &&
+          JSON.stringify(savedSchema.schema) === JSON.stringify(schema.schema),
+      );
     },
     [savedSchemas],
   );
@@ -50,11 +55,7 @@ export const StructuredOutputSchemaSection = () => {
   useEffect(() => {
     if (structuredOutputSchema && !structuredOutputSchema.existingLlmSchema) {
       const matchingSavedSchema = savedSchemas.find(
-        (savedSchema) =>
-          savedSchema.name === structuredOutputSchema.name &&
-          savedSchema.description === structuredOutputSchema.description &&
-          JSON.stringify(savedSchema.schema) ===
-            JSON.stringify(structuredOutputSchema.schema),
+        (savedSchema) => savedSchema.name === structuredOutputSchema.name,
       );
 
       if (matchingSavedSchema) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes tool and schema update issues by adjusting form reset logic and matching criteria in playground components.
> 
>   - **Behavior**:
>     - Update form reset logic in `CreateOrEditLLMSchemaDialog.tsx` and `CreateOrEditLLMToolDialog.tsx` to check for `props.defaultValues` before resetting.
>     - Modify tool and schema matching logic in `PlaygroundTools/index.tsx` and `StructuredOutputSchemaSection.tsx` to match by name only, allowing updates when names exist.
>   - **Functions**:
>     - Add `props.defaultValues` to `useEffect` dependencies in `CreateOrEditLLMSchemaDialog.tsx` and `CreateOrEditLLMToolDialog.tsx`.
>     - Update `isToolSaved` and `isSchemaSaved` functions to include description and parameters/schema comparison.
>   - **Misc**:
>     - Add JSON parsing for `metadata` in `parseStructuredOutputSchema()` in `JumpToPlaygroundButton.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9302a9220283f20dc0bd367206bf2875ee9ad0c6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->