### PR TITLE
fix(trace-graph): validate node existence before selection and handle errors gracefully

### DIFF
--- a/web/src/features/trace-graph-view/components/TraceGraphCanvas.tsx
+++ b/web/src/features/trace-graph-view/components/TraceGraphCanvas.tsx
@@ -183,11 +183,28 @@ export const TraceGraphCanvas: React.FC<TraceGraphCanvasProps> = (props) => {
     if (!network) return;
 
     if (selectedNodeName) {
-      network.selectNodes([selectedNodeName]);
+      // Validate that the node exists before trying to select it
+      const nodeExists = graphData.nodes.includes(selectedNodeName);
+
+      if (nodeExists) {
+        try {
+          network.selectNodes([selectedNodeName]);
+        } catch (error) {
+          console.error("Error selecting node:", selectedNodeName, error);
+          // Fallback to clearing selection
+          network.unselectAll();
+        }
+      } else {
+        console.warn(
+          "Cannot select node that doesn't exist:",
+          selectedNodeName,
+        );
+        network.unselectAll();
+      }
     } else {
       network.unselectAll();
     }
-  }, [selectedNodeName]);
+  }, [selectedNodeName, graphData.nodes]);
 
   if (!graphData.nodes.length) {
     return (

--- a/web/src/features/trace-graph-view/components/TraceGraphView.tsx
+++ b/web/src/features/trace-graph-view/components/TraceGraphView.tsx
@@ -32,8 +32,13 @@ export const TraceGraphView: React.FC<TraceGraphViewProps> = (props) => {
       (o) => o.id === currentObservationId,
     )?.node;
 
-    setSelectedNodeName(nodeName ?? null);
-  }, [currentObservationId, agentGraphData]);
+    // Only set selectedNodeName if the node actually exists in the graph
+    if (nodeName && graph.nodes.includes(nodeName)) {
+      setSelectedNodeName(nodeName);
+    } else {
+      setSelectedNodeName(null);
+    }
+  }, [currentObservationId, agentGraphData, graph.nodes]);
 
   const onCanvasNodeNameChange = useCallback(
     (nodeName: string | null) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Validate node existence before selection and handle errors in `TraceGraphCanvas.tsx` and `TraceGraphView.tsx`.
> 
>   - **Behavior**:
>     - Validate node existence before selection in `TraceGraphCanvas.tsx`.
>     - Handle errors during node selection in `TraceGraphCanvas.tsx` by logging errors and clearing selection.
>     - Ensure `selectedNodeName` is set only if the node exists in `TraceGraphView.tsx`.
>   - **Error Handling**:
>     - Log error if node selection fails in `TraceGraphCanvas.tsx`.
>     - Log warning if attempting to select a non-existent node in `TraceGraphCanvas.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 11dbdbcf8ec663c6f1c3ff1a6be2df2618d4eec5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->