### PR TITLE
perf(traces-table): skip re-render of table body component on peek navigation

### DIFF
--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -232,16 +232,6 @@ export function DataTable<TData extends object, TValue>({
     ? table.getHeaderGroups()
     : [table.getHeaderGroups().slice(-1)[0]];
 
-  const shouldUseMemoization = useMemo(() => {
-    return (
-      table.getState().columnSizingInfo.isResizingColumn || // During column resize
-      !!peekView // Always use memoization when peek view is available
-    );
-  }, [
-    table.getState().columnSizingInfo.isResizingColumn,
-    peekView, // Remove peekViewId from dependencies
-  ]);
-
   return (
     <>
       <div
@@ -361,7 +351,8 @@ export function DataTable<TData extends object, TValue>({
                 </TableRow>
               ))}
             </TableHeader>
-            {shouldUseMemoization ? (
+            {table.getState().columnSizingInfo.isResizingColumn ||
+            !!peekView ? (
               <MemoizedTableBody
                 table={table}
                 rowheighttw={rowheighttw}

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { type OrderByState } from "@langfuse/shared";
-import React, { useState, useMemo, useCallback, useContext } from "react";
+import React, { useState, useMemo, useCallback, useRef } from "react";
 import DocPopup from "@/src/components/layouts/doc-popup";
 import { DataTablePagination } from "@/src/components/table/data-table-pagination";
 import {
@@ -36,6 +36,7 @@ import {
 import { TablePeekView } from "@/src/components/table/peek";
 import { type PeekViewProps } from "@/src/components/table/peek/hooks/usePeekView";
 import { usePeekView } from "@/src/components/table/peek/hooks/usePeekView";
+import { useRowHighlighting } from "@/src/components/table/hooks/useRowHighlighting";
 import { isEqual } from "lodash";
 
 interface DataTableProps<TData, TValue> {
@@ -189,6 +190,12 @@ export function DataTable<TData extends object, TValue>({
     peekView,
   });
 
+  // Add table container ref for row highlighting
+  const tableContainerRef = useRef<HTMLDivElement>(null);
+
+  // Use row highlighting hook to apply bg-accent without re-renders
+  useRowHighlighting(peekViewId, tableContainerRef);
+
   const handleOnRowClick = useCallback(
     (row: TData) => {
       handleOnRowClickPeek?.(row);
@@ -244,6 +251,7 @@ export function DataTable<TData extends object, TValue>({
         )}
       >
         <div
+          ref={tableContainerRef}
           className={cn("relative w-full overflow-auto border-t")}
           style={{ ...columnSizeVars }}
         >
@@ -438,11 +446,10 @@ function TableRowComponent<TData>({
   onRowClick?: (row: TData) => void;
   children: React.ReactNode;
 }) {
-  // const router = useRouter();
-  // const peekViewId = router.query.peek as string | undefined;
   return (
     <TableRow
       data-row-index={row.index}
+      data-row-id={row.id}
       onClick={() => onRowClick?.(row.original)}
       onKeyDown={(e) => {
         if (e.key === "Enter") {
@@ -452,7 +459,6 @@ function TableRowComponent<TData>({
       className={cn(
         "hover:bg-accent",
         !!onRowClick ? "cursor-pointer" : "cursor-default",
-        // peekViewId && peekViewId === row.id ? "bg-accent" : undefined,
       )}
     >
       {children}

--- a/web/src/components/table/hooks/useRowHighlighting.ts
+++ b/web/src/components/table/hooks/useRowHighlighting.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Hook that handles row highlighting without causing React re-renders.
+ * Uses direct DOM manipulation to apply/remove CSS classes based on the current peek ID.
+ *
+ * @param peekViewId - The ID of the currently selected row for peek view
+ * @param tableContainerRef - Ref to the table container element
+ */
+export const useRowHighlighting = (
+  peekViewId: string | undefined,
+  tableContainerRef: React.RefObject<HTMLElement>,
+) => {
+  const lastHighlightedRowRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const tableContainer = tableContainerRef.current;
+    if (!tableContainer) return;
+
+    // Remove previous highlighting
+    if (lastHighlightedRowRef.current) {
+      lastHighlightedRowRef.current.classList.remove("bg-accent");
+      lastHighlightedRowRef.current = null;
+    }
+
+    // Apply new highlighting if peekViewId exists
+    if (peekViewId) {
+      // Find the row with matching data-row-id attribute
+      const targetRow = tableContainer.querySelector(
+        `[data-row-id="${peekViewId}"]`,
+      ) as HTMLElement;
+
+      if (targetRow) {
+        targetRow.classList.add("bg-accent");
+        lastHighlightedRowRef.current = targetRow;
+      }
+    }
+  }, [peekViewId, tableContainerRef]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (lastHighlightedRowRef.current) {
+        lastHighlightedRowRef.current.classList.remove("bg-accent");
+      }
+    };
+  }, []);
+};

--- a/web/src/components/table/hooks/useRowHighlighting.ts
+++ b/web/src/components/table/hooks/useRowHighlighting.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
 /**
  * Hook that handles row highlighting without causing React re-renders.
@@ -11,38 +11,23 @@ export const useRowHighlighting = (
   peekViewId: string | undefined,
   tableContainerRef: React.RefObject<HTMLElement>,
 ) => {
-  const lastHighlightedRowRef = useRef<HTMLElement | null>(null);
-
   useEffect(() => {
     const tableContainer = tableContainerRef.current;
     if (!tableContainer) return;
 
-    // Remove previous highlighting
-    if (lastHighlightedRowRef.current) {
-      lastHighlightedRowRef.current.classList.remove("bg-accent");
-      lastHighlightedRowRef.current = null;
-    }
+    // Remove all existing highlights
+    tableContainer.querySelectorAll(".bg-accent").forEach((row) => {
+      row.classList.remove("bg-accent");
+    });
 
-    // Apply new highlighting if peekViewId exists
+    // Add highlight to current row if peekViewId exists
     if (peekViewId) {
-      // Find the row with matching data-row-id attribute
       const targetRow = tableContainer.querySelector(
         `[data-row-id="${peekViewId}"]`,
-      ) as HTMLElement;
-
+      );
       if (targetRow) {
         targetRow.classList.add("bg-accent");
-        lastHighlightedRowRef.current = targetRow;
       }
     }
   }, [peekViewId, tableContainerRef]);
-
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      if (lastHighlightedRowRef.current) {
-        lastHighlightedRowRef.current.classList.remove("bg-accent");
-      }
-    };
-  }, []);
 };

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -176,7 +176,7 @@ export function TablePeekView<TData>({
         </SheetHeader>
         <Separator />
         <div className="flex max-h-full min-h-0 flex-1 flex-col">
-          <div className="flex-1 overflow-auto">
+          <div key={selectedRowId} className="flex-1 overflow-auto">
             {typeof children === "function" ? children(row) : children}
           </div>
         </div>

--- a/web/src/components/table/peek/hooks/usePeekView.ts
+++ b/web/src/components/table/peek/hooks/usePeekView.ts
@@ -126,7 +126,7 @@ export const usePeekView = <TData extends object>({
         setRow(row);
       }
     },
-    [], // Empty dependency array - stable!
+    [peekView],
   );
 
   // Update the row state when the peekViewId changes on detail page navigation

--- a/web/src/components/table/peek/hooks/usePeekView.ts
+++ b/web/src/components/table/peek/hooks/usePeekView.ts
@@ -36,6 +36,13 @@ function getInitialRow<TData>(
   }
 }
 
+// Helper function to get current URL peek parameter
+function getCurrentPeekUrl() {
+  const url = new URL(window.location.href);
+  const params = new URLSearchParams(url.search);
+  return params.get("peek") ?? undefined;
+}
+
 type UsePeekViewProps<TData> = {
   getRow: (id: string) => TData | undefined;
   peekView?: PeekViewProps<TData>;
@@ -60,9 +67,8 @@ export const usePeekView = <TData extends object>({
   getRow,
   peekView,
 }: UsePeekViewProps<TData>) => {
-  const url = new URL(window.location.href);
-  const params = new URLSearchParams(url.search);
-  const peekViewId = params.get("peek") ?? undefined;
+  // Get current peek ID from URL
+  const peekViewId = getCurrentPeekUrl();
 
   const [row, setRow] = useState<TData | undefined>(
     getInitialRow(peekViewId, getRow),
@@ -101,10 +107,8 @@ export const usePeekView = <TData extends object>({
     (row: TData) => {
       if (!peekView) return;
 
-      const url = new URL(window.location.href);
-      const params = new URLSearchParams(url.search);
-      // Get the current peekViewId from router directly
-      const currentPeekViewId = params.get("peek") ?? undefined;
+      // Get current peek ID from URL
+      const currentPeekViewId = getCurrentPeekUrl();
 
       const rowId =
         "id" in row && typeof row.id === "string" ? row.id : undefined;

--- a/web/src/components/table/peek/hooks/useTracePeekState.ts
+++ b/web/src/components/table/peek/hooks/useTracePeekState.ts
@@ -1,14 +1,17 @@
-import { useRouter } from "next/router";
 import { useCallback } from "react";
 
 export const useTracePeekState = (pathname: string) => {
-  const router = useRouter();
-  const { peek, timestamp } = router.query;
+  const url = new URL(window.location.href);
+  const params = new URLSearchParams(url.search);
+  const peek = params.get("peek");
+  const timestamp = params.get("timestamp");
 
   const setPeekView = useCallback(
     (open: boolean, id?: string, time?: string) => {
       const url = new URL(window.location.href);
       const params = new URLSearchParams(url.search);
+      const peek = params.get("peek");
+      const timestamp = params.get("timestamp");
 
       if (!open || !id) {
         // close peek view
@@ -17,7 +20,7 @@ export const useTracePeekState = (pathname: string) => {
         params.delete("observation");
         params.delete("display");
       } else if (open && id !== peek) {
-        // open peek view or update peek view
+        // open or update
         params.set("peek", id);
         const relevantTimestamp = time ?? (timestamp as string);
         if (relevantTimestamp) params.set("timestamp", relevantTimestamp);
@@ -26,16 +29,21 @@ export const useTracePeekState = (pathname: string) => {
         return;
       }
 
-      router.replace(
+      const newSearch = params.toString();
+      const newUrl = pathname + (newSearch ? `?${newSearch}` : "");
+
+      window.history.replaceState(
         {
-          pathname,
-          query: params.toString(),
+          ...window.history.state,
+          as: newUrl,
+          url: newUrl,
         },
-        undefined,
-        { shallow: true },
+        "",
+        newUrl,
       );
     },
-    [router, pathname, peek, timestamp],
+    // [router, peek, timestamp, pathname]
+    [],
   );
 
   return {

--- a/web/src/components/table/peek/hooks/useTracePeekState.ts
+++ b/web/src/components/table/peek/hooks/useTracePeekState.ts
@@ -35,7 +35,7 @@ export const useTracePeekState = (pathname: string) => {
       }
       // If same ID is already open, do nothing
     },
-    [getCurrentParams, updateParams, clearParams], // All stable functions
+    [getCurrentParams, updateParams, clearParams],
   );
 
   return {

--- a/web/src/components/table/peek/hooks/useUrlParams.ts
+++ b/web/src/components/table/peek/hooks/useUrlParams.ts
@@ -1,0 +1,101 @@
+import { useCallback } from "react";
+
+export interface UrlParamsState {
+  peek?: string;
+  timestamp?: string;
+  observation?: string;
+  display?: string;
+}
+
+export interface UseUrlParamsReturn {
+  getCurrentParams: () => UrlParamsState;
+  updateParams: (updates: Partial<UrlParamsState>) => void;
+  clearParams: (paramNames: (keyof UrlParamsState)[]) => void;
+}
+
+/**
+ * A simplified hook for managing URL parameters related to peek views and navigation.
+ *
+ * Provides stable utility functions for reading and updating URL parameters without
+ * reactive state to avoid unnecessary re-renders.
+ *
+ * @param pathname - The current pathname to preserve when updating URL
+ * @returns Object with utility functions for URL parameter management
+ */
+export const useUrlParams = (pathname: string): UseUrlParamsReturn => {
+  // Get current URL parameters (call this when you need fresh values)
+  const getCurrentParams = useCallback((): UrlParamsState => {
+    const url = new URL(window.location.href);
+    const searchParams = new URLSearchParams(url.search);
+
+    return {
+      peek: searchParams.get("peek") ?? undefined,
+      timestamp: searchParams.get("timestamp") ?? undefined,
+      observation: searchParams.get("observation") ?? undefined,
+      display: searchParams.get("display") ?? undefined,
+    };
+  }, []);
+
+  // Update multiple parameters at once
+  const updateParams = useCallback(
+    (updates: Partial<UrlParamsState>) => {
+      const url = new URL(window.location.href);
+      const searchParams = new URLSearchParams(url.search);
+
+      // Apply updates
+      Object.entries(updates).forEach(([key, value]) => {
+        if (value === undefined) {
+          searchParams.delete(key);
+        } else {
+          searchParams.set(key, value);
+        }
+      });
+
+      const newSearch = searchParams.toString();
+      const newUrl = pathname + (newSearch ? `?${newSearch}` : "");
+
+      window.history.replaceState(
+        {
+          ...window.history.state,
+          as: newUrl,
+          url: newUrl,
+        },
+        "",
+        newUrl,
+      );
+    },
+    [pathname],
+  );
+
+  // Clear specific parameters
+  const clearParams = useCallback(
+    (paramNames: (keyof UrlParamsState)[]) => {
+      const url = new URL(window.location.href);
+      const searchParams = new URLSearchParams(url.search);
+
+      paramNames.forEach((paramName) => {
+        searchParams.delete(paramName);
+      });
+
+      const newSearch = searchParams.toString();
+      const newUrl = pathname + (newSearch ? `?${newSearch}` : "");
+
+      window.history.replaceState(
+        {
+          ...window.history.state,
+          as: newUrl,
+          url: newUrl,
+        },
+        "",
+        newUrl,
+      );
+    },
+    [pathname],
+  );
+
+  return {
+    getCurrentParams,
+    updateParams,
+    clearParams,
+  };
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimize table body rendering during peek navigation by using `useRowHighlighting` and efficient URL parameter management.
> 
>   - **Behavior**:
>     - Introduces `useRowHighlighting` hook in `useRowHighlighting.ts` to manage row highlighting without re-renders.
>     - Modifies `handleOnRowClick` in `data-table.tsx` to remove dependency on `inflatedPeekView`.
>     - Updates `usePeekView` in `usePeekView.ts` to manage peek view state and URL parameters more efficiently.
>   - **Components**:
>     - Removes `SelectedRowContext` from `data-table.tsx`.
>     - Adds `tableContainerRef` in `data-table.tsx` for row highlighting.
>   - **Hooks**:
>     - Adds `useUrlParams` in `useUrlParams.ts` for URL parameter management.
>     - Updates `useTracePeekState` in `useTracePeekState.ts` to use `useUrlParams` for managing peek state.
>   - **Misc**:
>     - Minor refactoring in `TablePeekView` in `peek.tsx` to use `key` prop for `selectedRowId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e9319e2b046b482aa7b27681c1781c410f95034b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->