### PR TITLE
fix(data-tables): pagination not adjusted by enter key

### DIFF
--- a/web/src/components/table/data-table-pagination.tsx
+++ b/web/src/components/table/data-table-pagination.tsx
@@ -47,6 +47,29 @@ export function DataTablePagination<TData>({
     }
   }, [currentPage, pageCount, setPageIndex]);
 
+  const handlePageNavigation = (newValue: string) => {
+    if (newValue === "") {
+      table.setPageIndex(0);
+      setInputState(1);
+      return;
+    }
+
+    // if nan, reset to current page
+    if (isNaN(Number(newValue))) {
+      setInputState(currentPage);
+      return;
+    }
+
+    const newPageIndex = Number(newValue) - 1;
+    if (newPageIndex < 0 || newPageIndex >= pageCount) {
+      setInputState(currentPage);
+      return;
+    }
+
+    table.setPageIndex(newPageIndex);
+    setInputState(newPageIndex + 1);
+  };
+
   return (
     <div className="flex items-center justify-between">
       <div className="flex-1 text-sm text-muted-foreground">
@@ -94,28 +117,14 @@ export function DataTablePagination<TData>({
                 onChange={(e) => {
                   setInputState(e.target.value);
                 }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    handlePageNavigation(e.currentTarget.value);
+                  }
+                }}
                 onBlur={(e) => {
-                  const newValue = e.target.value;
-                  if (newValue === "") {
-                    table.setPageIndex(0);
-                    setInputState(1);
-                    return;
-                  }
-
-                  // if nan, reset to current page
-                  if (isNaN(Number(newValue))) {
-                    setInputState(currentPage);
-                    return;
-                  }
-
-                  const newPageIndex = Number(newValue) - 1;
-                  if (newPageIndex < 0 || newPageIndex >= pageCount) {
-                    setInputState(currentPage);
-                    return;
-                  }
-
-                  table.setPageIndex(newPageIndex);
-                  setInputState(newPageIndex + 1);
+                  handlePageNavigation(e.target.value);
                 }}
                 className="h-8 appearance-none"
                 style={{


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes pagination adjustment issue in `DataTablePagination` by introducing `handlePageNavigation` function for consistent page navigation logic.
> 
>   - **Behavior**:
>     - Fixes pagination adjustment issue when Enter key is pressed in `DataTablePagination`.
>     - Introduces `handlePageNavigation` function to handle page navigation logic.
>     - `handlePageNavigation` is called on Enter key press and input blur events.
>   - **Functions**:
>     - Adds `handlePageNavigation` to encapsulate page navigation logic in `data-table-pagination.tsx`.
>     - Removes redundant logic from `onBlur` and `onKeyDown` handlers, now using `handlePageNavigation`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9e0c38573c2eb040cc46e867144db932f05a982d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->