### PR TITLE
fix: loading state of csv import button

### DIFF
--- a/web/src/features/datasets/components/PreviewCsvImport.tsx
+++ b/web/src/features/datasets/components/PreviewCsvImport.tsx
@@ -457,8 +457,8 @@ export function PreviewCsvImport({
         <Button
           disabled={
             (selectedInputColumn.size === 0 &&
-            selectedExpectedColumn.size === 0 &&
-            selectedMetadataColumn.size === 0) ||
+              selectedExpectedColumn.size === 0 &&
+              selectedMetadataColumn.size === 0) ||
             progress.status === "processing"
           }
           loading={progress.status === "processing"}

--- a/web/src/features/datasets/components/PreviewCsvImport.tsx
+++ b/web/src/features/datasets/components/PreviewCsvImport.tsx
@@ -456,13 +456,15 @@ export function PreviewCsvImport({
         </Button>
         <Button
           disabled={
-            selectedInputColumn.size === 0 &&
+            (selectedInputColumn.size === 0 &&
             selectedExpectedColumn.size === 0 &&
-            selectedMetadataColumn.size === 0
+            selectedMetadataColumn.size === 0) ||
+            progress.status === "processing"
           }
+          loading={progress.status === "processing"}
           onClick={handleImport}
         >
-          Import
+          {progress.status === "processing" ? "Importing..." : "Import"}
         </Button>
         {progress.status === "processing" && (
           <div className="mt-2">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances `PreviewCsvImport` button to prevent duplicate imports by disabling it and showing a loading spinner during the process.
> 
>   - **Behavior**:
>     - Disables "Import" button in `PreviewCsvImport` when import starts.
>     - Shows loading spinner and changes text to "Importing..." during import.
>     - Prevents duplicate dataset submissions.
>   - **UI**:
>     - Updates button state based on `progress.status` in `PreviewCsvImport`.
>     - Adds loading spinner to button when `progress.status` is "processing".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 24817373d942f85b35c8cb12fc144f51da9ee391. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->