### PR TITLE
feat(quickstart+readme): add python SDK v3 examples

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -213,8 +213,8 @@ LANGFUSE_HOST="https://cloud.langfuse.com" # 🇪🇺 欧盟区域
 
 创建示例代码（文件名：**main.py**）：
 
-````python:main.py
-from langfuse.decorators import observe
+```python:main.py
+from langfuse import observe
 from langfuse.openai import openai  # OpenAI 集成
 
 @observe()

--- a/README.ja.md
+++ b/README.ja.md
@@ -219,7 +219,7 @@ LANGFUSE_HOST="https://cloud.langfuse.com" # 🇪🇺 EUリージョン
 ```
 
 ```python:/@observe()/ /from langfuse.openai import openai/ filename="main.py"
-from langfuse.decorators import observe
+from langfuse import observe
 from langfuse.openai import openai  # OpenAI統合
 
 @observe()

--- a/README.kr.md
+++ b/README.kr.md
@@ -201,7 +201,7 @@ LANGFUSE_HOST="https://cloud.langfuse.com" # 🇪🇺 EU region
 ```
 
 ```python:main.py
-from langfuse.decorators import observe
+from langfuse import observe
 from langfuse.openai import openai # OpenAI integration
 
 @observe()

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ LANGFUSE_HOST="https://cloud.langfuse.com" # 🇪🇺 EU region
 ```
 
 ```python /@observe()/ /from langfuse.openai import openai/ filename="main.py"
-from langfuse.decorators import observe
+from langfuse import observe
 from langfuse.openai import openai # OpenAI integration
 
 @observe()

--- a/web/src/features/public-api/components/QuickstartExamples.tsx
+++ b/web/src/features/public-api/components/QuickstartExamples.tsx
@@ -22,7 +22,6 @@ export const QuickstartExamples = (p: {
     { value: "openai", label: "OpenAI" },
     { value: "langchain", label: "Langchain" },
     { value: "langchain-js", label: "Langchain JS" },
-    { value: "llamaindex", label: "LlamaIndex" },
     { value: "other", label: "Other" },
   ];
   const host = `${uiCustomization?.hostname ?? window.origin}${env.NEXT_PUBLIC_BASE_PATH ?? ""}`;
@@ -196,32 +195,6 @@ export const QuickstartExamples = (p: {
             for more details and an end-to-end example.
           </p>
         </TabsContent>
-        <TabsContent value="llamaindex">
-          <p className="mt-2 text-xs text-muted-foreground">
-            The integration uses the LlamaIndex callback system to automatically
-            capture detailed traces of your LlamaIndex executions.
-          </p>
-          <CodeView
-            content="pip install langfuse llama-index"
-            className="my-2"
-          />
-          <CodeView
-            content={LLAMA_INDEX_CODE({ publicKey, secretKey, host })}
-            className="my-2"
-          />
-          <p className="mt-2 text-xs text-muted-foreground">
-            See the{" "}
-            <a
-              href="https://langfuse.com/docs/integrations/llama-index"
-              className="underline"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              LlamaIndex Integration docs
-            </a>{" "}
-            for more details and an end-to-end example.
-          </p>
-        </TabsContent>
         <TabsContent value="other">
           <p className="mt-2 text-xs text-muted-foreground">
             Use the{" "}
@@ -283,12 +256,16 @@ const LANGCHAIN_PYTHON_CODE = (p: {
   publicKey: string;
   secretKey: string;
   host: string;
-}) => `from langfuse.callback import CallbackHandler
-langfuse_handler = CallbackHandler(
+}) => `from langfuse import Langfuse
+from langfuse.langchain import CallbackHandler
+
+langfuse = Langfuse(
     public_key="${p.publicKey}",
     secret_key="${p.secretKey}",
     host="${p.host}"
 )
+
+langfuse_handler = CallbackHandler()
 
 # <Your Langchain code here>
  
@@ -316,18 +293,3 @@ await chain.invoke(
   { input: "<user_input>" },
   { callbacks: [langfuseHandler] }
 );`;
-
-const LLAMA_INDEX_CODE = (p: {
-  publicKey: string;
-  secretKey: string;
-  host: string;
-}) => `from llama_index.core import Settings
-from llama_index.core.callbacks import CallbackManager
-from langfuse.llama_index import LlamaIndexCallbackHandler
- 
-langfuse_callback_handler = LlamaIndexCallbackHandler(
-    public_key="${p.publicKey}",
-    secret_key="${p.secretKey}",
-    host="${p.host}"
-)
-Settings.callback_manager = CallbackManager([langfuse_callback_handler])`;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update README files to change Python SDK import path and remove LlamaIndex integration from QuickstartExamples component.
> 
>   - **README Updates**:
>     - Change import path from `from langfuse.decorators import observe` to `from langfuse import observe` in `README.md`, `README.cn.md`, `README.ja.md`, and `README.kr.md`.
>   - **QuickstartExamples Component**:
>     - Remove `llamaindex` tab and related content from `QuickstartExamples.tsx`.
>     - Update `LANGCHAIN_PYTHON_CODE` to use `from langfuse import Langfuse` and `CallbackHandler`.
>     - Update `LANGCHAIN_JS_CODE` to use `CallbackHandler` from `langfuse-langchain`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 395dda47286b756b6a5d1d6d60f5f4b1c5b8fdb6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->