### PR TITLE
Fix misleading delete message for evaluators

### DIFF
--- a/web/src/components/deleteButton.tsx
+++ b/web/src/components/deleteButton.tsx
@@ -339,6 +339,7 @@ export function DeleteEvalConfigButton(props: DeleteButtonProps) {
         })
       }
       entityToDeleteName="running evaluator"
+      customDeletePrompt="This will delete the evaluator configuration. Associated scores will remain but become orphaned."
       executeDeleteMutation={executeDeleteMutation}
       isDeleteMutationLoading={evaluatorMutation.isLoading}
     />


### PR DESCRIPTION
## Description
Fixes misleading delete message for evaluators that promised to delete "all data associated" but only deleted the evaluator configuration.

## Problem
- UI text claimed deleting evaluator would remove "all the data associated with this running evaluator"
- Backend only deleted the `jobConfiguration` record
- Related scores remained orphaned (configId set to null)
- Users were misled about what actually gets deleted

## Solution
- Added honest `customDeletePrompt` to `DeleteEvalConfigButton`
- New message clearly states that scores will remain but become orphaned
- No breaking changes - this is a UI text fix only

## Testing
- [x] Verified the new message appears in delete confirmation dialog
- [x] Confirmed backend behavior unchanged (scores remain orphaned as before)
- [x] No functional changes to deletion logic

Fixes #7579
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix misleading delete message in `DeleteEvalConfigButton` to clarify only evaluator configuration is deleted, not associated scores.
> 
>   - **UI Update**:
>     - In `DeleteEvalConfigButton`, added `customDeletePrompt` to clarify that only evaluator configuration is deleted, and scores remain orphaned.
>   - **Behavior**:
>     - No changes to backend deletion logic; scores still become orphaned.
>   - **Testing**:
>     - Verified new message in delete confirmation dialog.
>     - Confirmed backend behavior remains unchanged.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6c32485de8f8d1054f16ff0619f3c3ed45e9d72c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->