### PR TITLE
fix: center align dataset description vertically

### DIFF
--- a/web/src/features/datasets/components/DatasetsTable.tsx
+++ b/web/src/features/datasets/components/DatasetsTable.tsx
@@ -110,7 +110,7 @@ export function DatasetsTable(props: { projectId: string }) {
       size: 200,
       cell: ({ row }) => {
         const description: RowData["description"] = row.getValue("description");
-        return <div className="h-full overflow-y-auto">{description}</div>;
+        return <div className="h-full overflow-y-auto flex items-center">{description}</div>;
       },
     },
     {


### PR DESCRIPTION
before: 
![image](https://github.com/user-attachments/assets/bfe867c0-1e96-48ad-a5ca-faf2707eda1e)


after:
![2025-06-18_11-34-50_screenshot@2x](https://github.com/user-attachments/assets/c50ff0a4-35f0-4235-816c-166cb6d9f8d3)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Center aligns dataset description vertically in `DatasetsTable`.
> 
>   - **UI Update**:
>     - Center aligns dataset description vertically in `DatasetsTable` by adding `flex items-center` to the `div` in the `cell` function for the `description` column.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d5384fcc2c8da79baa61de889ab73cf27cc957c2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->