### PR TITLE
perf: do not parse io

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -21,7 +21,7 @@ import { UiColumnMappings } from "../../tableDefinitions";
 import { convertDateToClickhouseDateTime } from "../clickhouse/client";
 import {
   convertClickhouseToDomain,
-  TraceDomainWithoutIO,
+  TraceDomainWithStringIO,
 } from "./traces_converters";
 import { TraceDomain } from "../../domain";
 import { clickhouseSearchCondition } from "../queries/clickhouse-sql/search";
@@ -504,7 +504,7 @@ export const getTraceById = async <ConvertToAsString extends boolean = false>({
   convertToString?: ConvertToAsString;
 }): Promise<
   ConvertToAsString extends true
-    ? { stringified: string; domain: TraceDomainWithoutIO } | undefined
+    ? TraceDomainWithStringIO | undefined
     : TraceDomain | undefined
 > => {
   const records = await measureAndReturn({
@@ -588,8 +588,7 @@ export const getTraceById = async <ConvertToAsString extends boolean = false>({
 
   res.forEach((trace) => {
     const timestamp = convertToString
-      ? (trace as { stringified: string; domain: TraceDomainWithoutIO }).domain
-          .timestamp
+      ? (trace as TraceDomainWithStringIO).timestamp
       : (trace as TraceDomain).timestamp;
     recordDistribution(
       "langfuse.query_by_id_age",
@@ -601,7 +600,7 @@ export const getTraceById = async <ConvertToAsString extends boolean = false>({
   });
 
   return res.shift() as ConvertToAsString extends true
-    ? { stringified: string; domain: TraceDomainWithoutIO } | undefined
+    ? TraceDomainWithStringIO | undefined
     : TraceDomain | undefined;
 };
 

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "INLINE_RUNTIME_CHUNK=false dotenv -e ../.env -- next build",
-    "dev": "dotenv -e ../.env -- next dev",
+    "dev": "dotenv -e ../.env -- next dev --turbo",
     "lint": "dotenv -e ../.env -- next lint --max-warnings 0",
     "lint:fix": "dotenv -e ../.env -- next lint --fix",
     "clean": "rm -rf node_modules",

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -265,7 +265,10 @@ export const generateTracesForPublicApi = async ({
 
   return result.map((trace) => {
     return {
-      ...convertClickhouseToDomain(trace),
+      ...convertClickhouseToDomain<false>({
+        record: trace,
+        convertToString: false,
+      }),
       // Conditionally include additional fields based on request
       ...(includeObservations && { observations: trace.observations ?? null }),
       ...(includeScores && { scores: trace.scores ?? null }),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimizes trace handling by avoiding JSON parsing for IO fields, adds string-based IO type, and updates `dev` script for faster builds.
> 
>   - **Behavior**:
>     - Avoids JSON parsing for `input` and `output` fields in `convertClickhouseToDomain()` when `convertToString` is true, returning raw strings instead.
>     - Updates `getTraceById()` in `traces.ts` to support `convertToString` option, returning `TraceDomainWithStringIO`.
>     - In `traces.ts` and `traces.ts` (public API), replaces `convertClickhouseToDomain` calls with new signature to handle `convertToString`.
>   - **Types**:
>     - Adds `TraceDomainWithStringIO` type in `traces_converters.ts` for handling string-based IO fields.
>   - **Scripts**:
>     - Updates `dev` script in `package.json` to use `--turbo` flag for faster development builds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3802437f8051bc588ad13a38d53e0a6e47d0a0b3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->