### PR TITLE
fix(TracesTable): stabilize control column definition

### DIFF
--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -981,12 +981,12 @@ export default function TracesTable({
 
   const [columnVisibility, setColumnVisibility] =
     useColumnVisibility<TracesTableRow>(
-      `traceColumnVisibility-${projectId}`,
+      `traceColumnVisibility-${projectId}${hideControls ? "-hideControls" : "-showControls"}`,
       columns,
     );
 
   const [columnOrder, setColumnOrder] = useColumnOrder<TracesTableRow>(
-    "traceColumnOrder",
+    `traceColumnOrder-${projectId}${hideControls ? "-hideControls" : "-showControls"}`,
     columns,
   );
 

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -435,37 +435,35 @@ export default function TracesTable({
     },
   ];
 
-  const controlColumns: LangfuseColumnDef<TracesTableRow>[] = hideControls
-    ? []
-    : [
-        selectActionColumn,
-        {
-          accessorKey: "bookmarked",
-          header: undefined,
-          id: "bookmarked",
-          size: 30,
-          isPinned: true,
-          cell: ({ row }) => {
-            const bookmarked: TracesTableRow["bookmarked"] =
-              row.getValue("bookmarked");
-            const traceId = row.getValue("id");
-            return typeof traceId === "string" &&
-              typeof bookmarked === "boolean" ? (
-              <StarTraceToggle
-                tracesFilter={tracesAllQueryFilter}
-                traceId={traceId}
-                projectId={projectId}
-                value={bookmarked}
-                size="icon-xs"
-              />
-            ) : undefined;
-          },
-          enableSorting: true,
-        },
-      ];
-
   const columns: LangfuseColumnDef<TracesTableRow>[] = [
-    ...controlColumns,
+    selectActionColumn,
+    ...(hideControls
+      ? []
+      : [
+          {
+            accessorKey: "bookmarked",
+            header: undefined,
+            id: "bookmarked",
+            size: 30,
+            isPinned: true,
+            cell: ({ row }: { row: Row<TracesTableRow> }) => {
+              const bookmarked: TracesTableRow["bookmarked"] =
+                row.getValue("bookmarked");
+              const traceId = row.getValue("id");
+              return typeof traceId === "string" &&
+                typeof bookmarked === "boolean" ? (
+                <StarTraceToggle
+                  tracesFilter={tracesAllQueryFilter}
+                  traceId={traceId}
+                  projectId={projectId}
+                  value={bookmarked}
+                  size="icon-xs"
+                />
+              ) : undefined;
+            },
+            enableSorting: true,
+          },
+        ]),
     {
       accessorKey: "timestamp",
       header: "Timestamp",


### PR DESCRIPTION
- Ensured conditional rendering of the bookmarked column remains intact while simplifying the structure.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Simplifies `TracesTable` column structure and stabilizes control column rendering based on `hideControls` flag in `traces.tsx`.
> 
>   - **Behavior**:
>     - Simplifies column structure in `TracesTable` in `traces.tsx` by integrating `controlColumns` directly into `columns`.
>     - Ensures conditional rendering of the `bookmarked` column based on `hideControls` flag.
>   - **State Management**:
>     - Updates `useColumnVisibility` and `useColumnOrder` keys to include `hideControls` state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 05791c0b5aa4b979880c5351e75389e049f809e0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->