### PR TITLE
chore(cloud): increase user limit on core plan

### DIFF
--- a/web/src/features/entitlements/constants/entitlements.ts
+++ b/web/src/features/entitlements/constants/entitlements.ts
@@ -49,7 +49,7 @@ export const entitlementAccess: Record<
   "cloud:hobby": {
     entitlements: [...cloudAllPlansEntitlements],
     entitlementLimits: {
-      "organization-member-count": 2,
+      "organization-member-count": 3, // 2 acc to billing page, 1 overage possible
       "data-access-days": 30,
       "annotation-queue-count": 1,
       "model-based-evaluations-count-evaluators": 1,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase `organization-member-count` limit from 2 to 3 for `cloud:hobby` plan in `entitlements.ts`.
> 
>   - **Behavior**:
>     - Increase `organization-member-count` limit from 2 to 3 for `cloud:hobby` plan in `entitlements.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e1915c4728d47ea9a18a25c69e0d1e8ee5a208f3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->