### PR TITLE
fix: add auth headers to ctx within middleware, update not found logging

### DIFF
--- a/web/src/features/public-api/server/apiAuth.ts
+++ b/web/src/features/public-api/server/apiAuth.ts
@@ -250,7 +250,7 @@ export class ApiAuthService {
             };
           }
         } catch (error: unknown) {
-          logger.error(
+          logger.info(
             `Error verifying auth header: ${error instanceof Error ? error.message : null}`,
             error,
           );

--- a/web/src/features/public-api/server/withMiddlewares.ts
+++ b/web/src/features/public-api/server/withMiddlewares.ts
@@ -2,8 +2,17 @@ import { isPrismaException } from "@/src/utils/exceptions";
 import { cors, runMiddleware } from "@/src/features/public-api/server/cors";
 import { type NextApiRequest, type NextApiResponse } from "next";
 import { type ZodError } from "zod/v4";
-import { BaseError, MethodNotAllowedError } from "@langfuse/shared";
-import { logger, traceException } from "@langfuse/shared/src/server";
+import {
+  BaseError,
+  LangfuseNotFoundError,
+  MethodNotAllowedError,
+} from "@langfuse/shared";
+import {
+  logger,
+  traceException,
+  contextWithLangfuseProps,
+} from "@langfuse/shared/src/server";
+import * as opentelemetry from "@opentelemetry/api";
 
 const httpMethods = ["GET", "POST", "PUT", "DELETE", "PATCH"] as const;
 export type HttpMethod = (typeof httpMethods)[number];
@@ -20,60 +29,72 @@ const defaultHandler = () => {
 
 export function withMiddlewares(handlers: Handlers) {
   return async (req: NextApiRequest, res: NextApiResponse) => {
-    try {
-      await runMiddleware(req, res, cors);
+    const ctx = contextWithLangfuseProps({
+      headers: req.headers,
+    });
 
-      const method = req.method as HttpMethod;
-      if (!handlers[method]) throw new MethodNotAllowedError();
+    return opentelemetry.context.with(ctx, async () => {
+      try {
+        await runMiddleware(req, res, cors);
 
-      const finalHandlers: Required<Handlers> = {
-        ...{
-          GET: defaultHandler,
-          POST: defaultHandler,
-          PUT: defaultHandler,
-          DELETE: defaultHandler,
-          PATCH: defaultHandler,
-        },
-        ...handlers,
-      };
+        const method = req.method as HttpMethod;
+        if (!handlers[method]) throw new MethodNotAllowedError();
 
-      return await finalHandlers[method](req, res);
-    } catch (error) {
-      logger.error(error);
+        const finalHandlers: Required<Handlers> = {
+          ...{
+            GET: defaultHandler,
+            POST: defaultHandler,
+            PUT: defaultHandler,
+            DELETE: defaultHandler,
+            PATCH: defaultHandler,
+          },
+          ...handlers,
+        };
 
-      if (error instanceof BaseError) {
-        if (error.httpCode >= 500 && error.httpCode < 600) {
-          traceException(error);
+        return await finalHandlers[method](req, res);
+      } catch (error) {
+        if (error instanceof LangfuseNotFoundError) {
+          logger.info(error);
+        } else {
+          logger.error(error);
         }
-        return res.status(error.httpCode).json({
-          message: error.message,
-          error: error.name,
-        });
-      }
 
-      if (isPrismaException(error)) {
+        if (error instanceof BaseError) {
+          if (error.httpCode >= 500 && error.httpCode < 600) {
+            traceException(error);
+          }
+          return res.status(error.httpCode).json({
+            message: error.message,
+            error: error.name,
+          });
+        }
+
+        if (isPrismaException(error)) {
+          traceException(error);
+          return res.status(500).json({
+            message: "Internal Server Error",
+            error: "An unknown error occurred",
+          });
+        }
+
+        // Instanceof check fails here as shared package zod has different instances
+        if (isZodError(error)) {
+          return res.status(400).json({
+            message: "Invalid request data",
+            error: error.issues,
+          });
+        }
+
         traceException(error);
         return res.status(500).json({
           message: "Internal Server Error",
-          error: "An unknown error occurred",
+          error:
+            error instanceof Error
+              ? error.message
+              : "An unknown error occurred",
         });
       }
-
-      // Instanceof check fails here as shared package zod has different instances
-      if (isZodError(error)) {
-        return res.status(400).json({
-          message: "Invalid request data",
-          error: error.issues,
-        });
-      }
-
-      traceException(error);
-      return res.status(500).json({
-        message: "Internal Server Error",
-        error:
-          error instanceof Error ? error.message : "An unknown error occurred",
-      });
-    }
+    });
   };
 }
 

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -115,10 +115,17 @@ const withErrorHandling = t.middleware(async ({ ctx, next }) => {
   const res = await next({ ctx }); // pass the context to the next middleware
 
   if (!res.ok) {
-    logger.error(
-      `middleware intercepted error with code ${res.error.code}`,
-      res.error,
-    );
+    if (res.error.code === "NOT_FOUND") {
+      logger.info(
+        `middleware intercepted error with code ${res.error.code}`,
+        res.error,
+      );
+    } else {
+      logger.error(
+        `middleware intercepted error with code ${res.error.code}`,
+        res.error,
+      );
+    }
 
     // Throw a new TRPC error with:
     // - The same error code as the original error


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve logging and context handling in middleware by adjusting log levels and propagating headers.
> 
>   - **Logging**:
>     - Change logging level from `error` to `info` for auth header verification failures in `apiAuth.ts`.
>     - Log `LangfuseNotFoundError` as `info` instead of `error` in `withMiddlewares.ts` and `trpc.ts`.
>   - **Context Handling**:
>     - Add `contextWithLangfuseProps` to propagate headers in `withMiddlewares.ts` and `trpc.ts`.
>   - **Error Handling**:
>     - Handle `NOT_FOUND` errors with `info` logging in `trpc.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for da20adf348deb24af4d7b690cf311ad58a219bec. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->