### PR TITLE
fix(data-tables): table peeks and full links should respect custom basePaths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,3 +178,8 @@ When running locally with seed data:
 To get a project, use the `get_project` capability with the full project name as it is in the title.
 - bad: message-placeholder-in-chat-messages-2beb6f02ec48
 - good: Message placeholder in chat messages
+
+## Front-end Tips
+
+### Window Location Handling
+- Whenever you want to use or do use window.location..., ensure that you also add proper handling for a custom basePath

--- a/web/src/components/table/peek/hooks/useDatasetComparePeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/useDatasetComparePeekNavigation.ts
@@ -1,9 +1,10 @@
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
+import { getPathnameWithoutBasePath } from "@/src/utils/api";
 
 export const useDatasetComparePeekNavigation = () => {
   const getNavigationPath = (entry: ListEntry) => {
     const url = new URL(window.location.href);
-    const pathname = window.location.pathname;
+    const pathname = getPathnameWithoutBasePath();
 
     // Update the path part
     url.pathname = pathname;

--- a/web/src/components/table/peek/hooks/useDatasetComparePeekState.ts
+++ b/web/src/components/table/peek/hooks/useDatasetComparePeekState.ts
@@ -1,5 +1,6 @@
 import { useRouter } from "next/router";
 import { useCallback, useState } from "react";
+import { getPathnameWithoutBasePath } from "@/src/utils/api";
 
 export const useDatasetComparePeekState = () => {
   const router = useRouter();
@@ -15,7 +16,7 @@ export const useDatasetComparePeekState = () => {
     (open: boolean, itemId?: string) => {
       const url = new URL(window.location.href);
       const params = new URLSearchParams(url.search);
-      const pathname = window.location.pathname;
+      const pathname = getPathnameWithoutBasePath();
 
       if (!open || !itemId) {
         // close peek view

--- a/web/src/components/table/peek/hooks/useEvalTemplatesPeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/useEvalTemplatesPeekNavigation.ts
@@ -1,6 +1,7 @@
 import { type EvalsTemplateRow } from "@/src/features/evals/components/eval-templates-table";
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 import { useRouter } from "next/router";
+import { getPathnameWithoutBasePath } from "@/src/utils/api";
 
 export const useEvalTemplatesPeekNavigation = () => {
   const router = useRouter();
@@ -8,7 +9,7 @@ export const useEvalTemplatesPeekNavigation = () => {
 
   const getNavigationPath = (entry: ListEntry) => {
     const url = new URL(window.location.href);
-    const pathname = window.location.pathname;
+    const pathname = getPathnameWithoutBasePath();
 
     // Update the path part
     url.pathname = pathname;
@@ -28,7 +29,8 @@ export const useEvalTemplatesPeekNavigation = () => {
     const pathname = `/project/${projectId}/evals/templates/${encodeURIComponent(peek as string)}`;
 
     if (openInNewTab) {
-      window.open(pathname, "_blank");
+      const pathnameWithBasePath = `${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}${pathname}`;
+      window.open(pathnameWithBasePath, "_blank");
     } else {
       router.push(pathname);
     }

--- a/web/src/components/table/peek/hooks/useObservationPeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/useObservationPeekNavigation.ts
@@ -1,6 +1,7 @@
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 import { useRouter } from "next/router";
 import { type ObservationsTableRow } from "@/src/components/table/use-cases/observations";
+import { getPathnameWithoutBasePath } from "@/src/utils/api";
 
 export const useObservationPeekNavigation = () => {
   const router = useRouter();
@@ -8,7 +9,7 @@ export const useObservationPeekNavigation = () => {
 
   const getNavigationPath = (entry: ListEntry) => {
     const url = new URL(window.location.href);
-    const pathname = window.location.pathname;
+    const pathname = getPathnameWithoutBasePath();
 
     // Update the path part
     url.pathname = pathname;
@@ -42,7 +43,8 @@ export const useObservationPeekNavigation = () => {
     const pathname = `/project/${projectId}/traces/${encodeURIComponent(row.traceId as string)}?timestamp=${timestamp}&display=${display}&observation=${peek as string}`;
 
     if (openInNewTab) {
-      window.open(pathname, "_blank");
+      const pathnameWithBasePath = `${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}${pathname}`;
+      window.open(pathnameWithBasePath, "_blank");
     } else {
       router.push(pathname);
     }

--- a/web/src/components/table/peek/hooks/useObservationPeekState.ts
+++ b/web/src/components/table/peek/hooks/useObservationPeekState.ts
@@ -1,5 +1,6 @@
 import { useRouter } from "next/router";
 import { useCallback } from "react";
+import { getPathnameWithoutBasePath } from "@/src/utils/api";
 
 export const useObservationPeekState = () => {
   const router = useRouter();
@@ -9,7 +10,7 @@ export const useObservationPeekState = () => {
     (open: boolean, id?: string, time?: string) => {
       const url = new URL(window.location.href);
       const params = new URLSearchParams(url.search);
-      const pathname = window.location.pathname;
+      const pathname = getPathnameWithoutBasePath();
 
       if (!open || !id) {
         // close peek view

--- a/web/src/components/table/peek/hooks/usePeekState.ts
+++ b/web/src/components/table/peek/hooks/usePeekState.ts
@@ -1,5 +1,6 @@
 import { useRouter } from "next/router";
 import { useCallback } from "react";
+import { getPathnameWithoutBasePath } from "@/src/utils/api";
 
 export const usePeekState = () => {
   const router = useRouter();
@@ -9,7 +10,7 @@ export const usePeekState = () => {
     (open: boolean, id?: string) => {
       const url = new URL(window.location.href);
       const params = new URLSearchParams(url.search);
-      const pathname = window.location.pathname;
+      const pathname = getPathnameWithoutBasePath();
 
       if (!open || !id) {
         // close peek view

--- a/web/src/components/table/peek/hooks/useRunningEvaluatorsPeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/useRunningEvaluatorsPeekNavigation.ts
@@ -1,9 +1,10 @@
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
+import { getPathnameWithoutBasePath } from "@/src/utils/api";
 
 export const useRunningEvaluatorsPeekNavigation = () => {
   const getNavigationPath = (entry: ListEntry) => {
     const url = new URL(window.location.href);
-    const pathname = window.location.pathname;
+    const pathname = getPathnameWithoutBasePath();
 
     // Update the path part
     url.pathname = pathname;

--- a/web/src/components/table/peek/hooks/useTracePeekNavigation.ts
+++ b/web/src/components/table/peek/hooks/useTracePeekNavigation.ts
@@ -1,5 +1,6 @@
 import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 import { useRouter } from "next/router";
+import { getPathnameWithoutBasePath } from "@/src/utils/api";
 
 export const useTracePeekNavigation = () => {
   const router = useRouter();
@@ -7,7 +8,7 @@ export const useTracePeekNavigation = () => {
 
   const getNavigationPath = (entry: ListEntry) => {
     const url = new URL(window.location.href);
-    const pathname = window.location.pathname;
+    const pathname = getPathnameWithoutBasePath();
 
     // Update the path part
     url.pathname = pathname;
@@ -38,7 +39,8 @@ export const useTracePeekNavigation = () => {
     const pathname = `/project/${projectId}/traces/${encodeURIComponent(peek as string)}?timestamp=${timestamp}&display=${display}`;
 
     if (openInNewTab) {
-      window.open(pathname, "_blank");
+      const pathnameWithBasePath = `${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}${pathname}`;
+      window.open(pathnameWithBasePath, "_blank");
     } else {
       router.push(pathname);
     }

--- a/web/src/components/table/peek/hooks/useTracePeekState.ts
+++ b/web/src/components/table/peek/hooks/useTracePeekState.ts
@@ -1,5 +1,6 @@
 import { useRouter } from "next/router";
 import { useCallback } from "react";
+import { getPathnameWithoutBasePath } from "@/src/utils/api";
 
 export const useTracePeekState = () => {
   const router = useRouter();
@@ -9,7 +10,7 @@ export const useTracePeekState = () => {
     (open: boolean, id?: string, time?: string) => {
       const url = new URL(window.location.href);
       const params = new URLSearchParams(url.search);
-      const pathname = window.location.pathname;
+      const pathname = getPathnameWithoutBasePath();
 
       if (!open || !id) {
         // close peek view

--- a/web/src/components/table/peek/peek-dataset-compare-detail.tsx
+++ b/web/src/components/table/peek/peek-dataset-compare-detail.tsx
@@ -72,12 +72,11 @@ export const PeekDatasetCompareDetail = ({
   };
 
   const handleSetCurrentObservationId = (id?: string) => {
-    if (id && traceId)
-      window.open(
-        `/project/${projectId}/traces/${encodeURIComponent(traceId)}?observation=${encodeURIComponent(id)}`,
-        "_blank",
-        "noopener noreferrer",
-      );
+    if (id && traceId) {
+      const pathname = `/project/${projectId}/traces/${encodeURIComponent(traceId)}?observation=${encodeURIComponent(id)}`;
+      const pathnameWithBasePath = `${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}${pathname}`;
+      window.open(pathnameWithBasePath, "_blank", "noopener noreferrer");
+    }
   };
 
   if (!row) return <Skeleton className="min-h-full w-full" />;
@@ -183,15 +182,13 @@ export const PeekDatasetCompareDetail = ({
                               variant="outline"
                               size="icon"
                               title="View full trace"
-                              onClick={() =>
-                                window.open(
-                                  run?.observationId
-                                    ? `/project/${projectId}/traces/${encodeURIComponent(run.traceId)}?observation=${encodeURIComponent(run.observationId)}`
-                                    : `/project/${projectId}/traces/${encodeURIComponent(run.traceId)}`,
-                                  "_blank",
-                                  "noopener noreferrer",
-                                )
-                              }
+                              onClick={() => {
+                                const pathname = run?.observationId
+                                  ? `/project/${projectId}/traces/${encodeURIComponent(run.traceId)}?observation=${encodeURIComponent(run.observationId)}`
+                                  : `/project/${projectId}/traces/${encodeURIComponent(run.traceId)}`;
+                                const pathnameWithBasePath = `${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}${pathname}`;
+                                window.open(pathnameWithBasePath, "_blank", "noopener noreferrer");
+                              }}
                             >
                               <ListTree className="h-4 w-4" />
                             </Button>

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -4,6 +4,8 @@
  *
  * We also create a few inference helpers for input and output types.
  */
+
+import { captureException } from "@sentry/nextjs";
 import {
   createTRPCProxyClient,
   httpBatchLink,
@@ -13,17 +15,15 @@ import {
   TRPCClientError,
   type TRPCLink,
 } from "@trpc/client";
-import { observable } from "@trpc/server/observable";
 import { createTRPCNext } from "@trpc/next";
 import { type inferRouterInputs, type inferRouterOutputs } from "@trpc/server";
+import { observable } from "@trpc/server/observable";
 import superjson from "superjson";
-
+import { env } from "@/src/env.mjs";
+import { showVersionUpdateToast } from "@/src/features/notifications/showVersionUpdateToast";
 import { type AppRouter } from "@/src/server/api/root";
 import { setUpSuperjson } from "@/src/utils/superjson";
 import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
-import { showVersionUpdateToast } from "@/src/features/notifications/showVersionUpdateToast";
-import { captureException } from "@sentry/nextjs";
-import { env } from "@/src/env.mjs";
 
 setUpSuperjson();
 
@@ -36,6 +36,19 @@ const getBaseUrl = () => {
         : `http://localhost:${process.env.PORT ?? 3000}`;
 
   return `${hostname}${env.NEXT_PUBLIC_BASE_PATH ?? ""}`;
+};
+
+// Get current pathname without the base path prefix
+// for client-side navigation with a custom basePath set
+export const getPathnameWithoutBasePath = () => {
+  const pathname = window.location.pathname;
+  const basePath = env.NEXT_PUBLIC_BASE_PATH;
+
+  if (basePath && pathname.startsWith(basePath)) {
+    return pathname.slice(basePath.length) || "/";
+  }
+
+  return pathname;
 };
 
 // global build id used to compare versions to show refresh toast on stale cache hit serving deprecated files


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix navigation and link generation to respect custom base paths in data tables.
> 
>   - **Behavior**:
>     - Ensure navigation respects custom base paths by using `getPathnameWithoutBasePath()` in `useDatasetComparePeekNavigation.ts`, `useDatasetComparePeekState.ts`, `useEvalTemplatesPeekNavigation.ts`, `useObservationPeekNavigation.ts`, `useObservationPeekState.ts`, `usePeekState.ts`, `useRunningEvaluatorsPeekNavigation.ts`, `useTracePeekNavigation.ts`, and `useTracePeekState.ts`.
>     - Update link opening in new tabs to include base path in `useEvalTemplatesPeekNavigation.ts`, `useObservationPeekNavigation.ts`, `useTracePeekNavigation.ts`, and `peek-dataset-compare-detail.tsx`.
>   - **Utils**:
>     - Add `getPathnameWithoutBasePath()` to `api.ts` to strip base path from current pathname for client-side navigation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b7b4802d566ddb8d82299510e2eb79928eac9440. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->