### PR TITLE
feat(table): persist column sizes in local storage

### DIFF
--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -38,6 +38,7 @@ import { type PeekViewProps } from "@/src/components/table/peek/hooks/usePeekVie
 import { usePeekView } from "@/src/components/table/peek/hooks/usePeekView";
 import { isEqual } from "lodash";
 import { useRouter } from "next/router";
+import { useColumnSizing } from "@/src/components/table/hooks/useColumnSizing";
 
 interface DataTableProps<TData, TValue> {
   columns: LangfuseColumnDef<TData, TValue>[];
@@ -65,6 +66,7 @@ interface DataTableProps<TData, TValue> {
   peekView?: PeekViewProps<TData>;
   pinFirstColumn?: boolean;
   hidePagination?: boolean;
+  tableName: string;
 }
 
 export interface AsyncTableData<T> {
@@ -120,6 +122,7 @@ export function DataTable<TData extends object, TValue>({
   peekView,
   pinFirstColumn = false,
   hidePagination = false,
+  tableName,
 }: DataTableProps<TData, TValue>) {
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const rowheighttw = getRowHeightTailwindClass(rowHeight, customRowHeights);
@@ -135,6 +138,8 @@ export function DataTable<TData extends object, TValue>({
     });
     return flatColumnsByGroup;
   }, [columns]);
+
+  const { columnSizing, setColumnSizing } = useColumnSizing(tableName);
 
   const table = useReactTable({
     data: data.data ?? [],
@@ -169,7 +174,9 @@ export function DataTable<TData extends object, TValue>({
         ? insertArrayAfterKey(columnOrder, flattedColumnsByGroup)
         : undefined,
       rowSelection,
+      columnSizing,
     },
+    onColumnSizingChange: setColumnSizing,
     manualFiltering: true,
     defaultColumn: {
       minSize: 20,

--- a/web/src/components/table/hooks/useColumnSizing.ts
+++ b/web/src/components/table/hooks/useColumnSizing.ts
@@ -1,0 +1,44 @@
+import useLocalStorage from "@/src/components/useLocalStorage";
+import { type ColumnSizingState } from "@tanstack/react-table";
+import { debounce } from "lodash";
+import { useEffect, useMemo, useState } from "react";
+
+/**
+ * Persists table column widths to localStorage with automatic debounced saving.
+ *
+ * @param tableId - Unique identifier for the table to scope column settings
+ * @returns Column sizing state, setter, and utility functions for TanStack Table integration
+ *
+ * @note Limitation: Multi-tab sync occurs only on page refresh/navigation, not in real-time.
+ * @note Column state is initialized once on mount from localStorage.
+ */
+export const useColumnSizing = (tableId: string) => {
+  const [storedSizing, setStoredSizing] = useLocalStorage<ColumnSizingState>(
+    `table-columns-${tableId}`,
+    {},
+  );
+
+  const [columnSizing, setColumnSizing] =
+    useState<ColumnSizingState>(storedSizing);
+
+  // Debounced storage update
+  const debouncedSave = useMemo(
+    () =>
+      debounce((sizing: ColumnSizingState) => {
+        if (tableId && Object.keys(sizing).length > 0) {
+          setStoredSizing(sizing);
+        }
+      }, 500),
+    [tableId, setStoredSizing],
+  );
+
+  // Save to storage when state changes
+  useEffect(() => {
+    debouncedSave(columnSizing);
+  }, [columnSizing, debouncedSave]);
+
+  return {
+    columnSizing,
+    setColumnSizing,
+  };
+};

--- a/web/src/components/table/use-cases/models.tsx
+++ b/web/src/components/table/use-cases/models.tsx
@@ -295,6 +295,7 @@ export default function ModelTable({ projectId }: { projectId: string }) {
       />
       <SettingsTableCard>
         <DataTable
+          tableName={"models"}
           columns={columns}
           data={
             models.isLoading

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -995,6 +995,7 @@ export default function ObservationsTable({
         }}
       />
       <DataTable
+        tableName={"observations"}
         columns={columns}
         peekView={peekConfig}
         data={

--- a/web/src/components/table/use-cases/score-configs.tsx
+++ b/web/src/components/table/use-cases/score-configs.tsx
@@ -254,6 +254,7 @@ export function ScoreConfigsTable({ projectId }: { projectId: string }) {
       />
       <SettingsTableCard>
         <DataTable
+          tableName={"scoreConfigs"}
           columns={columns}
           data={
             configs.isLoading

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -678,6 +678,7 @@ export default function ScoresTable({
         }}
       />
       <DataTable
+        tableName={"scores"}
         columns={columns}
         data={
           scores.isLoading || isViewLoading

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -590,6 +590,7 @@ export default function SessionsTable({
         }}
       />
       <DataTable
+        tableName={"sessions"}
         columns={columns}
         data={
           sessions.isLoading || isViewLoading

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -1207,6 +1207,7 @@ export default function TracesTable({
         rowHeight={rowHeight}
         pinFirstColumn={!hideControls}
         peekView={peekConfig}
+        tableName={"traces"}
       />
     </>
   );

--- a/web/src/ee/features/audit-log-viewer/AuditLogsTable.tsx
+++ b/web/src/ee/features/audit-log-viewer/AuditLogsTable.tsx
@@ -138,6 +138,7 @@ export function AuditLogsTable(props: { projectId: string }) {
       />
       <SettingsTableCard>
         <DataTable
+          tableName={"auditLogs"}
           columns={columns}
           data={
             auditLogs.isLoading

--- a/web/src/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
@@ -370,6 +370,7 @@ export function AnnotationQueueItemsTable({
         ]}
       />
       <DataTable
+        tableName={"annotationQueueItems"}
         columns={columns}
         data={
           items.isLoading

--- a/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
@@ -238,6 +238,7 @@ export function AnnotationQueuesTable({ projectId }: { projectId: string }) {
         setRowHeight={setRowHeight}
       />
       <DataTable
+        tableName={"annotationQueues"}
         columns={columns}
         data={
           queues.isLoading

--- a/web/src/features/automations/components/AutomationExecutionsTable.tsx
+++ b/web/src/features/automations/components/AutomationExecutionsTable.tsx
@@ -158,6 +158,7 @@ export const AutomationExecutionsTable: React.FC<
         setRowHeight={setRowHeight}
       />
       <DataTable
+        tableName={"automationExecutions"}
         columns={columns}
         data={{
           isLoading,

--- a/web/src/features/background-migrations/components/background-migrations.tsx
+++ b/web/src/features/background-migrations/components/background-migrations.tsx
@@ -87,6 +87,7 @@ export default function BackgroundMigrationsTable() {
       <Header title="Background Migrations" />
       <DataTableToolbar columns={columns} />
       <DataTable
+        tableName={"backgroundMigrations"}
         columns={columns}
         data={
           backgroundMigrations.isLoading

--- a/web/src/features/batch-exports/components/BatchExportsTable.tsx
+++ b/web/src/features/batch-exports/components/BatchExportsTable.tsx
@@ -134,6 +134,7 @@ export function BatchExportsTable(props: { projectId: string }) {
   return (
     <>
       <DataTable
+        tableName={"batchExports"}
         columns={columns}
         data={
           batchExports.isLoading

--- a/web/src/features/dashboard/components/DashboardTable.tsx
+++ b/web/src/features/dashboard/components/DashboardTable.tsx
@@ -282,6 +282,7 @@ export function DashboardTable() {
 
   return (
     <DataTable
+      tableName={"dashboards"}
       columns={dashboardColumns}
       data={
         dashboards.isLoading

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -419,6 +419,7 @@ function DatasetCompareRunsTableInternal(props: {
         }
       />
       <DataTable
+        tableName={"datasetCompareRuns"}
         columns={columns}
         columnVisibility={columnVisibility}
         onColumnVisibilityChange={setColumnVisibility}

--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -368,6 +368,7 @@ export function DatasetItemsTable({
         actionButtons={[menuItems, batchExportButton].filter(Boolean)}
       />
       <DataTable
+        tableName={"datasetItems"}
         columns={columns}
         data={
           items.isLoading

--- a/web/src/features/datasets/components/DatasetRunItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsTable.tsx
@@ -295,6 +295,7 @@ export function DatasetRunItemsTable(
         setRowHeight={setRowHeight}
       />
       <DataTable
+        tableName={"datasetRunItems"}
         columns={columns}
         data={
           runItems.isLoading

--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -618,6 +618,7 @@ export function DatasetRunsTable(props: {
               ]}
             />
             <DataTable
+              tableName={"datasetRuns"}
               columns={columns}
               data={
                 runs.isLoading
@@ -678,6 +679,7 @@ export function DatasetRunsTable(props: {
             ]}
           />
           <DataTable
+            tableName={"datasetRuns"}
             columns={columns}
             data={
               runs.isLoading

--- a/web/src/features/datasets/components/DatasetsTable.tsx
+++ b/web/src/features/datasets/components/DatasetsTable.tsx
@@ -282,6 +282,7 @@ export function DatasetsTable(props: { projectId: string }) {
         }}
       />
       <DataTable
+        tableName={"datasets"}
         columns={columns}
         data={
           datasets.isLoading || isViewLoading

--- a/web/src/features/evals/components/eval-log.tsx
+++ b/web/src/features/evals/components/eval-log.tsx
@@ -206,6 +206,7 @@ export default function EvalLogTable({
         filterColumnDefinition={evalExecutionsFilterCols}
       />
       <DataTable
+        tableName={"evalLogs"}
         columns={columns}
         data={
           logs.isLoading

--- a/web/src/features/evals/components/eval-templates-table.tsx
+++ b/web/src/features/evals/components/eval-templates-table.tsx
@@ -324,6 +324,7 @@ export default function EvalsTemplateTable({
         }}
       />
       <DataTable
+        tableName={"evalTemplates"}
         columns={columns}
         peekView={{
           itemType: "EVALUATOR",

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -371,6 +371,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
         }}
       />
       <DataTable
+        tableName={"evalConfigs"}
         columns={columns}
         peekView={{
           itemType: "RUNNING_EVALUATOR",

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -469,6 +469,7 @@ export function PromptTable() {
         }}
       />
       <DataTable
+        tableName={"prompts"}
         columns={promptColumns}
         data={
           prompts.isLoading

--- a/web/src/features/rbac/components/MembersTable.tsx
+++ b/web/src/features/rbac/components/MembersTable.tsx
@@ -362,6 +362,7 @@ export function MembersTable({
       {showSettingsCard ? (
         <SettingsTableCard>
           <DataTable
+            tableName={"members"}
             columns={columns}
             data={
               members.isLoading
@@ -393,6 +394,7 @@ export function MembersTable({
         </SettingsTableCard>
       ) : (
         <DataTable
+          tableName={"members"}
           columns={columns}
           data={
             members.isLoading

--- a/web/src/features/rbac/components/MembershipInvitesPage.tsx
+++ b/web/src/features/rbac/components/MembershipInvitesPage.tsx
@@ -210,6 +210,7 @@ export function MembershipInvitesPage({
       <Header title="Membership Invites" />
       <DataTableToolbar columns={columns} />
       <DataTable
+        tableName={"membershipInvites"}
         columns={columns}
         data={
           invites.isLoading

--- a/web/src/features/widgets/components/WidgetTable.tsx
+++ b/web/src/features/widgets/components/WidgetTable.tsx
@@ -228,6 +228,7 @@ export function DashboardWidgetTable() {
 
   return (
     <DataTable
+      tableName={"widgets"}
       columns={widgetColumns}
       data={
         widgets.isLoading

--- a/web/src/pages/project/[projectId]/prompts/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/metrics.tsx
@@ -437,6 +437,7 @@ export default function PromptVersionTable({
         />
       </div>
       <DataTable
+        tableName={"promptVersions"}
         columns={columns}
         data={
           promptVersions.isLoading

--- a/web/src/pages/project/[projectId]/users.tsx
+++ b/web/src/pages/project/[projectId]/users.tsx
@@ -356,6 +356,7 @@ const UsersTable = () => {
         }}
       />
       <DataTable
+        tableName={"users"}
         columns={columns}
         data={
           users.isLoading


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add feature to persist table column sizes in local storage using a new `useColumnSizing` hook and `tableName` prop in `DataTable`.
> 
>   - **Behavior**:
>     - Persist table column widths to `localStorage` using `useColumnSizing` hook in `data-table.tsx`.
>     - Introduces `tableName` prop in `DataTable` component to uniquely identify tables.
>   - **Hooks**:
>     - New `useColumnSizing` hook in `useColumnSizing.ts` to manage column sizing state with debounced saving to `localStorage`.
>   - **Components**:
>     - Add `tableName` prop to `DataTable` instances in `models.tsx`, `observations.tsx`, and `score-configs.tsx` ... and 20 other places.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1694dd2bc9788c3602be8459e66abc5c76601086. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->