### PR TITLE
style(scores): limit height of grouped scores hovercard

### DIFF
--- a/web/src/components/grouped-score-badge.tsx
+++ b/web/src/components/grouped-score-badge.tsx
@@ -63,7 +63,7 @@ const ScoreGroupBadge = <T extends APIScoreV2 | LastUserScore>({
                 <HoverCardTrigger className="inline-block">
                   <MessageCircleMoreIcon className="mb-[0.0625rem] !size-3" />
                 </HoverCardTrigger>
-                <HoverCardContent className="overflow-hidden whitespace-normal break-normal">
+                <HoverCardContent className="max-h-[50dvh] overflow-y-auto whitespace-normal break-normal">
                   <p className="whitespace-pre-wrap">{s.comment}</p>
                 </HoverCardContent>
               </HoverCard>
@@ -73,7 +73,7 @@ const ScoreGroupBadge = <T extends APIScoreV2 | LastUserScore>({
                 <HoverCardTrigger className="inline-block">
                   <BracesIcon className="mb-[0.0625rem] !size-3" />
                 </HoverCardTrigger>
-                <HoverCardContent className="overflow-hidden whitespace-normal break-normal rounded-md border-none p-0">
+                <HoverCardContent className="max-h-[50dvh] overflow-y-auto whitespace-normal break-normal rounded-md border-none p-0">
                   <JSONView codeClassName="!rounded-md" json={s.metadata} />
                 </HoverCardContent>
               </HoverCard>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Limit height and enable scrolling for `HoverCardContent` in `ScoreGroupBadge` in `grouped-score-badge.tsx`.
> 
>   - **Styling**:
>     - In `grouped-score-badge.tsx`, set `max-h-[50dvh]` and `overflow-y-auto` for `HoverCardContent` in `ScoreGroupBadge` to limit height and enable scrolling.
>     - Affects hovercards for both `s.comment` and `s.metadata` in `ScoreGroupBadge`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e886b901ffdb7a7e6f285fb5f90c207c4afa64e0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->