### PR TITLE
fix(evals): show loading state of detail buttons only if preview is enabled

### DIFF
--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -402,20 +402,21 @@ export const InnerEvaluatorForm = (props: {
             onCheckedChange={setShowPreview}
             disabled={props.disabled}
           />
-          {traceWithObservations && showPreview ? (
-            <DetailPageNav
-              currentId={traceWithObservations.id}
-              listKey="traces"
-              path={(entry) =>
-                `/project/${props.projectId}/evals/new?evaluator=${props.evalTemplate.id}&traceId=${entry.id}`
-              }
-            />
-          ) : (
-            <div className="flex flex-row gap-1">
-              <Skeleton className="h-8 w-[54px]" />
-              <Skeleton className="h-8 w-[54px]" />
-            </div>
-          )}
+          {showPreview &&
+            (traceWithObservations ? (
+              <DetailPageNav
+                currentId={traceWithObservations.id}
+                listKey="traces"
+                path={(entry) =>
+                  `/project/${props.projectId}/evals/new?evaluator=${props.evalTemplate.id}&traceId=${entry.id}`
+                }
+              />
+            ) : (
+              <div className="flex flex-row gap-1">
+                <Skeleton className="h-8 w-[54px]" />
+                <Skeleton className="h-8 w-[54px]" />
+              </div>
+            ))}
         </>
       )}
     </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `InnerEvaluatorForm`, detail buttons now show loading state only if `showPreview` is enabled, improving UI consistency.
> 
>   - **Behavior**:
>     - In `InnerEvaluatorForm`, detail buttons now show loading state only if `showPreview` is enabled.
>     - Previously, loading state was shown regardless of `showPreview` setting.
>   - **UI Components**:
>     - Adjusted conditional rendering logic for `DetailPageNav` and `Skeleton` components in `inner-evaluator-form.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f56da956ad90c7c09e85ad80c9048ef735d364ca. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->