### PR TITLE
fix(prompts): custom label creation popover too wide

### DIFF
--- a/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
+++ b/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
@@ -47,7 +47,7 @@ export function SetPromptVersionLabels({
   const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
   const [labels, setLabels] = useState<string[]>([]);
   const [isAddingLabel, setIsAddingLabel] = useState(false);
-  const labelsChanged = JSON.stringify(selectedLabels.sort()) !== JSON.stringify(prompt.labels.sort());
+  const labelsChanged = JSON.stringify([...selectedLabels].sort()) !== JSON.stringify([...prompt.labels].sort());
   const customLabelScrollRef = useRef<HTMLDivElement | null>(null);
 
   const usedLabelsInProject = api.prompts.allLabels.useQuery(

--- a/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
+++ b/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
@@ -47,6 +47,7 @@ export function SetPromptVersionLabels({
   const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
   const [labels, setLabels] = useState<string[]>([]);
   const [isAddingLabel, setIsAddingLabel] = useState(false);
+  const labelsChanged = JSON.stringify(selectedLabels.sort()) !== JSON.stringify(prompt.labels.sort());
   const customLabelScrollRef = useRef<HTMLDivElement | null>(null);
 
   const usedLabelsInProject = api.prompts.allLabels.useQuery(
@@ -225,6 +226,7 @@ export function SetPromptVersionLabels({
                 : "default"
             }
             loading={mutatePromptVersionLabels.isLoading}
+            disabled={!labelsChanged}
             className="w-full"
             onClick={handleSubmitLabels}
           >

--- a/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
+++ b/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
@@ -116,7 +116,7 @@ export function SetPromptVersionLabels({
       <PopoverTrigger asChild data-version-trigger="true">
         <div
           className={cn(
-            "flex min-w-0 max-w-full cursor-pointer flex-wrap gap-1",
+            "flex w-fit min-w-0 max-w-full cursor-pointer flex-wrap gap-1",
             !hasAccess && "cursor-not-allowed",
           )}
         >
@@ -143,7 +143,7 @@ export function SetPromptVersionLabels({
         </div>
       </PopoverTrigger>
       <PopoverContent
-        className="max-h-[50vh] overflow-y-auto"
+        className="max-w-[90vw] sm:max-w-md"
         align="start"
         side="bottom"
         sideOffset={5}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjust popover width and button enabling logic in `SetPromptVersionLabels` component for better UI and functionality.
> 
>   - **UI Adjustments**:
>     - Change `PopoverTrigger` div class to `"flex w-fit min-w-0 max-w-full cursor-pointer flex-wrap gap-1"` to adjust width.
>     - Update `PopoverContent` class to `"max-w-[90vw] sm:max-w-md"` to limit popover width.
>   - **Functionality**:
>     - Add `labelsChanged` state to track changes in selected labels.
>     - Disable submit button if `labelsChanged` is false in `SetPromptVersionLabels`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9d954eda58addb9bd6e9a32464cb38b87602a484. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->