### PR TITLE
fix: remove automations cud for members

### DIFF
--- a/web/src/features/automations/components/automations.tsx
+++ b/web/src/features/automations/components/automations.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/src/components/ui/dialog";
 import { type AutomationDomain } from "@langfuse/shared";
 import { ErrorPage } from "@/src/components/error-page";
+import { getPathnameWithoutBasePath } from "@/src/utils/api";
 
 export default function AutomationsPage() {
   const router = useRouter();
@@ -86,14 +87,31 @@ export default function AutomationsPage() {
         view === "list"
       ) {
         // Auto-select the topmost automation if none is currently selected
-        setUrlParams({
-          view: "list",
-          automationId: automations[0].id,
-          tab: urlParams.tab,
-        });
+        // Use router.replace to avoid creating new history entry
+        const url = new URL(window.location.href);
+        const params = new URLSearchParams(url.search);
+        const pathname = getPathnameWithoutBasePath();
+
+        params.set("automationId", automations[0].id);
+
+        router.replace(
+          {
+            pathname,
+            query: params.toString(),
+          },
+          undefined,
+          { shallow: true },
+        );
       }
     }
-  }, [automations, selectedAutomation, view, setUrlParams, urlParams.tab]);
+  }, [
+    automations,
+    selectedAutomation,
+    view,
+    setUrlParams,
+    urlParams.tab,
+    router,
+  ]);
 
   const handleCreateAutomation = () => {
     setUrlParams({

--- a/web/src/features/rbac/constants/projectAccessRights.ts
+++ b/web/src/features/rbac/constants/projectAccessRights.ts
@@ -218,7 +218,6 @@ export const projectRoleAccessRights: Record<Role, ProjectScope[]> = {
     "TableViewPresets:CUD",
     "TableViewPresets:read",
     "automations:read",
-    "automations:CUD",
   ],
   VIEWER: [
     "project:read",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `automations:CUD` from `MEMBER` role and update URL handling in `automations.tsx` to prevent new history entries.
> 
>   - **Access Rights**:
>     - Remove `automations:CUD` from `MEMBER` role in `projectAccessRights.ts`.
>   - **URL Handling**:
>     - Use `router.replace` in `automations.tsx` to update URL without creating new history entry when auto-selecting topmost automation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 13d21c29002b501f9c883238d3840da1ec14072f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->