### PR TITLE
fix(evals): add missing Dialog Body and Footer components

### DIFF
--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -91,6 +91,7 @@ export const PeekViewEvaluatorConfigDetail = ({
           }
           disabled={true}
           shouldWrapVariables={true}
+          useDialog={false}
         />
       </div>
     </div>

--- a/web/src/components/table/peek/peek-evaluator-template-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-template-detail.tsx
@@ -37,6 +37,7 @@ export const PeekViewEvaluatorTemplateDetail = ({
           existingEvalTemplate={template}
           isEditing={false}
           preventRedirect={true}
+          useDialog={false}
         />
       </div>
     </div>

--- a/web/src/features/evals/components/eval-template-detail.tsx
+++ b/web/src/features/evals/components/eval-template-detail.tsx
@@ -119,6 +119,7 @@ export const EvalTemplateDetail = () => {
       ) : isEditing ? (
         <div className="overflow-y-auto p-3 pt-1">
           <EvalTemplateForm
+            useDialog={false}
             projectId={projectId}
             existingEvalTemplate={displayTemplate}
             isEditing={isEditing}
@@ -129,6 +130,7 @@ export const EvalTemplateDetail = () => {
         <div className="grid flex-1 grid-cols-[1fr,auto] overflow-hidden contain-layout">
           <div className="flex max-h-full min-h-0 flex-col overflow-y-auto px-3 pt-1">
             <EvalTemplateForm
+              useDialog={false}
               projectId={projectId}
               existingEvalTemplate={displayTemplate}
               isEditing={isEditing}

--- a/web/src/features/evals/components/eval-templates-table.tsx
+++ b/web/src/features/evals/components/eval-templates-table.tsx
@@ -383,6 +383,7 @@ export default function EvalsTemplateTable({
           <EvalTemplateForm
             projectId={projectId}
             preventRedirect={true}
+            useDialog={true}
             isEditing={true}
             existingEvalTemplate={template.data ?? undefined}
             onFormSuccess={() => {
@@ -412,6 +413,7 @@ export default function EvalsTemplateTable({
           <EvalTemplateForm
             projectId={projectId}
             preventRedirect={true}
+            useDialog={true}
             isEditing={true}
             existingEvalTemplate={
               cloneTemplate.data

--- a/web/src/features/evals/components/evaluator-form.tsx
+++ b/web/src/features/evals/components/evaluator-form.tsx
@@ -5,6 +5,7 @@ import { type PartialConfig } from "@/src/features/evals/types";
 export const EvaluatorForm = (props: {
   projectId: string;
   evalTemplates: EvalTemplate[];
+  useDialog: boolean;
   disabled?: boolean;
   existingEvaluator?: PartialConfig & { evalTemplate: EvalTemplate };
   onFormSuccess?: () => void;
@@ -36,6 +37,7 @@ export const EvaluatorForm = (props: {
         mode={props.mode}
         preventRedirect={props.preventRedirect ?? true}
         preprocessFormValues={props.preprocessFormValues}
+        useDialog={props.useDialog}
       />
     </>
   );

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -446,6 +446,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
                   : undefined
               }
               shouldWrapVariables={true}
+              useDialog={true}
               mode="edit"
               onFormSuccess={() => {
                 setEditConfigId(null);

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -68,6 +68,7 @@ import {
 } from "@/src/features/evals/components/evaluation-prompt-preview";
 import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 import { Skeleton } from "@/src/components/ui/skeleton";
+import { DialogBody, DialogFooter } from "@/src/components/ui/dialog";
 
 // Lazy load TracesTable
 const TracesTable = lazy(
@@ -125,6 +126,7 @@ const TracesPreview = ({
 export const InnerEvaluatorForm = (props: {
   projectId: string;
   evalTemplate: EvalTemplate;
+  useDialog: boolean;
   disabled?: boolean;
   existingEvaluator?: PartialConfig;
   onFormSuccess?: () => void;
@@ -414,6 +416,644 @@ export const InnerEvaluatorForm = (props: {
     </div>
   );
 
+  const formBody = (
+    <div className="grid gap-4">
+      <FormField
+        control={form.control}
+        name="scoreName"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Generated Score Name</FormLabel>
+            <FormControl>
+              <Input {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      {!props.hideTargetSection && (
+        <Card className="flex max-w-full flex-col gap-2 overflow-y-auto p-4">
+          <span className="text-lg font-medium">Target</span>
+          <div className="flex flex-col gap-4">
+            <FormField
+              control={form.control}
+              name="timeScope"
+              render={({ field }) => (
+                <FormItem className="flex-1">
+                  <FormLabel>Evaluator runs on</FormLabel>
+                  <FormControl>
+                    <div className="flex flex-col gap-2">
+                      <div className="items-top flex space-x-2">
+                        <Checkbox
+                          id="newObjects"
+                          checked={field.value.includes("NEW")}
+                          onCheckedChange={(checked) => {
+                            const newValue = checked
+                              ? [...field.value, "NEW"]
+                              : field.value.filter((v) => v !== "NEW");
+                            field.onChange(newValue);
+                          }}
+                          disabled={props.disabled}
+                        />
+                        <div className="grid gap-1.5 leading-none">
+                          <label
+                            htmlFor="newObjects"
+                            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                          >
+                            New{" "}
+                            {form.watch("target") === "trace"
+                              ? "traces"
+                              : "dataset run items"}
+                          </label>
+                        </div>
+                      </div>
+                      <div className="items-top flex space-x-2">
+                        <Checkbox
+                          id="existingObjects"
+                          checked={field.value.includes("EXISTING")}
+                          onCheckedChange={(checked) => {
+                            const newValue = checked
+                              ? [...field.value, "EXISTING"]
+                              : field.value.filter((v) => v !== "EXISTING");
+                            field.onChange(newValue);
+                          }}
+                          disabled={
+                            props.disabled ||
+                            (props.mode === "edit" &&
+                              field.value.includes("EXISTING"))
+                          }
+                        />
+                        <div className="flex items-center gap-1.5 leading-none">
+                          <label
+                            htmlFor="existingObjects"
+                            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                          >
+                            Existing{" "}
+                            {form.watch("target") === "trace"
+                              ? "traces"
+                              : "dataset run items"}
+                          </label>
+                          {field.value.includes("EXISTING") &&
+                            props.mode !== "edit" &&
+                            !props.disabled && (
+                              <ExecutionCountTooltip
+                                projectId={props.projectId}
+                                item={form.watch("target")}
+                                filter={form.watch("filter")}
+                              />
+                            )}
+                        </div>
+                      </div>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="target"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Target data</FormLabel>
+                  <FormControl>
+                    <Tabs
+                      defaultValue="trace"
+                      value={field.value}
+                      onValueChange={(value) => {
+                        const isTrace = isTraceTarget(value);
+                        const langfuseObject: LangfuseObject = isTrace
+                          ? "trace"
+                          : "dataset_item";
+                        const newMapping = form
+                          .getValues("mapping")
+                          .map((field) => ({
+                            ...field,
+                            langfuseObject,
+                          }));
+                        form.setValue("filter", []);
+                        form.setValue("mapping", newMapping);
+                        setAvailableVariables(
+                          isTrace
+                            ? availableTraceEvalVariables
+                            : availableDatasetEvalVariables,
+                        );
+                        field.onChange(value);
+                      }}
+                    >
+                      <TabsList>
+                        <TabsTrigger
+                          value="trace"
+                          disabled={props.disabled || props.mode === "edit"}
+                        >
+                          Live tracing data
+                        </TabsTrigger>
+                        <TabsTrigger
+                          value="dataset"
+                          disabled={props.disabled || props.mode === "edit"}
+                        >
+                          Experiment runs
+                        </TabsTrigger>
+                      </TabsList>
+                    </Tabs>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="filter"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Target filter</FormLabel>
+                  {isTraceTarget(form.watch("target")) ? (
+                    <>
+                      <FormControl>
+                        <div className="max-w-[500px]">
+                          <InlineFilterBuilder
+                            columns={tracesTableColsWithOptions(
+                              traceFilterOptions,
+                              evalTraceTableCols,
+                            )}
+                            filterState={field.value ?? []}
+                            onChange={(
+                              value: z.infer<typeof singleFilter>[],
+                            ) => {
+                              field.onChange(value);
+                              if (router.query.traceId) {
+                                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                                const { traceId, ...otherParams } =
+                                  router.query;
+                                router.replace(
+                                  {
+                                    pathname: router.pathname,
+                                    query: otherParams,
+                                  },
+                                  undefined,
+                                  { shallow: true },
+                                );
+                              }
+                            }}
+                            disabled={props.disabled}
+                            columnsWithCustomSelect={["tags"]}
+                          />
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                    </>
+                  ) : (
+                    <>
+                      <FormControl>
+                        <InlineFilterBuilder
+                          columns={datasetFormFilterColsWithOptions(
+                            datasetFilterOptions,
+                            evalDatasetFormFilterCols,
+                          )}
+                          filterState={field.value ?? []}
+                          onChange={field.onChange}
+                          disabled={props.disabled}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </>
+                  )}
+                </FormItem>
+              )}
+            />
+
+            {form.watch("target") === "trace" && !props.disabled && (
+              <TracesPreview
+                projectId={props.projectId}
+                filterState={form.watch("filter") ?? []}
+              />
+            )}
+
+            <FormField
+              control={form.control}
+              name="sampling"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Sampling</FormLabel>
+                  <FormControl>
+                    <div className="max-w-[500px]">
+                      <Slider
+                        disabled={props.disabled}
+                        min={0}
+                        max={1}
+                        step={0.0001}
+                        value={[field.value]}
+                        onValueChange={(value) => field.onChange(value[0])}
+                        showInput={true}
+                        displayAsPercentage={true}
+                      />
+                    </div>
+                  </FormControl>
+                  <div className="flex flex-col">
+                    <FormDescription className="mt-1 flex flex-row gap-1">
+                      <TimeScopeDescription
+                        projectId={props.projectId}
+                        timeScope={form.watch("timeScope")}
+                        target={
+                          form.watch("target") as "trace" | "dataset_item"
+                        }
+                      />
+                    </FormDescription>
+                  </div>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </Card>
+      )}
+      <Card className="min-w-0 max-w-full p-4">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-lg font-medium">Variable mapping</span>
+        </div>
+        {form.watch("target") === "trace" && !props.disabled && (
+          <FormDescription>
+            Preview of the evaluation prompt with the variables replaced with
+            the first matched trace data subject to the filters.
+          </FormDescription>
+        )}
+        <div className="flex max-w-full flex-col gap-4">
+          <FormField
+            control={form.control}
+            name="mapping"
+            render={() => (
+              <>
+                <div
+                  className={cn(
+                    "my-2 flex max-w-full flex-col gap-2",
+                    !props.shouldWrapVariables && "lg:flex-row",
+                  )}
+                >
+                  {showPreview ? (
+                    traceWithObservations ? (
+                      <EvaluationPromptPreview
+                        evalTemplate={props.evalTemplate}
+                        trace={traceWithObservations}
+                        variableMapping={form.watch("mapping")}
+                        isLoading={isLoading}
+                        className={cn(
+                          "min-h-48",
+                          !props.shouldWrapVariables && "lg:w-2/3",
+                        )}
+                        controlButtons={mappingControlButtons}
+                      />
+                    ) : (
+                      <div className="flex max-h-full min-h-[200px] w-full flex-col gap-1 lg:w-2/3">
+                        <div className="flex flex-row items-end justify-between">
+                          <span className="h-fit px-1 text-start text-sm font-medium">
+                            Evaluation Prompt
+                          </span>
+                          <div className="flex justify-end">
+                            {mappingControlButtons}
+                          </div>
+                        </div>
+                        <div className="flex h-full w-full flex-1 items-center justify-center rounded border">
+                          <p className="text-center text-sm text-muted-foreground">
+                            No trace data found, please adjust filters or switch
+                            to not show preview.
+                          </p>
+                        </div>
+                      </div>
+                    )
+                  ) : (
+                    <JSONView
+                      title={"Evaluation Prompt"}
+                      json={props.evalTemplate.prompt ?? null}
+                      className={cn(
+                        "min-h-48",
+                        !props.shouldWrapVariables && "lg:w-2/3",
+                      )}
+                      codeClassName="flex-1"
+                      collapseStringsAfterLength={null}
+                      controlButtons={mappingControlButtons}
+                    />
+                  )}
+                  <div
+                    className={cn(
+                      "flex flex-col gap-2",
+                      !props.shouldWrapVariables && "lg:w-1/3",
+                    )}
+                  >
+                    {fields.map((mappingField, index) => (
+                      <Card className="flex flex-col gap-2 p-4" key={index}>
+                        <div
+                          className={cn(
+                            "text-sm font-semibold",
+                            getVariableColor(index),
+                          )}
+                        >
+                          {"{{"}
+                          {mappingField.templateVariable}
+                          {"}}"}
+                          <DocPopup
+                            description={
+                              "Variable in the template to be replaced with the mapped data."
+                            }
+                            href={
+                              "https://langfuse.com/docs/scores/model-based-evals"
+                            }
+                          />
+                        </div>
+                        <FormField
+                          control={form.control}
+                          key={`${mappingField.id}-langfuseObject`}
+                          name={`mapping.${index}.langfuseObject`}
+                          render={({ field }) => (
+                            <div className="flex items-center gap-2">
+                              <VariableMappingDescription
+                                title="Object"
+                                description={
+                                  "Langfuse object to retrieve the data from."
+                                }
+                                href={
+                                  "https://langfuse.com/docs/scores/model-based-evals"
+                                }
+                              />
+                              <FormItem className="w-2/3">
+                                <FormControl>
+                                  <Select
+                                    disabled={props.disabled}
+                                    defaultValue={field.value}
+                                    onValueChange={(value) => {
+                                      field.onChange(value);
+                                      form.setValue(
+                                        `mapping.${index}.objectName`,
+                                        undefined,
+                                      );
+                                    }}
+                                  >
+                                    <SelectTrigger>
+                                      <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      {availableVariables.map((evalObject) => (
+                                        <SelectItem
+                                          value={evalObject.id}
+                                          key={evalObject.id}
+                                        >
+                                          {evalObject.display}
+                                        </SelectItem>
+                                      ))}
+                                    </SelectContent>
+                                  </Select>
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            </div>
+                          )}
+                        />
+
+                        {!isTraceOrDatasetObject(
+                          form.watch(`mapping.${index}.langfuseObject`),
+                        ) ? (
+                          <FormField
+                            control={form.control}
+                            key={`${mappingField.id}-objectName`}
+                            name={`mapping.${index}.objectName`}
+                            render={({ field }) => {
+                              const type = String(
+                                form.watch(`mapping.${index}.langfuseObject`),
+                              ).toUpperCase() as ObservationType;
+                              const nameOptions = Array.from(
+                                observationTypeToNames.get(type) ?? [],
+                              );
+                              const isCustomOption =
+                                field.value === "custom" ||
+                                (field.value &&
+                                  !nameOptions.includes(field.value));
+                              return (
+                                <div className="flex items-center gap-2">
+                                  <VariableMappingDescription
+                                    title={"Object Name"}
+                                    description={
+                                      "Name of the Langfuse object to retrieve the data from."
+                                    }
+                                    href={
+                                      "https://langfuse.com/docs/scores/model-based-evals"
+                                    }
+                                  />
+                                  <FormItem className="w-2/3">
+                                    <FormControl>
+                                      {isCustomOption ? (
+                                        <div className="flex flex-col gap-2">
+                                          <Select
+                                            onValueChange={(value) => {
+                                              if (value !== "custom") {
+                                                field.onChange(value);
+                                              }
+                                            }}
+                                            value="custom"
+                                            disabled={props.disabled}
+                                          >
+                                            <SelectTrigger>
+                                              <SelectValue>
+                                                Enter name...
+                                              </SelectValue>
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                              {nameOptions?.map((name) => (
+                                                <SelectItem
+                                                  key={name}
+                                                  value={name}
+                                                >
+                                                  {name}
+                                                </SelectItem>
+                                              ))}
+                                              <SelectItem
+                                                key="custom"
+                                                value="custom"
+                                              >
+                                                Enter name...
+                                              </SelectItem>
+                                            </SelectContent>
+                                          </Select>
+                                          <Input
+                                            value={
+                                              field.value === "custom"
+                                                ? ""
+                                                : field.value || ""
+                                            }
+                                            onChange={(e) =>
+                                              field.onChange(e.target.value)
+                                            }
+                                            placeholder="Enter langfuse object name"
+                                            disabled={props.disabled}
+                                          />
+                                        </div>
+                                      ) : (
+                                        <Select
+                                          {...field}
+                                          value={field.value ?? ""}
+                                          onValueChange={field.onChange}
+                                          disabled={props.disabled}
+                                        >
+                                          <SelectTrigger>
+                                            <SelectValue />
+                                          </SelectTrigger>
+                                          <SelectContent>
+                                            {nameOptions?.map((name) => (
+                                              <SelectItem
+                                                key={name}
+                                                value={name}
+                                              >
+                                                {name}
+                                              </SelectItem>
+                                            ))}
+                                            <SelectItem
+                                              key="custom"
+                                              value="custom"
+                                            >
+                                              Enter name...
+                                            </SelectItem>
+                                          </SelectContent>
+                                        </Select>
+                                      )}
+                                    </FormControl>
+                                    <FormMessage />
+                                  </FormItem>
+                                </div>
+                              );
+                            }}
+                          />
+                        ) : undefined}
+
+                        <FormField
+                          control={form.control}
+                          key={`${mappingField.id}-selectedColumnId`}
+                          name={`mapping.${index}.selectedColumnId`}
+                          render={({ field }) => (
+                            <div className="flex items-center gap-2">
+                              <VariableMappingDescription
+                                title={"Object Variable"}
+                                description={
+                                  "Variable on the Langfuse object to insert into the template."
+                                }
+                                href={
+                                  "https://langfuse.com/docs/scores/model-based-evals"
+                                }
+                              />
+                              <FormItem className="w-2/3">
+                                <FormControl>
+                                  <Select
+                                    disabled={props.disabled}
+                                    defaultValue={field.value ?? undefined}
+                                    onValueChange={(value) => {
+                                      const availableColumns =
+                                        availableVariables.find(
+                                          (evalObject) =>
+                                            evalObject.id ===
+                                            form.watch(
+                                              `mapping.${index}.langfuseObject`,
+                                            ),
+                                        )?.availableColumns;
+
+                                      const column = availableColumns?.find(
+                                        (column) => column.id === value,
+                                      );
+
+                                      field.onChange(column?.id);
+                                    }}
+                                  >
+                                    <SelectTrigger>
+                                      <SelectValue placeholder="Object type" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      {availableVariables
+                                        .find(
+                                          (evalObject) =>
+                                            evalObject.id ===
+                                            form.watch(
+                                              `mapping.${index}.langfuseObject`,
+                                            ),
+                                        )
+                                        ?.availableColumns.map((column) => (
+                                          <SelectItem
+                                            value={column.id}
+                                            key={column.id}
+                                          >
+                                            {column.name}
+                                          </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                  </Select>
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            </div>
+                          )}
+                        />
+                        {fieldHasJsonSelectorOption(
+                          form.watch(`mapping.${index}.selectedColumnId`),
+                        ) ? (
+                          <FormField
+                            control={form.control}
+                            key={`${mappingField.id}-jsonSelector`}
+                            name={`mapping.${index}.jsonSelector`}
+                            render={({ field }) => (
+                              <div className="flex items-center gap-2">
+                                <VariableMappingDescription
+                                  title={"JsonPath"}
+                                  description={
+                                    "Optional selection: Use JsonPath syntax to select from a JSON object stored on a trace. If not selected, we will pass the entire object into the prompt."
+                                  }
+                                  href={
+                                    "https://langfuse.com/docs/scores/model-based-evals"
+                                  }
+                                />
+                                <FormItem className="w-2/3">
+                                  <FormControl>
+                                    <Input
+                                      {...field}
+                                      value={field.value ?? ""}
+                                      disabled={props.disabled}
+                                      placeholder="Optional"
+                                    />
+                                  </FormControl>
+                                  <FormMessage />
+                                </FormItem>
+                              </div>
+                            )}
+                          />
+                        ) : undefined}
+                      </Card>
+                    ))}
+                  </div>
+                </div>
+                <FormMessage />
+              </>
+            )}
+          />
+        </div>
+      </Card>
+    </div>
+  );
+
+  const formFooter = (
+    <>
+      {!props.disabled ? (
+        <Button
+          type="submit"
+          loading={createJobMutation.isLoading || updateJobMutation.isLoading}
+          className="mt-3"
+        >
+          Execute
+        </Button>
+      ) : null}
+      {formError ? (
+        <p className="text-red text-center">
+          <span className="font-bold">Error:</span> {formError}
+        </p>
+      ) : null}
+    </>
+  );
+
   return (
     <Form {...form}>
       <form
@@ -421,642 +1061,14 @@ export const InnerEvaluatorForm = (props: {
         onSubmit={form.handleSubmit(onSubmit)}
         className="flex w-full flex-col gap-4"
       >
-        <div className="grid gap-4">
-          <FormField
-            control={form.control}
-            name="scoreName"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Generated Score Name</FormLabel>
-                <FormControl>
-                  <Input {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          {!props.hideTargetSection && (
-            <Card className="flex max-w-full flex-col gap-2 overflow-y-auto p-4">
-              <span className="text-lg font-medium">Target</span>
-              <div className="flex flex-col gap-4">
-                <FormField
-                  control={form.control}
-                  name="timeScope"
-                  render={({ field }) => (
-                    <FormItem className="flex-1">
-                      <FormLabel>Evaluator runs on</FormLabel>
-                      <FormControl>
-                        <div className="flex flex-col gap-2">
-                          <div className="items-top flex space-x-2">
-                            <Checkbox
-                              id="newObjects"
-                              checked={field.value.includes("NEW")}
-                              onCheckedChange={(checked) => {
-                                const newValue = checked
-                                  ? [...field.value, "NEW"]
-                                  : field.value.filter((v) => v !== "NEW");
-                                field.onChange(newValue);
-                              }}
-                              disabled={props.disabled}
-                            />
-                            <div className="grid gap-1.5 leading-none">
-                              <label
-                                htmlFor="newObjects"
-                                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                              >
-                                New{" "}
-                                {form.watch("target") === "trace"
-                                  ? "traces"
-                                  : "dataset run items"}
-                              </label>
-                            </div>
-                          </div>
-                          <div className="items-top flex space-x-2">
-                            <Checkbox
-                              id="existingObjects"
-                              checked={field.value.includes("EXISTING")}
-                              onCheckedChange={(checked) => {
-                                const newValue = checked
-                                  ? [...field.value, "EXISTING"]
-                                  : field.value.filter((v) => v !== "EXISTING");
-                                field.onChange(newValue);
-                              }}
-                              disabled={
-                                props.disabled ||
-                                (props.mode === "edit" &&
-                                  field.value.includes("EXISTING"))
-                              }
-                            />
-                            <div className="flex items-center gap-1.5 leading-none">
-                              <label
-                                htmlFor="existingObjects"
-                                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                              >
-                                Existing{" "}
-                                {form.watch("target") === "trace"
-                                  ? "traces"
-                                  : "dataset run items"}
-                              </label>
-                              {field.value.includes("EXISTING") &&
-                                props.mode !== "edit" &&
-                                !props.disabled && (
-                                  <ExecutionCountTooltip
-                                    projectId={props.projectId}
-                                    item={form.watch("target")}
-                                    filter={form.watch("filter")}
-                                  />
-                                )}
-                            </div>
-                          </div>
-                        </div>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
+        {props.useDialog ? <DialogBody>{formBody}</DialogBody> : formBody}
 
-                <FormField
-                  control={form.control}
-                  name="target"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Target data</FormLabel>
-                      <FormControl>
-                        <Tabs
-                          defaultValue="trace"
-                          value={field.value}
-                          onValueChange={(value) => {
-                            const isTrace = isTraceTarget(value);
-                            const langfuseObject: LangfuseObject = isTrace
-                              ? "trace"
-                              : "dataset_item";
-                            const newMapping = form
-                              .getValues("mapping")
-                              .map((field) => ({
-                                ...field,
-                                langfuseObject,
-                              }));
-                            form.setValue("filter", []);
-                            form.setValue("mapping", newMapping);
-                            setAvailableVariables(
-                              isTrace
-                                ? availableTraceEvalVariables
-                                : availableDatasetEvalVariables,
-                            );
-                            field.onChange(value);
-                          }}
-                        >
-                          <TabsList>
-                            <TabsTrigger
-                              value="trace"
-                              disabled={props.disabled || props.mode === "edit"}
-                            >
-                              Live tracing data
-                            </TabsTrigger>
-                            <TabsTrigger
-                              value="dataset"
-                              disabled={props.disabled || props.mode === "edit"}
-                            >
-                              Experiment runs
-                            </TabsTrigger>
-                          </TabsList>
-                        </Tabs>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="filter"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Target filter</FormLabel>
-                      {isTraceTarget(form.watch("target")) ? (
-                        <>
-                          <FormControl>
-                            <div className="max-w-[500px]">
-                              <InlineFilterBuilder
-                                columns={tracesTableColsWithOptions(
-                                  traceFilterOptions,
-                                  evalTraceTableCols,
-                                )}
-                                filterState={field.value ?? []}
-                                onChange={(
-                                  value: z.infer<typeof singleFilter>[],
-                                ) => {
-                                  field.onChange(value);
-                                  if (router.query.traceId) {
-                                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                                    const { traceId, ...otherParams } =
-                                      router.query;
-                                    router.replace(
-                                      {
-                                        pathname: router.pathname,
-                                        query: otherParams,
-                                      },
-                                      undefined,
-                                      { shallow: true },
-                                    );
-                                  }
-                                }}
-                                disabled={props.disabled}
-                                columnsWithCustomSelect={["tags"]}
-                              />
-                            </div>
-                          </FormControl>
-                          <FormMessage />
-                        </>
-                      ) : (
-                        <>
-                          <FormControl>
-                            <InlineFilterBuilder
-                              columns={datasetFormFilterColsWithOptions(
-                                datasetFilterOptions,
-                                evalDatasetFormFilterCols,
-                              )}
-                              filterState={field.value ?? []}
-                              onChange={field.onChange}
-                              disabled={props.disabled}
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </>
-                      )}
-                    </FormItem>
-                  )}
-                />
-
-                {form.watch("target") === "trace" && !props.disabled && (
-                  <TracesPreview
-                    projectId={props.projectId}
-                    filterState={form.watch("filter") ?? []}
-                  />
-                )}
-
-                <FormField
-                  control={form.control}
-                  name="sampling"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Sampling</FormLabel>
-                      <FormControl>
-                        <div className="max-w-[500px]">
-                          <Slider
-                            disabled={props.disabled}
-                            min={0}
-                            max={1}
-                            step={0.0001}
-                            value={[field.value]}
-                            onValueChange={(value) => field.onChange(value[0])}
-                            showInput={true}
-                            displayAsPercentage={true}
-                          />
-                        </div>
-                      </FormControl>
-                      <div className="flex flex-col">
-                        <FormDescription className="mt-1 flex flex-row gap-1">
-                          <TimeScopeDescription
-                            projectId={props.projectId}
-                            timeScope={form.watch("timeScope")}
-                            target={
-                              form.watch("target") as "trace" | "dataset_item"
-                            }
-                          />
-                        </FormDescription>
-                      </div>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-            </Card>
-          )}
-          <Card className="min-w-0 max-w-full p-4">
-            <div className="mb-2 flex items-center justify-between">
-              <span className="text-lg font-medium">Variable mapping</span>
-            </div>
-            {form.watch("target") === "trace" && !props.disabled && (
-              <FormDescription>
-                Preview of the evaluation prompt with the variables replaced
-                with the first matched trace data subject to the filters.
-              </FormDescription>
-            )}
-            <div className="flex max-w-full flex-col gap-4">
-              <FormField
-                control={form.control}
-                name="mapping"
-                render={() => (
-                  <>
-                    <div
-                      className={cn(
-                        "my-2 flex max-w-full flex-col gap-2",
-                        !props.shouldWrapVariables && "lg:flex-row",
-                      )}
-                    >
-                      {showPreview ? (
-                        traceWithObservations ? (
-                          <EvaluationPromptPreview
-                            evalTemplate={props.evalTemplate}
-                            trace={traceWithObservations}
-                            variableMapping={form.watch("mapping")}
-                            isLoading={isLoading}
-                            className={cn(
-                              "min-h-48",
-                              !props.shouldWrapVariables && "lg:w-2/3",
-                            )}
-                            controlButtons={mappingControlButtons}
-                          />
-                        ) : (
-                          <div className="flex max-h-full min-h-[200px] w-full flex-col gap-1 lg:w-2/3">
-                            <div className="flex flex-row items-end justify-between">
-                              <span className="h-fit px-1 text-start text-sm font-medium">
-                                Evaluation Prompt
-                              </span>
-                              <div className="flex justify-end">
-                                {mappingControlButtons}
-                              </div>
-                            </div>
-                            <div className="flex h-full w-full flex-1 items-center justify-center rounded border">
-                              <p className="text-center text-sm text-muted-foreground">
-                                No trace data found, please adjust filters or
-                                switch to not show preview.
-                              </p>
-                            </div>
-                          </div>
-                        )
-                      ) : (
-                        <JSONView
-                          title={"Evaluation Prompt"}
-                          json={props.evalTemplate.prompt ?? null}
-                          className={cn(
-                            "min-h-48",
-                            !props.shouldWrapVariables && "lg:w-2/3",
-                          )}
-                          codeClassName="flex-1"
-                          collapseStringsAfterLength={null}
-                          controlButtons={mappingControlButtons}
-                        />
-                      )}
-                      <div
-                        className={cn(
-                          "flex flex-col gap-2",
-                          !props.shouldWrapVariables && "lg:w-1/3",
-                        )}
-                      >
-                        {fields.map((mappingField, index) => (
-                          <Card className="flex flex-col gap-2 p-4" key={index}>
-                            <div
-                              className={cn(
-                                "text-sm font-semibold",
-                                getVariableColor(index),
-                              )}
-                            >
-                              {"{{"}
-                              {mappingField.templateVariable}
-                              {"}}"}
-                              <DocPopup
-                                description={
-                                  "Variable in the template to be replaced with the mapped data."
-                                }
-                                href={
-                                  "https://langfuse.com/docs/scores/model-based-evals"
-                                }
-                              />
-                            </div>
-                            <FormField
-                              control={form.control}
-                              key={`${mappingField.id}-langfuseObject`}
-                              name={`mapping.${index}.langfuseObject`}
-                              render={({ field }) => (
-                                <div className="flex items-center gap-2">
-                                  <VariableMappingDescription
-                                    title="Object"
-                                    description={
-                                      "Langfuse object to retrieve the data from."
-                                    }
-                                    href={
-                                      "https://langfuse.com/docs/scores/model-based-evals"
-                                    }
-                                  />
-                                  <FormItem className="w-2/3">
-                                    <FormControl>
-                                      <Select
-                                        disabled={props.disabled}
-                                        defaultValue={field.value}
-                                        onValueChange={(value) => {
-                                          field.onChange(value);
-                                          form.setValue(
-                                            `mapping.${index}.objectName`,
-                                            undefined,
-                                          );
-                                        }}
-                                      >
-                                        <SelectTrigger>
-                                          <SelectValue />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                          {availableVariables.map(
-                                            (evalObject) => (
-                                              <SelectItem
-                                                value={evalObject.id}
-                                                key={evalObject.id}
-                                              >
-                                                {evalObject.display}
-                                              </SelectItem>
-                                            ),
-                                          )}
-                                        </SelectContent>
-                                      </Select>
-                                    </FormControl>
-                                    <FormMessage />
-                                  </FormItem>
-                                </div>
-                              )}
-                            />
-
-                            {!isTraceOrDatasetObject(
-                              form.watch(`mapping.${index}.langfuseObject`),
-                            ) ? (
-                              <FormField
-                                control={form.control}
-                                key={`${mappingField.id}-objectName`}
-                                name={`mapping.${index}.objectName`}
-                                render={({ field }) => {
-                                  const type = String(
-                                    form.watch(
-                                      `mapping.${index}.langfuseObject`,
-                                    ),
-                                  ).toUpperCase() as ObservationType;
-                                  const nameOptions = Array.from(
-                                    observationTypeToNames.get(type) ?? [],
-                                  );
-                                  const isCustomOption =
-                                    field.value === "custom" ||
-                                    (field.value &&
-                                      !nameOptions.includes(field.value));
-                                  return (
-                                    <div className="flex items-center gap-2">
-                                      <VariableMappingDescription
-                                        title={"Object Name"}
-                                        description={
-                                          "Name of the Langfuse object to retrieve the data from."
-                                        }
-                                        href={
-                                          "https://langfuse.com/docs/scores/model-based-evals"
-                                        }
-                                      />
-                                      <FormItem className="w-2/3">
-                                        <FormControl>
-                                          {isCustomOption ? (
-                                            <div className="flex flex-col gap-2">
-                                              <Select
-                                                onValueChange={(value) => {
-                                                  if (value !== "custom") {
-                                                    field.onChange(value);
-                                                  }
-                                                }}
-                                                value="custom"
-                                                disabled={props.disabled}
-                                              >
-                                                <SelectTrigger>
-                                                  <SelectValue>
-                                                    Enter name...
-                                                  </SelectValue>
-                                                </SelectTrigger>
-                                                <SelectContent>
-                                                  {nameOptions?.map((name) => (
-                                                    <SelectItem
-                                                      key={name}
-                                                      value={name}
-                                                    >
-                                                      {name}
-                                                    </SelectItem>
-                                                  ))}
-                                                  <SelectItem
-                                                    key="custom"
-                                                    value="custom"
-                                                  >
-                                                    Enter name...
-                                                  </SelectItem>
-                                                </SelectContent>
-                                              </Select>
-                                              <Input
-                                                value={
-                                                  field.value === "custom"
-                                                    ? ""
-                                                    : field.value || ""
-                                                }
-                                                onChange={(e) =>
-                                                  field.onChange(e.target.value)
-                                                }
-                                                placeholder="Enter langfuse object name"
-                                                disabled={props.disabled}
-                                              />
-                                            </div>
-                                          ) : (
-                                            <Select
-                                              {...field}
-                                              value={field.value ?? ""}
-                                              onValueChange={field.onChange}
-                                              disabled={props.disabled}
-                                            >
-                                              <SelectTrigger>
-                                                <SelectValue />
-                                              </SelectTrigger>
-                                              <SelectContent>
-                                                {nameOptions?.map((name) => (
-                                                  <SelectItem
-                                                    key={name}
-                                                    value={name}
-                                                  >
-                                                    {name}
-                                                  </SelectItem>
-                                                ))}
-                                                <SelectItem
-                                                  key="custom"
-                                                  value="custom"
-                                                >
-                                                  Enter name...
-                                                </SelectItem>
-                                              </SelectContent>
-                                            </Select>
-                                          )}
-                                        </FormControl>
-                                        <FormMessage />
-                                      </FormItem>
-                                    </div>
-                                  );
-                                }}
-                              />
-                            ) : undefined}
-
-                            <FormField
-                              control={form.control}
-                              key={`${mappingField.id}-selectedColumnId`}
-                              name={`mapping.${index}.selectedColumnId`}
-                              render={({ field }) => (
-                                <div className="flex items-center gap-2">
-                                  <VariableMappingDescription
-                                    title={"Object Variable"}
-                                    description={
-                                      "Variable on the Langfuse object to insert into the template."
-                                    }
-                                    href={
-                                      "https://langfuse.com/docs/scores/model-based-evals"
-                                    }
-                                  />
-                                  <FormItem className="w-2/3">
-                                    <FormControl>
-                                      <Select
-                                        disabled={props.disabled}
-                                        defaultValue={field.value ?? undefined}
-                                        onValueChange={(value) => {
-                                          const availableColumns =
-                                            availableVariables.find(
-                                              (evalObject) =>
-                                                evalObject.id ===
-                                                form.watch(
-                                                  `mapping.${index}.langfuseObject`,
-                                                ),
-                                            )?.availableColumns;
-
-                                          const column = availableColumns?.find(
-                                            (column) => column.id === value,
-                                          );
-
-                                          field.onChange(column?.id);
-                                        }}
-                                      >
-                                        <SelectTrigger>
-                                          <SelectValue placeholder="Object type" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                          {availableVariables
-                                            .find(
-                                              (evalObject) =>
-                                                evalObject.id ===
-                                                form.watch(
-                                                  `mapping.${index}.langfuseObject`,
-                                                ),
-                                            )
-                                            ?.availableColumns.map((column) => (
-                                              <SelectItem
-                                                value={column.id}
-                                                key={column.id}
-                                              >
-                                                {column.name}
-                                              </SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                      </Select>
-                                    </FormControl>
-                                    <FormMessage />
-                                  </FormItem>
-                                </div>
-                              )}
-                            />
-                            {fieldHasJsonSelectorOption(
-                              form.watch(`mapping.${index}.selectedColumnId`),
-                            ) ? (
-                              <FormField
-                                control={form.control}
-                                key={`${mappingField.id}-jsonSelector`}
-                                name={`mapping.${index}.jsonSelector`}
-                                render={({ field }) => (
-                                  <div className="flex items-center gap-2">
-                                    <VariableMappingDescription
-                                      title={"JsonPath"}
-                                      description={
-                                        "Optional selection: Use JsonPath syntax to select from a JSON object stored on a trace. If not selected, we will pass the entire object into the prompt."
-                                      }
-                                      href={
-                                        "https://langfuse.com/docs/scores/model-based-evals"
-                                      }
-                                    />
-                                    <FormItem className="w-2/3">
-                                      <FormControl>
-                                        <Input
-                                          {...field}
-                                          value={field.value ?? ""}
-                                          disabled={props.disabled}
-                                          placeholder="Optional"
-                                        />
-                                      </FormControl>
-                                      <FormMessage />
-                                    </FormItem>
-                                  </div>
-                                )}
-                              />
-                            ) : undefined}
-                          </Card>
-                        ))}
-                      </div>
-                    </div>
-                    <FormMessage />
-                  </>
-                )}
-              />
-            </div>
-          </Card>
-        </div>
-
-        {!props.disabled ? (
-          <Button
-            type="submit"
-            loading={createJobMutation.isLoading || updateJobMutation.isLoading}
-            className="mt-3"
-          >
-            Execute
-          </Button>
-        ) : null}
+        {props.useDialog ? (
+          <DialogFooter>{formFooter}</DialogFooter>
+        ) : (
+          <div className="mt-4 flex flex-row justify-end">{formFooter}</div>
+        )}
       </form>
-      {formError ? (
-        <p className="text-red text-center">
-          <span className="font-bold">Error:</span> {formError}
-        </p>
-      ) : null}
     </Form>
   );
 };

--- a/web/src/features/evals/components/run-evaluator-form.tsx
+++ b/web/src/features/evals/components/run-evaluator-form.tsx
@@ -20,6 +20,7 @@ export function RunEvaluatorForm({
         evalTemplates={evalTemplates}
         templateId={evaluatorId}
         preventRedirect={false}
+        useDialog={false}
       />
     </Card>
   );

--- a/web/src/features/evals/components/select-evaluator-list.tsx
+++ b/web/src/features/evals/components/select-evaluator-list.tsx
@@ -121,6 +121,7 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
             projectId={projectId}
             preventRedirect={true}
             isEditing={true}
+            useDialog={true}
             onFormSuccess={(newTemplate) => {
               setIsCreateTemplateOpen(false);
               void utils.evals.allTemplates.invalidate();

--- a/web/src/features/evals/components/template-form.tsx
+++ b/web/src/features/evals/components/template-form.tsx
@@ -46,6 +46,7 @@ type PartialEvalTemplate = Omit<
 
 export const EvalTemplateForm = (props: {
   projectId: string;
+  useDialog: boolean;
   existingEvalTemplate?: PartialEvalTemplate;
   onFormSuccess?: (template?: EvalTemplate) => void;
   onBeforeSubmit?: (
@@ -149,6 +150,7 @@ export type EvalTemplateFormPreFill = {
 
 export const InnerEvalTemplateForm = (props: {
   projectId: string;
+  useDialog: boolean;
   // pre-filled values from langfuse-defined template or template from db
   preFilledFormValues?: EvalTemplateFormPreFill;
   // template to be updated
@@ -345,6 +347,190 @@ export const InnerEvalTemplateForm = (props: {
         }
       });
   }
+
+  const formBody = (
+    <>
+      {!props.existingEvalTemplateId ? (
+        <>
+          <div className="col-span-1 row-span-1 lg:col-span-2">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <>
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder="Select a template name" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                </>
+              )}
+            />
+          </div>
+          <div className="lg:col-span-0 col-span-1 row-span-1"></div>
+        </>
+      ) : undefined}
+
+      {/* Model Selection Section */}
+      <Card>
+        <CardContent>
+          <p className="my-2 font-semibold">Model</p>
+          <FormField
+            control={form.control}
+            name="shouldUseDefaultModel"
+            render={({ field }) => (
+              <FormItem className="mt-3 flex flex-row items-center space-x-3 space-y-0">
+                <FormControl>
+                  <Checkbox
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    disabled={!props.isEditing}
+                  />
+                </FormControl>
+                <div className="space-y-0 leading-none">
+                  <FormLabel>Use default evaluation model</FormLabel>
+                  <FormDescription className="text-xs">
+                    <ManageDefaultEvalModel
+                      projectId={props.projectId}
+                      variant="color-coded"
+                      setUpMessage="No default model set. Set up default evaluation model"
+                      className="text-sm font-normal"
+                    />
+                  </FormDescription>
+                </div>
+              </FormItem>
+            )}
+          />
+          {/* Only show model parameters if using custom model */}
+          {!useDefaultModel &&
+            (!props.isEditing && !isCustomModelValid ? (
+              <div className="mt-2 flex items-center space-x-1 text-sm text-destructive">
+                <AlertCircle className="h-4 w-4" />
+                <p>
+                  This evaluator is configured to use{" "}
+                  {modelParams.provider.value}s models but no API key exists.
+                  Add a key or choose another provider.
+                </p>
+              </div>
+            ) : (
+              <ModelParameters
+                customHeader={
+                  <p className="text-sm font-medium leading-none">
+                    Custom model configuration
+                  </p>
+                }
+                {...{
+                  modelParams,
+                  availableModels,
+                  availableProviders,
+                  updateModelParamValue: updateModelParamValue,
+                  setModelParamEnabled,
+                  modelParamsDescription:
+                    "Select a model which supports function calling.",
+                }}
+                formDisabled={!props.isEditing}
+              />
+            ))}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-6">
+          <div className="space-y-2">
+            <p className="my-2 font-semibold">Prompt</p>
+            <FormField
+              control={form.control}
+              name="prompt"
+              render={({ field }) => (
+                <>
+                  <FormItem>
+                    <FormLabel>Evaluation prompt</FormLabel>
+                    <FormDescription>
+                      Define your llm-as-a-judge evaluation template. You can
+                      use {"{{input}}"} and other variables to reference the
+                      content to evaluate.
+                    </FormDescription>
+                    <FormControl>
+                      <CodeMirrorEditor
+                        value={field.value}
+                        onChange={field.onChange}
+                        editable={props.isEditing}
+                        mode="prompt"
+                        minHeight={200}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                    <PromptVariableListPreview
+                      variables={extractedVariables ?? []}
+                    />
+                  </FormItem>
+                </>
+              )}
+            />
+          </div>
+
+          <FormField
+            control={form.control}
+            name="outputReasoning"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Score reasoning prompt</FormLabel>
+                <FormDescription>
+                  Define how the LLM should explain its evaluation. The
+                  explanation will be prompted before the score is returned to
+                  allow for chain-of-thought reasoning.
+                </FormDescription>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="outputScore"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Score range prompt</FormLabel>
+                <FormDescription>
+                  Define how the LLM should return the evaluation score in
+                  natural language. Needs to yield a numeric value.
+                </FormDescription>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </CardContent>
+      </Card>
+    </>
+  );
+
+  const formFooter = (
+    <>
+      {props.isEditing && (
+        <Button
+          type="submit"
+          loading={createEvalTemplateMutation.isLoading}
+          className="w-full"
+        >
+          Save
+        </Button>
+      )}
+      {formError ? (
+        <p className="text-red text-center">
+          <span className="font-bold">Error:</span> {formError}
+        </p>
+      ) : null}
+    </>
+  );
+
   return (
     <Form {...form}>
       <form
@@ -352,187 +538,13 @@ export const InnerEvalTemplateForm = (props: {
         onSubmit={form.handleSubmit(onSubmit)}
         className="mt-2 space-y-4"
       >
-        <DialogBody>
-          {!props.existingEvalTemplateId ? (
-            <>
-              <div className="col-span-1 row-span-1 lg:col-span-2">
-                <FormField
-                  control={form.control}
-                  name="name"
-                  render={({ field }) => (
-                    <>
-                      <FormItem>
-                        <FormLabel>Name</FormLabel>
-                        <FormControl>
-                          <Input
-                            {...field}
-                            placeholder="Select a template name"
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    </>
-                  )}
-                />
-              </div>
-              <div className="lg:col-span-0 col-span-1 row-span-1"></div>
-            </>
-          ) : undefined}
+        {props.useDialog ? <DialogBody>{formBody}</DialogBody> : formBody}
 
-          {/* Model Selection Section */}
-          <Card>
-            <CardContent>
-              <p className="my-2 font-semibold">Model</p>
-              <FormField
-                control={form.control}
-                name="shouldUseDefaultModel"
-                render={({ field }) => (
-                  <FormItem className="mt-3 flex flex-row items-center space-x-3 space-y-0">
-                    <FormControl>
-                      <Checkbox
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                        disabled={!props.isEditing}
-                      />
-                    </FormControl>
-                    <div className="space-y-0 leading-none">
-                      <FormLabel>Use default evaluation model</FormLabel>
-                      <FormDescription className="text-xs">
-                        <ManageDefaultEvalModel
-                          projectId={props.projectId}
-                          variant="color-coded"
-                          setUpMessage="No default model set. Set up default evaluation model"
-                          className="text-sm font-normal"
-                        />
-                      </FormDescription>
-                    </div>
-                  </FormItem>
-                )}
-              />
-              {/* Only show model parameters if using custom model */}
-              {!useDefaultModel &&
-                (!props.isEditing && !isCustomModelValid ? (
-                  <div className="mt-2 flex items-center space-x-1 text-sm text-destructive">
-                    <AlertCircle className="h-4 w-4" />
-                    <p>
-                      This evaluator is configured to use{" "}
-                      {modelParams.provider.value}s models but no API key
-                      exists. Add a key or choose another provider.
-                    </p>
-                  </div>
-                ) : (
-                  <ModelParameters
-                    customHeader={
-                      <p className="text-sm font-medium leading-none">
-                        Custom model configuration
-                      </p>
-                    }
-                    {...{
-                      modelParams,
-                      availableModels,
-                      availableProviders,
-                      updateModelParamValue: updateModelParamValue,
-                      setModelParamEnabled,
-                      modelParamsDescription:
-                        "Select a model which supports function calling.",
-                    }}
-                    formDisabled={!props.isEditing}
-                  />
-                ))}
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardContent className="space-y-6">
-              <div className="space-y-2">
-                <p className="my-2 font-semibold">Prompt</p>
-                <FormField
-                  control={form.control}
-                  name="prompt"
-                  render={({ field }) => (
-                    <>
-                      <FormItem>
-                        <FormLabel>Evaluation prompt</FormLabel>
-                        <FormDescription>
-                          Define your llm-as-a-judge evaluation template. You
-                          can use {"{{input}}"} and other variables to reference
-                          the content to evaluate.
-                        </FormDescription>
-                        <FormControl>
-                          <CodeMirrorEditor
-                            value={field.value}
-                            onChange={field.onChange}
-                            editable={props.isEditing}
-                            mode="prompt"
-                            minHeight={200}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                        <PromptVariableListPreview
-                          variables={extractedVariables ?? []}
-                        />
-                      </FormItem>
-                    </>
-                  )}
-                />
-              </div>
-
-              <FormField
-                control={form.control}
-                name="outputReasoning"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Score reasoning prompt</FormLabel>
-                    <FormDescription>
-                      Define how the LLM should explain its evaluation. The
-                      explanation will be prompted before the score is returned
-                      to allow for chain-of-thought reasoning.
-                    </FormDescription>
-                    <FormControl>
-                      <Input {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name="outputScore"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Score range prompt</FormLabel>
-                    <FormDescription>
-                      Define how the LLM should return the evaluation score in
-                      natural language. Needs to yield a numeric value.
-                    </FormDescription>
-                    <FormControl>
-                      <Input {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </CardContent>
-          </Card>
-        </DialogBody>
-
-        <DialogFooter>
-          {props.isEditing && (
-            <Button
-              type="submit"
-              loading={createEvalTemplateMutation.isLoading}
-              className="w-full"
-            >
-              Save
-            </Button>
-          )}
-          {formError ? (
-            <p className="text-red text-center">
-              <span className="font-bold">Error:</span> {formError}
-            </p>
-          ) : null}
-        </DialogFooter>
+        {props.useDialog ? (
+          <DialogFooter>{formFooter}</DialogFooter>
+        ) : (
+          formFooter
+        )}
       </form>
     </Form>
   );

--- a/web/src/features/evals/pages/new-template.tsx
+++ b/web/src/features/evals/pages/new-template.tsx
@@ -30,7 +30,11 @@ export default function NewTemplatesPage() {
         ],
       }}
     >
-      <EvalTemplateForm projectId={projectId} isEditing={true} />
+      <EvalTemplateForm
+        projectId={projectId}
+        isEditing={true}
+        useDialog={false}
+      />
     </Page>
   );
 }

--- a/web/src/features/experiments/components/CreateExperimentsForm.tsx
+++ b/web/src/features/experiments/components/CreateExperimentsForm.tsx
@@ -804,6 +804,7 @@ export const CreateExperimentsForm = ({
             </DialogTitle>
             <EvaluatorForm
               projectId={projectId}
+              useDialog={true}
               evalTemplates={evalTemplates.data?.templates ?? []}
               templateId={selectedEvaluatorData.templateId}
               existingEvaluator={selectedEvaluatorData.evaluator}

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
@@ -306,6 +306,7 @@ export default function Dataset() {
               Evaluator
             </DialogTitle>
             <EvaluatorForm
+              useDialog={true}
               projectId={projectId}
               evalTemplates={evalTemplates.data?.templates ?? []}
               templateId={selectedEvaluatorData.templateId}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `useDialog` prop to `EvaluatorForm` and `EvalTemplateForm` for conditional dialog rendering across components.
> 
>   - **Behavior**:
>     - Add `useDialog` prop to `EvaluatorForm` and `EvalTemplateForm` to control rendering within a dialog.
>     - Set `useDialog` to `true` in `EvaluatorForm` in `evaluator-table.tsx` and `dataset/index.tsx` for dialog rendering.
>     - Set `useDialog` to `false` in `EvalTemplateForm` in `new-template.tsx` and `eval-template-detail.tsx` for non-dialog rendering.
>   - **Components**:
>     - Update `InnerEvaluatorForm` and `InnerEvalTemplateForm` to conditionally render `DialogBody` and `DialogFooter` based on `useDialog` prop.
>     - Modify `PeekViewEvaluatorConfigDetail` and `PeekViewEvaluatorTemplateDetail` to pass `useDialog` prop to forms.
>   - **Misc**:
>     - Adjust `CreateExperimentsForm` and `SelectEvaluatorList` to use `useDialog` prop for evaluator forms.
>     - Ensure consistent dialog usage across `EvaluatorForm` and `EvalTemplateForm` in various components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4416c0e4b0ef2a66fbca4c4a16ae0da4916d174f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->