### PR TITLE
feat: include all values from scoreConfig in filterOptions

### DIFF
--- a/web/src/__tests__/async/traces-trpc.servertest.ts
+++ b/web/src/__tests__/async/traces-trpc.servertest.ts
@@ -6,7 +6,12 @@ import { pruneDatabase } from "@/src/__tests__/test-utils";
 import { prisma } from "@langfuse/shared/src/db";
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
-import { createTrace, createTracesCh } from "@langfuse/shared/src/server";
+import {
+  createTrace,
+  createTracesCh,
+  createTraceScore,
+  createScoresCh,
+} from "@langfuse/shared/src/server";
 import { randomUUID } from "crypto";
 
 describe("traces trpc", () => {
@@ -135,6 +140,58 @@ describe("traces trpc", () => {
       expect(traceRes?.projectId).toEqual(projectId);
       expect(traceRes?.name).toEqual(trace.name);
       expect(traceRes?.timestamp).toEqual(new Date(trace.timestamp));
+    });
+  });
+
+  describe("traces.filterOptions", () => {
+    it("should include all possible categorical score values from score configs", async () => {
+      // Create a trace
+      const trace = createTrace({
+        project_id: projectId,
+      });
+      await createTracesCh([trace]);
+
+      // Create a categorical score config with multiple possible values
+      const scoreConfig = await prisma.scoreConfig.create({
+        data: {
+          projectId: projectId,
+          name: "sentiment",
+          dataType: "CATEGORICAL",
+          categories: [
+            { label: "positive", value: 1 },
+            { label: "neutral", value: 0 },
+            { label: "negative", value: -1 },
+          ],
+        },
+      });
+
+      // Create only one actual score (subset of possible values)
+      const score = createTraceScore({
+        project_id: projectId,
+        trace_id: trace.id,
+        name: "sentiment",
+        string_value: "custom",
+        data_type: "CATEGORICAL",
+        config_id: scoreConfig.id,
+      });
+      await createScoresCh([score]);
+
+      // Get filter options
+      const filterOptions = await caller.traces.filterOptions({
+        projectId,
+      });
+
+      // Find the sentiment score in categorical scores
+      const sentimentScore = filterOptions.score_categories.find(
+        (score) => score.label === "sentiment",
+      );
+
+      expect(sentimentScore).toBeDefined();
+      expect(sentimentScore?.values).toEqual(
+        expect.arrayContaining(["custom", "positive", "neutral", "negative"]),
+      );
+      // Should include all possible values from config, not just the actual score value
+      expect(sentimentScore?.values).toHaveLength(4);
     });
   });
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `getCategoricalScoresGroupedByName` to include all possible categorical values from score configurations, with tests verifying this behavior.
> 
>   - **Behavior**:
>     - `getCategoricalScoresGroupedByName` in `scores.ts` now includes all possible categorical values from `scoreConfig` in the results.
>     - Uses `prisma` to fetch `scoreConfig` for categorical scores and merges with existing values.
>   - **Tests**:
>     - Added test in `traces-trpc.servertest.ts` to verify all possible categorical values are included in filter options.
>     - Test creates a trace and a categorical score config, then checks if filter options include all config values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8dd4c344f817494897a3e9bfa5846b5a2c8e606e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->