### PR TITLE
fix: handle dataset queries with cached traces in evals

### DIFF
--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -257,7 +257,7 @@ export const createEvalJobs = async ({
       // Evaluate filter in memory using the cached trace
       traceExists = InMemoryFilterService.evaluateFilter(
         cachedTrace,
-        validatedFilter,
+        traceFilter,
         mapTraceFilterColumn,
       );
 
@@ -268,7 +268,7 @@ export const createEvalJobs = async ({
         traceId: event.traceId,
         configId: config.id,
         matches: traceExists,
-        filterCount: validatedFilter.length,
+        filterCount: traceFilter.length,
       });
     } else {
       // Fall back to database query for complex filters or when no cached trace
@@ -289,7 +289,7 @@ export const createEvalJobs = async ({
       });
       recordIncrement("langfuse.evaluation-execution.trace_db_lookup", 1, {
         hasCached: Boolean(cachedTrace).toString(),
-        requiredDatabaseLookup: requiresDatabaseLookup(validatedFilter)
+        requiredDatabaseLookup: requiresDatabaseLookup(traceFilter)
           ? "true"
           : "false",
       });

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -252,7 +252,8 @@ export const createEvalJobs = async ({
 
     // Use cached trace for in-memory filtering when possible, i.e. all fields can
     // be checked in-memory.
-    if (cachedTrace && !requiresDatabaseLookup(validatedFilter)) {
+    const traceFilter = config.target_object === "trace" ? validatedFilter : [];
+    if (cachedTrace && !requiresDatabaseLookup(traceFilter)) {
       // Evaluate filter in memory using the cached trace
       traceExists = InMemoryFilterService.evaluateFilter(
         cachedTrace,
@@ -279,7 +280,7 @@ export const createEvalJobs = async ({
           "timestamp" in event
             ? new Date(event.timestamp)
             : new Date(jobTimestamp),
-        filter: config.target_object === "trace" ? validatedFilter : [],
+        filter: traceFilter,
         maxTimeStamp,
         exactTimestamp:
           "exactTimestamp" in event && event.exactTimestamp


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds test and optimizes `createEvalJobs` to handle dataset queries with cached traces, improving in-memory filtering and evaluation efficiency.
> 
>   - **Behavior**:
>     - Adds test `handle dataset upsert with cached traces` in `evalService.test.ts` to ensure dataset queries with cached traces are handled without errors.
>     - Modifies `createEvalJobs` in `evalService.ts` to use cached traces for in-memory filtering when possible, optimizing evaluation.
>   - **Functions**:
>     - Updates `createEvalJobs` to differentiate between `trace` and `dataset` configurations, using `traceFilter` for in-memory checks.
>     - Adjusts logging and metrics in `createEvalJobs` to reflect cache usage and database lookup requirements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e7bcff377fc0f7bf401d987358cb8f8e66b6692e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->