### PR TITLE
fix(evals): do not throw errors if eval model does not consistently return JSON

### DIFF
--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -151,6 +151,7 @@ export const evalJobExecutorQueueProcessor = async (
       (e instanceof ApiError && e.message.includes("TypeError")) || // Zod parsing the response failed. User should update prompt to consistently return expected output structure.
       (e instanceof ApiError &&
         e.message.includes("Error: Unterminated string in JSON at position")) || // When evaluator model is configured with too low max_tokens, the structured output response is invalid JSON
+      (e instanceof ApiError && e.message.includes("is not valid JSON")) || // When evaluator model is not consistently returning valid JSON on structured output calls
       (e instanceof BaseError &&
         e.message.includes(
           "Please ensure the mapped data exists and consider extending the job delay.",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds handling for `ApiError` with message "is not valid JSON" in `evalJobExecutorQueueProcessor` to prevent errors from inconsistent JSON responses.
> 
>   - **Behavior**:
>     - In `evalJobExecutorQueueProcessor` in `evalQueue.ts`, added handling for `ApiError` with message "is not valid JSON" to prevent errors when evaluator model returns inconsistent JSON.
>     - This prevents throwing errors for this specific case, allowing the process to continue without interruption.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 46b0107fd9b02f5f2136d9e2445ea3402e14269f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->