### PR TITLE
chore(cloud): remove posthog groups to reduce costs

### DIFF
--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -125,7 +125,7 @@ export default api.withTRPC(MyApp);
 function UserTracking() {
   const session = useSession();
   const sessionUser = session.data?.user;
-  const { organization, project } = useQueryProjectOrOrganization();
+  const { organization } = useQueryProjectOrOrganization();
 
   // Track user identity and properties
   const lastIdentifiedUser = useRef<string | null>(null);
@@ -152,12 +152,6 @@ function UserTracking() {
             ) ?? undefined,
           LANGFUSE_CLOUD_REGION: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
         });
-      const emailDomain = sessionUser.email?.split("@")[1];
-      if (emailDomain)
-        posthog.group("emailDomain", emailDomain, {
-          domain: emailDomain,
-          LANGFUSE_CLOUD_REGION: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
-        });
 
       // Sentry
       setUser({
@@ -177,56 +171,11 @@ function UserTracking() {
       // PostHog
       if (env.NEXT_PUBLIC_POSTHOG_KEY && env.NEXT_PUBLIC_POSTHOG_HOST) {
         posthog.reset();
-        posthog.resetGroups();
       }
       // Sentry
       setUser(null);
     }
   }, [sessionUser, session.status]);
-
-  // Track organization group
-  const lastIdentifiedOrganization = useRef<string | null>(null);
-  useEffect(() => {
-    if (
-      organization?.id &&
-      lastIdentifiedOrganization.current !== JSON.stringify(organization.id)
-    ) {
-      lastIdentifiedOrganization.current = JSON.stringify(organization.id);
-      if (env.NEXT_PUBLIC_POSTHOG_KEY && env.NEXT_PUBLIC_POSTHOG_HOST) {
-        posthog.group("organization", organization.id, {
-          id: organization.id,
-          name: organization.name,
-          plan: organization.plan,
-          countProjects: organization.projects.length,
-          LANGFUSE_CLOUD_REGION: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
-        });
-      }
-    }
-  }, [organization]);
-
-  // Track project group
-  const lastIdentifiedProjectAndOrg = useRef<string | null>(null);
-  useEffect(() => {
-    if (
-      project?.id &&
-      lastIdentifiedProjectAndOrg.current !==
-        JSON.stringify({ project, organization })
-    ) {
-      lastIdentifiedProjectAndOrg.current = JSON.stringify({
-        project,
-        organization,
-      });
-      if (env.NEXT_PUBLIC_POSTHOG_KEY && env.NEXT_PUBLIC_POSTHOG_HOST) {
-        posthog.group("project", project.id, {
-          id: project.id,
-          name: project.name,
-          organizationId: organization?.id,
-          plan: organization?.plan,
-          LANGFUSE_CLOUD_REGION: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
-        });
-      }
-    }
-  }, [project, organization]);
 
   // update chat thread details
   const plan = organization?.plan;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove PostHog group tracking in `UserTracking` to reduce costs.
> 
>   - **Behavior**:
>     - Removes PostHog group tracking for `emailDomain`, `organization`, and `project` in `UserTracking`.
>     - Eliminates `posthog.resetGroups()` call in `UserTracking`.
>   - **Functions**:
>     - Updates `useQueryProjectOrOrganization()` to exclude `project` in `UserTracking`.
>   - **Misc**:
>     - Removes unused variables and hooks related to group tracking in `UserTracking`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for dfc2a58fff53f1870d861672cf41e1b4704a2dbf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->