### PR TITLE
fix: avoid ambigious identifiers for full-text search

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/search.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/search.ts
@@ -5,13 +5,16 @@ const regexIndefiniteCharacters = "%";
 export const clickhouseSearchCondition = (
   query?: string,
   searchType?: TracingSearchType[],
+  tablePrefix?: string,
 ) => {
+  const prefix = tablePrefix ? `${tablePrefix}.` : "";
+
   const conditions = [
     !searchType || searchType.includes("id")
-      ? `id ILIKE {searchString: String} OR user_id ILIKE {searchString: String} OR name ILIKE {searchString: String}`
+      ? `${prefix}id ILIKE {searchString: String} OR ${prefix}user_id ILIKE {searchString: String} OR ${prefix}name ILIKE {searchString: String}`
       : null,
     searchType && searchType.includes("content")
-      ? `input ILIKE {searchString: String} OR output ILIKE {searchString: String}`
+      ? `${prefix}input ILIKE {searchString: String} OR ${prefix}output ILIKE {searchString: String}`
       : null,
   ].filter(Boolean);
 

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -687,7 +687,7 @@ const getObservationsTableInternal = async <T>(
   const appliedScoresFilter = scoresFilter.apply();
   const appliedObservationsFilter = observationsFilter.apply();
 
-  const search = clickhouseSearchCondition(opts.searchQuery, opts.searchType);
+  const search = clickhouseSearchCondition(opts.searchQuery, opts.searchType, "o");
 
   const scoresCte = `WITH scores_agg AS (
     SELECT

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -461,7 +461,7 @@ export const getTracesGroupedByUsers = async (
   );
 
   const tracesFilterRes = tracesFilter.apply();
-  const search = clickhouseSearchCondition(searchQuery);
+  const search = clickhouseSearchCondition(searchQuery, undefined, "t");
 
   // We mainly use queries like this to retrieve filter options.
   // Therefore, we can skip final as some inaccuracy in count is acceptable.
@@ -707,7 +707,7 @@ export const getTotalUserCount = async (
   );
 
   const tracesFilterRes = tracesFilter.apply();
-  const search = clickhouseSearchCondition(searchQuery);
+  const search = clickhouseSearchCondition(searchQuery, undefined, "t");
 
   const query = `
     SELECT COUNT(DISTINCT t.user_id) AS totalCount

--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -329,7 +329,7 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
   const scoresFilterRes = scoresFilter.apply();
   const observationFilterRes = observationsFilter.apply();
 
-  const search = clickhouseSearchCondition(searchQuery, searchType);
+  const search = clickhouseSearchCondition(searchQuery, searchType, "t");
 
   const defaultOrder = orderBy?.order && orderBy?.column === "timestamp";
   const orderByCols = [

--- a/web/src/__tests__/async/observations-trpc.servertest.ts
+++ b/web/src/__tests__/async/observations-trpc.servertest.ts
@@ -1,0 +1,128 @@
+/** @jest-environment node */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import type { Session } from "next-auth";
+import { pruneDatabase } from "@/src/__tests__/test-utils";
+import { prisma } from "@langfuse/shared/src/db";
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import {
+  createTrace,
+  createTracesCh,
+  createObservation,
+  createObservationsCh,
+  createTraceScore,
+  createScoresCh,
+} from "@langfuse/shared/src/server";
+import { randomUUID } from "crypto";
+
+describe("traces trpc", () => {
+  const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
+
+  beforeEach(async () => await pruneDatabase());
+
+  const session: Session = {
+    expires: "1",
+    user: {
+      id: "user-1",
+      canCreateOrganizations: true,
+      name: "Demo User",
+      organizations: [
+        {
+          id: "seed-org-id",
+          name: "Test Organization",
+          role: "OWNER",
+          plan: "cloud:hobby",
+          cloudConfig: undefined,
+          projects: [
+            {
+              id: projectId,
+              role: "ADMIN",
+              retentionDays: 30,
+              deletedAt: null,
+              name: "Test Project",
+            },
+          ],
+        },
+      ],
+      featureFlags: {
+        excludeClickhouseRead: false,
+        templateFlag: true,
+      },
+      admin: true,
+    },
+    environment: {} as any,
+  };
+
+  const ctx = createInnerTRPCContext({ session });
+  const caller = appRouter.createCaller({ ...ctx, prisma });
+
+  describe("generations.all", () => {
+    it("should get all generations with full text search and trace + scores filter", async () => {
+      const traceId = randomUUID();
+      const generationId = randomUUID();
+      const scoreId = randomUUID();
+
+      // Create trace with searchable content
+      const trace = createTrace({
+        id: traceId,
+        project_id: projectId,
+        name: "test-trace-name",
+        user_id: "test-user-123",
+      });
+
+      await createTracesCh([trace]);
+
+      // Create generation with searchable input/output content
+      const generation = createObservation({
+        id: generationId,
+        project_id: projectId,
+        trace_id: traceId,
+        type: "GENERATION",
+        name: "test-generation",
+        input: "Hello world, this is a test input",
+        output: "This is a test response output",
+      });
+
+      await createObservationsCh([generation]);
+
+      // Create score for the trace
+      const score = createTraceScore({
+        id: scoreId,
+        project_id: projectId,
+        trace_id: traceId,
+        name: "quality-score",
+        value: 0.85,
+      });
+
+      await createScoresCh([score]);
+
+      // Test with full-text search, trace filter, and score filter
+      const generations = await caller.generations.all({
+        projectId,
+        searchQuery: "test input", // Full-text search
+        searchType: ["content"], // Search in input/output content
+        filter: [
+          {
+            column: "Trace Name",
+            operator: "contains",
+            value: "test-trace",
+            type: "string",
+          },
+          {
+            column: "Scores (numeric)",
+            key: "test",
+            operator: ">=",
+            value: 5,
+            type: "numberObject",
+          },
+        ],
+        orderBy: null,
+        limit: 50,
+        page: 0,
+      });
+
+      expect(generations.generations).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add table prefix to `clickhouseSearchCondition` to avoid ambiguous identifiers in full-text search and update related calls.
> 
>   - **Behavior**:
>     - Add `tablePrefix` parameter to `clickhouseSearchCondition` in `search.ts` to avoid ambiguous identifiers in full-text search.
>     - Update calls to `clickhouseSearchCondition` in `observations.ts`, `traces.ts`, and `traces-ui-table-service.ts` to include table prefixes (`"o"` or `"t"`).
>   - **Testing**:
>     - Add `observations-trpc.servertest.ts` to test full-text search with trace and score filters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bc46efe70a0f3e2a3b3336c0f316a142cf8f9126. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->