### PR TITLE
fix(exports): propagate search state to export

### DIFF
--- a/packages/shared/src/features/batchExport/types.ts
+++ b/packages/shared/src/features/batchExport/types.ts
@@ -5,6 +5,7 @@ import { BatchExport } from "@prisma/client";
 import { singleFilter } from "../../interfaces/filters";
 import { orderBy } from "../../interfaces/orderBy";
 import { BatchTableNames } from "../../interfaces/tableNames";
+import { TracingSearchType } from "../../interfaces/search";
 
 export enum BatchExportStatus {
   QUEUED = "QUEUED",
@@ -43,6 +44,8 @@ export const exportOptions: Record<
 export const BatchExportQuerySchema = z.object({
   tableName: z.enum(BatchTableNames),
   filter: z.array(singleFilter).nullable(),
+  searchQuery: z.string().optional(),
+  searchType: z.array(TracingSearchType).optional(),
   orderBy,
   limit: z.number().optional(),
   page: z.number().optional(),

--- a/web/src/components/BatchExportTableButton.tsx
+++ b/web/src/components/BatchExportTableButton.tsx
@@ -26,6 +26,7 @@ export type BatchExportTableButtonProps = {
   orderByState: OrderByState;
   filterState: any;
   searchQuery?: any;
+  searchType?: any;
 };
 
 export const BatchExportTableButton: React.FC<BatchExportTableButtonProps> = (
@@ -62,6 +63,8 @@ export const BatchExportTableButton: React.FC<BatchExportTableButtonProps> = (
       query: {
         tableName: props.tableName,
         filter: props.filterState,
+        searchQuery: props.searchQuery || undefined,
+        searchType: props.searchType || undefined,
         orderBy: props.orderByState,
       },
     });

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -977,7 +977,13 @@ export default function ObservationsTable({
         setDateRangeAndOption={setDateRangeAndOption}
         actionButtons={
           <BatchExportTableButton
-            {...{ projectId, filterState, orderByState }}
+            {...{
+              projectId,
+              filterState,
+              orderByState,
+              searchQuery,
+              searchType,
+            }}
             tableName={BatchExportTableName.Observations}
             key="batchExport"
           />

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -1136,7 +1136,13 @@ export default function TracesTable({
               />
             ) : null,
             <BatchExportTableButton
-              {...{ projectId, filterState, orderByState }}
+              {...{
+                projectId,
+                filterState,
+                orderByState,
+                searchQuery,
+                searchType,
+              }}
               tableName={BatchExportTableName.Traces}
               key="batchExport"
             />,

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -1016,4 +1016,54 @@ describe("batch export test suite", () => {
       expect(row.orgId).toBe(orgId);
     });
   });
+
+  it("should export traces with searchQuery and searchType filters applied correctly", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    // Create traces with specific searchable content
+    const traces = [
+      createTrace({
+        project_id: projectId,
+        id: "search-test-id-1",
+        name: "findable-trace-name",
+        user_id: "searchable-user-123",
+        timestamp: new Date("2024-01-01").getTime(),
+      }),
+      createTrace({
+        project_id: projectId,
+        id: "search-test-id-2",
+        name: "another-trace",
+        user_id: "different-user-456",
+        timestamp: new Date("2024-01-02").getTime(),
+      }),
+      createTrace({
+        project_id: projectId,
+        id: "other-trace-id",
+        name: "unrelated-name",
+        user_id: "unrelated-user",
+        timestamp: new Date("2024-01-03").getTime(),
+      }),
+    ];
+
+    await createTracesCh(traces);
+
+    const streamByName = await getDatabaseReadStream({
+      projectId: projectId,
+      tableName: BatchExportTableName.Traces,
+      cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      filter: [],
+      orderBy: { column: "timestamp", order: "ASC" },
+      searchQuery: "findable-trace",
+      searchType: ["id"],
+    });
+
+    const rowsByName: any[] = [];
+    for await (const chunk of streamByName) {
+      rowsByName.push(chunk);
+    }
+
+    expect(rowsByName).toHaveLength(1);
+    expect(rowsByName[0].name).toBe("findable-trace-name");
+    expect(rowsByName[0].id).toBe("search-test-id-1");
+  });
 });

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -244,7 +244,9 @@ export const getDatabaseReadStream = async ({
             filter: filter
               ? [...filter, createdAtCutoffFilterCh]
               : [createdAtCutoffFilterCh],
-            orderBy: orderBy,
+            searchQuery,
+            searchType: searchType ?? ["id" as const],
+            orderBy,
             selectIOAndMetadata: true,
             clickhouseConfigs,
           });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds search functionality to batch exports, allowing filtering by `searchQuery` and `searchType`, with updates to components and tests.
> 
>   - **Behavior**:
>     - Adds `searchQuery` and `searchType` to `BatchExportQuerySchema` in `types.ts`.
>     - Updates `BatchExportTableButton` in `BatchExportTableButton.tsx` to include `searchQuery` and `searchType` in export queries.
>     - Modifies `getDatabaseReadStream` in `getDatabaseReadStream.ts` to handle `searchQuery` and `searchType` for `observations` and `traces`.
>   - **Components**:
>     - Updates `ObservationsTable` and `TracesTable` to pass `searchQuery` and `searchType` to `BatchExportTableButton`.
>   - **Tests**:
>     - Adds test in `batchExport.test.ts` to verify `searchQuery` and `searchType` filters in trace exports.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c8f4bbb0bd2785d042403ac044b09618b82d36e8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->