### PR TITLE
chore: ignore all pending linting errors and enforce zero warnings

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 72",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "db:migrate": "DISABLE_ERD=false dotenv -e ../../.env -- npx prisma migrate dev",
     "db:push": "DISABLE_ERD=false dotenv -e ../../.env -- npx prisma db push",

--- a/packages/shared/scripts/seeder/seed-postgres.ts
+++ b/packages/shared/scripts/seeder/seed-postgres.ts
@@ -178,7 +178,7 @@ async function main() {
 
   const seedApiKey = {
     id: "seed-api-key",
-    secret: process.env.SEED_SECRET_KEY ?? "sk-lf-1234567890",
+    secret: process.env.SEED_SECRET_KEY ?? "sk-lf-1234567890", // eslint-disable-line turbo/no-undeclared-env-vars
     public: "pk-lf-1234567890",
     note: "seeded key",
   };
@@ -241,7 +241,7 @@ async function main() {
 
     const secondKey = {
       id: "seed-api-key-2",
-      secret: process.env.SEED_SECRET_KEY ?? "sk-lf-asdfghjkl",
+      secret: process.env.SEED_SECRET_KEY ?? "sk-lf-asdfghjkl", // eslint-disable-line turbo/no-undeclared-env-vars
       public: "pk-lf-asdfghjkl",
       note: "seeded key 2",
     };
@@ -274,7 +274,7 @@ async function main() {
     await createTraceSessions(project1, project2);
 
     // If openai key is in environment, add it to the projects LLM API keys
-    const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+    const OPENAI_API_KEY = process.env.OPENAI_API_KEY; // eslint-disable-line turbo/no-undeclared-env-vars
 
     if (OPENAI_API_KEY) {
       await prisma.llmApiKeys.create({

--- a/packages/shared/src/db.ts
+++ b/packages/shared/src/db.ts
@@ -88,7 +88,7 @@ declare const globalThis: {
   kyselyPrismaGlobal: { $kysely: Kysely<DB> } | undefined;
 } & typeof global;
 
-if (process.env.NODE_ENV === "development") {
+if (process.env.NODE_ENV === "development") { // eslint-disable-line turbo/no-undeclared-env-vars
   globalThis.prismaGlobal ??= createPrismaInstance(); // regular instantiation
   globalThis.kyselyPrismaGlobal ??= globalThis.prismaGlobal.$extends(
     kyselyExtension({

--- a/packages/shared/src/domain/table-view-presets.ts
+++ b/packages/shared/src/domain/table-view-presets.ts
@@ -3,11 +3,11 @@ import { orderBy } from "../interfaces/orderBy";
 import z from "zod/v4";
 
 export enum TableViewPresetTableName {
-  Traces = "traces",
-  Observations = "observations",
-  Scores = "scores",
-  Sessions = "sessions",
-  Datasets = "datasets",
+  Traces = "traces", // eslint-disable-line no-unused-vars
+  Observations = "observations", // eslint-disable-line no-unused-vars
+  Scores = "scores", // eslint-disable-line no-unused-vars
+  Sessions = "sessions", // eslint-disable-line no-unused-vars
+  Datasets = "datasets", // eslint-disable-line no-unused-vars
 }
 
 const TableViewPresetDomainSchema = z.object({

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -109,6 +109,6 @@ const EnvSchema = z.object({
 });
 
 export const env: z.infer<typeof EnvSchema> =
-  process.env.DOCKER_BUILD === "1"
+  process.env.DOCKER_BUILD === "1" // eslint-disable-line turbo/no-undeclared-env-vars
     ? (process.env as any)
     : EnvSchema.parse(removeEmptyEnvVariables(process.env));

--- a/packages/shared/src/features/batchExport/types.ts
+++ b/packages/shared/src/features/batchExport/types.ts
@@ -8,16 +8,16 @@ import { BatchTableNames } from "../../interfaces/tableNames";
 import { TracingSearchType } from "../../interfaces/search";
 
 export enum BatchExportStatus {
-  QUEUED = "QUEUED",
-  PROCESSING = "PROCESSING",
-  COMPLETED = "COMPLETED",
-  FAILED = "FAILED",
+  QUEUED = "QUEUED", // eslint-disable-line no-unused-vars
+  PROCESSING = "PROCESSING", // eslint-disable-line no-unused-vars
+  COMPLETED = "COMPLETED", // eslint-disable-line no-unused-vars
+  FAILED = "FAILED", // eslint-disable-line no-unused-vars
 }
 
 export enum BatchExportFileFormat {
-  JSON = "JSON",
-  CSV = "CSV",
-  JSONL = "JSONL",
+  JSON = "JSON", // eslint-disable-line no-unused-vars
+  CSV = "CSV", // eslint-disable-line no-unused-vars
+  JSONL = "JSONL", // eslint-disable-line no-unused-vars
 }
 
 // Use shared BatchTableNames enum for consistency across batch operations

--- a/packages/shared/src/features/evals/utilities.ts
+++ b/packages/shared/src/features/evals/utilities.ts
@@ -42,7 +42,7 @@ function parseJsonDefault(selectedColumn: unknown, jsonSelector: string) {
 export function extractValueFromObject(
   obj: Record<string, unknown>,
   mapping: z.infer<typeof variableMapping>,
-  parseJson?: (selectedColumn: unknown, jsonSelector: string) => unknown,
+  parseJson?: (selectedColumn: unknown, jsonSelector: string) => unknown, // eslint-disable-line no-unused-vars
 ): { value: string; error: Error | null } {
   const selectedColumn = obj[mapping.selectedColumnId];
   const jsonParser = parseJson || parseJsonDefault;

--- a/packages/shared/src/features/scores/scoreConfigTypes.ts
+++ b/packages/shared/src/features/scores/scoreConfigTypes.ts
@@ -150,7 +150,7 @@ const ValidatedScoreConfigSchema = z
  */
 export const filterAndValidateDbScoreConfigList = (
   scoreConfigs: ScoreConfigDbType[],
-  onParseError?: (error: z.ZodError) => void,
+  onParseError?: (error: z.ZodError) => void, // eslint-disable-line no-unused-vars
 ): ValidatedScoreConfig[] =>
   scoreConfigs.reduce((acc, ts) => {
     const result = ValidatedScoreConfigSchema.safeParse(ts);

--- a/packages/shared/src/interfaces/tableNames.ts
+++ b/packages/shared/src/interfaces/tableNames.ts
@@ -4,11 +4,11 @@
  * to avoid coupling between different batch operation types.
  */
 export enum BatchTableNames {
-  Scores = "scores",
-  Sessions = "sessions",
-  Traces = "traces",
-  Observations = "observations",
-  DatasetRunItems = "dataset_run_items",
-  DatasetItems = "dataset_items",
-  AuditLogs = "audit_logs",
+  Scores = "scores", // eslint-disable-line no-unused-vars
+  Sessions = "sessions", // eslint-disable-line no-unused-vars
+  Traces = "traces", // eslint-disable-line no-unused-vars
+  Observations = "observations", // eslint-disable-line no-unused-vars
+  DatasetRunItems = "dataset_run_items", // eslint-disable-line no-unused-vars
+  DatasetItems = "dataset_items", // eslint-disable-line no-unused-vars
+  AuditLogs = "audit_logs", // eslint-disable-line no-unused-vars
 }

--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -45,7 +45,7 @@ const getS3StorageServiceClient = (bucketName: string): StorageService => {
   return s3StorageServiceClient;
 };
 
-export type TokenCountDelegate = (p: {
+export type TokenCountDelegate = (p: { // eslint-disable-line no-unused-vars
   model: Model;
   text: unknown;
 }) => number | undefined;

--- a/packages/shared/src/server/instrumentation/index.ts
+++ b/packages/shared/src/server/instrumentation/index.ts
@@ -22,7 +22,7 @@ export type SpanCtx = {
   traceContext?: TCarrier;
 };
 
-type AsyncCallbackFn<T> = (span: opentelemetry.Span) => Promise<T>;
+type AsyncCallbackFn<T> = (span: opentelemetry.Span) => Promise<T>; // eslint-disable-line no-unused-vars
 
 export async function instrumentAsync<T>(
   ctx: SpanCtx,
@@ -64,7 +64,7 @@ export async function instrumentAsync<T>(
   );
 }
 
-type SyncCallbackFn<T> = (span: opentelemetry.Span) => T;
+type SyncCallbackFn<T> = (span: opentelemetry.Span) => T; // eslint-disable-line no-unused-vars
 
 export function instrumentSync<T>(
   ctx: SpanCtx,

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -63,7 +63,7 @@ type FetchLLMCompletionParams = LLMCompletionParams & {
 };
 
 export async function fetchLLMCompletion(
-  params: LLMCompletionParams & {
+  params: LLMCompletionParams & { // eslint-disable-line no-unused-vars
     streaming: true;
   },
 ): Promise<{
@@ -72,7 +72,7 @@ export async function fetchLLMCompletion(
 }>;
 
 export async function fetchLLMCompletion(
-  params: LLMCompletionParams & {
+  params: LLMCompletionParams & { // eslint-disable-line no-unused-vars
     streaming: false;
   },
 ): Promise<{
@@ -81,7 +81,7 @@ export async function fetchLLMCompletion(
 }>;
 
 export async function fetchLLMCompletion(
-  params: LLMCompletionParams & {
+  params: LLMCompletionParams & { // eslint-disable-line no-unused-vars
     streaming: false;
     structuredOutputSchema: ZodSchema;
   },
@@ -91,7 +91,7 @@ export async function fetchLLMCompletion(
 }>;
 
 export async function fetchLLMCompletion(
-  params: LLMCompletionParams & {
+  params: LLMCompletionParams & { // eslint-disable-line no-unused-vars
     tools: LLMToolDefinition[];
     streaming: false;
   },

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -432,19 +432,19 @@ export class FilterList {
     this.filters.push(...filter);
   }
 
-  find(predicate: (filter: Filter) => boolean) {
+  find(predicate: (filter: Filter) => boolean) { // eslint-disable-line no-unused-vars
     return this.filters.find(predicate);
   }
 
-  filter(predicate: (filter: Filter) => boolean) {
+  filter(predicate: (filter: Filter) => boolean) { // eslint-disable-line no-unused-vars
     return new FilterList(this.filters.filter(predicate));
   }
 
-  some(predicate: (filter: Filter) => boolean) {
+  some(predicate: (filter: Filter) => boolean) { // eslint-disable-line no-unused-vars
     return this.filters.some(predicate);
   }
 
-  forEach(callback: (filter: Filter) => void) {
+  forEach(callback: (filter: Filter) => void) { // eslint-disable-line no-unused-vars
     this.filters.forEach(callback);
   }
 

--- a/packages/shared/src/server/redis/getQueue.ts
+++ b/packages/shared/src/server/redis/getQueue.ts
@@ -70,8 +70,9 @@ export function getQueue(
       return ScoreDeleteQueue.getInstance();
     case QueueName.DeadLetterRetryQueue:
       return DeadLetterRetryQueue.getInstance();
-    default:
-      const exhaustiveCheckDefault: never = queueName;
+    default: {
+      const exhaustiveCheckDefault: never = queueName; // eslint-disable-line no-case-declarations, no-unused-vars
       throw new Error(`Queue ${queueName} not found`);
+    }
   }
 }

--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -167,9 +167,9 @@ const createRedisClient = () => {
 
 declare global {
   // eslint-disable-next-line no-var
-  var redis: undefined | ReturnType<typeof createRedisClient>;
+  var redis: undefined | ReturnType<typeof createRedisClient>; // eslint-disable-line no-unused-vars
 }
 
-export const redis = globalThis.redis ?? createRedisClient();
+export const redis = globalThis.redis ?? createRedisClient(); // eslint-disable-line no-undef
 
-if (env.NODE_ENV !== "production") globalThis.redis = redis;
+if (env.NODE_ENV !== "production") globalThis.redis = redis; // eslint-disable-line no-undef

--- a/packages/shared/src/server/services/InMemoryFilterService.ts
+++ b/packages/shared/src/server/services/InMemoryFilterService.ts
@@ -13,7 +13,7 @@ export class InMemoryFilterService {
   static evaluateFilter<T>(
     data: T,
     filter: FilterState,
-    fieldMapper: (data: T, column: string) => unknown,
+    fieldMapper: (data: T, column: string) => unknown, // eslint-disable-line no-unused-vars
   ): boolean {
     try {
       // If no filters, data matches
@@ -45,7 +45,7 @@ export class InMemoryFilterService {
   private static evaluateFilterCondition<T>(
     data: T,
     condition: FilterCondition,
-    fieldMapper: (data: T, column: string) => unknown,
+    fieldMapper: (data: T, column: string) => unknown, // eslint-disable-line no-unused-vars
   ): boolean {
     const { column, type, operator } = condition;
 

--- a/packages/shared/src/server/services/PromptService/types.ts
+++ b/packages/shared/src/server/services/PromptService/types.ts
@@ -13,8 +13,8 @@ export type PromptParams = {
 );
 
 export enum PromptServiceMetrics {
-  PromptCacheHit = "prompt_cache_hit",
-  PromptCacheMiss = "prompt_cache_miss",
+  PromptCacheHit = "prompt_cache_hit", // eslint-disable-line no-unused-vars
+  PromptCacheMiss = "prompt_cache_miss", // eslint-disable-line no-unused-vars
 }
 
 export type PartialPrompt = Pick<

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -28,21 +28,21 @@ type UploadFile = {
 };
 
 export interface StorageService {
-  uploadFile(params: UploadFile): Promise<{ signedUrl: string }>;
+  uploadFile(params: UploadFile): Promise<{ signedUrl: string }>; // eslint-disable-line no-unused-vars
 
-  uploadJson(path: string, body: Record<string, unknown>[]): Promise<void>;
+  uploadJson(path: string, body: Record<string, unknown>[]): Promise<void>; // eslint-disable-line no-unused-vars
 
-  download(path: string): Promise<string>;
+  download(path: string): Promise<string>; // eslint-disable-line no-unused-vars
 
-  listFiles(prefix: string): Promise<{ file: string; createdAt: Date }[]>;
+  listFiles(prefix: string): Promise<{ file: string; createdAt: Date }[]>; // eslint-disable-line no-unused-vars
 
   getSignedUrl(
-    fileName: string,
-    ttlSeconds: number,
-    asAttachment?: boolean,
+    fileName: string, // eslint-disable-line no-unused-vars
+    ttlSeconds: number, // eslint-disable-line no-unused-vars
+    asAttachment?: boolean, // eslint-disable-line no-unused-vars
   ): Promise<string>;
 
-  getSignedUploadUrl(params: {
+  getSignedUploadUrl(params: { // eslint-disable-line no-unused-vars
     path: string;
     ttlSeconds: number;
     sha256Hash: string;
@@ -50,7 +50,7 @@ export interface StorageService {
     contentLength: number;
   }): Promise<string>;
 
-  deleteFiles(paths: string[]): Promise<void>;
+  deleteFiles(paths: string[]): Promise<void>; // eslint-disable-line no-unused-vars
 }
 
 export class StorageServiceFactory {
@@ -213,7 +213,7 @@ class AzureBlobStorageService implements StorageService {
   }
 
   private async streamToString(
-    readableStream: NodeJS.ReadableStream,
+    readableStream: NodeJS.ReadableStream, // eslint-disable-line no-undef
   ): Promise<string> {
     return new Promise((resolve, reject) => {
       const chunks: string[] = [];

--- a/packages/shared/src/server/utils/DatabaseReadStream.ts
+++ b/packages/shared/src/server/utils/DatabaseReadStream.ts
@@ -24,12 +24,12 @@ export class DatabaseReadStream<EntityType> extends Readable {
 
   constructor(
     // the delegate function takes care of querying the database in a paginated manner
-    private queryDelegate: (
-      pageSize: number,
-      offset: number
+    private queryDelegate: ( // eslint-disable-line no-unused-vars
+      pageSize: number, // eslint-disable-line no-unused-vars
+      offset: number // eslint-disable-line no-unused-vars
     ) => Promise<Array<EntityType>>,
-    private pageSize: number,
-    private maxRecords?: number
+    private pageSize: number, // eslint-disable-line no-unused-vars
+    private maxRecords?: number // eslint-disable-line no-unused-vars
   ) {
     super({ objectMode: true }); // Set object mode to true to allow pushing objects to the stream rather than strings or buffers
 

--- a/packages/shared/src/server/utils/transforms/transformStreamToCsv.ts
+++ b/packages/shared/src/server/utils/transforms/transformStreamToCsv.ts
@@ -11,7 +11,7 @@ export function transformStreamToCsv(): Transform {
     objectMode: true,
     transform(
       row: Record<string, any>,
-      encoding: BufferEncoding,
+      encoding: BufferEncoding, // eslint-disable-line no-undef
       callback: TransformCallback,
     ): void {
       if (isFirstChunk) {

--- a/packages/shared/src/server/utils/transforms/transformStreamToJson.ts
+++ b/packages/shared/src/server/utils/transforms/transformStreamToJson.ts
@@ -9,8 +9,8 @@ export function transformStreamToJson(): Transform {
 
     transform(
       row: any,
-      encoding: BufferEncoding,
-      callback: TransformCallback
+      encoding: BufferEncoding, // eslint-disable-line no-undef, no-unused-vars
+      callback: TransformCallback,
     ): void {
       if (isFirstElement) {
         this.push("["); // Push the opening bracket for the first element

--- a/packages/shared/src/server/utils/transforms/transformStreamToJsonl.ts
+++ b/packages/shared/src/server/utils/transforms/transformStreamToJsonl.ts
@@ -7,7 +7,7 @@ export function transformStreamToJsonl(): Transform {
 
     transform(
       row: Record<string, any>,
-      encoding: BufferEncoding,
+      encoding: BufferEncoding, // eslint-disable-line no-undef, no-unused-vars
       callback: TransformCallback,
     ): void {
       this.push(stringify(row) + "\n");

--- a/worker/package.json
+++ b/worker/package.json
@@ -13,7 +13,7 @@
     "start": "dotenv -e ../.env -- node dist/index.js",
     "build": "tsc",
     "dev": "dotenv -e ../.env -- nodemon src/index.ts",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 21",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "refill-ingestion-events": "dotenv -e ../.env -- tsx src/scripts/s3-ingestion-event-relpay.ts",
     "refill-billing-event": "dotenv -e ../.env -- tsx src/scripts/refill-billing-event.ts"

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -232,6 +232,6 @@ const EnvSchema = z.object({
 });
 
 export const env: z.infer<typeof EnvSchema> =
-  process.env.DOCKER_BUILD === "1"
+  process.env.DOCKER_BUILD === "1" // eslint-disable-line turbo/no-undeclared-env-vars
     ? (process.env as any)
     : EnvSchema.parse(removeEmptyEnvVariables(process.env));

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -26,7 +26,7 @@ export class ClickhouseWriter {
   queue: ClickhouseQueue;
 
   isIntervalFlushInProgress: boolean;
-  intervalId: NodeJS.Timeout | null = null;
+  intervalId: NodeJS.Timeout | null = null; // eslint-disable-line no-undef
 
   private constructor() {
     this.batchSize = env.LANGFUSE_INGESTION_CLICKHOUSE_WRITE_BATCH_SIZE;
@@ -239,11 +239,11 @@ export class ClickhouseWriter {
 }
 
 export enum TableName {
-  Traces = "traces",
-  TracesMt = "traces_mt",
-  Scores = "scores",
-  Observations = "observations",
-  BlobStorageFileLog = "blob_storage_file_log",
+  Traces = "traces", // eslint-disable-line no-unused-vars
+  TracesMt = "traces_mt", // eslint-disable-line no-unused-vars
+  Scores = "scores", // eslint-disable-line no-unused-vars
+  Observations = "observations", // eslint-disable-line no-unused-vars
+  BlobStorageFileLog = "blob_storage_file_log", // eslint-disable-line no-unused-vars
 }
 
 type RecordInsertType<T extends TableName> = T extends TableName.Scores

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -93,8 +93,8 @@ export class IngestionService {
   constructor(
     private redis: Redis | Cluster,
     private prisma: PrismaClient,
-    private clickHouseWriter: ClickhouseWriter,
-    private clickhouseClient: ClickhouseClientType,
+    private clickHouseWriter: ClickhouseWriter, // eslint-disable-line no-unused-vars
+    private clickhouseClient: ClickhouseClientType, // eslint-disable-line no-unused-vars
   ) {
     this.promptService = new PromptService(prisma, redis);
   }
@@ -813,7 +813,7 @@ export class IngestionService {
   > {
     const providedUsageDetails = Object.fromEntries(
       Object.entries(observationRecord.provided_usage_details).filter(
-        ([k, v]) => v != null && v >= 0,
+        ([k, v]) => v != null && v >= 0, // eslint-disable-line no-unused-vars
       ),
     );
 
@@ -871,7 +871,7 @@ export class IngestionService {
     const { provided_cost_details } = observationRecord;
 
     const providedCostKeys = Object.entries(provided_cost_details ?? {})
-      .filter(([_, value]) => value != null)
+      .filter(([_, value]) => value != null) // eslint-disable-line no-unused-vars
       .map(([key]) => key);
 
     // If user has provided any cost point, do not calculate any other cost points
@@ -918,7 +918,7 @@ export class IngestionService {
       finalTotalCost = finalCostDetails.total;
     } else if (finalCostEntries.length > 0) {
       finalTotalCost = finalCostEntries.reduce(
-        (acc, [_, cost]) => acc + cost,
+        (acc, [_, cost]) => acc + cost, // eslint-disable-line no-unused-vars
         0,
       );
 
@@ -982,7 +982,7 @@ export class IngestionService {
     return result;
   }
 
-  private async getClickhouseRecord(params: {
+  private async getClickhouseRecord(params: { // eslint-disable-line no-unused-vars
     projectId: string;
     entityId: string;
     table: TableName.Traces;
@@ -991,7 +991,7 @@ export class IngestionService {
       params: Record<string, unknown>;
     };
   }): Promise<TraceRecordInsertType | null>;
-  private async getClickhouseRecord(params: {
+  private async getClickhouseRecord(params: { // eslint-disable-line no-unused-vars, no-dupe-class-members
     projectId: string;
     entityId: string;
     table: TableName.Scores;
@@ -1000,7 +1000,7 @@ export class IngestionService {
       params: Record<string, unknown>;
     };
   }): Promise<ScoreRecordInsertType | null>;
-  private async getClickhouseRecord(params: {
+  private async getClickhouseRecord(params: { // eslint-disable-line no-unused-vars, no-dupe-class-members
     projectId: string;
     entityId: string;
     table: TableName.Observations;
@@ -1009,7 +1009,7 @@ export class IngestionService {
       params: Record<string, unknown>;
     };
   }): Promise<ObservationRecordInsertType | null>;
-  private async getClickhouseRecord(params: {
+  private async getClickhouseRecord(params: { // eslint-disable-line no-dupe-class-members
     projectId: string;
     entityId: string;
     table: TableName;
@@ -1207,7 +1207,7 @@ export class IngestionService {
         ...("usageDetails" in obs.body
           ? (Object.fromEntries(
               Object.entries(obs.body.usageDetails ?? {}).filter(
-                ([_, val]) => val != null,
+                ([_, val]) => val != null, // eslint-disable-line no-unused-vars
               ),
             ) as Record<string, number>)
           : {}),
@@ -1228,7 +1228,7 @@ export class IngestionService {
         ...("costDetails" in obs.body
           ? (Object.fromEntries(
               Object.entries(obs.body.costDetails ?? {}).filter(
-                ([_, val]) => val != null,
+                ([_, val]) => val != null, // eslint-disable-line no-unused-vars
               ),
             ) as Record<string, number>)
           : {}),

--- a/worker/src/utils/shutdown.ts
+++ b/worker/src/utils/shutdown.ts
@@ -9,7 +9,7 @@ import { WorkerManager } from "../queues/workerManager";
 import { prisma } from "@langfuse/shared/src/db";
 import { BackgroundMigrationManager } from "../backgroundMigrations/backgroundMigrationManager";
 
-export const onShutdown: NodeJS.SignalsListener = async (signal) => {
+export const onShutdown: NodeJS.SignalsListener = async (signal) => { // eslint-disable-line no-undef
   logger.info(`Received ${signal}, closing server...`);
   setSigtermReceived();
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enforce zero linting warnings by setting `--max-warnings` to 0 and suppressing specific ESLint warnings across the codebase.
> 
>   - **Linting**:
>     - Set `--max-warnings` to 0 in `lint` scripts in `package.json` for `shared` and `worker` packages.
>     - Suppress `no-unused-vars` warnings using `eslint-disable-line` in various files, including `seed-postgres.ts`, `db.ts`, and `table-view-presets.ts`.
>     - Suppress `turbo/no-undeclared-env-vars` warnings in `seed-postgres.ts`, `db.ts`, and `env.ts`.
>     - Suppress `no-case-declarations` and `no-undef` warnings in `getQueue.ts` and `redis.ts`.
>   - **Misc**:
>     - Minor code comments added to explain ESLint suppressions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 68a02e23890b7ff51bc188aa9ca2eeb252cc22dc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->