### PR TITLE
chore: allow bullmq-api for non-cloud deployments

### DIFF
--- a/web/src/pages/api/admin/bullmq/index.ts
+++ b/web/src/pages/api/admin/bullmq/index.ts
@@ -40,7 +40,7 @@ export default async function handler(
       return;
     }
 
-    if (!AdminApiAuthService.handleAdminAuth(req, res)) {
+    if (!AdminApiAuthService.handleAdminAuth(req, res, false)) {
       return;
     }
 


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/7024
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allow non-cloud deployments to use bullmq API by modifying `handleAdminAuth` call in `index.ts`.
> 
>   - **Behavior**:
>     - Modify `handleAdminAuth` call in `index.ts` to allow non-cloud deployments by passing `false` as the third argument.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8a1a418571554936176ad9915a88fb7c0ad96f55. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->