### PR TITLE
chore(ui): changed wording on checkout page

### DIFF
--- a/web/src/ee/features/billing/utils/stripeProducts.ts
+++ b/web/src/ee/features/billing/utils/stripeProducts.ts
@@ -68,7 +68,7 @@ export const stripeProducts: StripeProduct[] = [
         : "prod_QhK9qKGH25BTcS", // live
     mappedPlan: "cloud:team",
     checkout: {
-      title: "Team",
+      title: "Pro + Teams Add-on",
       description: "Organizational and security controls for larger teams.",
       price: "$499 / month",
       usagePrice: "$8/100k events (100k included)",


### PR DESCRIPTION
Old wording confused users as they were looking for the teams add on on the upgrade page:
![image (6)](https://github.com/user-attachments/assets/5ea2cae7-153b-4894-bf20-80e98c68c466)


New: 
![CleanShot 2025-05-27 at 18 15 14](https://github.com/user-attachments/assets/4f97dd4a-e262-4747-b1ce-83953260c203)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updated checkout title in `stripeProducts.ts` from "Team" to "Pro + Teams Add-on" for clarity.
> 
>   - **UI Change**:
>     - Updated `title` in `stripeProducts` array in `stripeProducts.ts` from "Team" to "Pro + Teams Add-on" to clarify product offering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a7009c9bc631efb1bd1e497bb21ba7c5a48c4a76. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->