### PR TITLE
feat: Add explicit moveToFailed handling for maxAttempt jobs in queue processors

### DIFF
--- a/packages/shared/src/server/redis/dlqRetryQueue.ts
+++ b/packages/shared/src/server/redis/dlqRetryQueue.ts
@@ -47,7 +47,7 @@ export class DeadLetterRetryQueue {
           QueueJobs.DeadLetterRetryJob,
           { timestamp: new Date() },
           {
-            repeat: { pattern: "0 */2 * * * *" }, // every 10 minutes (with seconds precision)
+            repeat: { pattern: "0 */10 * * * *" }, // every 10 minutes (with seconds precision)
           },
         )
         .catch((err) => {

--- a/packages/shared/src/server/redis/dlqRetryQueue.ts
+++ b/packages/shared/src/server/redis/dlqRetryQueue.ts
@@ -47,7 +47,7 @@ export class DeadLetterRetryQueue {
           QueueJobs.DeadLetterRetryJob,
           { timestamp: new Date() },
           {
-            repeat: { pattern: "0 */10 * * * *" }, // every 10 minutes (with seconds precision)
+            repeat: { pattern: "0 */2 * * * *" }, // every 10 minutes (with seconds precision)
           },
         )
         .catch((err) => {

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -69,7 +69,9 @@ export const ingestionQueueProcessorBuilder = (
           updated_at: new Date().getTime(),
           event_ts: new Date().getTime(),
           is_deleted: 0,
-        });
+        },
+        job.id,
+      );
       }
 
       // If fileKey was processed within the last minutes, i.e. has a match in redis, we skip processing.
@@ -228,6 +230,7 @@ export const ingestionQueueProcessorBuilder = (
         job.data.payload.data.eventBodyId,
         firstS3WriteTime,
         events,
+        job.id,
       );
     } catch (e) {
       logger.error(

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -70,7 +70,7 @@ export const ingestionQueueProcessorBuilder = (
           event_ts: new Date().getTime(),
           is_deleted: 0,
         },
-        job.id,
+        job.id ?? "",
       );
       }
 
@@ -230,7 +230,7 @@ export const ingestionQueueProcessorBuilder = (
         job.data.payload.data.eventBodyId,
         firstS3WriteTime,
         events,
-        job.id,
+        job.id ?? "",
       );
     } catch (e) {
       logger.error(

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -57,21 +57,23 @@ export const ingestionQueueProcessorBuilder = (
 
       if (job.data.payload.data.fileKey && job.data.payload.data.fileKey) {
         const fileName = `${job.data.payload.data.fileKey}.json`;
-        clickhouseWriter.addToQueue(TableName.BlobStorageFileLog, {
-          id: randomUUID(),
-          project_id: job.data.payload.authCheck.scope.projectId,
-          entity_type: getClickhouseEntityType(job.data.payload.data.type),
-          entity_id: job.data.payload.data.eventBodyId,
-          event_id: job.data.payload.data.fileKey,
-          bucket_name: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
-          bucket_path: `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${getClickhouseEntityType(job.data.payload.data.type)}/${job.data.payload.data.eventBodyId}/${fileName}`,
-          created_at: new Date().getTime(),
-          updated_at: new Date().getTime(),
-          event_ts: new Date().getTime(),
-          is_deleted: 0,
-        },
-        job.id ?? "",
-      );
+        clickhouseWriter.addToQueue(
+          TableName.BlobStorageFileLog,
+          {
+            id: randomUUID(),
+            project_id: job.data.payload.authCheck.scope.projectId,
+            entity_type: getClickhouseEntityType(job.data.payload.data.type),
+            entity_id: job.data.payload.data.eventBodyId,
+            event_id: job.data.payload.data.fileKey,
+            bucket_name: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
+            bucket_path: `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${getClickhouseEntityType(job.data.payload.data.type)}/${job.data.payload.data.eventBodyId}/${fileName}`,
+            created_at: new Date().getTime(),
+            updated_at: new Date().getTime(),
+            event_ts: new Date().getTime(),
+            is_deleted: 0,
+          },
+          job.id ?? "",
+        );
       }
 
       // If fileKey was processed within the last minutes, i.e. has a match in redis, we skip processing.

--- a/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
+++ b/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
@@ -425,7 +425,7 @@ describe("ClickhouseWriter", () => {
       .spyOn(clickhouseClientMock, "insert")
       .mockRejectedValue(new Error("DB Error"));
 
-    const mockGetJob = vi.fn(() => null); // Job not found
+    const mockGetJob = vi.fn(() => null);
     const mockGetInstance = vi.fn(() => ({
       getJob: mockGetJob,
     }));
@@ -452,9 +452,8 @@ describe("ClickhouseWriter", () => {
       .mockRejectedValue(new Error("DB Error"));
 
     const mockMoveToFailed = vi.fn();
-    const mockGetJobFirstShard = vi.fn(() => null); // Job not found in first shard
+    const mockGetJobFirstShard = vi.fn(() => null);
     const mockGetJobSecondShard = vi.fn(() => ({
-      // Job found in second shard
       moveToFailed: mockMoveToFailed,
     }));
 

--- a/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
+++ b/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
@@ -14,6 +14,23 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
     recordHistogram: vi.fn(),
     recordCount: vi.fn(),
     recordGauge: vi.fn(),
+    recordIncrement: vi.fn(),
+    getQueue: vi.fn(() => ({
+      getJob: vi.fn(() => ({
+        moveToFailed: vi.fn(),
+      })),
+    })),
+    QueueName: {
+      IngestionQueue: "ingestion-queue",
+    },
+    IngestionQueue: {
+      getShardNames: vi.fn(() => ["default"]),
+      getInstance: vi.fn(() => ({
+        getJob: vi.fn(() => ({
+          moveToFailed: vi.fn(),
+        })),
+      })),
+    },
     logger: {
       info: vi.fn(),
       debug: vi.fn(),
@@ -53,7 +70,8 @@ describe("ClickhouseWriter", () => {
     // Reset singleton instance
     await writer.shutdown();
 
-    ClickhouseWriter.instance = null;
+    // Reset the instance using a different approach
+    (ClickhouseWriter as any).instance = null;
   });
 
   it("should be a singleton", () => {
@@ -77,7 +95,7 @@ describe("ClickhouseWriter", () => {
 
   it("should add items to the queue", () => {
     const traceData = { id: "1", name: "test" };
-    writer.addToQueue(TableName.Traces, traceData as any);
+    writer.addToQueue(TableName.Traces, traceData as any, "job-1");
 
     expect(writer["queue"][TableName.Traces]).toHaveLength(1);
     expect(writer["queue"][TableName.Traces][0].data).toEqual(traceData);
@@ -89,7 +107,11 @@ describe("ClickhouseWriter", () => {
       .mockResolvedValue();
 
     for (let i = 0; i < writer.batchSize; i++) {
-      writer.addToQueue(TableName.Traces, { id: `${i}`, name: "test" } as any);
+      writer.addToQueue(
+        TableName.Traces,
+        { id: `${i}`, name: "test" } as any,
+        `job-${i}`,
+      );
     }
 
     await vi.advanceTimersByTimeAsync(writer.writeInterval);
@@ -102,7 +124,7 @@ describe("ClickhouseWriter", () => {
     const mockInsert = vi
       .spyOn(clickhouseClientMock, "insert")
       .mockResolvedValue();
-    writer.addToQueue(TableName.Traces, { id: "1", name: "test" });
+    writer.addToQueue(TableName.Traces, { id: "1", name: "test" }, "job-1");
 
     await vi.advanceTimersByTimeAsync(writer.writeInterval);
 
@@ -115,7 +137,7 @@ describe("ClickhouseWriter", () => {
       .mockRejectedValueOnce(new Error("DB Error"))
       .mockResolvedValueOnce();
 
-    writer.addToQueue(TableName.Traces, { id: "1", name: "test" });
+    writer.addToQueue(TableName.Traces, { id: "1", name: "test" }, "job-1");
 
     await vi.advanceTimersByTimeAsync(writer.writeInterval);
 
@@ -134,25 +156,35 @@ describe("ClickhouseWriter", () => {
       .spyOn(clickhouseClientMock, "insert")
       .mockRejectedValue(new Error("DB Error"));
 
-    writer.addToQueue(TableName.Traces, { id: "1", name: "test" });
+    writer.addToQueue(TableName.Traces, { id: "1", name: "test" }, "job-1");
 
-    for (let i = 0; i < writer.maxAttempts; i++) {
+    // Advance timers for maxAttempts + 1 times to trigger the max attempts logic
+    for (let i = 0; i < writer.maxAttempts + 1; i++) {
       await vi.advanceTimersByTimeAsync(writer.writeInterval);
     }
 
-    await vi.advanceTimersByTimeAsync(writer.writeInterval);
-
     expect(mockInsert).toHaveBeenCalledTimes(writer.maxAttempts);
-    expect(
-      logger.error.mock.calls.some((call) =>
-        call[0].includes("Max attempts reached"),
-      ),
-    ).toBe(true);
+
+    // Debug: Log all error calls to see what's actually being logged
+    console.log(
+      "All logger.error calls:",
+      logger.error.mock.calls.map((call) => call[0]),
+    );
+
+    // Check if any error call contains the expected message
+    const hasMaxAttemptsError = logger.error.mock.calls.some((call) => {
+      const message = call[0];
+      return (
+        typeof message === "string" && message.includes("Max attempts reached")
+      );
+    });
+
+    expect(hasMaxAttemptsError).toBe(true);
     expect(writer["queue"][TableName.Traces]).toHaveLength(0);
   });
 
   it("should shutdown gracefully", async () => {
-    writer.addToQueue(TableName.Traces, { id: "1", name: "test" });
+    writer.addToQueue(TableName.Traces, { id: "1", name: "test" }, "job-1");
     const mockInsert = vi
       .spyOn(clickhouseClientMock, "insert")
       .mockResolvedValue();
@@ -171,9 +203,13 @@ describe("ClickhouseWriter", () => {
       .spyOn(clickhouseClientMock, "insert")
       .mockResolvedValue();
 
-    writer.addToQueue(TableName.Traces, { id: "1", name: "trace" });
-    writer.addToQueue(TableName.Scores, { id: "2", name: "score" });
-    writer.addToQueue(TableName.Observations, { id: "3", name: "observation" });
+    writer.addToQueue(TableName.Traces, { id: "1", name: "trace" }, "job-1");
+    writer.addToQueue(TableName.Scores, { id: "2", name: "score" }, "job-2");
+    writer.addToQueue(
+      TableName.Observations,
+      { id: "3", name: "observation" },
+      "job-3",
+    );
 
     await vi.advanceTimersByTimeAsync(writer.writeInterval);
 
@@ -188,7 +224,7 @@ describe("ClickhouseWriter", () => {
       .spyOn(clickhouseClientMock, "insert")
       .mockResolvedValue();
     writer["isIntervalFlushInProgress"] = true;
-    writer.addToQueue(TableName.Traces, { id: "1", name: "test" });
+    writer.addToQueue(TableName.Traces, { id: "1", name: "test" }, "job-1");
 
     await vi.advanceTimersByTimeAsync(writer.writeInterval);
 
@@ -210,8 +246,8 @@ describe("ClickhouseWriter", () => {
     const mockInsert = vi
       .spyOn(clickhouseClientMock, "insert")
       .mockResolvedValue();
-    writer.addToQueue(TableName.Traces, { id: "1", name: "trace" });
-    writer.addToQueue(TableName.Scores, { id: "2", name: "score" });
+    writer.addToQueue(TableName.Traces, { id: "1", name: "trace" }, "job-1");
+    writer.addToQueue(TableName.Scores, { id: "2", name: "score" }, "job-2");
 
     await writer["flushAll"](true);
 
@@ -224,11 +260,15 @@ describe("ClickhouseWriter", () => {
     const mockInsert = vi
       .spyOn(clickhouseClientMock, "insert")
       .mockImplementation(() => {
-        writer.addToQueue(TableName.Traces, { id: "2", name: "test2" });
+        writer.addToQueue(
+          TableName.Traces,
+          { id: "2", name: "test2" },
+          "job-2",
+        );
         return Promise.resolve();
       });
 
-    writer.addToQueue(TableName.Traces, { id: "1", name: "test1" });
+    writer.addToQueue(TableName.Traces, { id: "1", name: "test1" }, "job-1");
 
     await vi.advanceTimersByTimeAsync(writer.writeInterval);
 
@@ -244,7 +284,11 @@ describe("ClickhouseWriter", () => {
     const concurrentWrites = 1000;
 
     const writes = Array.from({ length: concurrentWrites }, (_, i) =>
-      writer.addToQueue(TableName.Traces, { id: `${i}`, name: `test${i}` }),
+      writer.addToQueue(
+        TableName.Traces,
+        { id: `${i}`, name: `test${i}` },
+        `job-${i}`,
+      ),
     );
 
     await Promise.all(writes);
@@ -264,7 +308,7 @@ describe("ClickhouseWriter", () => {
       .spyOn(clickhouseClientMock, "insert")
       .mockResolvedValue();
 
-    writer.addToQueue(TableName.Traces, { id: "1", name: "test" });
+    writer.addToQueue(TableName.Traces, { id: "1", name: "test" }, "job-1");
 
     await vi.advanceTimersByTimeAsync(writer.writeInterval);
 
@@ -288,7 +332,7 @@ describe("ClickhouseWriter", () => {
       .mockRejectedValueOnce(new Error("Timeout"))
       .mockResolvedValueOnce();
 
-    writer.addToQueue(TableName.Traces, { id: "1", name: "test" });
+    writer.addToQueue(TableName.Traces, { id: "1", name: "test" }, "job-1");
 
     await vi.advanceTimersByTimeAsync(writer.writeInterval);
     expect(logger.error).toHaveBeenCalledWith(
@@ -311,7 +355,11 @@ describe("ClickhouseWriter", () => {
     const partialQueueSize = Math.floor(writer.batchSize / 2);
 
     for (let i = 0; i < partialQueueSize; i++) {
-      writer.addToQueue(TableName.Traces, { id: `${i}`, name: "test" } as any);
+      writer.addToQueue(
+        TableName.Traces,
+        { id: `${i}`, name: "test" } as any,
+        `job-${i}`,
+      );
     }
 
     await vi.advanceTimersByTimeAsync(writer.writeInterval);
@@ -333,13 +381,191 @@ describe("ClickhouseWriter", () => {
       .mockRejectedValueOnce(new Error("DB Error"))
       .mockResolvedValue();
 
-    writer.addToQueue(TableName.Traces, { id: "1", name: "test1" });
+    writer.addToQueue(TableName.Traces, { id: "1", name: "test1" }, "job-1");
     await vi.advanceTimersByTimeAsync(writer.writeInterval);
 
-    writer.addToQueue(TableName.Traces, { id: "2", name: "test2" });
+    writer.addToQueue(TableName.Traces, { id: "2", name: "test2" }, "job-2");
     await vi.advanceTimersByTimeAsync(writer.writeInterval);
 
     expect(mockInsert).toHaveBeenCalledTimes(2);
     expect(writer["queue"][TableName.Traces]).toHaveLength(0);
+  });
+
+  it("should call moveToFailed when max attempts are reached", async () => {
+    const mockInsert = vi
+      .spyOn(clickhouseClientMock, "insert")
+      .mockRejectedValue(new Error("DB Error"));
+
+    const mockMoveToFailed = vi.fn();
+    const mockGetJob = vi.fn(() => ({
+      moveToFailed: mockMoveToFailed,
+    }));
+    const mockGetInstance = vi.fn(() => ({
+      getJob: mockGetJob,
+    }));
+
+    // Update the mock to return our specific mock functions
+    (serverExports.IngestionQueue.getInstance as any).mockImplementation(
+      mockGetInstance,
+    );
+
+    writer.addToQueue(TableName.Traces, { id: "1", name: "test" }, "job-1");
+
+    // Advance timers for maxAttempts + 1 times to trigger the max attempts logic
+    for (let i = 0; i < writer.maxAttempts + 1; i++) {
+      await vi.advanceTimersByTimeAsync(writer.writeInterval);
+    }
+
+    expect(mockGetInstance).toHaveBeenCalled();
+    expect(mockGetJob).toHaveBeenCalledWith("job-1");
+    expect(mockMoveToFailed).toHaveBeenCalledWith(expect.any(Error), "token");
+  });
+
+  it("should handle job not found when max attempts are reached", async () => {
+    const mockInsert = vi
+      .spyOn(clickhouseClientMock, "insert")
+      .mockRejectedValue(new Error("DB Error"));
+
+    const mockGetJob = vi.fn(() => null); // Job not found
+    const mockGetInstance = vi.fn(() => ({
+      getJob: mockGetJob,
+    }));
+
+    (serverExports.IngestionQueue.getInstance as any).mockImplementation(
+      mockGetInstance,
+    );
+
+    writer.addToQueue(TableName.Traces, { id: "1", name: "test" }, "job-1");
+
+    // Advance timers for maxAttempts + 1 times to trigger the max attempts logic
+    for (let i = 0; i < writer.maxAttempts + 1; i++) {
+      await vi.advanceTimersByTimeAsync(writer.writeInterval);
+    }
+
+    expect(mockGetInstance).toHaveBeenCalled();
+    expect(mockGetJob).toHaveBeenCalledWith("job-1");
+    // Should not throw error when job is not found
+    expect(writer["queue"][TableName.Traces]).toHaveLength(0);
+  });
+
+  it("should handle multiple shards when looking for job", async () => {
+    const mockInsert = vi
+      .spyOn(clickhouseClientMock, "insert")
+      .mockRejectedValue(new Error("DB Error"));
+
+    const mockMoveToFailed = vi.fn();
+    const mockGetJobFirstShard = vi.fn(() => null); // Job not found in first shard
+    const mockGetJobSecondShard = vi.fn(() => ({
+      // Job found in second shard
+      moveToFailed: mockMoveToFailed,
+    }));
+
+    const mockGetInstance = vi
+      .fn()
+      .mockReturnValueOnce({ getJob: mockGetJobFirstShard })
+      .mockReturnValueOnce({ getJob: mockGetJobSecondShard });
+
+    (serverExports.IngestionQueue.getShardNames as any).mockReturnValue([
+      "shard1",
+      "shard2",
+    ]);
+    (serverExports.IngestionQueue.getInstance as any).mockImplementation(
+      mockGetInstance,
+    );
+
+    writer.addToQueue(TableName.Traces, { id: "1", name: "test" }, "job-1");
+
+    // Advance timers for maxAttempts + 1 times to trigger the max attempts logic
+    for (let i = 0; i < writer.maxAttempts + 1; i++) {
+      await vi.advanceTimersByTimeAsync(writer.writeInterval);
+    }
+
+    expect(mockGetInstance).toHaveBeenCalledTimes(2);
+    expect(mockGetJobFirstShard).toHaveBeenCalledWith("job-1");
+    expect(mockGetJobSecondShard).toHaveBeenCalledWith("job-1");
+    expect(mockMoveToFailed).toHaveBeenCalledWith(expect.any(Error), "token");
+  });
+
+  it("should increment error metrics when max attempts are reached", async () => {
+    const mockInsert = vi
+      .spyOn(clickhouseClientMock, "insert")
+      .mockRejectedValue(new Error("DB Error"));
+
+    const mockRecordIncrement = vi.fn();
+    (serverExports.recordIncrement as any).mockImplementation(
+      mockRecordIncrement,
+    );
+
+    writer.addToQueue(TableName.Traces, { id: "1", name: "test" }, "job-1");
+
+    // Advance timers for maxAttempts + 1 times to trigger the max attempts logic
+    for (let i = 0; i < writer.maxAttempts + 1; i++) {
+      await vi.advanceTimersByTimeAsync(writer.writeInterval);
+    }
+
+    expect(mockRecordIncrement).toHaveBeenCalledWith(
+      "langfuse.queue.clickhouse_writer.error",
+    );
+  });
+
+  it("should handle different table types with max attempts logic", async () => {
+    const mockInsert = vi
+      .spyOn(clickhouseClientMock, "insert")
+      .mockRejectedValue(new Error("DB Error"));
+
+    const mockMoveToFailed = vi.fn();
+    const mockGetJob = vi.fn(() => ({
+      moveToFailed: mockMoveToFailed,
+    }));
+    const mockGetInstance = vi.fn(() => ({
+      getJob: mockGetJob,
+    }));
+
+    (serverExports.IngestionQueue.getInstance as any).mockImplementation(
+      mockGetInstance,
+    );
+
+    // Test with different table types
+    writer.addToQueue(TableName.Traces, { id: "1", name: "test" }, "job-1");
+    writer.addToQueue(TableName.Scores, { id: "2", name: "test" }, "job-2");
+    writer.addToQueue(
+      TableName.Observations,
+      { id: "3", name: "test" },
+      "job-3",
+    );
+
+    // Advance timers for maxAttempts + 1 times to trigger the max attempts logic
+    for (let i = 0; i < writer.maxAttempts + 1; i++) {
+      await vi.advanceTimersByTimeAsync(writer.writeInterval);
+    }
+
+    expect(mockMoveToFailed).toHaveBeenCalledTimes(3);
+    expect(writer["queue"][TableName.Traces]).toHaveLength(0);
+    expect(writer["queue"][TableName.Scores]).toHaveLength(0);
+    expect(writer["queue"][TableName.Observations]).toHaveLength(0);
+  });
+
+  it("should preserve job data when logging max attempts error", async () => {
+    const mockInsert = vi
+      .spyOn(clickhouseClientMock, "insert")
+      .mockRejectedValue(new Error("DB Error"));
+
+    const testData = { id: "1", name: "test", customField: "value" };
+    writer.addToQueue(TableName.Traces, testData as any, "job-1");
+
+    // Advance timers for maxAttempts + 1 times to trigger the max attempts logic
+    for (let i = 0; i < writer.maxAttempts + 1; i++) {
+      await vi.advanceTimersByTimeAsync(writer.writeInterval);
+    }
+
+    // Check that the error log includes the original data
+    const errorLogCall = logger.error.mock.calls.find((call) =>
+      call[0].includes(
+        "Max attempts reached for traces record. Dropping record.",
+      ),
+    );
+
+    expect(errorLogCall).toBeDefined();
+    expect(errorLogCall[1]).toEqual({ item: testData });
   });
 });

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -226,7 +226,6 @@ export class IngestionService {
     finalScoreRecord.created_at =
       clickhouseScoreRecord?.created_at ?? createdAtTimestamp.getTime();
 
-<<<<<<< HEAD
     this.clickHouseWriter.addToQueue(TableName.Scores, finalScoreRecord, jobId);
 
     if (
@@ -236,9 +235,6 @@ export class IngestionService {
       const traceMtRecord = convertScoreToTraceMt(finalScoreRecord);
       this.clickHouseWriter.addToQueue(TableName.TracesMt, traceMtRecord, jobId);
     }
-=======
-    this.clickHouseWriter.addToQueue(TableName.Scores, finalScoreRecord, jobId);
->>>>>>> ee3e54358 (fix: clickhouse worker failed when over maxattempt)
   }
 
   private async processTraceEventList(params: {

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -149,7 +149,8 @@ export class IngestionService {
     scoreEventList: ScoreEventType[];
     jobId: string;
   }) {
-    const { projectId, entityId, createdAtTimestamp, scoreEventList, jobId } = params;
+    const { projectId, entityId, createdAtTimestamp, scoreEventList, jobId } =
+      params;
     if (scoreEventList.length === 0) return;
 
     const timeSortedEvents =
@@ -233,7 +234,11 @@ export class IngestionService {
       finalScoreRecord.trace_id
     ) {
       const traceMtRecord = convertScoreToTraceMt(finalScoreRecord);
-      this.clickHouseWriter.addToQueue(TableName.TracesMt, traceMtRecord, jobId);
+      this.clickHouseWriter.addToQueue(
+        TableName.TracesMt,
+        traceMtRecord,
+        jobId,
+      );
     }
   }
 
@@ -244,7 +249,8 @@ export class IngestionService {
     traceEventList: TraceEventType[];
     jobId: string;
   }) {
-    const { projectId, entityId, createdAtTimestamp, traceEventList, jobId } = params;
+    const { projectId, entityId, createdAtTimestamp, traceEventList, jobId } =
+      params;
     if (traceEventList.length === 0) return;
 
     const timeSortedEvents =
@@ -340,7 +346,11 @@ export class IngestionService {
       env.LANGFUSE_EXPERIMENT_INSERT_INTO_AGGREGATING_MERGE_TREES === "true"
     ) {
       const traceMtRecord = convertTraceToTraceMt(finalTraceRecord);
-      this.clickHouseWriter.addToQueue(TableName.TracesMt, traceMtRecord, jobId);
+      this.clickHouseWriter.addToQueue(
+        TableName.TracesMt,
+        traceMtRecord,
+        jobId,
+      );
     }
 
     // Add trace into trace upsert queue for eval processing
@@ -367,8 +377,13 @@ export class IngestionService {
     observationEventList: ObservationEvent[];
     jobId: string;
   }) {
-    const { projectId, entityId, createdAtTimestamp, observationEventList, jobId } =
-      params;
+    const {
+      projectId,
+      entityId,
+      createdAtTimestamp,
+      observationEventList,
+      jobId,
+    } = params;
     if (observationEventList.length === 0) return;
 
     const timeSortedEvents =
@@ -462,7 +477,11 @@ export class IngestionService {
         is_deleted: 0,
       };
 
-      this.clickHouseWriter.addToQueue(TableName.Traces, wrapperTraceRecord, jobId);
+      this.clickHouseWriter.addToQueue(
+        TableName.Traces,
+        wrapperTraceRecord,
+        jobId,
+      );
       finalObservationRecord.trace_id = finalObservationRecord.id;
     }
 
@@ -477,7 +496,11 @@ export class IngestionService {
       finalObservationRecord.trace_id
     ) {
       const traceMtRecord = convertObservationToTraceMt(finalObservationRecord);
-      this.clickHouseWriter.addToQueue(TableName.TracesMt, traceMtRecord, jobId);
+      this.clickHouseWriter.addToQueue(
+        TableName.TracesMt,
+        traceMtRecord,
+        jobId,
+      );
     }
   }
 

--- a/worker/src/services/dlq/dlqRetryService.ts
+++ b/worker/src/services/dlq/dlqRetryService.ts
@@ -2,8 +2,9 @@ import {
   logger,
   QueueName,
   recordHistogram,
+  getQueue,
+  IngestionQueue,
 } from "@langfuse/shared/src/server";
-import { getQueue } from "@langfuse/shared/src/server";
 
 export class DlqRetryService {
   private static retryQueues = [
@@ -25,7 +26,9 @@ export class DlqRetryService {
     );
     const retryQueues = DlqRetryService.retryQueues;
     for (const queueName of retryQueues) {
-      const queue = getQueue(queueName);
+      const queue = queueName.startsWith(QueueName.IngestionQueue)
+        ? IngestionQueue.getInstance({ shardName: queueName })
+        : getQueue(queueName as Exclude<QueueName, QueueName.IngestionQueue>);
 
       if (!queue) {
         logger.error(`Queue ${queueName} not found`);

--- a/worker/src/services/dlq/dlqRetryService.ts
+++ b/worker/src/services/dlq/dlqRetryService.ts
@@ -12,6 +12,8 @@ export class DlqRetryService {
     QueueName.ScoreDelete,
     QueueName.BatchActionQueue,
     QueueName.DataRetentionProcessingQueue,
+    QueueName.TraceUpsert,
+    QueueName.IngestionQueue,
   ] as const;
 
   // called each 10 minutes, defined by the bull cron job

--- a/worker/src/services/dlq/dlqRetryService.ts
+++ b/worker/src/services/dlq/dlqRetryService.ts
@@ -13,7 +13,6 @@ export class DlqRetryService {
     QueueName.ScoreDelete,
     QueueName.BatchActionQueue,
     QueueName.DataRetentionProcessingQueue,
-    QueueName.TraceUpsert,
     QueueName.IngestionQueue,
   ] as const;
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds explicit `moveToFailed()` handling for jobs that reach their maximum attempts across queue processors. The following TODO comment in `worker/src/services/ClickhouseWriter/index.ts` has been implemented:

> TODO - Add to a dead letter queue in Redis rather than dropping.

Currently, only the IngestionQueue (which goes through ClickhouseWriter) properly moves jobs to the failed state when maxAttempt is reached, while other queue processors rely on BullMQ's default behavior.

The changes ensure that:
- Queue processors explicitly call `moveToFailed()` when a job reaches its maximum attempts
- Failed jobs are properly moved to the Dead Letter Queue (DLQ) for retry processing through the existing DlqRetryService
- Consistent error handling and logging across all queue types
- Better observability of job failures through the existing DLQ retry mechanism

This improves the reliability of the job processing system and ensures that failed jobs can be properly monitored and retried through the existing DLQ infrastructure.

Fixes #6380 - This change addresses the issue where trace ingestion fails during ClickHouse downtime and data is not recovered after restart. By implementing proper `moveToFailed` handling across all queue processors, failed jobs (including those that fail due to ClickHouse connectivity issues) will be moved to the DLQ and can be retried when ClickHouse becomes available again, preventing permanent data loss during ClickHouse downtime.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds explicit `moveToFailed()` handling for max attempt jobs in `ClickhouseWriter`, ensuring failed jobs are moved to DLQ for retry, with updated tests for this behavior.
> 
>   - **Behavior**:
>     - Adds explicit `moveToFailed()` handling for jobs reaching max attempts in `ClickhouseWriter`.
>     - Failed jobs are moved to the Dead Letter Queue (DLQ) for retry processing.
>     - Consistent error handling and logging across all queue types.
>   - **Queue Processing**:
>     - Updates `ingestionQueueProcessorBuilder` to pass `job.id` to `ClickhouseWriter.addToQueue()`.
>     - Modifies `DlqRetryService` to include `IngestionQueue` in retry logic.
>   - **Testing**:
>     - Updates `ClickhouseWriter.unit.test.ts` to test `moveToFailed()` and DLQ handling.
>     - Adds tests for handling multiple shards and job not found scenarios.
>   - **Misc**:
>     - Implements TODO in `ClickhouseWriter` to handle max attempts by moving jobs to DLQ instead of dropping.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ed0967608a212785af5e2cf45f67fc052b2c9d0c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->