### PR TITLE
chore(ui): change link on traces and observations table to data model docs page

### DIFF
--- a/web/src/pages/project/[projectId]/observations.tsx
+++ b/web/src/pages/project/[projectId]/observations.tsx
@@ -31,7 +31,7 @@ export default function Generations() {
         help: {
           description:
             "An observation captures a single function call in an application. See docs to learn more.",
-          href: "https://langfuse.com/docs/tracing",
+          href: "https://langfuse.com/docs/tracing-data-model",
         },
       }}
       scrollable={showOnboarding}

--- a/web/src/pages/project/[projectId]/traces.tsx
+++ b/web/src/pages/project/[projectId]/traces.tsx
@@ -31,7 +31,7 @@ export default function Traces() {
         help: {
           description:
             "A trace represents a single function/api invocation. Traces contain observations. See docs to learn more.",
-          href: "https://langfuse.com/docs/tracing",
+          href: "https://langfuse.com/docs/tracing-data-model",
         },
       }}
       scrollable={showOnboarding}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update documentation links in `observations.tsx` and `traces.tsx` to point to the data model page.
> 
>   - **Behavior**:
>     - Update `href` in `observations.tsx` and `traces.tsx` to point to `https://langfuse.com/docs/tracing-data-model` instead of `https://langfuse.com/docs/tracing`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7aa9c9031bfdb135b1803e9c1db89bc8b072a51a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->