### PR TITLE
style(TagButton): reduce size of spinner icon

### DIFF
--- a/web/src/features/tag/components/TagButton.tsx
+++ b/web/src/features/tag/components/TagButton.tsx
@@ -14,7 +14,7 @@ export const TagButton: React.FC<{
     variant="tertiary"
     size="icon-sm"
     disabled={viewOnly}
-    className={cn(viewOnly && "cursor-default", "h-fit min-h-6")}
+    className={cn(viewOnly && "cursor-default")}
     loading={loading}
   >
     <TagIcon className="mr-1 h-3.5 w-3.5 flex-shrink-0" />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `h-fit min-h-6` from `TagButton` to reduce spinner icon size.
> 
>   - **Style Update**:
>     - In `TagButton.tsx`, removed `h-fit min-h-6` from `className` in `TagButton` component to reduce spinner icon size.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5b073380349717922e05725be7c7c345e8ead2d4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->