### PR TITLE
chore: Dataset run view supports local caching

### DIFF
--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
@@ -48,16 +48,16 @@ export default function Dataset() {
   const [isCreateExperimentDialogOpen, setIsCreateExperimentDialogOpen] =
     useState(false);
   const [selectedMetrics, setSelectedMetrics] = useLocalStorage<string[]>(
-    `${projectId}-dataset-chart-metrics`,
+    `${projectId}-${datasetId-chart-metrics`,
     RESOURCE_METRICS.map((metric) => metric.key),
   );
 
-  const [scoreOptions, setScoreOptions] = useState<
+   const [scoreOptions, setScoreOptions] = useLocalStorage<
     {
       key: string;
       value: string;
     }[]
-  >([]);
+  >(`${projectId}-${datasetId}-score-options`, []);
 
   const dataset = api.datasets.byId.useQuery({
     datasetId,


### PR DESCRIPTION
Dataset run view supports local caching

## What does this PR do?

Dataset run view supports local caching

Fixes # (issue)

<img width="1856" alt="image" src="https://github.com/user-attachments/assets/587c6a4c-81c8-441b-91cf-aa35b3fb9c02" />

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

had check
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds local caching for `selectedMetrics` and `scoreOptions` in dataset run view using `useLocalStorage`.
> 
>   - **Behavior**:
>     - Implements local caching for `selectedMetrics` and `scoreOptions` using `useLocalStorage` in `index.tsx`.
>     - Caches `selectedMetrics` with key `${projectId}-${datasetId}-chart-metrics`.
>     - Caches `scoreOptions` with key `${projectId}-${datasetId}-score-options`.
>   - **Misc**:
>     - Fixes a typo in the local storage key for `selectedMetrics` in `index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 275881902955111c2e1f1184ce29cb49754f5e08. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->