### PR TITLE
fix(observation-ui): enhance badge rendering with text truncation and improved value display

### DIFF
--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -326,15 +326,28 @@ export const ObservationPreview = ({
                     typeof preloadedObservation.modelParameters === "object"
                       ? Object.entries(preloadedObservation.modelParameters)
                           .filter(Boolean)
-                          .map(([key, value]) => (
-                            <Badge variant="tertiary" key={key}>
-                              {key}:{" "}
-                              {Object.prototype.toString.call(value) ===
+                          .map(([key, value]) => {
+                            const valueString =
+                              Object.prototype.toString.call(value) ===
                               "[object Object]"
                                 ? JSON.stringify(value)
-                                : value?.toString()}
-                            </Badge>
-                          ))
+                                : value?.toString();
+                            return (
+                              <Badge
+                                variant="tertiary"
+                                key={key}
+                                className="h-6 max-w-md"
+                              >
+                                {/* CHILD: This span handles the text truncation */}
+                                <span
+                                  className="overflow-hidden text-ellipsis whitespace-nowrap"
+                                  title={valueString}
+                                >
+                                  {key}: {valueString}
+                                </span>
+                              </Badge>
+                            );
+                          })
                       : null}
                   </Fragment>
                 </Fragment>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance badge rendering in `ObservationPreview.tsx` with text truncation and tooltips for long `modelParameters` values.
> 
>   - **UI Enhancement**:
>     - In `ObservationPreview.tsx`, enhance badge rendering by adding text truncation for long values using a span with `overflow-hidden`, `text-ellipsis`, and `whitespace-nowrap` classes.
>     - Applies to badges displaying `modelParameters` values, ensuring better display of long text.
>   - **Behavior**:
>     - Tooltip added to display full value on hover for truncated text in badges.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 403ed1d5c469ebd5d854629dd27262d0e62bc45c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->