### PR TITLE
fix(default-model): allow set up flow to add LLM API key

### DIFF
--- a/web/src/ee/features/evals/pages/default-evaluation-model.tsx
+++ b/web/src/ee/features/evals/pages/default-evaluation-model.tsx
@@ -113,7 +113,7 @@ export default function DefaultEvaluationModelPage() {
           <Dialog open={isEditing} onOpenChange={setIsEditing}>
             <DialogTrigger asChild>
               <Button
-                disabled={!hasWriteAccess || !modelParams.provider.value}
+                disabled={!hasWriteAccess}
                 onClick={() => {
                   setIsEditing(true);
                 }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplifies setup flow in `default-evaluation-model.tsx` by enabling button based solely on `hasWriteAccess`.
> 
>   - **Behavior**:
>     - In `default-evaluation-model.tsx`, the `Button` enabling the setup flow is now only disabled based on `hasWriteAccess`, removing the dependency on `modelParams.provider.value`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a434ab587221479dbb8e9e8ee3481dabccfa1442. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->