### PR TITLE
fix(datasets): allow users to update metadata and description while keeping name constant 

### DIFF
--- a/web/src/features/datasets/components/DatasetForm.tsx
+++ b/web/src/features/datasets/components/DatasetForm.tsx
@@ -120,6 +120,7 @@ export const DatasetForm = (props: DatasetFormProps) => {
     allNames: allDatasetNames,
     form,
     errorMessage: "Dataset name already exists.",
+    whitelistedName: props.mode === "update" ? props.datasetName : undefined,
   });
 
   function onSubmit(values: z.infer<typeof formSchema>) {

--- a/web/src/features/datasets/components/DatasetsTable.tsx
+++ b/web/src/features/datasets/components/DatasetsTable.tsx
@@ -110,7 +110,11 @@ export function DatasetsTable(props: { projectId: string }) {
       size: 200,
       cell: ({ row }) => {
         const description: RowData["description"] = row.getValue("description");
-        return <div className="h-full overflow-y-auto flex items-center">{description}</div>;
+        return (
+          <div className="flex h-full items-center overflow-y-auto">
+            {description}
+          </div>
+        );
       },
     },
     {
@@ -189,6 +193,7 @@ export function DatasetsTable(props: { projectId: string }) {
                   datasetId={key.id}
                   datasetName={key.name}
                   datasetDescription={row.getValue("description") ?? undefined}
+                  datasetMetadata={row.getValue("metadata") ?? undefined}
                 />
               </DropdownMenuItem>
               <DropdownMenuItem asChild>

--- a/web/src/hooks/useUniqueNameValidation.tsx
+++ b/web/src/hooks/useUniqueNameValidation.tsx
@@ -6,6 +6,7 @@ interface UseUniqueNameValidationProps {
   allNames: { value: string }[];
   form: UseFormReturn<any>;
   errorMessage: string;
+  whitelistedName?: string;
 }
 
 export const useUniqueNameValidation = ({
@@ -13,6 +14,7 @@ export const useUniqueNameValidation = ({
   allNames,
   form,
   errorMessage,
+  whitelistedName,
 }: UseUniqueNameValidationProps) => {
   useEffect(() => {
     if (!currentName) {
@@ -21,13 +23,14 @@ export const useUniqueNameValidation = ({
     }
 
     const isNewName = !allNames.map((name) => name.value).includes(currentName);
+    const isWhitelistedName = whitelistedName === currentName;
 
-    if (!isNewName) {
+    if (!isNewName && !isWhitelistedName) {
       form.setError("name", {
         message: errorMessage,
       });
     } else {
       form.clearErrors("name");
     }
-  }, [currentName, allNames, form, errorMessage]);
+  }, [currentName, allNames, form, errorMessage, whitelistedName]);
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add whitelisted name validation for dataset updates and include metadata in dataset actions in `DatasetsTable.tsx`.
> 
>   - **Behavior**:
>     - Add `whitelistedName` to `useUniqueNameValidation` in `DatasetForm.tsx` to allow existing dataset names during updates.
>     - Update `DatasetsTable.tsx` to include `metadata` in the dataset actions dropdown.
>   - **Validation**:
>     - Modify `useUniqueNameValidation` to accept `whitelistedName` and skip error if current name matches.
>   - **UI**:
>     - Adjust `DatasetsTable.tsx` description cell layout for better alignment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 44f9eb3999b0f796dd7dbe4cc91462dec279c917. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->