### PR TITLE
feat(sidebar): persist collapsed state

### DIFF
--- a/web/src/components/nav/nav-main.tsx
+++ b/web/src/components/nav/nav-main.tsx
@@ -11,7 +11,7 @@ import {
   useSidebar,
 } from "@/src/components/ui/sidebar";
 import Link from "next/link";
-import { type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { cn } from "@/src/utils/tailwind";
 import {
   HoverCard,
@@ -61,16 +61,27 @@ function NavItemContent({ item }: { item: NavMainItem }) {
 
 export function NavMain({ items }: { items: NavMainItem[] }) {
   const { open } = useSidebar();
+  const [hoveredItem, setHoveredItem] = useState<string | null>(null);
   return (
     <SidebarGroup>
       <SidebarMenu>
         {items.map((item) =>
           item.items && item.items.length > 0 ? (
-            <HoverCard key={item.title} openDelay={100} closeDelay={100}>
+            <HoverCard
+              key={item.title}
+              openDelay={100}
+              closeDelay={100}
+              onOpenChange={(isOpen) =>
+                setHoveredItem(isOpen ? item.title : null)
+              }
+            >
               <SidebarMenuItem>
                 <HoverCardTrigger>
                   <SidebarMenuButton
-                    isActive={item.items.some((i) => i.isActive)}
+                    isActive={
+                      item.items.some((i) => i.isActive) ||
+                      hoveredItem === item.title
+                    }
                   >
                     <NavItemContent item={item} />
                     <ChevronRightIcon className="ml-auto" />

--- a/web/src/components/nav/nav-main.tsx
+++ b/web/src/components/nav/nav-main.tsx
@@ -1,12 +1,5 @@
 "use client";
-
-import { ChevronRight, type LucideIcon } from "lucide-react";
-
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/src/components/ui/collapsible";
+import { type LucideIcon } from "lucide-react";
 import {
   SidebarGroup,
   SidebarMenu,
@@ -20,6 +13,12 @@ import {
 import Link from "next/link";
 import { type ReactNode } from "react";
 import { cn } from "@/src/utils/tailwind";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTitle,
+  HoverCardTrigger,
+} from "@/src/components/ui/hover-card";
 
 export type NavMainItem = {
   title: string;
@@ -66,14 +65,15 @@ export function NavMain({ items }: { items: NavMainItem[] }) {
       <SidebarMenu>
         {items.map((item) =>
           item.items && item.items.length > 0 ? (
-            <Collapsible
+            <HoverCard
               key={item.title}
-              asChild
-              defaultOpen={item.isActive || item.items.some((i) => i.isActive)}
-              className="group/collapsible"
+              openDelay={100}
+              // asChild
+              // defaultOpen={item.isActive || item.items.some((i) => i.isActive)}
+              // className="group/collapsible"
             >
               <SidebarMenuItem>
-                <CollapsibleTrigger asChild>
+                <HoverCardTrigger>
                   <SidebarMenuButton
                     tooltip={item.title}
                     onClick={(e) => {
@@ -86,10 +86,14 @@ export function NavMain({ items }: { items: NavMainItem[] }) {
                     isActive={!open && item.items.some((i) => i.isActive)}
                   >
                     <NavItemContent item={item} />
-                    <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
                   </SidebarMenuButton>
-                </CollapsibleTrigger>
-                <CollapsibleContent>
+                </HoverCardTrigger>
+                <HoverCardContent
+                  side="right"
+                  align="start"
+                  className="relative isolate z-[9999]"
+                >
+                  <HoverCardTitle>{item.title}</HoverCardTitle>
                   <SidebarMenuSub>
                     {item.items.map((subItem) => (
                       <SidebarMenuSubItem key={subItem.title}>
@@ -107,9 +111,9 @@ export function NavMain({ items }: { items: NavMainItem[] }) {
                       </SidebarMenuSubItem>
                     ))}
                   </SidebarMenuSub>
-                </CollapsibleContent>
+                </HoverCardContent>
               </SidebarMenuItem>
-            </Collapsible>
+            </HoverCard>
           ) : (
             <SidebarMenuItem key={item.title}>
               {item.menuNode || (

--- a/web/src/components/nav/nav-main.tsx
+++ b/web/src/components/nav/nav-main.tsx
@@ -19,6 +19,7 @@ import {
   HoverCardTitle,
   HoverCardTrigger,
 } from "@/src/components/ui/hover-card";
+import { Portal } from "@radix-ui/react-hover-card";
 
 export type NavMainItem = {
   title: string;
@@ -75,32 +76,34 @@ export function NavMain({ items }: { items: NavMainItem[] }) {
                     <ChevronRightIcon className="ml-auto" />
                   </SidebarMenuButton>
                 </HoverCardTrigger>
-                <HoverCardContent
-                  side="right"
-                  align="start"
-                  // relative + isolate create a new stacking context
-                  // z-[9999] ensures this appears above other elements, even across different stacking contexts
-                  className="relative isolate z-[9999] p-1"
-                >
-                  {!open && <HoverCardTitle>{item.title}</HoverCardTitle>}
-                  <SidebarMenuSub>
-                    {item.items.map((subItem) => (
-                      <SidebarMenuSubItem key={subItem.title}>
-                        <SidebarMenuSubButton
-                          asChild
-                          isActive={subItem.isActive}
-                        >
-                          <Link
-                            href={subItem.url}
-                            target={subItem.newTab ? "_blank" : undefined}
+                <Portal>
+                  <HoverCardContent
+                    side="right"
+                    align="start"
+                    // relative + isolate create a new stacking context
+                    // z-[9999] ensures this appears above other elements, even across different stacking contexts
+                    className="relative isolate z-[9999] p-1"
+                  >
+                    {!open && <HoverCardTitle>{item.title}</HoverCardTitle>}
+                    <SidebarMenuSub>
+                      {item.items.map((subItem) => (
+                        <SidebarMenuSubItem key={subItem.title}>
+                          <SidebarMenuSubButton
+                            asChild
+                            isActive={subItem.isActive}
                           >
-                            <span>{subItem.title}</span>
-                          </Link>
-                        </SidebarMenuSubButton>
-                      </SidebarMenuSubItem>
-                    ))}
-                  </SidebarMenuSub>
-                </HoverCardContent>
+                            <Link
+                              href={subItem.url}
+                              target={subItem.newTab ? "_blank" : undefined}
+                            >
+                              <span>{subItem.title}</span>
+                            </Link>
+                          </SidebarMenuSubButton>
+                        </SidebarMenuSubItem>
+                      ))}
+                    </SidebarMenuSub>
+                  </HoverCardContent>
+                </Portal>
               </SidebarMenuItem>
             </HoverCard>
           ) : (

--- a/web/src/components/nav/nav-main.tsx
+++ b/web/src/components/nav/nav-main.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { type LucideIcon } from "lucide-react";
+import { ChevronRightIcon, type LucideIcon } from "lucide-react";
 import {
   SidebarGroup,
   SidebarMenu,
@@ -59,41 +59,30 @@ function NavItemContent({ item }: { item: NavMainItem }) {
 }
 
 export function NavMain({ items }: { items: NavMainItem[] }) {
-  const { open, setOpen } = useSidebar();
+  const { open } = useSidebar();
   return (
     <SidebarGroup>
       <SidebarMenu>
         {items.map((item) =>
           item.items && item.items.length > 0 ? (
-            <HoverCard
-              key={item.title}
-              openDelay={100}
-              // asChild
-              // defaultOpen={item.isActive || item.items.some((i) => i.isActive)}
-              // className="group/collapsible"
-            >
+            <HoverCard key={item.title} openDelay={100} closeDelay={100}>
               <SidebarMenuItem>
                 <HoverCardTrigger>
                   <SidebarMenuButton
-                    tooltip={item.title}
-                    onClick={(e) => {
-                      if (!open) {
-                        e.preventDefault();
-                        setOpen(true);
-                      }
-                    }}
-                    // when closed, the parent should be active if any of the children are active
-                    isActive={!open && item.items.some((i) => i.isActive)}
+                    isActive={item.items.some((i) => i.isActive)}
                   >
                     <NavItemContent item={item} />
+                    <ChevronRightIcon className="ml-auto" />
                   </SidebarMenuButton>
                 </HoverCardTrigger>
                 <HoverCardContent
                   side="right"
                   align="start"
-                  className="relative isolate z-[9999]"
+                  // relative + isolate create a new stacking context
+                  // z-[9999] ensures this appears above other elements, even across different stacking contexts
+                  className="relative isolate z-[9999] p-1"
                 >
-                  <HoverCardTitle>{item.title}</HoverCardTitle>
+                  {!open && <HoverCardTitle>{item.title}</HoverCardTitle>}
                   <SidebarMenuSub>
                     {item.items.map((subItem) => (
                       <SidebarMenuSubItem key={subItem.title}>

--- a/web/src/components/ui/hover-card.tsx
+++ b/web/src/components/ui/hover-card.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
+import { Portal } from "@radix-ui/react-hover-card";
 
 import { cn } from "@/src/utils/tailwind";
 
@@ -13,17 +14,34 @@ const HoverCardContent = React.forwardRef<
   React.ElementRef<typeof HoverCardPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
 >(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <HoverCardPrimitive.Content
+  <Portal>
+    <HoverCardPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-64 rounded-md border bg-popover p-3 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </Portal>
+));
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
+
+const HoverCardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
     ref={ref}
-    align={align}
-    sideOffset={sideOffset}
     className={cn(
-      "z-50 w-64 rounded-md border bg-popover p-3 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "mb-2 text-sm font-semibold leading-none tracking-tight",
       className,
     )}
     {...props}
   />
 ));
-HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
+HoverCardTitle.displayName = "HoverCardTitle";
 
-export { HoverCard, HoverCardTrigger, HoverCardContent };
+export { HoverCard, HoverCardTrigger, HoverCardContent, HoverCardTitle };

--- a/web/src/components/ui/hover-card.tsx
+++ b/web/src/components/ui/hover-card.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
-import { Portal } from "@radix-ui/react-hover-card";
 
 import { cn } from "@/src/utils/tailwind";
 
@@ -14,18 +13,16 @@ const HoverCardContent = React.forwardRef<
   React.ElementRef<typeof HoverCardPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
 >(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <Portal>
-    <HoverCardPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        "z-50 w-64 rounded-md border bg-popover p-3 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        className,
-      )}
-      {...props}
-    />
-  </Portal>
+  <HoverCardPrimitive.Content
+    ref={ref}
+    align={align}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 w-64 rounded-md border bg-popover p-3 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className,
+    )}
+    {...props}
+  />
 ));
 HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
 

--- a/web/src/components/ui/hover-card.tsx
+++ b/web/src/components/ui/hover-card.tsx
@@ -36,7 +36,7 @@ const HoverCardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={cn(
-      "mb-2 text-sm font-semibold leading-none tracking-tight",
+      "p-2 text-sm font-semibold leading-none tracking-tight",
       className,
     )}
     {...props}

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -4,8 +4,8 @@ import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { type VariantProps, cva } from "class-variance-authority";
 import { PanelLeft } from "lucide-react";
-
 import { useIsMobile } from "@/src/hooks/use-mobile";
+import useLocalStorage from "@/src/components/useLocalStorage";
 import { cn } from "@/src/utils/tailwind";
 import { Button } from "@/src/components/ui/button";
 import { Input } from "@/src/components/ui/input";
@@ -20,8 +20,7 @@ import {
 } from "@/src/components/ui/tooltip";
 import { Portal } from "@radix-ui/react-tooltip";
 
-const SIDEBAR_COOKIE_NAME = "sidebar:state";
-const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+const SIDEBAR_STORAGE_KEY = "sidebar:state";
 const SIDEBAR_WIDTH = "13rem";
 const SIDEBAR_WIDTH_MOBILE = "12rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
@@ -71,24 +70,23 @@ const SidebarProvider = React.forwardRef<
     const isMobile = useIsMobile();
     const [openMobile, setOpenMobile] = React.useState(false);
 
+    // Use local storage to persist sidebar state
+    const [storedOpen, setStoredOpen] = useLocalStorage(SIDEBAR_STORAGE_KEY, defaultOpen);
+
     // This is the internal state of the sidebar.
     // We use openProp and setOpenProp for control from outside the component.
-    const [_open, _setOpen] = React.useState(defaultOpen);
-    const open = openProp ?? _open;
+    const open = openProp ?? storedOpen;
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {
+        const newValue = typeof value === "function" ? value(open) : value;
+        
         if (setOpenProp) {
-          return setOpenProp?.(
-            typeof value === "function" ? value(open) : value,
-          );
+          return setOpenProp?.(newValue);
         }
 
-        _setOpen(value);
-
-        // This sets the cookie to keep the sidebar state.
-        document.cookie = `${SIDEBAR_COOKIE_NAME}=${open}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+        setStoredOpen(newValue);
       },
-      [setOpenProp, open],
+      [setOpenProp, open, setStoredOpen],
     );
 
     // Helper to toggle the sidebar.

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -23,7 +23,7 @@ import { Portal } from "@radix-ui/react-tooltip";
 const SIDEBAR_COOKIE_NAME = "sidebar:state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = "13rem";
-const SIDEBAR_WIDTH_MOBILE = "18rem";
+const SIDEBAR_WIDTH_MOBILE = "12rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 
@@ -597,7 +597,7 @@ const SidebarMenuButton = React.forwardRef<
             hidden={state !== "collapsed" || isMobile}
             // relative + isolate create a new stacking context
             // z-[9999] ensures this appears above other elements, even across different stacking contexts
-            className="relative isolate z-[9999]"
+            className="relative isolate z-[9999] text-sm font-semibold"
             {...tooltip}
           />
         </Portal>
@@ -705,7 +705,7 @@ const SidebarMenuSub = React.forwardRef<
     ref={ref}
     data-sidebar="menu-sub"
     className={cn(
-      "border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5",
+      "flex min-w-0 translate-x-px flex-col gap-1 border-sidebar-border py-0.5",
       "group-data-[collapsible=icon]:hidden",
       className,
     )}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Persist sidebar collapsed state using local storage and refactor navigation to use hover cards for submenus.
> 
>   - **Behavior**:
>     - Persist sidebar collapsed state using local storage in `sidebar.tsx`, replacing cookie-based persistence.
>     - Refactor `nav-main.tsx` to use `HoverCard` for submenus instead of `Collapsible`.
>     - Adjust sidebar width for mobile in `sidebar.tsx`.
>   - **Components**:
>     - Add `HoverCardTitle` to `hover-card.tsx` for displaying titles in hover cards.
>   - **Misc**:
>     - Rename `ChevronRight` to `ChevronRightIcon` in `nav-main.tsx` and `sidebar.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for db3d9ed4a5473dc9c2014547396f5a3a97673683. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->