### PR TITLE
fix(traces): jumptoplayground possible for langgraph traces with tools

### DIFF
--- a/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -166,9 +166,9 @@ const isLangGraphTrace = (generation: { metadata: string | null }): boolean => {
 
 // Normalize LangGraph tool messages by converting tool-name roles to "tool"
 const normalizeLangGraphMessage = (
-  message: any,
+  message: unknown,
   isLangGraph: boolean = false,
-): any => {
+): unknown => {
   if (!message || typeof message !== "object" || !("role" in message)) {
     return message;
   }

--- a/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -32,6 +32,10 @@ import {
   isPlaceholder,
   PromptType,
 } from "@langfuse/shared";
+import {
+  LANGGRAPH_NODE_TAG,
+  LANGGRAPH_STEP_TAG,
+} from "@/src/features/trace-graph-view/types";
 import { api } from "@/src/utils/api";
 import { cn } from "@/src/utils/tailwind";
 
@@ -140,6 +144,52 @@ export const JumpToPlaygroundButton: React.FC<JumpToPlaygroundButtonProps> = (
   );
 };
 
+// Is LangGraph Trace? Decide from metadata. If so, we might need to recognise roles as tool names
+const isLangGraphTrace = (generation: { metadata: string | null }): boolean => {
+  if (!generation.metadata) return false;
+
+  try {
+    let metadata = generation.metadata;
+    if (typeof metadata === "string") {
+      metadata = JSON.parse(metadata);
+    }
+
+    if (typeof metadata === "object" && metadata !== null) {
+      return LANGGRAPH_NODE_TAG in metadata || LANGGRAPH_STEP_TAG in metadata;
+    }
+  } catch {
+    // Ignore JSON parsing errors
+  }
+
+  return false;
+};
+
+// Normalize LangGraph tool messages by converting tool-name roles to "tool"
+const normalizeLangGraphMessage = (
+  message: any,
+  isLangGraph: boolean = false,
+): any => {
+  if (!message || typeof message !== "object" || !("role" in message)) {
+    return message;
+  }
+
+  const validRoles = Object.values(ChatMessageRole);
+
+  if (isLangGraph && !validRoles.includes(message.role as ChatMessageRole)) {
+    // LangGraph sets role to tool name instead of "tool"
+    // Convert to proper tool message format
+    return {
+      ...message,
+      role: ChatMessageRole.Tool,
+      // TODO: remove?
+      // Preserve original role in case needed for debugging
+      _originalRole: message.role,
+    };
+  }
+
+  return message;
+};
+
 const ParsedChatMessageListSchema = z.array(
   z.union([
     // Regular chat message
@@ -170,6 +220,7 @@ const ParsedChatMessageListSchema = z.array(
             .optional(),
         })
         .optional(),
+      _originalRole: z.string().optional(), // original LangGraph role
     }),
     PlaceholderMessageSchema,
   ]),
@@ -251,9 +302,26 @@ const parsePrompt = (
   prompt: Prompt & { resolvedPrompt?: Prisma.JsonValue },
 ): PlaygroundCache => {
   if (prompt.type === PromptType.Chat) {
-    const parsedMessages = ParsedChatMessageListSchema.safeParse(
-      prompt.resolvedPrompt,
-    );
+    // For prompts, we can't detect LangGraph from metadata, so we check for invalid roles
+    // If any msg has an invalid role, we assume it might be LangGraph format
+    const isLangGraph =
+      Array.isArray(prompt.resolvedPrompt) &&
+      (prompt.resolvedPrompt as any[]).some(
+        (msg) =>
+          msg &&
+          typeof msg === "object" &&
+          "role" in msg &&
+          !Object.values(ChatMessageRole).includes(msg.role as ChatMessageRole),
+      );
+
+    const normalizedMessages = Array.isArray(prompt.resolvedPrompt)
+      ? (prompt.resolvedPrompt as any[]).map((msg) =>
+          normalizeLangGraphMessage(msg, isLangGraph),
+        )
+      : prompt.resolvedPrompt;
+
+    const parsedMessages =
+      ParsedChatMessageListSchema.safeParse(normalizedMessages);
 
     return parsedMessages.success
       ? { messages: parsedMessages.data.map(transformToPlaygroundMessage) }
@@ -283,8 +351,9 @@ const parseGeneration = (
 ): PlaygroundCache => {
   if (generation.type !== "GENERATION") return null;
 
+  const isLangGraph = isLangGraphTrace(generation);
   const modelParams = parseModelParams(generation, modelToProviderMap);
-  const tools = parseTools(generation);
+  const tools = parseTools(generation, isLangGraph);
   const structuredOutputSchema = parseStructuredOutputSchema(generation);
 
   let input = generation.input?.valueOf();
@@ -324,9 +393,15 @@ const parseGeneration = (
   }
 
   if (typeof input === "object") {
-    const parsedMessages = ParsedChatMessageListSchema.safeParse(
-      "messages" in input ? input["messages"] : input,
-    );
+    const messageData = "messages" in input ? input["messages"] : input;
+    const normalizedMessages = Array.isArray(messageData)
+      ? (messageData as any[]).map((msg) =>
+          normalizeLangGraphMessage(msg, isLangGraph),
+        )
+      : messageData;
+
+    const parsedMessages =
+      ParsedChatMessageListSchema.safeParse(normalizedMessages);
 
     if (parsedMessages.success)
       return {
@@ -340,9 +415,14 @@ const parseGeneration = (
   }
 
   if (typeof input === "object" && "messages" in input) {
-    const parsedMessages = ParsedChatMessageListSchema.safeParse(
-      input["messages"],
-    );
+    const normalizedMessages = Array.isArray(input["messages"])
+      ? (input["messages"] as any[]).map((msg) =>
+          normalizeLangGraphMessage(msg, isLangGraph),
+        )
+      : input["messages"];
+
+    const parsedMessages =
+      ParsedChatMessageListSchema.safeParse(normalizedMessages);
 
     if (parsedMessages.success)
       return {
@@ -406,6 +486,7 @@ function parseTools(
     output: string | null;
     metadata: string | null;
   },
+  isLangGraph: boolean = false,
 ): PlaygroundTool[] {
   // OpenAI Schema
   try {
@@ -426,9 +507,15 @@ function parseTools(
     const input = JSON.parse(generation.input as string);
 
     if (typeof input === "object" && input !== null) {
-      const parsedMessages = ParsedChatMessageListSchema.safeParse(
-        "messages" in input ? input["messages"] : input,
-      );
+      const messageData = "messages" in input ? input["messages"] : input;
+      const normalizedMessages = Array.isArray(messageData)
+        ? (messageData as any[]).map((msg) =>
+            normalizeLangGraphMessage(msg, isLangGraph),
+          )
+        : messageData;
+
+      const parsedMessages =
+        ParsedChatMessageListSchema.safeParse(normalizedMessages);
 
       if (parsedMessages.success)
         return parsedMessages.data


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances JumpToPlaygroundButton to support LangGraph traces by normalizing tool messages and updating parsing logic.
> 
>   - **LangGraph Handling**:
>     - Adds `isLangGraphTrace()` to detect LangGraph traces from metadata.
>     - Adds `normalizeLangGraphMessage()` to convert LangGraph tool-name roles to "tool".
>   - **Parsing Logic**:
>     - Updates `parsePrompt()` and `parseGeneration()` to normalize LangGraph messages and handle invalid roles.
>     - Modifies `parseTools()` to support LangGraph traces.
>   - **Schema Updates**:
>     - Updates `ParsedChatMessageListSchema` to include `_originalRole` for LangGraph messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9e6c834dd56a899c456ef37aba9136ab0acd953f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->