### PR TITLE
fix: long trace names shouldn't break at icons

### DIFF
--- a/web/src/components/trace/ObservationTree.tsx
+++ b/web/src/components/trace/ObservationTree.tsx
@@ -173,13 +173,13 @@ const ObservationTreeTraceNode = (props: {
     >
       <div className="flex w-full flex-row items-start justify-between gap-1 py-1">
         <div className="flex w-full flex-col items-start gap-2 -space-y-1 py-1.5">
-          <div className="flex items-center gap-2 min-w-0">
+          <div className="flex items-center gap-2">
             <ItemBadge
               type="TRACE"
               isSmall={true}
               className="flex-shrink-0 scale-75"
             />
-            <span className="break-words text-sm font-medium min-w-0">
+            <span className="break-all text-sm font-medium">
               {props.trace.name}
             </span>
             {props.comments && props.showComments ? (
@@ -390,17 +390,18 @@ const ObservationTreeNodeCard = ({
           )}
           ref={currentObservationRef}
         >
-          {/* Type badge */}
-          <ItemBadge
-            type={observation.type}
-            isSmall
-            className="flex-shrink-0 scale-75"
-          />
+          {/* Type badge and name */}
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <ItemBadge
+              type={observation.type}
+              isSmall
+              className="flex-shrink-0 scale-75"
+            />
+            <span className="text-sm font-medium whitespace-nowrap">{observation.name}</span>
+          </div>
 
-          {/* Name and duration */}
+          {/* Duration */}
           <div className="flex items-center gap-2">
-            <span className="text-sm font-medium">{observation.name}</span>
-
             {comments && showComments ? (
               <CommentCountIcon count={comments.get(observation.id)} />
             ) : null}

--- a/web/src/components/trace/ObservationTree.tsx
+++ b/web/src/components/trace/ObservationTree.tsx
@@ -173,13 +173,13 @@ const ObservationTreeTraceNode = (props: {
     >
       <div className="flex w-full flex-row items-start justify-between gap-1 py-1">
         <div className="flex w-full flex-col items-start gap-2 -space-y-1 py-1.5">
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex items-center gap-2 min-w-0">
             <ItemBadge
               type="TRACE"
               isSmall={true}
               className="flex-shrink-0 scale-75"
             />
-            <span className="break-all text-sm font-medium">
+            <span className="break-words text-sm font-medium min-w-0">
               {props.trace.name}
             </span>
             {props.comments && props.showComments ? (

--- a/web/src/components/trace/ObservationTree.tsx
+++ b/web/src/components/trace/ObservationTree.tsx
@@ -173,7 +173,7 @@ const ObservationTreeTraceNode = (props: {
     >
       <div className="flex w-full flex-row items-start justify-between gap-1 py-1">
         <div className="flex w-full flex-col items-start gap-2 -space-y-1 py-1.5">
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <ItemBadge
               type="TRACE"
               isSmall={true}
@@ -400,7 +400,7 @@ const ObservationTreeNodeCard = ({
             <span className="text-sm font-medium whitespace-nowrap">{observation.name}</span>
           </div>
 
-          {/* Duration */}
+          {/* Duration and Comments */}
           <div className="flex items-center gap-2">
             {comments && showComments ? (
               <CommentCountIcon count={comments.get(observation.id)} />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes trace name display in `ObservationTreeNodeCard` to prevent line breaks at icons by grouping badge and name, and applying `whitespace-nowrap`.
> 
>   - **Behavior**:
>     - In `ObservationTreeNodeCard`, group `ItemBadge` and `observation.name` in a `div` with `flex-shrink-0` to prevent line breaks at icons.
>     - Apply `whitespace-nowrap` to `observation.name` to ensure the name does not break at icons.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3c7b1cc47cd99a28cbe377aaa32d18034661dcc8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->