### PR TITLE
chore(dialog): move close button to DialogHeader for improved accessibility

### DIFF
--- a/web/src/components/deleteButton.tsx
+++ b/web/src/components/deleteButton.tsx
@@ -117,7 +117,7 @@ export function DeleteButton({
       </PopoverTrigger>
       <PopoverContent onClick={(e) => e.stopPropagation()}>
         <h2 className="text-md mb-3 font-semibold">Please confirm</h2>
-        <p className="mb-3 text-sm">
+        <p className="mb-3 max-w-72 text-sm">
           {customDeletePrompt ??
             `This action cannot be undone and removes all the data associated with
             this ${entityToDeleteName}.`}

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -75,10 +75,12 @@ const DialogContent = React.forwardRef<
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="absolute right-3 top-3 z-20 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
+        <div className="[&:has(.dialog-header)]:hidden [&:not(:has(.dialog-header))]:absolute [&:not(:has(.dialog-header))]:right-3 [&:not(:has(.dialog-header))]:top-3 [&:not(:has(.dialog-header))]:z-20">
+          <DialogPrimitive.Close className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        </div>
       </DialogPrimitive.Content>
     </DialogPortal>
   ),
@@ -91,11 +93,20 @@ const DialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "sticky top-0 z-10 flex flex-shrink-0 flex-col space-y-1.5 rounded-t-lg border-b bg-background p-6 pb-4 text-center sm:text-left",
+      "dialog-header sticky top-0 z-30 flex flex-shrink-0 flex-col space-y-1.5 rounded-t-lg border-b bg-background p-6 pb-4 text-center sm:text-left",
       className,
     )}
     {...props}
-  />
+  >
+    <DialogPrimitive.Close
+      className="absolute right-3 top-3 z-20 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
+      tabIndex={-1}
+    >
+      <X className="h-4 w-4" />
+      <span className="sr-only">Close</span>
+    </DialogPrimitive.Close>
+    {props.children}
+  </div>
 );
 DialogHeader.displayName = "DialogHeader";
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move close button to `DialogHeader` in `dialog.tsx` for improved accessibility and conditional visibility.
> 
>   - **Behavior**:
>     - Move close button from `DialogContent` to `DialogHeader` in `dialog.tsx`.
>     - Close button now hidden in `DialogContent` if `DialogHeader` is present.
>   - **UI Components**:
>     - `DialogHeader` now includes a close button with specific styling and accessibility features.
>     - `DialogContent` conditionally hides its close button if a header is present.
>   - **Misc**:
>     - Minor style adjustment in `deleteButton.tsx` for `PopoverContent` text width.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 671eef46ce9f5c16cac58a276fee31d9fb951df1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->