### PR TITLE
chore: remove popup from count for historic eval elements

### DIFF
--- a/web/src/ee/features/evals/components/execution-count-tooltip.tsx
+++ b/web/src/ee/features/evals/components/execution-count-tooltip.tsx
@@ -1,9 +1,5 @@
-<<<<<<< Updated upstream:web/src/ee/features/evals/components/execution-count-tooltip.tsx
 import { InfoIcon, Loader } from "lucide-react";
 import { type EvalFormType } from "@/src/ee/features/evals/utils/evaluator-form-utils";
-=======
-import { type EvalFormType } from "@/src/features/evals/utils/evaluator-form-utils";
->>>>>>> Stashed changes:web/src/features/evals/components/execution-count-tooltip.tsx
 import { api } from "@/src/utils/api";
 import { compactNumberFormatter } from "@/src/utils/numbers";
 import { useEvalTargetCount } from "@/src/ee/features/evals/hooks/useEvalTargetCount";
@@ -23,14 +19,12 @@ export const ExecutionCountTooltip = ({
     projectId,
   });
 
-  let { isLoading, totalCount, isTraceTarget } = useEvalTargetCount({
+  const { isLoading, totalCount, isTraceTarget } = useEvalTargetCount({
     projectId,
     item,
     filter,
     enabled: true,
   });
-
-  isLoading = true;
 
   return (
     <>

--- a/web/src/ee/features/evals/components/execution-count-tooltip.tsx
+++ b/web/src/ee/features/evals/components/execution-count-tooltip.tsx
@@ -1,12 +1,10 @@
+<<<<<<< Updated upstream:web/src/ee/features/evals/components/execution-count-tooltip.tsx
 import { InfoIcon, Loader } from "lucide-react";
 import { type EvalFormType } from "@/src/ee/features/evals/utils/evaluator-form-utils";
+=======
+import { type EvalFormType } from "@/src/features/evals/utils/evaluator-form-utils";
+>>>>>>> Stashed changes:web/src/features/evals/components/execution-count-tooltip.tsx
 import { api } from "@/src/utils/api";
-import { useState } from "react";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/src/components/ui/tooltip";
 import { compactNumberFormatter } from "@/src/utils/numbers";
 import { useEvalTargetCount } from "@/src/ee/features/evals/hooks/useEvalTargetCount";
 
@@ -21,40 +19,34 @@ export const ExecutionCountTooltip = ({
   item,
   filter,
 }: ExecutionCountTooltipProps) => {
-  const [isOpen, setIsOpen] = useState(false);
-
   const globalConfig = api.evals.globalJobConfigs.useQuery({
     projectId,
   });
 
-  const { isLoading, totalCount, isTraceTarget } = useEvalTargetCount({
+  let { isLoading, totalCount, isTraceTarget } = useEvalTargetCount({
     projectId,
     item,
     filter,
-    enabled: isOpen, // utilize `isOpen` to only query if user hovers over tooltip to avoid unnecessary queries
+    enabled: true,
   });
 
+  isLoading = true;
+
   return (
-    <Tooltip open={isOpen} onOpenChange={setIsOpen}>
-      <TooltipTrigger>
-        <InfoIcon className="h-4 w-4" />
-      </TooltipTrigger>
-      <TooltipContent>
-        <div className="text-sm">
-          We execute the evaluation on{" "}
-          {isLoading ? (
-            <Loader className="inline-block h-4 w-4 animate-spin" />
-          ) : (
-            compactNumberFormatter(
-              !globalConfig.data ||
-                (totalCount && totalCount < globalConfig.data)
-                ? totalCount
-                : globalConfig.data,
-            )
-          )}{" "}
-          {isTraceTarget ? "traces" : "dataset run items"}.
-        </div>
-      </TooltipContent>
-    </Tooltip>
+    <>
+      <span className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+        (
+        {isLoading ? (
+          <span className="inline-block font-mono">...</span>
+        ) : (
+          compactNumberFormatter(
+            !globalConfig.data || (totalCount && totalCount < globalConfig.data)
+              ? totalCount
+              : globalConfig.data,
+          )
+        )}
+        {isTraceTarget ? " traces" : " dataset run items"})
+      </span>
+    </>
   );
 };

--- a/web/src/ee/features/evals/components/execution-count-tooltip.tsx
+++ b/web/src/ee/features/evals/components/execution-count-tooltip.tsx
@@ -1,4 +1,3 @@
-import { InfoIcon, Loader } from "lucide-react";
 import { type EvalFormType } from "@/src/ee/features/evals/utils/evaluator-form-utils";
 import { api } from "@/src/utils/api";
 import { compactNumberFormatter } from "@/src/utils/numbers";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove tooltip from `ExecutionCountTooltip`, making execution count always visible without hover interaction.
> 
>   - **Behavior**:
>     - Removed tooltip functionality from `ExecutionCountTooltip` in `execution-count-tooltip.tsx`.
>     - Execution count is now always visible, no hover interaction required.
>   - **Code Simplification**:
>     - Removed `useState` and tooltip-related imports and components.
>     - Simplified rendering logic to use a `span` element for displaying execution count.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cda760a1efc16a00be202a68f35156f328a3098a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->