### PR TITLE
chore: add timestamp column to AMTs for backwards compat

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(find:*)",
-      "Bash(rg:*)"
+      "Bash(rg:*)",
+      "Bash(grep:*)"
     ],
     "deny": []
   }

--- a/worker/src/services/IngestionService/README.md
+++ b/worker/src/services/IngestionService/README.md
@@ -65,6 +65,7 @@ CREATE TABLE traces_all_amt
     -- Identifiers
     `project_id`         String,
     `id`                 String,
+    `timestamp`          SimpleAggregateFunction(min, DateTime64(3)),  -- Backward compatibility: redundant with start_time
     `start_time`         SimpleAggregateFunction(min, DateTime64(3)),
     `end_time`           SimpleAggregateFunction(max, Nullable(DateTime64(3))),
     `name`               SimpleAggregateFunction(anyLast, Nullable(String)),
@@ -112,6 +113,7 @@ SELECT
     -- Identifiers
     t0.project_id                                                                              as project_id,
     t0.id                                                                                      as id,
+    min(t0.start_time)                                                                         as timestamp,  -- Backward compatibility: redundant with start_time
     min(t0.start_time)                                                                         as start_time,
     max(coalesce(t0.end_time, t0.start_time))                                                  as end_time,
     anyLast(t0.name)                                                                           as name,
@@ -150,6 +152,7 @@ CREATE TABLE traces_7d_amt
     -- Identifiers
     `project_id`         String,
     `id`                 String,
+    `timestamp`          SimpleAggregateFunction(min, DateTime64(3)),  -- Backward compatibility: redundant with start_time
     `start_time`         SimpleAggregateFunction(min, DateTime64(3)),
     `end_time`           SimpleAggregateFunction(max, Nullable(DateTime64(3))),
     `name`               SimpleAggregateFunction(anyLast, Nullable(String)),
@@ -197,6 +200,7 @@ SELECT
     -- Identifiers
     t0.project_id                                                                              as project_id,
     t0.id                                                                                      as id,
+    min(t0.start_time)                                                                         as timestamp,  -- Backward compatibility: redundant with start_time
     min(t0.start_time)                                                                         as start_time,
     max(coalesce(t0.end_time, t0.start_time))                                                  as end_time,
     anyLast(t0.name)                                                                           as name,
@@ -235,6 +239,7 @@ CREATE TABLE traces_30d_amt
     -- Identifiers
     `project_id`         String,
     `id`                 String,
+    `timestamp`          SimpleAggregateFunction(min, DateTime64(3)),  -- Backward compatibility: redundant with start_time
     `start_time`         SimpleAggregateFunction(min, DateTime64(3)),
     `end_time`           SimpleAggregateFunction(max, Nullable(DateTime64(3))),
     `name`               SimpleAggregateFunction(anyLast, Nullable(String)),
@@ -282,6 +287,7 @@ SELECT
     -- Identifiers
     t0.project_id                                                                              as project_id,
     t0.id                                                                                      as id,
+    min(t0.start_time)                                                                         as timestamp,  -- Backward compatibility: redundant with start_time
     min(t0.start_time)                                                                         as start_time,
     max(coalesce(t0.end_time, t0.start_time))                                                  as end_time,
     anyLast(t0.name)                                                                           as name,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `timestamp` column to AMT tables for backward compatibility and update settings to allow `Bash(grep:*)`.
> 
>   - **Database Schema**:
>     - Add `timestamp` column to `traces_all_amt`, `traces_7d_amt`, and `traces_30d_amt` tables in `README.md` for backward compatibility with `start_time`.
>     - Update materialized views to include `timestamp` derived from `start_time`.
>   - **Settings**:
>     - Allow `Bash(grep:*)` in `.claude/settings.local.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 797d7467c5807766203a4ce9ac01392361fe8fe2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->