### PR TITLE
fix(prompts): undefined prompt name when clicking on metrics

### DIFF
--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -214,6 +214,9 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
                 <div>
                   <FormItem>
                     <FormLabel>Name</FormLabel>
+                    <FormDescription>
+                      Use slashes &apos;/&apos; in prompt names to organize them into <a target="_blank" href="https://langfuse.com/docs/prompts/get-started#prompt-folders-for-organization"><i>folders</i></a>.
+                    </FormDescription>
                     <FormControl>
                       <Input placeholder="Name your prompt" {...field} />
                     </FormControl>

--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -215,7 +215,7 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
                   <FormItem>
                     <FormLabel>Name</FormLabel>
                     <FormDescription>
-                      Use slashes &apos;/&apos; in prompt names to organize them into <a target="_blank" href="https://langfuse.com/docs/prompts/get-started#prompt-folders-for-organization"><i>folders</i></a>.
+                      Use slashes &apos;/&apos; in prompt names to organize them into <a target="_blank" rel="noopener noreferrer" href="https://langfuse.com/docs/prompts/get-started#prompt-folders-for-organization"><i>folders</i></a>.
                     </FormDescription>
                     <FormControl>
                       <Input placeholder="Name your prompt" {...field} />

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -95,25 +95,16 @@ ${labels.length > 0 ? labels.map((label) => `const prompt = await langfuse.getPr
 langfuse.getPrompt("${name}", ${version})
 `;
 
-export const PromptDetail = () => {
+export const PromptDetail = ({ promptName: promptNameProp }: { promptName?: string } = {}) => {
   const projectId = useProjectIdFromURL();
   const capture = usePostHogClientCapture();
   const router = useRouter();
 
-  // Handle both [promptName] route and catch-all [...folder] route
-  const promptName = router.query.promptName
-    ? decodeURIComponent(router.query.promptName as string)
-    : (() => {
-        const folder = router.query.folder;
-        if (Array.isArray(folder)) {
-          // Remove 'metrics' from the end if present, as it's not part of the prompt name
-          const segments = folder[folder.length - 1] === 'metrics' ? folder.slice(0, -1) : folder;
-          return segments.join('/');
-        } else if (typeof folder === 'string') {
-          return folder;
-        }
-        return '';
-      })();
+  const promptName = promptNameProp || (
+    router.query.promptName
+      ? decodeURIComponent(router.query.promptName as string)
+      : ''
+  );
   const [currentPromptVersion, setCurrentPromptVersion] = useQueryParam(
     "version",
     NumberParam,

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -106,7 +106,9 @@ export const PromptDetail = () => {
     : (() => {
         const folder = router.query.folder;
         if (Array.isArray(folder)) {
-          return folder.join('/');
+          // Remove 'metrics' if present, it's not part of the prompt name
+          const segments = folder.filter(segment => segment !== 'metrics');
+          return segments.join('/');
         } else if (typeof folder === 'string') {
           return folder;
         }

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -106,8 +106,8 @@ export const PromptDetail = () => {
     : (() => {
         const folder = router.query.folder;
         if (Array.isArray(folder)) {
-          // 'metrics' is not part of the prompt name
-          const segments = folder.filter(segment => segment !== 'metrics');
+          // Remove 'metrics' from the end if present, as it's not part of the prompt name
+          const segments = folder[folder.length - 1] === 'metrics' ? folder.slice(0, -1) : folder;
           return segments.join('/');
         } else if (typeof folder === 'string') {
           return folder;

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -106,7 +106,7 @@ export const PromptDetail = () => {
     : (() => {
         const folder = router.query.folder;
         if (Array.isArray(folder)) {
-          // Remove 'metrics' if present, it's not part of the prompt name
+          // 'metrics' is not part of the prompt name
           const segments = folder.filter(segment => segment !== 'metrics');
           return segments.join('/');
         } else if (typeof folder === 'string') {

--- a/web/src/pages/project/[projectId]/prompts/[[...folder]].tsx
+++ b/web/src/pages/project/[projectId]/prompts/[[...folder]].tsx
@@ -22,7 +22,8 @@ export default function PromptsWithFolder() {
   // Determine view type based on route segments
   // NOTE: there is a bug here, that if the user directly accesses a prompt name which ends in `/metrics`,
   // the prompt metrics page will be shown for a non-existing prompt name. Doesn't happen if the user clicks
-  // this in the UI (we URL encode here and don't strip metrics).
+  // this in the UI (we URL encode here and don't strip metrics). We could resolve this with another API call
+  // to check the prompt name existance.
   const segmentsArray = Array.isArray(routeSegments) ? routeSegments : [];
   const isMetricsPage = segmentsArray.length > 0 && segmentsArray[segmentsArray.length - 1] === 'metrics';
   const promptNameFromRoute = segmentsArray.length > 0

--- a/web/src/pages/project/[projectId]/prompts/[[...folder]].tsx
+++ b/web/src/pages/project/[projectId]/prompts/[[...folder]].tsx
@@ -11,6 +11,7 @@ import { useEntitlementLimit } from "@/src/features/entitlements/hooks";
 import { PromptDetail } from "@/src/features/prompts/components/prompt-detail";
 import PromptMetrics from "./metrics";
 import { useQueryParams, StringParam } from "use-query-params";
+import React from "react";
 
 export default function PromptsWithFolder() {
   const router = useRouter();
@@ -23,7 +24,7 @@ export default function PromptsWithFolder() {
   // NOTE: there is a bug here, that if the user directly accesses a prompt name which ends in `/metrics`,
   // the prompt metrics page will be shown for a non-existing prompt name. Doesn't happen if the user clicks
   // this in the UI (we URL encode here and don't strip metrics). We could resolve this with another API call
-  // to check the prompt name existance.
+  // to check the prompt name existence.
   const segmentsArray = Array.isArray(routeSegments) ? routeSegments : [];
   const isMetricsPage = segmentsArray.length > 0 && segmentsArray[segmentsArray.length - 1] === 'metrics';
   const promptNameFromRoute = segmentsArray.length > 0

--- a/web/src/pages/project/[projectId]/prompts/[[...folder]].tsx
+++ b/web/src/pages/project/[projectId]/prompts/[[...folder]].tsx
@@ -63,9 +63,9 @@ export default function PromptsWithFolder() {
   // Decide what to render: metrics, detail, or folder view
   if (promptNameFromRoute.length > 0) {
     if (isMetricsPage) {
-      return <PromptMetrics />;
+      return <PromptMetrics promptName={promptNameFromRoute} />;
     }
-    return <PromptDetail />;
+    return <PromptDetail promptName={promptNameFromRoute} />;
   }
 
   return (

--- a/web/src/pages/project/[projectId]/prompts/[[...folder]].tsx
+++ b/web/src/pages/project/[projectId]/prompts/[[...folder]].tsx
@@ -20,6 +20,9 @@ export default function PromptsWithFolder() {
   const folderQueryParam = queryParams.folder || '';
 
   // Determine view type based on route segments
+  // NOTE: there is a bug here, that if the user directly accesses a prompt name which ends in `/metrics`,
+  // the prompt metrics page will be shown for a non-existing prompt name. Doesn't happen if the user clicks
+  // this in the UI (we URL encode here and don't strip metrics).
   const segmentsArray = Array.isArray(routeSegments) ? routeSegments : [];
   const isMetricsPage = segmentsArray.length > 0 && segmentsArray[segmentsArray.length - 1] === 'metrics';
   const promptNameFromRoute = segmentsArray.length > 0

--- a/web/src/pages/project/[projectId]/prompts/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/metrics.tsx
@@ -80,15 +80,13 @@ function joinPromptCoreAndMetricData(
 export default function PromptVersionTable() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
+  // Decide prompt name if direct route or catchall (through click on metrics tab)
   const promptName = router.query.promptName
-    // direct route / query param call
     ? decodeURIComponent(router.query.promptName as string)
-    // catchall route through click on metrics tab in prompt details page
     : (() => {
         const folder = router.query.folder;
         if (Array.isArray(folder)) {
-          // Remove 'metrics' from the end if present, as it's not part of the prompt name
-          const segments = folder.filter(segment => segment !== 'metrics');
+          const segments = folder[folder.length - 1] === 'metrics' ? folder.slice(0, -1) : folder;
           return segments.join('/');
         }
         if (typeof folder === 'string') {

--- a/web/src/pages/project/[projectId]/prompts/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/metrics.tsx
@@ -80,7 +80,22 @@ function joinPromptCoreAndMetricData(
 export default function PromptVersionTable() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
-  const promptName = decodeURIComponent(router.query.promptName as string);
+  const promptName = router.query.promptName
+    // direct route / query param call
+    ? decodeURIComponent(router.query.promptName as string)
+    // catchall route through click on metrics tab in prompt details page
+    : (() => {
+        const folder = router.query.folder;
+        if (Array.isArray(folder)) {
+          // Remove 'metrics' from the end if present, as it's not part of the prompt name
+          const segments = folder.filter(segment => segment !== 'metrics');
+          return segments.join('/');
+        }
+        if (typeof folder === 'string') {
+          return folder;
+        }
+        return '';
+      })();
 
   const [paginationState, setPaginationState] = useQueryParams({
     pageIndex: withDefault(NumberParam, 0),

--- a/web/src/pages/project/[projectId]/prompts/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/metrics.tsx
@@ -77,23 +77,14 @@ function joinPromptCoreAndMetricData(
   return { status: "success", combinedData };
 }
 
-export default function PromptVersionTable() {
+export default function PromptVersionTable({ promptName: promptNameProp }: { promptName?: string } = {}) {
   const router = useRouter();
   const projectId = router.query.projectId as string;
-  // Decide prompt name if direct route or catchall (through click on metrics tab)
-  const promptName = router.query.promptName
-    ? decodeURIComponent(router.query.promptName as string)
-    : (() => {
-        const folder = router.query.folder;
-        if (Array.isArray(folder)) {
-          const segments = folder[folder.length - 1] === 'metrics' ? folder.slice(0, -1) : folder;
-          return segments.join('/');
-        }
-        if (typeof folder === 'string') {
-          return folder;
-        }
-        return '';
-      })();
+  const promptName = promptNameProp || (
+    router.query.promptName
+      ? decodeURIComponent(router.query.promptName as string)
+      : ''
+  );
 
   const [paginationState, setPaginationState] = useQueryParams({
     pageIndex: withDefault(NumberParam, 0),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix undefined prompt name issue in metrics by passing `promptName` prop to components and updating routing logic.
> 
>   - **Behavior**:
>     - Fix undefined prompt name issue when accessing metrics by passing `promptName` prop to `PromptDetail` and `PromptVersionTable`.
>     - Update routing logic in `[[...folder]].tsx` to correctly handle metrics pages by extracting prompt name from route segments.
>   - **Components**:
>     - Modify `PromptDetail` and `PromptVersionTable` to accept `promptName` prop.
>     - Update `PromptMetrics` usage in `[[...folder]].tsx` to pass `promptName`.
>   - **Misc**:
>     - Add `FormDescription` for prompt name field in `NewPromptForm` to guide users on organizing prompts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1efa685b28f7fe36f1e5023bb9dafffba0e08486. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->