### PR TITLE
fix: adjust trace session indexes for faster API accesses

### DIFF
--- a/packages/shared/prisma/migrations/20250714151410_add_trace_session_combined_index/migration.sql
+++ b/packages/shared/prisma/migrations/20250714151410_add_trace_session_combined_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "trace_sessions_project_id_created_at_idx" ON "trace_sessions"("project_id", "created_at" DESC);

--- a/packages/shared/prisma/migrations/20250714151410_remove_trace_session_created_at_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20250714151410_remove_trace_session_created_at_idx/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX CONCURRENTLY IF EXISTS "trace_sessions_created_at_idx";

--- a/packages/shared/prisma/migrations/20250714151410_remove_trace_session_project_id_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20250714151410_remove_trace_session_project_id_idx/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX CONCURRENTLY IF EXISTS "trace_sessions_project_id_idx";

--- a/packages/shared/prisma/migrations/20250714151410_remove_trace_session_updated_at_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20250714151410_remove_trace_session_updated_at_idx/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX CONCURRENTLY IF EXISTS "trace_sessions_updated_at_idx";

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -311,9 +311,7 @@ model TraceSession {
   environment String   @default("default")
 
   @@id([id, projectId])
-  @@index([projectId])
-  @@index([createdAt])
-  @@index([updatedAt])
+  @@index([projectId, createdAt(sort: Desc)])
   @@map("trace_sessions")
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimizes `trace_sessions` access by adding a combined index and refactoring query logic for improved performance.
> 
>   - **Database Indexes**:
>     - Adds combined index `trace_sessions_project_id_created_at_idx` on `trace_sessions` for `project_id` and `created_at DESC`.
>     - Removes individual indexes `trace_sessions_created_at_idx`, `trace_sessions_project_id_idx`, and `trace_sessions_updated_at_idx`.
>   - **Schema Changes**:
>     - Updates `TraceSession` model in `schema.prisma` to use the new combined index.
>   - **API Changes**:
>     - Refactors query logic in `index.ts` to utilize the new combined index for fetching sessions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1d7fbeaacd7fc5561959ff13ca71932f3c2b9a95. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->