### PR TITLE
feat(playground): allow non-streaming responses

### DIFF
--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -294,6 +294,10 @@ export const env = createEnv({
     NEXT_PUBLIC_PLAIN_APP_ID: z.string().optional(),
     NEXT_PUBLIC_BUILD_ID: z.string().optional(),
     NEXT_PUBLIC_BASE_PATH: z.string().optional(),
+    NEXT_PUBLIC_LANGFUSE_PLAYGROUND_STREAMING_ENABLED_DEFAULT: z
+      .enum(["true", "false"])
+      .optional()
+      .default("true"),
   },
 
   /**
@@ -493,6 +497,9 @@ export const env = createEnv({
       process.env.LANGFUSE_UI_VISIBLE_PRODUCT_MODULES,
     LANGFUSE_UI_HIDDEN_PRODUCT_MODULES:
       process.env.LANGFUSE_UI_HIDDEN_PRODUCT_MODULES,
+    // Playground
+    NEXT_PUBLIC_LANGFUSE_PLAYGROUND_STREAMING_ENABLED_DEFAULT:
+      process.env.NEXT_PUBLIC_LANGFUSE_PLAYGROUND_STREAMING_ENABLED_DEFAULT,
     // EE License
     LANGFUSE_EE_LICENSE_KEY: process.env.LANGFUSE_EE_LICENSE_KEY,
     ADMIN_API_KEY: process.env.ADMIN_API_KEY,

--- a/web/src/features/playground/page/components/Messages.tsx
+++ b/web/src/features/playground/page/components/Messages.tsx
@@ -10,6 +10,7 @@ import { Switch } from "@/src/components/ui/switch";
 import { Settings } from "lucide-react";
 import useLocalStorage from "@/src/components/useLocalStorage";
 import { env } from "@/src/env.mjs";
+import useCommandEnter from "@/src/features/playground/page/hooks/useCommandEnter";
 
 import { GenerationOutput } from "./GenerationOutput";
 import { ChatMessages } from "@/src/components/ChatMessages";
@@ -49,6 +50,11 @@ const SubmitButton = () => {
     "langfuse-playground-streaming",
     defaultStreamingEnabled,
   );
+
+  // Handle command+enter with streaming preference
+  useCommandEnter(!isStreaming, async () => {
+    await handleSubmit(streamingEnabled);
+  });
 
   return (
     <div className="flex items-center gap-2">

--- a/web/src/features/playground/page/components/Messages.tsx
+++ b/web/src/features/playground/page/components/Messages.tsx
@@ -1,5 +1,14 @@
 import { Button } from "@/src/components/ui/button";
 import { usePlaygroundContext } from "@/src/features/playground/page/context";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/src/components/ui/dropdown-menu";
+import { Switch } from "@/src/components/ui/switch";
+import { ChevronDown } from "lucide-react";
+import useLocalStorage from "@/src/components/useLocalStorage";
 
 import { GenerationOutput } from "./GenerationOutput";
 import { ChatMessages } from "@/src/components/ChatMessages";
@@ -33,16 +42,46 @@ export const Messages: React.FC<MessagesContext> = (props) => {
 
 const SubmitButton = () => {
   const { handleSubmit, isStreaming } = usePlaygroundContext();
+  const [streamingEnabled, setStreamingEnabled] = useLocalStorage(
+    "langfuse-playground-streaming",
+    true,
+  );
 
   return (
-    <Button
-      className="flex-0"
-      onClick={() => {
-        handleSubmit().catch((err) => console.error(err));
-      }}
-      loading={isStreaming}
-    >
-      <p>Submit (Ctrl + Enter)</p>
-    </Button>
+    <div className="flex">
+      <Button
+        className="flex-1 rounded-r-none"
+        onClick={() => {
+          handleSubmit(streamingEnabled).catch((err) => console.error(err));
+        }}
+        loading={isStreaming}
+      >
+        <p>Submit (Ctrl + Enter)</p>
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="icon"
+            className="rounded-l-none border-l-0 px-2"
+            disabled={isStreaming}
+          >
+            <ChevronDown className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-48">
+          <DropdownMenuItem
+            className="flex items-center justify-between"
+            onClick={(e) => e.preventDefault()}
+          >
+            <span>Stream responses</span>
+            <Switch
+              checked={streamingEnabled}
+              onCheckedChange={setStreamingEnabled}
+            />
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 };

--- a/web/src/features/playground/page/components/Messages.tsx
+++ b/web/src/features/playground/page/components/Messages.tsx
@@ -7,8 +7,9 @@ import {
   DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
 import { Switch } from "@/src/components/ui/switch";
-import { ChevronDown } from "lucide-react";
+import { Settings } from "lucide-react";
 import useLocalStorage from "@/src/components/useLocalStorage";
+import { env } from "@/src/env.mjs";
 
 import { GenerationOutput } from "./GenerationOutput";
 import { ChatMessages } from "@/src/components/ChatMessages";
@@ -42,15 +43,17 @@ export const Messages: React.FC<MessagesContext> = (props) => {
 
 const SubmitButton = () => {
   const { handleSubmit, isStreaming } = usePlaygroundContext();
+  const defaultStreamingEnabled =
+    env.NEXT_PUBLIC_LANGFUSE_PLAYGROUND_STREAMING_ENABLED_DEFAULT === "true";
   const [streamingEnabled, setStreamingEnabled] = useLocalStorage(
     "langfuse-playground-streaming",
-    true,
+    defaultStreamingEnabled,
   );
 
   return (
-    <div className="flex items-center">
+    <div className="flex items-center gap-2">
       <Button
-        className="flex-1 rounded-r-none border-r-0"
+        className="flex-1"
         onClick={() => {
           handleSubmit(streamingEnabled).catch((err) => console.error(err));
         }}
@@ -61,13 +64,12 @@ const SubmitButton = () => {
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
-            variant="default"
-            size="sm"
-            className="h-8 rounded-l-none border-l border-primary-foreground/20 bg-primary px-2 py-1 hover:bg-primary/90"
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 focus:outline-none focus:ring-0 focus-visible:ring-0"
             disabled={isStreaming}
-            tabIndex={-1}
           >
-            <ChevronDown className="h-3.5 w-3.5" />
+            <Settings className="h-4 w-4" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-52">
@@ -77,6 +79,11 @@ const SubmitButton = () => {
           >
             <div className="flex flex-col">
               <span className="font-medium">Stream responses</span>
+              <span className="text-xs text-muted-foreground">
+                {streamingEnabled
+                  ? "Real-time response streaming"
+                  : "Complete response at once"}
+              </span>
             </div>
             <Switch
               checked={streamingEnabled}

--- a/web/src/features/playground/page/components/Messages.tsx
+++ b/web/src/features/playground/page/components/Messages.tsx
@@ -48,9 +48,9 @@ const SubmitButton = () => {
   );
 
   return (
-    <div className="flex">
+    <div className="flex items-center">
       <Button
-        className="flex-1 rounded-r-none"
+        className="flex-1 rounded-r-none border-r-0"
         onClick={() => {
           handleSubmit(streamingEnabled).catch((err) => console.error(err));
         }}
@@ -61,20 +61,23 @@ const SubmitButton = () => {
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
-            variant="outline"
-            size="icon"
-            className="rounded-l-none border-l-0 px-2"
+            variant="default"
+            size="sm"
+            className="h-8 rounded-l-none border-l border-primary-foreground/20 bg-primary px-2 py-1 hover:bg-primary/90"
             disabled={isStreaming}
+            tabIndex={-1}
           >
-            <ChevronDown className="h-4 w-4" />
+            <ChevronDown className="h-3.5 w-3.5" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-48">
+        <DropdownMenuContent align="end" className="w-52">
           <DropdownMenuItem
-            className="flex items-center justify-between"
+            className="flex cursor-pointer items-center justify-between py-2.5"
             onClick={(e) => e.preventDefault()}
           >
-            <span>Stream responses</span>
+            <div className="flex flex-col">
+              <span className="font-medium">Stream responses</span>
+            </div>
             <Switch
               checked={streamingEnabled}
               onCheckedChange={setStreamingEnabled}

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -10,7 +10,6 @@ import React, {
 import { v4 as uuidv4 } from "uuid";
 
 import { createEmptyMessage } from "@/src/components/ChatMessages/utils/createEmptyMessage";
-import useCommandEnter from "@/src/features/playground/page/hooks/useCommandEnter";
 import { useModelParams } from "@/src/features/playground/page/hooks/useModelParams";
 import usePlaygroundCache from "@/src/features/playground/page/hooks/usePlaygroundCache";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -383,7 +383,7 @@ export const PlaygroundProvider: React.FC<PropsWithChildren> = ({
     ],
   );
 
-  useCommandEnter(!isStreaming, handleSubmit);
+  // Command enter handling moved to Messages component to access streaming preference
 
   const updatePromptVariableValue = useCallback(
     (variable: string, value: string) => {

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -443,7 +443,7 @@ async function getChatCompletionWithTools(
   messages: ChatMessageWithId[],
   modelParams: UIModelParams,
   tools: unknown[],
-  streaming: boolean = true,
+  streaming: boolean = false,
 ): Promise<ToolCallResponse> {
   if (!projectId) throw Error("Project ID is not set");
 
@@ -484,7 +484,7 @@ async function getChatCompletionWithStructuredOutput(
   messages: ChatMessageWithId[],
   modelParams: UIModelParams,
   structuredOutputSchema: PlaygroundSchema | null,
-  streaming: boolean = true,
+  streaming: boolean = false,
 ): Promise<string> {
   if (!projectId) throw Error("Project ID is not set");
 

--- a/web/src/features/playground/server/validateChatCompletionBody.ts
+++ b/web/src/features/playground/server/validateChatCompletionBody.ts
@@ -21,6 +21,7 @@ export const ChatCompletionBodySchema = z.object({
   modelParams: ModelParamsSchema,
   tools: z.array(LLMToolDefinitionSchema).optional(),
   structuredOutputSchema: LLMJSONSchema.optional(),
+  streaming: z.boolean().optional().default(true),
 });
 
 export const validateChatCompletionBody = (input: unknown) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for non-streaming responses in the playground with configurable default and UI toggle.
> 
>   - **Behavior**:
>     - Add non-streaming response handling in `chatCompletionHandler` and `getChatCompletionNonStreaming()` in `index.tsx`.
>     - Default streaming behavior configurable via `NEXT_PUBLIC_LANGFUSE_PLAYGROUND_STREAMING_ENABLED_DEFAULT` in `env.mjs`.
>   - **UI Components**:
>     - Add dropdown menu in `Messages.tsx` to toggle streaming preference.
>     - Use `useLocalStorage` to persist streaming preference in `SubmitButton`.
>   - **Server**:
>     - Update `chatCompletionHandler.ts` to handle non-streaming responses.
>     - Modify `validateChatCompletionBody.ts` to include `streaming` option in request validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0d0554b31eb659742c07bd427b55dac7de807fcf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->