### PR TITLE
chore: disable length metric collection on worker

### DIFF
--- a/packages/shared/src/server/redis/batchActionQueue.ts
+++ b/packages/shared/src/server/redis/batchActionQueue.ts
@@ -15,37 +15,42 @@ export class BatchActionQueue {
   public static getInstance(): Queue<
     TQueueJobTypes[QueueName.BatchActionQueue]
   > | null {
-    if (BatchActionQueue.instance) return BatchActionQueue.instance;
+    try {
+      if (BatchActionQueue.instance) return BatchActionQueue.instance;
 
-    const newRedis = createNewRedisInstance({
-      enableOfflineQueue: false,
-      ...redisQueueRetryOptions,
-    });
+      const newRedis = createNewRedisInstance({
+        enableOfflineQueue: false,
+        ...redisQueueRetryOptions,
+      });
 
-    BatchActionQueue.instance = newRedis
-      ? new Queue<TQueueJobTypes[QueueName.BatchActionQueue]>(
-          QueueName.BatchActionQueue,
-          {
-            connection: newRedis,
-            defaultJobOptions: {
-              removeOnComplete: true,
-              removeOnFail: 10_000,
-              attempts: 10,
-              backoff: {
-                type: "exponential",
-                delay: 5000,
+      BatchActionQueue.instance = newRedis
+        ? new Queue<TQueueJobTypes[QueueName.BatchActionQueue]>(
+            QueueName.BatchActionQueue,
+            {
+              connection: newRedis,
+              defaultJobOptions: {
+                removeOnComplete: true,
+                removeOnFail: 10_000,
+                attempts: 10,
+                backoff: {
+                  type: "exponential",
+                  delay: 5000,
+                },
               },
             },
-          },
-        )
-      : null;
+          )
+        : null;
 
-    BatchActionQueue.instance?.on("error", (err) => {
-      logger.error("BatchActionQueue error", err);
-    });
+      BatchActionQueue.instance?.on("error", (err) => {
+        logger.error("BatchActionQueue error", err);
+      });
 
-    collectQueueMetrics(BatchActionQueue.instance, QueueName.BatchActionQueue);
-
-    return BatchActionQueue.instance;
+      return BatchActionQueue.instance;
+    } finally {
+      collectQueueMetrics(
+        BatchActionQueue.instance,
+        QueueName.BatchActionQueue,
+      );
+    }
   }
 }

--- a/packages/shared/src/server/redis/batchActionQueue.ts
+++ b/packages/shared/src/server/redis/batchActionQueue.ts
@@ -1,6 +1,10 @@
 import { Queue } from "bullmq";
 import { QueueName, TQueueJobTypes } from "../queues";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 
 export class BatchActionQueue {
@@ -39,6 +43,8 @@ export class BatchActionQueue {
     BatchActionQueue.instance?.on("error", (err) => {
       logger.error("BatchActionQueue error", err);
     });
+
+    collectQueueMetrics(BatchActionQueue.instance, QueueName.BatchActionQueue);
 
     return BatchActionQueue.instance;
   }

--- a/packages/shared/src/server/redis/batchExport.ts
+++ b/packages/shared/src/server/redis/batchExport.ts
@@ -1,6 +1,10 @@
 import { Queue } from "bullmq";
 import { QueueName, TQueueJobTypes } from "../queues";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 
 export class BatchExportQueue {
@@ -38,6 +42,8 @@ export class BatchExportQueue {
     BatchExportQueue.instance?.on("error", (err) => {
       logger.error("BatchExportQueue error", err);
     });
+
+    collectQueueMetrics(BatchExportQueue.instance, QueueName.BatchExport);
 
     return BatchExportQueue.instance;
   }

--- a/packages/shared/src/server/redis/blobStorageIntegrationProcessingQueue.ts
+++ b/packages/shared/src/server/redis/blobStorageIntegrationProcessingQueue.ts
@@ -1,6 +1,10 @@
 import { Queue } from "bullmq";
 import { QueueName } from "../queues";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 
 export class BlobStorageIntegrationProcessingQueue {
@@ -35,6 +39,11 @@ export class BlobStorageIntegrationProcessingQueue {
       logger.error("BlobStorageIntegrationProcessingQueue error", err);
     });
 
+    collectQueueMetrics(
+      BlobStorageIntegrationProcessingQueue.instance,
+      QueueName.BlobStorageIntegrationProcessingQueue,
+    );
+
     return BlobStorageIntegrationProcessingQueue.instance;
   }
-} 
+}

--- a/packages/shared/src/server/redis/blobStorageIntegrationQueue.ts
+++ b/packages/shared/src/server/redis/blobStorageIntegrationQueue.ts
@@ -1,6 +1,10 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 
 export class BlobStorageIntegrationQueue {
@@ -49,6 +53,11 @@ export class BlobStorageIntegrationQueue {
           logger.error("Error adding BlobStorageIntegrationJob schedule", err);
         });
     }
+
+    collectQueueMetrics(
+      BlobStorageIntegrationQueue.instance,
+      QueueName.BlobStorageIntegrationQueue,
+    );
 
     return BlobStorageIntegrationQueue.instance;
   }

--- a/packages/shared/src/server/redis/cloudUsageMeteringQueue.ts
+++ b/packages/shared/src/server/redis/cloudUsageMeteringQueue.ts
@@ -1,7 +1,11 @@
 import { Queue } from "bullmq";
 import { env } from "../../env";
 import { QueueName, QueueJobs } from "../queues";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 
 export class CloudUsageMeteringQueue {
@@ -56,6 +60,11 @@ export class CloudUsageMeteringQueue {
         {},
       );
     }
+
+    collectQueueMetrics(
+      CloudUsageMeteringQueue.instance,
+      QueueName.CloudUsageMeteringQueue,
+    );
 
     return CloudUsageMeteringQueue.instance;
   }

--- a/packages/shared/src/server/redis/cloudUsageMeteringQueue.ts
+++ b/packages/shared/src/server/redis/cloudUsageMeteringQueue.ts
@@ -12,60 +12,62 @@ export class CloudUsageMeteringQueue {
   private static instance: Queue | null = null;
 
   public static getInstance(): Queue | null {
-    if (!env.STRIPE_SECRET_KEY) {
-      return null;
-    }
+    try {
+      if (!env.STRIPE_SECRET_KEY) {
+        return null;
+      }
 
-    if (CloudUsageMeteringQueue.instance) {
-      return CloudUsageMeteringQueue.instance;
-    }
+      if (CloudUsageMeteringQueue.instance) {
+        return CloudUsageMeteringQueue.instance;
+      }
 
-    const newRedis = createNewRedisInstance({
-      enableOfflineQueue: false,
-      ...redisQueueRetryOptions,
-    });
+      const newRedis = createNewRedisInstance({
+        enableOfflineQueue: false,
+        ...redisQueueRetryOptions,
+      });
 
-    CloudUsageMeteringQueue.instance = newRedis
-      ? new Queue(QueueName.CloudUsageMeteringQueue, {
-          connection: newRedis,
-          defaultJobOptions: {
-            removeOnComplete: true,
-            removeOnFail: 100,
-            attempts: 5,
-            backoff: {
-              type: "exponential",
-              delay: 5000,
+      CloudUsageMeteringQueue.instance = newRedis
+        ? new Queue(QueueName.CloudUsageMeteringQueue, {
+            connection: newRedis,
+            defaultJobOptions: {
+              removeOnComplete: true,
+              removeOnFail: 100,
+              attempts: 5,
+              backoff: {
+                type: "exponential",
+                delay: 5000,
+              },
             },
+          })
+        : null;
+
+      CloudUsageMeteringQueue.instance?.on("error", (err) => {
+        logger.error("CloudUsageMeteringQueue error", err);
+      });
+
+      if (CloudUsageMeteringQueue.instance) {
+        CloudUsageMeteringQueue.instance.add(
+          QueueJobs.CloudUsageMeteringJob,
+          {},
+          {
+            // Run at minute 5 of every hour (e.g. 1:05, 2:05, 3:05, etc)
+            repeat: { pattern: "5 * * * *" },
           },
-        })
-      : null;
+        );
 
-    CloudUsageMeteringQueue.instance?.on("error", (err) => {
-      logger.error("CloudUsageMeteringQueue error", err);
-    });
+        CloudUsageMeteringQueue.instance.add(
+          QueueJobs.CloudUsageMeteringJob,
+          {},
+          {},
+        );
+      }
 
-    if (CloudUsageMeteringQueue.instance) {
-      CloudUsageMeteringQueue.instance.add(
-        QueueJobs.CloudUsageMeteringJob,
-        {},
-        {
-          // Run at minute 5 of every hour (e.g. 1:05, 2:05, 3:05, etc)
-          repeat: { pattern: "5 * * * *" },
-        },
-      );
-
-      CloudUsageMeteringQueue.instance.add(
-        QueueJobs.CloudUsageMeteringJob,
-        {},
-        {},
+      return CloudUsageMeteringQueue.instance;
+    } finally {
+      collectQueueMetrics(
+        CloudUsageMeteringQueue.instance,
+        QueueName.CloudUsageMeteringQueue,
       );
     }
-
-    collectQueueMetrics(
-      CloudUsageMeteringQueue.instance,
-      QueueName.CloudUsageMeteringQueue,
-    );
-
-    return CloudUsageMeteringQueue.instance;
   }
 }

--- a/packages/shared/src/server/redis/coreDataS3ExportQueue.ts
+++ b/packages/shared/src/server/redis/coreDataS3ExportQueue.ts
@@ -1,6 +1,10 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 import { env } from "../../env";
 
@@ -54,6 +58,11 @@ export class CoreDataS3ExportQueue {
           logger.error("Error adding CoreDataS3ExportJob schedule", err);
         });
     }
+
+    collectQueueMetrics(
+      CoreDataS3ExportQueue.instance,
+      QueueName.CoreDataS3ExportQueue,
+    );
 
     return CoreDataS3ExportQueue.instance;
   }

--- a/packages/shared/src/server/redis/createEvalQueue.ts
+++ b/packages/shared/src/server/redis/createEvalQueue.ts
@@ -15,37 +15,39 @@ export class CreateEvalQueue {
   public static getInstance(): Queue<
     TQueueJobTypes[QueueName.CreateEvalQueue]
   > | null {
-    if (CreateEvalQueue.instance) return CreateEvalQueue.instance;
+    try {
+      if (CreateEvalQueue.instance) return CreateEvalQueue.instance;
 
-    const newRedis = createNewRedisInstance({
-      enableOfflineQueue: false,
-      ...redisQueueRetryOptions,
-    });
+      const newRedis = createNewRedisInstance({
+        enableOfflineQueue: false,
+        ...redisQueueRetryOptions,
+      });
 
-    CreateEvalQueue.instance = newRedis
-      ? new Queue<TQueueJobTypes[QueueName.CreateEvalQueue]>(
-          QueueName.CreateEvalQueue,
-          {
-            connection: newRedis,
-            defaultJobOptions: {
-              removeOnComplete: 100, // Important: If not true, new jobs for that ID would be ignored as jobs in the complete set are still considered as part of the queue
-              removeOnFail: 100_000,
-              attempts: 5,
-              backoff: {
-                type: "exponential",
-                delay: 5000,
+      CreateEvalQueue.instance = newRedis
+        ? new Queue<TQueueJobTypes[QueueName.CreateEvalQueue]>(
+            QueueName.CreateEvalQueue,
+            {
+              connection: newRedis,
+              defaultJobOptions: {
+                removeOnComplete: 100, // Important: If not true, new jobs for that ID would be ignored as jobs in the complete set are still considered as part of the queue
+                removeOnFail: 100_000,
+                attempts: 5,
+                backoff: {
+                  type: "exponential",
+                  delay: 5000,
+                },
               },
             },
-          },
-        )
-      : null;
+          )
+        : null;
 
-    CreateEvalQueue.instance?.on("error", (err) => {
-      logger.error("CreateEvalQueue error", err);
-    });
+      CreateEvalQueue.instance?.on("error", (err) => {
+        logger.error("CreateEvalQueue error", err);
+      });
 
-    collectQueueMetrics(CreateEvalQueue.instance, QueueName.CreateEvalQueue);
-
-    return CreateEvalQueue.instance;
+      return CreateEvalQueue.instance;
+    } finally {
+      collectQueueMetrics(CreateEvalQueue.instance, QueueName.CreateEvalQueue);
+    }
   }
 }

--- a/packages/shared/src/server/redis/createEvalQueue.ts
+++ b/packages/shared/src/server/redis/createEvalQueue.ts
@@ -1,6 +1,10 @@
 import { QueueName, TQueueJobTypes } from "../queues";
 import { Queue } from "bullmq";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 
 export class CreateEvalQueue {
@@ -39,6 +43,8 @@ export class CreateEvalQueue {
     CreateEvalQueue.instance?.on("error", (err) => {
       logger.error("CreateEvalQueue error", err);
     });
+
+    collectQueueMetrics(CreateEvalQueue.instance, QueueName.CreateEvalQueue);
 
     return CreateEvalQueue.instance;
   }

--- a/packages/shared/src/server/redis/dataRetentionProcessingQueue.ts
+++ b/packages/shared/src/server/redis/dataRetentionProcessingQueue.ts
@@ -1,6 +1,10 @@
 import { Queue } from "bullmq";
 import { QueueName } from "../queues";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 
 export class DataRetentionProcessingQueue {
@@ -34,6 +38,11 @@ export class DataRetentionProcessingQueue {
     DataRetentionProcessingQueue.instance?.on("error", (err) => {
       logger.error("DataRetentionProcessingQueue error", err);
     });
+
+    collectQueueMetrics(
+      DataRetentionProcessingQueue.instance,
+      QueueName.DataRetentionProcessingQueue,
+    );
 
     return DataRetentionProcessingQueue.instance;
   }

--- a/packages/shared/src/server/redis/dataRetentionQueue.ts
+++ b/packages/shared/src/server/redis/dataRetentionQueue.ts
@@ -1,6 +1,10 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 
 export class DataRetentionQueue {
@@ -49,6 +53,11 @@ export class DataRetentionQueue {
           logger.error("Error adding DataRetentionQueue schedule", err);
         });
     }
+
+    collectQueueMetrics(
+      DataRetentionQueue.instance,
+      QueueName.DataRetentionQueue,
+    );
 
     return DataRetentionQueue.instance;
   }

--- a/packages/shared/src/server/redis/dataRetentionQueue.ts
+++ b/packages/shared/src/server/redis/dataRetentionQueue.ts
@@ -11,54 +11,56 @@ export class DataRetentionQueue {
   private static instance: Queue | null = null;
 
   public static getInstance(): Queue | null {
-    if (DataRetentionQueue.instance) {
-      return DataRetentionQueue.instance;
-    }
+    try {
+      if (DataRetentionQueue.instance) {
+        return DataRetentionQueue.instance;
+      }
 
-    const newRedis = createNewRedisInstance({
-      enableOfflineQueue: false,
-      ...redisQueueRetryOptions,
-    });
+      const newRedis = createNewRedisInstance({
+        enableOfflineQueue: false,
+        ...redisQueueRetryOptions,
+      });
 
-    DataRetentionQueue.instance = newRedis
-      ? new Queue(QueueName.DataRetentionQueue, {
-          connection: newRedis,
-          defaultJobOptions: {
-            removeOnComplete: true,
-            removeOnFail: 100,
-            attempts: 5,
-            backoff: {
-              type: "exponential",
-              delay: 5000,
+      DataRetentionQueue.instance = newRedis
+        ? new Queue(QueueName.DataRetentionQueue, {
+            connection: newRedis,
+            defaultJobOptions: {
+              removeOnComplete: true,
+              removeOnFail: 100,
+              attempts: 5,
+              backoff: {
+                type: "exponential",
+                delay: 5000,
+              },
             },
-          },
-        })
-      : null;
+          })
+        : null;
 
-    DataRetentionQueue.instance?.on("error", (err) => {
-      logger.error("DataRetentionQueue error", err);
-    });
+      DataRetentionQueue.instance?.on("error", (err) => {
+        logger.error("DataRetentionQueue error", err);
+      });
 
-    if (DataRetentionQueue.instance) {
-      logger.debug("Scheduling jobs for DataRetentionQueue");
-      DataRetentionQueue.instance
-        .add(
-          QueueJobs.DataRetentionJob,
-          {},
-          {
-            repeat: { pattern: "15 3 * * *" }, // every day at 3:15am
-          },
-        )
-        .catch((err) => {
-          logger.error("Error adding DataRetentionQueue schedule", err);
-        });
+      if (DataRetentionQueue.instance) {
+        logger.debug("Scheduling jobs for DataRetentionQueue");
+        DataRetentionQueue.instance
+          .add(
+            QueueJobs.DataRetentionJob,
+            {},
+            {
+              repeat: { pattern: "15 3 * * *" }, // every day at 3:15am
+            },
+          )
+          .catch((err) => {
+            logger.error("Error adding DataRetentionQueue schedule", err);
+          });
+      }
+
+      return DataRetentionQueue.instance;
+    } finally {
+      collectQueueMetrics(
+        DataRetentionQueue.instance,
+        QueueName.DataRetentionQueue,
+      );
     }
-
-    collectQueueMetrics(
-      DataRetentionQueue.instance,
-      QueueName.DataRetentionQueue,
-    );
-
-    return DataRetentionQueue.instance;
   }
 }

--- a/packages/shared/src/server/redis/datasetRunItemUpsert.ts
+++ b/packages/shared/src/server/redis/datasetRunItemUpsert.ts
@@ -1,6 +1,6 @@
 import { QueueName, TQueueJobTypes } from "../queues";
 import { Queue } from "bullmq";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import { createNewRedisInstance, redisQueueRetryOptions, collectQueueMetrics } from "./redis";
 import { logger } from "../logger";
 
 export class DatasetRunItemUpsertQueue {
@@ -41,6 +41,9 @@ export class DatasetRunItemUpsertQueue {
     DatasetRunItemUpsertQueue.instance?.on("error", (err) => {
       logger.error("DatasetRunItemUpsertQueue error", err);
     });
+
+    // Collect queue metrics without blocking
+    collectQueueMetrics(DatasetRunItemUpsertQueue.instance, QueueName.DatasetRunItemUpsert);
 
     return DatasetRunItemUpsertQueue.instance;
   }

--- a/packages/shared/src/server/redis/dlqRetryQueue.ts
+++ b/packages/shared/src/server/redis/dlqRetryQueue.ts
@@ -1,6 +1,10 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 
 export class DeadLetterRetryQueue {
@@ -49,6 +53,11 @@ export class DeadLetterRetryQueue {
           logger.error("Error adding DeadLetterRetryQueue schedule", err);
         });
     }
+
+    collectQueueMetrics(
+      DeadLetterRetryQueue.instance,
+      QueueName.DeadLetterRetryQueue,
+    );
 
     return DeadLetterRetryQueue.instance;
   }

--- a/packages/shared/src/server/redis/dlqRetryQueue.ts
+++ b/packages/shared/src/server/redis/dlqRetryQueue.ts
@@ -11,54 +11,56 @@ export class DeadLetterRetryQueue {
   private static instance: Queue | null = null;
 
   public static getInstance(): Queue | null {
-    if (DeadLetterRetryQueue.instance) {
-      return DeadLetterRetryQueue.instance;
-    }
+    try {
+      if (DeadLetterRetryQueue.instance) {
+        return DeadLetterRetryQueue.instance;
+      }
 
-    const newRedis = createNewRedisInstance({
-      enableOfflineQueue: false,
-      ...redisQueueRetryOptions,
-    });
+      const newRedis = createNewRedisInstance({
+        enableOfflineQueue: false,
+        ...redisQueueRetryOptions,
+      });
 
-    DeadLetterRetryQueue.instance = newRedis
-      ? new Queue(QueueName.DeadLetterRetryQueue, {
-          connection: newRedis,
-          defaultJobOptions: {
-            removeOnComplete: true,
-            removeOnFail: 100,
-            attempts: 5,
-            backoff: {
-              type: "exponential",
-              delay: 5000,
+      DeadLetterRetryQueue.instance = newRedis
+        ? new Queue(QueueName.DeadLetterRetryQueue, {
+            connection: newRedis,
+            defaultJobOptions: {
+              removeOnComplete: true,
+              removeOnFail: 100,
+              attempts: 5,
+              backoff: {
+                type: "exponential",
+                delay: 5000,
+              },
             },
-          },
-        })
-      : null;
+          })
+        : null;
 
-    DeadLetterRetryQueue.instance?.on("error", (err) => {
-      logger.error("DeadLetterRetryQueue error", err);
-    });
+      DeadLetterRetryQueue.instance?.on("error", (err) => {
+        logger.error("DeadLetterRetryQueue error", err);
+      });
 
-    if (DeadLetterRetryQueue.instance) {
-      logger.debug("Scheduling jobs for DeadLetterRetryQueue");
-      DeadLetterRetryQueue.instance
-        .add(
-          QueueJobs.DeadLetterRetryJob,
-          { timestamp: new Date() },
-          {
-            repeat: { pattern: "0 */10 * * * *" }, // every 10 minutes (with seconds precision)
-          },
-        )
-        .catch((err) => {
-          logger.error("Error adding DeadLetterRetryQueue schedule", err);
-        });
+      if (DeadLetterRetryQueue.instance) {
+        logger.debug("Scheduling jobs for DeadLetterRetryQueue");
+        DeadLetterRetryQueue.instance
+          .add(
+            QueueJobs.DeadLetterRetryJob,
+            { timestamp: new Date() },
+            {
+              repeat: { pattern: "0 */10 * * * *" }, // every 10 minutes (with seconds precision)
+            },
+          )
+          .catch((err) => {
+            logger.error("Error adding DeadLetterRetryQueue schedule", err);
+          });
+      }
+
+      return DeadLetterRetryQueue.instance;
+    } finally {
+      collectQueueMetrics(
+        DeadLetterRetryQueue.instance,
+        QueueName.DeadLetterRetryQueue,
+      );
     }
-
-    collectQueueMetrics(
-      DeadLetterRetryQueue.instance,
-      QueueName.DeadLetterRetryQueue,
-    );
-
-    return DeadLetterRetryQueue.instance;
   }
 }

--- a/packages/shared/src/server/redis/evalExecutionQueue.ts
+++ b/packages/shared/src/server/redis/evalExecutionQueue.ts
@@ -1,7 +1,11 @@
 import { Queue } from "bullmq";
 import { logger } from "../logger";
 import { TQueueJobTypes, QueueName } from "../queues";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 
 export class EvalExecutionQueue {
   private static instance: Queue<
@@ -39,6 +43,11 @@ export class EvalExecutionQueue {
     EvalExecutionQueue.instance?.on("error", (err) => {
       logger.error("EvalExecutionQueue error", err);
     });
+
+    collectQueueMetrics(
+      EvalExecutionQueue.instance,
+      QueueName.EvaluationExecution,
+    );
 
     return EvalExecutionQueue.instance;
   }

--- a/packages/shared/src/server/redis/experimentCreateQueue.ts
+++ b/packages/shared/src/server/redis/experimentCreateQueue.ts
@@ -1,7 +1,11 @@
 import { Queue } from "bullmq";
 import { logger } from "../logger";
 import { TQueueJobTypes, QueueName } from "../queues";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 
 export class ExperimentCreateQueue {
   private static instance: Queue<
@@ -39,6 +43,11 @@ export class ExperimentCreateQueue {
     ExperimentCreateQueue.instance?.on("error", (err) => {
       logger.error("ExperimentCreateQueue error", err);
     });
+
+    collectQueueMetrics(
+      ExperimentCreateQueue.instance,
+      QueueName.ExperimentCreate,
+    );
 
     return ExperimentCreateQueue.instance;
   }

--- a/packages/shared/src/server/redis/ingestionQueue.ts
+++ b/packages/shared/src/server/redis/ingestionQueue.ts
@@ -1,6 +1,10 @@
 import { Queue } from "bullmq";
 import { QueueName, TQueueJobTypes } from "../queues";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 
 export class IngestionQueue {
@@ -39,6 +43,8 @@ export class IngestionQueue {
     IngestionQueue.instance?.on("error", (err) => {
       logger.error("IngestionQueue error", err);
     });
+
+    collectQueueMetrics(IngestionQueue.instance, QueueName.IngestionQueue);
 
     return IngestionQueue.instance;
   }
@@ -81,6 +87,11 @@ export class SecondaryIngestionQueue {
     SecondaryIngestionQueue.instance?.on("error", (err) => {
       logger.error("SecondaryIngestionQueue error", err);
     });
+
+    collectQueueMetrics(
+      SecondaryIngestionQueue.instance,
+      QueueName.IngestionSecondaryQueue,
+    );
 
     return SecondaryIngestionQueue.instance;
   }

--- a/packages/shared/src/server/redis/ingestionQueue.ts
+++ b/packages/shared/src/server/redis/ingestionQueue.ts
@@ -15,38 +15,40 @@ export class IngestionQueue {
   public static getInstance(): Queue<
     TQueueJobTypes[QueueName.IngestionQueue]
   > | null {
-    if (IngestionQueue.instance) return IngestionQueue.instance;
+    try {
+      if (IngestionQueue.instance) return IngestionQueue.instance;
 
-    const newRedis = createNewRedisInstance({
-      enableOfflineQueue: false,
-      ...redisQueueRetryOptions,
-    });
+      const newRedis = createNewRedisInstance({
+        enableOfflineQueue: false,
+        ...redisQueueRetryOptions,
+      });
 
-    IngestionQueue.instance = newRedis
-      ? new Queue<TQueueJobTypes[QueueName.IngestionQueue]>(
-          QueueName.IngestionQueue,
-          {
-            connection: newRedis,
-            defaultJobOptions: {
-              removeOnComplete: true,
-              removeOnFail: 100_000,
-              attempts: 5,
-              backoff: {
-                type: "exponential",
-                delay: 5000,
+      IngestionQueue.instance = newRedis
+        ? new Queue<TQueueJobTypes[QueueName.IngestionQueue]>(
+            QueueName.IngestionQueue,
+            {
+              connection: newRedis,
+              defaultJobOptions: {
+                removeOnComplete: true,
+                removeOnFail: 100_000,
+                attempts: 5,
+                backoff: {
+                  type: "exponential",
+                  delay: 5000,
+                },
               },
             },
-          },
-        )
-      : null;
+          )
+        : null;
 
-    IngestionQueue.instance?.on("error", (err) => {
-      logger.error("IngestionQueue error", err);
-    });
+      IngestionQueue.instance?.on("error", (err) => {
+        logger.error("IngestionQueue error", err);
+      });
 
-    collectQueueMetrics(IngestionQueue.instance, QueueName.IngestionQueue);
-
-    return IngestionQueue.instance;
+      return IngestionQueue.instance;
+    } finally {
+      collectQueueMetrics(IngestionQueue.instance, QueueName.IngestionQueue);
+    }
   }
 }
 
@@ -58,41 +60,43 @@ export class SecondaryIngestionQueue {
   public static getInstance(): Queue<
     TQueueJobTypes[QueueName.IngestionSecondaryQueue]
   > | null {
-    if (SecondaryIngestionQueue.instance)
-      return SecondaryIngestionQueue.instance;
+    try {
+      if (SecondaryIngestionQueue.instance)
+        return SecondaryIngestionQueue.instance;
 
-    const newRedis = createNewRedisInstance({
-      enableOfflineQueue: false,
-      ...redisQueueRetryOptions,
-    });
+      const newRedis = createNewRedisInstance({
+        enableOfflineQueue: false,
+        ...redisQueueRetryOptions,
+      });
 
-    SecondaryIngestionQueue.instance = newRedis
-      ? new Queue<TQueueJobTypes[QueueName.IngestionSecondaryQueue]>(
-          QueueName.IngestionSecondaryQueue,
-          {
-            connection: newRedis,
-            defaultJobOptions: {
-              removeOnComplete: true,
-              removeOnFail: 100_000,
-              attempts: 5,
-              backoff: {
-                type: "exponential",
-                delay: 5000,
+      SecondaryIngestionQueue.instance = newRedis
+        ? new Queue<TQueueJobTypes[QueueName.IngestionSecondaryQueue]>(
+            QueueName.IngestionSecondaryQueue,
+            {
+              connection: newRedis,
+              defaultJobOptions: {
+                removeOnComplete: true,
+                removeOnFail: 100_000,
+                attempts: 5,
+                backoff: {
+                  type: "exponential",
+                  delay: 5000,
+                },
               },
             },
-          },
-        )
-      : null;
+          )
+        : null;
 
-    SecondaryIngestionQueue.instance?.on("error", (err) => {
-      logger.error("SecondaryIngestionQueue error", err);
-    });
+      SecondaryIngestionQueue.instance?.on("error", (err) => {
+        logger.error("SecondaryIngestionQueue error", err);
+      });
 
-    collectQueueMetrics(
-      SecondaryIngestionQueue.instance,
-      QueueName.IngestionSecondaryQueue,
-    );
-
-    return SecondaryIngestionQueue.instance;
+      return SecondaryIngestionQueue.instance;
+    } finally {
+      collectQueueMetrics(
+        SecondaryIngestionQueue.instance,
+        QueueName.IngestionSecondaryQueue,
+      );
+    }
   }
 }

--- a/packages/shared/src/server/redis/meteringDataPostgresExportQueue.ts
+++ b/packages/shared/src/server/redis/meteringDataPostgresExportQueue.ts
@@ -1,6 +1,10 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 import { env } from "../../env";
 
@@ -57,6 +61,11 @@ export class MeteringDataPostgresExportQueue {
           );
         });
     }
+
+    collectQueueMetrics(
+      MeteringDataPostgresExportQueue.instance,
+      QueueName.MeteringDataPostgresExportQueue,
+    );
 
     return MeteringDataPostgresExportQueue.instance;
   }

--- a/packages/shared/src/server/redis/postHogIntegrationProcessingQueue.ts
+++ b/packages/shared/src/server/redis/postHogIntegrationProcessingQueue.ts
@@ -1,6 +1,10 @@
 import { Queue } from "bullmq";
 import { QueueName } from "../queues";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 
 export class PostHogIntegrationProcessingQueue {
@@ -34,6 +38,11 @@ export class PostHogIntegrationProcessingQueue {
     PostHogIntegrationProcessingQueue.instance?.on("error", (err) => {
       logger.error("PostHogIntegrationProcessingQueue error", err);
     });
+
+    collectQueueMetrics(
+      PostHogIntegrationProcessingQueue.instance,
+      QueueName.PostHogIntegrationProcessingQueue,
+    );
 
     return PostHogIntegrationProcessingQueue.instance;
   }

--- a/packages/shared/src/server/redis/postHogIntegrationProcessingQueue.ts
+++ b/packages/shared/src/server/redis/postHogIntegrationProcessingQueue.ts
@@ -11,39 +11,41 @@ export class PostHogIntegrationProcessingQueue {
   private static instance: Queue | null = null;
 
   public static getInstance(): Queue | null {
-    if (PostHogIntegrationProcessingQueue.instance) {
-      return PostHogIntegrationProcessingQueue.instance;
-    }
+    try {
+      if (PostHogIntegrationProcessingQueue.instance) {
+        return PostHogIntegrationProcessingQueue.instance;
+      }
 
-    const newRedis = createNewRedisInstance({
-      enableOfflineQueue: false,
-      ...redisQueueRetryOptions,
-    });
+      const newRedis = createNewRedisInstance({
+        enableOfflineQueue: false,
+        ...redisQueueRetryOptions,
+      });
 
-    PostHogIntegrationProcessingQueue.instance = newRedis
-      ? new Queue(QueueName.PostHogIntegrationProcessingQueue, {
-          connection: newRedis,
-          defaultJobOptions: {
-            removeOnComplete: true,
-            removeOnFail: 100_000,
-            attempts: 5,
-            backoff: {
-              type: "exponential",
-              delay: 5000,
+      PostHogIntegrationProcessingQueue.instance = newRedis
+        ? new Queue(QueueName.PostHogIntegrationProcessingQueue, {
+            connection: newRedis,
+            defaultJobOptions: {
+              removeOnComplete: true,
+              removeOnFail: 100_000,
+              attempts: 5,
+              backoff: {
+                type: "exponential",
+                delay: 5000,
+              },
             },
-          },
-        })
-      : null;
+          })
+        : null;
 
-    PostHogIntegrationProcessingQueue.instance?.on("error", (err) => {
-      logger.error("PostHogIntegrationProcessingQueue error", err);
-    });
+      PostHogIntegrationProcessingQueue.instance?.on("error", (err) => {
+        logger.error("PostHogIntegrationProcessingQueue error", err);
+      });
 
-    collectQueueMetrics(
-      PostHogIntegrationProcessingQueue.instance,
-      QueueName.PostHogIntegrationProcessingQueue,
-    );
-
-    return PostHogIntegrationProcessingQueue.instance;
+      return PostHogIntegrationProcessingQueue.instance;
+    } finally {
+      collectQueueMetrics(
+        PostHogIntegrationProcessingQueue.instance,
+        QueueName.PostHogIntegrationProcessingQueue,
+      );
+    }
   }
 }

--- a/packages/shared/src/server/redis/postHogIntegrationQueue.ts
+++ b/packages/shared/src/server/redis/postHogIntegrationQueue.ts
@@ -1,6 +1,10 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 
 export class PostHogIntegrationQueue {
@@ -49,6 +53,11 @@ export class PostHogIntegrationQueue {
           logger.error("Error adding PostHogIntegrationJob schedule", err);
         });
     }
+
+    collectQueueMetrics(
+      PostHogIntegrationQueue.instance,
+      QueueName.PostHogIntegrationQueue,
+    );
 
     return PostHogIntegrationQueue.instance;
   }

--- a/packages/shared/src/server/redis/postHogIntegrationQueue.ts
+++ b/packages/shared/src/server/redis/postHogIntegrationQueue.ts
@@ -11,54 +11,56 @@ export class PostHogIntegrationQueue {
   private static instance: Queue | null = null;
 
   public static getInstance(): Queue | null {
-    if (PostHogIntegrationQueue.instance) {
-      return PostHogIntegrationQueue.instance;
-    }
+    try {
+      if (PostHogIntegrationQueue.instance) {
+        return PostHogIntegrationQueue.instance;
+      }
 
-    const newRedis = createNewRedisInstance({
-      enableOfflineQueue: false,
-      ...redisQueueRetryOptions,
-    });
+      const newRedis = createNewRedisInstance({
+        enableOfflineQueue: false,
+        ...redisQueueRetryOptions,
+      });
 
-    PostHogIntegrationQueue.instance = newRedis
-      ? new Queue(QueueName.PostHogIntegrationQueue, {
-          connection: newRedis,
-          defaultJobOptions: {
-            removeOnComplete: true,
-            removeOnFail: 100,
-            attempts: 5,
-            backoff: {
-              type: "exponential",
-              delay: 5000,
+      PostHogIntegrationQueue.instance = newRedis
+        ? new Queue(QueueName.PostHogIntegrationQueue, {
+            connection: newRedis,
+            defaultJobOptions: {
+              removeOnComplete: true,
+              removeOnFail: 100,
+              attempts: 5,
+              backoff: {
+                type: "exponential",
+                delay: 5000,
+              },
             },
-          },
-        })
-      : null;
+          })
+        : null;
 
-    PostHogIntegrationQueue.instance?.on("error", (err) => {
-      logger.error("PostHogIntegrationQueue error", err);
-    });
+      PostHogIntegrationQueue.instance?.on("error", (err) => {
+        logger.error("PostHogIntegrationQueue error", err);
+      });
 
-    if (PostHogIntegrationQueue.instance) {
-      logger.debug("Scheduling jobs for PostHogIntegrationQueue");
-      PostHogIntegrationQueue.instance
-        .add(
-          QueueJobs.PostHogIntegrationJob,
-          {},
-          {
-            repeat: { pattern: "30 * * * *" }, // every hour at 30 minutes past
-          },
-        )
-        .catch((err) => {
-          logger.error("Error adding PostHogIntegrationJob schedule", err);
-        });
+      if (PostHogIntegrationQueue.instance) {
+        logger.debug("Scheduling jobs for PostHogIntegrationQueue");
+        PostHogIntegrationQueue.instance
+          .add(
+            QueueJobs.PostHogIntegrationJob,
+            {},
+            {
+              repeat: { pattern: "30 * * * *" }, // every hour at 30 minutes past
+            },
+          )
+          .catch((err) => {
+            logger.error("Error adding PostHogIntegrationJob schedule", err);
+          });
+      }
+
+      return PostHogIntegrationQueue.instance;
+    } finally {
+      collectQueueMetrics(
+        PostHogIntegrationQueue.instance,
+        QueueName.PostHogIntegrationQueue,
+      );
     }
-
-    collectQueueMetrics(
-      PostHogIntegrationQueue.instance,
-      QueueName.PostHogIntegrationQueue,
-    );
-
-    return PostHogIntegrationQueue.instance;
   }
 }

--- a/packages/shared/src/server/redis/projectDelete.ts
+++ b/packages/shared/src/server/redis/projectDelete.ts
@@ -1,6 +1,10 @@
 import { QueueName, TQueueJobTypes } from "../queues";
 import { Queue } from "bullmq";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 
 export class ProjectDeleteQueue {
@@ -40,6 +44,8 @@ export class ProjectDeleteQueue {
     ProjectDeleteQueue.instance?.on("error", (err) => {
       logger.error("ProjectDeleteQueue error", err);
     });
+
+    collectQueueMetrics(ProjectDeleteQueue.instance, QueueName.ProjectDelete);
 
     return ProjectDeleteQueue.instance;
   }

--- a/packages/shared/src/server/redis/projectDelete.ts
+++ b/packages/shared/src/server/redis/projectDelete.ts
@@ -15,38 +15,40 @@ export class ProjectDeleteQueue {
   public static getInstance(): Queue<
     TQueueJobTypes[QueueName.ProjectDelete]
   > | null {
-    if (ProjectDeleteQueue.instance) return ProjectDeleteQueue.instance;
+    try {
+      if (ProjectDeleteQueue.instance) return ProjectDeleteQueue.instance;
 
-    const newRedis = createNewRedisInstance({
-      enableOfflineQueue: false,
-      ...redisQueueRetryOptions,
-    });
+      const newRedis = createNewRedisInstance({
+        enableOfflineQueue: false,
+        ...redisQueueRetryOptions,
+      });
 
-    ProjectDeleteQueue.instance = newRedis
-      ? new Queue<TQueueJobTypes[QueueName.ProjectDelete]>(
-          QueueName.ProjectDelete,
-          {
-            connection: newRedis,
-            defaultJobOptions: {
-              removeOnComplete: true,
-              removeOnFail: 100_000,
-              attempts: 10,
-              delay: 60_000, // 1 minute
-              backoff: {
-                type: "exponential",
-                delay: 5000,
+      ProjectDeleteQueue.instance = newRedis
+        ? new Queue<TQueueJobTypes[QueueName.ProjectDelete]>(
+            QueueName.ProjectDelete,
+            {
+              connection: newRedis,
+              defaultJobOptions: {
+                removeOnComplete: true,
+                removeOnFail: 100_000,
+                attempts: 10,
+                delay: 60_000, // 1 minute
+                backoff: {
+                  type: "exponential",
+                  delay: 5000,
+                },
               },
             },
-          },
-        )
-      : null;
+          )
+        : null;
 
-    ProjectDeleteQueue.instance?.on("error", (err) => {
-      logger.error("ProjectDeleteQueue error", err);
-    });
+      ProjectDeleteQueue.instance?.on("error", (err) => {
+        logger.error("ProjectDeleteQueue error", err);
+      });
 
-    collectQueueMetrics(ProjectDeleteQueue.instance, QueueName.ProjectDelete);
-
-    return ProjectDeleteQueue.instance;
+      return ProjectDeleteQueue.instance;
+    } finally {
+      collectQueueMetrics(ProjectDeleteQueue.instance, QueueName.ProjectDelete);
+    }
   }
 }

--- a/packages/shared/src/server/redis/scoreDelete.ts
+++ b/packages/shared/src/server/redis/scoreDelete.ts
@@ -1,12 +1,19 @@
 import { QueueName, TQueueJobTypes } from "../queues";
 import { Queue } from "bullmq";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 
 export class ScoreDeleteQueue {
-  private static instance: Queue<TQueueJobTypes[QueueName.ScoreDelete]> | null = null;
+  private static instance: Queue<TQueueJobTypes[QueueName.ScoreDelete]> | null =
+    null;
 
-  public static getInstance(): Queue<TQueueJobTypes[QueueName.ScoreDelete]> | null {
+  public static getInstance(): Queue<
+    TQueueJobTypes[QueueName.ScoreDelete]
+  > | null {
     if (ScoreDeleteQueue.instance) return ScoreDeleteQueue.instance;
 
     const newRedis = createNewRedisInstance({
@@ -15,24 +22,29 @@ export class ScoreDeleteQueue {
     });
 
     ScoreDeleteQueue.instance = newRedis
-      ? new Queue<TQueueJobTypes[QueueName.ScoreDelete]>(QueueName.ScoreDelete, {
-          connection: newRedis,
-          defaultJobOptions: {
-            removeOnComplete: true,
-            removeOnFail: 100_000,
-            attempts: 2,
-            backoff: {
-              type: "exponential",
-              delay: 30_000,
+      ? new Queue<TQueueJobTypes[QueueName.ScoreDelete]>(
+          QueueName.ScoreDelete,
+          {
+            connection: newRedis,
+            defaultJobOptions: {
+              removeOnComplete: true,
+              removeOnFail: 100_000,
+              attempts: 2,
+              backoff: {
+                type: "exponential",
+                delay: 30_000,
+              },
             },
           },
-        })
+        )
       : null;
 
     ScoreDeleteQueue.instance?.on("error", (err) => {
       logger.error("ScoreDeleteQueue error", err);
     });
 
+    collectQueueMetrics(ScoreDeleteQueue.instance, QueueName.ScoreDelete);
+
     return ScoreDeleteQueue.instance;
   }
-} 
+}

--- a/packages/shared/src/server/redis/traceDelete.ts
+++ b/packages/shared/src/server/redis/traceDelete.ts
@@ -1,6 +1,10 @@
 import { QueueName, TQueueJobTypes } from "../queues";
 import { Queue } from "bullmq";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 
 export class TraceDeleteQueue {
@@ -38,6 +42,8 @@ export class TraceDeleteQueue {
     TraceDeleteQueue.instance?.on("error", (err) => {
       logger.error("TraceDeleteQueue error", err);
     });
+
+    collectQueueMetrics(TraceDeleteQueue.instance, QueueName.TraceDelete);
 
     return TraceDeleteQueue.instance;
   }

--- a/packages/shared/src/server/redis/traceUpsert.ts
+++ b/packages/shared/src/server/redis/traceUpsert.ts
@@ -1,6 +1,10 @@
 import { QueueName, TQueueJobTypes } from "../queues";
 import { Queue } from "bullmq";
-import { createNewRedisInstance, redisQueueRetryOptions } from "./redis";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  collectQueueMetrics,
+} from "./redis";
 import { logger } from "../logger";
 
 export class TraceUpsertQueue {
@@ -39,6 +43,8 @@ export class TraceUpsertQueue {
     TraceUpsertQueue.instance?.on("error", (err) => {
       logger.error("TraceUpsertQueue error", err);
     });
+
+    collectQueueMetrics(TraceUpsertQueue.instance, QueueName.TraceUpsert);
 
     return TraceUpsertQueue.instance;
   }

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -1,11 +1,9 @@
-import { Job, Processor, Queue, Worker, WorkerOptions } from "bullmq";
+import { Job, Processor, Worker, WorkerOptions } from "bullmq";
 import {
-  getQueue,
   convertQueueNameToMetricName,
   createNewRedisInstance,
   logger,
   QueueName,
-  recordGauge,
   recordHistogram,
   recordIncrement,
   redisQueueRetryOptions,
@@ -14,10 +12,6 @@ import {
 
 export class WorkerManager {
   private static workers: { [key: string]: Worker } = {};
-
-  private static getQueue(queueName: QueueName): Queue | null {
-    return getQueue(queueName);
-  }
 
   private static metricWrapper(
     processor: Processor,
@@ -35,27 +29,27 @@ export class WorkerManager {
         },
       );
       const result = await processor(job);
-      const queue = WorkerManager.getQueue(queueName);
-      await Promise.allSettled([
-        queue?.count().then((count) => {
-          recordGauge(
-            convertQueueNameToMetricName(queueName) + ".length",
-            count,
-            {
-              unit: "records",
-            },
-          );
-        }),
-        queue?.getFailedCount().then((count) => {
-          recordGauge(
-            convertQueueNameToMetricName(queueName) + ".dlq_length",
-            count,
-            {
-              unit: "records",
-            },
-          );
-        }),
-      ]);
+      // const queue = getQueue(queueName);
+      // await Promise.allSettled([
+      //   queue?.count().then((count) => {
+      //     recordGauge(
+      //       convertQueueNameToMetricName(queueName) + ".length",
+      //       count,
+      //       {
+      //         unit: "records",
+      //       },
+      //     );
+      //   }),
+      //   queue?.getFailedCount().then((count) => {
+      //     recordGauge(
+      //       convertQueueNameToMetricName(queueName) + ".dlq_length",
+      //       count,
+      //       {
+      //         unit: "records",
+      //       },
+      //     );
+      //   }),
+      // ]);
       recordHistogram(
         convertQueueNameToMetricName(queueName) + ".processing_time",
         Date.now() - startTime,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Disable length metric collection on worker and move it to queue initialization in multiple queue files.
> 
>   - **Behavior**:
>     - Disables length metric collection in `WorkerManager` in `workerManager.ts` by commenting out the logic.
>     - Adds `collectQueueMetrics` call in `finally` block of `getInstance` methods in various queue files to handle metric collection.
>   - **Files Affected**:
>     - `batchActionQueue.ts`, `batchExport.ts`, `blobStorageIntegrationProcessingQueue.ts` and 20 other files updated to include `collectQueueMetrics`.
>     - `redis.ts` updated to include `collectQueueMetrics` function definition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 67bf7ab23c5d3a636b50ba8001583ab5b49f6ac7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->