### PR TITLE
chore(ui-markdown-viewer): stop interpreting `$`currency symbol as latex math block marker

### DIFF
--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -11,7 +11,6 @@ import {
 import ReactMarkdown, { type Options } from "react-markdown";
 import Link from "next/link";
 import remarkGfm from "remark-gfm";
-import remarkMath from "remark-math";
 import { CodeBlock } from "@/src/components/ui/Codeblock";
 import { useTheme } from "next-themes";
 import { ImageOff, Info } from "lucide-react";
@@ -127,7 +126,7 @@ function MarkdownRenderer({
           "space-y-2 overflow-x-auto break-words text-sm",
           className,
         )}
-        remarkPlugins={[remarkGfm, remarkMath]}
+        remarkPlugins={[remarkGfm]}
         components={{
           p({ children, node }) {
             if (isImageNode(node)) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `remarkMath` plugin from `MarkdownViewer.tsx` to stop interpreting `$` as LaTeX math block marker.
> 
>   - **Behavior**:
>     - Removed `remarkMath` plugin from `MarkdownViewer.tsx` to stop interpreting `$` as LaTeX math block marker.
>   - **Rendering**:
>     - Markdown now treats `$` as a regular character, not a math block marker.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9050938fc01b8738f2b14db7c53ce71c27d98e4c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->