### PR TITLE
fix(dataset-run-items-api-spec): correct response type

### DIFF
--- a/fern/apis/server/definition/dataset-run-items.yml
+++ b/fern/apis/server/definition/dataset-run-items.yml
@@ -27,7 +27,7 @@ service:
           limit:
             type: optional<integer>
             docs: limit of items per page
-          response: PaginatedDatasetRunItems
+      response: PaginatedDatasetRunItems
 
 types:
   CreateDatasetRunItemRequest:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -875,14 +875,13 @@ paths:
           schema:
             type: integer
             nullable: true
-        - name: response
-          in: query
-          required: true
-          schema:
-            $ref: '#/components/schemas/PaginatedDatasetRunItems'
       responses:
-        '204':
+        '200':
           description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedDatasetRunItems'
         '400':
           description: ''
           content:

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -649,7 +649,7 @@
           "request": {
             "description": "List dataset run items",
             "url": {
-              "raw": "{{baseUrl}}/api/public/dataset-run-items?datasetId=&runName=&page=&limit=&response=",
+              "raw": "{{baseUrl}}/api/public/dataset-run-items?datasetId=&runName=&page=&limit=",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -678,11 +678,6 @@
                   "key": "limit",
                   "value": "",
                   "description": "limit of items per page"
-                },
-                {
-                  "key": "response",
-                  "value": "",
-                  "description": null
                 }
               ],
               "variable": []


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Corrects the response type for the `list` endpoint in the `dataset-run-items` API, updating the OpenAPI spec and Postman collection accordingly.
> 
>   - **API Specification**:
>     - Corrects response type for `list` endpoint in `dataset-run-items.yml` from `204` to `200`.
>     - Updates `openapi.yml` to reflect the correct response type and schema for `200` status.
>   - **Postman Collection**:
>     - Removes `response` query parameter from `dataset-run-items` endpoint in `collection.json` to align with updated API behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 19eaeb0d26da4ffac883da0f6a8f15d2af91d88d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->