### PR TITLE
fix: gracefully fail exceeded context length for evals

### DIFF
--- a/worker/src/queues/batchExportQueue.ts
+++ b/worker/src/queues/batchExportQueue.ts
@@ -31,7 +31,7 @@ export const batchExportQueueProcessor = async (
       .execute();
 
     logger.error(
-      `Failed Batch Export job for id ${job.data.payload.batchExportId}`,
+      `Failed Batch Export job for id ${job.data.payload.batchExportId} and project id ${job.data.payload.projectId}`,
       e,
     );
     traceException(e);

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -142,6 +142,10 @@ export const evalJobExecutorQueueProcessor = async (
 
     // do not log expected errors (api failures + missing api keys not provided by the user)
     if (
+      (e instanceof BaseError &&
+        e.message.includes(
+          "Could not parse response content as the length limit was reached",
+        )) || // output tokens too long
       (e instanceof BaseError && e.message.includes("API key for provider")) || // api key not provided
       (e instanceof BaseError &&
         e.message.includes(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves error handling and logging in `batchExportQueueProcessor` and `evalJobExecutorQueueProcessor` for specific error cases.
> 
>   - **Error Handling**:
>     - In `batchExportQueue.ts`, enhanced error logging to include `projectId` in `batchExportQueueProcessor`.
>     - In `evalQueue.ts`, added specific handling for errors with message "Could not parse response content as the length limit was reached" in `evalJobExecutorQueueProcessor`.
>   - **Logging**:
>     - Improved error message in `batchExportQueueProcessor` to include `projectId`.
>     - Added condition to skip logging for specific expected errors in `evalJobExecutorQueueProcessor`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2f12558973e7d85383d5a22de352b05c22652bea. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->