### PR TITLE
fix: fix select all UI bug

### DIFF
--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -413,8 +413,10 @@ export default function TracesTable({
 
   const displayCount = totalCountQuery.isLoading ? (
     <span className="inline-block font-mono">...</span>
-  ) : (
+  ) : selectAll ? (
     compactNumberFormatter(totalCountQuery.data?.totalCount)
+  ) : (
+    compactNumberFormatter(Object.keys(selectedRows).length)
   );
 
   const tableActions: TableAction[] = [


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix display count in `TracesTable` to show selected rows count when `selectAll` is not active.
> 
>   - **UI Bug Fix**:
>     - In `traces.tsx`, fix display count logic in `TracesTable` to show the number of selected rows when `selectAll` is not active.
>     - Uses `compactNumberFormatter` to format the count of `Object.keys(selectedRows).length` instead of `totalCountQuery.data?.totalCount`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 97492bfb8eebc74a784d1989f321b7ccc8dd66fd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->