### PR TITLE
chore(dashboard): remove breakdowns by 1:N dimensional relations

### DIFF
--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -56,20 +56,6 @@ export const traceView: ViewDeclarationType = {
       type: "string",
       description: "Deployment environment (e.g., production, staging).",
     },
-    observationName: {
-      sql: "name",
-      alias: "observationName",
-      type: "string",
-      relationTable: "observations",
-      description: "Name of the observation.",
-    },
-    scoreName: {
-      sql: "name",
-      alias: "scoreName",
-      type: "string",
-      relationTable: "scores",
-      description: "Name of the score.",
-    },
   },
   measures: {
     count: {
@@ -247,13 +233,6 @@ export const observationsView: ViewDeclarationType = {
       type: "string",
       relationTable: "traces",
       description: "Version of the parent trace.",
-    },
-    scoreName: {
-      sql: "name",
-      alias: "scoreName",
-      type: "string",
-      relationTable: "scores",
-      description: "Name of the score.",
     },
   },
   measures: {


### PR DESCRIPTION
This is known to be breaking for users that have existing charts, but given that their behaviour was underdefined in the first place, we accept this.

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `observationName` and `scoreName` dimensions from `traceView` and `observationsView` in `dataModel.ts`.
> 
>   - **Dimensions Removed**:
>     - Removed `observationName` and `scoreName` from `traceView` dimensions.
>     - Removed `scoreName` from `observationsView` dimensions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5bb4395f90b2bb802e0b9a65de4c09b1102fc7ca. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->