### PR TITLE
chore: show frontend name for histogram chart type

### DIFF
--- a/web/src/features/widgets/components/SelectWidgetDialog.tsx
+++ b/web/src/features/widgets/components/SelectWidgetDialog.tsx
@@ -144,6 +144,8 @@ export function SelectWidgetDialog({
                               return "Pie Chart (Total Value)";
                             case "NUMBER":
                               return "Big Number (Total Value)";
+                            case "HISTOGRAM":
+                              return "Histogram (Total Value)";
                             default:
                               return widget.chartType;
                           }

--- a/web/src/features/widgets/components/WidgetTable.tsx
+++ b/web/src/features/widgets/components/WidgetTable.tsx
@@ -200,6 +200,8 @@ export function DashboardWidgetTable() {
             return "Pie Chart (Total Value)";
           case "NUMBER":
             return "Big Number (Total Value)";
+          case "HISTOGRAM":
+            return "Histogram (Total Value)";
           default:
             return "Unknown Chart Type";
         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for displaying 'Histogram (Total Value)' for 'HISTOGRAM' chart type in `SelectWidgetDialog` and `DashboardWidgetTable`.
> 
>   - **Behavior**:
>     - Add support for 'HISTOGRAM' chart type in `SelectWidgetDialog` and `DashboardWidgetTable`.
>     - Displays 'Histogram (Total Value)' for 'HISTOGRAM' chart type in both components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 935f319757a146769a80ce68b30873d3df5a0c1c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->