### PR TITLE
fix(scores): update score validation logic to accept inclusive ranges for score config validation

### DIFF
--- a/packages/shared/src/features/scores/interfaces/ingestion/validation.ts
+++ b/packages/shared/src/features/scores/interfaces/ingestion/validation.ts
@@ -37,13 +37,13 @@ const ScorePropsAgainstConfigNumeric = z
     dataType: z.literal("NUMERIC"),
   })
   .superRefine((data, ctx) => {
-    if (isPresent(data.maxValue) && data.value >= data.maxValue) {
+    if (isPresent(data.maxValue) && data.value > data.maxValue) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: `Value exceeds maximum value of ${data.maxValue} defined in config`,
       });
     }
-    if (isPresent(data.minValue) && data.value <= data.minValue) {
+    if (isPresent(data.minValue) && data.value < data.minValue) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: `Value is below minimum value of ${data.minValue} defined in config`,

--- a/web/src/__tests__/async/scores-api-v1.servertest.ts
+++ b/web/src/__tests__/async/scores-api-v1.servertest.ts
@@ -244,6 +244,67 @@ describe("/api/public/scores API Endpoint", () => {
         "test-key": "test-value-updated",
       });
     });
+
+    it("should post score with score config if in valid range", async () => {
+      const configId = v4();
+      const traceId = v4();
+      const scoreId = v4();
+
+      const { projectId: projectId, auth } = await createOrgProjectAndApiKey();
+
+      const config = await prisma.scoreConfig.create({
+        data: {
+          name: "score-name",
+          id: configId,
+          dataType: "NUMERIC",
+          maxValue: 100,
+          projectId: projectId,
+        },
+      });
+
+      const trace = createTrace({
+        id: traceId,
+        project_id: projectId,
+      });
+      await createTracesCh([trace]);
+
+      const score = createTraceScore({
+        id: scoreId,
+        project_id: projectId,
+        trace_id: traceId,
+        name: "score-name",
+        value: 100,
+        source: "API",
+        comment: "comment",
+        metadata: { "test-key": "test-value" },
+        observation_id: null,
+        environment: "production",
+        config_id: config.id,
+      });
+      await createScoresCh([score]);
+
+      const fetchedScore = await makeZodVerifiedAPICall(
+        GetScoreResponseV1,
+        "GET",
+        `/api/public/scores/${scoreId}`,
+        undefined,
+        auth,
+      );
+
+      expect(fetchedScore.body?.id).toBe(scoreId);
+      expect(fetchedScore.body?.traceId).toBe(traceId);
+      expect(fetchedScore.body?.name).toBe("score-name");
+      expect(fetchedScore.body?.value).toBe(100);
+      expect(fetchedScore.body?.configId).toBe(configId);
+      expect(fetchedScore.body?.observationId).toBeNull();
+      expect(fetchedScore.body?.comment).toBe("comment");
+      expect(fetchedScore.body?.source).toBe("API");
+      expect(fetchedScore.body?.projectId).toBe(projectId);
+      expect(fetchedScore.body?.environment).toBe("production");
+      expect(fetchedScore.body?.metadata).toEqual({
+        "test-key": "test-value-updated",
+      });
+    });
   });
 
   describe("GET /api/public/scores", () => {

--- a/web/src/__tests__/async/scores-api-v1.servertest.ts
+++ b/web/src/__tests__/async/scores-api-v1.servertest.ts
@@ -302,7 +302,7 @@ describe("/api/public/scores API Endpoint", () => {
       expect(fetchedScore.body?.projectId).toBe(projectId);
       expect(fetchedScore.body?.environment).toBe("production");
       expect(fetchedScore.body?.metadata).toEqual({
-        "test-key": "test-value-updated",
+        "test-key": "test-value",
       });
     });
   });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update score validation logic to use inclusive ranges for numeric scores and add corresponding test case.
> 
>   - **Validation Logic**:
>     - Update `ScorePropsAgainstConfigNumeric` in `validation.ts` to use inclusive ranges for `minValue` and `maxValue`.
>     - Change comparison operators from `>=` to `>` and `<=` to `<`.
>   - **Testing**:
>     - Add test case in `scores-api-v1.servertest.ts` to verify scores within inclusive range are accepted.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 13dd9e0377a033c13dc09412cdf3f2c9334e7b28. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->