### PR TITLE
chore(evals): re-introduce delay input field for evaluation timing

### DIFF
--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -666,6 +666,24 @@ export const InnerEvaluatorForm = (props: {
                 </FormItem>
               )}
             />
+
+            <FormField
+              control={form.control}
+              name="delay"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Delay (seconds)</FormLabel>
+                  <FormControl>
+                    <Input {...field} type="number" />
+                  </FormControl>
+                  <FormDescription>
+                    Time between first Trace/Dataset run event and evaluation
+                    execution to ensure all data is available
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
           </div>
         </Card>
       )}

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -674,7 +674,7 @@ export const InnerEvaluatorForm = (props: {
                 <FormItem>
                   <FormLabel>Delay (seconds)</FormLabel>
                   <FormControl>
-                    <Input {...field} type="number" />
+                    <Input {...field} type="number" min={0} />
                   </FormControl>
                   <FormDescription>
                     Time between first Trace/Dataset run event and evaluation

--- a/web/src/features/evals/utils/evaluator-form-utils.ts
+++ b/web/src/features/evals/utils/evaluator-form-utils.ts
@@ -16,7 +16,7 @@ export const evalConfigFormSchema = z.object({
   filter: z.array(singleFilter).nullable(), // reusing the filter type from the tables
   mapping: z.array(wipVariableMapping),
   sampling: z.coerce.number().gt(0).lte(1),
-  delay: z.coerce.number().optional().default(10),
+  delay: z.coerce.number().min(0).optional().default(10),
   timeScope: TimeScopeSchema,
 });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reintroduces delay input field in `InnerEvaluatorForm` and updates schema validation for delay in `evalConfigFormSchema`.
> 
>   - **Behavior**:
>     - Adds `delay` input field to `InnerEvaluatorForm` in `inner-evaluator-form.tsx` for specifying delay in seconds.
>     - Updates `evalConfigFormSchema` in `evaluator-form-utils.ts` to validate `delay` as a non-negative number.
>   - **Misc**:
>     - Default `delay` value set to 10 seconds in `evalConfigFormSchema`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c19bf062e3aab37838352efd0393bf7e8e16d9e4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->