### PR TITLE
feat(cloud): add stripe productid of cloud enterprise plan

### DIFF
--- a/web/src/ee/features/billing/utils/stripeProducts.ts
+++ b/web/src/ee/features/billing/utils/stripeProducts.ts
@@ -1,6 +1,10 @@
 import { env } from "@/src/env.mjs";
 import { type Plan } from "@langfuse/shared";
 
+const isTestEnvironment =
+  env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "DEV" ||
+  env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "STAGING";
+
 type StripeProduct = {
   stripeProductId: string;
   mappedPlan: Plan;
@@ -17,11 +21,9 @@ type StripeProduct = {
 // map of planid to plan name
 export const stripeProducts: StripeProduct[] = [
   {
-    stripeProductId:
-      env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "DEV" ||
-      env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "STAGING"
-        ? "prod_RoBuRrXjIUBIJ8" // test
-        : "prod_RoYirvRQ4Kc6po", // live
+    stripeProductId: isTestEnvironment
+      ? "prod_RoBuRrXjIUBIJ8" // test
+      : "prod_RoYirvRQ4Kc6po", // live
     mappedPlan: "cloud:core",
     checkout: {
       title: "Core",
@@ -38,11 +40,9 @@ export const stripeProducts: StripeProduct[] = [
     },
   },
   {
-    stripeProductId:
-      env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "DEV" ||
-      env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "STAGING"
-        ? "prod_QgDNYKXcBfvUQ3" // test
-        : "prod_QhK7UMhrkVeF6R", // live
+    stripeProductId: isTestEnvironment
+      ? "prod_QgDNYKXcBfvUQ3" // test
+      : "prod_QhK7UMhrkVeF6R", // live
     mappedPlan: "cloud:pro",
     checkout: {
       title: "Pro",
@@ -61,11 +61,9 @@ export const stripeProducts: StripeProduct[] = [
     },
   },
   {
-    stripeProductId:
-      env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "DEV" ||
-      env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "STAGING"
-        ? "prod_QgDOxTD64U6KDv" // test
-        : "prod_QhK9qKGH25BTcS", // live
+    stripeProductId: isTestEnvironment
+      ? "prod_QgDOxTD64U6KDv" // test
+      : "prod_QhK9qKGH25BTcS", // live
     mappedPlan: "cloud:team",
     checkout: {
       title: "Pro + Teams Add-on",
@@ -80,6 +78,13 @@ export const stripeProducts: StripeProduct[] = [
         "Data retention management",
       ],
     },
+  },
+  {
+    stripeProductId: isTestEnvironment
+      ? "prod_SToP5nTZpC4yO8" // test
+      : "prod_STnXok7GSSDmyF", // live
+    mappedPlan: "cloud:enterprise",
+    checkout: null,
   },
 ];
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds new Stripe product ID for cloud enterprise plan and refactors environment check in `stripeProducts.ts`.
> 
>   - **Behavior**:
>     - Adds new Stripe product ID for `cloud:enterprise` plan in `stripeProducts.ts`.
>     - `cloud:enterprise` plan has no `checkout` option, indicating no new user subscriptions.
>   - **Refactoring**:
>     - Introduces `isTestEnvironment` constant to determine environment in `stripeProducts.ts`.
>     - Refactors `stripeProductId` assignments to use `isTestEnvironment` in `stripeProducts.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for afa2b0ee6b1aa4de4bc7cf132fc06279c994876f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->