### PR TITLE
chore(seeder): tweak session and prompt data

### DIFF
--- a/packages/shared/scripts/seeder/seed-clickhouse.ts
+++ b/packages/shared/scripts/seeder/seed-clickhouse.ts
@@ -14,7 +14,7 @@ async function main() {
     }
     await prepareClickhouse(projectIds, {
       numberOfDays: 3,
-      totalObservations: 10000,
+      totalObservations: 1000,
       numberOfRuns: 3,
     });
 

--- a/packages/shared/scripts/seeder/seed-postgres.ts
+++ b/packages/shared/scripts/seeder/seed-postgres.ts
@@ -272,8 +272,7 @@ async function main() {
     await generateQueuesForProject([project1, project2], configIdsAndNames);
     await generatePromptsForProject([project1, project2]);
     await createDatasets(project1, project2);
-
-    // await uploadObjects(sessions, comments, queueItems);
+    await createTraceSessions(project1, project2);
 
     // If openai key is in environment, add it to the projects LLM API keys
     const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
@@ -774,6 +773,20 @@ async function generateConfigsForProject(projects: Project[]) {
     }),
   );
   return projectIdsToConfigs;
+}
+
+async function createTraceSessions(project1: Project, project2: Project) {
+  for (const project of [project1, project2]) {
+    for (let i = 0; i < 100; i++) {
+      await prisma.traceSession.create({
+        data: {
+          projectId: project.id,
+          id: `session_${i}`,
+          createdAt: new Date(),
+        },
+      });
+    }
+  }
 }
 
 async function generateConfigs(project: Project) {

--- a/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
+++ b/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
@@ -95,7 +95,7 @@ export class ClickHouseQueryBuilder {
         if(randUniform(0, 1) < 0.2, '${escapedNestedJson}',
           '${escapedChatMl}'
         ) AS output,
-        if(randUniform(0, 1) < 0.3, concat('session_', toString(rand() % 100)), NULL) AS session_id,
+        if(randUniform(0, 1) < 0.3, concat('session_', toString(rand() % 20)), NULL) AS session_id,
         now() AS created_at,
         now() AS updated_at,
         now() AS event_ts,
@@ -207,7 +207,7 @@ export class ClickHouseQueryBuilder {
         '${projectId}' AS project_id,
         '${environment}' AS environment,
         concat('trace-bulk-', toString(number % ${tracesCount}), '-${projectId.slice(-8)}') AS trace_id,
-        if(randUniform(0, 1) < 0.3, concat('session_', toString(rand() % 100)), NULL) AS session_id,
+        if(randUniform(0, 1) < 0.3, concat('session_', toString(rand() % 20)), NULL) AS session_id,
         NULL AS dataset_run_id,
         if(randUniform(0, 1) < 0.1, concat('obs-bulk-', toString(rand() % (${tracesCount} * 5)), '-${projectId.slice(-8)}'), NULL) AS observation_id,
         concat('metric_', toString((number % ${scoresPerTrace * 5}) + 1)) AS name,

--- a/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
+++ b/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
@@ -95,7 +95,7 @@ export class ClickHouseQueryBuilder {
         if(randUniform(0, 1) < 0.2, '${escapedNestedJson}',
           '${escapedChatMl}'
         ) AS output,
-        if(randUniform(0, 1) < 0.3, concat('session_', toString(rand() % 20)), NULL) AS session_id,
+        if(randUniform(0, 1) < 0.3, concat('session_', toString(rand() % 100)), NULL) AS session_id,
         now() AS created_at,
         now() AS updated_at,
         now() AS event_ts,
@@ -207,7 +207,7 @@ export class ClickHouseQueryBuilder {
         '${projectId}' AS project_id,
         '${environment}' AS environment,
         concat('trace-bulk-', toString(number % ${tracesCount}), '-${projectId.slice(-8)}') AS trace_id,
-        if(randUniform(0, 1) < 0.3, concat('session_', toString(rand() % 20)), NULL) AS session_id,
+        if(randUniform(0, 1) < 0.3, concat('session_', toString(rand() % 100)), NULL) AS session_id,
         NULL AS dataset_run_id,
         if(randUniform(0, 1) < 0.1, concat('obs-bulk-', toString(rand() % (${tracesCount} * 5)), '-${projectId.slice(-8)}'), NULL) AS observation_id,
         concat('metric_', toString((number % ${scoresPerTrace * 5}) + 1)) AS name,

--- a/packages/shared/scripts/seeder/utils/data-generators.ts
+++ b/packages/shared/scripts/seeder/utils/data-generators.ts
@@ -102,6 +102,7 @@ export class DataGenerator {
       metadata: { experimentType: "langfuse-prompt-experiments" },
       public: false,
       bookmarked: false,
+      session_id: null,
       tags: [],
     });
   }
@@ -471,6 +472,7 @@ export class DataGenerator {
         );
         const trace = createTrace({
           id: traceId,
+          session_id: null,
           project_id: projectId,
           name: this.randomElement(REALISTIC_TRACE_NAMES),
           input: this.generateEvaluationInput(),

--- a/packages/shared/scripts/seeder/utils/postgres-seed-constants.ts
+++ b/packages/shared/scripts/seeder/utils/postgres-seed-constants.ts
@@ -236,6 +236,15 @@ export const SEED_TEXT_PROMPTS = [
     tags: ["tag1", "tag2"],
   },
   {
+    id: `countries-experiment-prompt`,
+    createdBy: "user-1",
+    prompt: "What is the capital of {{country}}?",
+    name: "countries-experiment-prompt",
+    version: 1,
+    labels: ["production", "latest"],
+    tags: ["tag1", "tag2"],
+  },
+  {
     id: `folder-customer-prompt-1`,
     createdBy: "user-1",
     prompt: "Folder prompt 1 content",

--- a/packages/shared/scripts/seeder/utils/seeder-orchestrator.ts
+++ b/packages/shared/scripts/seeder/utils/seeder-orchestrator.ts
@@ -189,10 +189,10 @@ export class SeederOrchestrator {
     for (const projectId of projectIds) {
       logger.info(`Processing synthetic data for project ${projectId}`);
 
+      const observationsPerTrace = 15;
       const tracesPerProject = Math.floor(
-        (opts.totalObservations || 1000) / 25,
+        (opts.totalObservations || 1000) / observationsPerTrace,
       );
-      const observationsPerTrace = 25;
       const scoresPerTrace = 10;
 
       // For large datasets, use bulk generation for better performance


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adjust seeding scripts by reducing observations, adding trace sessions, and introducing a new prompt.
> 
>   - **Behavior**:
>     - Reduce `totalObservations` from 10000 to 1000 in `seed-clickhouse.ts`.
>     - Replace commented `uploadObjects` with `createTraceSessions` in `seed-postgres.ts`.
>     - Add `createTraceSessions()` function in `seed-postgres.ts` to create 100 trace sessions per project.
>   - **Data Generation**:
>     - Add `session_id: null` to `createTrace` calls in `data-generators.ts`.
>   - **Prompts**:
>     - Add new prompt `countries-experiment-prompt` to `SEED_TEXT_PROMPTS` in `postgres-seed-constants.ts`.
>   - **Misc**:
>     - Adjust `observationsPerTrace` from 25 to 15 in `seeder-orchestrator.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f2ca5210417b3674d01a53f5437b0760024fb417. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->