### PR TITLE
fix(playground): resolve prompts when jumping to playground

### DIFF
--- a/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -27,6 +27,7 @@ import {
   OpenAIToolSchema,
   type ChatMessage,
   OpenAIResponseFormatSchema,
+  Prisma,
 } from "@langfuse/shared";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import { api } from "@/src/utils/api";
@@ -35,7 +36,7 @@ import { cn } from "@/src/utils/tailwind";
 type JumpToPlaygroundButtonProps = (
   | {
       source: "prompt";
-      prompt: Prompt;
+      prompt: Prompt & { resolvedPrompt?: Prisma.JsonValue };
       analyticsEventName: "prompt_detail:test_in_playground_button_click";
     }
   | {
@@ -231,15 +232,19 @@ const transformToPlaygroundMessage = (
   }
 };
 
-const parsePrompt = (prompt: Prompt): PlaygroundCache => {
+const parsePrompt = (
+  prompt: Prompt & { resolvedPrompt?: Prisma.JsonValue },
+): PlaygroundCache => {
   if (prompt.type === PromptType.Chat) {
-    const parsedMessages = ParsedChatMessageListSchema.safeParse(prompt.prompt);
+    const parsedMessages = ParsedChatMessageListSchema.safeParse(
+      prompt.resolvedPrompt,
+    );
 
     return parsedMessages.success
       ? { messages: parsedMessages.data.map(transformToPlaygroundMessage) }
       : null;
   } else {
-    const promptString = prompt.prompt?.valueOf();
+    const promptString = prompt.resolvedPrompt;
 
     return {
       messages: [

--- a/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/ee/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -27,7 +27,7 @@ import {
   OpenAIToolSchema,
   type ChatMessage,
   OpenAIResponseFormatSchema,
-  Prisma,
+  type Prisma,
 } from "@langfuse/shared";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import { api } from "@/src/utils/api";

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -386,7 +386,10 @@ export const PromptDetail = () => {
               <div className="flex h-full flex-wrap content-start items-start justify-end gap-1 lg:flex-nowrap">
                 <JumpToPlaygroundButton
                   source="prompt"
-                  prompt={prompt}
+                  prompt={{
+                    ...prompt,
+                    resolvedPrompt: promptGraph.data?.resolvedPrompt,
+                  }}
                   analyticsEventName="prompt_detail:test_in_playground_button_click"
                   variant="outline"
                 />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes prompt resolution in `JumpToPlaygroundButton` by using `resolvedPrompt` in `JumpToPlaygroundButton.tsx` and `prompt-detail.tsx`.
> 
>   - **Behavior**:
>     - `JumpToPlaygroundButton` now uses `resolvedPrompt` for `prompt` prop in `JumpToPlaygroundButton.tsx`.
>     - `parsePrompt()` updated to handle `resolvedPrompt` in `JumpToPlaygroundButton.tsx`.
>   - **Components**:
>     - `PromptDetail` in `prompt-detail.tsx` passes `resolvedPrompt` to `JumpToPlaygroundButton`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for da2f711e794cf778dbc3489bb0ba0daa7b6a5c6b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->