### PR TITLE
chore: retry socket hang ups for CH queries

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -105,6 +105,7 @@ const EnvSchema = z.object({
     .number()
     .default(80e6), // 80MB
   LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS: z.coerce.number().default(240_000), // 4 minutes
+  LANGFUSE_CLICKHOUSE_QUERY_MAX_ATTEMPTS: z.coerce.number().default(3), // Maximum attempts for socket hang up errors
   LANGFUSE_SKIP_S3_LIST_FOR_OBSERVATIONS_PROJECT_IDS: z.string().optional(),
 });
 

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -9,6 +9,7 @@ import { randomUUID } from "crypto";
 import { getClickhouseEntityType } from "../clickhouse/schemaUtils";
 import { NodeClickHouseClientConfigOptions } from "@clickhouse/client/dist/config";
 import { context, SpanKind, trace } from "@opentelemetry/api";
+import { backOff } from "exponential-backoff";
 import {
   StorageService,
   StorageServiceFactory,
@@ -203,6 +204,18 @@ export async function* queryClickhouseStream<T>(opts: {
   }
 }
 
+/**
+ * Determines if an error is retryable (socket hang up, connection reset, etc.)
+ */
+function isRetryableError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  const errorMessage = (error as Error).message?.toLowerCase() || "";
+
+  // Check for socket hang up and other network-related errors
+  return errorMessage.includes("socket hang up");
+}
+
 export async function queryClickhouse<T>(opts: {
   query: string;
   params?: Record<string, unknown> | undefined;
@@ -218,40 +231,75 @@ export async function queryClickhouse<T>(opts: {
       span.setAttribute("db.query.text", opts.query);
       span.setAttribute("db.operation.name", "SELECT");
 
-      const res = await clickhouseClient(opts.clickhouseConfigs).query({
-        query: opts.query,
-        format: "JSONEachRow",
-        query_params: opts.params,
-        clickhouse_settings: {
-          log_comment: JSON.stringify(opts.tags ?? {}),
-        },
-      });
-      // same logic as for prisma. we want to see queries in development
-      if (env.NODE_ENV === "development") {
-        logger.info(`clickhouse:query ${res.query_id} ${opts.query}`);
-      }
+      // Retry logic for socket hang up and other network errors
+      return await backOff(
+        async () => {
+          const res = await clickhouseClient(opts.clickhouseConfigs).query({
+            query: opts.query,
+            format: "JSONEachRow",
+            query_params: opts.params,
+            clickhouse_settings: {
+              log_comment: JSON.stringify(opts.tags ?? {}),
+            },
+          });
 
-      span.setAttribute("ch.queryId", res.query_id);
-
-      // add summary headers to the span. Helps to tune performance
-      const summaryHeader = res.response_headers["x-clickhouse-summary"];
-      if (summaryHeader) {
-        try {
-          const summary = Array.isArray(summaryHeader)
-            ? JSON.parse(summaryHeader[0])
-            : JSON.parse(summaryHeader);
-          for (const key in summary) {
-            span.setAttribute(`ch.${key}`, summary[key]);
+          // same logic as for prisma. we want to see queries in development
+          if (env.NODE_ENV === "development") {
+            logger.info(`clickhouse:query ${res.query_id} ${opts.query}`);
           }
-        } catch (error) {
-          logger.debug(
-            `Failed to parse clickhouse summary header ${summaryHeader}`,
-            error,
-          );
-        }
-      }
 
-      return await res.json<T>();
+          span.setAttribute("ch.queryId", res.query_id);
+
+          // add summary headers to the span. Helps to tune performance
+          const summaryHeader = res.response_headers["x-clickhouse-summary"];
+          if (summaryHeader) {
+            try {
+              const summary = Array.isArray(summaryHeader)
+                ? JSON.parse(summaryHeader[0])
+                : JSON.parse(summaryHeader);
+              for (const key in summary) {
+                span.setAttribute(`ch.${key}`, summary[key]);
+              }
+            } catch (error) {
+              logger.debug(
+                `Failed to parse clickhouse summary header ${summaryHeader}`,
+                error,
+              );
+            }
+          }
+
+          return await res.json<T>();
+        },
+        {
+          numOfAttempts: env.LANGFUSE_CLICKHOUSE_QUERY_MAX_ATTEMPTS,
+          retry: (error: Error, attemptNumber: number) => {
+            const shouldRetry = isRetryableError(error);
+            if (shouldRetry) {
+              logger.warn(
+                `ClickHouse query failed with retryable error (attempt ${attemptNumber}/${env.LANGFUSE_CLICKHOUSE_QUERY_MAX_ATTEMPTS}): ${error.message}`,
+                {
+                  error: error.message,
+                  attemptNumber,
+                  tags: opts.tags,
+                },
+              );
+              span.addEvent("clickhouse-query-retry", {
+                "retry.attempt": attemptNumber,
+                "retry.error": error.message,
+              });
+            } else {
+              logger.error(
+                `ClickHouse query failed with non-retryable error: ${error.message}`,
+                {
+                  error: error.message,
+                  tags: opts.tags,
+                },
+              );
+            }
+            return shouldRetry;
+          },
+        },
+      );
     },
   );
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds retry logic for ClickHouse queries to handle socket hang-up errors with configurable retry attempts.
> 
>   - **Behavior**:
>     - Adds retry logic for ClickHouse queries in `queryClickhouse()` in `clickhouse.ts` using exponential backoff for socket hang-up errors.
>     - Introduces `isRetryableError()` to identify retryable errors.
>     - Logs retry attempts and errors with `logger` and `span.addEvent()`.
>   - **Environment**:
>     - Adds `LANGFUSE_CLICKHOUSE_QUERY_MAX_ATTEMPTS` to `env.ts` with a default of 3 for maximum retry attempts.
>   - **Imports**:
>     - Imports `backOff` from `exponential-backoff` in `clickhouse.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ff765eadaa6caf2018228b69759ced35a1c0c501. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->