### PR TITLE
chore: use --turbo always in web dev

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "INLINE_RUNTIME_CHUNK=false dotenv -e ../.env -- next build",
-    "dev": "dotenv -e ../.env -- next dev",
+    "dev": "dotenv -e ../.env -- next dev --turbo",
     "lint": "dotenv -e ../.env -- next lint --max-warnings 0",
     "lint:fix": "dotenv -e ../.env -- next lint --fix",
     "clean": "rm -rf node_modules",

--- a/web/src/__tests__/async/prompts.v2.servertest.ts
+++ b/web/src/__tests__/async/prompts.v2.servertest.ts
@@ -294,7 +294,7 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       testPromptEquality(createPromptParams, fetchedPrompt.body);
     });
 
-    (it("should fetch the latest prompt if label is latest", async () => {
+    it("should fetch the latest prompt if label is latest", async () => {
       const { projectId, auth } = await createOrgProjectAndApiKey();
       const promptName = "latestPrompt_" + nanoid();
 
@@ -396,7 +396,7 @@ describe("/api/public/v2/prompts API Endpoint", () => {
         }
 
         testPromptEquality(productionPromptParams, fetchedPrompt.body);
-      }));
+      });
 
     it("should return a 404 if prompt does not exist", async () => {
       const fetchedPrompt = await makeAPICall<Prompt>(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `dev` script to use `--turbo` flag and fix syntax error in test file.
> 
>   - **Scripts**:
>     - Update `dev` script in `package.json` to include `--turbo` flag for `next dev`.
>   - **Tests**:
>     - Fix syntax error in `prompts.v2.servertest.ts` by removing an extra parenthesis in a test case.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f333c4527f14333c0eb13c9fec31275b2c6198fa. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->