### PR TITLE
refactor(datasets-compare): implement context for managing selected resource metrics

### DIFF
--- a/web/src/components/table/peek/peek-dataset-compare-detail.tsx
+++ b/web/src/components/table/peek/peek-dataset-compare-detail.tsx
@@ -14,10 +14,7 @@ import { PanelLeftOpen, PanelLeftClose, ListTree } from "lucide-react";
 import { cn } from "@/src/utils/tailwind";
 import { Command } from "@/src/components/ui/command";
 import DocPopup from "@/src/components/layouts/doc-popup";
-import type {
-  DatasetCompareRunRowData,
-  DatasetRunMetric,
-} from "@/src/features/datasets/components/DatasetCompareRunsTable";
+import type { DatasetCompareRunRowData } from "@/src/features/datasets/components/DatasetCompareRunsTable";
 import { useRouter } from "next/router";
 import { usePeekData } from "@/src/components/table/peek/hooks/usePeekData";
 
@@ -25,7 +22,6 @@ export type PeekDatasetCompareDetailProps = {
   projectId: string;
   runsData: RouterOutputs["datasets"]["baseRunDataByDatasetId"];
   scoreKeyToDisplayName: Map<string, string>;
-  selectedMetrics?: DatasetRunMetric[];
   row?: DatasetCompareRunRowData;
 };
 
@@ -33,7 +29,6 @@ export const PeekDatasetCompareDetail = ({
   projectId,
   runsData,
   scoreKeyToDisplayName,
-  selectedMetrics = ["scores", "resourceMetrics"],
   row,
 }: PeekDatasetCompareDetailProps) => {
   const router = useRouter();
@@ -173,7 +168,6 @@ export const PeekDatasetCompareDetail = ({
                         value={run}
                         projectId={projectId}
                         scoreKeyToDisplayName={scoreKeyToDisplayName}
-                        selectedMetrics={selectedMetrics}
                         output={row.expectedOutput}
                         isHighlighted={id === runId}
                         actionButtons={
@@ -187,7 +181,11 @@ export const PeekDatasetCompareDetail = ({
                                   ? `/project/${projectId}/traces/${encodeURIComponent(run.traceId)}?observation=${encodeURIComponent(run.observationId)}`
                                   : `/project/${projectId}/traces/${encodeURIComponent(run.traceId)}`;
                                 const pathnameWithBasePath = `${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}${pathname}`;
-                                window.open(pathnameWithBasePath, "_blank", "noopener noreferrer");
+                                window.open(
+                                  pathnameWithBasePath,
+                                  "_blank",
+                                  "noopener noreferrer",
+                                );
                               }}
                             >
                               <ListTree className="h-4 w-4" />

--- a/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
+++ b/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
@@ -12,10 +12,8 @@ import {
 } from "@/src/components/ui/dialog";
 import { DialogTrigger } from "@/src/components/ui/dialog";
 import { DialogContent } from "@/src/components/ui/dialog";
-import {
-  type DatasetRunMetric,
-  type RunMetrics,
-} from "@/src/features/datasets/components/DatasetCompareRunsTable";
+import { type RunMetrics } from "@/src/features/datasets/components/DatasetCompareRunsTable";
+import { useDatasetCompareMetrics } from "@/src/features/datasets/contexts/DatasetCompareMetricsContext";
 import { api } from "@/src/utils/api";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import { cn } from "@/src/utils/tailwind";
@@ -36,19 +34,18 @@ const DatasetAggregateCell = ({
   projectId,
   observationId,
   scoreKeyToDisplayName,
-  selectedMetrics,
   actionButtons,
   output,
   isHighlighted = false,
 }: RunMetrics & {
   projectId: string;
   scoreKeyToDisplayName: Map<string, string>;
-  selectedMetrics: DatasetRunMetric[];
   actionButtons?: ReactNode;
   output?: Prisma.JsonValue;
   isHighlighted?: boolean;
 }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const { selectedMetrics } = useDatasetCompareMetrics();
   // conditionally fetch the trace or observation depending on the presence of observationId
   const trace = api.traces.byId.useQuery(
     { traceId, projectId },
@@ -239,7 +236,6 @@ export const DatasetAggregateTableCell = ({
   value,
   projectId,
   scoreKeyToDisplayName,
-  selectedMetrics,
   actionButtons,
   output,
   isHighlighted = false,
@@ -247,7 +243,6 @@ export const DatasetAggregateTableCell = ({
   value: RunMetrics;
   projectId: string;
   scoreKeyToDisplayName: Map<string, string>;
-  selectedMetrics: DatasetRunMetric[];
   actionButtons?: ReactNode;
   output?: Prisma.JsonValue;
   isHighlighted?: boolean;
@@ -257,7 +252,6 @@ export const DatasetAggregateTableCell = ({
       projectId={projectId}
       {...value}
       scoreKeyToDisplayName={scoreKeyToDisplayName}
-      selectedMetrics={selectedMetrics}
       actionButtons={actionButtons}
       output={output}
       isHighlighted={isHighlighted}

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -109,8 +109,7 @@ function DatasetCompareRunsTableInternal(props: {
   runsData?: RouterOutputs["datasets"]["baseRunDataByDatasetId"];
   localExperiments: { key: string; value: string }[];
 }) {
-  const { selectedMetrics, toggleMetric, isMetricSelected } =
-    useDatasetCompareMetrics();
+  const { toggleMetric, isMetricSelected } = useDatasetCompareMetrics();
   const [isMetricsDropdownOpen, setIsMetricsDropdownOpen] = useState(false);
   const [unchangedCounts, setUnchangedCounts] = useState<
     Record<string, number>
@@ -464,7 +463,6 @@ function DatasetCompareRunsTableInternal(props: {
               projectId={props.projectId}
               scoreKeyToDisplayName={scoreKeyToDisplayName}
               runsData={props.runsData ?? []}
-              selectedMetrics={selectedMetrics}
               row={row}
             />
           ),

--- a/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
+++ b/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
@@ -5,7 +5,6 @@ import {
   type RunMetrics,
   type RunAggregate,
   type DatasetCompareRunRowData,
-  type DatasetRunMetric,
 } from "@/src/features/datasets/components/DatasetCompareRunsTable";
 import { type Row } from "@tanstack/react-table";
 import React from "react";
@@ -14,7 +13,6 @@ export const constructDatasetRunAggregateColumns = ({
   runAggregateColumnProps,
   projectId,
   scoreKeyToDisplayName,
-  selectedMetrics,
   cellsLoading = false,
 }: {
   runAggregateColumnProps: {
@@ -25,7 +23,6 @@ export const constructDatasetRunAggregateColumns = ({
   }[];
   projectId: string;
   scoreKeyToDisplayName: Map<string, string>;
-  selectedMetrics: DatasetRunMetric[];
   cellsLoading?: boolean;
 }): LangfuseColumnDef<DatasetCompareRunRowData>[] => {
   return runAggregateColumnProps.map((col) => {
@@ -62,7 +59,6 @@ export const constructDatasetRunAggregateColumns = ({
             value={value}
             projectId={projectId}
             scoreKeyToDisplayName={scoreKeyToDisplayName}
-            selectedMetrics={selectedMetrics}
           />
         );
       },

--- a/web/src/features/datasets/contexts/DatasetCompareMetricsContext.tsx
+++ b/web/src/features/datasets/contexts/DatasetCompareMetricsContext.tsx
@@ -1,0 +1,63 @@
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+const DATASET_RUN_METRICS = ["scores", "resourceMetrics"] as const;
+export type DatasetRunMetric = (typeof DATASET_RUN_METRICS)[number];
+
+interface DatasetCompareMetricsContextValue {
+  selectedMetrics: DatasetRunMetric[];
+  setSelectedMetrics: (metrics: DatasetRunMetric[]) => void;
+  toggleMetric: (metric: DatasetRunMetric) => void;
+  isMetricSelected: (metric: DatasetRunMetric) => boolean;
+}
+
+const DatasetCompareMetricsContext = createContext<
+  DatasetCompareMetricsContextValue | undefined
+>(undefined);
+
+interface DatasetCompareMetricsProviderProps {
+  children: ReactNode;
+  defaultMetrics?: DatasetRunMetric[];
+}
+
+export function DatasetCompareMetricsProvider({
+  children,
+  defaultMetrics = ["scores", "resourceMetrics"],
+}: DatasetCompareMetricsProviderProps) {
+  const [selectedMetrics, setSelectedMetrics] =
+    useState<DatasetRunMetric[]>(defaultMetrics);
+
+  const toggleMetric = (metric: DatasetRunMetric) => {
+    setSelectedMetrics((prev) =>
+      prev.includes(metric)
+        ? prev.filter((m) => m !== metric)
+        : [...prev, metric],
+    );
+  };
+
+  const isMetricSelected = (metric: DatasetRunMetric) => {
+    return selectedMetrics.includes(metric);
+  };
+
+  return (
+    <DatasetCompareMetricsContext.Provider
+      value={{
+        selectedMetrics,
+        setSelectedMetrics,
+        toggleMetric,
+        isMetricSelected,
+      }}
+    >
+      {children}
+    </DatasetCompareMetricsContext.Provider>
+  );
+}
+
+export function useDatasetCompareMetrics() {
+  const context = useContext(DatasetCompareMetricsContext);
+  if (context === undefined) {
+    throw new Error(
+      "useDatasetCompareMetrics must be used within a DatasetCompareMetricsProvider",
+    );
+  }
+  return context;
+}

--- a/web/src/features/datasets/hooks/useDatasetRunAggregateColumns.ts
+++ b/web/src/features/datasets/hooks/useDatasetRunAggregateColumns.ts
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 import { constructDatasetRunAggregateColumns } from "@/src/features/datasets/components/DatasetRunAggregateColumnHelpers";
-import { type DatasetRunMetric } from "@/src/features/datasets/components/DatasetCompareRunsTable";
 import { type RouterOutputs } from "@/src/utils/api";
 
 export function useDatasetRunAggregateColumns({
@@ -8,14 +7,12 @@ export function useDatasetRunAggregateColumns({
   runIds,
   runsData,
   scoreKeyToDisplayName,
-  selectedMetrics,
   cellsLoading = false,
 }: {
   projectId: string;
   runIds: string[];
   runsData: RouterOutputs["datasets"]["baseRunDataByDatasetId"];
   scoreKeyToDisplayName: Map<string, string>;
-  selectedMetrics: DatasetRunMetric[];
   cellsLoading?: boolean;
 }) {
   const runAggregateColumnProps = runIds.map((runId) => {
@@ -34,15 +31,8 @@ export function useDatasetRunAggregateColumns({
       cellsLoading,
       projectId,
       scoreKeyToDisplayName,
-      selectedMetrics,
     });
-  }, [
-    runAggregateColumnProps,
-    cellsLoading,
-    projectId,
-    scoreKeyToDisplayName,
-    selectedMetrics,
-  ]);
+  }, [runAggregateColumnProps, cellsLoading, projectId, scoreKeyToDisplayName]);
 
   return {
     runAggregateColumns,

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
@@ -17,6 +17,7 @@ import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAcces
 import {
   Dialog,
   DialogContent,
+  DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from "@/src/components/ui/dialog";
@@ -301,10 +302,12 @@ export default function Dataset() {
           }}
         >
           <DialogContent className="max-h-[90vh] max-w-screen-md overflow-y-auto">
-            <DialogTitle>
-              {selectedEvaluatorData.evaluator.id ? "Edit" : "Configure"}{" "}
-              Evaluator
-            </DialogTitle>
+            <DialogHeader>
+              <DialogTitle>
+                {selectedEvaluatorData.evaluator.id ? "Edit" : "Configure"}{" "}
+                Evaluator
+              </DialogTitle>
+            </DialogHeader>
             <EvaluatorForm
               useDialog={true}
               projectId={projectId}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor to use context for managing selected resource metrics in dataset comparison, centralizing state management and simplifying components.
> 
>   - **Context Management**:
>     - Introduces `DatasetCompareMetricsContext` in `DatasetCompareMetricsContext.tsx` to manage selected resource metrics.
>     - Provides `toggleMetric` and `isMetricSelected` functions for metric management.
>   - **Component Updates**:
>     - Refactors `DatasetCompareRunsTable` and `DatasetAggregateTableCell` to use the new context for metric selection.
>     - Removes `selectedMetrics` prop from `PeekDatasetCompareDetail` and `DatasetAggregateTableCell`.
>   - **Miscellaneous**:
>     - Updates `DatasetCompareRunsTable.tsx` to wrap `DatasetCompareRunsTableInternal` with `DatasetCompareMetricsProvider`.
>     - Adjusts `useDatasetRunAggregateColumns` to remove `selectedMetrics` dependency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f310ebd7f68f88f7f320ea1746c40f37e96925b2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->