### PR TITLE
fix(ui): enable clipboard copying for self-hosted instances 

### DIFF
--- a/web/src/components/publish-object-switch.tsx
+++ b/web/src/components/publish-object-switch.tsx
@@ -8,6 +8,7 @@ import {
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { api } from "@/src/utils/api";
+import { copyTextToClipboard } from "@/src/utils/clipboard";
 import { CheckIcon, Globe, Link, Share2 } from "lucide-react";
 import { useState } from "react";
 
@@ -96,7 +97,7 @@ const Base = (props: {
 
   const copyUrl = () => {
     setIsCopied(true);
-    void navigator.clipboard.writeText(window.location.href);
+    void copyTextToClipboard(window.location.href);
     setTimeout(() => setIsCopied(false), 2500);
   };
 

--- a/web/src/components/table/table-view-presets/hooks/useViewMutations.ts
+++ b/web/src/components/table/table-view-presets/hooks/useViewMutations.ts
@@ -1,5 +1,6 @@
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { api } from "@/src/utils/api";
+import { copyTextToClipboard } from "@/src/utils/clipboard";
 
 type UseViewMutationsProps = {
   handleSetViewId: (viewId: string | null) => void;
@@ -42,7 +43,7 @@ export const useViewMutations = ({
   const generatePermalinkMutation =
     api.TableViewPresets.generatePermalink.useMutation({
       onSuccess: (data) => {
-        navigator.clipboard.writeText(data);
+        copyTextToClipboard(data);
         showSuccessToast({
           title: "Permalink copied to clipboard",
           description: "You can now share the permalink with others",

--- a/web/src/components/trace/CopyIdsPopover.tsx
+++ b/web/src/components/trace/CopyIdsPopover.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/src/components/ui/popover";
 import { cn } from "@/src/utils/tailwind";
 import { Label } from "@/src/components/ui/label";
+import { copyTextToClipboard } from "@/src/utils/clipboard";
 
 interface IdItem {
   name: string;
@@ -24,7 +25,7 @@ export const CopyIdsPopover = ({
   const [copiedId, setCopiedId] = useState<string | null>(null);
 
   const handleCopy = (textToCopy: string) => {
-    navigator.clipboard.writeText(textToCopy);
+    copyTextToClipboard(textToCopy);
     setCopiedId(textToCopy);
     setTimeout(() => setCopiedId(null), 1500);
   };

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -13,6 +13,7 @@ import { type MediaReturnType } from "@/src/features/media/validation";
 import { LangfuseMediaView } from "@/src/components/ui/LangfuseMediaView";
 import { MarkdownJsonViewHeader } from "@/src/components/ui/MarkdownJsonView";
 import { renderContentWithPromptButtons } from "@/src/features/prompts/components/renderContentWithPromptButtons";
+import { copyTextToClipboard } from "@/src/utils/clipboard";
 
 const IO_TABLE_CHAR_LIMIT = 10000;
 
@@ -40,7 +41,8 @@ export function JSONView(props: {
       : (props.collapseStringsAfterLength ?? 500);
 
   const handleOnCopy = () => {
-    void navigator.clipboard.writeText(stringifyJsonNode(parsedJson));
+    const textToCopy = stringifyJsonNode(parsedJson);
+    void copyTextToClipboard(textToCopy);
   };
 
   const handleOnValueChange = () => {
@@ -156,11 +158,11 @@ export function CodeView(props: {
 
   const handleCopy = () => {
     setIsCopied(true);
-    void navigator.clipboard.writeText(
+    const content =
       typeof props.content === "string"
         ? props.content
-        : (props.content?.join("\n") ?? ""),
-    );
+        : (props.content?.join("\n") ?? "");
+    void copyTextToClipboard(content);
     setTimeout(() => setIsCopied(false), 1000);
   };
 

--- a/web/src/components/ui/Codeblock.tsx
+++ b/web/src/components/ui/Codeblock.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/src/components/ui/button";
+import { copyTextToClipboard } from "@/src/utils/clipboard";
 import { cn } from "@/src/utils/tailwind";
 import { Check, Copy } from "lucide-react";
 import { type FC, memo, useState } from "react";
@@ -50,7 +51,7 @@ const CodeBlock: FC<Props> = memo(({ language, value, theme, className }) => {
   const [isCopied, setIsCopied] = useState(false);
   const handleCopy = () => {
     setIsCopied(true);
-    void navigator.clipboard.writeText(value ?? "");
+    void copyTextToClipboard(value ?? "");
     setTimeout(() => setIsCopied(false), 1000);
   };
 

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -325,7 +325,7 @@ export function MarkdownView({
                   <ResizableImage src={content.image_url.url.toString()} />
                 </div>
               ) : MediaReferenceStringSchema.safeParse(content.image_url.url)
-                .success ? (
+                  .success ? (
                 <LangfuseMediaView
                   mediaReferenceString={content.image_url.url}
                 />

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -33,6 +33,7 @@ import { LangfuseMediaView } from "@/src/components/ui/LangfuseMediaView";
 import { type MediaReturnType } from "@/src/features/media/validation";
 import { JSONView } from "@/src/components/ui/CodeJsonViewer";
 import { MarkdownJsonViewHeader } from "@/src/components/ui/MarkdownJsonView";
+import { copyTextToClipboard } from "@/src/utils/clipboard";
 
 type ReactMarkdownNode = ReactMarkdownExtraProps["node"];
 type ReactMarkdownNodeChildren = Exclude<
@@ -280,7 +281,7 @@ export function MarkdownView({
       typeof markdown === "string"
         ? markdown
         : parseOpenAIContentParts(markdown);
-    void navigator.clipboard.writeText(rawText);
+    void copyTextToClipboard(rawText);
   };
 
   const handleOnValueChange = () => {
@@ -333,7 +334,7 @@ export function MarkdownView({
                   <ResizableImage src={content.image_url.url.toString()} />
                 </div>
               ) : MediaReferenceStringSchema.safeParse(content.image_url.url)
-                  .success ? (
+                .success ? (
                 <LangfuseMediaView
                   mediaReferenceString={content.image_url.url}
                 />

--- a/web/src/ee/features/playground/page/components/GenerationOutput.tsx
+++ b/web/src/ee/features/playground/page/components/GenerationOutput.tsx
@@ -5,6 +5,7 @@ import { CheckIcon, CopyIcon, PlusIcon } from "@radix-ui/react-icons";
 import { ChatMessageRole, ChatMessageType } from "@langfuse/shared";
 import { BracesIcon } from "lucide-react";
 import { ToolCallCard } from "@/src/components/ChatMessages/ToolCallCard";
+import { copyTextToClipboard } from "@/src/utils/clipboard";
 
 export const GenerationOutput = () => {
   const [isCopied, setIsCopied] = useState(false);
@@ -16,7 +17,8 @@ export const GenerationOutput = () => {
 
   const handleCopy = () => {
     setIsCopied(true);
-    void navigator.clipboard.writeText(isJson ? outputJson : output);
+    const textToCopy = isJson ? outputJson : output;
+    void copyTextToClipboard(textToCopy);
     setTimeout(() => setIsCopied(false), 1000);
   };
 
@@ -97,10 +99,10 @@ export const GenerationOutput = () => {
         </pre>
         {outputToolCalls.length > 0
           ? outputToolCalls.map((toolCall) => (
-              <div className="mt-4" key={toolCall.id}>
-                <ToolCallCard toolCall={toolCall} />
-              </div>
-            ))
+            <div className="mt-4" key={toolCall.id}>
+              <ToolCallCard toolCall={toolCall} />
+            </div>
+          ))
           : null}
       </div>
     </div>

--- a/web/src/features/playground/page/components/GenerationOutput.tsx
+++ b/web/src/features/playground/page/components/GenerationOutput.tsx
@@ -99,10 +99,10 @@ export const GenerationOutput = () => {
         </pre>
         {outputToolCalls.length > 0
           ? outputToolCalls.map((toolCall) => (
-            <div className="mt-4" key={toolCall.id}>
-              <ToolCallCard toolCall={toolCall} />
-            </div>
-          ))
+              <div className="mt-4" key={toolCall.id}>
+                <ToolCallCard toolCall={toolCall} />
+              </div>
+            ))
           : null}
       </div>
     </div>

--- a/web/src/features/prompts/components/PromptSelectionDialog.tsx
+++ b/web/src/features/prompts/components/PromptSelectionDialog.tsx
@@ -18,6 +18,7 @@ import {
 import { Label } from "@/src/components/ui/label";
 import { api } from "@/src/utils/api";
 import { CopyIcon, ExternalLinkIcon } from "lucide-react";
+import { copyTextToClipboard } from "@/src/utils/clipboard";
 
 type PromptSelectionDialogProps = {
   isOpen: boolean;
@@ -41,7 +42,7 @@ export function PromptSelectionDialog({
     useState<string>("");
 
   const copySelectedTag = useCallback(() => {
-    navigator.clipboard.writeText(selectedTag);
+    copyTextToClipboard(selectedTag);
   }, [selectedTag]);
 
   useEffect(() => {
@@ -177,18 +178,18 @@ export function PromptSelectionDialog({
                   <SelectContent>
                     {selectionType === "version"
                       ? selectedPrompt?.versions.map((version) => (
-                          <SelectItem
-                            key={version.toString()}
-                            value={version.toString()}
-                          >
-                            {version}
-                          </SelectItem>
-                        ))
+                        <SelectItem
+                          key={version.toString()}
+                          value={version.toString()}
+                        >
+                          {version}
+                        </SelectItem>
+                      ))
                       : selectedPrompt?.labels.map((label) => (
-                          <SelectItem key={label} value={label}>
-                            {label}
-                          </SelectItem>
-                        ))}
+                        <SelectItem key={label} value={label}>
+                          {label}
+                        </SelectItem>
+                      ))}
                   </SelectContent>
                 </Select>
                 {selectedVersionOrLabel && (

--- a/web/src/utils/clipboard.ts
+++ b/web/src/utils/clipboard.ts
@@ -1,0 +1,45 @@
+/**
+ * Clipboard Copy Fallback
+ *
+ * This fallback implementation enables copying text to clipboard when the secure Clipboard API
+ * isn't available. This typically occurs when the page isn't served over HTTPS (TLS).
+ *
+ * Examples of affected scenarios:
+ * - Self-hosted deployments without configured HTTPS certificates.
+ * - Websites served over plain HTTP (except localhost and local IP addresses).
+ *
+ * Note:
+ * - Local resources like http://localhost, http://127.0.0.1, and http://*.localhost are NOT affected.
+ *
+ * Important:
+ * - This fallback method uses `execCommand`, which is deprecated.
+ * - It will stop working once browsers fully remove support for `execCommand`.
+ */
+const _unsafeNonSecureCopyToClipboard = (text: string) => {
+  try {
+    const textArea = document.createElement("textarea");
+    textArea.value = text;
+    textArea.style.position = "fixed";
+    textArea.style.left = "-9999px";
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+    document.execCommand("copy");
+    document.body.removeChild(textArea);
+  } catch (error) {
+    console.error("Unable to copy to clipboard", error);
+  }
+};
+
+/**
+ * Copy text to clipboard using clipboard api or fallback to _unsafeNonSecureCopyToClipboard for non secure contexts
+ *
+ * @param text - Text to copy to clipboard
+ * @returns Promise<void>
+ */
+export const copyTextToClipboard = async (text: string) => {
+  if (typeof navigator.clipboard?.writeText === "function") {
+    return navigator.clipboard.writeText(text);
+  }
+  return _unsafeNonSecureCopyToClipboard(text);
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replaces direct clipboard API calls with a new utility function `copyTextToClipboard` across the codebase, adding a fallback for non-secure contexts.
> 
>   - **Clipboard Copying**:
>     - Replaces `navigator.clipboard.writeText` with `copyTextToClipboard` in `publish-object-switch.tsx`, `useViewMutations.ts`, and `CopyIdsPopover.tsx`.
>     - Updates `CodeJsonViewer.tsx`, `Codeblock.tsx`, and `MarkdownViewer.tsx` to use `copyTextToClipboard`.
>     - Modifies `GenerationOutput.tsx` and `PromptSelectionDialog.tsx` to use `copyTextToClipboard`.
>   - **Utility Function**:
>     - Adds `copyTextToClipboard` in `clipboard.ts` with a fallback for non-secure contexts using `execCommand`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6195316a2e621350ede962c3429cc7f995df2651. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->