### PR TITLE
chore: add opt-out flag from queue length metric checks

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -232,6 +232,11 @@ const EnvSchema = z.object({
     .enum(["true", "false"])
     .default("false"),
 
+  // Whether to collect queue length metrics. Experimental flag to understand redis performance around this command.
+  LANGFUSE_COLLECT_QUEUE_LENGTH_METRICS: z
+    .enum(["true", "false"])
+    .default("true"),
+
   LANGFUSE_S3_CONCURRENT_READS: z.coerce.number().positive().default(50),
   LANGFUSE_CLICKHOUSE_PROJECT_DELETION_CONCURRENCY_DURATION_MS: z.coerce
     .number()

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -11,6 +11,7 @@ import {
   redisQueueRetryOptions,
   traceException,
 } from "@langfuse/shared/src/server";
+import { env } from "../env";
 
 export class WorkerManager {
   private static workers: { [key: string]: Worker } = {};
@@ -35,27 +36,33 @@ export class WorkerManager {
         },
       );
       const result = await processor(job);
-      const queue = WorkerManager.getQueue(queueName);
-      await Promise.allSettled([
-        queue?.count().then((count) => {
-          recordGauge(
-            convertQueueNameToMetricName(queueName) + ".length",
-            count,
-            {
-              unit: "records",
-            },
-          );
-        }),
-        queue?.getFailedCount().then((count) => {
-          recordGauge(
-            convertQueueNameToMetricName(queueName) + ".dlq_length",
-            count,
-            {
-              unit: "records",
-            },
-          );
-        }),
-      ]);
+
+      // Collect queue metrics if enabled (defaults to true)
+      const collectQueueMetrics =
+        env.LANGFUSE_COLLECT_QUEUE_LENGTH_METRICS !== "false";
+      if (collectQueueMetrics) {
+        const queue = WorkerManager.getQueue(queueName);
+        await Promise.allSettled([
+          queue?.count().then((count) => {
+            recordGauge(
+              convertQueueNameToMetricName(queueName) + ".length",
+              count,
+              {
+                unit: "records",
+              },
+            );
+          }),
+          queue?.getFailedCount().then((count) => {
+            recordGauge(
+              convertQueueNameToMetricName(queueName) + ".dlq_length",
+              count,
+              {
+                unit: "records",
+              },
+            );
+          }),
+        ]);
+      }
       recordHistogram(
         convertQueueNameToMetricName(queueName) + ".processing_time",
         Date.now() - startTime,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `LANGFUSE_COLLECT_QUEUE_LENGTH_METRICS` flag to control queue length metric collection in `workerManager.ts`.
> 
>   - **Behavior**:
>     - Adds `LANGFUSE_COLLECT_QUEUE_LENGTH_METRICS` flag in `env.ts` to control queue length metric collection.
>     - Default value for `LANGFUSE_COLLECT_QUEUE_LENGTH_METRICS` is `true`.
>     - In `workerManager.ts`, queue length metrics are collected only if `LANGFUSE_COLLECT_QUEUE_LENGTH_METRICS` is not `false`.
>   - **Files**:
>     - `env.ts`: Adds `LANGFUSE_COLLECT_QUEUE_LENGTH_METRICS` to `EnvSchema`.
>     - `workerManager.ts`: Updates `metricWrapper()` to conditionally collect queue metrics based on the new flag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ba2be88a728c48db8be040945dccbcc1a1626a78. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->