### PR TITLE
chore: add backoff retries to clickhouse writer

### DIFF
--- a/worker/src/utils/shutdown.ts
+++ b/worker/src/utils/shutdown.ts
@@ -23,9 +23,6 @@ export const onShutdown: NodeJS.SignalsListener = async (signal) => {
   // Shutdown background migrations
   await BackgroundMigrationManager.close();
 
-  // Shutdown clickhouse connections
-  await ClickHouseClientManager.getInstance().closeAllConnections();
-
   // Flush all pending writes to Clickhouse AFTER closing ingestion queue worker that is writing to it
   await ClickhouseWriter.getInstance().shutdown();
   logger.info("Clickhouse writer has been shut down.");
@@ -35,6 +32,9 @@ export const onShutdown: NodeJS.SignalsListener = async (signal) => {
 
   await prisma.$disconnect();
   logger.info("Prisma connection has been closed.");
+
+  // Shutdown clickhouse connections
+  await ClickHouseClientManager.getInstance().closeAllConnections();
 
   freeAllTokenizers();
   logger.info("All tokenizers are cleaned up from memory.");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add backoff retries to `ClickhouseWriter` for retryable errors and adjust shutdown sequence to close Clickhouse connections after flushing writes.
> 
>   - **Retries**:
>     - Add `backOff` retries in `flush()` in `ClickhouseWriter` for retryable errors (e.g., socket hang-ups).
>     - Introduce `isRetryableError()` to identify retryable errors.
>   - **Shutdown**:
>     - Move `ClickHouseClientManager.closeAllConnections()` after `ClickhouseWriter.shutdown()` in `shutdown.ts` to ensure all writes are flushed before closing connections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 46c32f7895adb81a9565ba809db880daa9718dac. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->