### PR TITLE
fix(dashboard): correctly display name filters on widget edit

### DIFF
--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -190,7 +190,21 @@ export function WidgetForm({
   const { selectedOption, dateRange, setDateRangeAndOption } =
     useDashboardDateRange({ defaultRelativeAggregation: "7 days" });
   const [userFilterState, setUserFilterState] = useState<FilterState>(
-    initialValues.filters ?? [],
+    initialValues.filters?.map((filter) => {
+      if (filter.column === "name") {
+        // We need to map the generic `name` property to the correct column name for the selected view
+        return {
+          ...filter,
+          column:
+            initialValues.view === "traces"
+              ? "traceName"
+              : initialValues.view === "observations"
+                ? "observationName"
+                : "scoreName",
+        };
+      }
+      return filter;
+    }) ?? [],
   );
 
   const traceFilterOptions = api.traces.filterOptions.useQuery(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes name filter mapping in `WidgetForm` to correctly map `name` to the appropriate column based on the selected view.
> 
>   - **Behavior**:
>     - Fixes name filter mapping in `WidgetForm` to correctly map `name` to `traceName`, `observationName`, or `scoreName` based on `initialValues.view`.
>   - **Misc**:
>     - No changes to other functionalities or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f6a1f02c769aa69762a096eb3657ddede28efaf2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->