### PR TITLE
chore: enable sentry replays

### DIFF
--- a/web/sentry.client.config.ts
+++ b/web/sentry.client.config.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
 
-const isEuOrUsRegionNonHipaa = process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== undefined ? ["EU", "US"].includes(process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) : false;
+const isEuOrUsRegionNonHipaa = ["EU", "US"].includes(process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,

--- a/web/sentry.client.config.ts
+++ b/web/sentry.client.config.ts
@@ -1,5 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
+const isEuOrUsRegionNonHipaa = process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== undefined ? ["EU", "US"].includes(process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) : false;
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
@@ -7,7 +9,10 @@ Sentry.init({
 
   // Replay may only be enabled for the client-side
   integrations: [
-    Sentry.replayIntegration(),
+    Sentry.replayIntegration({
+      maskAllText: !isEuOrUsRegionNonHipaa,
+      blockAllMedia: !isEuOrUsRegionNonHipaa,
+    }),
     Sentry.browserTracingIntegration(),
     Sentry.httpClientIntegration(),
     // Sentry.debugIntegration(),

--- a/web/sentry.client.config.ts
+++ b/web/sentry.client.config.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
 
-const isEuOrUsRegionNonHipaa = ["EU", "US"].includes(process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
+const isEuOrUsRegionNonHipaa = process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== undefined ? ["EU", "US"].includes(process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) : false;
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enable Sentry replays with region-based text masking and media blocking in `sentry.client.config.ts`.
> 
>   - **Behavior**:
>     - Enable Sentry replays in `sentry.client.config.ts` with `maskAllText` and `blockAllMedia` set based on `isEuOrUsRegionNonHipaa`.
>     - `isEuOrUsRegionNonHipaa` checks if `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` is "EU" or "US" and not undefined.
>   - **Configuration**:
>     - `replaysSessionSampleRate` and `replaysOnErrorSampleRate` set to capture 100% of sessions and error sessions respectively.
>     - `tracesSampleRate` and `profilesSampleRate` configured for performance monitoring and profiling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 77c76fe825d52d2c5d1802288046f82d06e24a50. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->