### PR TITLE
chore: track clickhouse calls in ingestion-pipeline as clients

### DIFF
--- a/web/src/features/public-api/server/apiAuth.ts
+++ b/web/src/features/public-api/server/apiAuth.ts
@@ -121,7 +121,7 @@ export class ApiAuthService {
       { name: "api-auth-verify" },
       async () => {
         if (!authHeader) {
-          logger.error("No authorization header");
+          logger.debug("No authorization header");
           return {
             validKey: false,
             error: "No authorization header",

--- a/web/src/features/public-api/server/withMiddlewares.ts
+++ b/web/src/features/public-api/server/withMiddlewares.ts
@@ -6,6 +6,7 @@ import {
   BaseError,
   LangfuseNotFoundError,
   MethodNotAllowedError,
+  UnauthorizedError,
 } from "@langfuse/shared";
 import {
   logger,
@@ -53,7 +54,10 @@ export function withMiddlewares(handlers: Handlers) {
 
         return await finalHandlers[method](req, res);
       } catch (error) {
-        if (error instanceof LangfuseNotFoundError) {
+        if (
+          error instanceof LangfuseNotFoundError ||
+          error instanceof UnauthorizedError
+        ) {
           logger.info(error);
         } else {
           logger.error(error);

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -1,4 +1,4 @@
-import { Redis, Cluster } from "ioredis";
+import { Cluster, Redis } from "ioredis";
 import { v4 } from "uuid";
 import { Prisma } from "@prisma/client";
 import {
@@ -10,11 +10,12 @@ import {
 } from "@langfuse/shared";
 import {
   ClickhouseClientType,
-  IngestionEntityTypes,
+  convertDateToClickhouseDateTime,
   convertObservationReadToInsert,
   convertScoreReadToInsert,
   convertTraceReadToInsert,
   eventTypes,
+  IngestionEntityTypes,
   IngestionEventType,
   instrumentAsync,
   logger,
@@ -23,6 +24,8 @@ import {
   ObservationRecordInsertType,
   observationRecordReadSchema,
   PromptService,
+  QueueJobs,
+  recordIncrement,
   ScoreEventType,
   scoreRecordInsertSchema,
   ScoreRecordInsertType,
@@ -31,12 +34,9 @@ import {
   traceRecordInsertSchema,
   TraceRecordInsertType,
   traceRecordReadSchema,
-  validateAndInflateScore,
-  UsageCostType,
-  convertDateToClickhouseDateTime,
   TraceUpsertQueue,
-  QueueJobs,
-  recordIncrement,
+  UsageCostType,
+  validateAndInflateScore,
 } from "@langfuse/shared/src/server";
 
 import { tokenCount } from "../../features/tokenisation/usage";
@@ -49,6 +49,7 @@ import {
 import { randomUUID } from "crypto";
 import { env } from "../../env";
 import { findModel } from "../modelMatch";
+import { SpanKind } from "@opentelemetry/api";
 
 type InsertRecord =
   | TraceRecordInsertType
@@ -889,8 +890,11 @@ export class IngestionService {
     const { projectId, entityId, table, additionalFilters } = params;
 
     return await instrumentAsync(
-      { name: `get-clickhouse-${table}` },
+      { name: `get-clickhouse-${table}`, spanKind: SpanKind.CLIENT },
       async (span) => {
+        span.setAttribute("ch.query.table", table);
+        span.setAttribute("db.system", "clickhouse");
+        span.setAttribute("db.operation.name", "SELECT");
         span.setAttribute("projectId", projectId);
         const queryResult = await this.clickhouseClient.query({
           query: `
@@ -911,6 +915,25 @@ export class IngestionService {
             }),
           },
         });
+
+        span.setAttribute("ch.queryId", queryResult.query_id);
+        const summaryHeader =
+          queryResult.response_headers["x-clickhouse-summary"];
+        if (summaryHeader) {
+          try {
+            const summary = Array.isArray(summaryHeader)
+              ? JSON.parse(summaryHeader[0])
+              : JSON.parse(summaryHeader);
+            for (const key in summary) {
+              span.setAttribute(`ch.${key}`, summary[key]);
+            }
+          } catch (error) {
+            logger.debug(
+              `Failed to parse clickhouse summary header ${summaryHeader}`,
+              error,
+            );
+          }
+        }
 
         const result = await queryResult.json();
 

--- a/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
@@ -11,7 +11,11 @@ import * as clickhouseWriteExports from "../../ClickhouseWriter";
 
 const mockAddToClickhouseWriter = vi.fn();
 const mockClickhouseClient = {
-  query: async () => ({ json: async () => [] }),
+  query: async () => ({
+    json: async () => [],
+    query_id: "1",
+    response_headers: { "x-clickhouse-summary": [] },
+  }),
 };
 
 vi.mock("../../ClickhouseWriter", async (importOriginal) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance Clickhouse query tracking in `IngestionService` with OpenTelemetry spans and update logging and tests accordingly.
> 
>   - **IngestionService**:
>     - Add OpenTelemetry client spans to `getClickhouseRecord()` for Clickhouse queries, setting attributes like `ch.query.table`, `db.system`, `db.operation.name`, and `ch.queryId`.
>     - Parse and log Clickhouse summary headers in `getClickhouseRecord()`.
>   - **Logging**:
>     - Change log level from `error` to `debug` for missing authorization header in `apiAuth.ts`.
>     - Log `UnauthorizedError` as info in `withMiddlewares.ts`.
>   - **Tests**:
>     - Update `mockClickhouseClient` in `calculateTokenCost.unit.test.ts` to include `query_id` and `response_headers`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c52f266669a78fe4c8ffad10b43be7a38d67a3f0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->