### PR TITLE
perf: enable API Key and Prompt caching in redis by default

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -172,7 +172,6 @@ jobs:
           cp .env.dev.example .env
           grep -v -e '^LANGFUSE_S3_BATCH_EXPORT_ENABLED=' -e '^NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT=' .env.dev.example > .env
           echo "LANGFUSE_INGESTION_QUEUE_DELAY_MS=1" >> .env
-          echo "LANGFUSE_CACHE_PROMPT_ENABLED=false" >> .env
           echo "LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS=1" >> .env
       - name: Run dev containers
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -172,6 +172,7 @@ jobs:
           cp .env.dev.example .env
           grep -v -e '^LANGFUSE_S3_BATCH_EXPORT_ENABLED=' -e '^NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT=' .env.dev.example > .env
           echo "LANGFUSE_INGESTION_QUEUE_DELAY_MS=1" >> .env
+          echo "LANGFUSE_CACHE_PROMPT_ENABLED=false" >> .env
           echo "LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS=1" >> .env
       - name: Run dev containers
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -434,8 +434,6 @@ jobs:
       - name: Load default env
         run: |
           cp .env.dev.example .env
-          echo "LANGFUSE_CACHE_API_KEY_ENABLED=true" >> .env
-          echo "LANGFUSE_CACHE_PROMPT_ENABLED=true" >> .env
       - name: Run + migrate
         run: |
           docker compose -f docker-compose.dev.yml up -d

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -31,8 +31,8 @@ const EnvSchema = z.object({
       "ENCRYPTION_KEY must be 256 bits, 64 string characters in hex format, generate via: openssl rand -hex 32",
     )
     .optional(),
-  LANGFUSE_CACHE_PROMPT_ENABLED: z.enum(["true", "false"]).default("false"),
-  LANGFUSE_CACHE_PROMPT_TTL_SECONDS: z.coerce.number().default(60 * 60),
+  LANGFUSE_CACHE_PROMPT_ENABLED: z.enum(["true", "false"]).default("true"),
+  LANGFUSE_CACHE_PROMPT_TTL_SECONDS: z.coerce.number().default(300),
   CLICKHOUSE_URL: z.string().url(),
   CLICKHOUSE_CLUSTER_NAME: z.string().default("default"),
   CLICKHOUSE_DB: z.string().default("default"),

--- a/packages/shared/src/server/services/PromptService/index.ts
+++ b/packages/shared/src/server/services/PromptService/index.ts
@@ -30,7 +30,7 @@ export class PromptService {
     (name: string, value?: number) => void,
     cacheEnabled?: boolean, // used for testing
   ) {
-    if (cacheEnabled) {
+    if (cacheEnabled !== undefined) {
       this.cacheEnabled = cacheEnabled;
     } else {
       this.cacheEnabled =

--- a/packages/shared/src/server/services/PromptService/index.ts
+++ b/packages/shared/src/server/services/PromptService/index.ts
@@ -28,12 +28,14 @@ export class PromptService {
     private metricIncrementer?: // used for otel metrics
     // eslint-disable-next-line no-unused-vars
     (name: string, value?: number) => void,
-    cacheEnabled: boolean = true, // used for testing
+    cacheEnabled?: boolean, // used for testing
   ) {
-    this.cacheEnabled =
-      Boolean(redis) &&
-      cacheEnabled &&
-      env.LANGFUSE_CACHE_PROMPT_ENABLED === "true";
+    if (cacheEnabled) {
+      this.cacheEnabled = cacheEnabled;
+    } else {
+      this.cacheEnabled =
+        Boolean(redis) && env.LANGFUSE_CACHE_PROMPT_ENABLED === "true";
+    }
 
     this.ttlSeconds = env.LANGFUSE_CACHE_PROMPT_TTL_SECONDS;
   }

--- a/packages/shared/src/server/services/PromptService/index.ts
+++ b/packages/shared/src/server/services/PromptService/index.ts
@@ -28,11 +28,12 @@ export class PromptService {
     private metricIncrementer?: // used for otel metrics
     // eslint-disable-next-line no-unused-vars
     (name: string, value?: number) => void,
-    cacheEnabled?: boolean, // used for testing
+    cacheEnabled: boolean = true, // used for testing
   ) {
     this.cacheEnabled =
       Boolean(redis) &&
-      (cacheEnabled || env.LANGFUSE_CACHE_PROMPT_ENABLED === "true");
+      cacheEnabled &&
+      env.LANGFUSE_CACHE_PROMPT_ENABLED === "true";
 
     this.ttlSeconds = env.LANGFUSE_CACHE_PROMPT_TTL_SECONDS;
   }

--- a/web/jest.config.mjs
+++ b/web/jest.config.mjs
@@ -68,8 +68,4 @@ const config = {
   ],
 };
 
-process.env = Object.assign(process.env, {
-  LANGFUSE_CACHE_API_KEY_ENABLED: "true",
-});
-
 export default config;

--- a/web/src/__tests__/async/prompts.v2.servertest.ts
+++ b/web/src/__tests__/async/prompts.v2.servertest.ts
@@ -506,7 +506,6 @@ describe("/api/public/v2/prompts API Endpoint", () => {
         auth,
       );
 
-      console.log(`Response body: ${JSON.stringify(response.body, null, 2)}`);
       expect(response.status).toBe(201);
 
       const { body: fetchedPrompt } = await makeAPICall(

--- a/web/src/__tests__/async/prompts.v2.servertest.ts
+++ b/web/src/__tests__/async/prompts.v2.servertest.ts
@@ -506,6 +506,7 @@ describe("/api/public/v2/prompts API Endpoint", () => {
         auth,
       );
 
+      console.log(`Response body: ${JSON.stringify(response.body, null, 2)}`);
       expect(response.status).toBe(201);
 
       const { body: fetchedPrompt } = await makeAPICall(

--- a/web/src/__tests__/promptCache.servertest.ts
+++ b/web/src/__tests__/promptCache.servertest.ts
@@ -97,7 +97,7 @@ describe("PromptService", () => {
         "prompt:project1:testPrompt:1",
         JSON.stringify(mockPrompt),
         "EX",
-        3600,
+        300,
       );
 
       expect(mockRedis.sadd).toHaveBeenCalledWith(

--- a/web/src/__tests__/promptCache.servertest.ts
+++ b/web/src/__tests__/promptCache.servertest.ts
@@ -54,7 +54,6 @@ describe("PromptService", () => {
       mockPrisma,
       mockRedis,
       mockMetricIncrementer,
-      true,
     );
   });
 
@@ -200,7 +199,6 @@ describe("PromptService", () => {
         mockPrisma,
         null,
         mockMetricIncrementer,
-        true,
       );
     });
 

--- a/web/src/__tests__/promptCache.servertest.ts
+++ b/web/src/__tests__/promptCache.servertest.ts
@@ -54,6 +54,7 @@ describe("PromptService", () => {
       mockPrisma,
       mockRedis,
       mockMetricIncrementer,
+      true,
     );
   });
 

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -199,8 +199,8 @@ export const env = createEnv({
       .optional(),
 
     // langfuse caching
-    LANGFUSE_CACHE_API_KEY_ENABLED: z.enum(["true", "false"]).default("false"),
-    LANGFUSE_CACHE_API_KEY_TTL_SECONDS: z.coerce.number().default(120),
+    LANGFUSE_CACHE_API_KEY_ENABLED: z.enum(["true", "false"]).default("true"),
+    LANGFUSE_CACHE_API_KEY_TTL_SECONDS: z.coerce.number().default(300),
 
     // Multimodal media upload to S3
     LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH: z.coerce

--- a/web/src/features/public-api/server/apiAuth.ts
+++ b/web/src/features/public-api/server/apiAuth.ts
@@ -9,6 +9,7 @@ import {
   logger,
   instrumentAsync,
   addUserToSpan,
+  safeMultiDel,
 } from "@langfuse/shared/src/server";
 import {
   type PrismaClient,
@@ -48,9 +49,10 @@ export class ApiAuthService {
 
     if (this.redis) {
       logger.info(`Invalidating API keys in redis for ${identifier}`);
-      await this.redis.del(
-        filteredHashKeys.map((hash) => this.createRedisKey(hash)),
+      const keysToDelete = filteredHashKeys.map((hash) =>
+        this.createRedisKey(hash),
       );
+      await safeMultiDel(this.redis, keysToDelete);
     }
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enable Redis caching for API keys and prompts by default, adjust TTL values, and implement safe key deletion in cluster mode.
> 
>   - **Behavior**:
>     - Enable Redis caching for API keys and prompts by default in `env.ts` and `env.mjs`.
>     - Change default TTL for `LANGFUSE_CACHE_PROMPT_TTL_SECONDS` and `LANGFUSE_CACHE_API_KEY_TTL_SECONDS` to 300 seconds in `env.ts` and `env.mjs`.
>     - Remove explicit cache enabling in `pipeline.yml` and `jest.config.mjs`.
>   - **Redis Operations**:
>     - Add `safeMultiDel()` in `redis.ts` for safe key deletion in cluster mode.
>     - Use `safeMultiDel()` in `PromptService` and `ApiAuthService` for cache invalidation.
>   - **PromptService**:
>     - Modify constructor in `PromptService` to enable caching based on environment variable.
>     - Update `invalidateCache()` to use `safeMultiDel()` for key deletion.
>   - **ApiAuthService**:
>     - Use `safeMultiDel()` for invalidating API keys in Redis.
>   - **Tests**:
>     - Update `promptCache.servertest.ts` to reflect new TTL and caching behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7f6ccb58a74ecd63c67a14c2cf292552c9ff3992. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->