### PR TITLE
fix(otel): read resourceAttributes for release attribute

### DIFF
--- a/web/src/features/otel/server/index.ts
+++ b/web/src/features/otel/server/index.ts
@@ -724,7 +724,10 @@ export const convertOtelSpanToIngestionEvent = (
             attributes?.[LangfuseOtelSpanAttributes.VERSION] ??
             resourceAttributes?.["service.version"] ??
             null,
-          release: attributes?.[LangfuseOtelSpanAttributes.RELEASE] ?? null,
+          release:
+            attributes?.[LangfuseOtelSpanAttributes.RELEASE] ??
+            resourceAttributes?.[LangfuseOtelSpanAttributes.RELEASE] ??
+            null,
           userId: extractUserId(attributes),
           sessionId: extractSessionId(attributes),
           public:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix `release` attribute extraction in `convertOtelSpanToIngestionEvent` to read from `resourceAttributes` if not found in `attributes`.
> 
>   - **Behavior**:
>     - In `convertOtelSpanToIngestionEvent` in `index.ts`, the `release` attribute is now read from `resourceAttributes` if not found in `attributes`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 350b66b8ce583040a13165ede1c2b19a80333da9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->