### PR TITLE
chore: refactor chart display names into single util

### DIFF
--- a/web/src/features/widgets/chart-library/utils.ts
+++ b/web/src/features/widgets/chart-library/utils.ts
@@ -60,3 +60,29 @@ export const isTimeSeriesChart = (
 // Used for a combination of YAxis styling workarounds as discussed in https://github.com/recharts/recharts/issues/2027#issuecomment-769674096.
 export const formatAxisLabel = (label: string): string =>
   label.length > 13 ? label.slice(0, 13).concat("…") : label;
+
+/**
+ * Maps chart types to their human-readable display names.
+ */
+export function getChartTypeDisplayName(
+  chartType: DashboardWidgetChartType,
+): string {
+  switch (chartType) {
+    case "LINE_TIME_SERIES":
+      return "Line Chart (Time Series)";
+    case "BAR_TIME_SERIES":
+      return "Bar Chart (Time Series)";
+    case "HORIZONTAL_BAR":
+      return "Horizontal Bar Chart (Total Value)";
+    case "VERTICAL_BAR":
+      return "Vertical Bar Chart (Total Value)";
+    case "PIE":
+      return "Pie Chart (Total Value)";
+    case "NUMBER":
+      return "Big Number (Total Value)";
+    case "HISTOGRAM":
+      return "Histogram (Total Value)";
+    default:
+      return "Unknown Chart Type";
+  }
+}

--- a/web/src/features/widgets/components/SelectWidgetDialog.tsx
+++ b/web/src/features/widgets/components/SelectWidgetDialog.tsx
@@ -20,6 +20,8 @@ import {
   TableCell,
 } from "@/src/components/ui/table";
 import { startCase } from "lodash";
+import { getChartTypeDisplayName } from "@/src/features/widgets/chart-library/utils";
+import { type DashboardWidgetChartType } from "@langfuse/shared/src/db";
 
 export type WidgetItem = {
   id: string;
@@ -130,26 +132,9 @@ export function SelectWidgetDialog({
                         {startCase(widget.view.toLowerCase())}
                       </TableCell>
                       <TableCell>
-                        {(() => {
-                          switch (widget.chartType) {
-                            case "LINE_TIME_SERIES":
-                              return "Line Chart (Time Series)";
-                            case "BAR_TIME_SERIES":
-                              return "Bar Chart (Time Series)";
-                            case "HORIZONTAL_BAR":
-                              return "Horizontal Bar Chart (Total Value)";
-                            case "VERTICAL_BAR":
-                              return "Vertical Bar Chart (Total Value)";
-                            case "PIE":
-                              return "Pie Chart (Total Value)";
-                            case "NUMBER":
-                              return "Big Number (Total Value)";
-                            case "HISTOGRAM":
-                              return "Histogram (Total Value)";
-                            default:
-                              return widget.chartType;
-                          }
-                        })()}
+                        {getChartTypeDisplayName(
+                          widget.chartType as DashboardWidgetChartType,
+                        )}
                       </TableCell>
                     </TableRow>
                   ))}

--- a/web/src/features/widgets/components/WidgetTable.tsx
+++ b/web/src/features/widgets/components/WidgetTable.tsx
@@ -22,6 +22,8 @@ import {
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { useRouter } from "next/router";
+import { getChartTypeDisplayName } from "@/src/features/widgets/chart-library/utils";
+import { type DashboardWidgetChartType } from "@langfuse/shared/src/db";
 
 type WidgetTableRow = {
   id: string;
@@ -186,26 +188,8 @@ export function DashboardWidgetTable() {
       id: "chartType",
       enableSorting: true,
       size: 100,
-      cell: (row) => {
-        switch (row.getValue()) {
-          case "LINE_TIME_SERIES":
-            return "Line Chart (Time Series)";
-          case "BAR_TIME_SERIES":
-            return "Bar Chart (Time Series)";
-          case "HORIZONTAL_BAR":
-            return "Horizontal Bar Chart (Total Value)";
-          case "VERTICAL_BAR":
-            return "Vertical Bar Chart (Total Value)";
-          case "PIE":
-            return "Pie Chart (Total Value)";
-          case "NUMBER":
-            return "Big Number (Total Value)";
-          case "HISTOGRAM":
-            return "Histogram (Total Value)";
-          default:
-            return "Unknown Chart Type";
-        }
-      },
+      cell: (row) =>
+        getChartTypeDisplayName(row.getValue() as DashboardWidgetChartType),
     }),
     columnHelper.accessor("createdAt", {
       header: "Created At",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor to centralize chart type display name logic into `getChartTypeDisplayName` utility function, reducing duplication in `SelectWidgetDialog.tsx` and `WidgetTable.tsx`.
> 
>   - **Refactor**:
>     - Introduced `getChartTypeDisplayName` in `utils.ts` to map chart types to display names.
>     - Replaced inline chart type display logic with `getChartTypeDisplayName` in `SelectWidgetDialog.tsx` and `WidgetTable.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 87becc55c092f7732604a8be64fd6344f6d17511. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->