### PR TITLE
fix(otel): trace update events on present metadata

### DIFF
--- a/web/src/features/otel/server/OtelIngestionProcessor.ts
+++ b/web/src/features/otel/server/OtelIngestionProcessor.ts
@@ -619,7 +619,7 @@ export class OtelIngestionProcessor {
   }
 
   private hasTraceUpdates(attributes: Record<string, unknown>): boolean {
-    return [
+    const hasExactMatchingAttributeName = [
       LangfuseOtelSpanAttributes.TRACE_NAME,
       LangfuseOtelSpanAttributes.TRACE_INPUT,
       LangfuseOtelSpanAttributes.TRACE_OUTPUT,
@@ -637,6 +637,13 @@ export class OtelIngestionProcessor {
       `${LangfuseOtelSpanAttributes.TRACE_METADATA}.langfuse_user_id`,
       `${LangfuseOtelSpanAttributes.TRACE_METADATA}.langfuse_tags`,
     ].some((traceAttribute) => Boolean(attributes[traceAttribute]));
+
+    const attributeKeys = Object.keys(attributes);
+    const hasTraceMetadataKey = attributeKeys.some((key) =>
+      key.startsWith(LangfuseOtelSpanAttributes.TRACE_METADATA),
+    );
+
+    return hasExactMatchingAttributeName || hasTraceMetadataKey;
   }
 
   private extractResourceAttributes(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `hasTraceUpdates()` in `OtelIngestionProcessor.ts` to detect trace updates by checking for keys starting with `TRACE_METADATA`.
> 
>   - **Behavior**:
>     - Update `hasTraceUpdates()` in `OtelIngestionProcessor.ts` to check for keys starting with `TRACE_METADATA`.
>     - Ensures trace updates are detected when metadata keys are present.
>   - **Misc**:
>     - Refactor `hasTraceUpdates()` to improve readability by separating logic into `hasExactMatchingAttributeName` and `hasTraceMetadataKey`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 40f031a44866079dbe2016184e3399a226207c1a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->