### PR TITLE
add LANGFUSE_S3_REQUEST_TIMEOUT configuration

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -60,6 +60,7 @@ const EnvSchema = z.object({
     .enum(["true", "false"])
     .default("false"),
   LANGFUSE_S3_CONCURRENT_WRITES: z.coerce.number().positive().default(50),
+  LANGFUSE_S3_REQUEST_TIMEOUT: z.coerce.number().positive().default(15_000),
   LANGFUSE_S3_EVENT_UPLOAD_BUCKET: z.string({
     required_error: "Langfuse requires a bucket name for S3 Event Uploads.",
   }),

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -403,6 +403,7 @@ class S3StorageService implements StorageService {
         httpsAgent: {
           maxSockets: env.LANGFUSE_S3_CONCURRENT_WRITES,
         },
+        requestTimeout: env.LANGFUSE_S3_REQUEST_TIMEOUT,
       },
     });
 
@@ -419,6 +420,7 @@ class S3StorageService implements StorageService {
             httpsAgent: {
               maxSockets: env.LANGFUSE_S3_CONCURRENT_WRITES,
             },
+            requestTimeout: env.LANGFUSE_S3_REQUEST_TIMEOUT,
           },
         })
       : this.client;


### PR DESCRIPTION
## What does this PR do?

Fixes S3 upload timeout issues that occur daily when system load is high. The AWS SDK's default timeout settings are insufficient during peak periods, causing uploads to fail with RequestTimeout errors.

### Changes:
- Add a new configuration environment variable: LANGFUSE_S3_REQUEST_TIMEOUT

### Related issue:
https://github.com/aws/aws-sdk-js-v3/issues/6762

### Related doc:
https://github.com/aws/aws-sdk-js-v3/blob/main/supplemental-docs/CLIENTS.md#nodejs-requesthandler

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`npm run prettier`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `LANGFUSE_S3_REQUEST_TIMEOUT` configuration to address S3 upload timeout issues during high load.
> 
>   - **Behavior**:
>     - Adds `LANGFUSE_S3_REQUEST_TIMEOUT` environment variable to configure S3 request timeout in `env.ts`.
>     - Updates `S3StorageService` in `StorageService.ts` to use `LANGFUSE_S3_REQUEST_TIMEOUT` for `requestTimeout` in S3 client configuration.
>   - **Related**:
>     - Addresses issue with AWS SDK default timeout settings during peak load.
>     - Related issue: [aws-sdk-js-v3#6762](https://github.com/aws/aws-sdk-js-v3/issues/6762).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a10f71c52bfd8afc7c0b2421d208944bf876b1f9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->