### PR TITLE
chore: add .env values for sdk integration tests

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -75,7 +75,11 @@ REDIS_PORT=6379
 REDIS_AUTH="myredissecret"
 
 # openssl rand -hex 32 used only here
-ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000 
+ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000
 
 # speeds up local development by not executing init scripts on server startup
 NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT="false"
+
+# For SDK integration tests to pass, decrease the ingestion queue delay by uncommenting the env vars:
+# LANGFUSE_INGESTION_QUEUE_DELAY_MS=10
+# LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS=10


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add environment variables to `.env.dev.example` for SDK integration tests to decrease ingestion queue delay.
> 
>   - **Environment Variables**:
>     - Add `LANGFUSE_INGESTION_QUEUE_DELAY_MS` and `LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS` to `.env.dev.example` for SDK integration tests.
>     - These variables are commented out by default and intended to decrease ingestion queue delay during tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8ef248ef9505f137188ce2dbf1bbdc9862db06cf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->