### PR TITLE
fix(datasets): prevent delete modal from closing on mouse navigation event

### DIFF
--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
@@ -256,7 +256,13 @@ export default function Dataset() {
                     projectId={projectId}
                   />
                 </DropdownMenuItem>
-                <DropdownMenuItem asChild>
+                <DropdownMenuItem
+                  asChild
+                  onSelect={(event) => {
+                    event.preventDefault();
+                    return false;
+                  }}
+                >
                   <DeleteDatasetButton
                     itemId={datasetId}
                     projectId={projectId}

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/items.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/items.tsx
@@ -95,7 +95,13 @@ export default function DatasetItems() {
                     projectId={projectId}
                   />
                 </DropdownMenuItem>
-                <DropdownMenuItem asChild>
+                <DropdownMenuItem
+                  asChild
+                  onSelect={(event) => {
+                    event.preventDefault();
+                    return false;
+                  }}
+                >
                   <DeleteDatasetButton
                     itemId={datasetId}
                     projectId={projectId}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevent delete modal from closing on mouse navigation events in `index.tsx` and `items.tsx`.
> 
>   - **Behavior**:
>     - Prevents delete modal from closing on mouse navigation events by adding `event.preventDefault()` in `onSelect` handler for `DropdownMenuItem` in `index.tsx` and `items.tsx`.
>   - **Files Affected**:
>     - `index.tsx`: Modified `DropdownMenuItem` for `DeleteDatasetButton` to prevent default behavior.
>     - `items.tsx`: Applied the same change to `DropdownMenuItem` for `DeleteDatasetButton`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7b60ebbe6ab961b5518b2c4f40acacc6e2367cb4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->