### PR TITLE
fix(observation): filter out null values from model parameters in ObservationPreview

### DIFF
--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -325,7 +325,7 @@ export const ObservationPreview = ({
                     {preloadedObservation.modelParameters &&
                     typeof preloadedObservation.modelParameters === "object"
                       ? Object.entries(preloadedObservation.modelParameters)
-                          .filter(Boolean)
+                          .filter(([_, value]) => value !== null)
                           .map(([key, value]) => {
                             const valueString =
                               Object.prototype.toString.call(value) ===


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Filters out null values from model parameters in `ObservationPreview` to ensure only non-null parameters are displayed.
> 
>   - **Behavior**:
>     - In `ObservationPreview`, filters out `null` values from `modelParameters` before mapping them.
>     - Ensures only non-null model parameters are displayed as badges.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7bcd71b1e70620b869cbaab48123c7c1816889b8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->