### PR TITLE
fix(otel): keep hex ids in place in id parsing

### DIFF
--- a/web/src/features/otel/server/OtelIngestionProcessor.ts
+++ b/web/src/features/otel/server/OtelIngestionProcessor.ts
@@ -345,13 +345,9 @@ export class OtelIngestionProcessor {
     const events: IngestionEventType[] = [];
     const attributes = this.extractSpanAttributes(span);
 
-    const traceId = Buffer.from(span.traceId?.data ?? span.traceId).toString(
-      "hex",
-    );
+    const traceId = this.parseId(span.traceId?.data ?? span.traceId);
     const parentObservationId = span?.parentSpanId
-      ? Buffer.from(span.parentSpanId?.data ?? span.parentSpanId).toString(
-          "hex",
-        )
+      ? this.parseId(span.parentSpanId?.data ?? span.parentSpanId)
       : null;
 
     const spanAttributeMetadata = this.extractMetadata(
@@ -528,7 +524,7 @@ export class OtelIngestionProcessor {
     } = params;
 
     const observation = {
-      id: Buffer.from(span.spanId?.data ?? span.spanId).toString("hex"),
+      id: this.parseId(span.spanId?.data ?? span.spanId),
       traceId,
       parentObservationId,
       name: this.extractName(span.name, attributes),
@@ -1272,9 +1268,7 @@ export class OtelIngestionProcessor {
       resourceSpans.forEach((resourceSpan) => {
         for (const scopeSpan of resourceSpan?.scopeSpans ?? []) {
           for (const span of scopeSpan?.spans ?? []) {
-            traceIds.add(
-              Buffer.from(span.traceId?.data ?? span.traceId).toString("hex"),
-            );
+            traceIds.add(this.parseId(span.traceId?.data ?? span.traceId));
           }
         }
       });
@@ -1316,6 +1310,12 @@ export class OtelIngestionProcessor {
       // Return empty set to continue processing (fail-safe behavior)
       return new Set();
     }
+  }
+
+  private parseId(data: any): string {
+    // JS SDK sends IDs already in hex strings
+    // Python SDK sends Int array
+    return typeof data === "string" ? data : Buffer.from(data).toString("hex");
   }
 
   /**


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor ID parsing in `OtelIngestionProcessor.ts` using a new `parseId` function to handle hex IDs consistently across SDKs.
> 
>   - **ID Parsing**:
>     - Introduced `parseId()` function in `OtelIngestionProcessor.ts` to handle ID parsing.
>     - Replaced `Buffer.from(...).toString("hex")` with `parseId()` for `traceId`, `parentSpanId`, and `spanId` in `processSpan()`, `createObservationEvent()`, and `getSeenTracesSet()`.
>   - **Functionality**:
>     - `parseId()` checks if data is a string (JS SDK) or converts from buffer to hex (Python SDK).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 039c9d073423676f3dbef2039d1a40841882e748. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->