### PR TITLE
fix(dashboards): represent small numbers in scientific notation

### DIFF
--- a/web/src/features/widgets/chart-library/HistogramChart.tsx
+++ b/web/src/features/widgets/chart-library/HistogramChart.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { type DataPoint } from "@/src/features/widgets/chart-library/chart-props";
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer } from "recharts";
 import { ChartContainer, ChartTooltip } from "@/src/components/ui/chart";
-import { compactNumberFormatter } from "@/src/utils/numbers";
+import { compactSmallNumberFormatter } from "@/src/utils/numbers";
 
 interface HistogramDataPoint {
   binLabel: string;
@@ -22,7 +22,7 @@ const HistogramChart = ({ data }: { data: DataPoint[] }) => {
       // ClickHouse histogram format: [(lower, upper, height), ...]
       return (firstDataPoint.metric as [number, number, number][]).map(
         ([lower, upper, height]) => ({
-          binLabel: `[${compactNumberFormatter(lower)}, ${compactNumberFormatter(upper)}]`,
+          binLabel: `[${compactSmallNumberFormatter(lower)}, ${compactSmallNumberFormatter(upper)}]`,
           count: height,
           lower,
           upper,

--- a/web/src/utils/numbers.ts
+++ b/web/src/utils/numbers.ts
@@ -12,7 +12,7 @@ export const compactNumberFormatter = (
 };
 
 /**
- * Specialized formatter for very small numbers (10^-6 to 10^-15 range)
+ * Specialized formatter for very small numbers (10^-3 to 10^-15 range)
  * Uses scientific notation for compact representation with ~3 significant digits
  */
 export const compactSmallNumberFormatter = (

--- a/web/src/utils/numbers.ts
+++ b/web/src/utils/numbers.ts
@@ -11,6 +11,29 @@ export const compactNumberFormatter = (
   }).format(number ?? 0);
 };
 
+/**
+ * Specialized formatter for very small numbers (10^-6 to 10^-15 range)
+ * Uses scientific notation for compact representation with ~3 significant digits
+ */
+export const compactSmallNumberFormatter = (
+  number?: number | bigint,
+  significantDigits: number = 3,
+) => {
+  const num = Number(number ?? 0);
+
+  if (num === 0) return "0";
+
+  const absNum = Math.abs(num);
+
+  // For numbers >= 1e-3, use standard compact formatting
+  if (absNum >= 1e-3) {
+    return compactNumberFormatter(num, significantDigits);
+  }
+
+  // For very small numbers, use scientific notation
+  return num.toExponential(significantDigits - 1);
+};
+
 export const numberFormatter = (
   number?: number | bigint,
   fractionDigits?: number,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `compactSmallNumberFormatter` for small numbers and updates `HistogramChart` to use it for bin labels.
> 
>   - **Behavior**:
>     - `compactSmallNumberFormatter` added to `numbers.ts` for numbers in 10^-6 to 10^-15 range, using scientific notation.
>     - `HistogramChart` in `HistogramChart.tsx` now uses `compactSmallNumberFormatter` for bin labels.
>   - **Functions**:
>     - `compactNumberFormatter` remains for numbers >= 1e-3.
>     - `compactSmallNumberFormatter` handles numbers < 1e-3 with scientific notation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c083b9b74036056bc35ba59ed7e81b6e3a9f8467. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->