### PR TITLE
refactor(peek): remove urlPathname parameter from peek navigation and state hooks

### DIFF
--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -41,8 +41,6 @@ export type DataTablePeekViewProps<TData> = {
   customTitlePrefix?: string;
 
   // Navigation and URL handling
-  /** The base pathname for constructing URLs */
-  urlPathname: string;
   /** Function to get navigation path for a list entry */
   getNavigationPath?: (entry: ListEntry) => string;
   /** Whether to update the row when the peekViewId changes on detail page navigation. Defaults to false. */

--- a/web/src/components/table/peek/hooks/useDatasetComparePeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/useDatasetComparePeekNavigation.ts
@@ -1,11 +1,12 @@
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 
-export const useDatasetComparePeekNavigation = (urlPathname: string) => {
+export const useDatasetComparePeekNavigation = () => {
   const getNavigationPath = (entry: ListEntry) => {
     const url = new URL(window.location.href);
+    const pathname = window.location.pathname;
 
     // Update the path part
-    url.pathname = urlPathname;
+    url.pathname = pathname;
 
     // Keep all existing query params
     const params = new URLSearchParams(url.search);

--- a/web/src/components/table/peek/hooks/useDatasetComparePeekState.ts
+++ b/web/src/components/table/peek/hooks/useDatasetComparePeekState.ts
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router";
 import { useCallback, useState } from "react";
 
-export const useDatasetComparePeekState = (pathname: string) => {
+export const useDatasetComparePeekState = () => {
   const router = useRouter();
   const { peek: datasetItem } = router.query;
 
@@ -15,6 +15,7 @@ export const useDatasetComparePeekState = (pathname: string) => {
     (open: boolean, itemId?: string) => {
       const url = new URL(window.location.href);
       const params = new URLSearchParams(url.search);
+      const pathname = window.location.pathname;
 
       if (!open || !itemId) {
         // close peek view
@@ -35,7 +36,7 @@ export const useDatasetComparePeekState = (pathname: string) => {
         { shallow: true },
       );
     },
-    [router, datasetItem, pathname],
+    [router, datasetItem],
   );
 
   return {

--- a/web/src/components/table/peek/hooks/useEvalTemplatesPeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/useEvalTemplatesPeekNavigation.ts
@@ -2,15 +2,16 @@ import { type EvalsTemplateRow } from "@/src/features/evals/components/eval-temp
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 import { useRouter } from "next/router";
 
-export const useEvalTemplatesPeekNavigation = (urlPathname: string) => {
+export const useEvalTemplatesPeekNavigation = () => {
   const router = useRouter();
   const { projectId, peek } = router.query;
 
   const getNavigationPath = (entry: ListEntry) => {
     const url = new URL(window.location.href);
+    const pathname = window.location.pathname;
 
     // Update the path part
-    url.pathname = urlPathname;
+    url.pathname = pathname;
 
     // Keep all existing query params
     const params = new URLSearchParams(url.search);

--- a/web/src/components/table/peek/hooks/useObservationPeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/useObservationPeekNavigation.ts
@@ -2,15 +2,16 @@ import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 import { useRouter } from "next/router";
 import { type ObservationsTableRow } from "@/src/components/table/use-cases/observations";
 
-export const useObservationPeekNavigation = (urlPathname: string) => {
+export const useObservationPeekNavigation = () => {
   const router = useRouter();
   const { projectId, peek } = router.query;
 
   const getNavigationPath = (entry: ListEntry) => {
     const url = new URL(window.location.href);
+    const pathname = window.location.pathname;
 
     // Update the path part
-    url.pathname = urlPathname;
+    url.pathname = pathname;
 
     // Keep all existing query params
     const params = new URLSearchParams(url.search);

--- a/web/src/components/table/peek/hooks/useObservationPeekState.ts
+++ b/web/src/components/table/peek/hooks/useObservationPeekState.ts
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router";
 import { useCallback } from "react";
 
-export const useObservationPeekState = (pathname: string) => {
+export const useObservationPeekState = () => {
   const router = useRouter();
   const { peek, timestamp } = router.query;
 
@@ -9,6 +9,7 @@ export const useObservationPeekState = (pathname: string) => {
     (open: boolean, id?: string, time?: string) => {
       const url = new URL(window.location.href);
       const params = new URLSearchParams(url.search);
+      const pathname = window.location.pathname;
 
       if (!open || !id) {
         // close peek view
@@ -35,7 +36,7 @@ export const useObservationPeekState = (pathname: string) => {
         { shallow: true },
       );
     },
-    [router, pathname, peek, timestamp],
+    [router, peek, timestamp],
   );
 
   return {

--- a/web/src/components/table/peek/hooks/usePeekState.ts
+++ b/web/src/components/table/peek/hooks/usePeekState.ts
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router";
 import { useCallback } from "react";
 
-export const usePeekState = (pathname: string) => {
+export const usePeekState = () => {
   const router = useRouter();
   const { peek } = router.query;
 
@@ -9,6 +9,7 @@ export const usePeekState = (pathname: string) => {
     (open: boolean, id?: string) => {
       const url = new URL(window.location.href);
       const params = new URLSearchParams(url.search);
+      const pathname = window.location.pathname;
 
       if (!open || !id) {
         // close peek view
@@ -29,7 +30,7 @@ export const usePeekState = (pathname: string) => {
         { shallow: true },
       );
     },
-    [router, pathname, peek],
+    [router, peek],
   );
 
   return {

--- a/web/src/components/table/peek/hooks/useRunningEvaluatorsPeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/useRunningEvaluatorsPeekNavigation.ts
@@ -1,11 +1,12 @@
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 
-export const useRunningEvaluatorsPeekNavigation = (urlPathname: string) => {
+export const useRunningEvaluatorsPeekNavigation = () => {
   const getNavigationPath = (entry: ListEntry) => {
     const url = new URL(window.location.href);
+    const pathname = window.location.pathname;
 
     // Update the path part
-    url.pathname = urlPathname;
+    url.pathname = pathname;
 
     // Keep all existing query params
     const params = new URLSearchParams(url.search);

--- a/web/src/components/table/peek/hooks/useTracePeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/useTracePeekNavigation.ts
@@ -1,15 +1,16 @@
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 import { useRouter } from "next/router";
 
-export const useTracePeekNavigation = (urlPathname: string) => {
+export const useTracePeekNavigation = () => {
   const router = useRouter();
   const { projectId, peek } = router.query;
 
   const getNavigationPath = (entry: ListEntry) => {
     const url = new URL(window.location.href);
+    const pathname = window.location.pathname;
 
     // Update the path part
-    url.pathname = urlPathname;
+    url.pathname = pathname;
 
     // Keep all existing query params
     const params = new URLSearchParams(url.search);

--- a/web/src/components/table/peek/hooks/useTracePeekState.ts
+++ b/web/src/components/table/peek/hooks/useTracePeekState.ts
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router";
 import { useCallback } from "react";
 
-export const useTracePeekState = (pathname: string) => {
+export const useTracePeekState = () => {
   const router = useRouter();
   const { peek, timestamp } = router.query;
 
@@ -9,6 +9,7 @@ export const useTracePeekState = (pathname: string) => {
     (open: boolean, id?: string, time?: string) => {
       const url = new URL(window.location.href);
       const params = new URLSearchParams(url.search);
+      const pathname = window.location.pathname;
 
       if (!open || !id) {
         // close peek view
@@ -35,7 +36,7 @@ export const useTracePeekState = (pathname: string) => {
         { shallow: true },
       );
     },
-    [router, pathname, peek, timestamp],
+    [router, peek, timestamp],
   );
 
   return {

--- a/web/src/components/table/peek/peek-dataset-compare-detail.tsx
+++ b/web/src/components/table/peek/peek-dataset-compare-detail.tsx
@@ -46,9 +46,7 @@ export const PeekDatasetCompareDetail = ({
       : undefined;
 
   const { datasetItemId, selectedRunItemProps, setSelectedRunItemProps } =
-    useDatasetComparePeekState(
-      `/project/${projectId}/datasets/${datasetId}/compare`,
-    );
+    useDatasetComparePeekState();
   const { runId, traceId } = selectedRunItemProps ?? {};
 
   const trace = usePeekData({

--- a/web/src/components/table/peek/peek-dataset-compare-detail.tsx
+++ b/web/src/components/table/peek/peek-dataset-compare-detail.tsx
@@ -23,7 +23,6 @@ import { usePeekData } from "@/src/components/table/peek/hooks/usePeekData";
 
 export type PeekDatasetCompareDetailProps = {
   projectId: string;
-  datasetId: string;
   runsData: RouterOutputs["datasets"]["baseRunDataByDatasetId"];
   scoreKeyToDisplayName: Map<string, string>;
   selectedMetrics?: DatasetRunMetric[];
@@ -32,7 +31,6 @@ export type PeekDatasetCompareDetailProps = {
 
 export const PeekDatasetCompareDetail = ({
   projectId,
-  datasetId,
   runsData,
   scoreKeyToDisplayName,
   selectedMetrics = ["scores", "resourceMetrics"],

--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -22,7 +22,7 @@ export const PeekViewEvaluatorConfigDetail = ({
   projectId: string;
   row?: EvaluatorDataRow;
 }) => {
-  const { peekId } = usePeekState("evals");
+  const { peekId } = usePeekState();
 
   const { data: evalConfig } = usePeekEvalConfigData({
     jobConfigurationId: peekId,

--- a/web/src/components/table/peek/peek-evaluator-template-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-template-detail.tsx
@@ -10,7 +10,7 @@ export const PeekViewEvaluatorTemplateDetail = ({
 }: {
   projectId: string;
 }) => {
-  const { peekId } = usePeekState("eval-templates");
+  const { peekId } = usePeekState();
 
   const { data: template } = usePeekEvalTemplateData({
     templateId: peekId,

--- a/web/src/components/table/peek/peek-observation-detail.tsx
+++ b/web/src/components/table/peek/peek-observation-detail.tsx
@@ -12,7 +12,7 @@ export const PeekViewObservationDetail = ({
   projectId: string;
   row?: ObservationsTableRow;
 }) => {
-  const { peekId, timestamp } = useObservationPeekState("observations");
+  const { peekId, timestamp } = useObservationPeekState();
   const effectiveTimestamp = row?.timestamp ?? timestamp;
 
   const trace = usePeekData({

--- a/web/src/components/table/peek/peek-trace-detail.tsx
+++ b/web/src/components/table/peek/peek-trace-detail.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from "@/src/components/ui/skeleton";
 import { StringParam, useQueryParam, withDefault } from "use-query-params";
 
 export const PeekViewTraceDetail = ({ projectId }: { projectId: string }) => {
-  const { peekId, timestamp } = useTracePeekState("traces");
+  const { peekId, timestamp } = useTracePeekState();
   const trace = usePeekData({
     projectId,
     traceId: peekId,

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -859,11 +859,8 @@ export default function ObservationsTable({
     columns,
   );
 
-  const urlPathname = `/project/${projectId}/observations`;
-
-  const { getNavigationPath, expandPeek } =
-    useObservationPeekNavigation(urlPathname);
-  const { setPeekView } = useObservationPeekState(urlPathname);
+  const { getNavigationPath, expandPeek } = useObservationPeekNavigation();
+  const { setPeekView } = useObservationPeekState();
   const { isLoading: isViewLoading, ...viewControllers } = useTableViewManager({
     tableName: TableViewPresetTableName.Observations,
     projectId,
@@ -885,7 +882,6 @@ export default function ObservationsTable({
       itemType: "TRACE",
       customTitlePrefix: "Observation ID:",
       listKey: "observations",
-      urlPathname,
       onOpenChange: setPeekView,
       onExpand: expandPeek,
       shouldUpdateRowOnDetailPageNavigation: true,
@@ -897,7 +893,6 @@ export default function ObservationsTable({
     }),
     [
       projectId,
-      urlPathname,
       generations.dataUpdatedAt,
       getNavigationPath,
       expandPeek,

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -1001,19 +1001,14 @@ export default function TracesTable({
     columns,
   );
 
-  const urlPathname = userId
-    ? `/project/${projectId}/users/${userId}`
-    : `/project/${projectId}/traces`;
-
-  const { getNavigationPath, expandPeek } = useTracePeekNavigation(urlPathname);
-  const { setPeekView } = useTracePeekState(urlPathname);
+  const { getNavigationPath, expandPeek } = useTracePeekNavigation();
+  const { setPeekView } = useTracePeekState();
 
   const peekConfig = useMemo(() => {
     if (hideControls) return undefined;
     return {
       itemType: "TRACE" as const,
       listKey: "traces",
-      urlPathname,
       peekEventOptions: {
         ignoredSelectors: ['[role="checkbox"]', '[aria-label="bookmark"]'],
       },
@@ -1032,7 +1027,6 @@ export default function TracesTable({
     setPeekView,
     expandPeek,
     getNavigationPath,
-    urlPathname,
     traces.dataUpdatedAt,
     traceMetrics.dataUpdatedAt,
   ]);

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -379,11 +379,9 @@ export function DatasetCompareRunsTable(props: {
       columns,
     );
 
-  const urlPathname = `/project/${props.projectId}/datasets/${props.datasetId}/compare`;
-
-  const { setPeekView } = useDatasetComparePeekState(urlPathname);
+  const { setPeekView } = useDatasetComparePeekState();
   const { getNavigationPath, shouldUpdateRowOnDetailPageNavigation } =
-    useDatasetComparePeekNavigation(urlPathname);
+    useDatasetComparePeekNavigation();
 
   return (
     <>
@@ -467,7 +465,6 @@ export function DatasetCompareRunsTable(props: {
         }}
         peekView={{
           itemType: "DATASET_ITEM",
-          urlPathname,
           tableDataUpdatedAt: Math.max(
             baseDatasetItems.dataUpdatedAt,
             ...runs.map(({ items }) => items.dataUpdatedAt),

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -476,7 +476,6 @@ export function DatasetCompareRunsTable(props: {
           children: (row?: DatasetCompareRunRowData) => (
             <PeekDatasetCompareDetail
               projectId={props.projectId}
-              datasetId={props.datasetId}
               scoreKeyToDisplayName={scoreKeyToDisplayName}
               runsData={props.runsData ?? []}
               selectedMetrics={selectedMetrics}

--- a/web/src/features/evals/components/eval-templates-table.tsx
+++ b/web/src/features/evals/components/eval-templates-table.tsx
@@ -290,10 +290,8 @@ export default function EvalsTemplateTable({
       columns,
     );
 
-  const urlPathname = `/project/${projectId}/evals/templates`;
-  const { getNavigationPath, expandPeek } =
-    useEvalTemplatesPeekNavigation(urlPathname);
-  const { setPeekView } = usePeekState(urlPathname);
+  const { getNavigationPath, expandPeek } = useEvalTemplatesPeekNavigation();
+  const { setPeekView } = usePeekState();
 
   const convertToTableRow = (
     template: RouterOutputs["evals"]["templateNames"]["templates"][number],
@@ -330,7 +328,6 @@ export default function EvalsTemplateTable({
         peekView={{
           itemType: "EVALUATOR",
           listKey: "eval-templates",
-          urlPathname,
           onOpenChange: setPeekView,
           onExpand: expandPeek,
           shouldUpdateRowOnDetailPageNavigation: true,

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -318,9 +318,8 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       columns,
     );
 
-  const urlPathname = `/project/${projectId}/evals`;
-  const { getNavigationPath } = useRunningEvaluatorsPeekNavigation(urlPathname);
-  const { setPeekView } = usePeekState(urlPathname);
+  const { getNavigationPath } = useRunningEvaluatorsPeekNavigation();
+  const { setPeekView } = usePeekState();
 
   const convertToTableRow = (
     jobConfig: RouterOutputs["evals"]["allConfigs"]["configs"][number],
@@ -376,7 +375,6 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
         peekView={{
           itemType: "RUNNING_EVALUATOR",
           listKey: "evals",
-          urlPathname,
           onOpenChange: setPeekView,
           shouldUpdateRowOnDetailPageNavigation: true,
           peekEventOptions: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove `urlPathname` parameter from peek navigation and state hooks, simplifying URL handling across components.
> 
>   - **Behavior**:
>     - Remove `urlPathname` parameter from `DataTablePeekViewProps` in `peek.tsx`.
>     - Update `useDatasetComparePeekNavigation`, `useEvalTemplatesPeekNavigation`, `useObservationPeekNavigation`, `useRunningEvaluatorsPeekNavigation`, `useTracePeekNavigation` to use `window.location.pathname` instead of `urlPathname`.
>     - Update `useDatasetComparePeekState`, `useObservationPeekState`, `usePeekState`, `useTracePeekState` to remove `pathname` parameter and use `window.location.pathname`.
>   - **Components**:
>     - Update `PeekDatasetCompareDetail`, `PeekViewEvaluatorConfigDetail`, `PeekViewEvaluatorTemplateDetail`, `PeekViewObservationDetail`, `PeekViewTraceDetail` to reflect changes in state hooks.
>     - Update `ObservationsTable`, `TracesTable`, `DatasetCompareRunsTable`, `EvalsTemplateTable`, `EvaluatorTable` to remove `urlPathname` usage.
>   - **Misc**:
>     - Remove `datasetId` parameter from `PeekDatasetCompareDetailProps` in `peek-dataset-compare-detail.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8af238e1a814132eeae5918f075ed81e0c54be3d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->