### PR TITLE
fix(prompts): bottom pagination buttons didn't respond

### DIFF
--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -486,12 +486,7 @@ export function PromptTable() {
         setOrderBy={setOrderByState}
         pagination={{
           totalCount,
-          onChange: (newPaginationState) => {
-            setQueryParams({
-              ...queryParams,
-              ...newPaginationState,
-            });
-          },
+          onChange: setQueryParams,
           state: paginationState,
         }}
       />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes unresponsive bottom pagination buttons in `PromptTable` by simplifying the `onChange` function.
> 
>   - **Behavior**:
>     - Fixes issue where bottom pagination buttons in `PromptTable` were unresponsive.
>     - Simplifies `onChange` function for pagination by directly using `setQueryParams` instead of a custom function.
>   - **Code**:
>     - Updates `onChange` in `PromptTable` pagination to use `setQueryParams` directly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e92e427d1dcc2ff1afa72dffa82feab63ec0cf47. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->