### PR TITLE
fix(scores): add environment field to upsert annotation score

### DIFF
--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -432,6 +432,7 @@ export const scoresRouter = createTRPCRouter({
           trace_id: score.traceId,
           observation_id: score.observationId,
           session_id: score.sessionId,
+          environment: score.environment,
         });
 
         updatedScore = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `environment` field to `upsertScore` in `updateAnnotationScore` mutation to include environment context.
> 
>   - **Behavior**:
>     - Adds `environment` field to `upsertScore` call in `updateAnnotationScore` mutation in `scores.ts` to include environment context when updating annotation scores.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2fbcb5b5a7a9467c9687b24c596de358e249eddd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->