### PR TITLE
fix(dashboard): allow score numeric value filter and metric

### DIFF
--- a/web/src/__tests__/queryBuilder.servertest.ts
+++ b/web/src/__tests__/queryBuilder.servertest.ts
@@ -2084,7 +2084,7 @@ describe("queryBuilder", () => {
         // Verify SQL includes segment filter for NUMERIC types
         // Verify SQL includes segment filter for non-NUMERIC types
         expect(compiledQuery).toContain("position(scores_numeric.data_type, {");
-        expect(compiledQuery).toContain("): String}) = 0");
+        expect(compiledQuery).toContain(": String}) = 0");
         expect(Object.values(parameters)).toContain("CATEGORICAL");
 
         const result = await (

--- a/web/src/__tests__/queryBuilder.servertest.ts
+++ b/web/src/__tests__/queryBuilder.servertest.ts
@@ -200,6 +200,39 @@ describe("queryBuilder", () => {
           orderBy: null,
         } as QueryType,
       ],
+      [
+        "scores-numeric query with filters and time dimension",
+        {
+          view: "scores-numeric",
+          dimensions: [],
+          metrics: [
+            {
+              measure: "value",
+              aggregation: "sum",
+            },
+          ],
+          filters: [
+            {
+              column: "name",
+              operator: "=",
+              value: "Money-saved-eval-test",
+              type: "string",
+            },
+            {
+              column: "value",
+              operator: ">",
+              value: 0,
+              type: "number",
+            },
+          ],
+          timeDimension: {
+            granularity: "auto",
+          },
+          fromTimestamp: "2025-07-02T12:39:49.089Z",
+          toTimestamp: "2025-07-09T12:39:49.089Z",
+          orderBy: null,
+        } as QueryType,
+      ],
     ])(
       "should compile query to valid SQL: (%s)",
       async (_name, query: QueryType) => {
@@ -2051,7 +2084,7 @@ describe("queryBuilder", () => {
         // Verify SQL includes segment filter for NUMERIC types
         // Verify SQL includes segment filter for non-NUMERIC types
         expect(compiledQuery).toContain("position(scores_numeric.data_type, {");
-        expect(compiledQuery).toContain(": String}) = 0");
+        expect(compiledQuery).toContain("): String}) = 0");
         expect(Object.values(parameters)).toContain("CATEGORICAL");
 
         const result = await (

--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -517,7 +517,7 @@ export const scoresNumericView: ViewDeclarationType = {
       description: "Identifier of the observation associated with the score.",
     },
     value: {
-      sql: "value",
+      sql: "scores_numeric.value",
       alias: "value",
       type: "number",
       description: "Value of the score.",

--- a/web/src/features/query/server/queryBuilder.ts
+++ b/web/src/features/query/server/queryBuilder.ts
@@ -837,8 +837,6 @@ export class QueryBuilder {
       withFillClause,
     );
 
-    console.log("Built SQL Query:", sql);
-
     return {
       query: sql,
       parameters,

--- a/web/src/features/query/server/queryBuilder.ts
+++ b/web/src/features/query/server/queryBuilder.ts
@@ -837,6 +837,8 @@ export class QueryBuilder {
       withFillClause,
     );
 
+    console.log("Built SQL Query:", sql);
+
     return {
       query: sql,
       parameters,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add test for filtering numeric scores with time dimension and update SQL query for `value` in `scoresNumericView`.
> 
>   - **Tests**:
>     - Add test case for "scores-numeric query with filters and time dimension" in `queryBuilder.servertest.ts`.
>   - **Data Model**:
>     - Update `sql` for `value` in `scoresNumericView` in `dataModel.ts` to `scores_numeric.value` for more precise SQL queries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ced36d7a7cbce4d1da7241dbc043e717f4ace6b2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->