### PR TITLE
fix: Ensure json output for single value csv import

### DIFF
--- a/web/src/features/datasets/lib/csvHelpers.ts
+++ b/web/src/features/datasets/lib/csvHelpers.ts
@@ -214,7 +214,6 @@ export function parseColumns(
   headerMap: Map<string, number>,
 ): Prisma.JsonValue {
   if (columnNames.length === 0) return null;
-  // Always return JSON object, even for single columns
   return Object.fromEntries(
     columnNames.map((col) => [col, parseValue(row[headerMap.get(col)!])]),
   );

--- a/web/src/features/datasets/lib/csvHelpers.ts
+++ b/web/src/features/datasets/lib/csvHelpers.ts
@@ -214,9 +214,7 @@ export function parseColumns(
   headerMap: Map<string, number>,
 ): Prisma.JsonValue {
   if (columnNames.length === 0) return null;
-  if (columnNames.length === 1) {
-    return parseValue(row[headerMap.get(columnNames[0])!]);
-  }
+  // Always return JSON object, even for single columns
   return Object.fromEntries(
     columnNames.map((col) => [col, parseValue(row[headerMap.get(col)!])]),
   );


### PR DESCRIPTION
```
## What does this PR do?

This PR ensures that when importing CSVs, the `input`, `expectedOutput`, and `metadata` fields of dataset items are consistently stored as JSON objects. Previously, a single mapped column would result in a scalar value, leading to inconsistent data structures. Now, even single-column mappings will be wrapped in a JSON object (e.g., `{"columnName": "value"}`).

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `parseColumns` in `csvHelpers.ts` now returns JSON objects for single-column CSV imports, ensuring consistent data structure.
> 
>   - **Behavior**:
>     - `parseColumns` in `csvHelpers.ts` now returns JSON objects for single-column CSV imports, ensuring consistent data structure.
>   - **Code Changes**:
>     - Removed conditional logic for single-column handling in `parseColumns`.
>     - Updated comment in `parseColumns` to reflect new behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f12ce042164a80bcf21f0798d7d190a8a0163140. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->