### PR TITLE
feat(ui): Add trace download button, exports trace and observation metadata as json

### DIFF
--- a/web/src/components/trace/TracePage.tsx
+++ b/web/src/components/trace/TracePage.tsx
@@ -10,6 +10,22 @@ import Page from "@/src/components/layouts/page";
 import { Trace } from "@/src/components/trace";
 import { TagTraceDetailsPopover } from "@/src/features/tag/components/TagTraceDetailsPopover";
 import { useIsAuthenticatedAndProjectMember } from "@/src/features/auth/hooks";
+import { Button } from "@/src/components/ui/button";
+import { Download } from "lucide-react";
+
+function downloadTraceAsJson(traceData: any, traceId: string) {
+  const jsonString = JSON.stringify(traceData, null, 2);
+  const blob = new Blob([jsonString], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `trace-${traceId}.json`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
 
 export function TracePage({
   traceId,
@@ -128,6 +144,14 @@ export function TracePage({
         ),
         actionButtonsRight: (
           <>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => downloadTraceAsJson(trace.data, traceId)}
+              title="Download trace as JSON"
+            >
+              <Download className="h-4 w-4" />
+            </Button>
             <DetailPageNav
               currentId={traceId}
               path={(entry) => {

--- a/web/src/components/trace/TracePage.tsx
+++ b/web/src/components/trace/TracePage.tsx
@@ -10,22 +10,6 @@ import Page from "@/src/components/layouts/page";
 import { Trace } from "@/src/components/trace";
 import { TagTraceDetailsPopover } from "@/src/features/tag/components/TagTraceDetailsPopover";
 import { useIsAuthenticatedAndProjectMember } from "@/src/features/auth/hooks";
-import { Button } from "@/src/components/ui/button";
-import { Download } from "lucide-react";
-
-function downloadTraceAsJson(traceData: any, traceId: string) {
-  const jsonString = JSON.stringify(traceData, null, 2);
-  const blob = new Blob([jsonString], { type: "application/json" });
-  const url = URL.createObjectURL(blob);
-  
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = `trace-${traceId}.json`;
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-  URL.revokeObjectURL(url);
-}
 
 export function TracePage({
   traceId,
@@ -144,14 +128,6 @@ export function TracePage({
         ),
         actionButtonsRight: (
           <>
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={() => downloadTraceAsJson(trace.data, traceId)}
-              title="Download trace as JSON"
-            >
-              <Download className="h-4 w-4" />
-            </Button>
             <DetailPageNav
               currentId={traceId}
               path={(entry) => {
@@ -193,6 +169,7 @@ export function TracePage({
           observations={trace.data.observations}
           selectedTab={selectedTab}
           setSelectedTab={setSelectedTab}
+          fullTraceData={trace.data}
         />
       </div>
     </Page>

--- a/web/src/components/trace/TracePage.tsx
+++ b/web/src/components/trace/TracePage.tsx
@@ -169,7 +169,6 @@ export function TracePage({
           observations={trace.data.observations}
           selectedTab={selectedTab}
           setSelectedTab={setSelectedTab}
-          fullTraceData={trace.data}
         />
       </div>
     </Page>

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -223,7 +223,7 @@ export function Trace(props: {
     document.body.removeChild(link);
     URL.revokeObjectURL(url);
     
-    capture("trace_detail:download_json", { traceId: props.trace.id });
+    capture("trace_detail:download_button_click");
   }, [props.trace, props.observations, capture]);
 
   const [expandedItems, setExpandedItems] = useSessionStorage<string[]>(

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -279,15 +279,6 @@ export function Trace(props: {
             )}
             {viewType === "detailed" && (
               <div className="flex flex-row items-center gap-2">
-                <Button
-                  variant="outline"
-                  size="icon"
-                  onClick={downloadTraceAsJson}
-                  title="Download trace as JSON"
-                  disabled={!props.fullTraceData}
-                >
-                  <Download className="h-4 w-4" />
-                </Button>
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button variant="ghost" size="icon">
@@ -416,6 +407,16 @@ export function Trace(props: {
                     </DropdownMenuSub>
                   </DropdownMenuContent>
                 </DropdownMenu>
+                {props.fullTraceData && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={downloadTraceAsJson}
+                    title="Download trace as JSON"
+                  >
+                    <Download className="h-4 w-4" />
+                  </Button>
+                )}
                 <Switch
                   checked={props.selectedTab?.includes("timeline")}
                   onCheckedChange={(checked) =>

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -67,7 +67,6 @@ export function Trace(props: {
     newValue?: string | null,
     updateType?: UrlUpdateType,
   ) => void;
-  fullTraceData?: any; // Full trace data for download
 }) {
   const viewType = props.viewType ?? "detailed";
   const isValidObservationId = props.isValidObservationId ?? true;
@@ -207,22 +206,25 @@ export function Trace(props: {
   }, []);
 
   const downloadTraceAsJson = useCallback(() => {
-    if (props.fullTraceData) {
-      const jsonString = JSON.stringify(props.fullTraceData, null, 2);
-      const blob = new Blob([jsonString], { type: "application/json" });
-      const url = URL.createObjectURL(blob);
-      
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = `trace-${props.trace.id}.json`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(url);
-      
-      capture("trace_detail:download_button_click", { traceId: props.trace.id });
-    }
-  }, [props.fullTraceData, props.trace.id, capture]);
+    const exportData = {
+      trace: props.trace,
+      observations: props.observations,
+    };
+    
+    const jsonString = JSON.stringify(exportData, null, 2);
+    const blob = new Blob([jsonString], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `trace-${props.trace.id}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    
+    capture("trace_detail:download_json", { traceId: props.trace.id });
+  }, [props.trace, props.observations, capture]);
 
   const [expandedItems, setExpandedItems] = useSessionStorage<string[]>(
     `${props.trace.id}-expanded`,
@@ -407,7 +409,7 @@ export function Trace(props: {
                     </DropdownMenuSub>
                   </DropdownMenuContent>
                 </DropdownMenu>
-                {props.fullTraceData && (
+                {props.trace && (
                   <Button
                     variant="ghost"
                     size="icon"

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -220,7 +220,7 @@ export function Trace(props: {
       document.body.removeChild(link);
       URL.revokeObjectURL(url);
       
-      capture("trace_detail:download_json", { traceId: props.trace.id });
+      capture("trace_detail:download_button_click", { traceId: props.trace.id });
     }
   }, [props.fullTraceData, props.trace.id, capture]);
 

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -409,16 +409,14 @@ export function Trace(props: {
                     </DropdownMenuSub>
                   </DropdownMenuContent>
                 </DropdownMenu>
-                {props.trace && (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={downloadTraceAsJson}
-                    title="Download trace as JSON"
-                  >
-                    <Download className="h-4 w-4" />
-                  </Button>
-                )}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={downloadTraceAsJson}
+                  title="Download trace as JSON"
+                >
+                  <Download className="h-4 w-4" />
+                </Button>
                 <Switch
                   checked={props.selectedTab?.includes("timeline")}
                   onCheckedChange={(checked) =>

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -15,7 +15,11 @@ const events = {
     "bookmark_button_click",
     "column_visibility_changed",
   ],
-  trace: ["delete_form_open", "delete", "delete_form_submit"],
+  trace: [
+    "delete_form_open",
+    "delete",
+    "delete_form_submit",
+  ],
   trace_detail: [
     "publish_button_click",
     "bookmark_button_click",
@@ -27,6 +31,7 @@ const events = {
     "io_pretty_format_toggle_group",
     "test_in_playground_button_click",
     "display_mode_switch",
+    "download_button_click",
   ],
   generations: ["export"],
   saved_views: [

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -15,11 +15,7 @@ const events = {
     "bookmark_button_click",
     "column_visibility_changed",
   ],
-  trace: [
-    "delete_form_open",
-    "delete",
-    "delete_form_submit",
-  ],
+  trace: ["delete_form_open", "delete", "delete_form_submit"],
   trace_detail: [
     "publish_button_click",
     "bookmark_button_click",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a download button to export trace and observation metadata as JSON and logs the event to PostHog analytics.
> 
>   - **Feature**:
>     - Adds `downloadTraceAsJson` function in `index.tsx` to export trace and observation metadata as JSON.
>     - Adds a download button in `Trace` component in `index.tsx` to trigger JSON export.
>   - **Analytics**:
>     - Logs "trace_detail:download_button_click" event in `usePostHogClientCapture.ts` when download button is clicked.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fe2c476a14302f3b16001fac678034d361826230. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->