### PR TITLE
fix(ui) Enforce alphanumeric dataset names

### DIFF
--- a/web/src/features/datasets/components/DatasetForm.tsx
+++ b/web/src/features/datasets/components/DatasetForm.tsx
@@ -57,7 +57,14 @@ const formSchema = z.object({
     .min(1, { message: "Input is required" })
     .refine((name) => name.trim().length > 0, {
       message: "Input should not be only whitespace",
-    }),
+    })
+    .refine(
+      (name) => /^[a-zA-Z0-9_-]+$/.test(name.trim()),
+      {
+        message:
+          "Name must be alphanumeric and can only contain letters, numbers, underscores, or hyphens.",
+      },
+    ),
   description: z.string(),
   metadata: z.string().refine(
     (value) => {

--- a/web/src/features/datasets/components/DatasetForm.tsx
+++ b/web/src/features/datasets/components/DatasetForm.tsx
@@ -118,8 +118,10 @@ export const DatasetForm = (props: DatasetFormProps) => {
     },
   );
 
-  const allDatasetNames = useMemo(() => {
-    return allDatasets.data?.map((dataset) => ({ value: dataset.name })) ?? [];
+  const allDatasetNames = useMemo<{ value: string }[]>(() => {
+    return (
+      allDatasets.data?.map((dataset: { name: string }) => ({ value: dataset.name })) ?? []
+    );
   }, [allDatasets.data]);
 
   useUniqueNameValidation({

--- a/web/types/langfuse-shared.d.ts
+++ b/web/types/langfuse-shared.d.ts
@@ -1,0 +1,3 @@
+declare module "@langfuse/shared" {
+  export * from "../../packages/shared/src";
+}


### PR DESCRIPTION
![CleanShot 2025-07-02 at 18 01 17@2x](https://github.com/user-attachments/assets/4a10c5d3-c4bb-4756-b2d6-be4744705a35)

%23%23 What does this PR do%3F

This PR enforces alphanumeric naming conventions for datasets in the UI, preventing the creation of names that cause API errors (e.g., names containing spaces). This is achieved by adding client-side validation for dataset names.

Additionally, this PR resolves TypeScript linter errors by:
- Adding type declarations for the `@langfuse/shared` module.
- Providing explicit type annotations for the `useMemo` hook in `DatasetForm.tsx`.

Fixes %23

%23%23 Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

%23%23 Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

%23%23 Checklist

<!-- Remove bullet points below that don't apply to you -->

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`npm run prettier`)
- [ ] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my PR needs changes to the documentation
- [ ] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [ ] I haven't added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enforces alphanumeric dataset names and resolves TypeScript linter errors in `DatasetForm.tsx`.
> 
>   - **Behavior**:
>     - Enforces alphanumeric dataset names in `DatasetForm.tsx` using regex in `formSchema`.
>     - Prevents names with spaces or non-alphanumeric characters.
>   - **TypeScript**:
>     - Adds type declarations for `@langfuse/shared` in `langfuse-shared.d.ts`.
>     - Adds explicit type annotations for `useMemo` in `DatasetForm.tsx`.
>   - **Misc**:
>     - Resolves TypeScript linter errors in `DatasetForm.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ab3b450609afd55e350775f46c264bc34120e2e5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->