### PR TITLE
style(CreateScoreConfigButton): add padding to confirmation message for improved readability

### DIFF
--- a/web/src/features/scores/components/CreateScoreConfigButton.tsx
+++ b/web/src/features/scores/components/CreateScoreConfigButton.tsx
@@ -468,7 +468,7 @@ export function CreateScoreConfigButton({ projectId }: { projectId: string }) {
                   <DialogTitle>Confirm Submission</DialogTitle>
                 </DialogHeader>
                 <DialogBody>
-                  <p className="text-sm">
+                  <p className="py-4 text-sm">
                     Score configs cannot be edited or deleted after they have
                     been created. Are you sure you want to proceed?
                   </p>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds padding to confirmation message in `CreateScoreConfigButton.tsx` for better readability.
> 
>   - **Style**:
>     - Adds `py-4` padding to the confirmation message paragraph in `CreateScoreConfigButton.tsx` for improved readability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8a90ea8fe72d26b756fe7c92316e2f8d98c927b5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->