### PR TITLE
perf: only read trace identifiers for historic eval read stream

### DIFF
--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -157,7 +157,7 @@ export type TracesTableMetricsClickhouseReturnType = {
 };
 
 export type FetchTracesTableProps = {
-  select: "count" | "rows" | "metrics";
+  select: "count" | "rows" | "metrics" | "identifiers";
   projectId: string;
   filter: FilterState;
   searchQuery?: string;
@@ -169,84 +169,37 @@ export type FetchTracesTableProps = {
   tags?: Record<string, string>;
 };
 
-export const getTracesTableCount = async (props: {
-  projectId: string;
-  filter: FilterState;
-  searchQuery?: string;
-  searchType: TracingSearchType[];
-  orderBy?: OrderByState;
-  limit?: number;
-  page?: number;
-}) => {
-  const countRows = await getTracesTableGeneric<{ count: string }>({
-    select: "count",
-    tags: { kind: "count" },
-    ...props,
-  });
-
-  const converted = countRows.map((row) => ({
-    count: Number(row.count),
-  }));
-
-  return converted.length > 0 ? converted[0].count : 0;
+// Define return type mapping for better type safety
+type SelectReturnTypeMap = {
+  count: { count: string };
+  metrics: TracesTableMetricsClickhouseReturnType;
+  rows: TracesTableReturnType;
+  identifiers: { id: string; projectId: string; timestamp: string };
 };
 
-export const getTracesTableMetrics = async (props: {
-  projectId: string;
-  filter: FilterState;
-  searchQuery?: string;
-  orderBy?: OrderByState;
-  limit?: number;
-  page?: number;
-  clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
-}): Promise<Array<Omit<TracesMetricsUiReturnType, "scores">>> => {
-  const countRows =
-    await getTracesTableGeneric<TracesTableMetricsClickhouseReturnType>({
-      select: "metrics",
-      tags: { kind: "analytic" },
-      ...props,
-    });
+// Function overloads for type-safe select-specific returns
+async function getTracesTableGeneric(
+  props: FetchTracesTableProps & { select: "count" },
+): Promise<Array<SelectReturnTypeMap["count"]>>;
 
-  return countRows.map(convertToUITableMetrics);
-};
+async function getTracesTableGeneric(
+  props: FetchTracesTableProps & { select: "metrics" },
+): Promise<Array<SelectReturnTypeMap["metrics"]>>;
 
-export const getTracesTable = async (p: {
-  projectId: string;
-  filter: FilterState;
-  searchQuery?: string;
-  searchType?: TracingSearchType[];
-  orderBy?: OrderByState;
-  limit?: number;
-  page?: number;
-  clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
-}) => {
-  const {
-    projectId,
-    filter,
-    searchQuery,
-    searchType,
-    orderBy,
-    limit,
-    page,
-    clickhouseConfigs,
-  } = p;
-  const rows = await getTracesTableGeneric<TracesTableReturnType>({
-    select: "rows",
-    tags: { kind: "list" },
-    projectId,
-    filter,
-    searchQuery,
-    searchType,
-    orderBy,
-    limit,
-    page,
-    clickhouseConfigs,
-  });
+async function getTracesTableGeneric(
+  props: FetchTracesTableProps & { select: "rows" },
+): Promise<Array<SelectReturnTypeMap["rows"]>>;
 
-  return rows.map(convertToUiTableRows);
-};
+async function getTracesTableGeneric(
+  props: FetchTracesTableProps & { select: "identifiers" },
+): Promise<Array<SelectReturnTypeMap["identifiers"]>>;
 
-const getTracesTableGeneric = async <T>(props: FetchTracesTableProps) => {
+// Implementation with union type for internal use
+async function getTracesTableGeneric(
+  props: FetchTracesTableProps,
+): Promise<Array<SelectReturnTypeMap[keyof SelectReturnTypeMap]>>;
+
+async function getTracesTableGeneric(props: FetchTracesTableProps) {
   const {
     select,
     projectId,
@@ -296,6 +249,12 @@ const getTracesTableGeneric = async <T>(props: FetchTracesTableProps) => {
         t.environment as environment,
         t.session_id as session_id,
         t.public as public`;
+      break;
+    case "identifiers":
+      sqlSelect = `
+        t.id as id,
+        t.project_id as project_id,
+        t.timestamp as timestamp`;
       break;
     default:
       throw new Error(`Unknown select type: ${select}`);
@@ -484,7 +443,9 @@ const getTracesTableGeneric = async <T>(props: FetchTracesTableProps) => {
     ${limit !== undefined && page !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
   `;
 
-  const res = await queryClickhouse<T>({
+  const res = await queryClickhouse<
+    SelectReturnTypeMap[keyof SelectReturnTypeMap]
+  >({
     query: query,
     params: {
       limit: limit,
@@ -506,4 +467,103 @@ const getTracesTableGeneric = async <T>(props: FetchTracesTableProps) => {
   });
 
   return res;
+}
+
+export const getTracesTableCount = async (props: {
+  projectId: string;
+  filter: FilterState;
+  searchQuery?: string;
+  searchType: TracingSearchType[];
+  orderBy?: OrderByState;
+  limit?: number;
+  page?: number;
+}) => {
+  const countRows = await getTracesTableGeneric({
+    select: "count",
+    tags: { kind: "count" },
+    ...props,
+  });
+
+  const converted = countRows.map((row) => ({
+    count: Number(row.count),
+  }));
+
+  return converted.length > 0 ? converted[0].count : 0;
+};
+
+export const getTracesTableMetrics = async (props: {
+  projectId: string;
+  filter: FilterState;
+  searchQuery?: string;
+  orderBy?: OrderByState;
+  limit?: number;
+  page?: number;
+  clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
+}): Promise<Array<Omit<TracesMetricsUiReturnType, "scores">>> => {
+  const countRows = await getTracesTableGeneric({
+    select: "metrics",
+    tags: { kind: "analytic" },
+    ...props,
+  });
+
+  return countRows.map(convertToUITableMetrics);
+};
+
+export const getTracesTable = async (p: {
+  projectId: string;
+  filter: FilterState;
+  searchQuery?: string;
+  searchType?: TracingSearchType[];
+  orderBy?: OrderByState;
+  limit?: number;
+  page?: number;
+  clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
+}) => {
+  const {
+    projectId,
+    filter,
+    searchQuery,
+    searchType,
+    orderBy,
+    limit,
+    page,
+    clickhouseConfigs,
+  } = p;
+  const rows = await getTracesTableGeneric({
+    select: "rows",
+    tags: { kind: "list" },
+    projectId,
+    filter,
+    searchQuery,
+    searchType,
+    orderBy,
+    limit,
+    page,
+    clickhouseConfigs,
+  });
+
+  return rows.map(convertToUiTableRows);
+};
+
+export const getTraceIdentifiers = async (props: {
+  projectId: string;
+  filter: FilterState;
+  searchQuery?: string;
+  searchType?: TracingSearchType[];
+  orderBy?: OrderByState;
+  limit?: number;
+  page?: number;
+  clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
+}) => {
+  const identifiers = await getTracesTableGeneric({
+    select: "identifiers",
+    tags: { kind: "list" },
+    ...props,
+  });
+
+  return identifiers.map((row) => ({
+    id: row.id,
+    projectId: row.projectId,
+    timestamp: parseClickhouseUTCDateTimeFormat(row.timestamp),
+  }));
 };

--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -179,23 +179,28 @@ type SelectReturnTypeMap = {
 
 // Function overloads for type-safe select-specific returns
 async function getTracesTableGeneric(
+  // eslint-disable-next-line no-unused-vars
   props: FetchTracesTableProps & { select: "count" },
 ): Promise<Array<SelectReturnTypeMap["count"]>>;
 
 async function getTracesTableGeneric(
+  // eslint-disable-next-line no-unused-vars
   props: FetchTracesTableProps & { select: "metrics" },
 ): Promise<Array<SelectReturnTypeMap["metrics"]>>;
 
 async function getTracesTableGeneric(
+  // eslint-disable-next-line no-unused-vars
   props: FetchTracesTableProps & { select: "rows" },
 ): Promise<Array<SelectReturnTypeMap["rows"]>>;
 
 async function getTracesTableGeneric(
+  // eslint-disable-next-line no-unused-vars
   props: FetchTracesTableProps & { select: "identifiers" },
 ): Promise<Array<SelectReturnTypeMap["identifiers"]>>;
 
 // Implementation with union type for internal use
 async function getTracesTableGeneric(
+  // eslint-disable-next-line no-unused-vars
   props: FetchTracesTableProps,
 ): Promise<Array<SelectReturnTypeMap[keyof SelectReturnTypeMap]>>;
 

--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -253,7 +253,7 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
     case "identifiers":
       sqlSelect = `
         t.id as id,
-        t.project_id as project_id,
+        t.project_id as projectId,
         t.timestamp as timestamp`;
       break;
     default:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimizes trace identifier reading by adding `identifiers` selection and streamlining database read operations for historic evaluations.
> 
>   - **Behavior**:
>     - Adds `identifiers` to `select` options in `FetchTracesTableProps` in `traces-ui-table-service.ts`.
>     - Introduces `getTraceIdentifiers` function in `traces-ui-table-service.ts` to fetch trace identifiers.
>     - Implements `getTraceIdentifierStream` in `getDatabaseReadStream.ts` for efficient trace identifier streaming.
>   - **Functions**:
>     - Refactors `getTracesTableGeneric` in `traces-ui-table-service.ts` to support `identifiers` selection.
>     - Adds function overloads for `getTracesTableGeneric` to ensure type-safe returns.
>   - **Integration**:
>     - Updates `handleBatchActionJob` in `handleBatchActionJob.ts` to use `getTraceIdentifierStream` for trace-related actions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 723ad0f519dfbc54fe3acc611137233c7063e73a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->