### PR TITLE
fix: stripe webhook should also match subscriptions which were not created via checkout session

### DIFF
--- a/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
+++ b/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
@@ -7,7 +7,11 @@ import { type NextRequest, NextResponse } from "next/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { stripeClient } from "@/src/ee/features/billing/utils/stripe";
 import type Stripe from "stripe";
-import { CloudConfigSchema, parseDbOrg } from "@langfuse/shared";
+import {
+  CloudConfigSchema,
+  type Organization,
+  parseDbOrg,
+} from "@langfuse/shared";
 import { traceException, redis, logger } from "@langfuse/shared/src/server";
 import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
 
@@ -91,56 +95,45 @@ export async function stripeWebhookApiHandler(req: NextRequest) {
   return NextResponse.json({ received: true }, { status: 200 });
 }
 
-async function handleSubscriptionChanged(
-  subscription: Stripe.Subscription,
-  action: "created" | "deleted" | "updated",
-) {
-  const subscriptionId = subscription.id;
+async function getOrgBasedOnActiveSubscriptionId(
+  subscriptionId: string,
+): Promise<Organization | null> {
+  const orgBasedOnSubscriptionId = await prisma.organization.findFirst({
+    where: {
+      cloudConfig: {
+        path: ["stripe", "activeSubscriptionId"],
+        equals: subscriptionId,
+      },
+    },
+  });
+  return orgBasedOnSubscriptionId;
+}
 
-  // Attempt to find the org based on the subscription id
-  // const org = await prisma.organization.findFirst({
-  //   where: {
-  //     cloudConfig: {
-
-  //       stripe: {
-  //         activeSubscriptionId: subscriptionId,
-  //       },
-  //     },
-  //   },
-  // });
-  // if (!org) {
-  //   logger.error("[Stripe Webhook] Organization not found");
-  //   traceException("[Stripe Webhook] Organization not found");
-  //   return;
-  // }
-
+async function getOrgBasedOnCheckoutSessionAttachedToSubscription(
+  subscriptionId: string,
+): Promise<Organization | null> {
   // get the checkout session from the subscription to retrieve the client reference for this subscription
   const checkoutSessionsResponse = await stripeClient?.checkout.sessions.list({
     subscription: subscriptionId,
     limit: 1,
   });
   if (!checkoutSessionsResponse || checkoutSessionsResponse.data.length !== 1) {
-    logger.error("[Stripe Webhook] No checkout session found");
-    traceException("[Stripe Webhook] No checkout session found");
-    return;
+    logger.warn("[Stripe Webhook] No checkout session found");
+    return null;
   }
   const checkoutSession = checkoutSessionsResponse.data[0];
 
   // the client reference is passed to the stripe checkout session via the pricing page
   const clientReference = checkoutSession.client_reference_id;
   if (!clientReference) {
-    logger.error("[Stripe Webhook] No client reference");
-    traceException("[Stripe Webhook] No client reference");
-    return NextResponse.json(
-      { message: "No client reference" },
-      { status: 400 },
-    );
+    logger.warn("[Stripe Webhook] No client reference");
+    return null;
   }
   if (!isStripeClientReferenceFromCurrentCloudRegion(clientReference)) {
     logger.info(
       "[Stripe Webhook] Client reference not from current cloud region",
     );
-    return;
+    return null;
   }
   const orgId = getOrgIdFromStripeClientReference(clientReference);
 
@@ -150,9 +143,31 @@ async function handleSubscriptionChanged(
       id: orgId,
     },
   });
+  return organization;
+}
+
+async function handleSubscriptionChanged(
+  subscription: Stripe.Subscription,
+  action: "created" | "deleted" | "updated",
+) {
+  const subscriptionId = subscription.id;
+
+  let organization: Organization | null = null;
+
+  // For existing subscriptions, we can use the active subscription id to find the org
+  // More reliable than the checkout session attached to the subscription for subscriptions that were manually set up
+  organization = await getOrgBasedOnActiveSubscriptionId(subscriptionId);
+
+  // Reuquired fallback for new subscriptions
   if (!organization) {
-    logger.error("[Stripe Webhook] Organization not found");
-    traceException("[Stripe Webhook] Organization not found");
+    organization =
+      await getOrgBasedOnCheckoutSessionAttachedToSubscription(subscriptionId);
+  }
+
+  if (!organization) {
+    logger.info(
+      "[Stripe Webhook] Organization not found for this subscription",
+    );
     return;
   }
   const parsedOrg = parseDbOrg(organization);

--- a/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
+++ b/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
@@ -158,7 +158,7 @@ async function handleSubscriptionChanged(
   // More reliable than the checkout session attached to the subscription for subscriptions that were manually set up
   organization = await getOrgBasedOnActiveSubscriptionId(subscriptionId);
 
-  // Reuquired fallback for new subscriptions
+  // Required fallback for new subscriptions
   if (!organization) {
     organization =
       await getOrgBasedOnCheckoutSessionAttachedToSubscription(subscriptionId);

--- a/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
+++ b/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
@@ -97,6 +97,23 @@ async function handleSubscriptionChanged(
 ) {
   const subscriptionId = subscription.id;
 
+  // Attempt to find the org based on the subscription id
+  // const org = await prisma.organization.findFirst({
+  //   where: {
+  //     cloudConfig: {
+
+  //       stripe: {
+  //         activeSubscriptionId: subscriptionId,
+  //       },
+  //     },
+  //   },
+  // });
+  // if (!org) {
+  //   logger.error("[Stripe Webhook] Organization not found");
+  //   traceException("[Stripe Webhook] Organization not found");
+  //   return;
+  // }
+
   // get the checkout session from the subscription to retrieve the client reference for this subscription
   const checkoutSessionsResponse = await stripeClient?.checkout.sessions.list({
     subscription: subscriptionId,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `stripeWebhookApiHandler.ts` to match subscriptions not created via checkout session and adjust logging levels for certain errors.
> 
>   - **Behavior**:
>     - `handleSubscriptionChanged` now matches subscriptions not created via checkout session by using `getOrgBasedOnActiveSubscriptionId` and `getOrgBasedOnCheckoutSessionAttachedToSubscription`.
>     - Changes error logging to warning for missing checkout session and client reference in `getOrgBasedOnCheckoutSessionAttachedToSubscription`.
>   - **Functions**:
>     - Adds `getOrgBasedOnActiveSubscriptionId` to find organizations by active subscription ID.
>     - Adds `getOrgBasedOnCheckoutSessionAttachedToSubscription` to find organizations by checkout session attached to subscription.
>   - **Logging**:
>     - Changes error logs to warnings for missing checkout session and client reference in `getOrgBasedOnCheckoutSessionAttachedToSubscription`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7f2896fcd31d7983a9dafd6fdeae7527e9e85cc2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->