### PR TITLE
fix(graph-view): do not JSON parse node names

### DIFF
--- a/web/src/features/trace-graph-view/components/TraceGraphView.tsx
+++ b/web/src/features/trace-graph-view/components/TraceGraphView.tsx
@@ -70,12 +70,7 @@ function parseGraph(params: { agentGraphData: AgentGraphDataResponse[] }): {
   const nodeToParentObservationMap = new Map<string, string>();
 
   agentGraphData.forEach((o) => {
-    const { node: rawNode, step } = o;
-
-    let node = rawNode;
-    try {
-      node = JSON.parse(rawNode);
-    } catch {}
+    const { node, step } = o;
 
     stepToNodeMap.set(step, node);
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove unnecessary JSON parsing of node names in `parseGraph` function in `TraceGraphView.tsx`.
> 
>   - **Behavior**:
>     - Remove JSON parsing of `node` names in `parseGraph` function in `TraceGraphView.tsx`.
>     - Directly assigns `node` from `AgentGraphDataResponse` without parsing.
>   - **Misc**:
>     - Simplifies code by removing try-catch block for JSON parsing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 273ca6016cce942210243686c6e28ad90da435bf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->