### PR TITLE
chore(models): adjust price of o3 to reflected updated openai pricing

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1594,14 +1594,14 @@
     "model_name": "o3",
     "match_pattern": "(?i)^(o3)$",
     "created_at": "2025-04-16T23:26:54.132Z",
-    "updated_at": "2025-04-16T23:26:54.132Z",
+    "updated_at": "2025-06-10T23:26:54.132Z",
     "prices": {
-      "input": 10e-6,
-      "input_cached_tokens": 2.5e-6,
-      "input_cache_read": 2.5e-6,
-      "output": 40e-6,
-      "output_reasoning_tokens": 40e-6,
-      "output_reasoning": 40e-6
+      "input": 2e-6,
+      "input_cached_tokens": 0.5e-6,
+      "input_cache_read": 0.5e-6,
+      "output": 8e-6,
+      "output_reasoning_tokens": 8e-6,
+      "output_reasoning": 8e-6
     },
     "tokenizer_config": null,
     "tokenizer_id": null
@@ -1611,14 +1611,14 @@
     "model_name": "o3-2025-04-16",
     "match_pattern": "(?i)^(o3-2025-04-16)$",
     "created_at": "2025-04-16T23:26:54.132Z",
-    "updated_at": "2025-04-16T23:26:54.132Z",
+    "updated_at": "2025-06-10T23:26:54.132Z",
     "prices": {
-      "input": 10e-6,
-      "input_cached_tokens": 2.5e-6,
-      "input_cache_read": 2.5e-6,
-      "output": 40e-6,
-      "output_reasoning_tokens": 40e-6,
-      "output_reasoning": 40e-6
+      "input": 2e-6,
+      "input_cached_tokens": 0.5e-6,
+      "input_cache_read": 0.5e-6,
+      "output": 8e-6,
+      "output_reasoning_tokens": 8e-6,
+      "output_reasoning": 8e-6
     },
     "tokenizer_config": null,
     "tokenizer_id": null


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updated `o3` model pricing in `default-model-prices.json` to reflect new OpenAI pricing.
> 
>   - **Pricing Update**:
>     - Adjusted prices for `o3` and `o3-2025-04-16` models in `default-model-prices.json`.
>     - Updated `input` price from `10e-6` to `2e-6`.
>     - Updated `input_cached_tokens` and `input_cache_read` prices from `2.5e-6` to `0.5e-6`.
>     - Updated `output`, `output_reasoning_tokens`, and `output_reasoning` prices from `40e-6` to `8e-6`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f6852a5ced4e6692ba262263c18b550c482155ee. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->