### PR TITLE
fix(PopoverFilterBuilder): ensure filter buttons do not submit forms

### DIFF
--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -104,7 +104,7 @@ export function PopoverFilterBuilder({
         }}
       >
         <PopoverTrigger asChild>
-          <Button variant="outline">
+          <Button variant="outline" type="button">
             <span>Filters</span>
             {filterState.length > 0 && filterState.length < 3 ? (
               <InlineFilterState
@@ -142,6 +142,7 @@ export function PopoverFilterBuilder({
         <Button
           onClick={() => setWipFilterState([])}
           variant="ghost"
+          type="button"
           size="icon"
           className="ml-0.5"
         >
@@ -586,6 +587,7 @@ function FilterBuilderForm({
                   <Button
                     onClick={() => removeFilter(i)}
                     variant="ghost"
+                    type="button"
                     disabled={disabled}
                     size="xs"
                   >


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `type="button"` for buttons in `PopoverFilterBuilder` and `FilterBuilderForm` to prevent form submission.
> 
>   - **Behavior**:
>     - Set `type="button"` for `Button` components in `PopoverFilterBuilder` and `FilterBuilderForm` to prevent form submission.
>     - Affects buttons for opening popover, clearing filters, and removing filters.
>   - **Components**:
>     - `PopoverFilterBuilder`: Ensures filter buttons do not submit forms.
>     - `FilterBuilderForm`: Ensures add and remove filter buttons do not submit forms.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f0882700d90cd9ff3fa7e829096bac05002c7ffa. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->