### PR TITLE
fix: gracefully handle missing config for webhooks

### DIFF
--- a/packages/shared/src/server/automations/webhooks.ts
+++ b/packages/shared/src/server/automations/webhooks.ts
@@ -48,7 +48,10 @@ export const executeWebhook = async (input: WebhookInput) => {
     });
 
     if (!automation) {
-      throw new LangfuseNotFoundError(`Automation ${automationId} not found`);
+      logger.warn(
+        `Automation ${automationId} not found for project ${projectId}. We ack the job and will not retry.`,
+      );
+      return;
     }
 
     const actionConfig = await getActionByIdWithSecrets({
@@ -179,7 +182,10 @@ export const executeWebhook = async (input: WebhookInput) => {
     });
 
     if (!automation) {
-      throw new LangfuseNotFoundError(`Automation ${automationId} not found`);
+      logger.warn(
+        `Automation ${automationId} not found for project ${projectId}. We ack the job and will not retry.`,
+      );
+      return;
     }
 
     const shouldRetryJob =


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `executeWebhook` now handles missing automation configurations gracefully by logging a warning and returning without error.
> 
>   - **Behavior**:
>     - In `webhooks.ts`, `executeWebhook` now logs a warning and returns if `automation` is not found, instead of throwing `LangfuseNotFoundError`.
>     - Similar change for missing `automation` in the error handling block of `executeWebhook`.
>   - **Tests**:
>     - Added test case in `webhooks.test.ts` to verify `executeWebhook` handles missing automation gracefully without throwing an error.
>     - Ensures no execution record is created when automation is missing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4cc03fe30c4d10d39fc185e710d61f5e3859c2a6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->