### PR TITLE
feat: Add gen_ai.conversation.id support

### DIFF
--- a/web/src/features/otel/server/OtelIngestionProcessor.ts
+++ b/web/src/features/otel/server/OtelIngestionProcessor.ts
@@ -1044,6 +1044,7 @@ export class OtelIngestionProcessor {
     const userIdKeys = [
       "langfuse.session.id",
       "session.id",
+      "gen_ai.conversation.id",
       `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langfuse_session_id`,
       `${LangfuseOtelSpanAttributes.TRACE_METADATA}.langfuse_session_id`,
     ];


### PR DESCRIPTION
context: https://github.com/orgs/langfuse/discussions/7737

This pull request contains changes generated by Cursor background composer.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for `gen_ai.conversation.id` in `OtelIngestionProcessor` with prioritization over existing session identifiers and update tests accordingly.
> 
>   - **Behavior**:
>     - Add support for `gen_ai.conversation.id` in `OtelIngestionProcessor` to extract `sessionId`.
>     - Prioritize `langfuse.session.id` and `session.id` over `gen_ai.conversation.id` when all are present.
>   - **Tests**:
>     - Add test case in `otelMapping.servertest.ts` to verify extraction of `sessionId` from `gen_ai.conversation.id`.
>     - Add test cases to ensure prioritization of `langfuse.session.id` and `session.id` over `gen_ai.conversation.id`.
>   - **Misc**:
>     - Update `userIdKeys` and `sessionIdKeys` in `OtelIngestionProcessor.ts` to include `gen_ai.conversation.id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2ce19bd256d0a4febe4307d734c6db45eae956f5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->