### PR TITLE
fix: remove invalid metrics and dimensions from pivot table widget on view change

### DIFF
--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -1425,53 +1425,7 @@ export function WidgetForm({
                 <Label htmlFor="chart-type-select">Chart Type</Label>
                 <Select
                   value={selectedChartType}
-                  onValueChange={(value) => {
-                    const newChartType = value as DashboardWidgetChartType;
-                    const wasPivotTable = selectedChartType === "PIVOT_TABLE";
-                    const willBePivotTable = newChartType === "PIVOT_TABLE";
-
-                    // Handle transition from regular chart to pivot table
-                    if (!wasPivotTable && willBePivotTable) {
-                      // Initialize pivot table with current single metric if it's valid for the current view
-                      const currentViewDeclaration =
-                        viewDeclarations[selectedView];
-                      if (selectedMeasure in currentViewDeclaration.measures) {
-                        setSelectedMetrics([
-                          {
-                            id: `${selectedAggregation}_${selectedMeasure}`,
-                            measure: selectedMeasure,
-                            aggregation: selectedAggregation,
-                            label: `${startCase(selectedAggregation)} ${startCase(selectedMeasure)}`,
-                          },
-                        ]);
-                      } else {
-                        // Fallback to count if current metric is invalid
-                        setSelectedMetrics([
-                          {
-                            id: "count_count",
-                            measure: "count",
-                            aggregation: "count" as z.infer<
-                              typeof metricAggregations
-                            >,
-                            label: "Count Count",
-                          },
-                        ]);
-                      }
-                      // Initialize with current dimension if valid, otherwise empty
-                      const currentViewDimensions =
-                        currentViewDeclaration.dimensions;
-                      if (
-                        selectedDimension !== "none" &&
-                        selectedDimension in currentViewDimensions
-                      ) {
-                        setPivotDimensions([selectedDimension]);
-                      } else {
-                        setPivotDimensions([]);
-                      }
-                    }
-
-                    setSelectedChartType(newChartType);
-                  }}
+                  onValueChange={setSelectedChartType}
                 >
                   <SelectTrigger id="chart-type-select">
                     <SelectValue placeholder="Select a chart type" />

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -991,9 +991,42 @@ export function WidgetForm({
                   value={selectedView}
                   onValueChange={(value) => {
                     if (value !== selectedView) {
+                      const newView = value as z.infer<typeof views>;
+                      const newViewDeclaration = viewDeclarations[newView];
+
+                      // Reset regular chart fields
                       setSelectedMeasure("count");
                       setSelectedAggregation("count");
                       setSelectedDimension("none");
+
+                      // Handle pivot table metrics - filter out invalid measures for the new view
+                      if (selectedChartType === "PIVOT_TABLE") {
+                        const validMetrics = selectedMetrics.filter(
+                          (metric) =>
+                            metric.measure in newViewDeclaration.measures,
+                        );
+
+                        // Ensure we have at least one valid metric (count is always available)
+                        if (validMetrics.length === 0) {
+                          validMetrics.push({
+                            id: "count_count",
+                            measure: "count",
+                            aggregation: "count" as z.infer<
+                              typeof metricAggregations
+                            >,
+                            label: "Count Count",
+                          });
+                        }
+
+                        setSelectedMetrics(validMetrics);
+
+                        // Handle pivot table dimensions - filter out invalid dimensions for the new view
+                        const validDimensions = pivotDimensions.filter(
+                          (dimension) =>
+                            dimension in newViewDeclaration.dimensions,
+                        );
+                        setPivotDimensions(validDimensions);
+                      }
                     }
                     setSelectedView(value as z.infer<typeof views>);
                   }}
@@ -1109,39 +1142,38 @@ export function WidgetForm({
                                 </Select>
                               </div>
 
-                              {currentMeasure &&
-                                currentMeasure !== "count" && (
-                                  <div className="flex-1">
-                                    <Select
-                                      value={currentAggregation}
-                                      onValueChange={(value) =>
-                                        updatePivotMetric(
-                                          index,
-                                          currentMeasure,
-                                          value as z.infer<
-                                            typeof metricAggregations
-                                          >,
-                                        )
-                                      }
-                                    >
-                                      <SelectTrigger>
-                                        <SelectValue placeholder="Select aggregation" />
-                                      </SelectTrigger>
-                                      <SelectContent>
-                                        {aggregationsForIndex.map(
-                                          (aggregation) => (
-                                            <SelectItem
-                                              key={aggregation}
-                                              value={aggregation}
-                                            >
-                                              {startCase(aggregation)}
-                                            </SelectItem>
-                                          ),
-                                        )}
-                                      </SelectContent>
-                                    </Select>
-                                  </div>
-                                )}
+                              {currentMeasure && currentMeasure !== "count" && (
+                                <div className="flex-1">
+                                  <Select
+                                    value={currentAggregation}
+                                    onValueChange={(value) =>
+                                      updatePivotMetric(
+                                        index,
+                                        currentMeasure,
+                                        value as z.infer<
+                                          typeof metricAggregations
+                                        >,
+                                      )
+                                    }
+                                  >
+                                    <SelectTrigger>
+                                      <SelectValue placeholder="Select aggregation" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      {aggregationsForIndex.map(
+                                        (aggregation) => (
+                                          <SelectItem
+                                            key={aggregation}
+                                            value={aggregation}
+                                          >
+                                            {startCase(aggregation)}
+                                          </SelectItem>
+                                        ),
+                                      )}
+                                    </SelectContent>
+                                  </Select>
+                                </div>
+                              )}
                             </div>
                           </div>
                         );
@@ -1393,7 +1425,53 @@ export function WidgetForm({
                 <Label htmlFor="chart-type-select">Chart Type</Label>
                 <Select
                   value={selectedChartType}
-                  onValueChange={setSelectedChartType}
+                  onValueChange={(value) => {
+                    const newChartType = value as DashboardWidgetChartType;
+                    const wasPivotTable = selectedChartType === "PIVOT_TABLE";
+                    const willBePivotTable = newChartType === "PIVOT_TABLE";
+
+                    // Handle transition from regular chart to pivot table
+                    if (!wasPivotTable && willBePivotTable) {
+                      // Initialize pivot table with current single metric if it's valid for the current view
+                      const currentViewDeclaration =
+                        viewDeclarations[selectedView];
+                      if (selectedMeasure in currentViewDeclaration.measures) {
+                        setSelectedMetrics([
+                          {
+                            id: `${selectedAggregation}_${selectedMeasure}`,
+                            measure: selectedMeasure,
+                            aggregation: selectedAggregation,
+                            label: `${startCase(selectedAggregation)} ${startCase(selectedMeasure)}`,
+                          },
+                        ]);
+                      } else {
+                        // Fallback to count if current metric is invalid
+                        setSelectedMetrics([
+                          {
+                            id: "count_count",
+                            measure: "count",
+                            aggregation: "count" as z.infer<
+                              typeof metricAggregations
+                            >,
+                            label: "Count Count",
+                          },
+                        ]);
+                      }
+                      // Initialize with current dimension if valid, otherwise empty
+                      const currentViewDimensions =
+                        currentViewDeclaration.dimensions;
+                      if (
+                        selectedDimension !== "none" &&
+                        selectedDimension in currentViewDimensions
+                      ) {
+                        setPivotDimensions([selectedDimension]);
+                      } else {
+                        setPivotDimensions([]);
+                      }
+                    }
+
+                    setSelectedChartType(newChartType);
+                  }}
                 >
                   <SelectTrigger id="chart-type-select">
                     <SelectValue placeholder="Select a chart type" />


### PR DESCRIPTION
… view change

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes a bug where invalid metrics and dimensions remain in the widget on view change, causing a 500 in the query builder.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes bug in `WidgetForm.tsx` to remove invalid metrics and dimensions on view change for pivot table widgets.
> 
>   - **Behavior**:
>     - Fixes bug in `WidgetForm.tsx` where invalid metrics and dimensions were not removed on view change, causing errors.
>     - Filters out invalid metrics and dimensions for pivot table widgets when the view changes.
>     - Ensures at least one valid metric is retained, defaulting to "count" if necessary.
>   - **Functions**:
>     - Updates `onValueChange` for view selection to filter metrics and dimensions based on the new view's valid options.
>     - Modifies `setSelectedMetrics` and `setPivotDimensions` to handle invalid entries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b147c363f2e11acaf0457d33d9f952762d351859. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->