### PR TITLE
fix(prompts): prompt name validation cleared when name blurred

### DIFF
--- a/web/src/features/prompts/components/NewPromptForm/validation.ts
+++ b/web/src/features/prompts/components/NewPromptForm/validation.ts
@@ -10,7 +10,9 @@ const NewPromptBaseSchema = z.object({
   name: z
     .string()
     .min(1, "Enter a name")
-    .regex(/^[^|]*$/, "Prompt name cannot contain '|' character"),
+    .regex(/^[^|]*$/, "Prompt name cannot contain '|' character")
+    .regex(/^[a-zA-Z0-9_\-.]+$/, "Name must be alphanumeric with optional underscores, hyphens, or periods")
+    .refine((name) => name !== "new", "Prompt name cannot be 'new'"),
   isActive: z.boolean({
     required_error: "Enter whether the prompt should go live",
   }),

--- a/web/src/features/prompts/hooks/usePromptNameValidation.tsx
+++ b/web/src/features/prompts/hooks/usePromptNameValidation.tsx
@@ -13,7 +13,7 @@ export const usePromptNameValidation = ({
   form,
 }: UsePromptNameValidationProps) => {
   useEffect(() => {
-    if (!currentName) return;
+    if (!currentName || !allPrompts) return;
 
     const isNewPrompt = !allPrompts
       ?.map((prompt) => prompt.value)
@@ -21,15 +21,11 @@ export const usePromptNameValidation = ({
 
     if (!isNewPrompt) {
       form.setError("name", { message: "Prompt name already exists." });
-    } else if (currentName === "new") {
-      form.setError("name", { message: "Prompt name cannot be 'new'" });
-    } else if (!/^[a-zA-Z0-9_\-.]+$/.test(currentName)) {
-      form.setError("name", {
-        message:
-          "Name must be alphanumeric with optional underscores, hyphens, or periods",
-      });
     } else {
-      form.clearErrors("name");
+      const currentError = form.getFieldState("name").error;
+      if (currentError?.message === "Prompt name already exists.") {
+        form.clearErrors("name");
+      }
     }
   }, [currentName, allPrompts, form]);
 };


### PR DESCRIPTION
## What does this PR do?

on unfocus of the text element, the validation errors are cleared. they are cleared because the zod schema validates again with a different ruleset and removes the errors.

https://github.com/user-attachments/assets/26e2277f-ed45-4d2c-8e49-b41d33d53069

