### PR TITLE
feat(prompts): Add search bar to prompts table

### DIFF
--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -12,7 +12,13 @@ import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
 import { useOrderByState } from "@/src/features/orderBy/hooks/useOrderByState";
 import { promptsTableColsWithOptions } from "@/src/server/api/definitions/promptsTable";
-import { NumberParam, StringParam, useQueryParams, withDefault, useQueryParam } from "use-query-params";
+import {
+  NumberParam,
+  StringParam,
+  useQueryParams,
+  withDefault,
+  useQueryParam,
+} from "use-query-params";
 import { createColumnHelper } from "@tanstack/react-table";
 import { joinTableCoreAndMetrics } from "@/src/components/table/utils/joinTableCoreAndMetrics";
 import { Skeleton } from "@/src/components/ui/skeleton";
@@ -40,7 +46,11 @@ type PromptTableRow = {
 };
 
 function createRow(
-  data: Partial<PromptTableRow> & { id: string; name: string; type: "folder" | "text" | "chat" }
+  data: Partial<PromptTableRow> & {
+    id: string;
+    name: string;
+    type: "folder" | "text" | "chat";
+  },
 ): PromptTableRow {
   return {
     version: undefined,
@@ -52,12 +62,14 @@ function createRow(
   };
 }
 
-function isFolder(row: PromptTableRow): row is PromptTableRow & { type: "folder" } {
+function isFolder(
+  row: PromptTableRow,
+): row is PromptTableRow & { type: "folder" } {
   return row.type === "folder";
 }
 
 function getDisplayName(fullPath: string, currentFolderPath: string): string {
-  return currentFolderPath === ''
+  return currentFolderPath === ""
     ? fullPath
     : fullPath.substring(currentFolderPath.length + 1);
 }
@@ -65,9 +77,9 @@ function getDisplayName(fullPath: string, currentFolderPath: string): string {
 function createBreadcrumbItems(currentFolderPath: string) {
   if (!currentFolderPath) return [];
 
-  const segments = currentFolderPath.split('/');
+  const segments = currentFolderPath.split("/");
   return segments.map((name, i) => {
-    const folderPath = segments.slice(0, i + 1).join('/');
+    const folderPath = segments.slice(0, i + 1).join("/");
     return {
       name,
       folderPath,
@@ -116,7 +128,7 @@ export function PromptTable() {
     pageSize: queryParams.pageSize,
   };
 
-  const currentFolderPath = queryParams.folder || '';
+  const currentFolderPath = queryParams.folder || "";
 
   const prompts = api.prompts.all.useQuery(
     {
@@ -184,7 +196,7 @@ export function PromptTable() {
         const prefix = `${currentFolderPath}/`;
         if (promptName.startsWith(prefix)) {
           const remainingPath = promptName.substring(prefix.length);
-          const slashIndex = remainingPath.indexOf('/');
+          const slashIndex = remainingPath.indexOf("/");
 
           if (slashIndex > 0) {
             // Subfolder
@@ -198,7 +210,7 @@ export function PromptTable() {
         }
       } else {
         // Root level
-        const slashIndex = promptName.indexOf('/');
+        const slashIndex = promptName.indexOf("/");
         if (slashIndex > 0) {
           const folderName = promptName.substring(0, slashIndex);
           uniqueFolders.add(folderName);
@@ -214,11 +226,13 @@ export function PromptTable() {
     // Add folder rows
     for (const folderPath of uniqueFolders) {
       const folderName = getDisplayName(folderPath, currentFolderPath);
-      combinedRows.push(createRow({
-        id: folderPath,
-        name: folderName,
-        type: "folder",
-      }));
+      combinedRows.push(
+        createRow({
+          id: folderPath,
+          name: folderName,
+          type: "folder",
+        }),
+      );
     }
 
     // Add matching prompts
@@ -233,7 +247,7 @@ export function PromptTable() {
           labels: prompt.labels,
           tags: prompt.tags,
           numberOfObservations: Number(prompt.observationCount ?? 0),
-        })
+        }),
       );
     }
 
@@ -301,7 +315,7 @@ export function PromptTable() {
                 setQueryParams({
                   folder: rowData.id,
                   pageIndex: 0,
-                  pageSize: queryParams.pageSize
+                  pageSize: queryParams.pageSize,
                 });
               }}
               title={displayName || ""}
@@ -414,7 +428,7 @@ export function PromptTable() {
   return (
     <>
       {currentFolderPath && (
-        <div className="pt-2 ml-2">
+        <div className="ml-2 pt-2">
           <Breadcrumb>
             <BreadcrumbList>
               <BreadcrumbItem>
@@ -424,38 +438,40 @@ export function PromptTable() {
                     setQueryParams({
                       folder: undefined,
                       pageIndex: 0,
-                      pageSize: queryParams.pageSize
+                      pageSize: queryParams.pageSize,
                     });
                   }}
                 >
                   <Home className="h-4 w-4" />
                 </BreadcrumbLink>
               </BreadcrumbItem>
-              {createBreadcrumbItems(currentFolderPath).flatMap((item, index, array) => [
-                index > 0 && (
-                  <BreadcrumbSeparator key={`sep-${item.folderPath}`}>
-                    <Slash />
-                  </BreadcrumbSeparator>
-                ),
-                <BreadcrumbItem key={item.folderPath}>
-                  {index === array.length - 1 ? (
-                    <BreadcrumbPage>{item.name}</BreadcrumbPage>
-                  ) : (
-                    <BreadcrumbLink
-                      className="cursor-pointer hover:underline"
-                      onClick={() => {
-                        setQueryParams({
-                          folder: item.folderPath,
-                          pageIndex: 0,
-                          pageSize: queryParams.pageSize
-                        });
-                      }}
-                    >
-                      {item.name}
-                    </BreadcrumbLink>
-                  )}
-                </BreadcrumbItem>
-              ])}
+              {createBreadcrumbItems(currentFolderPath).flatMap(
+                (item, index, array) => [
+                  index > 0 && (
+                    <BreadcrumbSeparator key={`sep-${item.folderPath}`}>
+                      <Slash />
+                    </BreadcrumbSeparator>
+                  ),
+                  <BreadcrumbItem key={item.folderPath}>
+                    {index === array.length - 1 ? (
+                      <BreadcrumbPage>{item.name}</BreadcrumbPage>
+                    ) : (
+                      <BreadcrumbLink
+                        className="cursor-pointer hover:underline"
+                        onClick={() => {
+                          setQueryParams({
+                            folder: item.folderPath,
+                            pageIndex: 0,
+                            pageSize: queryParams.pageSize,
+                          });
+                        }}
+                      >
+                        {item.name}
+                      </BreadcrumbLink>
+                    )}
+                  </BreadcrumbItem>,
+                ],
+              )}
             </BreadcrumbList>
           </Breadcrumb>
         </div>
@@ -493,11 +509,12 @@ export function PromptTable() {
                   isError: false,
                   data: processedRowData.rows?.map((item) => ({
                     id: item.id,
-                    name: item.type === 'folder'
-                      ? item.name
-                      : currentFolderPath
-                        ? item.name.substring(currentFolderPath.length + 1)
-                        : item.name,
+                    name:
+                      item.type === "folder"
+                        ? item.name
+                        : currentFolderPath
+                          ? item.name.substring(currentFolderPath.length + 1)
+                          : item.name,
                     version: item.version,
                     createdAt: item.createdAt,
                     type: item.type,

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -114,14 +114,13 @@ export function PromptTable() {
 
   // Reset pagination when search query changes
   useEffect(() => {
-    if (searchQuery) {
-      setQueryParams({
-        pageIndex: 0,
-        pageSize: queryParams.pageSize,
-        folder: queryParams.folder,
-      });
-    }
-  }, [searchQuery, setQueryParams, queryParams.pageSize, queryParams.folder]);
+    setQueryParams({
+      pageIndex: 0,
+      pageSize: queryParams.pageSize,
+      folder: queryParams.folder,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchQuery]);
 
   const paginationState = {
     pageIndex: queryParams.pageIndex,

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -40,6 +40,7 @@ const PromptFilterOptions = z.object({
   orderBy: orderBy,
   ...paginationZod,
   pathPrefix: z.string().optional(),
+  searchQuery: z.string().optional(),
 });
 
 export const promptRouter = createTRPCRouter({
@@ -90,6 +91,10 @@ export const promptRouter = createTRPCRouter({
         ? Prisma.sql` AND (p.name LIKE ${input.pathPrefix + "/%"} OR p.name = ${input.pathPrefix})`
         : Prisma.empty;
 
+      const searchFilter = input.searchQuery
+        ? Prisma.sql` AND p.name ILIKE ${`%${input.searchQuery}%`}`
+        : Prisma.empty;
+
       const [prompts, promptCount] = await Promise.all([
         // prompts
         ctx.prisma.$queryRaw<Array<Prompt>>(
@@ -111,20 +116,22 @@ export const promptRouter = createTRPCRouter({
             input.limit,
             input.page,
             pathFilter,
+            searchFilter,
           ),
         ),
-        // promptCount
-        ctx.prisma.$queryRaw<Array<{ totalCount: bigint }>>(
-          generatePromptQuery(
-            Prisma.sql` count(*) AS "totalCount"`,
-            input.projectId,
-            filterCondition,
-            Prisma.empty,
-            1, // limit
-            0, // page,
-            pathFilter,
+                  // promptCount
+          ctx.prisma.$queryRaw<Array<{ totalCount: bigint }>>(
+            generatePromptQuery(
+              Prisma.sql` count(*) AS "totalCount"`,
+              input.projectId,
+              filterCondition,
+              Prisma.empty,
+              1, // limit
+              0, // page,
+              pathFilter,
+              searchFilter,
+            ),
           ),
-        ),
       ]);
 
       return {
@@ -1233,6 +1240,7 @@ const generatePromptQuery = (
   limit: number,
   page: number,
   pathFilter: Prisma.Sql = Prisma.empty,
+  searchFilter: Prisma.Sql = Prisma.empty,
 ) => {
   return Prisma.sql`
   SELECT
@@ -1244,11 +1252,13 @@ const generatePromptQuery = (
      WHERE "project_id" = ${projectId}
      ${filterCondition}
      ${pathFilter}
+     ${searchFilter}
           GROUP BY name
         )
     AND "project_id" = ${projectId}
   ${filterCondition}
   ${pathFilter}
+  ${searchFilter}
   ${orderCondition}
   LIMIT ${limit} OFFSET ${page * limit};
 `;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a search bar to the prompts table, enabling filtering by prompt name with backend support for case-insensitive search.
> 
>   - **Frontend**:
>     - Adds `searchQuery` state and `setSearchQuery` function in `prompts-table.tsx` to manage search input.
>     - Resets pagination when `searchQuery` changes using `useEffect`.
>     - Updates `DataTableToolbar` with `searchConfig` to handle search input.
>     - Modifies `api.prompts.all.useQuery` to include `searchQuery` parameter.
>   - **Backend**:
>     - Updates `PromptFilterOptions` in `promptRouter.ts` to include `searchQuery`.
>     - Modifies `all` query in `promptRouter.ts` to filter prompts by `searchQuery` using `ILIKE` for case-insensitive search.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 594a042aac224217b52080e3d261d1a0ac003c30. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->