### PR TITLE
fix: propagate searchQuery to deleteMany call

### DIFF
--- a/packages/shared/src/features/batchAction/types.ts
+++ b/packages/shared/src/features/batchAction/types.ts
@@ -20,6 +20,8 @@ export type ActionId = z.infer<typeof ActionIdSchema>;
 export const BatchActionQuerySchema = z.object({
   filter: z.array(singleFilter).nullable(),
   orderBy,
+  searchQuery: z.string().optional(),
+  searchType: z.array(z.enum(["id", "content"])).optional(),
 });
 
 export type BatchActionQuery = z.infer<typeof BatchActionQuerySchema>;

--- a/packages/shared/src/features/batchAction/types.ts
+++ b/packages/shared/src/features/batchAction/types.ts
@@ -2,6 +2,7 @@ import z from "zod";
 import { singleFilter } from "../../interfaces/filters";
 import { orderBy } from "../../interfaces/orderBy";
 import { BatchTableNames } from "../../interfaces/tableNames";
+import { TracingSearchType } from "../../interfaces/search";
 
 /* eslint-disable no-unused-vars */
 export enum BatchActionType {
@@ -21,7 +22,7 @@ export const BatchActionQuerySchema = z.object({
   filter: z.array(singleFilter).nullable(),
   orderBy,
   searchQuery: z.string().optional(),
-  searchType: z.array(z.enum(["id", "content"])).optional(),
+  searchType: z.array(TracingSearchType).optional(),
 });
 
 export type BatchActionQuery = z.infer<typeof BatchActionQuerySchema>;

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -378,6 +378,8 @@ export default function TracesTable({
       query: {
         filter: filterState,
         orderBy: orderByState,
+        searchQuery: searchQuery || undefined,
+        searchType,
       },
       isBatchAction: selectAll,
     });

--- a/worker/src/features/batchAction/handleBatchActionJob.ts
+++ b/worker/src/features/batchAction/handleBatchActionJob.ts
@@ -150,7 +150,7 @@ export const handleBatchActionJob = async (
             filter: convertDatesInFiltersFromStrings(query.filter ?? []),
             orderBy: query.orderBy,
             searchQuery: query.searchQuery ?? undefined,
-            searchType: query.searchType ?? [],
+            searchType: query.searchType ?? ["id" as const],
           })
         : await getDatabaseReadStream({
             projectId: projectId,
@@ -159,7 +159,7 @@ export const handleBatchActionJob = async (
             orderBy: query.orderBy,
             tableName: tableName,
             searchQuery: query.searchQuery ?? undefined,
-            searchType: query.searchType ?? [],
+            searchType: query.searchType ?? ["id" as const],
           });
 
     // Process stream in database-sized batches

--- a/worker/src/features/batchAction/handleBatchActionJob.ts
+++ b/worker/src/features/batchAction/handleBatchActionJob.ts
@@ -149,6 +149,8 @@ export const handleBatchActionJob = async (
             cutoffCreatedAt: new Date(cutoffCreatedAt),
             filter: convertDatesInFiltersFromStrings(query.filter ?? []),
             orderBy: query.orderBy,
+            searchQuery: query.searchQuery ?? undefined,
+            searchType: query.searchType ?? [],
           })
         : await getDatabaseReadStream({
             projectId: projectId,
@@ -156,6 +158,8 @@ export const handleBatchActionJob = async (
             filter: convertDatesInFiltersFromStrings(query.filter ?? []),
             orderBy: query.orderBy,
             tableName: tableName,
+            searchQuery: query.searchQuery ?? undefined,
+            searchType: query.searchType ?? [],
           });
 
     // Process stream in database-sized batches
@@ -205,6 +209,8 @@ export const handleBatchActionJob = async (
             cutoffCreatedAt: new Date(cutoffCreatedAt),
             filter: convertDatesInFiltersFromStrings(query.filter ?? []),
             orderBy: query.orderBy,
+            searchQuery: query.searchQuery ?? undefined,
+            searchType: query.searchType,
             rowLimit: env.LANGFUSE_MAX_HISTORIC_EVAL_CREATION_LIMIT,
           }) // when reading from clickhouse, we only want to read the necessary identifiers.
         : await getDatabaseReadStream({

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -6,6 +6,7 @@ import {
   ScoreDomain,
   evalDatasetFormFilterCols,
   OrderByState,
+  TracingSearchType,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 import {
@@ -86,10 +87,14 @@ export const getDatabaseReadStream = async ({
   filter,
   orderBy,
   cutoffCreatedAt,
+  searchQuery,
+  searchType,
   rowLimit = env.BATCH_EXPORT_ROW_LIMIT,
 }: {
   projectId: string;
   cutoffCreatedAt: Date;
+  searchQuery?: string;
+  searchType?: TracingSearchType[];
   rowLimit?: number;
 } & BatchExportQueryType): Promise<DatabaseReadStream<unknown>> => {
   // Set createdAt cutoff to prevent exporting data that was created after the job was queued
@@ -291,7 +296,8 @@ export const getDatabaseReadStream = async ({
             filter: filter
               ? [...filter, createdAtCutoffFilter]
               : [createdAtCutoffFilter],
-            searchType: ["id" as const],
+            searchQuery,
+            searchType,
             orderBy,
             limit: pageSize,
             page: Math.floor(offset / pageSize),
@@ -473,9 +479,19 @@ export const getTraceIdentifierStream = async (props: {
   cutoffCreatedAt: Date;
   filter: FilterCondition[];
   orderBy: OrderByState;
+  searchQuery?: string;
+  searchType?: TracingSearchType[];
   rowLimit?: number;
 }): Promise<DatabaseReadStream<Array<TraceIdentifiers>>> => {
-  const { projectId, cutoffCreatedAt, filter, orderBy, rowLimit } = props;
+  const {
+    projectId,
+    cutoffCreatedAt,
+    filter,
+    orderBy,
+    searchQuery,
+    searchType,
+    rowLimit,
+  } = props;
 
   const createdAtCutoffFilter: FilterCondition = {
     column: "timestamp",
@@ -495,7 +511,8 @@ export const getTraceIdentifierStream = async (props: {
         filter: filter
           ? [...filter, createdAtCutoffFilter]
           : [createdAtCutoffFilter],
-        searchType: ["id" as const],
+        searchQuery,
+        searchType: searchType ?? ["id" as const],
         orderBy,
         limit: pageSize,
         page: Math.floor(offset / pageSize),

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -297,7 +297,7 @@ export const getDatabaseReadStream = async ({
               ? [...filter, createdAtCutoffFilter]
               : [createdAtCutoffFilter],
             searchQuery,
-            searchType,
+            searchType: searchType ?? ["id" as const],
             orderBy,
             limit: pageSize,
             page: Math.floor(offset / pageSize),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Propagate `searchQuery` and `searchType` to `deleteMany` call for trace deletions, updating schema and tests.
> 
>   - **Behavior**:
>     - Propagate `searchQuery` and `searchType` to `deleteMany` call in `traces.tsx`.
>     - Update `handleBatchActionJob` to handle `searchQuery` and `searchType` for trace deletions.
>   - **Schema**:
>     - Add `searchQuery` and `searchType` to `BatchActionQuerySchema` in `types.ts`.
>   - **Tests**:
>     - Add test for trace deletions with `searchQuery` in `batchAction.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0eccb20bc25f1ca0b605a8f14d1777a0479f9fcd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->