### PR TITLE
fix(prompts-api): make updates via API concurrency safe

### DIFF
--- a/packages/shared/src/server/services/PromptService/index.ts
+++ b/packages/shared/src/server/services/PromptService/index.ts
@@ -157,6 +157,12 @@ export class PromptService {
     }
   }
 
+  /**
+   * Lock the cache so reads will go to the database and not to Redis
+   *
+   * This is useful in order to return consistent data during the
+   * invalidation of the cache where we are looping through the relevant cache keys
+   */
   public async lockCache(
     params: Pick<PromptParams, "projectId" | "promptName">,
   ): Promise<void> {

--- a/web/src/features/prompts/server/actions/updatePrompts.ts
+++ b/web/src/features/prompts/server/actions/updatePrompts.ts
@@ -21,80 +21,97 @@ export const updatePrompt = async (params: UpdatePromptParams) => {
   try {
     await promptService.lockCache({ projectId, promptName: promptName });
 
-    const prompt = await promptService.getPrompt({
-      projectId,
-      promptName,
-      version: promptVersion,
-      label: undefined,
-    });
+    const result = prisma.$transaction(async (tx) => {
+      const prompt = (
+        await tx.$queryRaw<
+          Array<{
+            id: string;
+            name: string;
+            version: number;
+            labels: string[];
+          }>
+        >`
+        SELECT
+          *
+        FROM
+          prompts
+        WHERE
+          project_id = ${projectId}
+          AND name = ${promptName}
+          AND version = ${promptVersion} 
+        FOR UPDATE -- Important! This will lock the row for concurrent updates
+      `
+      )[0];
 
-    if (!prompt) {
-      throw new LangfuseNotFoundError(`Prompt not found: ${promptName}`);
-    }
-
-    const newLabelsSet = new Set([...newLabels, ...prompt.labels]);
-    const removedLabels = [];
-
-    // Prompt labels cannot be removed here since the newLabelsSet includes the old labels
-    // Keeping this dependent check below as a safeguard in case the above changes
-    for (const oldLabel of prompt.labels) {
-      if (!newLabelsSet.has(oldLabel)) {
-        removedLabels.push(oldLabel);
+      if (!prompt) {
+        throw new LangfuseNotFoundError(`Prompt not found: ${promptName}`);
       }
-    }
 
-    if (removedLabels.length > 0) {
-      const dependents = await prisma.$queryRaw<
-        {
-          parent_name: string;
-          parent_version: number;
-          child_version: number;
-          child_label: string;
-        }[]
-      >`
-      SELECT
-        p."name" AS "parent_name",
-        p."version" AS "parent_version",
-        pd."child_version" AS "child_version",
-        pd."child_label" AS "child_label"
-      FROM
-        prompt_dependencies pd
-        INNER JOIN prompts p ON p.id = pd.parent_id
-      WHERE
-        p.project_id = ${projectId}
-        AND pd.project_id = ${projectId}
-        AND pd.child_name = ${promptName}
-        AND pd."child_label" IS NOT NULL AND pd."child_label" IN (${Prisma.join(removedLabels)})
-      `;
+      const newLabelsSet = new Set([...newLabels, ...prompt.labels]);
+      const removedLabels = [];
 
-      if (dependents.length > 0) {
-        const dependencyMessages = dependents
-          .map(
-            (d) =>
-              `${d.parent_name} v${d.parent_version} depends on ${promptName} ${d.child_version ? `v${d.child_version}` : d.child_label}`,
-          )
-          .join("\n");
-
-        throw new InvalidRequestError(
-          `Other prompts are depending on the prompt label you are trying to remove:\n\n${dependencyMessages}\n\nPlease delete the dependent prompts first.`,
-        );
+      // Prompt labels cannot be removed here since the newLabelsSet includes the old labels
+      // Keeping this dependent check below as a safeguard in case the above changes
+      for (const oldLabel of prompt.labels) {
+        if (!newLabelsSet.has(oldLabel)) {
+          removedLabels.push(oldLabel);
+        }
       }
-    }
 
-    logger.info(
-      `Setting labels for prompt: ${prompt.id}, ${prompt.name}, ${prompt.version}, ${JSON.stringify(
-        Array.from(newLabelsSet),
-      )}`,
-    );
+      if (removedLabels.length > 0) {
+        const dependents = await tx.$queryRaw<
+          {
+            parent_name: string;
+            parent_version: number;
+            child_version: number;
+            child_label: string;
+          }[]
+        >`
+          SELECT
+            p."name" AS "parent_name",
+            p."version" AS "parent_version",
+            pd."child_version" AS "child_version",
+            pd."child_label" AS "child_label"
+          FROM
+            prompt_dependencies pd
+            INNER JOIN prompts p ON p.id = pd.parent_id
+          WHERE
+            p.project_id = ${projectId}
+            AND pd.project_id = ${projectId}
+            AND pd.child_name = ${promptName}
+            AND pd."child_label" IS NOT NULL AND pd."child_label" IN (${Prisma.join(removedLabels)})
+        `;
 
-    const tx = [
-      ...(await removeLabelsFromPreviousPromptVersions({
-        prisma,
-        projectId,
-        promptName,
-        labelsToRemove: [...new Set(newLabels)],
-      })),
-      prisma.prompt.update({
+        if (dependents.length > 0) {
+          const dependencyMessages = dependents
+            .map(
+              (d) =>
+                `${d.parent_name} v${d.parent_version} depends on ${promptName} ${d.child_version ? `v${d.child_version}` : d.child_label}`,
+            )
+            .join("\n");
+
+          throw new InvalidRequestError(
+            `Other prompts are depending on the prompt label you are trying to remove:\n\n${dependencyMessages}\n\nPlease delete the dependent prompts first.`,
+          );
+        }
+      }
+
+      logger.info(
+        `Setting labels for prompt: ${prompt.id}, ${prompt.name}, ${prompt.version}, ${JSON.stringify(
+          Array.from(newLabelsSet),
+        )}`,
+      );
+
+      await Promise.all(
+        await removeLabelsFromPreviousPromptVersions({
+          prisma: tx,
+          projectId,
+          promptName,
+          labelsToRemove: [...new Set(newLabels)],
+        }),
+      );
+
+      const updatedPrompt = tx.prompt.update({
         where: {
           id: prompt.id,
           projectId,
@@ -104,18 +121,18 @@ export const updatePrompt = async (params: UpdatePromptParams) => {
             set: Array.from(newLabelsSet),
           },
         },
-      }),
-    ];
+      });
+
+      return updatedPrompt;
+    });
 
     await promptService.invalidateCache({ projectId, promptName: promptName });
-
-    const res = await prisma.$transaction(tx);
-
     await promptService.unlockCache({ projectId, promptName: promptName });
 
-    return res[res.length - 1];
+    return result;
   } catch (e) {
     await promptService.unlockCache({ projectId, promptName: promptName });
+
     throw e;
   }
 };

--- a/web/src/features/prompts/server/handlers/promptVersionHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptVersionHandler.ts
@@ -37,6 +37,7 @@ export const promptVersionHandler = withMiddlewares({
         projectId: auth.scope.projectId,
         orgId: auth.scope.orgId,
         apiKeyId: auth.scope.apiKeyId,
+        after: prompt,
       });
 
       logger.info(`Prompt updated ${JSON.stringify(prompt)}`);

--- a/web/src/features/prompts/server/utils/updatePromptLabels.ts
+++ b/web/src/features/prompts/server/utils/updatePromptLabels.ts
@@ -6,7 +6,10 @@ export const removeLabelsFromPreviousPromptVersions = async ({
   promptName,
   labelsToRemove,
 }: {
-  prisma: PrismaClient;
+  prisma: Omit<
+    PrismaClient,
+    "$connect" | "$disconnect" | "$on" | "$transaction" | "$use" | "$extends"
+  >;
   projectId: string;
   promptName: string;
   labelsToRemove: string[];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance concurrency safety for prompt updates via API by adding row-level locking and cache locking mechanisms.
> 
>   - **Concurrency Safety**:
>     - Use row-level locking in `updatePrompt` in `updatePrompts.ts` to prevent concurrent updates.
>     - Add `lockCache` and `unlockCache` methods in `PromptService` to ensure cache consistency during updates.
>   - **Prompt Updates**:
>     - Modify `updatePrompt` in `updatePrompts.ts` to use transactions for updating prompts and checking dependencies.
>     - Update `promptVersionHandler.ts` to include `after` state in audit logs.
>   - **Misc**:
>     - Update `removeLabelsFromPreviousPromptVersions` in `updatePromptLabels.ts` to use a restricted `PrismaClient` type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e94a0c2ae1748bb0d11ea7a8573023cfc3f212cd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->