### PR TITLE
feat(posthog-export): Add environment attribute to PostHog exports

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1561,7 +1561,7 @@ export const getGenerationsForPostHog = async function* (
       langfuse_model: record.model,
       langfuse_level: record.level,
       langfuse_tags: record.trace_tags,
-      langfuse_environment: record.trace_environment,
+      langfuse_environment: record.environment,
       langfuse_event_version: "1.0.0",
       $session_id: record.posthog_session_id ?? null,
       $set: {

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -687,7 +687,11 @@ const getObservationsTableInternal = async <T>(
   const appliedScoresFilter = scoresFilter.apply();
   const appliedObservationsFilter = observationsFilter.apply();
 
-  const search = clickhouseSearchCondition(opts.searchQuery, opts.searchType, "o");
+  const search = clickhouseSearchCondition(
+    opts.searchQuery,
+    opts.searchType,
+    "o",
+  );
 
   const scoresCte = `WITH scores_agg AS (
     SELECT
@@ -1494,13 +1498,13 @@ export const getGenerationsForPostHog = async function* (
       o.provided_model_name as model,
       o.level as level,
       o.version as version,
+      o.environment as environment,
       t.id as trace_id,
       t.name as trace_name,
       t.session_id as trace_session_id,
       t.user_id as trace_user_id,
       t.release as trace_release,
       t.tags as trace_tags,
-      t.environment as trace_environment,
       t.metadata['$posthog_session_id'] as posthog_session_id
     FROM observations o FINAL
     LEFT JOIN traces t FINAL ON o.trace_id = t.id AND o.project_id = t.project_id

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1500,6 +1500,7 @@ export const getGenerationsForPostHog = async function* (
       t.user_id as trace_user_id,
       t.release as trace_release,
       t.tags as trace_tags,
+      t.environment as trace_environment,
       t.metadata['$posthog_session_id'] as posthog_session_id
     FROM observations o FINAL
     LEFT JOIN traces t FINAL ON o.trace_id = t.id AND o.project_id = t.project_id
@@ -1556,6 +1557,7 @@ export const getGenerationsForPostHog = async function* (
       langfuse_model: record.model,
       langfuse_level: record.level,
       langfuse_tags: record.trace_tags,
+      langfuse_environment: record.trace_environment,
       langfuse_event_version: "1.0.0",
       $session_id: record.posthog_session_id ?? null,
       $set: {

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1341,6 +1341,7 @@ export const getScoresForPostHog = async function* (
       t.user_id as trace_user_id,
       t.release as trace_release,
       t.tags as trace_tags,
+      t.environment as trace_environment,
       t.metadata['$posthog_session_id'] as posthog_session_id
     FROM scores s FINAL
     LEFT JOIN traces t FINAL ON s.trace_id = t.id AND s.project_id = t.project_id
@@ -1388,6 +1389,7 @@ export const getScoresForPostHog = async function* (
       langfuse_user_id: record.trace_user_id || "langfuse_unknown_user",
       langfuse_release: record.trace_release,
       langfuse_tags: record.trace_tags,
+      langfuse_environment: record.trace_environment,
       langfuse_event_version: "1.0.0",
       $session_id: record.posthog_session_id ?? null,
       $set: {

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1336,12 +1336,12 @@ export const getScoresForPostHog = async function* (
       s.name as name,
       s.value as value,
       s.comment as comment,
+      s.environment as environment,
       t.name as trace_name,
       t.session_id as trace_session_id,
       t.user_id as trace_user_id,
       t.release as trace_release,
       t.tags as trace_tags,
-      t.environment as trace_environment,
       t.metadata['$posthog_session_id'] as posthog_session_id
     FROM scores s FINAL
     LEFT JOIN traces t FINAL ON s.trace_id = t.id AND s.project_id = t.project_id

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1389,7 +1389,7 @@ export const getScoresForPostHog = async function* (
       langfuse_user_id: record.trace_user_id || "langfuse_unknown_user",
       langfuse_release: record.trace_release,
       langfuse_tags: record.trace_tags,
-      langfuse_environment: record.trace_environment,
+      langfuse_environment: record.environment,
       langfuse_event_version: "1.0.0",
       $session_id: record.posthog_session_id ?? null,
       $set: {

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -957,6 +957,7 @@ export const getTracesForPostHog = async function* (
       t.release as release,
       t.version as version,
       t.tags as tags,
+      t.environment as environment,
       t.metadata['$posthog_session_id'] as posthog_session_id,
       o.total_cost as total_cost,
       o.latency_milliseconds / 1000 as latency,
@@ -1006,6 +1007,7 @@ export const getTracesForPostHog = async function* (
       langfuse_release: record.release,
       langfuse_version: record.version,
       langfuse_tags: record.tags,
+      langfuse_environment: record.environment,
       langfuse_event_version: "1.0.0",
       $session_id: record.posthog_session_id ?? null,
       $set: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `environment` attribute to PostHog exports in `observations.ts`, `scores.ts`, and `traces.ts`.
> 
>   - **Behavior**:
>     - Add `environment` attribute to PostHog exports in `getGenerationsForPostHog()` in `observations.ts`, `getScoresForPostHog()` in `scores.ts`, and `getTracesForPostHog()` in `traces.ts`.
>   - **Data Export**:
>     - Update SQL queries to include `environment` field in the exported data for PostHog.
>   - **Misc**:
>     - Ensure consistency in data export by including `environment` across different data types (observations, scores, traces).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e90bbcc55af19e1f8a6724e0d4c6e0e3143882f1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->