### PR TITLE
chore: set default webhook selector without setting the browser history

### DIFF
--- a/web/src/features/automations/components/automations.tsx
+++ b/web/src/features/automations/components/automations.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/src/components/ui/dialog";
 import { type AutomationDomain } from "@langfuse/shared";
 import { ErrorPage } from "@/src/components/error-page";
+import { getPathnameWithoutBasePath } from "@/src/utils/api";
 
 export default function AutomationsPage() {
   const router = useRouter();
@@ -86,14 +87,31 @@ export default function AutomationsPage() {
         view === "list"
       ) {
         // Auto-select the topmost automation if none is currently selected
-        setUrlParams({
-          view: "list",
-          automationId: automations[0].id,
-          tab: urlParams.tab,
-        });
+        // Use router.replace to avoid creating new history entry
+        const url = new URL(window.location.href);
+        const params = new URLSearchParams(url.search);
+        const pathname = getPathnameWithoutBasePath();
+
+        params.set("automationId", automations[0].id);
+
+        router.replace(
+          {
+            pathname,
+            query: params.toString(),
+          },
+          undefined,
+          { shallow: true },
+        );
       }
     }
-  }, [automations, selectedAutomation, view, setUrlParams, urlParams.tab]);
+  }, [
+    automations,
+    selectedAutomation,
+    view,
+    setUrlParams,
+    urlParams.tab,
+    router,
+  ]);
 
   const handleCreateAutomation = () => {
     setUrlParams({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `AutomationsPage` to use `router.replace` for auto-selecting automations, preventing new history entries.
> 
>   - **Behavior**:
>     - Modify `useEffect` in `AutomationsPage` to use `router.replace` for auto-selecting topmost automation, preventing new history entries.
>     - Use `getPathnameWithoutBasePath` to correctly handle pathname in URL.
>   - **Imports**:
>     - Add `getPathnameWithoutBasePath` import in `automations.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 31dac6697a48812c21b6625d9d826cc6f4285638. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->