### PR TITLE
chore(sentry): restrict loggerLink to development environment only for less noise in sentry

### DIFF
--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -123,9 +123,10 @@ export const api = createTRPCNext<AppRouter>({
       links: [
         buildIdLink(),
         loggerLink({
-          enabled: (opts) =>
-            process.env.NODE_ENV === "development" ||
-            (opts.direction === "down" && opts.result instanceof Error),
+          // Only enable in development - production logs would be captured by Sentry
+          // in an unreadable format. We handle 5xx errors via captureException() in
+          // handleTrpcError and use DataDog for additional server-side logging.
+          enabled: () => process.env.NODE_ENV === "development",
         }),
         splitLink({
           condition(op) {
@@ -180,9 +181,10 @@ export const directApi = createTRPCProxyClient<AppRouter>({
   transformer: superjson,
   links: [
     loggerLink({
-      enabled: (opts) =>
-        process.env.NODE_ENV === "development" ||
-        (opts.direction === "down" && opts.result instanceof Error),
+      // Only enable in development - production logs would be captured by Sentry
+      // in an unreadable format. We handle 5xx errors via captureException() in
+      // handleTrpcError and use DataDog for additional server-side logging.
+      enabled: () => process.env.NODE_ENV === "development",
     }),
     httpBatchLink({
       url: `${getBaseUrl()}/api/trpc`,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Restrict `loggerLink` to development environment in `api.ts`, with production logs handled by Sentry and DataDog.
> 
>   - **Behavior**:
>     - Restrict `loggerLink` to development environment only in `api` and `directApi` in `api.ts`.
>     - Production logs are captured by Sentry and DataDog, with 5xx errors handled via `captureException()` in `handleTrpcError`.
>   - **Misc**:
>     - Update comments in `api.ts` to explain logging behavior changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1d1c68c56d026839701980dbb011623498691915. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->