### PR TITLE
chore(ui) Update LLM connection API key message

### DIFF
--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -33,6 +33,7 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import { type useUiCustomization } from "@/src/ee/features/ui-customization/useUiCustomization";
 import { DialogFooter } from "@/src/components/ui/dialog";
 import { DialogBody } from "@/src/components/ui/dialog";
+import { env } from "@/src/env.mjs";
 
 const createFormSchema = (mode: "create" | "update") =>
   z
@@ -447,7 +448,9 @@ export function CreateLLMApiKeyForm({
                 <FormItem>
                   <FormLabel>API Key</FormLabel>
                   <FormDescription>
-                    Your API keys are stored encrypted on our servers.
+                    {env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
+                      ? "Your API keys are stored encrypted on our servers."
+                      : "Your API keys are stored encrypted in your database."}
                   </FormDescription>
                   {currentAdapter === LLMAdapter.VertexAI && (
                     <FormDescription className="text-dark-yellow">
@@ -497,8 +500,11 @@ export function CreateLLMApiKeyForm({
                   <FormLabel>Extra Headers</FormLabel>
                   <FormDescription>
                     Optional additional HTTP headers to include with requests
-                    towards LLM provider. All header values stored encrypted on
-                    our servers.
+                    towards LLM provider. All header values stored encrypted{" "}
+                    {env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
+                      ? "on our servers"
+                      : "in your database"}
+                    .
                   </FormDescription>
 
                   {headerFields.map((header, index) => (


### PR DESCRIPTION
-> Message when adding LLM connection confuses self-hosters: "Your API keys are stored encrypted on our servers."

The text displayed when adding a new LLM Connection was updated in `/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx`. The intention was to differentiate the message for self-hosted Langfuse instances versus Langfuse Cloud.

The `env` object was imported to utilize `env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` for environment detection.

Two specific text instances were modified:
*   The API Key storage message now states:
    *   Cloud: "Your API keys are stored encrypted on our servers."
    *   Self-hosted: "Your API keys are stored encrypted in your database."
*   The Extra Headers storage message now states:
    *   Cloud: "All header values stored encrypted on our servers."
    *   Self-hosted: "All header values stored encrypted in your database."

This ensures self-hosted users are correctly informed that their credentials reside within their own database, aligning the message with the deployment environment. The changes were verified to compile and pass linting.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `CreateLLMApiKeyForm.tsx` to differentiate API key and header storage messages for cloud and self-hosted environments using `env`.
> 
>   - **Behavior**:
>     - Update API Key storage message in `CreateLLMApiKeyForm.tsx` to differentiate between cloud and self-hosted environments using `env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION`.
>     - Cloud: "Your API keys are stored encrypted on our servers."
>     - Self-hosted: "Your API keys are stored encrypted in your database."
>     - Update Extra Headers storage message similarly.
>   - **Environment**:
>     - Import `env` from `env.mjs` to detect environment type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1c06f94849fc3d1dadb825375398d517401dd920. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->