### PR TITLE
chore: only consider getWaitingCount for queue length

### DIFF
--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -37,7 +37,9 @@ export class WorkerManager {
         ? IngestionQueue.getInstance({ shardName: queueName })
         : getQueue(queueName as Exclude<QueueName, QueueName.IngestionQueue>);
       Promise.allSettled([
-        queue?.count().then((count) => {
+        // Here we only consider waiting jobs instead of the default ("waiting" or "delayed"
+        // or "prioritized" or "waiting-children") that count provides
+        queue?.getWaitingCount().then((count) => {
           recordGauge(
             convertQueueNameToMetricName(queueName) + ".length",
             count,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `workerManager.ts` to calculate queue length using only waiting jobs with `getWaitingCount()`.
> 
>   - **Behavior**:
>     - In `workerManager.ts`, modify queue length calculation to use `getWaitingCount()` instead of `count()`.
>     - Only considers waiting jobs, excluding delayed, prioritized, or waiting-children jobs.
>   - **Metrics**:
>     - Updates `recordGauge` to reflect the new queue length calculation based on waiting jobs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 370957d3f874dc9b29a611ee67f16faa1d9da10d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->