### PR TITLE
chore: set static backoff for query clickhouse retries

### DIFF
--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -298,6 +298,9 @@ export async function queryClickhouse<T>(opts: {
             }
             return shouldRetry;
           },
+          startingDelay: 100,
+          timeMultiple: 1,
+          maxDelay: 100,
         },
       );
     },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set static backoff parameters for retry logic in `queryClickhouse` function in `clickhouse.ts`.
> 
>   - **Behavior**:
>     - Set static backoff parameters in `queryClickhouse` function in `clickhouse.ts`.
>     - `startingDelay` set to 100ms, `timeMultiple` set to 1, `maxDelay` set to 100ms for retry logic.
>   - **Misc**:
>     - No changes to other functions or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ceba6b0fcc67894962be3d2e299c9daa6074ff51. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->