### PR TITLE
feat(api): add public API to create annotation queues

### DIFF
--- a/web/src/features/public-api/types/annotation-queues.ts
+++ b/web/src/features/public-api/types/annotation-queues.ts
@@ -57,6 +57,24 @@ export const GetAnnotationQueuesResponse = z
   })
   .strict();
 
+// POST /annotation-queues
+export const CreateAnnotationQueueBody = z
+  .object({
+    name: z.string(),
+    description: z.string().nullable(),
+    scoreConfigIds: z.array(z.string()).min(1, {
+      message: "At least one score config is required",
+    }),
+  })
+  .strict();
+
+// POST /annotation-queues
+export const CreateAnnotationQueueResponse = z
+  .object({
+    id: z.string(),
+  })
+  .strict();
+
 // GET /annotation-queues/:queueId
 export const GetAnnotationQueueByIdQuery = z
   .object({

--- a/web/src/pages/api/public/annotation-queues/index.ts
+++ b/web/src/pages/api/public/annotation-queues/index.ts
@@ -65,7 +65,7 @@ export default withMiddlewares({
             // Check if the queue exists
       const existingQueue = await prisma.annotationQueue.findFirst({
         where: {
-          id: body.name,
+          name: body.name,
           projectId: auth.scope.projectId,
         },
       });

--- a/web/src/pages/api/public/annotation-queues/index.ts
+++ b/web/src/pages/api/public/annotation-queues/index.ts
@@ -4,7 +4,10 @@ import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/cr
 import {
   GetAnnotationQueuesQuery,
   GetAnnotationQueuesResponse,
+  CreateAnnotationQueueBody,
+  CreateAnnotationQueueResponse,
 } from "@/src/features/public-api/types/annotation-queues";
+import { logger } from "@langfuse/shared/src/server";
 
 export default withMiddlewares({
   // NOTE: Post API requires entitlement check
@@ -51,6 +54,55 @@ export default withMiddlewares({
           totalItems,
           totalPages: Math.ceil(totalItems / query.limit),
         },
+      };
+    },
+  }),
+  POST: createAuthedProjectAPIRoute({
+    name: "Create annotation queue",
+    bodySchema: CreateAnnotationQueueBody,
+    responseSchema: CreateAnnotationQueueResponse,
+    fn: async ({ body, auth }) => {
+            // Check if the queue exists
+      const existingQueue = await prisma.annotationQueue.findFirst({
+        where: {
+          id: body.name,
+          projectId: auth.scope.projectId,
+        },
+      });
+
+      if (existingQueue) {
+          throw new Error("Failed to create annotation queue, since the queue name already exists");
+      }
+
+      // check if score configs are valid
+      const configs = await prisma.scoreConfig.findMany({
+        where: {
+          id: { in: body.scoreConfigIds },
+          projectId: auth.scope.projectId,
+        },
+      });
+      
+      if (configs.length !== body.scoreConfigIds.length) {
+        logger.warn("Failed to create annotation queue, and created the queue with only valid score configs");
+      }
+
+      const validScoreConfigIds = configs.map((config) => config.id);
+      if (validScoreConfigIds.length === 0) {
+        throw new Error("Failed to create annotation queue, since no valid score configs were found");
+      }
+
+
+      const queue = await prisma.annotationQueue.create({
+          data: {
+              projectId: auth.scope.projectId,
+              name: body.name,
+              description: body.description,
+              scoreConfigIds: validScoreConfigIds,
+          },
+      });
+
+      return {
+          id: queue.id,
       };
     },
   }),


### PR DESCRIPTION
## What does this PR do?

> Why? After our self-hosted Langfuse collected a sufficient amount of data, we realized that it is essential to create annotation queues periodically based on specific scenarios. Therefore, I developed this API for queue creation to support our scheduled tasks to automatically manage queues and their items.
 
This PR implements a public API for creating annotation queues. The API allows users to create a new annotation queue with the following features:
- Validates that the queue name doesn't already exist
- Validates and filters score configs to ensure only valid ones are associated with the queue
- Creates a new annotation queue with the provided name, description and valid score configs
- Returns the ID of the newly created queue

The implementation includes proper error handling for cases where:
- A queue with the same name already exists
- No valid score configs are found
- Some score configs are invalid (continues with valid ones but logs a warning)


## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't checked if my PR needs changes to the documentation
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a public API endpoint to create annotation queues with validation and error handling for queue names and score configurations.
> 
>   - **API Endpoint**:
>     - Adds `POST /annotation-queues` endpoint in `index.ts` to create annotation queues.
>     - Validates queue name uniqueness and score configuration validity.
>     - Returns the ID of the created queue.
>   - **Validation**:
>     - In `annotation-queues.ts`, defines `CreateAnnotationQueueBody` and `CreateAnnotationQueueResponse` schemas.
>     - Ensures at least one valid score config is required.
>   - **Error Handling**:
>     - Logs warning if some score configs are invalid but continues with valid ones.
>     - Throws error if no valid score configs are found or if queue name already exists.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6b6e1ebf3756d130d975af12aaba930355a1965b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->