### PR TITLE
fix(playground): overflow on large description

### DIFF
--- a/web/src/features/playground/page/components/PlaygroundTools/index.tsx
+++ b/web/src/features/playground/page/components/PlaygroundTools/index.tsx
@@ -258,7 +258,7 @@ export const PlaygroundTools = () => {
                     </div>
                   </div>
                   <p
-                    className="line-clamp-2 text-xs text-muted-foreground"
+                    className="line-clamp-2 break-all text-xs text-muted-foreground"
                     title={tool.description}
                   >
                     {tool.description}

--- a/web/src/features/playground/page/components/StructuredOutputSchemaSection.tsx
+++ b/web/src/features/playground/page/components/StructuredOutputSchemaSection.tsx
@@ -255,7 +255,7 @@ export const StructuredOutputSchemaSection = () => {
                   </div>
                 </div>
                 <p
-                  className="line-clamp-2 text-xs text-muted-foreground"
+                  className="line-clamp-2 break-all text-xs text-muted-foreground"
                   title={structuredOutputSchema.description}
                 >
                   {structuredOutputSchema.description}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `break-all` class to handle overflow in long descriptions in `PlaygroundTools` and `StructuredOutputSchemaSection`.
> 
>   - **UI Fix**:
>     - Add `break-all` class to `<p>` elements in `PlaygroundTools/index.tsx` and `StructuredOutputSchemaSection.tsx` to handle overflow in long descriptions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 168f2b51221cfabfb388895bda9f83f262126437. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->