### PR TITLE
fix: keep zod/v3 schema for langchainjs interactions

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -1,4 +1,6 @@
-import { type ZodSchema } from "zod/v4";
+// We continue to use zod v3 for langchainjs.
+// Corresponding issue report: https://github.com/langchain-ai/langchainjs/issues/8357.
+import { type ZodSchema } from "zod";
 
 import { ChatAnthropic } from "@langchain/anthropic";
 import { ChatVertexAI } from "@langchain/google-vertexai";

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -1,4 +1,7 @@
 import { z } from "zod/v4";
+// We continue to use zod v3 for langchainjs.
+// Corresponding issue report: https://github.com/langchain-ai/langchainjs/issues/8357.
+import { z as zv3 } from "zod";
 import {
   createTRPCRouter,
   protectedProjectProcedure,
@@ -832,9 +835,9 @@ export const evalRouter = createTRPCRouter({
               adapter: matchingLLMKey.adapter,
               ...input.modelParams,
             },
-            structuredOutputSchema: z.object({
-              score: z.string(),
-              reasoning: z.string(),
+            structuredOutputSchema: zv3.object({
+              score: zv3.string(),
+              reasoning: zv3.string(),
             }),
             config: matchingLLMKey.config,
           })

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from "crypto";
 import { sql } from "kysely";
 import { z } from "zod/v4";
+// We continue to use zod v3 for langchainjs.
+// Corresponding issue report: https://github.com/langchain-ai/langchainjs/issues/8357.
+import { z as zv3 } from "zod";
 import { JobConfigState } from "@prisma/client";
 import {
   QueueJobs,
@@ -494,10 +497,10 @@ export const evaluate = async ({
     `Evaluating job ${event.jobExecutionId} compiled prompt ${prompt}`,
   );
 
-  const parsedOutputSchema = z
+  const parsedOutputSchema = zv3
     .object({
-      score: z.string(),
-      reasoning: z.string(),
+      score: zv3.string(),
+      reasoning: zv3.string(),
     })
     .parse(template.outputSchema);
 
@@ -505,9 +508,9 @@ export const evaluate = async ({
     throw new InvalidRequestError("Output schema not found");
   }
 
-  const evalScoreSchema = z.object({
-    reasoning: z.string().describe(parsedOutputSchema.reasoning),
-    score: z.number().describe(parsedOutputSchema.score),
+  const evalScoreSchema = zv3.object({
+    reasoning: zv3.string().describe(parsedOutputSchema.reasoning),
+    score: zv3.number().describe(parsedOutputSchema.score),
   });
 
   const modelConfig = await DefaultEvalModelService.fetchValidModelConfig(

--- a/worker/src/features/utilities.ts
+++ b/worker/src/features/utilities.ts
@@ -6,7 +6,10 @@ import {
   type TraceParams,
 } from "@langfuse/shared/src/server";
 import { ApiError, LLMApiKeySchema, ZodModelConfig } from "@langfuse/shared";
-import { z, ZodSchema } from "zod/v4";
+import { z } from "zod/v4";
+// We continue to use zod v3 for langchainjs.
+// Corresponding issue report: https://github.com/langchain-ai/langchainjs/issues/8357.
+import { z as zv3, ZodSchema } from "zod";
 import { decrypt } from "@langfuse/shared/encryption";
 import { tokenCount } from "./tokenisation/usage";
 import Handlebars from "handlebars";
@@ -19,7 +22,7 @@ export async function callStructuredLLM<T extends ZodSchema>(
   provider: string,
   model: string,
   structuredOutputSchema: T,
-): Promise<z.infer<T>> {
+): Promise<zv3.infer<T>> {
   try {
     const { completion } = await fetchLLMCompletion({
       streaming: false,


### PR DESCRIPTION
c.f. https://github.com/langchain-ai/langchainjs/issues/8357
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix compatibility by using `zod v3` for `langchainjs` interactions, updating schema definitions and parsing accordingly.
> 
>   - **Compatibility Fix**:
>     - Use `zod v3` for `langchainjs` interactions due to compatibility issues (see issue #8357).
>     - Import `zod` as `zv3` in `fetchLLMCompletion.ts`, `router.ts`, `evalService.ts`, and `utilities.ts`.
>   - **Schema Adjustments**:
>     - Change `structuredOutputSchema` to use `zv3.object()` in `router.ts` and `evalService.ts`.
>     - Update `evalScoreSchema` and `parsedOutputSchema` to use `zv3` in `evalService.ts`.
>   - **Function Updates**:
>     - Modify `callStructuredLLM()` in `utilities.ts` to return `zv3.infer<T>`.
>     - Adjust `evaluate()` in `evalService.ts` to parse schemas with `zv3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ddd84480a3ff01fbb7abab08769f4730f24da8fb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->