### PR TITLE
fix(ee): pro plan label

### DIFF
--- a/packages/shared/src/features/entitlements/plans.ts
+++ b/packages/shared/src/features/entitlements/plans.ts
@@ -14,6 +14,7 @@ export const planLabels = {
   "cloud:pro": "Pro",
   "cloud:team": "Team",
   "cloud:enterprise": "Enterprise",
+  "self-hosted:pro": "Pro (self-hosted)",
   "self-hosted:enterprise": "Enterprise (self-hosted)",
 } as const;
 

--- a/web/src/components/VersionLabel.tsx
+++ b/web/src/components/VersionLabel.tsx
@@ -54,7 +54,7 @@ export const VersionLabel = ({ className }: { className?: string }) => {
       ? // self-host plan
         // TODO: clean up to use planLabels in packages/shared/src/features/entitlements/plans.ts
         {
-          short: "EE",
+          short: plan === "self-hosted:pro" ? "Pro" : "EE",
           long: planLabels[plan],
         }
       : // no plan, oss

--- a/web/src/features/entitlements/constants/entitlements.ts
+++ b/web/src/features/entitlements/constants/entitlements.ts
@@ -122,6 +122,16 @@ export const entitlementAccess: Record<
       "prompt-management-count-prompts": false,
     },
   },
+  "self-hosted:pro": {
+    entitlements: selfHostedAllPlansEntitlements,
+    entitlementLimits: {
+      "annotation-queue-count": false,
+      "organization-member-count": false,
+      "data-access-days": false,
+      "model-based-evaluations-count-evaluators": false,
+      "prompt-management-count-prompts": false,
+    },
+  },
   "self-hosted:enterprise": {
     entitlements: [
       ...selfHostedAllPlansEntitlements,

--- a/web/src/features/entitlements/server/getPlan.ts
+++ b/web/src/features/entitlements/server/getPlan.ts
@@ -60,5 +60,8 @@ export function getSelfHostedInstancePlanServerSide(): Plan | null {
   if (licenseKey.startsWith("langfuse_ee_")) {
     return "self-hosted:enterprise";
   }
+  if (licenseKey.startsWith("langfuse_pro_")) {
+    return "self-hosted:pro";
+  }
   return null;
 }

--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -213,6 +213,7 @@ const getPlanBasedRateLimitConfig = (
 ): z.infer<typeof RateLimitConfig> => {
   switch (plan) {
     case "oss":
+    case "self-hosted:pro":
     case "self-hosted:enterprise":
       return {
         resource,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for `self-hosted:pro` plan with appropriate labels, entitlements, and rate limiting.
> 
>   - **Behavior**:
>     - Add `self-hosted:pro` plan label in `plans.ts`.
>     - Update `VersionLabel.tsx` to display "Pro" for `self-hosted:pro` plan.
>     - Add `self-hosted:pro` plan handling in `getPlan.ts`.
>   - **Entitlements**:
>     - Add `self-hosted:pro` to `entitlementAccess` in `entitlements.ts` with specific entitlements and limits.
>   - **Rate Limiting**:
>     - Add `self-hosted:pro` to `getPlanBasedRateLimitConfig()` in `RateLimitService.ts` with no rate limits.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7875de01b15dbbe418fe3f89c8b904674d8f977b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->