### PR TITLE
chore(experimentService): extend logging

### DIFF
--- a/web/src/__tests__/async/prompts.v2.servertest.ts
+++ b/web/src/__tests__/async/prompts.v2.servertest.ts
@@ -294,7 +294,7 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       testPromptEquality(createPromptParams, fetchedPrompt.body);
     });
 
-    it("should fetch the latest prompt if label is latest", async () => {
+    (it("should fetch the latest prompt if label is latest", async () => {
       const { projectId, auth } = await createOrgProjectAndApiKey();
       const promptName = "latestPrompt_" + nanoid();
 
@@ -396,7 +396,7 @@ describe("/api/public/v2/prompts API Endpoint", () => {
         }
 
         testPromptEquality(productionPromptParams, fetchedPrompt.body);
-      });
+      }));
 
     it("should return a 404 if prompt does not exist", async () => {
       const fetchedPrompt = await makeAPICall<Prompt>(

--- a/web/src/__tests__/async/prompts.v2.servertest.ts
+++ b/web/src/__tests__/async/prompts.v2.servertest.ts
@@ -294,7 +294,7 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       testPromptEquality(createPromptParams, fetchedPrompt.body);
     });
 
-    (it("should fetch the latest prompt if label is latest", async () => {
+    it("should fetch the latest prompt if label is latest", async () => {
       const { projectId, auth } = await createOrgProjectAndApiKey();
       const promptName = "latestPrompt_" + nanoid();
 
@@ -396,7 +396,7 @@ describe("/api/public/v2/prompts API Endpoint", () => {
         }
 
         testPromptEquality(productionPromptParams, fetchedPrompt.body);
-      }));
+      });
 
     it("should return a 404 if prompt does not exist", async () => {
       const fetchedPrompt = await makeAPICall<Prompt>(

--- a/worker/src/features/experiments/experimentService.ts
+++ b/worker/src/features/experiments/experimentService.ts
@@ -282,6 +282,10 @@ export const createExperimentJob = async ({
       ),
     }));
 
+  logger.info(
+    `Found ${validatedDatasetItems.length} validated dataset items for dataset run ${runId}`,
+  );
+
   if (!validatedDatasetItems.length) {
     throw new InvalidRequestError(
       `No Dataset ${datasetId} item input matches expected prompt variables or placeholders format`,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a log statement in `createExperimentJob` to log the number of validated dataset items for a dataset run.
> 
>   - **Logging**:
>     - Adds a new log statement in `createExperimentJob` in `experimentService.ts` to log the number of validated dataset items for a dataset run.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 23321176b36efeaa7115038217c4dff7d618753c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->