### PR TITLE
fix(prompts): don't allow placeholders and variable with same name on same prompt version

### DIFF
--- a/web/src/__tests__/prompts.v2.servertest.ts
+++ b/web/src/__tests__/prompts.v2.servertest.ts
@@ -931,7 +931,7 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       expect(response.body).toHaveProperty("error");
       expect(response.body).toHaveProperty("message");
       // @ts-expect-error
-      expect(response.body.message).toContain("used as both variables and placeholders");
+      expect(response.body.message).toContain("variables and placeholders must be unique");
       // @ts-expect-error
       expect(response.body.message).toContain("userName");
     });

--- a/web/src/__tests__/prompts.v2.servertest.ts
+++ b/web/src/__tests__/prompts.v2.servertest.ts
@@ -911,6 +911,65 @@ describe("/api/public/v2/prompts API Endpoint", () => {
         "This is a prompt in a folder structure",
       );
     });
+
+    it("should prevent creating a prompt with both a variable and placeholder with the same name", async () => {
+      const promptName = "prompt-same-name-conflict-" + nanoid();
+
+      // Try to create a prompt where the same name is used as both a variable and a placeholder
+      const response = await makeAPICall("POST", baseURI, {
+        name: promptName,
+        prompt: [
+          { role: "system", content: "Hello {{userName}}" },
+          { type: ChatMessageType.Placeholder, name: "userName" },
+          { role: "user", content: "How are you?" }
+        ],
+        type: "chat",
+      });
+
+      // This should fail with a 400 error
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty("error");
+      expect(response.body).toHaveProperty("message");
+      // @ts-expect-error
+      expect(response.body.message).toContain("used as both variables and placeholders");
+      // @ts-expect-error
+      expect(response.body.message).toContain("userName");
+    });
+
+    it("should allow creating a new version of a prompt with placeholder names that conflict a variable name in a previous version", async () => {
+      const promptName = "prompt-with-variable-conflict-" + nanoid();
+
+      // First, create a chat prompt with a message variable
+      const v1Response = await makeAPICall("POST", baseURI, {
+        name: promptName,
+        prompt: [
+          { role: "system", content: "You are a helpful {{conversationHistory}}" },
+          { role: "user", content: "Continue our conversation" }
+        ],
+        type: "chat",
+        labels: ["production"],
+      });
+
+      expect(v1Response.status).toBe(201);
+
+      // Try to create a new version with a text variable that has the same name as the placeholder
+      const v2Response = await makeAPICall("POST", baseURI, {
+        name: promptName,
+        prompt: [
+          { role: "system", content: "You are a helpful assistant with context: {{newHistory}}" },
+          { type: "placeholder", name: "conversationHistory" },
+          { role: "user", content: "Continue our conversation" }
+        ],
+        type: "chat"
+      });
+
+      // This should succeed, we allow cross-version name reuse
+      expect(v2Response.status).toBe(201);
+      expect(v2Response.body).toHaveProperty("id");
+      expect(v2Response.body).toHaveProperty("version");
+      // @ts-expect-error - Response body type is flexible for testing
+      expect(v2Response.body.version).toBe(2);
+    });
   });
 
   describe("when fetching a prompt list", () => {

--- a/web/src/features/playground/page/components/PromptVariableComponent.tsx
+++ b/web/src/features/playground/page/components/PromptVariableComponent.tsx
@@ -4,13 +4,16 @@ import { type PromptVariable } from "@langfuse/shared";
 import { CodeMirrorEditor } from "@/src/components/editor";
 
 import { usePlaygroundContext } from "../context";
+import { useNamingConflicts } from "../hooks/useNamingConflicts";
 
 export const PromptVariableComponent: React.FC<{
   promptVariable: PromptVariable;
 }> = ({ promptVariable }) => {
-  const { updatePromptVariableValue, deletePromptVariable } =
+  const { updatePromptVariableValue, deletePromptVariable, promptVariables, messagePlaceholders } =
     usePlaygroundContext();
   const { name, value, isUsed } = promptVariable;
+  const { isVariableConflicting } = useNamingConflicts(promptVariables, messagePlaceholders);
+  const hasConflict = isVariableConflicting(name);
 
   const handleInputChange = (value: string) => {
     updatePromptVariableValue(name, value);
@@ -32,7 +35,7 @@ export const PromptVariableComponent: React.FC<{
       <div className="mb-1 flex flex-row items-center">
         <span className="flex flex-1 flex-row space-x-2 text-xs">
           <p title={isUsedTooltip}>{isUsedIcon}</p>
-          <p className="min-w-[90px] truncate font-mono" title={name}>
+          <p className={`min-w-[90px] truncate font-mono ${hasConflict ? 'text-red-500' : ''}`} title={name}>
             {name}
           </p>
         </span>
@@ -53,11 +56,17 @@ export const PromptVariableComponent: React.FC<{
         onChange={(e) => handleInputChange(e)}
         mode="prompt"
         minHeight="none"
-        className="max-h-[10rem] w-full resize-y p-1 font-mono text-xs focus:outline-none"
+        className={`max-h-[10rem] w-full resize-y p-1 font-mono text-xs focus:outline-none ${hasConflict ? 'border border-red-500' : ''}`}
         editable={true}
         lineNumbers={false}
         placeholder={name}
       />
+
+      {hasConflict && (
+        <p className="mt-1 text-xs text-red-500">
+          Variable name conflicts with placeholder. Names must be unique.
+        </p>
+      )}
     </div>
   );
 };

--- a/web/src/features/playground/page/hooks/useNamingConflicts.ts
+++ b/web/src/features/playground/page/hooks/useNamingConflicts.ts
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+import { type PromptVariable } from "@langfuse/shared";
+import { type PlaceholderMessageFillIn } from "../types";
+
+export interface NamingConflictInfo {
+  hasConflicts: boolean;
+  conflictingNames: string[];
+  isVariableConflicting: (variableName: string) => boolean;
+  isPlaceholderConflicting: (placeholderName: string) => boolean;
+}
+
+/**
+ * Detects naming conflicts between variables and placeholders in the playground.
+ * Returns names of conflicting variables and placeholders.
+ */
+export const useNamingConflicts = (
+  variables: PromptVariable[],
+  placeholders: PlaceholderMessageFillIn[]
+): NamingConflictInfo => {
+  return useMemo(() => {
+    const variableNames = variables.map(v => v.name);
+    const placeholderNames = placeholders.map(p => p.name);
+
+    const conflictingNames = variableNames.filter(name =>
+      placeholderNames.includes(name)
+    );
+
+    const hasConflicts = conflictingNames.length > 0;
+
+    const isVariableConflicting = (variableName: string) =>
+      conflictingNames.includes(variableName);
+
+    const isPlaceholderConflicting = (placeholderName: string) =>
+      conflictingNames.includes(placeholderName);
+
+    return {
+      hasConflicts,
+      conflictingNames,
+      isVariableConflicting,
+      isPlaceholderConflicting,
+    };
+  }, [variables, placeholders]);
+};

--- a/web/src/features/prompts/server/actions/createPrompt.ts
+++ b/web/src/features/prompts/server/actions/createPrompt.ts
@@ -79,7 +79,7 @@ export const createPrompt = async ({
     const conflictingNames = variables.filter(v => placeholders.includes(v));
     if (conflictingNames.length > 0) {
       throw new InvalidRequestError(
-        `Cannot create prompt: variables and placeholders must be unique, the following are not: ${conflictingNames.join(", ")}`
+        `Cannot create prompt, variables and placeholders must be unique, the following are not: ${conflictingNames.join(", ")}`
       );
     }
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Prevents naming conflicts between variables and placeholders in prompts and updates UI to indicate conflicts.
> 
>   - **Behavior**:
>     - Prevents creation of prompts with variables and placeholders having the same name in `createPrompt` in `createPrompt.ts`.
>     - Allows cross-version name reuse for variables and placeholders in `prompts.v2.servertest.ts`.
>   - **UI Components**:
>     - Adds conflict detection and visual indication in `MessagePlaceholderComponent.tsx` and `PromptVariableComponent.tsx`.
>     - Displays error messages for naming conflicts in the UI.
>   - **Hooks**:
>     - Introduces `useNamingConflicts` hook to detect naming conflicts between variables and placeholders.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e5d5de6a614ca9bb40b30a456322c707a7e72ec5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->