### PR TITLE
chore: propagate additional properties on logs and spans

### DIFF
--- a/packages/shared/src/server/headerPropagation.ts
+++ b/packages/shared/src/server/headerPropagation.ts
@@ -30,6 +30,21 @@ export const contextWithLangfuseProps = (
         value: strValue,
       });
     });
+
+    // get x-langfuse-xxx headers and add them to the span
+    Object.keys(props.headers).forEach((name) => {
+      if (
+        name.toLowerCase().startsWith("x-langfuse") ||
+        name.toLowerCase().startsWith("x_langfuse")
+      ) {
+        const value = props.headers![name];
+        if (!value) return;
+        const strValue = Array.isArray(value) ? JSON.stringify(value) : value;
+        baggage = baggage.setEntry(`langfuse.header.${name}`, {
+          value: strValue,
+        });
+      }
+    });
   }
   if (props.userId) {
     baggage = baggage.setEntry("langfuse.user.id", { value: props.userId });

--- a/packages/shared/src/server/instrumentation/index.ts
+++ b/packages/shared/src/server/instrumentation/index.ts
@@ -157,6 +157,61 @@ export const traceException = (
   });
 };
 
+export const addUserToSpan = (
+  attributes: {
+    userId?: string;
+    projectId?: string;
+    email?: string;
+    orgId?: string;
+    plan?: string;
+  },
+  span?: opentelemetry.Span,
+) => {
+  const activeSpan = span ?? getCurrentSpan();
+
+  if (!activeSpan) {
+    return;
+  }
+
+  const ctx = opentelemetry.context.active();
+  let baggage =
+    opentelemetry.propagation.getBaggage(ctx) ??
+    opentelemetry.propagation.createBaggage();
+
+  if (attributes.userId) {
+    baggage = baggage.setEntry("user.id", {
+      value: attributes.userId,
+    });
+    activeSpan.setAttribute("user.id", attributes.userId);
+  }
+  if (attributes.email) {
+    baggage = baggage.setEntry("user.email", {
+      value: attributes.email,
+    });
+    activeSpan.setAttribute("user.email", attributes.email);
+  }
+  if (attributes.projectId) {
+    baggage = baggage.setEntry("langfuse.project.id", {
+      value: attributes.projectId,
+    });
+    activeSpan.setAttribute("langfuse.project.id", attributes.projectId);
+  }
+  if (attributes.orgId) {
+    baggage = baggage.setEntry("langfuse.org.id", {
+      value: attributes.orgId,
+    });
+    activeSpan.setAttribute("langfuse.org.id", attributes.orgId);
+  }
+  if (attributes.plan) {
+    baggage = baggage.setEntry("langfuse.org.plan", {
+      value: attributes.plan,
+    });
+    activeSpan.setAttribute("langfuse.org.plan", attributes.plan);
+  }
+
+  return opentelemetry.propagation.setBaggage(ctx, baggage);
+};
+
 export const getTracer = (name: string) => opentelemetry.trace.getTracer(name);
 
 const cloudWatchClient = new CloudWatchClient();

--- a/web/src/features/public-api/server/apiAuth.ts
+++ b/web/src/features/public-api/server/apiAuth.ts
@@ -8,6 +8,7 @@ import {
   OrgEnrichedApiKey,
   logger,
   instrumentAsync,
+  addUserToSpan,
 } from "@langfuse/shared/src/server";
 import {
   type PrismaClient,
@@ -203,6 +204,12 @@ export class ApiAuthService {
               throw new Error("Invalid credentials");
             }
 
+            addUserToSpan({
+              projectId: finalApiKey.projectId ?? undefined,
+              orgId: finalApiKey.orgId,
+              plan,
+            });
+
             const accessLevel =
               finalApiKey.scope === "ORGANIZATION" ? "organization" : "project";
 
@@ -234,6 +241,12 @@ export class ApiAuthService {
 
             const { orgId, cloudConfig } =
               this.extractOrgIdAndCloudConfig(dbKey);
+
+            addUserToSpan({
+              projectId: dbKey.projectId ?? undefined,
+              orgId,
+              plan: getOrganizationPlanServerSide(cloudConfig),
+            });
 
             return {
               validKey: true,
@@ -272,6 +285,7 @@ export class ApiAuthService {
         };
       },
     );
+
     return result;
   }
 

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -17,7 +17,6 @@
 import { type CreateNextContextOptions } from "@trpc/server/adapters/next";
 import { type Session } from "next-auth";
 import { tracing } from "@baselime/trpc-opentelemetry-middleware";
-import { contextWithLangfuseProps } from "@langfuse/shared/src/server";
 import { getServerAuthSession } from "@/src/server/auth";
 import { prisma, Role } from "@langfuse/shared/src/db";
 import * as z from "zod/v4";
@@ -63,6 +62,11 @@ export const createTRPCContext = async (opts: CreateNextContextOptions) => {
   // Get the headers from the request
   const headers = req.headers;
 
+  addUserToSpan({
+    userId: session?.user?.id,
+    email: session?.user?.email ?? undefined,
+  });
+
   return createInnerTRPCContext({ session, headers });
 };
 
@@ -78,7 +82,12 @@ import superjson from "superjson";
 import { ZodError } from "zod/v4";
 import { setUpSuperjson } from "@/src/utils/superjson";
 import { DB } from "@/src/server/db";
-import { getTraceById, logger } from "@langfuse/shared/src/server";
+import {
+  getTraceById,
+  logger,
+  addUserToSpan,
+  contextWithLangfuseProps,
+} from "@langfuse/shared/src/server";
 
 setUpSuperjson();
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance logging and tracing by propagating additional headers and user attributes to spans in `headerPropagation.ts`, `index.ts`, `apiAuth.ts`, and `trpc.ts`.
> 
>   - **Behavior**:
>     - Extend `contextWithLangfuseProps` in `headerPropagation.ts` to include `x-langfuse-xxx` headers in spans.
>     - Add `addUserToSpan` function in `index.ts` to propagate user attributes to spans.
>   - **Integration**:
>     - Use `addUserToSpan` in `apiAuth.ts` to add user and project details to spans during API key verification.
>     - Integrate `addUserToSpan` in `trpc.ts` to include user details in tRPC context creation.
>   - **Misc**:
>     - Minor refactoring in `apiAuth.ts` and `trpc.ts` to accommodate new span attributes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a9662091e3dc76bf031ea0c1c5d1330bb9898637. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->