### PR TITLE
chore(cloud): color of upgrade notification

### DIFF
--- a/web/src/ee/features/billing/components/UsageTracker.tsx
+++ b/web/src/ee/features/billing/components/UsageTracker.tsx
@@ -13,6 +13,7 @@ import {
 import { ActionButton } from "@/src/components/ActionButton";
 import { cn } from "@/src/utils/tailwind";
 import { AlertTriangle } from "lucide-react";
+import { useSidebar } from "@/src/components/ui/sidebar";
 
 export const UsageTracker = () => {
   const { organization } = useQueryProjectOrOrganization();
@@ -22,6 +23,7 @@ export const UsageTracker = () => {
     organizationId: organization?.id,
     scope: "langfuseCloudBilling:CRUD",
   });
+  const { setOpen } = useSidebar();
 
   const usageQuery = api.cloudBilling.getUsage.useQuery(
     {
@@ -56,33 +58,43 @@ export const UsageTracker = () => {
   const isCritical = percentage > 200;
 
   return (
-    <Card
-      className={cn(
-        "relative max-h-48 overflow-hidden rounded-md bg-opacity-50 shadow-none group-data-[collapsible=icon]:hidden",
-        isCritical && "border-destructive",
+    <>
+      {/* icon when critical and sidebar is collapsed */}
+      {isCritical && (
+        <AlertTriangle
+          className="hidden h-4 w-4 cursor-pointer self-center text-destructive group-data-[collapsible=icon]:inline-block"
+          onClick={() => setOpen(true)}
+        />
       )}
-    >
-      <CardHeader className="p-4 pb-0">
-        <CardTitle className="flex items-center gap-2 text-sm">
-          {isCritical && (
-            <AlertTriangle className="inline-block h-4 w-4 text-destructive" />
-          )}
-          Plan Usage Limit
-        </CardTitle>
-        <CardDescription>
-          {`${usage.toLocaleString()} / ${MAX_EVENTS_FREE_PLAN.toLocaleString()} (${percentage.toFixed(0)}%) ${usageType} in last 30 days. Please upgrade your plan to avoid interruptions.`}
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="p-4 pt-2">
-        <ActionButton
-          variant={isCritical ? "default" : "secondary"}
-          size="sm"
-          href={`/organization/${organization?.id}/settings/billing`}
-          hasAccess={hasAccess}
-        >
-          Upgrade plan
-        </ActionButton>
-      </CardContent>
-    </Card>
+      {/* card when sidebar is not collapsed */}
+      <Card
+        className={cn(
+          "relative max-h-48 overflow-hidden rounded-md bg-opacity-50 shadow-none group-data-[collapsible=icon]:hidden",
+          isCritical && "border-destructive",
+        )}
+      >
+        <CardHeader className="p-4 pb-0">
+          <CardTitle className="flex items-center gap-2 text-sm">
+            {isCritical && (
+              <AlertTriangle className="inline-block h-4 w-4 text-destructive" />
+            )}
+            Plan Usage Limit
+          </CardTitle>
+          <CardDescription>
+            {`${usage.toLocaleString()} / ${MAX_EVENTS_FREE_PLAN.toLocaleString()} (${percentage.toFixed(0)}%) ${usageType} in last 30 days. Please upgrade your plan to avoid interruptions.`}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-4 pt-2">
+          <ActionButton
+            variant={isCritical ? "default" : "secondary"}
+            size="sm"
+            href={`/organization/${organization?.id}/settings/billing`}
+            hasAccess={hasAccess}
+          >
+            Upgrade plan
+          </ActionButton>
+        </CardContent>
+      </Card>
+    </>
   );
 };

--- a/web/src/ee/features/billing/components/UsageTracker.tsx
+++ b/web/src/ee/features/billing/components/UsageTracker.tsx
@@ -11,6 +11,8 @@ import {
   CardTitle,
 } from "@/src/components/ui/card";
 import { ActionButton } from "@/src/components/ActionButton";
+import { cn } from "@/src/utils/tailwind";
+import { AlertTriangle } from "lucide-react";
 
 export const UsageTracker = () => {
   const { organization } = useQueryProjectOrOrganization();
@@ -45,23 +47,35 @@ export const UsageTracker = () => {
 
   const usage = usageQuery.data.usageCount || 0;
   const usageType = usageQuery.data.usageType;
-  const percentage = (usage / MAX_EVENTS_FREE_PLAN) * 100;
+  const percentage = 300 + (usage / MAX_EVENTS_FREE_PLAN) * 100;
 
   if (percentage < 90) {
     return null;
   }
 
+  const isCritical = percentage > 200;
+
   return (
-    <Card className="relative max-h-48 overflow-hidden rounded-md bg-opacity-50 shadow-none group-data-[collapsible=icon]:hidden">
+    <Card
+      className={cn(
+        "relative max-h-48 overflow-hidden rounded-md bg-opacity-50 shadow-none group-data-[collapsible=icon]:hidden",
+        isCritical && "border-destructive",
+      )}
+    >
       <CardHeader className="p-4 pb-0">
-        <CardTitle className="text-sm">Hobby Plan Usage Limit</CardTitle>
+        <CardTitle className="flex items-center gap-2 text-sm">
+          {isCritical && (
+            <AlertTriangle className="inline-block h-4 w-4 text-destructive" />
+          )}
+          Plan Usage Limit
+        </CardTitle>
         <CardDescription>
           {`${usage.toLocaleString()} / ${MAX_EVENTS_FREE_PLAN.toLocaleString()} (${percentage.toFixed(0)}%) ${usageType} in last 30 days. Please upgrade your plan to avoid interruptions.`}
         </CardDescription>
       </CardHeader>
       <CardContent className="p-4 pt-2">
         <ActionButton
-          variant="secondary"
+          variant={isCritical ? "default" : "secondary"}
           size="sm"
           href={`/organization/${organization?.id}/settings/billing`}
           hasAccess={hasAccess}

--- a/web/src/ee/features/billing/components/UsageTracker.tsx
+++ b/web/src/ee/features/billing/components/UsageTracker.tsx
@@ -49,7 +49,7 @@ export const UsageTracker = () => {
 
   const usage = usageQuery.data.usageCount || 0;
   const usageType = usageQuery.data.usageType;
-  const percentage = 300 + (usage / MAX_EVENTS_FREE_PLAN) * 100;
+  const percentage = (usage / MAX_EVENTS_FREE_PLAN) * 100;
 
   if (percentage < 90) {
     return null;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modify `UsageTracker` to display critical alerts and change styles when usage exceeds 200%.
> 
>   - **Behavior**:
>     - In `UsageTracker`, display `AlertTriangle` icon when usage exceeds 200% and sidebar is collapsed.
>     - Change card border to `border-destructive` when usage is critical (>200%).
>     - Change `ActionButton` variant to `default` when usage is critical.
>   - **Imports**:
>     - Add `cn` from `tailwind` and `AlertTriangle` from `lucide-react`.
>     - Add `useSidebar` from `sidebar`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 642ba35e858e4f3fedaa2565bd7821099e9b601f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->