### PR TITLE
chore: sort dataset (run) items by `created_at` and `id`

### DIFF
--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -344,7 +344,7 @@ export const datasetRouter = createTRPCRouter({
           expectedOutput: true,
           metadata: true,
         },
-        orderBy: { createdAt: "desc" },
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
         take: input.limit,
         skip: input.page * input.limit,
       });
@@ -866,7 +866,8 @@ export const datasetRouter = createTRPCRouter({
           dri.project_id = ${input.projectId}
           ${filterQuery}
         ORDER BY 
-          di.created_at DESC
+          di.created_at DESC,
+          di.id DESC
         LIMIT ${input.limit}
         OFFSET ${input.page * input.limit}
       `;


### PR DESCRIPTION
* `created_at` is not unique, we require a deterministic order of items to ensure data consistency
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sort dataset items by `created_at` and `id` in `dataset-router.ts` for deterministic ordering.
> 
>   - **Behavior**:
>     - Modify sorting of dataset items in `dataset-router.ts` to include `id` as a secondary key after `created_at` for deterministic ordering.
>     - Changes applied in `baseDatasetItemByDatasetId` and `runitemsByRunIdOrItemId` functions.
>   - **Reason**:
>     - Ensures data consistency when `created_at` is not unique.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bcd8aad66be57c26c29e15fb8254848c2adf3538. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->