### PR TITLE
chore: move trpc unauthed logging to info/warn

### DIFF
--- a/web/src/pages/api/trpc/[trpc].ts
+++ b/web/src/pages/api/trpc/[trpc].ts
@@ -13,10 +13,17 @@ export default createNextApiHandler({
   router: appRouter,
   createContext: createTRPCContext,
   onError: ({ path, error }) => {
-    logger.error(
-      `tRPC route failed on ${path ?? "<no-path>"}: ${error.message}`,
-      error,
-    );
+    if (error.code === "NOT_FOUND" || error.code === "UNAUTHORIZED") {
+      logger.info(
+        `tRPC route failed on ${path ?? "<no-path>"}: ${error.message}`,
+        error,
+      );
+    } else {
+      logger.error(
+        `tRPC route failed on ${path ?? "<no-path>"}: ${error.message}`,
+        error,
+      );
+    }
     traceException(error);
     return error;
   },

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -115,7 +115,7 @@ const withErrorHandling = t.middleware(async ({ ctx, next }) => {
   const res = await next({ ctx }); // pass the context to the next middleware
 
   if (!res.ok) {
-    if (res.error.code === "NOT_FOUND") {
+    if (res.error.code === "NOT_FOUND" || res.error.code === "UNAUTHORIZED") {
       logger.info(
         `middleware intercepted error with code ${res.error.code}`,
         res.error,
@@ -262,7 +262,7 @@ const enforceUserIsAuthedAndProjectMember = t.middleware(
         });
       }
       // not a member
-      logger.error(`User is not a member of this project with id ${projectId}`);
+      logger.warn(`User is not a member of this project with id ${projectId}`);
       throw new TRPCError({
         code: "UNAUTHORIZED",
         message: "User is not a member of this project",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change logging level to `info` for `NOT_FOUND` and `UNAUTHORIZED` errors in tRPC handlers and middleware, and to `warn` for unauthorized project access.
> 
>   - **Logging Changes**:
>     - In `[trpc].ts`, change logging level to `info` for `NOT_FOUND` and `UNAUTHORIZED` errors in `onError`.
>     - In `trpc.ts`, change logging level to `info` for `NOT_FOUND` and `UNAUTHORIZED` errors in `withErrorHandling` middleware.
>     - Change logging level to `warn` for unauthorized project access in `enforceUserIsAuthedAndProjectMember` middleware.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7a5dcd4ad52ef562893d92ab4b54e246ae758b30. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->