### PR TITLE
feat(otel): parse trace attributes from trace metadata

### DIFF
--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -2516,6 +2516,160 @@ describe("OTel Resource Span Mapping", () => {
       expect(traceEvent.body.metadata).toBeDefined();
     });
 
+    it("should create trace-create event when span has trace_metadata with user_id, session_id, and tags", async () => {
+      const traceId = "95f3b926c7d009925bcb5dbc27311120";
+      const seenTraces = new Set([traceId]);
+
+      const otelSpans = [
+        {
+          resource: {
+            attributes: [
+              {
+                key: "service.name",
+                value: { stringValue: "test-service" },
+              },
+            ],
+          },
+          scopeSpans: [
+            {
+              scope: {
+                name: "test-scope",
+                version: "1.0.0",
+              },
+              spans: [
+                {
+                  traceId: {
+                    type: "Buffer",
+                    data: [149, 243, 185, 38, 199, 208, 9, 146, 91, 203, 93, 188, 39, 49, 17, 32],
+                  },
+                  spanId: {
+                    type: "Buffer",
+                    data: [212, 62, 55, 183, 209, 126, 84, 118],
+                  },
+                  parentSpanId: {
+                    type: "Buffer",
+                    data: [131, 78, 40, 181, 145, 127, 190, 246],
+                  },
+                  name: "child-span",
+                  kind: 1,
+                  startTimeUnixNano: {
+                    low: 1047784088,
+                    high: 406627672,
+                    unsigned: true,
+                  },
+                  endTimeUnixNano: {
+                    low: 1047784088,
+                    high: 406627672,
+                    unsigned: true,
+                  },
+                  attributes: [
+                    {
+                      key: "langfuse.trace.metadata.langfuse_user_id",
+                      value: { stringValue: "user-123" },
+                    },
+                    {
+                      key: "langfuse.trace.metadata.langfuse_session_id",
+                      value: { stringValue: "session-456" },
+                    },
+                    {
+                      key: "langfuse.trace.metadata.langfuse_tags",
+                      value: { stringValue: "tag1,tag2" },
+                    },
+                  ],
+                  status: {},
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const events = (await Promise.all(otelSpans.map(async (span) => await convertOtelSpanToIngestionEvent(span, seenTraces, publicKey)))).flat();
+
+      const traceEvents = events.filter((e) => e.type === "trace-create");
+      expect(traceEvents.length).toBe(1);
+      expect(traceEvents[0].body.userId).toBe("user-123");
+      expect(traceEvents[0].body.sessionId).toBe("session-456");
+      expect(traceEvents[0].body.tags).toEqual(["tag1", "tag2"]);
+    });
+
+    it("should create trace-create event when span has observation_metadata with user_id, session_id, and tags", async () => {
+      const traceId = "95f3b926c7d009925bcb5dbc27311120";
+      const seenTraces = new Set([traceId]);
+
+      const otelSpans = [
+        {
+          resource: {
+            attributes: [
+              {
+                key: "service.name",
+                value: { stringValue: "test-service" },
+              },
+            ],
+          },
+          scopeSpans: [
+            {
+              scope: {
+                name: "test-scope",
+                version: "1.0.0",
+              },
+              spans: [
+                {
+                  traceId: {
+                    type: "Buffer",
+                    data: [149, 243, 185, 38, 199, 208, 9, 146, 91, 203, 93, 188, 39, 49, 17, 32],
+                  },
+                  spanId: {
+                    type: "Buffer",
+                    data: [212, 62, 55, 183, 209, 126, 84, 118],
+                  },
+                  parentSpanId: {
+                    type: "Buffer",
+                    data: [131, 78, 40, 181, 145, 127, 190, 246],
+                  },
+                  name: "child-span",
+                  kind: 1,
+                  startTimeUnixNano: {
+                    low: 1047784088,
+                    high: 406627672,
+                    unsigned: true,
+                  },
+                  endTimeUnixNano: {
+                    low: 1047784088,
+                    high: 406627672,
+                    unsigned: true,
+                  },
+                  attributes: [
+                    {
+                      key: "langfuse.observation.metadata.langfuse_user_id",
+                      value: { stringValue: "user-789" },
+                    },
+                    {
+                      key: "langfuse.observation.metadata.langfuse_session_id",
+                      value: { stringValue: "session-abc" },
+                    },
+                    {
+                      key: "langfuse.observation.metadata.langfuse_tags",
+                      value: { stringValue: "tag3,tag4" },
+                    },
+                  ],
+                  status: {},
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const events = (await Promise.all(otelSpans.map(async (span) => await convertOtelSpanToIngestionEvent(span, seenTraces, publicKey)))).flat();
+
+      const traceEvents = events.filter((e) => e.type === "trace-create");
+      expect(traceEvents.length).toBe(1);
+      expect(traceEvents[0].body.userId).toBe("user-789");
+      expect(traceEvents[0].body.sessionId).toBe("session-abc");
+      expect(traceEvents[0].body.tags).toEqual(["tag3", "tag4"]);
+    });
+
     it("should create full trace for span with trace updates even when seenTraces contains traceId", async () => {
       const traceId = "95f3b926c7d009925bcb5dbc27311120";
       const seenTraces = new Set([traceId]);

--- a/web/src/features/otel/server/OtelIngestionProcessor.ts
+++ b/web/src/features/otel/server/OtelIngestionProcessor.ts
@@ -586,6 +586,12 @@ export class OtelIngestionProcessor {
       LangfuseOtelSpanAttributes.TRACE_SESSION_ID,
       LangfuseOtelSpanAttributes.TRACE_PUBLIC,
       LangfuseOtelSpanAttributes.TRACE_TAGS,
+      `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langfuse_user_id`,
+      `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langfuse_session_id`,
+      `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langfuse_tags`,
+      `${LangfuseOtelSpanAttributes.TRACE_METADATA}.langfuse_session_id`,
+      `${LangfuseOtelSpanAttributes.TRACE_METADATA}.langfuse_user_id`,
+      `${LangfuseOtelSpanAttributes.TRACE_METADATA}.langfuse_tags`,
     ].some((traceAttribute) => Boolean(attributes[traceAttribute]));
   }
 
@@ -965,7 +971,12 @@ export class OtelIngestionProcessor {
   private extractUserId(
     attributes: Record<string, unknown>,
   ): string | undefined {
-    const userIdKeys = ["langfuse.user.id", "user.id"];
+    const userIdKeys = [
+      "langfuse.user.id",
+      "user.id",
+      `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langfuse_user_id`,
+      `${LangfuseOtelSpanAttributes.TRACE_METADATA}.langfuse_user_id`,
+    ];
 
     for (const key of userIdKeys) {
       if (attributes[key]) {
@@ -979,7 +990,12 @@ export class OtelIngestionProcessor {
   private extractSessionId(
     attributes: Record<string, unknown>,
   ): string | undefined {
-    const userIdKeys = ["langfuse.session.id", "session.id"];
+    const userIdKeys = [
+      "langfuse.session.id",
+      "session.id",
+      `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langfuse_session_id`,
+      `${LangfuseOtelSpanAttributes.TRACE_METADATA}.langfuse_session_id`,
+    ];
 
     for (const key of userIdKeys) {
       if (attributes[key]) {
@@ -1130,7 +1146,11 @@ export class OtelIngestionProcessor {
   private extractTags(attributes: Record<string, unknown>): string[] {
     const tagsValue =
       attributes[LangfuseOtelSpanAttributes.TRACE_TAGS] ||
-      attributes["langfuse.tags"];
+      attributes["langfuse.tags"] ||
+      attributes[
+        `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langfuse_tags`
+      ] ||
+      attributes[`${LangfuseOtelSpanAttributes.TRACE_METADATA}.langfuse_tags`];
 
     if (tagsValue === undefined || tagsValue === null) {
       return [];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances `OtelIngestionProcessor` to parse `user_id`, `session_id`, and `tags` from `trace_metadata` and `observation_metadata`, with corresponding tests added.
> 
>   - **Behavior**:
>     - `OtelIngestionProcessor` now parses `user_id`, `session_id`, and `tags` from `trace_metadata` and `observation_metadata` attributes.
>     - Updates `hasTraceUpdates()` to include new metadata keys for trace updates.
>     - Filters out shallow traces if full traces exist for the same `traceId`.
>   - **Tests**:
>     - Adds tests in `otelMapping.servertest.ts` to verify trace creation with `trace_metadata` and `observation_metadata`.
>     - Tests ensure `trace-create` events are generated with correct `userId`, `sessionId`, and `tags`.
>   - **Misc**:
>     - Updates `extractUserId()`, `extractSessionId()`, and `extractTags()` to handle new metadata keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e5238632a74bb31f3b7fe00315051e971c19deee. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->