### PR TITLE
feat(dashboard): add csv download from ui and loading state

### DIFF
--- a/web/src/features/widgets/chart-library/BigNumber.tsx
+++ b/web/src/features/widgets/chart-library/BigNumber.tsx
@@ -1,5 +1,6 @@
+import React, { useEffect, useRef, useState, useMemo } from "react";
 import { cn } from "@/src/utils/tailwind";
-import { useEffect, useRef, useState } from "react";
+import { type ChartProps } from "@/src/features/widgets/chart-library/chart-props";
 
 // Format large numbers with appropriate units and dynamic decimal places
 const formatBigNumber = (
@@ -96,28 +97,35 @@ const formatBigNumber = (
   }
 };
 
-export const BigNumber = ({
+export const BigNumber: React.FC<ChartProps> = ({
+  data,
   className,
-  metric,
-}: {
-  className?: string;
-  metric: React.ReactNode;
-}) => {
+}: ChartProps & { className?: string }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const textRef = useRef<HTMLSpanElement>(null);
   const [fontSize, setFontSize] = useState("text-6xl");
   const [maxCharacters, setMaxCharacters] = useState<number>();
 
-  // Convert metric to number if it's a string or number, otherwise use original
-  const numericValue =
-    typeof metric === "string" || typeof metric === "number"
-      ? parseFloat(String(metric))
-      : null;
+  // Calculate metric value from data - show loading if no data
+  const isLoading = !data || data.length === 0;
 
-  const displayValue =
-    numericValue !== null && !isNaN(numericValue)
-      ? formatBigNumber(numericValue, maxCharacters)
-      : { formatted: String(metric), unit: "" };
+  const calculatedMetric = useMemo(() => {
+    if (isLoading) return 0;
+
+    // Show the sum of all metrics, or just the first metric if only one
+    if (data.length === 1) {
+      return typeof data[0].metric === "number" ? data[0].metric : 0;
+    }
+
+    return data.reduce((acc, d) => {
+      const metric = typeof d.metric === "number" ? d.metric : 0;
+      return acc + metric;
+    }, 0);
+  }, [data, isLoading]);
+
+  const displayValue = !isLoading
+    ? formatBigNumber(calculatedMetric, maxCharacters)
+    : { formatted: "0", unit: "" };
 
   useEffect(() => {
     const resizeObserver = new ResizeObserver(() => {
@@ -156,10 +164,9 @@ export const BigNumber = ({
         const maxChars = Math.floor(availableWidth / charWidth);
 
         // Quick test with current display value
-        const testDisplayValue =
-          numericValue !== null && !isNaN(numericValue)
-            ? formatBigNumber(numericValue, maxChars)
-            : { formatted: String(metric), unit: "" };
+        const testDisplayValue = !isLoading
+          ? formatBigNumber(calculatedMetric, maxChars)
+          : { formatted: "0", unit: "" };
 
         const textLength = (testDisplayValue.formatted + testDisplayValue.unit)
           .length;
@@ -185,7 +192,11 @@ export const BigNumber = ({
     }
 
     return () => resizeObserver.disconnect();
-  }, [numericValue, metric]);
+  }, [calculatedMetric, isLoading]);
+
+  if (isLoading) {
+    return null;
+  }
 
   return (
     <div
@@ -199,11 +210,7 @@ export const BigNumber = ({
         <span
           ref={textRef}
           className={cn("text-center font-extrabold tracking-tight", fontSize)}
-          title={
-            numericValue !== null && !isNaN(numericValue)
-              ? numericValue.toString()
-              : String(metric)
-          }
+          title={calculatedMetric.toString()}
         >
           {displayValue.formatted}
         </span>

--- a/web/src/features/widgets/chart-library/Chart.tsx
+++ b/web/src/features/widgets/chart-library/Chart.tsx
@@ -93,7 +93,7 @@ export const Chart = ({
   );
 
   return (
-    <CardContent className="relative group h-full p-0">
+    <CardContent className="group relative h-full p-0">
       {shouldWarn ? renderWarning() : renderChart()}
       <DownloadDropdown data={renderedData} />
     </CardContent>

--- a/web/src/features/widgets/chart-library/Chart.tsx
+++ b/web/src/features/widgets/chart-library/Chart.tsx
@@ -11,7 +11,6 @@ import { type DashboardWidgetChartType } from "@langfuse/shared/src/db";
 import { Button } from "@/src/components/ui/button";
 import { AlertCircle } from "lucide-react";
 import { BigNumber } from "@/src/features/widgets/chart-library/BigNumber";
-import { DownloadDropdown } from "@/src/features/widgets/chart-library/DownloadDropdown";
 
 export const Chart = ({
   chartType,
@@ -93,9 +92,8 @@ export const Chart = ({
   );
 
   return (
-    <CardContent className="group relative h-full p-0">
+    <CardContent className="h-full p-0">
       {shouldWarn ? renderWarning() : renderChart()}
-      <DownloadDropdown data={renderedData} />
     </CardContent>
   );
 };

--- a/web/src/features/widgets/chart-library/Chart.tsx
+++ b/web/src/features/widgets/chart-library/Chart.tsx
@@ -11,6 +11,7 @@ import { type DashboardWidgetChartType } from "@langfuse/shared/src/db";
 import { Button } from "@/src/components/ui/button";
 import { AlertCircle } from "lucide-react";
 import { BigNumber } from "@/src/features/widgets/chart-library/BigNumber";
+import { DownloadDropdown } from "@/src/features/widgets/chart-library/DownloadDropdown";
 
 export const Chart = ({
   chartType,
@@ -92,8 +93,9 @@ export const Chart = ({
   );
 
   return (
-    <CardContent className="h-full p-0">
+    <CardContent className="relative group h-full p-0">
       {shouldWarn ? renderWarning() : renderChart()}
+      <DownloadDropdown data={renderedData} />
     </CardContent>
   );
 };

--- a/web/src/features/widgets/chart-library/Chart.tsx
+++ b/web/src/features/widgets/chart-library/Chart.tsx
@@ -56,15 +56,7 @@ export const Chart = ({
       case "HISTOGRAM":
         return <HistogramChart data={renderedData} />;
       case "NUMBER": {
-        // Show the sum of all metrics, or just the first metric if only one
-        const value =
-          renderedData.length === 1
-            ? renderedData[0].metric
-            : renderedData.reduce(
-                (acc, d) => acc + ((d.metric as number) || 0),
-                0,
-              );
-        return <BigNumber metric={value} />;
+        return <BigNumber data={renderedData} />;
       }
       default:
         return <HorizontalBarChart data={renderedData.slice(0, rowLimit)} />;

--- a/web/src/features/widgets/chart-library/DownloadButton.tsx
+++ b/web/src/features/widgets/chart-library/DownloadButton.tsx
@@ -1,4 +1,5 @@
-import { Download } from "lucide-react";
+import { Download, Check } from "lucide-react";
+import { useState } from "react";
 
 export function DownloadButton({
   data,
@@ -9,6 +10,8 @@ export function DownloadButton({
   fileName?: string;
   className?: string;
 }) {
+  const [isDownloaded, setIsDownloaded] = useState(false);
+
   const escapeCsvValue = (value: any): string => {
     const stringValue = String(value ?? "");
     if (
@@ -31,6 +34,12 @@ export function DownloadButton({
     a.click();
     a.remove();
     URL.revokeObjectURL(url);
+
+    // Show checkmark for 1 second
+    setIsDownloaded(true);
+    setTimeout(() => {
+      setIsDownloaded(false);
+    }, 1000);
   };
 
   const downloadCsv = () => {
@@ -53,12 +62,18 @@ export function DownloadButton({
 
   return (
     <button
-      onClick={downloadCsv}
+      onClick={() => {
+        if (isDownloaded) {
+          return;
+        }
+        downloadCsv();
+      }}
       className={`text-muted-foreground hover:text-foreground ${className || ""}`}
       aria-label="Download chart data as CSV"
       title="Download CSV"
+      disabled={isDownloaded}
     >
-      <Download size={16} />
+      {isDownloaded ? <Check size={16} /> : <Download size={16} />}
     </button>
   );
 }

--- a/web/src/features/widgets/chart-library/DownloadButton.tsx
+++ b/web/src/features/widgets/chart-library/DownloadButton.tsx
@@ -1,6 +1,6 @@
 import { Download } from "lucide-react";
 
-export function DownloadDropdown({
+export function DownloadButton({
   data,
   fileName = "chart-data",
   className,

--- a/web/src/features/widgets/chart-library/DownloadButton.tsx
+++ b/web/src/features/widgets/chart-library/DownloadButton.tsx
@@ -21,17 +21,21 @@ export function DownloadButton({
     return stringValue;
   };
 
+  const triggerDownload = (csvContent: string) => {
+    const blob = new Blob([csvContent], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${fileName}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  };
+
   const downloadCsv = () => {
     if (data.length === 0) {
-      const blob = new Blob([""], { type: "text/csv" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `${fileName}.csv`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
+      triggerDownload("");
       return;
     }
 
@@ -44,15 +48,7 @@ export function DownloadButton({
     ];
 
     const csvContent = csvRows.join("\n");
-    const blob = new Blob([csvContent], { type: "text/csv" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${fileName}.csv`;
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
+    triggerDownload(csvContent);
   };
 
   return (

--- a/web/src/features/widgets/chart-library/DownloadDropdown.tsx
+++ b/web/src/features/widgets/chart-library/DownloadDropdown.tsx
@@ -1,0 +1,48 @@
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/src/components/ui/dropdown-menu";
+import { Button } from "@/src/components/ui/button";
+import { Download } from "lucide-react";
+
+export function DownloadDropdown({ data, fileName = "chart-data" }: { data: Record<string, any>[]; fileName?: string }) {
+  const download = (content: string, type: string, extension: string) => {
+    const blob = new Blob([content], { type });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${fileName}.${extension}`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  const downloadJson = () => {
+    download(JSON.stringify(data, null, 2), "application/json", "json");
+  };
+
+  const downloadCsv = () => {
+    if (data.length === 0) {
+      download("", "text/csv", "csv");
+      return;
+    }
+    const headers = Object.keys(data[0]);
+    const csvRows = [
+      headers.join(","),
+      ...data.map((row) => headers.map((h) => JSON.stringify(row[h] ?? "")).join(",")),
+    ];
+    download(csvRows.join("\n"), "text/csv", "csv");
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button size="icon-xs" variant="ghost" className="absolute right-2 top-2 z-10 opacity-0 group-hover:opacity-100">
+          <Download className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onSelect={downloadCsv}>CSV</DropdownMenuItem>
+        <DropdownMenuItem onSelect={downloadJson}>JSON</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/web/src/features/widgets/chart-library/DownloadDropdown.tsx
+++ b/web/src/features/widgets/chart-library/DownloadDropdown.tsx
@@ -1,8 +1,19 @@
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/src/components/ui/dropdown-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/src/components/ui/dropdown-menu";
 import { Button } from "@/src/components/ui/button";
 import { Download } from "lucide-react";
 
-export function DownloadDropdown({ data, fileName = "chart-data" }: { data: Record<string, any>[]; fileName?: string }) {
+export function DownloadDropdown({
+  data,
+  fileName = "chart-data",
+}: {
+  data: Record<string, any>[];
+  fileName?: string;
+}) {
   const download = (content: string, type: string, extension: string) => {
     const blob = new Blob([content], { type });
     const url = URL.createObjectURL(blob);
@@ -19,6 +30,18 @@ export function DownloadDropdown({ data, fileName = "chart-data" }: { data: Reco
     download(JSON.stringify(data, null, 2), "application/json", "json");
   };
 
+  const escapeCsvValue = (value: any): string => {
+    const stringValue = String(value ?? "");
+    if (
+      stringValue.includes(",") ||
+      stringValue.includes('"') ||
+      stringValue.includes("\n")
+    ) {
+      return `"${stringValue.replace(/"/g, '""')}"`;
+    }
+    return stringValue;
+  };
+
   const downloadCsv = () => {
     if (data.length === 0) {
       download("", "text/csv", "csv");
@@ -27,7 +50,9 @@ export function DownloadDropdown({ data, fileName = "chart-data" }: { data: Reco
     const headers = Object.keys(data[0]);
     const csvRows = [
       headers.join(","),
-      ...data.map((row) => headers.map((h) => JSON.stringify(row[h] ?? "")).join(",")),
+      ...data.map((row) =>
+        headers.map((h) => escapeCsvValue(row[h])).join(","),
+      ),
     ];
     download(csvRows.join("\n"), "text/csv", "csv");
   };
@@ -35,7 +60,11 @@ export function DownloadDropdown({ data, fileName = "chart-data" }: { data: Reco
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button size="icon-xs" variant="ghost" className="absolute right-2 top-2 z-10 opacity-0 group-hover:opacity-100">
+        <Button
+          size="icon-xs"
+          variant="ghost"
+          className="absolute right-2 top-2 z-10 opacity-0 group-hover:opacity-100"
+        >
           <Download className="h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>

--- a/web/src/features/widgets/chart-library/DownloadDropdown.tsx
+++ b/web/src/features/widgets/chart-library/DownloadDropdown.tsx
@@ -1,35 +1,14 @@
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/src/components/ui/dropdown-menu";
-import { Button } from "@/src/components/ui/button";
 import { Download } from "lucide-react";
 
 export function DownloadDropdown({
   data,
   fileName = "chart-data",
+  className,
 }: {
   data: Record<string, any>[];
   fileName?: string;
+  className?: string;
 }) {
-  const download = (content: string, type: string, extension: string) => {
-    const blob = new Blob([content], { type });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${fileName}.${extension}`;
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
-  };
-
-  const downloadJson = () => {
-    download(JSON.stringify(data, null, 2), "application/json", "json");
-  };
-
   const escapeCsvValue = (value: any): string => {
     const stringValue = String(value ?? "");
     if (
@@ -44,9 +23,18 @@ export function DownloadDropdown({
 
   const downloadCsv = () => {
     if (data.length === 0) {
-      download("", "text/csv", "csv");
+      const blob = new Blob([""], { type: "text/csv" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${fileName}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
       return;
     }
+
     const headers = Object.keys(data[0]);
     const csvRows = [
       headers.join(","),
@@ -54,24 +42,27 @@ export function DownloadDropdown({
         headers.map((h) => escapeCsvValue(row[h])).join(","),
       ),
     ];
-    download(csvRows.join("\n"), "text/csv", "csv");
+
+    const csvContent = csvRows.join("\n");
+    const blob = new Blob([csvContent], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${fileName}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
   };
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          size="icon-xs"
-          variant="ghost"
-          className="absolute right-2 top-2 z-10 opacity-0 group-hover:opacity-100"
-        >
-          <Download className="h-4 w-4" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem onSelect={downloadCsv}>CSV</DropdownMenuItem>
-        <DropdownMenuItem onSelect={downloadJson}>JSON</DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <button
+      onClick={downloadCsv}
+      className={`text-muted-foreground hover:text-foreground ${className || ""}`}
+      aria-label="Download chart data as CSV"
+      title="Download CSV"
+    >
+      <Download size={16} />
+    </button>
   );
 }

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -20,7 +20,7 @@ import { useRouter } from "next/router";
 import { startCase } from "lodash";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
-import { DownloadDropdown } from "@/src/features/widgets/chart-library/DownloadDropdown";
+import { DownloadButton } from "@/src/features/widgets/chart-library/DownloadButton";
 
 export interface WidgetPlacement {
   id: string;
@@ -252,7 +252,7 @@ export function DashboardWidget({
               <Loader2 size={16} className="animate-spin" />
             </div>
           ) : (
-            <DownloadDropdown
+            <DownloadButton
               data={transformedData}
               fileName={widget.data.name}
               className="hidden group-hover:block"

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -14,6 +14,7 @@ import {
   TrashIcon,
   CopyIcon,
   GripVerticalIcon,
+  Loader2,
 } from "lucide-react";
 import { useRouter } from "next/router";
 import { startCase } from "lodash";
@@ -241,12 +242,22 @@ export function DashboardWidget({
               </button>
             </>
           )}
-          {/* Download button - always available */}
-          <DownloadDropdown
-            data={transformedData}
-            fileName={widget.data.name}
-            className="hidden group-hover:block"
-          />
+          {/* Download button or loading indicator - always available */}
+          {queryResult.isLoading ? (
+            <div
+              className="text-muted-foreground"
+              aria-label="Loading chart data"
+              title="Loading..."
+            >
+              <Loader2 size={16} className="animate-spin" />
+            </div>
+          ) : (
+            <DownloadDropdown
+              data={transformedData}
+              fileName={widget.data.name}
+              className="hidden group-hover:block"
+            />
+          )}
         </div>
       </div>
       <div

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -19,6 +19,7 @@ import { useRouter } from "next/router";
 import { startCase } from "lodash";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import { DownloadDropdown } from "@/src/features/widgets/chart-library/DownloadDropdown";
 
 export interface WidgetPlacement {
   id: string;
@@ -207,38 +208,46 @@ export function DashboardWidget({
             ? " ( 🪢 )"
             : null}
         </span>
-        {hasCUDAccess && (
-          <div className="flex space-x-2">
-            <GripVerticalIcon
-              size={16}
-              className="drag-handle hidden cursor-grab text-muted-foreground hover:text-foreground active:cursor-grabbing lg:group-hover:block"
-            />
-            {widget.data.owner === "PROJECT" ? (
+        <div className="flex space-x-2">
+          {hasCUDAccess && (
+            <>
+              <GripVerticalIcon
+                size={16}
+                className="drag-handle hidden cursor-grab text-muted-foreground hover:text-foreground active:cursor-grabbing lg:group-hover:block"
+              />
+              {widget.data.owner === "PROJECT" ? (
+                <button
+                  onClick={handleEdit}
+                  className="hidden text-muted-foreground hover:text-foreground group-hover:block"
+                  aria-label="Edit widget"
+                >
+                  <PencilIcon size={16} />
+                </button>
+              ) : widget.data.owner === "LANGFUSE" ? (
+                <button
+                  onClick={handleCopy}
+                  className="hidden text-muted-foreground hover:text-foreground group-hover:block"
+                  aria-label="Copy widget"
+                >
+                  <CopyIcon size={16} />
+                </button>
+              ) : null}
               <button
-                onClick={handleEdit}
-                className="hidden text-muted-foreground hover:text-foreground group-hover:block"
-                aria-label="Edit widget"
+                onClick={handleDelete}
+                className="hidden text-muted-foreground hover:text-destructive group-hover:block"
+                aria-label="Delete widget"
               >
-                <PencilIcon size={16} />
+                <TrashIcon size={16} />
               </button>
-            ) : widget.data.owner === "LANGFUSE" ? (
-              <button
-                onClick={handleCopy}
-                className="hidden text-muted-foreground hover:text-foreground group-hover:block"
-                aria-label="Copy widget"
-              >
-                <CopyIcon size={16} />
-              </button>
-            ) : null}
-            <button
-              onClick={handleDelete}
-              className="hidden text-muted-foreground hover:text-destructive group-hover:block"
-              aria-label="Delete widget"
-            >
-              <TrashIcon size={16} />
-            </button>
-          </div>
-        )}
+            </>
+          )}
+          {/* Download button - always available */}
+          <DownloadDropdown
+            data={transformedData}
+            fileName={widget.data.name}
+            className="hidden group-hover:block"
+          />
+        </div>
       </div>
       <div
         className="mb-4 truncate text-sm text-muted-foreground"


### PR DESCRIPTION
## Summary
- add a dropdown download menu for customizable dashboard charts
- show download button on chart hover

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6851784c6a8883299cfbb6d88e3c8996
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add CSV download feature and loading state to dashboard charts, refactor `BigNumber` for dynamic data handling.
> 
>   - **Features**:
>     - Add `DownloadButton` component for CSV download in `DownloadButton.tsx`.
>     - Show download button on chart hover in `DashboardWidget.tsx`.
>     - Add loading indicator for chart data in `DashboardWidget.tsx`.
>   - **Components**:
>     - Refactor `BigNumber` in `BigNumber.tsx` to calculate metrics from data and handle loading state.
>     - Update `Chart` in `Chart.tsx` to use `BigNumber` with data prop.
>   - **Misc**:
>     - Add `Loader2` icon for loading state in `DashboardWidget.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4718034064d6503f8c596701e378df872ea242bf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->