### PR TITLE
fix(models): zodResolver ignoring modelName

### DIFF
--- a/web/src/features/models/components/UpsertModelFormDrawer.tsx
+++ b/web/src/features/models/components/UpsertModelFormDrawer.tsx
@@ -149,7 +149,10 @@ export const UpsertModelFormDrawer = ({
       .mutateAsync({
         modelId: props.action === "edit" ? props.modelData.id : null,
         projectId: props.projectId,
-        modelName: values.modelName,
+        modelName:
+          props.action === "edit"
+            ? props.modelData.modelName
+            : values.modelName,
         matchPattern: values.matchPattern,
         prices: values.prices,
         tokenizerId: values.tokenizerId,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `modelName` handling in `UpsertModelFormDrawer` to use existing name when editing.
> 
>   - **Behavior**:
>     - Fixes `modelName` handling in `UpsertModelFormDrawer` to use existing `modelName` when `action` is "edit".
>     - Ensures `modelName` is not overwritten by new input during edit operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1de9a8d4ceb5fafbe4eaca5d20564eb2110e68fe. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->