### PR TITLE
Fix(prompt): default commit message empty

### DIFF
--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -92,7 +92,7 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
     name: initialPrompt?.name ?? (folderPath ? `${folderPath}/` : ""),
     config: JSON.stringify(initialPrompt?.config?.valueOf(), null, 2) || "{}",
     isActive: !Boolean(initialPrompt),
-    commitMessage: initialPrompt?.commitMessage ?? undefined,
+    commitMessage: undefined,
   };
 
   const form = useForm({
@@ -215,7 +215,16 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
                   <FormItem>
                     <FormLabel>Name</FormLabel>
                     <FormDescription>
-                      Use slashes &apos;/&apos; in prompt names to organize them into <a target="_blank" rel="noopener noreferrer" href="https://langfuse.com/docs/prompts/get-started#prompt-folders-for-organization"><i>folders</i></a>.
+                      Use slashes &apos;/&apos; in prompt names to organize them
+                      into{" "}
+                      <a
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href="https://langfuse.com/docs/prompts/get-started#prompt-folders-for-organization"
+                      >
+                        <i>folders</i>
+                      </a>
+                      .
                     </FormDescription>
                     <FormControl>
                       <Input placeholder="Name your prompt" {...field} />


### PR DESCRIPTION
## What does this PR do?
This PR ensures that when creating a new prompt, the default value for the commit message is empty.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #7463

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->
- I haven't added tests that prove my fix is effective or that my feature works

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets `commitMessage` default to `undefined` in `NewPromptForm` to ensure an empty commit message by default.
> 
>   - **Behavior**:
>     - Sets `commitMessage` default to `undefined` in `NewPromptForm` in `index.tsx`, ensuring the commit message is empty by default when creating a new prompt.
>   - **Misc**:
>     - Fixes formatting in `FormDescription` for prompt name organization instructions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e1fc3bafea1ffc77f6c109d0ad07946b4ad762f7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->