### PR TITLE
perf(traces-table): improve performance 

### DIFF
--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -544,8 +544,14 @@ const MemoizedTableBody = React.memo(TableBodyComponent, (prev, next) => {
   if (
     prev.tableSnapshot.tableDataUpdatedAt !==
     next.tableSnapshot.tableDataUpdatedAt
-  )
+  ) {
+    // console.log(
+    //   "tableDataUpdatedAt",
+    //   prev.tableSnapshot.tableDataUpdatedAt,
+    //   next.tableSnapshot.tableDataUpdatedAt,
+    // );
     return false;
+  }
   if (prev.table.options.data !== next.table.options.data) return false;
   if (prev.data.isLoading !== next.data.isLoading) return false;
   if (prev.rowheighttw !== next.rowheighttw) return false;

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -37,6 +37,7 @@ import { TablePeekView } from "@/src/components/table/peek";
 import { type PeekViewProps } from "@/src/components/table/peek/hooks/usePeekView";
 import { usePeekView } from "@/src/components/table/peek/hooks/usePeekView";
 import { isEqual } from "lodash";
+import { useRouter } from "next/router";
 
 interface DataTableProps<TData, TValue> {
   columns: LangfuseColumnDef<TData, TValue>[];
@@ -97,8 +98,6 @@ function isValidCssVariableName({
     : /^(?![0-9])([a-zA-Z][a-zA-Z0-9-_]*)$/;
   return regex.test(name);
 }
-
-const SelectedRowContext = React.createContext<string | undefined>(undefined);
 
 export function DataTable<TData extends object, TValue>({
   columns,
@@ -186,22 +185,24 @@ export function DataTable<TData extends object, TValue>({
     [],
   );
 
-  const { inflatedPeekView, peekViewId, handleOnRowClickPeek } = usePeekView({
+  const {
+    row: peekRow,
+    handleOnRowClickPeek,
+    peekViewId,
+  } = usePeekView({
     getRow: getRowMemoized,
     peekView,
   });
 
   const handleOnRowClick = useCallback(
     (row: TData) => {
-      if (inflatedPeekView) {
-        handleOnRowClickPeek?.(row);
-      }
+      handleOnRowClickPeek?.(row);
       onRowClick?.(row);
     },
-    [handleOnRowClickPeek, onRowClick, inflatedPeekView],
+    [handleOnRowClickPeek, onRowClick],
   );
 
-  const hasRowClickAction = !!onRowClick || !!inflatedPeekView;
+  const hasRowClickAction = !!onRowClick || !!peekView;
 
   // memo column sizes for performance
   // https://tanstack.com/table/v8/docs/guide/column-sizing#advanced-column-resizing-performance
@@ -241,151 +242,151 @@ export function DataTable<TData extends object, TValue>({
           className={cn("relative w-full overflow-auto border-t")}
           style={{ ...columnSizeVars }}
         >
-          <SelectedRowContext.Provider value={peekViewId}>
-            <Table>
-              <TableHeader className="sticky top-0 z-10">
-                {tableHeaders.map((headerGroup) => (
-                  <TableRow key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => {
-                      const columnDef = header.column
-                        .columnDef as LangfuseColumnDef<ModelTableRow>;
-                      const sortingEnabled = columnDef.enableSorting;
-                      // if the header id does not translate to a valid css variable name, default to 150px as width
-                      // may only happen for dynamic columns, as column names are user defined
-                      const width = isValidCssVariableName({
-                        name: header.id,
-                        includesHyphens: false,
-                      })
-                        ? `calc(var(--header-${header.id}-size) * 1px)`
-                        : 150;
+          <Table>
+            <TableHeader className="sticky top-0 z-10">
+              {tableHeaders.map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => {
+                    const columnDef = header.column
+                      .columnDef as LangfuseColumnDef<ModelTableRow>;
+                    const sortingEnabled = columnDef.enableSorting;
+                    // if the header id does not translate to a valid css variable name, default to 150px as width
+                    // may only happen for dynamic columns, as column names are user defined
+                    const width = isValidCssVariableName({
+                      name: header.id,
+                      includesHyphens: false,
+                    })
+                      ? `calc(var(--header-${header.id}-size) * 1px)`
+                      : 150;
 
-                      return header.column.getIsVisible() ? (
-                        <TableHead
-                          key={header.id}
-                          className={cn(
-                            "group p-1 first:pl-2",
-                            sortingEnabled && "cursor-pointer",
-                            pinFirstColumn &&
-                              header.index === 0 &&
-                              "sticky left-0 z-20 border-r bg-background",
-                          )}
-                          style={{ width }}
-                          onClick={(event) => {
-                            event.preventDefault();
+                    return header.column.getIsVisible() ? (
+                      <TableHead
+                        key={header.id}
+                        className={cn(
+                          "group p-1 first:pl-2",
+                          sortingEnabled && "cursor-pointer",
+                          pinFirstColumn &&
+                            header.index === 0 &&
+                            "sticky left-0 z-20 border-r bg-background",
+                        )}
+                        style={{ width }}
+                        onClick={(event) => {
+                          event.preventDefault();
 
-                            if (
-                              !setOrderBy ||
-                              !columnDef.id ||
-                              !sortingEnabled
-                            ) {
-                              return;
-                            }
+                          if (!setOrderBy || !columnDef.id || !sortingEnabled) {
+                            return;
+                          }
 
-                            if (orderBy?.column === columnDef.id) {
-                              if (orderBy.order === "DESC") {
-                                capture("table:column_sorting_header_click", {
-                                  column: columnDef.id,
-                                  order: "ASC",
-                                });
-                                setOrderBy({
-                                  column: columnDef.id,
-                                  order: "ASC",
-                                });
-                              } else {
-                                capture("table:column_sorting_header_click", {
-                                  column: columnDef.id,
-                                  order: "Disabled",
-                                });
-                                setOrderBy(null);
-                              }
-                            } else {
+                          if (orderBy?.column === columnDef.id) {
+                            if (orderBy.order === "DESC") {
                               capture("table:column_sorting_header_click", {
                                 column: columnDef.id,
-                                order: "DESC",
+                                order: "ASC",
                               });
                               setOrderBy({
                                 column: columnDef.id,
-                                order: "DESC",
+                                order: "ASC",
                               });
+                            } else {
+                              capture("table:column_sorting_header_click", {
+                                column: columnDef.id,
+                                order: "Disabled",
+                              });
+                              setOrderBy(null);
                             }
-                          }}
-                        >
-                          {header.isPlaceholder ? null : (
-                            <div className="flex select-none items-center">
-                              <span className="truncate">
-                                {flexRender(
-                                  header.column.columnDef.header,
-                                  header.getContext(),
-                                )}
-                              </span>
-                              {columnDef.headerTooltip && (
-                                <DocPopup
-                                  description={
-                                    columnDef.headerTooltip.description
-                                  }
-                                  href={columnDef.headerTooltip.href}
-                                />
+                          } else {
+                            capture("table:column_sorting_header_click", {
+                              column: columnDef.id,
+                              order: "DESC",
+                            });
+                            setOrderBy({
+                              column: columnDef.id,
+                              order: "DESC",
+                            });
+                          }
+                        }}
+                      >
+                        {header.isPlaceholder ? null : (
+                          <div className="flex select-none items-center">
+                            <span className="truncate">
+                              {flexRender(
+                                header.column.columnDef.header,
+                                header.getContext(),
                               )}
-                              {orderBy?.column === columnDef.id
-                                ? renderOrderingIndicator(orderBy)
-                                : null}
-
-                              <div
-                                onClick={(e) => {
-                                  e.preventDefault();
-                                  e.stopPropagation();
-                                }}
-                                onDoubleClick={() => header.column.resetSize()}
-                                onMouseDown={header.getResizeHandler()}
-                                onTouchStart={header.getResizeHandler()}
-                                className={cn(
-                                  "absolute right-0 top-0 h-full w-1.5 cursor-col-resize touch-none select-none bg-secondary opacity-0 group-hover:opacity-100",
-                                  header.column.getIsResizing() &&
-                                    "bg-primary-accent opacity-100",
-                                )}
+                            </span>
+                            {columnDef.headerTooltip && (
+                              <DocPopup
+                                description={
+                                  columnDef.headerTooltip.description
+                                }
+                                href={columnDef.headerTooltip.href}
                               />
-                            </div>
-                          )}
-                        </TableHead>
-                      ) : null;
-                    })}
-                  </TableRow>
-                ))}
-              </TableHeader>
-              {table.getState().columnSizingInfo.isResizingColumn ||
-              !!peekView ? (
-                <MemoizedTableBody
-                  table={table}
-                  rowheighttw={rowheighttw}
-                  columns={columns}
-                  data={data}
-                  help={help}
-                  onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
-                  pinFirstColumn={pinFirstColumn}
-                  tableSnapshot={{
-                    tableDataUpdatedAt: peekView?.tableDataUpdatedAt,
-                    columnVisibility,
-                    columnOrder,
-                    rowSelection,
-                  }}
-                />
-              ) : (
-                <TableBodyComponent
-                  table={table}
-                  rowheighttw={rowheighttw}
-                  columns={columns}
-                  data={data}
-                  help={help}
-                  onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
-                  pinFirstColumn={pinFirstColumn}
-                />
-              )}
-            </Table>
-          </SelectedRowContext.Provider>
+                            )}
+                            {orderBy?.column === columnDef.id
+                              ? renderOrderingIndicator(orderBy)
+                              : null}
+
+                            <div
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                              }}
+                              onDoubleClick={() => header.column.resetSize()}
+                              onMouseDown={header.getResizeHandler()}
+                              onTouchStart={header.getResizeHandler()}
+                              className={cn(
+                                "absolute right-0 top-0 h-full w-1.5 cursor-col-resize touch-none select-none bg-secondary opacity-0 group-hover:opacity-100",
+                                header.column.getIsResizing() &&
+                                  "bg-primary-accent opacity-100",
+                              )}
+                            />
+                          </div>
+                        )}
+                      </TableHead>
+                    ) : null;
+                  })}
+                </TableRow>
+              ))}
+            </TableHeader>
+            {table.getState().columnSizingInfo.isResizingColumn ||
+            !!peekView ? (
+              <MemoizedTableBody
+                table={table}
+                rowheighttw={rowheighttw}
+                columns={columns}
+                data={data}
+                help={help}
+                onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
+                pinFirstColumn={pinFirstColumn}
+                tableSnapshot={{
+                  tableDataUpdatedAt: peekView?.tableDataUpdatedAt,
+                  columnVisibility,
+                  columnOrder,
+                  rowSelection,
+                }}
+              />
+            ) : (
+              <TableBodyComponent
+                table={table}
+                rowheighttw={rowheighttw}
+                columns={columns}
+                data={data}
+                help={help}
+                onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
+                pinFirstColumn={pinFirstColumn}
+              />
+            )}
+          </Table>
         </div>
         <div className="grow"></div>
       </div>
-      {inflatedPeekView && <TablePeekView {...inflatedPeekView} />}
+      {peekView && (
+        <TablePeekView
+          peekView={peekView}
+          row={peekRow}
+          selectedRowId={peekViewId}
+        />
+      )}
       {!hidePagination && pagination !== undefined ? (
         <div
           className={cn(
@@ -439,7 +440,8 @@ function TableRowComponent<TData>({
   onRowClick?: (row: TData) => void;
   children: React.ReactNode;
 }) {
-  const peekViewId = useContext(SelectedRowContext);
+  const router = useRouter();
+  const selectedRowId = router.query.peek as string | undefined;
   return (
     <TableRow
       data-row-index={row.index}
@@ -452,7 +454,7 @@ function TableRowComponent<TData>({
       className={cn(
         "hover:bg-accent",
         !!onRowClick ? "cursor-pointer" : "cursor-default",
-        peekViewId && peekViewId === row.id ? "bg-accent" : undefined,
+        selectedRowId && selectedRowId === row.id ? "bg-accent" : undefined,
       )}
     >
       {children}

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { type OrderByState } from "@langfuse/shared";
-import React, { useState, useMemo, useCallback, useContext } from "react";
+import React, { useState, useMemo, useCallback } from "react";
 import DocPopup from "@/src/components/layouts/doc-popup";
 import { DataTablePagination } from "@/src/components/table/data-table-pagination";
 import {

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -547,11 +547,6 @@ const MemoizedTableBody = React.memo(TableBodyComponent, (prev, next) => {
     prev.tableSnapshot.tableDataUpdatedAt !==
     next.tableSnapshot.tableDataUpdatedAt
   ) {
-    // console.log(
-    //   "tableDataUpdatedAt",
-    //   prev.tableSnapshot.tableDataUpdatedAt,
-    //   next.tableSnapshot.tableDataUpdatedAt,
-    // );
     return false;
   }
   if (prev.table.options.data !== next.table.options.data) return false;

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -176,7 +176,7 @@ export function TablePeekView<TData>({
         </SheetHeader>
         <Separator />
         <div className="flex max-h-full min-h-0 flex-1 flex-col">
-          <div className="flex-1 overflow-auto">
+          <div className="flex-1 overflow-auto" key={selectedRowId}>
             {typeof children === "function" ? children(row) : children}
           </div>
         </div>

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -12,6 +12,7 @@ import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNa
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 import { cn } from "@/src/utils/tailwind";
 import { memo } from "react";
+import { type PeekViewProps } from "@/src/components/table/peek/hooks/usePeekView";
 
 type PeekViewItemType = Extract<
   LangfuseItemType,
@@ -82,114 +83,108 @@ export const createPeekEventHandler = (options?: PeekEventControlOptions) => {
   };
 };
 
-export const TablePeekView = memo(
-  function TablePeekView<TData>({
-    peekView,
-    row,
-    selectedRowId,
-  }: {
-    peekView: DataTablePeekViewProps<TData>;
-    row?: TData;
-    selectedRowId?: string | null;
-  }) {
-    const eventHandler = createPeekEventHandler(peekView.peekEventOptions);
+type TablePeekViewProps<T> = {
+  peekView: PeekViewProps<T>;
+  row?: T;
+  selectedRowId?: string | null;
+};
 
-    if (!selectedRowId) return null;
+function TablePeekViewComponent<TData>(props: TablePeekViewProps<TData>) {
+  const { peekView, row, selectedRowId } = props;
+  const eventHandler = createPeekEventHandler(peekView.peekEventOptions);
 
-    const handleOpenChange = (open: boolean) => {
-      if (!open && eventHandler()) {
-        return;
-      }
-      if (!!row && typeof row === "object" && "timestamp" in row) {
-        peekView.onOpenChange(
-          open,
-          selectedRowId,
-          (row as any).timestamp.toISOString(),
-        );
-      } else {
-        peekView.onOpenChange(open, selectedRowId);
-      }
-    };
+  if (!selectedRowId) return null;
 
-    const canExpand = typeof peekView.onExpand === "function";
+  const handleOpenChange = (open: boolean) => {
+    if (!open && eventHandler()) {
+      return;
+    }
+    if (!!row && typeof row === "object" && "timestamp" in row) {
+      peekView.onOpenChange(
+        open,
+        selectedRowId,
+        (row as any).timestamp.toISOString(),
+      );
+    } else {
+      peekView.onOpenChange(open, selectedRowId);
+    }
+  };
 
-    return (
-      <Sheet
-        open={!!selectedRowId}
-        onOpenChange={handleOpenChange}
-        modal={false}
+  const canExpand = typeof peekView.onExpand === "function";
+
+  return (
+    <Sheet open={!!selectedRowId} onOpenChange={handleOpenChange} modal={false}>
+      <SheetContent
+        onPointerDownOutside={(e) => {
+          // Prevent the default behavior of closing when clicking outside when we set modal={false}
+          e.preventDefault();
+        }}
+        side="right"
+        className="flex max-h-full min-h-0 min-w-[60vw] flex-col gap-0 overflow-hidden rounded-l-xl p-0"
       >
-        <SheetContent
-          onPointerDownOutside={(e) => {
-            // Prevent the default behavior of closing when clicking outside when we set modal={false}
-            e.preventDefault();
-          }}
-          side="right"
-          className="flex max-h-full min-h-0 min-w-[60vw] flex-col gap-0 overflow-hidden rounded-l-xl p-0"
-        >
-          <SheetHeader className="flex min-h-12 flex-row flex-nowrap items-center justify-between rounded-t-xl bg-header px-2">
-            <SheetTitle className="!mt-0 ml-2 flex min-w-0 flex-row items-center gap-2">
-              <ItemBadge type={peekView.itemType} showLabel />
-              <span
-                className="truncate text-sm font-medium focus:outline-none"
-                tabIndex={0}
-              >
-                {peekView.customTitlePrefix
-                  ? `${peekView.customTitlePrefix} ${selectedRowId}`
-                  : selectedRowId}
-              </span>
-            </SheetTitle>
-            <div
-              className={cn(
-                "!mt-0 flex flex-shrink-0 flex-row items-center gap-2",
-                !canExpand && "mr-8",
-              )}
+        <SheetHeader className="flex min-h-12 flex-row flex-nowrap items-center justify-between rounded-t-xl bg-header px-2">
+          <SheetTitle className="!mt-0 ml-2 flex min-w-0 flex-row items-center gap-2">
+            <ItemBadge type={peekView.itemType} showLabel />
+            <span
+              className="truncate text-sm font-medium focus:outline-none"
+              tabIndex={0}
             >
-              {selectedRowId &&
-                peekView.listKey &&
-                peekView.getNavigationPath && (
-                  <DetailPageNav
-                    currentId={selectedRowId}
-                    path={peekView.getNavigationPath}
-                    listKey={peekView.listKey}
-                  />
-                )}
-              {canExpand && (
-                <div className="!mt-0 mr-8 flex h-full flex-row items-center gap-1 border-l">
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    title="Open in current tab"
-                    className="ml-2"
-                    onClick={() => peekView.onExpand?.(false, row)}
-                  >
-                    <Expand className="h-4 w-4" />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    title="Open in new tab"
-                    onClick={() => peekView.onExpand?.(true, row)}
-                  >
-                    <ExternalLink className="h-4 w-4" />
-                  </Button>
-                </div>
+              {peekView.customTitlePrefix
+                ? `${peekView.customTitlePrefix} ${selectedRowId}`
+                : selectedRowId}
+            </span>
+          </SheetTitle>
+          <div
+            className={cn(
+              "!mt-0 flex flex-shrink-0 flex-row items-center gap-2",
+              !canExpand && "mr-8",
+            )}
+          >
+            {selectedRowId &&
+              peekView.listKey &&
+              peekView.getNavigationPath && (
+                <DetailPageNav
+                  currentId={selectedRowId}
+                  path={peekView.getNavigationPath}
+                  listKey={peekView.listKey}
+                />
               )}
-            </div>
-          </SheetHeader>
-          <Separator />
-          <div className="flex max-h-full min-h-0 flex-1 flex-col">
-            <div className="flex-1 overflow-auto" key={selectedRowId}>
-              {typeof peekView.children === "function"
-                ? peekView.children(row)
-                : peekView.children}
-            </div>
+            {canExpand && (
+              <div className="!mt-0 mr-8 flex h-full flex-row items-center gap-1 border-l">
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  title="Open in current tab"
+                  className="ml-2"
+                  onClick={() => peekView.onExpand?.(false, row)}
+                >
+                  <Expand className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  title="Open in new tab"
+                  onClick={() => peekView.onExpand?.(true, row)}
+                >
+                  <ExternalLink className="h-4 w-4" />
+                </Button>
+              </div>
+            )}
           </div>
-        </SheetContent>
-      </Sheet>
-    );
-  },
-  (prev, next) => {
-    return prev.selectedRowId === next.selectedRowId;
-  },
-);
+        </SheetHeader>
+        <Separator />
+        <div className="flex max-h-full min-h-0 flex-1 flex-col">
+          <div className="flex-1 overflow-auto" key={selectedRowId}>
+            {typeof peekView.children === "function"
+              ? peekView.children(row)
+              : peekView.children}
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export const TablePeekView = memo(TablePeekViewComponent, (prev, next) => {
+  return prev.selectedRowId === next.selectedRowId;
+}) as typeof TablePeekViewComponent;

--- a/web/src/components/table/peek/hooks/usePeekData.ts
+++ b/web/src/components/table/peek/hooks/usePeekData.ts
@@ -23,7 +23,7 @@ export const usePeekData = ({
         if (error.data?.code === "UNAUTHORIZED") return false;
         return failureCount < 3;
       },
-      staleTime: 1000 * 60 * 5,
+      staleTime: 60 * 1000, // 1 minute
     },
   );
 };

--- a/web/src/components/table/peek/hooks/usePeekData.ts
+++ b/web/src/components/table/peek/hooks/usePeekData.ts
@@ -23,6 +23,7 @@ export const usePeekData = ({
         if (error.data?.code === "UNAUTHORIZED") return false;
         return failureCount < 3;
       },
+      staleTime: 1000 * 60 * 5,
     },
   );
 };

--- a/web/src/components/table/peek/hooks/usePeekView.ts
+++ b/web/src/components/table/peek/hooks/usePeekView.ts
@@ -17,10 +17,7 @@ import { useEffect, useRef, useState } from "react";
  * isTableDataComplete: !metricsQuery.isLoading && metricsQuery.data !== undefined
  * ```
  */
-export type PeekViewProps<TData> = Omit<
-  DataTablePeekViewProps<TData>,
-  "selectedRowId" | "row"
-> & {
+export type PeekViewProps<TData> = DataTablePeekViewProps<TData> & {
   tableDataUpdatedAt: number;
 };
 
@@ -50,8 +47,8 @@ type UsePeekViewProps<TData> = {
  *
  * @returns An object containing:
  * - handleOnRowClickPeek: Function to handle row clicks for peek view
- * - inflatedPeekView: The peek view props with the selected row data
  * - peekViewId: The ID of the currently selected row for peek view
+ * - row: The currently selected row for peek view
  *
  * The peek view allows users to preview details of a row without navigating away from the table.
  * It manages the URL state via query parameters and handles row selection/deselection.
@@ -88,25 +85,21 @@ export const usePeekView = <TData extends object>({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const inflatedPeekView = peekView
-    ? { ...peekView, selectedRowId: peekViewId, row }
-    : undefined;
-
   // Update the row state when the user clicks on a row
   const handleOnRowClickPeek = (row: TData) => {
-    if (inflatedPeekView) {
+    if (peekView) {
       const rowId =
         "id" in row && typeof row.id === "string" ? row.id : undefined;
       // If clicking the same row that's already open, close it
-      if (rowId === inflatedPeekView.selectedRowId) {
-        inflatedPeekView.onOpenChange(false);
+      if (rowId === peekViewId) {
+        peekView.onOpenChange(false);
         setRow(undefined);
       }
       // If clicking a different row update the row data and URL
       else {
         const timestamp =
           "timestamp" in row ? (row.timestamp as Date) : undefined;
-        inflatedPeekView.onOpenChange(true, rowId, timestamp?.toISOString());
+        peekView.onOpenChange(true, rowId, timestamp?.toISOString());
         setRow(row);
       }
     }
@@ -120,7 +113,7 @@ export const usePeekView = <TData extends object>({
       row && "id" in row && typeof row.id === "string" ? row.id : undefined;
 
     if (peekViewId !== rowId) {
-      if (peekViewId && inflatedPeekView) {
+      if (peekViewId && peekView) {
         try {
           const row = getRow(peekViewId);
           if (row) {
@@ -136,7 +129,7 @@ export const usePeekView = <TData extends object>({
 
   return {
     handleOnRowClickPeek: peekView ? handleOnRowClickPeek : undefined,
-    inflatedPeekView,
     peekViewId,
+    row,
   };
 };

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import { Check, ChevronsDownUp, ChevronsUpDown, Copy } from "lucide-react";
 import { cn } from "@/src/utils/tailwind";
@@ -301,6 +301,8 @@ export const IOTableCell = ({
     </>
   );
 };
+
+export const MemoizedIOTableCell = memo(IOTableCell);
 
 export const JsonSkeleton = ({
   className,

--- a/web/src/features/datasets/components/DatasetRunItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsTable.tsx
@@ -11,7 +11,10 @@ import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context
 import { useEffect, useMemo } from "react";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
 import { cn } from "@/src/utils/tailwind";
-import { IOTableCell } from "@/src/components/ui/CodeJsonViewer";
+import {
+  IOTableCell,
+  MemoizedIOTableCell,
+} from "@/src/components/ui/CodeJsonViewer";
 import { ListTree } from "lucide-react";
 import {
   getScoreGroupColumnProps,
@@ -348,12 +351,8 @@ const TraceObservationIOCell = ({
     { traceId, projectId, fromTimestamp: fromTimestampModified },
     {
       enabled: observationId === undefined,
-      trpc: {
-        context: {
-          skipBatch: true,
-        },
-      },
       refetchOnMount: false, // prevents refetching loops
+      staleTime: 60 * 1000, // 1 minute
       onError: () => {},
     },
   );
@@ -365,12 +364,8 @@ const TraceObservationIOCell = ({
     },
     {
       enabled: observationId !== undefined,
-      trpc: {
-        context: {
-          skipBatch: true,
-        },
-      },
       refetchOnMount: false, // prevents refetching loops
+      staleTime: 60 * 1000, // 1 minute
       onError: () => {},
     },
   );
@@ -378,7 +373,7 @@ const TraceObservationIOCell = ({
   const data = observationId === undefined ? trace.data : observation.data;
 
   return (
-    <IOTableCell
+    <MemoizedIOTableCell
       isLoading={
         (!!!observationId ? trace.isLoading : observation.isLoading) || !data
       }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimize traces table performance by memoizing components and reducing unnecessary re-renders and network requests.
> 
>   - **Performance Improvements**:
>     - Memoize `TableBodyComponent` as `MemoizedTableBody` in `data-table.tsx` to reduce re-renders during column resizing and peek view navigation.
>     - Use `memo` for `IOTableCell` as `MemoizedIOTableCell` in `CodeJsonViewer.tsx` to optimize rendering of large JSON data.
>     - Set `staleTime` to 1 minute for data fetching hooks in `usePeekData.ts`, `usePeekView.ts`, and `DatasetRunItemsTable.tsx` to reduce network requests.
>   - **Behavior Changes**:
>     - Remove `SelectedRowContext` from `data-table.tsx` and use `useRouter` for row selection state.
>     - Simplify `handleOnRowClick` logic in `data-table.tsx` by removing `inflatedPeekView` dependency.
>     - Update `TablePeekView` in `peek.tsx` to use `memo` for performance and refactor props handling.
>   - **Miscellaneous**:
>     - Refactor `usePeekView` in `usePeekView.ts` to improve row state management and URL handling.
>     - Adjust `GenerationsDynamicCell` and `TracesDynamicCell` in `observations.tsx` and `traces.tsx` to use `MemoizedIOTableCell`.
>     - Update `DatasetRunItemsTable.tsx` to use `MemoizedIOTableCell` for `TraceObservationIOCell` and `DatasetItemIOCell`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f0ec3733d6cc608c783cbfdb2aea9e0018e738fe. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->