### PR TITLE
chore: forbid html elements on names and descriptions via trpc routes

### DIFF
--- a/packages/shared/src/features/annotation/types.ts
+++ b/packages/shared/src/features/annotation/types.ts
@@ -1,5 +1,6 @@
 import z from "zod/v4";
 import { type ScoreDataType } from "../../db";
+import { StringNoHTML, StringNoHTMLNonEmpty } from "../../utils/zod";
 
 const NUMERIC: ScoreDataType = "NUMERIC";
 const CATEGORICAL: ScoreDataType = "CATEGORICAL";
@@ -47,12 +48,12 @@ export type ScoreTargetSession = z.infer<typeof ScoreTargetSession>;
 export type ScoreTarget = z.infer<typeof ScoreTarget>;
 
 const CreateAnnotationScoreBase = z.object({
-  name: z.string(),
+  name: StringNoHTML,
   projectId: z.string(),
   environment: z.string().default("default"),
   scoreTarget: ScoreTarget,
   configId: z.string().optional(),
-  comment: z.string().nullish(),
+  comment: StringNoHTML.nullish(),
   queueId: z.string().nullish(),
 });
 
@@ -83,8 +84,8 @@ export const UpdateAnnotationScoreData = z.discriminatedUnion("dataType", [
 // annotation queues
 
 export const CreateQueueData = z.object({
-  name: z.string().min(1).max(35),
-  description: z.string().max(1000).optional(),
+  name: StringNoHTMLNonEmpty.max(35),
+  description: StringNoHTML.max(1000).optional(),
   scoreConfigIds: z.array(z.string()).min(1, {
     message: "At least 1 score config must be selected",
   }),

--- a/packages/shared/src/features/annotation/types.ts
+++ b/packages/shared/src/features/annotation/types.ts
@@ -48,7 +48,7 @@ export type ScoreTargetSession = z.infer<typeof ScoreTargetSession>;
 export type ScoreTarget = z.infer<typeof ScoreTarget>;
 
 const CreateAnnotationScoreBase = z.object({
-  name: StringNoHTML,
+  name: StringNoHTMLNonEmpty,
   projectId: z.string(),
   environment: z.string().default("default"),
   scoreTarget: ScoreTarget,

--- a/packages/shared/src/features/prompts/types.ts
+++ b/packages/shared/src/features/prompts/types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod/v4";
 import type { Prompt } from "../../../prisma/generated/types";
-import { jsonSchema, StringNoHTML } from "../../utils/zod";
+import { jsonSchema } from "../../utils/zod";
 import { COMMIT_MESSAGE_MAX_LENGTH } from "./constants";
 import { PromptChatMessageSchema } from "../../server/llm/types";
 import { PromptNameSchema } from "./validation";
@@ -36,7 +36,7 @@ const BaseCreateTextPromptSchema = z.object({
 const LegacyCreateTextPromptSchema = BaseCreateTextPromptSchema;
 
 export const CreateTextPromptSchema = BaseCreateTextPromptSchema.extend({
-  commitMessage: StringNoHTML.max(COMMIT_MESSAGE_MAX_LENGTH).nullish(),
+  commitMessage: z.string().max(COMMIT_MESSAGE_MAX_LENGTH).nullish(),
 });
 
 const BaseCreateChatPromptSchema = z.object({
@@ -51,7 +51,7 @@ const BaseCreateChatPromptSchema = z.object({
 const LegacyCreateChatPromptSchema = BaseCreateChatPromptSchema;
 
 export const CreateChatPromptSchema = BaseCreateChatPromptSchema.extend({
-  commitMessage: StringNoHTML.max(COMMIT_MESSAGE_MAX_LENGTH).nullish(),
+  commitMessage: z.string().max(COMMIT_MESSAGE_MAX_LENGTH).nullish(),
 });
 
 export const CreatePromptSchema = z.union([

--- a/packages/shared/src/features/prompts/types.ts
+++ b/packages/shared/src/features/prompts/types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod/v4";
 import type { Prompt } from "../../../prisma/generated/types";
-import { jsonSchema } from "../../utils/zod";
+import { jsonSchema, StringNoHTML } from "../../utils/zod";
 import { COMMIT_MESSAGE_MAX_LENGTH } from "./constants";
 import { PromptChatMessageSchema } from "../../server/llm/types";
 import { PromptNameSchema } from "./validation";
@@ -36,7 +36,7 @@ const BaseCreateTextPromptSchema = z.object({
 const LegacyCreateTextPromptSchema = BaseCreateTextPromptSchema;
 
 export const CreateTextPromptSchema = BaseCreateTextPromptSchema.extend({
-  commitMessage: z.string().max(COMMIT_MESSAGE_MAX_LENGTH).nullish(),
+  commitMessage: StringNoHTML.max(COMMIT_MESSAGE_MAX_LENGTH).nullish(),
 });
 
 const BaseCreateChatPromptSchema = z.object({
@@ -51,7 +51,7 @@ const BaseCreateChatPromptSchema = z.object({
 const LegacyCreateChatPromptSchema = BaseCreateChatPromptSchema;
 
 export const CreateChatPromptSchema = BaseCreateChatPromptSchema.extend({
-  commitMessage: z.string().max(COMMIT_MESSAGE_MAX_LENGTH).nullish(),
+  commitMessage: StringNoHTML.max(COMMIT_MESSAGE_MAX_LENGTH).nullish(),
 });
 
 export const CreatePromptSchema = z.union([

--- a/packages/shared/src/features/prompts/validation.ts
+++ b/packages/shared/src/features/prompts/validation.ts
@@ -1,12 +1,12 @@
-import { z } from "zod/v4";
+import { StringNoHTMLNonEmpty } from "../../utils/zod";
 
 /**
  * Prompt name validation schema for API, tRPC and client
  */
-export const PromptNameSchema = z
-  .string()
-  .min(1, "Enter a name")
-  .regex(/^[^|]*$/, "Prompt name cannot contain '|' character")
+export const PromptNameSchema = StringNoHTMLNonEmpty.regex(
+  /^[^|]*$/,
+  "Prompt name cannot contain '|' character",
+)
   .regex(/^[^/]/, "Name cannot start with a slash")
   .regex(/^(?!.*\/\/)/, "Name cannot contain consecutive slashes")
   .regex(/^.*[^/]$/, "Name cannot end with a slash")

--- a/packages/shared/src/utils/zod.ts
+++ b/packages/shared/src/utils/zod.ts
@@ -94,7 +94,7 @@ export const StringNoHTML = z.string().refine((val) => !htmlRegex.test(val), {
 
 export const StringNoHTMLNonEmpty = z
   .string()
-  .min(1)
+  .min(1, "Text cannot be empty")
   .refine((val) => !htmlRegex.test(val), {
     message: "Text cannot contain HTML tags",
   });

--- a/packages/shared/src/utils/zod.ts
+++ b/packages/shared/src/utils/zod.ts
@@ -80,13 +80,12 @@ export const paginationMetaResponseZod = z.object({
   totalPages: z.number().int().nonnegative(),
 });
 
-export const htmlRegex = /<[^>]*>/;
-export const noHtmlCheck = (value: string) => !htmlRegex.test(value);
-
 const urlRegex = /https?:\/\/[^\s/$.?#].[^\s]*/i;
 export const noUrlCheck = (value: string) => !urlRegex.test(value);
 
 export const NonEmptyString = z.string().min(1);
+
+export const htmlRegex = /<[^>]*>/;
 
 export const StringNoHTML = z.string().refine((val) => !htmlRegex.test(val), {
   message: "Text cannot contain HTML tags",

--- a/packages/shared/src/utils/zod.ts
+++ b/packages/shared/src/utils/zod.ts
@@ -88,6 +88,17 @@ export const noUrlCheck = (value: string) => !urlRegex.test(value);
 
 export const NonEmptyString = z.string().min(1);
 
+export const StringNoHTML = z.string().refine((val) => !htmlRegex.test(val), {
+  message: "Text cannot contain HTML tags",
+});
+
+export const StringNoHTMLNonEmpty = z
+  .string()
+  .min(1)
+  .refine((val) => !htmlRegex.test(val), {
+    message: "Text cannot contain HTML tags",
+  });
+
 /**
  * Validates an object against a Zod schema and helps with IDE type warnings.
  *

--- a/web/src/__tests__/async/prompts.v2.servertest.ts
+++ b/web/src/__tests__/async/prompts.v2.servertest.ts
@@ -922,6 +922,9 @@ describe("/api/public/v2/prompts API Endpoint", () => {
         );
         expect(response.status).toBe(400);
         expect(response.body.message).toBe("Invalid request data");
+        expect(JSON.stringify(response.body.error)).toContain(
+          `"message":"${expectedError}"`,
+        );
         const hasExpectedMessage = JSON.stringify(response.body.error).includes(
           `"message":"${expectedError}"`,
         );
@@ -969,7 +972,12 @@ describe("/api/public/v2/prompts API Endpoint", () => {
           auth,
         );
         await testInvalidName("new", "Prompt name cannot be 'new'", auth);
-        await testInvalidName("", "Enter a name", auth);
+        await testInvalidName("", "Text cannot be empty", auth);
+        await testInvalidName(
+          "Test <div>",
+          "Text cannot contain HTML tags",
+          auth,
+        );
       });
 
       it("should accept valid prompt names", async () => {

--- a/web/src/features/auth/lib/projectNameSchema.ts
+++ b/web/src/features/auth/lib/projectNameSchema.ts
@@ -1,12 +1,9 @@
-import { noHtmlCheck } from "@langfuse/shared";
 import * as z from "zod/v4";
+import { StringNoHTMLNonEmpty } from "@langfuse/shared";
 
 export const projectNameSchema = z.object({
-  name: z
-    .string()
-    .min(3, "Must have at least 3 characters")
-    .max(60, "Must have at most 60 characters")
-    .refine((value) => noHtmlCheck(value), {
-      message: "Input should not contain HTML",
-    }),
+  name: StringNoHTMLNonEmpty.min(3, "Must have at least 3 characters").max(
+    60,
+    "Must have at most 60 characters",
+  ),
 });

--- a/web/src/features/auth/lib/projectNameSchema.ts
+++ b/web/src/features/auth/lib/projectNameSchema.ts
@@ -1,8 +1,8 @@
 import * as z from "zod/v4";
-import { StringNoHTMLNonEmpty } from "@langfuse/shared";
+import { StringNoHTML } from "@langfuse/shared";
 
 export const projectNameSchema = z.object({
-  name: StringNoHTMLNonEmpty.min(3, "Must have at least 3 characters").max(
+  name: StringNoHTML.min(3, "Must have at least 3 characters").max(
     60,
     "Must have at most 60 characters",
   ),

--- a/web/src/features/auth/lib/signupSchema.ts
+++ b/web/src/features/auth/lib/signupSchema.ts
@@ -1,4 +1,4 @@
-import { noHtmlCheck, noUrlCheck } from "@langfuse/shared";
+import { noUrlCheck, StringNoHTMLNonEmpty } from "@langfuse/shared";
 import * as z from "zod/v4";
 
 export const passwordSchema = z
@@ -18,15 +18,9 @@ export const passwordSchema = z
   });
 
 export const signupSchema = z.object({
-  name: z
-    .string()
-    .min(1, { message: "Name is required" })
-    .refine((value) => noHtmlCheck(value), {
-      message: "Input should not contain HTML",
-    })
-    .refine((value) => noUrlCheck(value), {
-      message: "Input should not contain a URL",
-    }),
+  name: StringNoHTMLNonEmpty.refine((value) => noUrlCheck(value), {
+    message: "Input should not contain a URL",
+  }),
   email: z.string().email(),
   password: passwordSchema,
   referralSource: z.string().optional(),

--- a/web/src/features/dashboard/server/dashboard-router.ts
+++ b/web/src/features/dashboard/server/dashboard-router.ts
@@ -26,7 +26,13 @@ import {
   type QueryType,
   query as customQuery,
 } from "@/src/features/query/types";
-import { paginationZod, orderBy, InvalidRequestError } from "@langfuse/shared";
+import {
+  paginationZod,
+  orderBy,
+  InvalidRequestError,
+  StringNoHTML,
+  StringNoHTMLNonEmpty,
+} from "@langfuse/shared";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 
 // Define the dashboard list input schema
@@ -53,15 +59,15 @@ const UpdateDashboardDefinitionInput = z.object({
 const UpdateDashboardInput = z.object({
   projectId: z.string(),
   dashboardId: z.string(),
-  name: z.string().min(1, "Dashboard name is required"),
-  description: z.string(),
+  name: StringNoHTMLNonEmpty.min(1, "Dashboard name is required"),
+  description: StringNoHTML,
 });
 
 // Create dashboard input schema
 const CreateDashboardInput = z.object({
   projectId: z.string(),
-  name: z.string().min(1, "Dashboard name is required"),
-  description: z.string(),
+  name: StringNoHTMLNonEmpty.min(1, "Dashboard name is required"),
+  description: StringNoHTML,
 });
 
 // Clone dashboard input schema

--- a/web/src/features/dashboard/server/dashboard-router.ts
+++ b/web/src/features/dashboard/server/dashboard-router.ts
@@ -31,7 +31,6 @@ import {
   orderBy,
   InvalidRequestError,
   StringNoHTML,
-  StringNoHTMLNonEmpty,
 } from "@langfuse/shared";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 
@@ -59,14 +58,14 @@ const UpdateDashboardDefinitionInput = z.object({
 const UpdateDashboardInput = z.object({
   projectId: z.string(),
   dashboardId: z.string(),
-  name: StringNoHTMLNonEmpty.min(1, "Dashboard name is required"),
+  name: StringNoHTML.min(1, "Dashboard name is required"),
   description: StringNoHTML,
 });
 
 // Create dashboard input schema
 const CreateDashboardInput = z.object({
   projectId: z.string(),
-  name: StringNoHTMLNonEmpty.min(1, "Dashboard name is required"),
+  name: StringNoHTML.min(1, "Dashboard name is required"),
   description: StringNoHTML,
 });
 

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -432,7 +432,7 @@ export const datasetRouter = createTRPCRouter({
     .input(
       z.object({
         projectId: z.string(),
-        name: StringNoHTML,
+        name: StringNoHTMLNonEmpty,
         description: StringNoHTML.nullish(),
         metadata: z.string().nullish(),
       }),

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -7,7 +7,13 @@ import { Prisma, type Dataset } from "@langfuse/shared/src/db";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { DB } from "@/src/server/db";
-import { paginationZod, DatasetStatus, singleFilter } from "@langfuse/shared";
+import {
+  paginationZod,
+  DatasetStatus,
+  singleFilter,
+  StringNoHTML,
+  StringNoHTMLNonEmpty,
+} from "@langfuse/shared";
 import { TRPCError } from "@trpc/server";
 import {
   createDatasetRunsTable,
@@ -426,8 +432,8 @@ export const datasetRouter = createTRPCRouter({
     .input(
       z.object({
         projectId: z.string(),
-        name: z.string(),
-        description: z.string().nullish(),
+        name: StringNoHTML,
+        description: StringNoHTML.nullish(),
         metadata: z.string().nullish(),
       }),
     )
@@ -466,8 +472,8 @@ export const datasetRouter = createTRPCRouter({
       z.object({
         projectId: z.string(),
         datasetId: z.string(),
-        name: z.string().nullish(),
-        description: z.string().nullish(),
+        name: StringNoHTMLNonEmpty.nullish(),
+        description: StringNoHTML.nullish(),
         metadata: z.string().nullish(),
       }),
     )

--- a/web/src/features/organizations/utils/organizationNameSchema.ts
+++ b/web/src/features/organizations/utils/organizationNameSchema.ts
@@ -1,12 +1,9 @@
-import { noHtmlCheck } from "@langfuse/shared";
+import { StringNoHTMLNonEmpty } from "@langfuse/shared";
 import * as z from "zod/v4";
 
 export const organizationNameSchema = z.object({
-  name: z
-    .string()
-    .min(3, "Must have at least 3 characters")
-    .max(60, "Must have at most 60 characters")
-    .refine((value) => noHtmlCheck(value), {
-      message: "Input should not contain HTML",
-    }),
+  name: StringNoHTMLNonEmpty.min(3, "Must have at least 3 characters").max(
+    60,
+    "Must have at most 60 characters",
+  ),
 });

--- a/web/src/features/organizations/utils/organizationNameSchema.ts
+++ b/web/src/features/organizations/utils/organizationNameSchema.ts
@@ -1,8 +1,8 @@
-import { StringNoHTMLNonEmpty } from "@langfuse/shared";
+import { StringNoHTML } from "@langfuse/shared";
 import * as z from "zod/v4";
 
 export const organizationNameSchema = z.object({
-  name: StringNoHTMLNonEmpty.min(3, "Must have at least 3 characters").max(
+  name: StringNoHTML.min(3, "Must have at least 3 characters").max(
     60,
     "Must have at most 60 characters",
   ),

--- a/web/src/features/projects/server/projectsRouter.ts
+++ b/web/src/features/projects/server/projectsRouter.ts
@@ -17,12 +17,13 @@ import {
   getEnvironmentsForProject,
 } from "@langfuse/shared/src/server";
 import { randomUUID } from "crypto";
+import { StringNoHTMLNonEmpty } from "@langfuse/shared";
 
 export const projectsRouter = createTRPCRouter({
   create: protectedOrganizationProcedure
     .input(
       z.object({
-        name: z.string(),
+        name: StringNoHTMLNonEmpty,
         orgId: z.string(),
       }),
     )

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -19,6 +19,7 @@ import {
   PromptLabelSchema,
   promptsTableCols,
   PromptType,
+  StringNoHTML,
 } from "@langfuse/shared";
 import { orderBy, singleFilter } from "@langfuse/shared";
 import {
@@ -267,7 +268,7 @@ export const promptRouter = createTRPCRouter({
       z.object({
         projectId: z.string(),
         promptId: z.string(),
-        name: z.string(),
+        name: StringNoHTML,
         isSingleVersion: z.boolean(),
       }),
     )

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -19,7 +19,7 @@ import {
   PromptLabelSchema,
   promptsTableCols,
   PromptType,
-  StringNoHTML,
+  StringNoHTMLNonEmpty,
 } from "@langfuse/shared";
 import { orderBy, singleFilter } from "@langfuse/shared";
 import {
@@ -280,7 +280,7 @@ export const promptRouter = createTRPCRouter({
       z.object({
         projectId: z.string(),
         promptId: z.string(),
-        name: StringNoHTML,
+        name: StringNoHTMLNonEmpty,
         isSingleVersion: z.boolean(),
       }),
     )

--- a/web/src/features/public-api/server/projectApiKeyRouter.ts
+++ b/web/src/features/public-api/server/projectApiKeyRouter.ts
@@ -8,6 +8,7 @@ import * as z from "zod/v4";
 import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
 import { redis } from "@langfuse/shared/src/server";
 import { createAndAddApiKeysToDb } from "@langfuse/shared/src/server/auth/apiKeys";
+import { StringNoHTML } from "@langfuse/shared";
 
 export const projectApiKeysRouter = createTRPCRouter({
   byProjectId: protectedProjectProcedure
@@ -46,7 +47,7 @@ export const projectApiKeysRouter = createTRPCRouter({
     .input(
       z.object({
         projectId: z.string(),
-        note: z.string().optional(),
+        note: StringNoHTML.optional(),
       }),
     )
     .mutation(async ({ input, ctx }) => {
@@ -77,7 +78,7 @@ export const projectApiKeysRouter = createTRPCRouter({
       z.object({
         projectId: z.string(),
         keyId: z.string(),
-        note: z.string(),
+        note: StringNoHTML,
       }),
     )
     .mutation(async ({ input, ctx }) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add validation to prevent HTML elements in names and descriptions across various schemas and routes using `StringNoHTML` and `StringNoHTMLNonEmpty`.
> 
>   - **Validation**:
>     - Introduce `StringNoHTML` and `StringNoHTMLNonEmpty` in `zod.ts` to prevent HTML in strings.
>     - Apply `StringNoHTMLNonEmpty` to `name` fields in `CreateAnnotationScoreBase`, `CreateQueueData`, `PromptNameSchema`, `projectNameSchema`, `signupSchema`, `organizationNameSchema`, and `projectsRouter`.
>     - Apply `StringNoHTML` to `description` fields in `CreateQueueData`, `CreateDashboardInput`, `UpdateDashboardInput`, `CreateDataset`, `UpdateDataset`, and `projectApiKeyRouter`.
>   - **Tests**:
>     - Update `prompts.v2.servertest.ts` to test for HTML content in prompt names, ensuring validation errors are thrown.
>   - **Misc**:
>     - Remove `noHtmlCheck` function from `projectNameSchema.ts` and `organizationNameSchema.ts`.
>     - Update error messages in tests to reflect new validation rules.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 39435524e3a5721c6e8fa226cac1ae58aca66ce0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->