### PR TITLE
fix(graph-view): handle missing __start__ node for langgraph>=0.4

### DIFF
--- a/web/src/features/trace-graph-view/components/TraceGraphView.tsx
+++ b/web/src/features/trace-graph-view/components/TraceGraphView.tsx
@@ -6,6 +6,7 @@ import {
   type GraphCanvasData,
   LANGGRAPH_END_NODE_NAME,
   type AgentGraphDataResponse,
+  LANGGRAPH_START_NODE_NAME,
 } from "../types";
 
 type TraceGraphViewProps = {
@@ -69,7 +70,12 @@ function parseGraph(params: { agentGraphData: AgentGraphDataResponse[] }): {
   const nodeToParentObservationMap = new Map<string, string>();
 
   agentGraphData.forEach((o) => {
-    const { node, step } = o;
+    const { node: rawNode, step } = o;
+
+    let node = rawNode;
+    try {
+      node = JSON.parse(rawNode);
+    } catch {}
 
     stepToNodeMap.set(step, node);
 
@@ -84,6 +90,16 @@ function parseGraph(params: { agentGraphData: AgentGraphDataResponse[] }): {
           LANGGRAPH_END_NODE_NAME,
           o.parentObservationId,
         );
+
+        // Also initialize the start node if it hasn't been seen yet
+        // Langgraph >= v4 is no longer adding a span for the start node
+        if (!nodeToParentObservationMap.has(LANGGRAPH_START_NODE_NAME)) {
+          stepToNodeMap.set(0, LANGGRAPH_START_NODE_NAME);
+          nodeToParentObservationMap.set(
+            LANGGRAPH_START_NODE_NAME,
+            o.parentObservationId,
+          );
+        }
       }
 
       // Only register id if it is top-most to allow navigation on node click in graph


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix missing start node in `TraceGraphView` for langgraph >= 0.4 by initializing `LANGGRAPH_START_NODE_NAME` in `parseGraph`.
> 
>   - **Behavior**:
>     - In `TraceGraphView.tsx`, `parseGraph` function now initializes `LANGGRAPH_START_NODE_NAME` if missing, due to langgraph >= 0.4 not adding a start node span.
>     - Handles JSON parsing of `rawNode` in `parseGraph` to ensure valid node data.
>   - **Misc**:
>     - Imports `LANGGRAPH_START_NODE_NAME` in `TraceGraphView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6b12aefce4d97a94d9f8cf058958ab2ca7d4ebde. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->