### PR TITLE
fix(projects-api-docs): retentionDays to optional

### DIFF
--- a/fern/apis/server/definition/projects.yml
+++ b/fern/apis/server/definition/projects.yml
@@ -11,7 +11,7 @@ service:
       method: GET
       path: /projects
       response: Projects
-    
+
     create:
       docs: Create a new project (requires organization-scoped API key)
       method: POST
@@ -28,7 +28,7 @@ service:
               type: integer
               docs: Number of days to retain data. Must be 0 or at least 3 days. Requires data-retention entitlement for non-zero values. Optional.
       response: Project
-    
+
     update:
       docs: Update a project by ID (requires organization-scoped API key).
       method: PUT
@@ -47,7 +47,7 @@ service:
               type: integer
               docs: Number of days to retain data. Must be 0 or at least 3 days. Requires data-retention entitlement for non-zero values. Optional.
       response: Project
-    
+
     delete:
       docs: Delete a project by ID (requires organization-scoped API key). Project deletion is processed asynchronously.
       method: DELETE
@@ -57,7 +57,7 @@ service:
       response:
         status-code: 202
         type: ProjectDeletionResponse
-        
+
     # API Key endpoints
     getApiKeys:
       docs: Get all API keys for a project (requires organization-scoped API key)
@@ -104,14 +104,14 @@ types:
         type: map<string, unknown>
         docs: Metadata for the project
       retentionDays:
-        type: integer
+        type: optional<integer>
         docs: Number of days to retain data. Null or 0 means no retention. Omitted if no retention is configured.
 
   ProjectDeletionResponse:
     properties:
       success: boolean
       message: string
-      
+
   ApiKeyList:
     docs: List of API keys for a project
     properties:
@@ -137,7 +137,7 @@ types:
       secretKey: string
       displaySecretKey: string
       note: optional<string>
-      
+
   ApiKeyDeletionResponse:
     docs: Response for API key deletion
     properties:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -6550,6 +6550,7 @@ components:
           description: Metadata for the project
         retentionDays:
           type: integer
+          nullable: true
           description: >-
             Number of days to retain data. Null or 0 means no retention. Omitted
             if no retention is configured.
@@ -6557,7 +6558,6 @@ components:
         - id
         - name
         - metadata
-        - retentionDays
     ProjectDeletionResponse:
       title: ProjectDeletionResponse
       type: object


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> The PR makes the `retentionDays` field optional in the `Project` type, allowing it to be omitted if no data retention is configured.
> 
>   - **API Definition**:
>     - In `projects.yml`, `retentionDays` field in `Project` type changed from `integer` to `optional<integer>`.
>     - In `openapi.yml`, `retentionDays` field marked as `nullable: true`.
>   - **Behavior**:
>     - `retentionDays` can now be omitted if no retention is configured, allowing for more flexible project configurations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c60db192891ed28d487893c1589a66272380247a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->