### PR TITLE
fix(BigNumber): adjust decimal formatting to limit to a maximum of 3 decimal places

### DIFF
--- a/web/src/features/widgets/chart-library/BigNumber.tsx
+++ b/web/src/features/widgets/chart-library/BigNumber.tsx
@@ -67,7 +67,9 @@ const formatBigNumber = (
         )
       : 2;
     return {
-      formatted: value.toFixed(decimals).replace(/\.?0+$/, ""),
+      formatted: value
+        .toFixed(Math.max(0, Math.min(3, decimals)))
+        .replace(/\.?0+$/, ""),
       unit: "",
     };
   } else if (absValue > 0) {
@@ -84,7 +86,9 @@ const formatBigNumber = (
     const decimals = Math.min(neededDecimals, maxAllowedDecimals, 8); // Max 8 decimal places
 
     return {
-      formatted: value.toFixed(decimals).replace(/\.?0+$/, ""),
+      formatted: value
+        .toFixed(Math.max(0, Math.min(3, decimals)))
+        .replace(/\.?0+$/, ""),
       unit: "",
     };
   } else {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Limits decimal places to a maximum of 3 in `formatBigNumber` function in `BigNumber.tsx`.
> 
>   - **Behavior**:
>     - Limits decimal places to a maximum of 3 in `formatBigNumber` function in `BigNumber.tsx`.
>     - Applies to numbers >= 1 and small numbers > 0, ensuring no more than 3 decimal places are shown.
>   - **Formatting**:
>     - Uses `Math.max(0, Math.min(3, decimals))` to enforce the 3 decimal place limit in two locations within `formatBigNumber`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f048fdc93c9841c3579cfb5e7787c40ba71a6a37. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->