### PR TITLE
perf: increase retry batch action queue

### DIFF
--- a/packages/shared/src/server/redis/batchActionQueue.ts
+++ b/packages/shared/src/server/redis/batchActionQueue.ts
@@ -26,7 +26,7 @@ export class BatchActionQueue {
             defaultJobOptions: {
               removeOnComplete: true,
               removeOnFail: 10_000,
-              attempts: 2,
+              attempts: 10,
               backoff: {
                 type: "exponential",
                 delay: 5000,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase retry attempts from 2 to 10 in `BatchActionQueue` to improve job retry handling.
> 
>   - **Behavior**:
>     - Increase retry attempts from 2 to 10 in `BatchActionQueue` in `batchActionQueue.ts`.
>     - Uses exponential backoff with a delay of 5000ms for retries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 36271abe14b66b59e2a8c8d63e3385fc88c02536. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->