### PR TITLE
fix: do not store output of webhook automations

### DIFF
--- a/packages/shared/src/server/automations/webhooks.ts
+++ b/packages/shared/src/server/automations/webhooks.ts
@@ -164,10 +164,6 @@ export const executeWebhook = async (input: WebhookInput) => {
         status: ActionExecutionStatus.COMPLETED,
         startedAt: executionStart,
         finishedAt: new Date(),
-        output: {
-          httpStatus,
-          responseBody: responseBody?.substring(0, 1000), // Limit response body size
-        },
       },
     });
 

--- a/worker/src/__tests__/webhooks.test.ts
+++ b/worker/src/__tests__/webhooks.test.ts
@@ -276,10 +276,7 @@ describe("Webhook Integration Tests", () => {
         where: { id: executionId },
       });
       expect(execution?.status).toBe(ActionExecutionStatus.COMPLETED);
-      expect(execution?.output).toMatchObject({
-        httpStatus: 200,
-        responseBody: '{"success":true}',
-      });
+      expect(execution?.output).toBeNull();
       expect(execution?.startedAt).toBeDefined();
       expect(execution?.finishedAt).toBeDefined();
     });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove storing of webhook output in `executeWebhook` and update tests accordingly.
> 
>   - **Behavior**:
>     - Removed storing of `httpStatus` and `responseBody` in `executeWebhook` in `webhooks.ts`.
>     - Updated `webhooks.test.ts` to expect `execution?.output` to be `null` after webhook execution.
>   - **Tests**:
>     - Modified test in `webhooks.test.ts` to check for `null` output instead of matching `httpStatus` and `responseBody`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 10afc20d256ea28ed47b2b52a3b4b6b5d7bb152b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->