### PR TITLE
fix(otel): update condition checks for Langfuse attributes in ingestion processing

### DIFF
--- a/web/src/features/otel/server/OtelIngestionProcessor.ts
+++ b/web/src/features/otel/server/OtelIngestionProcessor.ts
@@ -1105,7 +1105,8 @@ export class OtelIngestionProcessor {
     attributes: Record<string, unknown>,
     isLangfuseSDKSpan: boolean,
   ): Record<string, unknown> {
-    if (isLangfuseSDKSpan) {
+    const hasLangfuseUsageDetails = attributes[LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS];
+    if (hasLangfuseUsageDetails) {
       try {
         return JSON.parse(
           attributes[
@@ -1149,7 +1150,8 @@ export class OtelIngestionProcessor {
     attributes: Record<string, unknown>,
     isLangfuseSDKSpan: boolean,
   ): Record<string, unknown> {
-    if (isLangfuseSDKSpan) {
+    const hasLangfuseCostDetails = attributes[LangfuseOtelSpanAttributes.OBSERVATION_COST_DETAILS];
+    if (hasLangfuseCostDetails) {
       try {
         return JSON.parse(
           attributes[

--- a/web/src/features/otel/server/OtelIngestionProcessor.ts
+++ b/web/src/features/otel/server/OtelIngestionProcessor.ts
@@ -564,11 +564,9 @@ export class OtelIngestionProcessor {
         null,
       usageDetails: this.extractUsageDetails(
         attributes,
-        isLangfuseSDKSpans,
       ) as any,
       costDetails: this.extractCostDetails(
         attributes,
-        isLangfuseSDKSpans,
       ) as any,
       ...this.extractInputAndOutput(span?.events ?? [], attributes),
     };
@@ -1103,7 +1101,6 @@ export class OtelIngestionProcessor {
 
   private extractUsageDetails(
     attributes: Record<string, unknown>,
-    isLangfuseSDKSpan: boolean,
   ): Record<string, unknown> {
     const hasLangfuseUsageDetails = attributes[LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS];
     if (hasLangfuseUsageDetails) {
@@ -1148,7 +1145,6 @@ export class OtelIngestionProcessor {
 
   private extractCostDetails(
     attributes: Record<string, unknown>,
-    isLangfuseSDKSpan: boolean,
   ): Record<string, unknown> {
     const hasLangfuseCostDetails = attributes[LangfuseOtelSpanAttributes.OBSERVATION_COST_DETAILS];
     if (hasLangfuseCostDetails) {


### PR DESCRIPTION
## What does this PR do?

When using third-party SDKs (e.g., Google ADK) with Langfuse SDK, `usage_details` and `cost_details` weren't processed correctly for cost calculation. The issue occurred because these methods only processed Langfuse-specific attributes when `isLangfuseSDKSpan` was true, which depends on scope name starting with "langfuse-sdk". Third-party SDKs set different scope names (e.g., "gcp.vertex.agent").

Fixes #7285

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `usage_details` and `cost_details` processing in `OtelIngestionProcessor` by removing `isLangfuseSDKSpan` dependency, allowing third-party SDKs to be correctly handled.
> 
>   - **Behavior**:
>     - Fixes processing of `usage_details` and `cost_details` in `OtelIngestionProcessor` by removing `isLangfuseSDKSpan` dependency.
>     - Now checks for `LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS` and `LangfuseOtelSpanAttributes.OBSERVATION_COST_DETAILS` directly.
>   - **Functions**:
>     - Updates `extractUsageDetails()` and `extractCostDetails()` in `OtelIngestionProcessor.ts` to remove `isLangfuseSDKSpan` parameter.
>     - Adjusts logic to check for specific attributes directly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8628f41890c90796f2799621b70b482561378103. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->