### PR TITLE
fix(otel): update trace name only for root spans

### DIFF
--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -459,7 +459,7 @@ describe("OTel Resource Span Mapping", () => {
       expect(traceEvent.body).toMatchObject({
         id: "95f3b926c7d009925bcb5dbc27311120",
         timestamp: "2025-05-05T13:42:33.936Z",
-        name: "my-span-with-custom-trace-id",
+        name: undefined,
         environment: "production",
       });
     });

--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -656,7 +656,9 @@ export const convertOtelSpanToIngestionEvent = (
           timestamp: startTimeISO,
           name:
             attributes[LangfuseOtelSpanAttributes.TRACE_NAME] ??
-            (is_root_span ? extractName(span.name, attributes) : undefined),
+            (!parentObservationId
+              ? extractName(span.name, attributes)
+              : undefined),
           metadata: {
             ...resourceAttributeMetadata,
             ...extractMetadata(attributes, "trace"),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `convertOtelSpanToIngestionEvent` to set trace name only for root spans, with test adjustments in `otelMapping.servertest.ts`.
> 
>   - **Behavior**:
>     - Update `convertOtelSpanToIngestionEvent` in `index.ts` to set trace name only for root spans (`is_root_span`).
>     - If `parentObservationId` is present, trace name is set to `undefined`.
>   - **Tests**:
>     - Update test in `otelMapping.servertest.ts` to expect `name: undefined` for non-root spans.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b5e385a079e37efb89df0f667872ce21f27edd72. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->