### PR TITLE
fix(otel): force modelparam values to be strings

### DIFF
--- a/web/src/features/otel/server/OtelIngestionProcessor.ts
+++ b/web/src/features/otel/server/OtelIngestionProcessor.ts
@@ -1060,7 +1060,12 @@ export class OtelIngestionProcessor {
     // Model params in Langfuse must be key value pairs where value is string
     if (typeof params === "object" && params != null)
       return Object.fromEntries(
-        Object.entries(params).map((e) => [e[0], JSON.stringify(e[1])]),
+        Object.entries(params).map((e) => [
+          e[0],
+          ["string", "number"].includes(typeof e[1])
+            ? e[1]
+            : JSON.stringify(e[1]),
+        ]),
       );
 
     return params;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Ensures model parameters are strings in `OtelIngestionProcessor` by using `sanitizeModelParams()` for various attributes.
> 
>   - **Behavior**:
>     - Ensures model parameters are strings in `OtelIngestionProcessor` by using `sanitizeModelParams()`.
>     - Handles `OBSERVATION_MODEL_PARAMETERS`, `llm.invocation_parameters`, `model_config`, and `gen_ai.request.*` attributes.
>   - **Functions**:
>     - Adds `sanitizeModelParams<T>(params: T): Record<string, string> | T` to convert model parameter values to strings.
>     - Updates `extractModelParameters()` to use `sanitizeModelParams()` for JSON parsed attributes.
>     - Updates `extractModelParameters()` to handle `gen_ai.request.*` attributes with `sanitizeModelParams()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 132bb22eabc9593fb9a373e076e5a1b3f8a1b789. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->