### PR TITLE
feat: line breaks on evaluation run tooltip hints

### DIFF
--- a/packages/shared/scripts/seeder/utils/data-generators.ts
+++ b/packages/shared/scripts/seeder/utils/data-generators.ts
@@ -442,7 +442,7 @@ export class DataGenerator {
           string_value: stringValue,
           data_type: scoreType as any,
           source: "API",
-          comment: "Generated score",
+          comment: "Generated score\ntest",
           environment: trace.environment,
         });
 

--- a/web/src/components/scores-table-cell.tsx
+++ b/web/src/components/scores-table-cell.tsx
@@ -71,7 +71,7 @@ export const ScoresTableCell = ({
               <MessageCircleMore size={12} />
             </HoverCardTrigger>
             <HoverCardContent className="overflow-hidden whitespace-normal break-normal">
-              <p>{aggregate.comment}</p>
+              <p className="whitespace-pre-wrap">{aggregate.comment}</p>
             </HoverCardContent>
           </HoverCard>
         )}

--- a/web/src/features/scores/components/AnnotateDrawerContent.tsx
+++ b/web/src/features/scores/components/AnnotateDrawerContent.tsx
@@ -718,7 +718,10 @@ export function AnnotateDrawerContent<Target extends ScoreTarget>({
                                             {!!score.comment && (
                                               <div className="mb-4 max-w-48 rounded border bg-background p-2 shadow-sm">
                                                 <p className="text-xs">
-                                                  Saved comment: {score.comment}
+                                                  Saved comment:{" "}
+                                                  <span className="whitespace-pre-wrap">
+                                                    {score.comment}
+                                                  </span>
                                                 </p>
                                               </div>
                                             )}


### PR DESCRIPTION
Support for line breaks on evaluation run tooltip hints has been implemented.

The issue was that tooltip text appeared as a single continuous line due to a lack of proper line break handling.

Changes were made to:
*   `web/src/components/scores-table-cell.tsx`: The `<p>` element displaying `aggregate.comment` within the score table cell tooltip was updated with `className="whitespace-pre-wrap"`. This ensures line breaks in score comments are preserved.
*   `web/src/features/scores/components/AnnotateDrawerContent.tsx`: Saved comments (`score.comment`) within the annotation drawer were wrapped in a `<span>` element with `className="whitespace-pre-wrap"`. This preserves line breaks for saved evaluation comments.

The `whitespace-pre-wrap` CSS class was used to preserve line breaks (`\n`) and maintain proper spacing, allowing text to wrap naturally. This aligns with existing styling patterns in the codebase. As a result, evaluation run tooltip hints and saved comments now display with structured, readable text.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Preserves line breaks in tooltip comments in `scores-table-cell.tsx` and `AnnotateDrawerContent.tsx` using `whitespace-pre-wrap`.
> 
>   - **Behavior**:
>     - Preserves line breaks in tooltip comments using `whitespace-pre-wrap` CSS class.
>     - Affects `aggregate.comment` in `scores-table-cell.tsx` and `score.comment` in `AnnotateDrawerContent.tsx`.
>   - **Misc**:
>     - Updates `comment` in `data-generators.ts` to include a line break for testing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d88e4d3b3b34098f6729fb0dacc906ce0a547d7d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->