### PR TITLE
chore(cloud): apply "cloud:demo" tier to demo org tenant in plain sup…

### DIFF
--- a/web/src/features/support-chat/trpc/plain.ts
+++ b/web/src/features/support-chat/trpc/plain.ts
@@ -79,7 +79,8 @@ export const plainRouter = createTRPCRouter({
             externalId: tenantIdentifier(org.id),
           },
           tierIdentifier: {
-            externalId: org.plan,
+            externalId:
+              org.id === env.NEXT_PUBLIC_DEMO_ORG_ID ? "cloud:demo" : org.plan,
           },
         });
       });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `tierIdentifier` to `cloud:demo` for demo organization in `plainRouter` in `plain.ts`.
> 
>   - **Behavior**:
>     - In `plainRouter` in `plain.ts`, set `tierIdentifier` to `cloud:demo` for organizations with ID matching `env.NEXT_PUBLIC_DEMO_ORG_ID`.
>     - Retains original `org.plan` for other organizations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3f8516313841f934679c2f7797a1d72704337e71. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->