### PR TITLE
chore: allow annotation queues on FOSS

### DIFF
--- a/web/src/features/entitlements/constants/entitlements.ts
+++ b/web/src/features/entitlements/constants/entitlements.ts
@@ -115,7 +115,7 @@ export const entitlementAccess: Record<
   oss: {
     entitlements: selfHostedAllPlansEntitlements,
     entitlementLimits: {
-      "annotation-queue-count": 0,
+      "annotation-queue-count": false,
       "organization-member-count": false,
       "data-access-days": false,
       "model-based-evaluations-count-evaluators": false,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `annotation-queue-count` for `oss` plan to unlimited in `entitlements.ts`.
> 
>   - **Behavior**:
>     - Change `annotation-queue-count` for `oss` plan in `entitlements.ts` from `0` to `false`, allowing unlimited annotation queues for FOSS users.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d353a3717e282d6e44a03441393e6833313f8f22. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->