### PR TITLE
fix(otel): skip multiproject check for non-python

### DIFF
--- a/web/src/features/otel/server/OtelIngestionProcessor.ts
+++ b/web/src/features/otel/server/OtelIngestionProcessor.ts
@@ -310,7 +310,11 @@ export class OtelIngestionProcessor {
         scopeSpan.scope?.name.startsWith("langfuse-sdk") ?? false;
       const scopeAttributes = this.extractScopeAttributes(scopeSpan);
 
-      this.validatePublicKey(isLangfuseSDKSpans, scopeAttributes);
+      this.validatePublicKey(
+        isLangfuseSDKSpans,
+        scopeAttributes,
+        resourceAttributes,
+      );
 
       if (isLangfuseSDKSpans) {
         recordIncrement("langfuse.otel.ingestion.langfuse_sdk_batch", 1);
@@ -598,11 +602,15 @@ export class OtelIngestionProcessor {
   private validatePublicKey(
     isLangfuseSDKSpans: boolean,
     scopeAttributes: Record<string, unknown>,
+    resourceAttributes: Record<string, unknown>,
   ): void {
     if (
       isLangfuseSDKSpans &&
       (!this.publicKey ||
-        (scopeAttributes["public_key"] as unknown as string) !== this.publicKey)
+        (scopeAttributes["public_key"] as unknown as string) !==
+          this.publicKey) &&
+      (resourceAttributes["telemetry.sdk.language"] as unknown as string) ===
+        "python" // Only Python has multi project setups. Node OTEL does not allow setting scope.attributes, thus skipping the check for node
     ) {
       throw new ForbiddenError(
         `Langfuse OTEL SDK span has different public key '${scopeAttributes["public_key"]}' than used for authentication '${this.publicKey}'. Discarding span.`,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `validatePublicKey()` in `OtelIngestionProcessor.ts` to skip multi-project check for non-Python languages.
> 
>   - **Behavior**:
>     - Modify `validatePublicKey()` in `OtelIngestionProcessor.ts` to skip multi-project check for non-Python languages.
>     - Specifically checks `resourceAttributes["telemetry.sdk.language"]` for "python" to apply the check.
>   - **Misc**:
>     - Update call to `validatePublicKey()` in `processResourceSpan()` to include `resourceAttributes`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f392759633a710e8e0d57ca527750b3927c5f03b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->