### PR TITLE
chore: allow trace deletions on entire history

### DIFF
--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -14,7 +14,11 @@ import { type Row, type RowSelectionState } from "@tanstack/react-table";
 import { useEffect, useMemo, useState } from "react";
 import { NumberParam, useQueryParams, withDefault } from "use-query-params";
 import type Decimal from "decimal.js";
-import { numberFormatter, usdFormatter } from "@/src/utils/numbers";
+import {
+  compactNumberFormatter,
+  numberFormatter,
+  usdFormatter,
+} from "@/src/utils/numbers";
 import { DeleteTraceButton } from "@/src/components/deleteButton";
 import {
   formatAsLabel,
@@ -405,6 +409,12 @@ export default function TracesTable({
     setSelectedRows({});
   };
 
+  const displayCount = totalCountQuery.isLoading ? (
+    <span className="inline-block font-mono">...</span>
+  ) : (
+    compactNumberFormatter(totalCountQuery.data?.totalCount)
+  );
+
   const tableActions: TableAction[] = [
     ...(hasTraceDeletionEntitlement
       ? [
@@ -412,8 +422,7 @@ export default function TracesTable({
             id: "trace-delete",
             type: BatchActionType.Delete,
             label: "Delete Traces",
-            description:
-              "This action permanently deletes traces and cannot be undone. Trace deletion happens asynchronously and may take up to 15 minutes.",
+            description: `This action permanently deletes ${displayCount} traces and cannot be undone. Trace deletion happens asynchronously and may take up to 15 minutes.`,
             accessCheck: {
               scope: "traces:delete",
               entitlement: "trace-deletion",

--- a/worker/src/features/batchAction/handleBatchActionJob.ts
+++ b/worker/src/features/batchAction/handleBatchActionJob.ts
@@ -149,7 +149,6 @@ export const handleBatchActionJob = async (
             cutoffCreatedAt: new Date(cutoffCreatedAt),
             filter: convertDatesInFiltersFromStrings(query.filter ?? []),
             orderBy: query.orderBy,
-            rowLimit: env.BATCH_ACTION_EXPORT_ROW_LIMIT,
           })
         : await getDatabaseReadStream({
             projectId: projectId,
@@ -157,7 +156,6 @@ export const handleBatchActionJob = async (
             filter: convertDatesInFiltersFromStrings(query.filter ?? []),
             orderBy: query.orderBy,
             tableName: tableName,
-            rowLimit: env.BATCH_ACTION_EXPORT_ROW_LIMIT,
           });
 
     // Process stream in database-sized batches


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance trace deletion by displaying count in UI and removing row limit for batch processing.
> 
>   - **Behavior**:
>     - Updates `traces.tsx` to display the number of traces to be deleted in the delete confirmation message using `compactNumberFormatter`.
>     - Removes `rowLimit` from `getTraceIdentifierStream` and `getDatabaseReadStream` calls in `handleBatchActionJob.ts`, allowing processing of entire history.
>   - **UI**:
>     - Adds `compactNumberFormatter` to format large numbers in `traces.tsx`.
>   - **Misc**:
>     - Minor description change in `traces.tsx` for trace deletion action.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1ffe51a12dd620596c08cf962c9fb98d13961ca5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->