### PR TITLE
fix(evals): use jsonpath-plus for JSONPath extraction in frontend preview

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -81,6 +81,7 @@
     "exponential-backoff": "^3.1.1",
     "https-proxy-agent": "^7.0.6",
     "ioredis": "^5.4.1",
+    "jsonpath-plus": "10.3.0",
     "kysely": "^0.27.4",
     "langchain": "^0.3.28",
     "langfuse-langchain": "3.37.4",

--- a/packages/shared/src/features/evals/utilities.ts
+++ b/packages/shared/src/features/evals/utilities.ts
@@ -28,24 +28,15 @@ export const parseUnknownToString = (value: unknown): string => {
 };
 
 function parseJsonDefault(selectedColumn: unknown, jsonSelector: string) {
-  // JSONPath extraction matching backend implementation
-  try {
-    const result = JSONPath({
-      path: jsonSelector,
-      json:
-        typeof selectedColumn === "string"
-          ? JSON.parse(selectedColumn)
-          : selectedColumn,
-    });
+  const result = JSONPath({
+    path: jsonSelector,
+    json:
+      typeof selectedColumn === "string"
+        ? JSON.parse(selectedColumn)
+        : selectedColumn,
+  });
 
-    return result.length > 0 ? result[0] : undefined;
-  } catch (error) {
-    console.error(
-      `Error parsing JSONPath selector: ${jsonSelector}`,
-      error,
-    );
-    throw error; // Re-throw to let caller handle it
-  }
+  return result.length > 0 ? result[0] : undefined;
 }
 
 export function extractValueFromObject(
@@ -63,9 +54,10 @@ export function extractValueFromObject(
     try {
       jsonSelectedColumn = jsonParser(selectedColumn, mapping.jsonSelector);
     } catch (err) {
-      error = err instanceof Error 
-        ? err 
-        : new Error("There was an unknown error parsing the JSON");
+      error =
+        err instanceof Error
+          ? err
+          : new Error("There was an unknown error parsing the JSON");
       jsonSelectedColumn = selectedColumn; // Fallback to original value
     }
   } else {

--- a/packages/shared/src/features/evals/utilities.ts
+++ b/packages/shared/src/features/evals/utilities.ts
@@ -1,4 +1,5 @@
 import z from "zod/v4";
+import { JSONPath } from "jsonpath-plus";
 import { variableMapping } from "./types";
 
 /**
@@ -27,40 +28,52 @@ export const parseUnknownToString = (value: unknown): string => {
 };
 
 function parseJsonDefault(selectedColumn: unknown, jsonSelector: string) {
-  // Front-end friendly JSON path extraction
-  const parsedJson =
-    typeof selectedColumn === "string"
-      ? JSON.parse(selectedColumn)
-      : selectedColumn;
+  // JSONPath extraction matching backend implementation
+  try {
+    const result = JSONPath({
+      path: jsonSelector,
+      json:
+        typeof selectedColumn === "string"
+          ? JSON.parse(selectedColumn)
+          : selectedColumn,
+    });
 
-  // Simple path extraction (could use a library)
-  return jsonSelector
-    .split(".")
-    .reduce((o, key) => (o as any)?.[key], parsedJson);
+    return result.length > 0 ? result[0] : undefined;
+  } catch (error) {
+    console.error(
+      `Error parsing JSONPath selector: ${jsonSelector}`,
+      error,
+    );
+    throw error; // Re-throw to let caller handle it
+  }
 }
 
 export function extractValueFromObject(
   obj: Record<string, unknown>,
   mapping: z.infer<typeof variableMapping>,
   parseJson?: (selectedColumn: unknown, jsonSelector: string) => unknown,
-): string {
+): { value: string; error: Error | null } {
   const selectedColumn = obj[mapping.selectedColumnId];
   const jsonParser = parseJson || parseJsonDefault;
 
   let jsonSelectedColumn;
+  let error: Error | null = null;
+
   if (mapping.jsonSelector && selectedColumn) {
     try {
       jsonSelectedColumn = jsonParser(selectedColumn, mapping.jsonSelector);
-    } catch (error) {
-      console.error(
-        `Error parsing JSON selector: ${mapping.jsonSelector}`,
-        error,
-      );
-      jsonSelectedColumn = selectedColumn;
+    } catch (err) {
+      error = err instanceof Error 
+        ? err 
+        : new Error("There was an unknown error parsing the JSON");
+      jsonSelectedColumn = selectedColumn; // Fallback to original value
     }
   } else {
     jsonSelectedColumn = selectedColumn;
   }
 
-  return parseUnknownToString(jsonSelectedColumn);
+  return {
+    value: parseUnknownToString(jsonSelectedColumn),
+    error,
+  };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       ioredis:
         specifier: ^5.4.1
         version: 5.4.1
+      jsonpath-plus:
+        specifier: 10.3.0
+        version: 10.3.0
       kysely:
         specifier: ^0.27.4
         version: 0.27.4

--- a/web/src/features/evals/components/evaluation-prompt-preview.tsx
+++ b/web/src/features/evals/components/evaluation-prompt-preview.tsx
@@ -3,7 +3,6 @@ import { Skeleton } from "@/src/components/ui/skeleton";
 import { useExtractVariables } from "@/src/features/evals/hooks/useExtractVariables";
 import { type VariableMapping } from "@/src/features/evals/utils/evaluator-form-utils";
 import { cn } from "@/src/utils/tailwind";
-import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
 import { type RouterOutput } from "@/src/utils/types";
 import { type EvalTemplate } from "@langfuse/shared";
 import Link from "next/link";

--- a/web/src/features/evals/components/evaluation-prompt-preview.tsx
+++ b/web/src/features/evals/components/evaluation-prompt-preview.tsx
@@ -129,16 +129,12 @@ export const EvaluationPromptPreview = ({
   className?: string;
   controlButtons?: React.ReactNode;
 }) => {
-  const { extractedVariables, isExtracting, error } = useExtractVariables({
+  const { extractedVariables, isExtracting } = useExtractVariables({
     variables: variableMapping.map(({ templateVariable }) => templateVariable),
     variableMapping: variableMapping,
     trace: trace,
     isLoading,
   });
-
-  if (error) {
-    trpcErrorToast(error);
-  }
 
   if (isExtracting) {
     return <Skeleton className="h-[200px] w-full" />;

--- a/web/src/features/evals/components/evaluation-prompt-preview.tsx
+++ b/web/src/features/evals/components/evaluation-prompt-preview.tsx
@@ -3,6 +3,7 @@ import { Skeleton } from "@/src/components/ui/skeleton";
 import { useExtractVariables } from "@/src/features/evals/hooks/useExtractVariables";
 import { type VariableMapping } from "@/src/features/evals/utils/evaluator-form-utils";
 import { cn } from "@/src/utils/tailwind";
+import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
 import { type RouterOutput } from "@/src/utils/types";
 import { type EvalTemplate } from "@langfuse/shared";
 import Link from "next/link";
@@ -128,12 +129,16 @@ export const EvaluationPromptPreview = ({
   className?: string;
   controlButtons?: React.ReactNode;
 }) => {
-  const { extractedVariables, isExtracting } = useExtractVariables({
+  const { extractedVariables, isExtracting, error } = useExtractVariables({
     variables: variableMapping.map(({ templateVariable }) => templateVariable),
     variableMapping: variableMapping,
     trace: trace,
     isLoading,
   });
+
+  if (error) {
+    trpcErrorToast(error);
+  }
 
   if (isExtracting) {
     return <Skeleton className="h-[200px] w-full" />;

--- a/web/src/features/evals/hooks/useExtractVariables.ts
+++ b/web/src/features/evals/hooks/useExtractVariables.ts
@@ -1,5 +1,6 @@
 import { type VariableMapping } from "@/src/features/evals/utils/evaluator-form-utils";
 import { api } from "@/src/utils/api";
+import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
 import { extractValueFromObject } from "@langfuse/shared";
 import { useEffect, useState, useRef } from "react";
 
@@ -48,6 +49,13 @@ export function useExtractVariables({
   // Create a stable reference to the trace ID
   const traceId = trace?.id;
   const traceIdRef = useRef<string | undefined>(traceId as string | undefined);
+
+  // Handle error toasts separately to avoid repeated toasts on re-renders
+  useEffect(() => {
+    if (extractionError) {
+      trpcErrorToast(extractionError);
+    }
+  }, [extractionError]);
 
   useEffect(() => {
     // Return early conditions
@@ -169,5 +177,5 @@ export function useExtractVariables({
     trace,
   ]);
 
-  return { extractedVariables, isExtracting, error: extractionError };
+  return { extractedVariables, isExtracting };
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Integrate `jsonpath-plus` for JSONPath extraction in frontend, enhancing error handling and extraction logic in `utilities.ts` and `useExtractVariables.ts`.
> 
>   - **Dependencies**:
>     - Add `jsonpath-plus` version `10.3.0` to `package.json`.
>   - **Utilities**:
>     - Replace manual JSON path extraction with `jsonpath-plus` in `parseJsonDefault()` in `utilities.ts`.
>     - Modify `extractValueFromObject()` in `utilities.ts` to return an error object along with the value.
>   - **Hooks**:
>     - Update `useExtractVariables()` in `useExtractVariables.ts` to handle errors using `trpcErrorToast` and manage extraction errors with state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9a68f1bfe02ee6f308b3021e5c3a21e8395d33f3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->