### PR TITLE
feat(model-prices): add o1-pro

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1819,5 +1819,35 @@
     },
     "tokenizer_config": null,
     "tokenizer_id": null
+  },
+  {
+    "id": "cmbrold5b000107lbftb9fdoo",
+    "model_name": "o1-pro",
+    "match_pattern": "(?i)^(o1-pro)$",
+    "created_at": "2025-06-10T22:26:54.132Z",
+    "updated_at": "2025-06-10T22:26:54.132Z",
+    "prices": {
+      "input": 150e-6,
+      "output": 600e-6,
+      "output_reasoning_tokens": 600e-6,
+      "output_reasoning": 600e-6
+    },
+    "tokenizer_config": null,
+    "tokenizer_id": null
+  },
+  {
+    "id": "cmbrolpax000207lb3xkedysz",
+    "model_name": "o1-pro-2025-03-19",
+    "match_pattern": "(?i)^(o1-pro-2025-03-19)$",
+    "created_at": "2025-06-10T22:26:54.132Z",
+    "updated_at": "2025-06-10T22:26:54.132Z",
+    "prices": {
+      "input": 150e-6,
+      "output": 600e-6,
+      "output_reasoning_tokens": 600e-6,
+      "output_reasoning": 600e-6
+    },
+    "tokenizer_config": null,
+    "tokenizer_id": null
   }
 ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `o1-pro` and `o1-pro-2025-03-19` models to `default-model-prices.json` with specified pricing but no tokenizer configuration.
> 
>   - **Models Added**:
>     - Added `o1-pro` model with ID `cmbrold5b000107lbftb9fdoo`.
>     - Added `o1-pro-2025-03-19` model with ID `cmbrolpax000207lb3xkedysz`.
>   - **Pricing**:
>     - Both models have the same pricing: `input` at 150e-6, `output` at 600e-6, `output_reasoning_tokens` at 600e-6, and `output_reasoning` at 600e-6.
>   - **Misc**:
>     - No tokenizer configuration or ID provided for these models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6646a6e62eb435b3fdd8b53ef3f9c2bc2f7d0ad2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->