### PR TITLE
fix(llm-connection-vertex): use zodV3 for structured output calls

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -1,4 +1,6 @@
-import { type ZodSchema } from "zod/v4";
+// We need to use Zod3 for structured outputs due to a bug in
+// ChatVertexAI. See issue: https://github.com/langfuse/langfuse/issues/7429
+import { type ZodSchema } from "zod/v3";
 
 import { ChatAnthropic } from "@langchain/anthropic";
 import { ChatVertexAI } from "@langchain/google-vertexai";

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -1,4 +1,5 @@
 import { z } from "zod/v4";
+import { z as zodV3 } from "zod/v3";
 import {
   createTRPCRouter,
   protectedProjectProcedure,
@@ -832,9 +833,9 @@ export const evalRouter = createTRPCRouter({
               adapter: matchingLLMKey.adapter,
               ...input.modelParams,
             },
-            structuredOutputSchema: z.object({
-              score: z.string(),
-              reasoning: z.string(),
+            structuredOutputSchema: zodV3.object({
+              score: zodV3.string(),
+              reasoning: zodV3.string(),
             }),
             config: matchingLLMKey.config,
           })

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import { sql } from "kysely";
 import { z } from "zod/v4";
+import { z as zodV3 } from "zod/v3";
 import { JobConfigState } from "@prisma/client";
 import {
   QueueJobs,
@@ -505,9 +506,9 @@ export const evaluate = async ({
     throw new InvalidRequestError("Output schema not found");
   }
 
-  const evalScoreSchema = z.object({
-    reasoning: z.string().describe(parsedOutputSchema.reasoning),
-    score: z.number().describe(parsedOutputSchema.score),
+  const evalScoreSchema = zodV3.object({
+    reasoning: zodV3.string().describe(parsedOutputSchema.reasoning),
+    score: zodV3.number().describe(parsedOutputSchema.score),
   });
 
   const modelConfig = await DefaultEvalModelService.fetchValidModelConfig(

--- a/worker/src/features/utilities.ts
+++ b/worker/src/features/utilities.ts
@@ -7,6 +7,7 @@ import {
 } from "@langfuse/shared/src/server";
 import { ApiError, LLMApiKeySchema, ZodModelConfig } from "@langfuse/shared";
 import { z } from "zod/v4";
+import { z as zodV3 } from "zod/v3";
 import { ZodSchema as ZodV3Schema } from "zod/v3";
 import { decrypt } from "@langfuse/shared/encryption";
 import { tokenCount } from "./tokenisation/usage";
@@ -20,7 +21,7 @@ export async function callStructuredLLM<T extends ZodV3Schema>(
   provider: string,
   model: string,
   structuredOutputSchema: T,
-): Promise<z.infer<T>> {
+): Promise<zodV3.infer<T>> {
   try {
     const { completion } = await fetchLLMCompletion({
       streaming: false,

--- a/worker/src/features/utilities.ts
+++ b/worker/src/features/utilities.ts
@@ -6,12 +6,13 @@ import {
   type TraceParams,
 } from "@langfuse/shared/src/server";
 import { ApiError, LLMApiKeySchema, ZodModelConfig } from "@langfuse/shared";
-import { z, ZodSchema } from "zod/v4";
+import { z } from "zod/v4";
+import { ZodSchema as ZodV3Schema } from "zod/v3";
 import { decrypt } from "@langfuse/shared/encryption";
 import { tokenCount } from "./tokenisation/usage";
 import Handlebars from "handlebars";
 
-export async function callStructuredLLM<T extends ZodSchema>(
+export async function callStructuredLLM<T extends ZodV3Schema>(
   jeId: string,
   llmApiKey: z.infer<typeof LLMApiKeySchema>,
   messages: ChatMessage[],


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Switch from Zod v4 to Zod v3 for structured output schemas due to a ChatVertexAI bug, updating relevant imports and functions.
> 
>   - **Behavior**:
>     - Switch from `zod/v4` to `zod/v3` for structured output schemas due to a bug in ChatVertexAI.
>     - Update `structuredOutputSchema` in `fetchLLMCompletion.ts`, `router.ts`, and `evalService.ts` to use `zodV3`.
>   - **Functions**:
>     - Modify `callStructuredLLM()` in `utilities.ts` to use `ZodV3Schema` and `zodV3.infer`.
>   - **Imports**:
>     - Add `zodV3` import in `router.ts`, `evalService.ts`, and `utilities.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 507cc48e032b0a16a5eba972de5762fe05d30825. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->