### PR TITLE
fix(prompts): prompt folder pagination fix

### DIFF
--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -196,7 +196,9 @@ export function PromptTable() {
           ? `${currentFolderPath}/${promptName.substring(currentFolderPath.length + 1).split("/")[0]}`
           : promptName.split("/")[0];
 
-        const folderName = getDisplayName(folderPath, currentFolderPath);
+        const folderName = currentFolderPath
+          ? folderPath.substring(currentFolderPath.length + 1)
+          : folderPath;
 
         combinedRows.push(
           createRow({
@@ -210,7 +212,9 @@ export function PromptTable() {
         combinedRows.push(
           createRow({
             id: prompt.id,
-            name: getDisplayName(prompt.id, currentFolderPath),
+            name: currentFolderPath
+              ? prompt.id.substring(currentFolderPath.length + 1)
+              : prompt.id,
             type: prompt.type as "text" | "chat",
             version: prompt.version,
             createdAt: prompt.createdAt,

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -184,13 +184,13 @@ export function PromptTable() {
       const promptName = prompt.id;
 
       // Check if this prompt represents a folder
-      const isfolderRepresentative = currentFolderPath
+      const isFolderRepresentative = currentFolderPath
         ? promptName.includes("/") &&
           promptName.startsWith(`${currentFolderPath}/`) &&
           promptName.substring(currentFolderPath.length + 1).includes("/")
         : promptName.includes("/");
 
-      if (isfolderRepresentative) {
+      if (isFolderRepresentative) {
         // Convert folder representative to folder item
         const folderPath = currentFolderPath
           ? `${currentFolderPath}/${promptName.substring(currentFolderPath.length + 1).split("/")[0]}`

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -174,7 +174,7 @@ export function PromptTable() {
     })),
   );
 
-  // Backend now returns folder representatives, so we just need to detect and convert them
+  // Backend returns folder representatives, so we just need to detect them
   const processedRowData = useMemo(() => {
     if (!promptsRowData.rows) return { ...promptsRowData, rows: [] };
 
@@ -301,6 +301,7 @@ export function PromptTable() {
           <TableLink
             path={`/project/${projectId}/prompts/${encodeURIComponent(rowData.id)}`}
             value={name}
+            title={rowData.id} // Show full prompt path on hover
           />
         ) : undefined;
       },

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -1024,7 +1024,7 @@ export const promptRouter = createTRPCRouter({
             name: input.name,
           },
           ...(input.limit !== undefined && input.page !== undefined
-            ? { take: input.input.limit, skip: input.page * input.limit }
+            ? { take: input.limit, skip: input.page * input.limit }
             : undefined),
           orderBy: [{ version: "desc" }],
         }),

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -88,6 +88,7 @@ export const promptRouter = createTRPCRouter({
         "prompts",
       );
 
+      // pathFilter: SQL WHERE clause to filter prompts by folder (e.g., "AND p.name LIKE 'folder/%'")
       const pathFilter =
         input.pathPrefix !== undefined && input.pathPrefix !== ""
           ? (() => {
@@ -126,9 +127,9 @@ export const promptRouter = createTRPCRouter({
             orderByCondition,
             input.limit,
             input.page,
-            pathFilter,
+            pathFilter, // SQL WHERE clause: filters DB to only prompts in current folder, derived from prefix.
             searchFilter,
-            input.pathPrefix,
+            input.pathPrefix, // Raw folder path: used for segment splitting & folder detection logic
           ),
         ),
         // promptCount
@@ -1340,7 +1341,7 @@ const generatePromptQuery = (
       SELECT
         p.*,  /* keep all columns */
         ROW_NUMBER() OVER (PARTITION BY ${segmentExpr} ORDER BY p.version DESC) AS rn,
-        CASE 
+        CASE
           WHEN SUBSTRING(p.name, CHAR_LENGTH(${prefix}) + 2) LIKE '%/%' THEN 1
           ELSE 2
         END as sort_priority  -- Folders first (1), individual prompts second (2)

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -77,9 +77,6 @@ export const promptRouter = createTRPCRouter({
         scope: "prompts:read",
       });
 
-      const limit: number = input.limit ?? 50;
-      const page: number = input.page ?? 0;
-
       const orderByCondition = orderByToPrismaSql(
         input.orderBy,
         promptsTableCols,
@@ -94,7 +91,7 @@ export const promptRouter = createTRPCRouter({
       const pathFilter =
         input.pathPrefix !== undefined && input.pathPrefix !== ""
           ? (() => {
-              const prefix = input.pathPrefix ;
+              const prefix = input.pathPrefix;
               return Prisma.sql` AND (p.name LIKE ${`${prefix}/%`} OR p.name = ${prefix})`;
             })()
           : Prisma.empty;
@@ -104,7 +101,7 @@ export const promptRouter = createTRPCRouter({
         input.searchQuery !== null &&
         input.searchQuery !== ""
           ? (() => {
-              const q = input.searchQuery ;
+              const q = input.searchQuery;
               return Prisma.sql` AND (p.name ILIKE ${`%${q}%`} OR EXISTS (SELECT 1 FROM UNNEST(p.tags) AS tag WHERE tag ILIKE ${`%${q}%`}))`;
             })()
           : Prisma.empty;
@@ -127,8 +124,8 @@ export const promptRouter = createTRPCRouter({
             input.projectId,
             filterCondition,
             orderByCondition,
-            limit,
-            page,
+            input.limit,
+            input.page,
             pathFilter,
             searchFilter,
             input.pathPrefix,
@@ -142,7 +139,7 @@ export const promptRouter = createTRPCRouter({
             filterCondition,
             Prisma.empty,
             1, // limit
-            0, // page,
+            0, // input.page,
             pathFilter,
             searchFilter,
             input.pathPrefix,
@@ -1026,7 +1023,7 @@ export const promptRouter = createTRPCRouter({
             name: input.name,
           },
           ...(input.limit !== undefined && input.page !== undefined
-            ? { take: input.limit, skip: input.page * input.limit }
+            ? { take: input.input.limit, skip: input.page * input.limit }
             : undefined),
           orderBy: [{ version: "desc" }],
         }),

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -1316,7 +1316,6 @@ const generatePromptQuery = (
   // CTE to get latest versions (same for root and folder queries)
   const latestCTE = Prisma.sql`
     latest AS (
-      /* Get latest version for each prompt name within the (optional) filters */
       SELECT p.*
       FROM prompts p
       WHERE (p.name, p.version) IN (

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -89,13 +89,12 @@ export const promptRouter = createTRPCRouter({
       );
 
       // pathFilter: SQL WHERE clause to filter prompts by folder (e.g., "AND p.name LIKE 'folder/%'")
-      const pathFilter =
-        input.pathPrefix !== undefined && input.pathPrefix !== ""
-          ? (() => {
-              const prefix = input.pathPrefix;
-              return Prisma.sql` AND (p.name LIKE ${`${prefix}/%`} OR p.name = ${prefix})`;
-            })()
-          : Prisma.empty;
+      const pathFilter = input.pathPrefix
+        ? (() => {
+            const prefix = input.pathPrefix;
+            return Prisma.sql` AND (p.name LIKE ${`${prefix}/%`} OR p.name = ${prefix})`;
+          })()
+        : Prisma.empty;
 
       const searchFilter =
         input.searchQuery !== undefined &&

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -1351,7 +1351,7 @@ const generatePromptQuery = (
       ${select}
     FROM grouped p
     WHERE rn = 1
-    ${orderCondition.sql ? Prisma.sql`ORDER BY p.sort_priority, ${Prisma.raw(orderCondition.sql.replace("ORDER BY ", ""))}` : Prisma.empty}
+    ${orderCondition.sql ? Prisma.sql`ORDER BY p.sort_priority, ${Prisma.raw(orderCondition.sql.replace(/ORDER BY /i, ""))}` : Prisma.empty}
     LIMIT ${limit} OFFSET ${page * limit};
     `;
   } else {
@@ -1401,7 +1401,7 @@ const generatePromptQuery = (
     SELECT
       ${select}
     FROM combined p
-    ${orderCondition.sql ? Prisma.sql`ORDER BY p.sort_priority, ${Prisma.raw(orderCondition.sql.replace("ORDER BY ", ""))}` : Prisma.empty}
+    ${orderCondition.sql ? Prisma.sql`ORDER BY p.sort_priority, ${Prisma.raw(orderCondition.sql.replace(/ORDER BY /i, ""))}` : Prisma.empty}
     LIMIT ${limit} OFFSET ${page * limit};
     `;
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes prompt folder pagination by updating folder and prompt differentiation logic in both frontend and backend components.
> 
>   - **Behavior**:
>     - Fixes prompt folder pagination by updating logic in `prompts-table.tsx` to correctly identify folder representatives and regular prompts.
>     - Removes `getDisplayName` function and updates folder detection logic in `processedRowData`.
>   - **Backend**:
>     - Updates `generatePromptQuery` in `promptRouter.ts` to handle folder and prompt differentiation using SQL CTEs and sorting logic.
>     - Adds `pathPrefix` handling for SQL query filtering in `promptRouter.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 92bd6edcda041f8c9ef9f308958b56936d533e0a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->