### PR TITLE
fix(button): set default button type to "button" if not specified

### DIFF
--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -73,6 +73,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={disabled || loading}
         onClick={loading || disabled ? undefined : onClick}
         {...props}
+        type={props.type || "button"}
       >
         {loading ? <Spinner /> : children}
       </Comp>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Sets default button type to "button" in `Button` component to prevent unintended form submissions.
> 
>   - **Behavior**:
>     - Sets default `type` to "button" in `Button` component in `button.tsx` if not specified.
>     - Prevents unintended form submissions when button is used in forms.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9d9ae22c1dfff488868d40c9dff0780e8a3f3c92. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->