### PR TITLE
fix(otel): set trace io from root span

### DIFF
--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -134,11 +134,11 @@ const extractInputAndOutput = (
 
   // Langfuse
   input =
-    domain === "trace"
+    domain === "trace" && attributes[LangfuseOtelSpanAttributes.TRACE_INPUT]
       ? attributes[LangfuseOtelSpanAttributes.TRACE_INPUT]
       : attributes[LangfuseOtelSpanAttributes.OBSERVATION_INPUT];
   output =
-    domain === "trace"
+    domain === "trace" && attributes[LangfuseOtelSpanAttributes.TRACE_INPUT]
       ? attributes[LangfuseOtelSpanAttributes.TRACE_OUTPUT]
       : attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT];
 

--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -138,7 +138,7 @@ const extractInputAndOutput = (
       ? attributes[LangfuseOtelSpanAttributes.TRACE_INPUT]
       : attributes[LangfuseOtelSpanAttributes.OBSERVATION_INPUT];
   output =
-    domain === "trace" && attributes[LangfuseOtelSpanAttributes.TRACE_INPUT]
+    domain === "trace" && attributes[LangfuseOtelSpanAttributes.TRACE_OUTPUT]
       ? attributes[LangfuseOtelSpanAttributes.TRACE_OUTPUT]
       : attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT];
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `extractInputAndOutput` in `index.ts` to conditionally set `input` and `output` based on `TRACE_INPUT` presence for `trace` domain.
> 
>   - **Behavior**:
>     - Fixes `extractInputAndOutput` in `index.ts` to set `input` and `output` only if `domain` is `trace` and `TRACE_INPUT` attribute is present.
>     - Prevents incorrect assignment of `input` and `output` when `TRACE_INPUT` is missing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5337340526af2f833cced63ff4bd8b94009df224. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->