### PR TITLE
fix: update Google AI Studio model name to preview version (#7086)

### DIFF
--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -332,7 +332,8 @@ export const vertexAIModels = [
 
 // WARNING: The first entry in the array is chosen as the default model to add LLM API keys. Make sure it supports top_p, max_tokens and temperature.
 export const googleAIStudioModels = [
-  "gemini-2.5-pro-exp-03-25",
+  "gemini-2.5-pro-preview-05-06",
+  "gemini-2.5-flash-preview-05-20",
   "gemini-2.0-flash",
   "gemini-2.0-flash-lite-preview",
   "gemini-2.0-flash-lite-preview-02-05",

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -319,7 +319,8 @@ export const anthropicModels = [
 
 // WARNING: The first entry in the array is chosen as the default model to add LLM API keys
 export const vertexAIModels = [
-  "gemini-2.5-pro-exp-03-25",
+  "gemini-2.5-pro-preview-05-06",
+  "gemini-2.5-flash-preview-05-20",
   "gemini-2.0-pro-exp-02-05",
   "gemini-2.0-flash",
   "gemini-2.0-flash-001",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `vertexAIModels` and `googleAIStudioModels` in `types.ts` to include new preview model versions as defaults.
> 
>   - **Model Updates**:
>     - Update `vertexAIModels` in `types.ts` to include `gemini-2.5-pro-preview-05-06` and `gemini-2.5-flash-preview-05-20` as the first entries.
>     - Update `googleAIStudioModels` in `types.ts` to include `gemini-2.5-pro-preview-05-06` and `gemini-2.5-flash-preview-05-20` as the first entries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bf1916a3885eb9db95bd04e61d6b69bc98b0ecd1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->