### PR TITLE
chore(layout): restructure main navigation

### DIFF
--- a/web/src/__e2e__/create-project.spec.ts
+++ b/web/src/__e2e__/create-project.spec.ts
@@ -108,9 +108,9 @@ test.describe("Create project", () => {
   });
 
   [
-    { title: "Traces", url: "/traces" },
+    { title: "Tracing", url: "/traces" },
     { title: "Sessions", url: "/sessions" },
-    { title: "Observations", url: "/observations" },
+    { title: "Tracing", url: "/observations" },
     { title: "Scores", url: "/scores" },
   ].forEach(({ title, url }) => {
     test(`Check ${title} page`, async ({ page }) => {

--- a/web/src/__e2e__/create-project.spec.ts
+++ b/web/src/__e2e__/create-project.spec.ts
@@ -108,12 +108,14 @@ test.describe("Create project", () => {
   });
 
   [
-    { title: "Tracing", url: "/traces" },
+    { title: "Tracing", url: "/traces", subTitle: "Traces" },
     { title: "Sessions", url: "/sessions" },
-    { title: "Tracing", url: "/observations" },
+    { title: "Tracing", url: "/observations", subTitle: "Observations" },
     { title: "Scores", url: "/scores" },
-  ].forEach(({ title, url }) => {
-    test(`Check ${title} page`, async ({ page }) => {
+  ].forEach(({ title, url, subTitle }) => {
+    test(`Check ${title} ${subTitle ? `- ${subTitle}` : ""} page`, async ({
+      page,
+    }) => {
       // const errors = await checkConsoleErrors(page);
       await signin(page);
 

--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -4,6 +4,22 @@ import BreadcrumbComponent from "@/src/components/layouts/breadcrumb";
 import DocPopup from "@/src/components/layouts/doc-popup";
 import { SidebarTrigger } from "@/src/components/ui/sidebar";
 import { cn } from "@/src/utils/tailwind";
+import Link from "next/link";
+
+type TabDefinition = {
+  value: string;
+  label: string;
+  href: string;
+  disabled?: boolean;
+  className?: string;
+};
+
+type PageTabsProps = {
+  tabs: TabDefinition[];
+  activeTab: string;
+  className?: string;
+  listClassName?: string;
+};
 
 export type PageHeaderProps = {
   title: string;
@@ -13,7 +29,7 @@ export type PageHeaderProps = {
   help?: { description: string; href?: string; className?: string };
   itemType?: LangfuseItemType;
   container?: boolean;
-  tabsComponent?: React.ReactNode;
+  tabsProps?: PageTabsProps;
 };
 
 const PageHeader = ({
@@ -23,7 +39,7 @@ const PageHeader = ({
   actionButtonsRight,
   breadcrumb,
   help,
-  tabsComponent,
+  tabsProps,
   container = false,
 }: PageHeaderProps) => {
   return (
@@ -96,7 +112,33 @@ const PageHeader = ({
             </div>
           </div>
 
-          <div className="ml-2">{tabsComponent}</div>
+          {tabsProps && (
+            <div className={cn("ml-2", tabsProps.className)}>
+              <div
+                className={cn(
+                  "inline-flex h-8 items-center justify-start",
+                  tabsProps.listClassName,
+                )}
+              >
+                {tabsProps.tabs.map((tab) => (
+                  <Link
+                    key={tab.value}
+                    href={tab.href}
+                    className={cn(
+                      "inline-flex h-full items-center justify-center whitespace-nowrap rounded-none border-b-4 border-transparent px-2 py-0.5 text-sm font-medium transition-all hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                      tab.value === tabsProps.activeTab
+                        ? "border-primary-accent bg-transparent shadow-none"
+                        : "",
+                      tab.disabled && "pointer-events-none opacity-50",
+                      tab.className,
+                    )}
+                  >
+                    {tab.label}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/web/src/components/layouts/routes.tsx
+++ b/web/src/components/layouts/routes.tsx
@@ -15,6 +15,8 @@ import {
   FileJson,
   Search,
   Home,
+  SquarePercent,
+  ClipboardPen,
 } from "lucide-react";
 import { type ReactNode } from "react";
 import { type Entitlement } from "@/src/features/entitlements/constants/entitlements";
@@ -27,6 +29,17 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import { CloudStatusMenu } from "@/src/features/cloud-status-notification/components/CloudStatusMenu";
 import { type ProductModule } from "@/src/ee/features/ui-customization/productModuleSchema";
 
+export enum RouteSection {
+  Main = "main",
+  Secondary = "secondary",
+}
+
+export enum RouteGroup {
+  Observability = "Observability",
+  PromptManagement = "Prompt Management",
+  Evaluation = "Evaluation",
+}
+
 export type Route = {
   title: string;
   menuNode?: ReactNode;
@@ -37,13 +50,14 @@ export type Route = {
   icon?: LucideIcon; // ignored for nested routes
   pathname: string; // link
   items?: Array<Route>; // folder
-  bottom?: boolean; // bottom of the sidebar, only for first level routes
+  section?: RouteSection; // which section of the sidebar (top/main/bottom)
   newTab?: boolean; // open in new tab
   entitlements?: Entitlement[]; // entitlements required, array treated as OR
   productModule?: ProductModule; // Product module this route belongs to. Used to show/hide modules via ui customization.
   show?: (p: {
     organization: User["organizations"][number] | undefined;
   }) => boolean;
+  group?: RouteGroup; // group this route belongs to (within a section)
 };
 
 export const ROUTES: Route[] = [
@@ -52,77 +66,49 @@ export const ROUTES: Route[] = [
     pathname: "", // Empty pathname since this is a dropdown
     icon: Search,
     menuNode: <CommandMenuTrigger />,
+    section: RouteSection.Main,
   },
   {
     title: "Organizations",
     pathname: "/",
     icon: Grid2X2,
     show: ({ organization }) => organization === undefined,
+    section: RouteSection.Main,
   },
   {
     title: "Projects",
     pathname: "/organization/[organizationId]",
     icon: Grid2X2,
+    section: RouteSection.Main,
   },
   {
     title: "Home",
     pathname: `/project/[projectId]`,
     icon: Home,
+    section: RouteSection.Main,
   },
   {
     title: "Dashboards",
     pathname: `/project/[projectId]/dashboards`,
     icon: LayoutDashboard,
     productModule: "dashboards",
+    section: RouteSection.Main,
   },
   {
     title: "Tracing",
-    pathname: `/project/[projectId]/traces`,
     icon: ListTree,
     productModule: "tracing",
-    items: [
-      {
-        title: "Traces",
-        pathname: `/project/[projectId]/traces`,
-      },
-      {
-        title: "Sessions",
-        pathname: `/project/[projectId]/sessions`,
-      },
-      {
-        title: "Observations",
-        pathname: `/project/[projectId]/observations`,
-      },
-      {
-        title: "Scores",
-        pathname: `/project/[projectId]/scores`,
-      },
-    ],
-  },
-  {
-    title: "Evaluation",
-    icon: Lightbulb,
-    pathname: `/project/[projectId]/annotation-queues`,
-    productModule: "evaluation",
-    projectRbacScopes: ["annotationQueues:read", "evalJob:read"],
-    items: [
-      {
-        title: "Human Annotation",
-        pathname: `/project/[projectId]/annotation-queues`,
-        projectRbacScopes: ["annotationQueues:read"],
-      },
-      {
-        title: "LLM-as-a-Judge",
-        pathname: `/project/[projectId]/evals`,
-        projectRbacScopes: ["evalJob:read"],
-      },
-    ],
+    group: RouteGroup.Observability,
+    section: RouteSection.Main,
+    pathname: `/project/[projectId]/traces`,
   },
   {
     title: "Users",
     pathname: `/project/[projectId]/users`,
     icon: UsersIcon,
     productModule: "tracing",
+    group: RouteGroup.Observability,
+    section: RouteSection.Main,
   },
   {
     title: "Prompts",
@@ -130,24 +116,54 @@ export const ROUTES: Route[] = [
     icon: FileJson,
     projectRbacScopes: ["prompts:read"],
     productModule: "prompt-management",
+    group: RouteGroup.PromptManagement,
+    section: RouteSection.Main,
   },
   {
     title: "Playground",
     pathname: "/project/[projectId]/playground",
     icon: TerminalIcon,
     productModule: "playground",
+    group: RouteGroup.PromptManagement,
+    section: RouteSection.Main,
+  },
+  {
+    title: "Scores",
+    pathname: `/project/[projectId]/scores`,
+    group: RouteGroup.Evaluation,
+    section: RouteSection.Main,
+    icon: SquarePercent,
+  },
+  {
+    title: "LLM-as-a-Judge",
+    icon: Lightbulb,
+    productModule: "evaluation",
+    projectRbacScopes: ["evalJob:read"],
+    group: RouteGroup.Evaluation,
+    section: RouteSection.Main,
+    pathname: `/project/[projectId]/evals`,
+  },
+  {
+    title: "Human Annotation",
+    pathname: `/project/[projectId]/annotation-queues`,
+    projectRbacScopes: ["annotationQueues:read"],
+    group: RouteGroup.Evaluation,
+    section: RouteSection.Main,
+    icon: ClipboardPen,
   },
   {
     title: "Datasets",
     pathname: `/project/[projectId]/datasets`,
     icon: Database,
     productModule: "datasets",
+    group: RouteGroup.Evaluation,
+    section: RouteSection.Main,
   },
   {
     title: "Upgrade",
     icon: Sparkle,
     pathname: "/project/[projectId]/settings/billing",
-    bottom: true,
+    section: RouteSection.Secondary,
     entitlements: ["cloud-billing"],
     organizationRbacScope: "langfuseCloudBilling:CRUD",
     show: ({ organization }) => organization?.plan === "cloud:hobby",
@@ -156,14 +172,14 @@ export const ROUTES: Route[] = [
     title: "Upgrade",
     icon: Sparkle,
     pathname: "/organization/[organizationId]/settings/billing",
-    bottom: true,
+    section: RouteSection.Secondary,
     entitlements: ["cloud-billing"],
     organizationRbacScope: "langfuseCloudBilling:CRUD",
     show: ({ organization }) => organization?.plan === "cloud:hobby",
   },
   {
     title: "Cloud Status",
-    bottom: true,
+    section: RouteSection.Secondary,
     pathname: "",
     menuNode: <CloudStatusMenu />,
   },
@@ -171,18 +187,18 @@ export const ROUTES: Route[] = [
     title: "Settings",
     pathname: "/project/[projectId]/settings",
     icon: Settings,
-    bottom: true,
+    section: RouteSection.Secondary,
   },
   {
     title: "Settings",
     pathname: "/organization/[organizationId]/settings",
     icon: Settings,
-    bottom: true,
+    section: RouteSection.Secondary,
   },
   {
     title: "Support",
     icon: LifeBuoy,
-    bottom: true,
+    section: RouteSection.Secondary,
     pathname: "", // Empty pathname since this is a dropdown
     menuNode: <SupportMenuDropdown />,
   },

--- a/web/src/components/layouts/routes.tsx
+++ b/web/src/components/layouts/routes.tsx
@@ -17,6 +17,7 @@ import {
   Home,
   SquarePercent,
   ClipboardPen,
+  Clock,
 } from "lucide-react";
 import { type ReactNode } from "react";
 import { type Entitlement } from "@/src/features/entitlements/constants/entitlements";
@@ -101,6 +102,14 @@ export const ROUTES: Route[] = [
     group: RouteGroup.Observability,
     section: RouteSection.Main,
     pathname: `/project/[projectId]/traces`,
+  },
+  {
+    title: "Sessions",
+    icon: Clock,
+    productModule: "tracing",
+    group: RouteGroup.Observability,
+    section: RouteSection.Main,
+    pathname: `/project/[projectId]/sessions`,
   },
   {
     title: "Users",

--- a/web/src/components/layouts/utilities/routes.ts
+++ b/web/src/components/layouts/utilities/routes.ts
@@ -1,0 +1,67 @@
+import { RouteSection, RouteGroup, ROUTES, type Route } from "../routes";
+
+export type NavigationItem = Omit<Route, "children" | "items"> & {
+  url: string;
+  isActive: boolean;
+  items?: NavigationItem[];
+};
+
+// Helper to group processed navigation items
+const groupProcessedNavigation = (items: NavigationItem[]) => {
+  const ungrouped = items.filter((item) => !item.group);
+  const grouped: Partial<Record<RouteGroup, NavigationItem[]>> = {};
+
+  // Only create groups that have actual items
+  items.forEach((item) => {
+    if (item.group) {
+      if (!grouped[item.group]) {
+        grouped[item.group] = [];
+      }
+      grouped[item.group]!.push(item);
+    }
+  });
+
+  // Return null for grouped if no groups were created
+  const groupedResult = Object.keys(grouped).length > 0 ? grouped : null;
+
+  // Build flattened array preserving group order
+  const groupedItems = groupedResult
+    ? [
+        ...(grouped[RouteGroup.Observability] || []),
+        ...(grouped[RouteGroup.PromptManagement] || []),
+        ...(grouped[RouteGroup.Evaluation] || []),
+      ]
+    : [];
+
+  return {
+    ungrouped,
+    grouped: groupedResult,
+    flattened: [...ungrouped, ...groupedItems],
+  };
+};
+
+export function processNavigation(
+  mapNavigation: (route: Route) => NavigationItem | null,
+) {
+  // First process all routes (apply filtering, permissions, etc.)
+  const allProcessedItems = ROUTES.map(mapNavigation).filter(
+    (item): item is NavigationItem => Boolean(item),
+  );
+
+  // Then group the processed items by section
+  const mainItems = allProcessedItems.filter(
+    (item) => item.section === RouteSection.Main,
+  );
+  const secondaryItems = allProcessedItems.filter(
+    (item) => item.section === RouteSection.Secondary,
+  );
+
+  const mainNavigation = groupProcessedNavigation(mainItems);
+  const secondaryNavigation = groupProcessedNavigation(secondaryItems);
+
+  return {
+    mainNavigation,
+    secondaryNavigation,
+    navigation: [...mainNavigation.flattened, ...secondaryNavigation.flattened],
+  };
+}

--- a/web/src/components/nav/app-sidebar.tsx
+++ b/web/src/components/nav/app-sidebar.tsx
@@ -20,10 +20,17 @@ import { Alert, AlertDescription } from "@/src/components/ui/alert";
 import { LangfuseLogo } from "@/src/components/LangfuseLogo";
 import { SidebarNotifications } from "@/src/components/nav/sidebar-notifications";
 import { UsageTracker } from "@/src/ee/features/billing/components/UsageTracker";
+import { type RouteGroup } from "@/src/components/layouts/routes";
 
 type AppSidebarProps = {
-  navItems: NavMainItem[];
-  secondaryNavItems: NavMainItem[];
+  navItems: {
+    grouped: Partial<Record<RouteGroup, NavMainItem[]>> | null;
+    ungrouped: NavMainItem[];
+  };
+  secondaryNavItems: {
+    grouped: Partial<Record<RouteGroup, NavMainItem[]>> | null;
+    ungrouped: NavMainItem[];
+  };
   userNavProps: UserNavigationProps;
 } & React.ComponentProps<typeof Sidebar>;
 

--- a/web/src/components/nav/nav-main.tsx
+++ b/web/src/components/nav/nav-main.tsx
@@ -1,31 +1,18 @@
 "use client";
-import { ChevronRightIcon, type LucideIcon } from "lucide-react";
+import { type LucideIcon } from "lucide-react";
 import {
   SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarMenuSub,
-  SidebarMenuSubButton,
-  SidebarMenuSubItem,
   useSidebar,
 } from "@/src/components/ui/sidebar";
 import Link from "next/link";
 import { useState, type ReactNode } from "react";
 import { cn } from "@/src/utils/tailwind";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/src/components/ui/dropdown-menu";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTitle,
-  HoverCardTrigger,
-} from "@/src/components/ui/hover-card";
-import { Portal } from "@radix-ui/react-hover-card";
+import { type RouteGroup } from "@/src/components/layouts/routes";
 
 export type NavMainItem = {
   title: string;
@@ -65,121 +52,70 @@ function NavItemContent({ item }: { item: NavMainItem }) {
   );
 }
 
-export function NavMain({ items }: { items: NavMainItem[] }) {
+export function NavMain({
+  items,
+}: {
+  items: {
+    grouped: Partial<Record<RouteGroup, NavMainItem[]>> | null;
+    ungrouped: NavMainItem[];
+  };
+}) {
   const { open, isMobile } = useSidebar();
   const [hoveredItem, setHoveredItem] = useState<string | null>(null);
   return (
-    <SidebarGroup>
-      <SidebarMenu>
-        {items.map((item) =>
-          item.items && item.items.length > 0 ? (
-            isMobile ? (
-              // Mobile: Use DropdownMenu (tap to show)
+    <>
+      <SidebarGroup>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            {items.ungrouped.map((item) => (
               <SidebarMenuItem key={item.title}>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <SidebarMenuButton
-                      isActive={item.items.some((i) => i.isActive)}
+                {item.menuNode || (
+                  <SidebarMenuButton
+                    asChild
+                    tooltip={item.title}
+                    isActive={item.isActive}
+                  >
+                    <Link
+                      href={item.url}
+                      target={item.newTab ? "blank" : undefined}
                     >
                       <NavItemContent item={item} />
-                      <ChevronRightIcon className="ml-auto h-4 w-4" />
-                    </SidebarMenuButton>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent
-                    side="bottom"
-                    align="start"
-                    sideOffset={4}
-                  >
-                    {item.items.map((subItem) => (
-                      <DropdownMenuItem key={subItem.title} asChild>
-                        <Link
-                          href={subItem.url}
-                          className={cn(
-                            "flex cursor-pointer items-center",
-                            subItem.isActive &&
-                              "bg-accent text-accent-foreground",
-                          )}
-                        >
-                          <span>{subItem.title}</span>
-                        </Link>
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                    </Link>
+                  </SidebarMenuButton>
+                )}
               </SidebarMenuItem>
-            ) : (
-              // Desktop: Use HoverCard (hover to show)
-              <HoverCard
-                key={item.title}
-                openDelay={0}
-                closeDelay={0}
-                onOpenChange={(isOpen) =>
-                  setHoveredItem(isOpen ? item.title : null)
-                }
-              >
-                <SidebarMenuItem>
-                  <HoverCardTrigger>
-                    <SidebarMenuButton
-                      isActive={
-                        item.items.some((i) => i.isActive) ||
-                        hoveredItem === item.title
-                      }
-                    >
-                      <NavItemContent item={item} />
-                      <ChevronRightIcon className="ml-auto" />
-                    </SidebarMenuButton>
-                  </HoverCardTrigger>
-                  <Portal>
-                    <HoverCardContent
-                      side="right"
-                      align="start"
-                      // relative + isolate create a new stacking context
-                      // z-[9999] ensures this appears above other elements, even across different stacking contexts
-                      className="relative isolate z-[9999] p-1"
-                    >
-                      {!open && <HoverCardTitle>{item.title}</HoverCardTitle>}
-                      <SidebarMenuSub>
-                        {item.items.map((subItem) => (
-                          <SidebarMenuSubItem key={subItem.title}>
-                            <SidebarMenuSubButton
-                              asChild
-                              isActive={subItem.isActive}
-                            >
-                              <Link
-                                href={subItem.url}
-                                target={subItem.newTab ? "_blank" : undefined}
-                              >
-                                <span>{subItem.title}</span>
-                              </Link>
-                            </SidebarMenuSubButton>
-                          </SidebarMenuSubItem>
-                        ))}
-                      </SidebarMenuSub>
-                    </HoverCardContent>
-                  </Portal>
-                </SidebarMenuItem>
-              </HoverCard>
-            )
-          ) : (
-            <SidebarMenuItem key={item.title}>
-              {item.menuNode || (
-                <SidebarMenuButton
-                  asChild
-                  tooltip={item.title}
-                  isActive={item.isActive}
-                >
-                  <Link
-                    href={item.url}
-                    target={item.newTab ? "blank" : undefined}
-                  >
-                    <NavItemContent item={item} />
-                  </Link>
-                </SidebarMenuButton>
-              )}
-            </SidebarMenuItem>
-          ),
-        )}
-      </SidebarMenu>
-    </SidebarGroup>
+            ))}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+      {items.grouped &&
+        Object.entries(items.grouped).map(([group, items]) => (
+          <SidebarGroup key={group}>
+            <SidebarGroupLabel>{group}</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {items.map((item) => (
+                  <SidebarMenuItem key={item.title}>
+                    {item.menuNode || (
+                      <SidebarMenuButton
+                        asChild
+                        tooltip={item.title}
+                        isActive={item.isActive}
+                      >
+                        <Link
+                          href={item.url}
+                          target={item.newTab ? "blank" : undefined}
+                        >
+                          <NavItemContent item={item} />
+                        </Link>
+                      </SidebarMenuButton>
+                    )}
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ))}
+    </>
   );
 }

--- a/web/src/components/nav/nav-main.tsx
+++ b/web/src/components/nav/nav-main.tsx
@@ -7,10 +7,9 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  useSidebar,
 } from "@/src/components/ui/sidebar";
 import Link from "next/link";
-import { useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import { cn } from "@/src/utils/tailwind";
 import { type RouteGroup } from "@/src/components/layouts/routes";
 
@@ -60,8 +59,6 @@ export function NavMain({
     ungrouped: NavMainItem[];
   };
 }) {
-  const { open, isMobile } = useSidebar();
-  const [hoveredItem, setHoveredItem] = useState<string | null>(null);
   return (
     <>
       <SidebarGroup>
@@ -77,7 +74,7 @@ export function NavMain({
                   >
                     <Link
                       href={item.url}
-                      target={item.newTab ? "blank" : undefined}
+                      target={item.newTab ? "_blank" : undefined}
                     >
                       <NavItemContent item={item} />
                     </Link>
@@ -104,7 +101,7 @@ export function NavMain({
                       >
                         <Link
                           href={item.url}
-                          target={item.newTab ? "blank" : undefined}
+                          target={item.newTab ? "_blank" : undefined}
                         >
                           <NavItemContent item={item} />
                         </Link>

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -369,7 +369,7 @@ const SidebarHeader = React.forwardRef<
     <div
       ref={ref}
       data-sidebar="header"
-      className={cn("flex min-h-12 flex-col py-2 md:h-fit", className)}
+      className={cn("flex min-h-12 flex-col pt-2 md:h-fit", className)}
       {...props}
     />
   );
@@ -415,7 +415,7 @@ const SidebarContent = React.forwardRef<
       ref={ref}
       data-sidebar="content"
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
         className,
       )}
       {...props}

--- a/web/src/features/command-k-menu/CommandMenu.tsx
+++ b/web/src/features/command-k-menu/CommandMenu.tsx
@@ -1,4 +1,3 @@
-import { type NavigationItem } from "@/src/components/layouts/layout";
 import {
   CommandDialog,
   CommandEmpty,
@@ -19,6 +18,7 @@ import { useProjectSettingsPages } from "@/src/pages/project/[projectId]/setting
 import { useOrganizationSettingsPages } from "@/src/pages/organization/[organizationId]/settings";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { api } from "@/src/utils/api";
+import { type NavigationItem } from "@/src/components/layouts/utilities/routes";
 
 export function CommandMenu({
   mainNavigation,

--- a/web/src/features/evals/pages/evaluators.tsx
+++ b/web/src/features/evals/pages/evaluators.tsx
@@ -6,10 +6,9 @@ import { Plus } from "lucide-react";
 import EvaluatorTable from "@/src/features/evals/components/evaluator-table";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import {
-  TabsBar,
-  TabsBarList,
-  TabsBarTrigger,
-} from "@/src/components/ui/tabs-bar";
+  getEvalsTabs,
+  EVALS_TABS,
+} from "@/src/features/navigation/utils/evals-tabs";
 import { ActionButton } from "@/src/components/ActionButton";
 import { api } from "@/src/utils/api";
 import { useEntitlementLimit } from "@/src/features/entitlements/hooks";
@@ -86,20 +85,10 @@ export default function EvaluatorsPage() {
               "Configure a langfuse managed or custom evaluator to evaluate incoming traces.",
             href: "https://langfuse.com/docs/scores/model-based-evals",
           },
-          tabsComponent: (
-            <TabsBar value="configs">
-              <TabsBarList>
-                <TabsBarTrigger value="configs">
-                  Running Evaluators
-                </TabsBarTrigger>
-                <TabsBarTrigger value="templates" asChild>
-                  <Link href={`/project/${projectId}/evals/templates`}>
-                    Evaluator Library
-                  </Link>
-                </TabsBarTrigger>
-              </TabsBarList>
-            </TabsBar>
-          ),
+          tabsProps: {
+            tabs: getEvalsTabs(projectId),
+            activeTab: EVALS_TABS.CONFIGS,
+          },
           actionButtonsRight: (
             <>
               <ManageDefaultEvalModel projectId={projectId} />

--- a/web/src/features/evals/pages/evaluators.tsx
+++ b/web/src/features/evals/pages/evaluators.tsx
@@ -1,6 +1,5 @@
 import Page from "@/src/components/layouts/page";
 import { useRouter } from "next/router";
-import Link from "next/link";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { Plus } from "lucide-react";
 import EvaluatorTable from "@/src/features/evals/components/evaluator-table";

--- a/web/src/features/evals/pages/templates.tsx
+++ b/web/src/features/evals/pages/templates.tsx
@@ -7,10 +7,9 @@ import { Lock, Plus } from "lucide-react";
 import EvalsTemplateTable from "@/src/features/evals/components/eval-templates-table";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import {
-  TabsBar,
-  TabsBarList,
-  TabsBarTrigger,
-} from "@/src/components/ui/tabs-bar";
+  getEvalsTabs,
+  EVALS_TABS,
+} from "@/src/features/navigation/utils/evals-tabs";
 import { ManageDefaultEvalModel } from "@/src/features/evals/components/manage-default-eval-model";
 
 export default function TemplatesPage() {

--- a/web/src/features/evals/pages/templates.tsx
+++ b/web/src/features/evals/pages/templates.tsx
@@ -38,20 +38,10 @@ export default function TemplatesPage() {
           description: "View all langfuse managed and custom evaluators.",
           href: "https://langfuse.com/docs/scores/model-based-evals",
         },
-        tabsComponent: (
-          <TabsBar value="templates">
-            <TabsBarList>
-              <TabsBarTrigger value="configs" asChild>
-                <Link href={`/project/${projectId}/evals`}>
-                  Running Evaluators
-                </Link>
-              </TabsBarTrigger>
-              <TabsBarTrigger value="templates">
-                Evaluator Library
-              </TabsBarTrigger>
-            </TabsBarList>
-          </TabsBar>
-        ),
+        tabsProps: {
+          tabs: getEvalsTabs(projectId),
+          activeTab: EVALS_TABS.TEMPLATES,
+        },
         actionButtonsRight: (
           <>
             <ManageDefaultEvalModel projectId={projectId} />

--- a/web/src/features/navigation/utils/dashboard-tabs.ts
+++ b/web/src/features/navigation/utils/dashboard-tabs.ts
@@ -1,0 +1,19 @@
+export const DASHBOARD_TABS = {
+  DASHBOARDS: "dashboards",
+  WIDGETS: "widgets",
+} as const;
+
+export type DashboardTab = (typeof DASHBOARD_TABS)[keyof typeof DASHBOARD_TABS];
+
+export const getDashboardTabs = (projectId: string) => [
+  {
+    value: DASHBOARD_TABS.DASHBOARDS,
+    label: "Dashboards",
+    href: `/project/${projectId}/dashboards`,
+  },
+  {
+    value: DASHBOARD_TABS.WIDGETS,
+    label: "Widgets",
+    href: `/project/${projectId}/widgets`,
+  },
+];

--- a/web/src/features/navigation/utils/dataset-tabs.ts
+++ b/web/src/features/navigation/utils/dataset-tabs.ts
@@ -1,0 +1,19 @@
+export const DATASET_TABS = {
+  RUNS: "runs",
+  ITEMS: "items",
+} as const;
+
+export type DatasetTab = (typeof DATASET_TABS)[keyof typeof DATASET_TABS];
+
+export const getDatasetTabs = (projectId: string, datasetId: string) => [
+  {
+    value: DATASET_TABS.RUNS,
+    label: "Runs",
+    href: `/project/${projectId}/datasets/${datasetId}`,
+  },
+  {
+    value: DATASET_TABS.ITEMS,
+    label: "Items",
+    href: `/project/${projectId}/datasets/${datasetId}/items`,
+  },
+];

--- a/web/src/features/navigation/utils/evals-tabs.ts
+++ b/web/src/features/navigation/utils/evals-tabs.ts
@@ -1,0 +1,19 @@
+export const EVALS_TABS = {
+  CONFIGS: "configs",
+  TEMPLATES: "templates",
+} as const;
+
+export type EvalsTab = (typeof EVALS_TABS)[keyof typeof EVALS_TABS];
+
+export const getEvalsTabs = (projectId: string) => [
+  {
+    value: EVALS_TABS.CONFIGS,
+    label: "Running Evaluators",
+    href: `/project/${projectId}/evals`,
+  },
+  {
+    value: EVALS_TABS.TEMPLATES,
+    label: "Evaluator Library",
+    href: `/project/${projectId}/evals/templates`,
+  },
+];

--- a/web/src/features/navigation/utils/prompt-tabs.ts
+++ b/web/src/features/navigation/utils/prompt-tabs.ts
@@ -1,0 +1,19 @@
+export const PROMPT_TABS = {
+  VERSIONS: "versions",
+  METRICS: "metrics",
+} as const;
+
+export type PromptTab = (typeof PROMPT_TABS)[keyof typeof PROMPT_TABS];
+
+export const getPromptTabs = (projectId: string, promptName: string) => [
+  {
+    value: PROMPT_TABS.VERSIONS,
+    label: "Versions",
+    href: `/project/${projectId}/prompts/${encodeURIComponent(promptName)}`,
+  },
+  {
+    value: PROMPT_TABS.METRICS,
+    label: "Metrics",
+    href: `/project/${projectId}/prompts/${encodeURIComponent(promptName)}/metrics`,
+  },
+];

--- a/web/src/features/navigation/utils/tracing-tabs.ts
+++ b/web/src/features/navigation/utils/tracing-tabs.ts
@@ -1,0 +1,31 @@
+import useLocalStorage from "@/src/components/useLocalStorage";
+
+export const TRACING_TABS = {
+  TRACES: "traces",
+  OBSERVATIONS: "observations",
+  SESSIONS: "sessions",
+} as const;
+
+export type TracingTab = (typeof TRACING_TABS)[keyof typeof TRACING_TABS];
+
+export const getTracingTabs = (projectId: string) => [
+  {
+    value: TRACING_TABS.TRACES,
+    label: "Traces",
+    href: `/project/${projectId}/traces`,
+  },
+  {
+    value: TRACING_TABS.OBSERVATIONS,
+    label: "Observations",
+    href: `/project/${projectId}/observations`,
+  },
+  {
+    value: TRACING_TABS.SESSIONS,
+    label: "Sessions",
+    href: `/project/${projectId}/sessions`,
+  },
+];
+
+export const useTracingTabLocalStorage = () => {
+  return useLocalStorage<TracingTab>("tracing-active-tab", TRACING_TABS.TRACES);
+};

--- a/web/src/features/navigation/utils/tracing-tabs.ts
+++ b/web/src/features/navigation/utils/tracing-tabs.ts
@@ -1,9 +1,6 @@
-import useLocalStorage from "@/src/components/useLocalStorage";
-
 export const TRACING_TABS = {
   TRACES: "traces",
   OBSERVATIONS: "observations",
-  SESSIONS: "sessions",
 } as const;
 
 export type TracingTab = (typeof TRACING_TABS)[keyof typeof TRACING_TABS];
@@ -19,13 +16,4 @@ export const getTracingTabs = (projectId: string) => [
     label: "Observations",
     href: `/project/${projectId}/observations`,
   },
-  {
-    value: TRACING_TABS.SESSIONS,
-    label: "Sessions",
-    href: `/project/${projectId}/sessions`,
-  },
 ];
-
-export const useTracingTabLocalStorage = () => {
-  return useLocalStorage<TracingTab>("tracing-active-tab", TRACING_TABS.TRACES);
-};

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -25,6 +25,10 @@ import {
   PRODUCTION_LABEL,
   PromptType,
 } from "@langfuse/shared";
+import {
+  getPromptTabs,
+  PROMPT_TABS,
+} from "@/src/features/navigation/utils/prompt-tabs";
 import { PromptHistoryNode } from "./prompt-history";
 import { JumpToPlaygroundButton } from "@/src/features/playground/page/components/JumpToPlaygroundButton";
 import { ChatMlArraySchema } from "@/src/components/schemas/ChatMlSchema";
@@ -281,20 +285,10 @@ export const PromptDetail = ({
             href: `/project/${projectId}/prompts/`,
           },
         ],
-        tabsComponent: (
-          <TabsBar value="versions">
-            <TabsBarList>
-              <TabsBarTrigger value="versions">Versions</TabsBarTrigger>
-              <TabsBarTrigger value="metrics" asChild>
-                <Link
-                  href={`/project/${projectId}/prompts/${encodeURIComponent(promptName)}/metrics`}
-                >
-                  Metrics
-                </Link>
-              </TabsBarTrigger>
-            </TabsBarList>
-          </TabsBar>
-        ),
+        tabsProps: {
+          tabs: getPromptTabs(projectId as string, promptName as string),
+          activeTab: PROMPT_TABS.VERSIONS,
+        },
         actionButtonsLeft: (
           <TagPromptDetailsPopover
             tags={prompt.tags}

--- a/web/src/pages/project/[projectId]/dashboards/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/index.tsx
@@ -1,16 +1,14 @@
 import { useRouter } from "next/router";
 import Page from "@/src/components/layouts/page";
 import { DashboardTable } from "@/src/features/dashboard/components/DashboardTable";
-import {
-  TabsBar,
-  TabsBarList,
-  TabsBarTrigger,
-} from "@/src/components/ui/tabs-bar";
-import Link from "next/link";
 import { ActionButton } from "@/src/components/ActionButton";
 import { PlusIcon } from "lucide-react";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import {
+  getDashboardTabs,
+  DASHBOARD_TABS,
+} from "@/src/features/navigation/utils/dashboard-tabs";
 
 export default function Dashboards() {
   const router = useRouter();
@@ -29,16 +27,10 @@ export default function Dashboards() {
           description: "Manage and create dashboards for your project.",
           href: "https://langfuse.com/docs/analytics/custom-dashboards",
         },
-        tabsComponent: (
-          <TabsBar value="dashboards">
-            <TabsBarList>
-              <TabsBarTrigger value="dashboards">Dashboards</TabsBarTrigger>
-              <TabsBarTrigger value="widgets" asChild>
-                <Link href={`/project/${projectId}/widgets`}>Widgets</Link>
-              </TabsBarTrigger>
-            </TabsBarList>
-          </TabsBar>
-        ),
+        tabsProps: {
+          tabs: getDashboardTabs(projectId),
+          activeTab: DASHBOARD_TABS.DASHBOARDS,
+        },
         actionButtonsRight: (
           <ActionButton
             icon={<PlusIcon className="h-4 w-4" aria-hidden="true" />}

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
@@ -30,10 +30,9 @@ import { RESOURCE_METRICS } from "@/src/features/dashboard/lib/score-analytics-u
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import Page from "@/src/components/layouts/page";
 import {
-  TabsBarList,
-  TabsBarTrigger,
-  TabsBar,
-} from "@/src/components/ui/tabs-bar";
+  getDatasetTabs,
+  DATASET_TABS,
+} from "@/src/features/navigation/utils/dataset-tabs";
 import { TemplateSelector } from "@/src/features/evals/components/template-selector";
 import { useEvaluatorDefaults } from "@/src/features/experiments/hooks/useEvaluatorDefaults";
 import { useExperimentEvaluatorData } from "@/src/features/experiments/hooks/useExperimentEvaluatorData";
@@ -163,20 +162,10 @@ export default function Dataset() {
               description: dataset.data.description,
             }
           : undefined,
-        tabsComponent: (
-          <TabsBar value="runs">
-            <TabsBarList>
-              <TabsBarTrigger value="runs">Runs</TabsBarTrigger>
-              <TabsBarTrigger value="items" asChild>
-                <Link
-                  href={`/project/${projectId}/datasets/${datasetId}/items`}
-                >
-                  Items
-                </Link>
-              </TabsBarTrigger>
-            </TabsBarList>
-          </TabsBar>
-        ),
+        tabsProps: {
+          tabs: getDatasetTabs(projectId, datasetId),
+          activeTab: DATASET_TABS.RUNS,
+        },
         actionButtonsRight: (
           <>
             <Dialog

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/items.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/items.tsx
@@ -1,11 +1,9 @@
 import { api } from "@/src/utils/api";
 import { useRouter } from "next/router";
 import {
-  TabsBar,
-  TabsBarList,
-  TabsBarTrigger,
-} from "@/src/components/ui/tabs-bar";
-import Link from "next/link";
+  getDatasetTabs,
+  DATASET_TABS,
+} from "@/src/features/navigation/utils/dataset-tabs";
 import { DatasetItemsTable } from "@/src/features/datasets/components/DatasetItemsTable";
 import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 import { DatasetActionButton } from "@/src/features/datasets/components/DatasetActionButton";
@@ -46,18 +44,10 @@ export default function DatasetItems() {
         breadcrumb: [
           { name: "Datasets", href: `/project/${projectId}/datasets` },
         ],
-        tabsComponent: (
-          <TabsBar value="items">
-            <TabsBarList>
-              <TabsBarTrigger value="runs" asChild>
-                <Link href={`/project/${projectId}/datasets/${datasetId}`}>
-                  Runs
-                </Link>
-              </TabsBarTrigger>
-              <TabsBarTrigger value="items">Items</TabsBarTrigger>
-            </TabsBarList>
-          </TabsBar>
-        ),
+        tabsProps: {
+          tabs: getDatasetTabs(projectId, datasetId),
+          activeTab: DATASET_TABS.ITEMS,
+        },
         actionButtonsRight: (
           <>
             <NewDatasetItemButton projectId={projectId} datasetId={datasetId} />

--- a/web/src/pages/project/[projectId]/observations.tsx
+++ b/web/src/pages/project/[projectId]/observations.tsx
@@ -1,12 +1,19 @@
+import React from "react";
 import { useRouter } from "next/router";
 import ObservationsTable from "@/src/components/table/use-cases/observations";
 import Page from "@/src/components/layouts/page";
 import { api } from "@/src/utils/api";
 import { TracesOnboarding } from "@/src/components/onboarding/TracesOnboarding";
+import {
+  getTracingTabs,
+  TRACING_TABS,
+  useTracingTabLocalStorage,
+} from "@/src/features/navigation/utils/tracing-tabs";
 
 export default function Generations() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
+  const [, setActiveTab] = useTracingTabLocalStorage();
 
   // Check if the user has any traces
   const { data: hasAnyTrace, isLoading } = api.traces.hasAny.useQuery(
@@ -24,14 +31,23 @@ export default function Generations() {
 
   const showOnboarding = !isLoading && !hasAnyTrace;
 
+  // Update local storage when this page loads
+  React.useEffect(() => {
+    setActiveTab(TRACING_TABS.OBSERVATIONS);
+  }, [setActiveTab]);
+
   return (
     <Page
       headerProps={{
-        title: "Observations",
+        title: "Tracing",
         help: {
           description:
             "An observation captures a single function call in an application. See docs to learn more.",
           href: "https://langfuse.com/docs/tracing-data-model",
+        },
+        tabsProps: {
+          tabs: getTracingTabs(projectId),
+          activeTab: TRACING_TABS.OBSERVATIONS,
         },
       }}
       scrollable={showOnboarding}

--- a/web/src/pages/project/[projectId]/observations.tsx
+++ b/web/src/pages/project/[projectId]/observations.tsx
@@ -7,13 +7,11 @@ import { TracesOnboarding } from "@/src/components/onboarding/TracesOnboarding";
 import {
   getTracingTabs,
   TRACING_TABS,
-  useTracingTabLocalStorage,
 } from "@/src/features/navigation/utils/tracing-tabs";
 
 export default function Generations() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
-  const [, setActiveTab] = useTracingTabLocalStorage();
 
   // Check if the user has any traces
   const { data: hasAnyTrace, isLoading } = api.traces.hasAny.useQuery(
@@ -30,11 +28,6 @@ export default function Generations() {
   );
 
   const showOnboarding = !isLoading && !hasAnyTrace;
-
-  // Update local storage when this page loads
-  React.useEffect(() => {
-    setActiveTab(TRACING_TABS.OBSERVATIONS);
-  }, [setActiveTab]);
 
   return (
     <Page

--- a/web/src/pages/project/[projectId]/prompts/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/metrics.tsx
@@ -7,12 +7,6 @@ import { useRouter } from "next/router";
 import { api } from "@/src/utils/api";
 import { NumberParam, useQueryParams, withDefault } from "use-query-params";
 import { type RouterOutput } from "@/src/utils/types";
-import {
-  TabsBar,
-  TabsBarList,
-  TabsBarTrigger,
-} from "@/src/components/ui/tabs-bar";
-import Link from "next/link";
 import TableLink from "@/src/components/table/table-link";
 import { numberFormatter, usdFormatter } from "@/src/utils/numbers";
 import { formatIntervalSeconds } from "@/src/utils/dates";
@@ -25,6 +19,10 @@ import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrde
 import Page from "@/src/components/layouts/page";
 import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 import { TruncatedLabels } from "@/src/components/TruncatedLabels";
+import {
+  getPromptTabs,
+  PROMPT_TABS,
+} from "@/src/features/navigation/utils/prompt-tabs";
 
 export type PromptVersionTableRow = {
   version: number;
@@ -409,20 +407,10 @@ export default function PromptVersionTable({
             listKey="prompts"
           />
         ),
-        tabsComponent: (
-          <TabsBar value="metrics">
-            <TabsBarList>
-              <TabsBarTrigger value="versions" asChild>
-                <Link
-                  href={`/project/${projectId}/prompts/${encodeURIComponent(promptName)}`}
-                >
-                  Versions
-                </Link>
-              </TabsBarTrigger>
-              <TabsBarTrigger value="metrics">Metrics</TabsBarTrigger>
-            </TabsBarList>
-          </TabsBar>
-        ),
+        tabsProps: {
+          tabs: getPromptTabs(projectId, promptName),
+          activeTab: PROMPT_TABS.METRICS,
+        },
       }}
     >
       <div className="gap-3">

--- a/web/src/pages/project/[projectId]/sessions.tsx
+++ b/web/src/pages/project/[projectId]/sessions.tsx
@@ -1,12 +1,19 @@
+import React from "react";
 import { useRouter } from "next/router";
 import SessionsTable from "@/src/components/table/use-cases/sessions";
 import Page from "@/src/components/layouts/page";
 import { SessionsOnboarding } from "@/src/components/onboarding/SessionsOnboarding";
 import { api } from "@/src/utils/api";
+import {
+  getTracingTabs,
+  TRACING_TABS,
+  useTracingTabLocalStorage,
+} from "@/src/features/navigation/utils/tracing-tabs";
 
 export default function Sessions() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
+  const [, setActiveTab] = useTracingTabLocalStorage();
 
   const { data: hasAnySession, isLoading } = api.sessions.hasAny.useQuery(
     { projectId },
@@ -23,14 +30,23 @@ export default function Sessions() {
 
   const showOnboarding = !isLoading && !hasAnySession;
 
+  // Update local storage when this page loads
+  React.useEffect(() => {
+    setActiveTab(TRACING_TABS.SESSIONS);
+  }, [setActiveTab]);
+
   return (
     <Page
       headerProps={{
-        title: "Sessions",
+        title: "Tracing",
         help: {
           description:
             "A session is a collection of related traces, such as a conversation or thread. To begin, add a sessionId to the trace.",
           href: "https://langfuse.com/docs/sessions",
+        },
+        tabsProps: {
+          tabs: getTracingTabs(projectId),
+          activeTab: TRACING_TABS.SESSIONS,
         },
       }}
       scrollable={showOnboarding}

--- a/web/src/pages/project/[projectId]/sessions.tsx
+++ b/web/src/pages/project/[projectId]/sessions.tsx
@@ -4,16 +4,10 @@ import SessionsTable from "@/src/components/table/use-cases/sessions";
 import Page from "@/src/components/layouts/page";
 import { SessionsOnboarding } from "@/src/components/onboarding/SessionsOnboarding";
 import { api } from "@/src/utils/api";
-import {
-  getTracingTabs,
-  TRACING_TABS,
-  useTracingTabLocalStorage,
-} from "@/src/features/navigation/utils/tracing-tabs";
 
 export default function Sessions() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
-  const [, setActiveTab] = useTracingTabLocalStorage();
 
   const { data: hasAnySession, isLoading } = api.sessions.hasAny.useQuery(
     { projectId },
@@ -30,23 +24,14 @@ export default function Sessions() {
 
   const showOnboarding = !isLoading && !hasAnySession;
 
-  // Update local storage when this page loads
-  React.useEffect(() => {
-    setActiveTab(TRACING_TABS.SESSIONS);
-  }, [setActiveTab]);
-
   return (
     <Page
       headerProps={{
-        title: "Tracing",
+        title: "Sessions",
         help: {
           description:
             "A session is a collection of related traces, such as a conversation or thread. To begin, add a sessionId to the trace.",
           href: "https://langfuse.com/docs/sessions",
-        },
-        tabsProps: {
-          tabs: getTracingTabs(projectId),
-          activeTab: TRACING_TABS.SESSIONS,
         },
       }}
       scrollable={showOnboarding}

--- a/web/src/pages/project/[projectId]/traces.tsx
+++ b/web/src/pages/project/[projectId]/traces.tsx
@@ -7,13 +7,11 @@ import { TracesOnboarding } from "@/src/components/onboarding/TracesOnboarding";
 import {
   getTracingTabs,
   TRACING_TABS,
-  useTracingTabLocalStorage,
 } from "@/src/features/navigation/utils/tracing-tabs";
 
 export default function Traces() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
-  const [, setActiveTab] = useTracingTabLocalStorage();
 
   // Check if the user has any traces
   const { data: hasAnyTrace, isLoading } = api.traces.hasAny.useQuery(
@@ -30,11 +28,6 @@ export default function Traces() {
   );
 
   const showOnboarding = !isLoading && !hasAnyTrace;
-
-  // Update local storage when this page loads
-  React.useEffect(() => {
-    setActiveTab(TRACING_TABS.TRACES);
-  }, [setActiveTab]);
 
   return (
     <Page

--- a/web/src/pages/project/[projectId]/traces.tsx
+++ b/web/src/pages/project/[projectId]/traces.tsx
@@ -1,12 +1,19 @@
+import React from "react";
 import { useRouter } from "next/router";
 import TracesTable from "@/src/components/table/use-cases/traces";
 import Page from "@/src/components/layouts/page";
 import { api } from "@/src/utils/api";
 import { TracesOnboarding } from "@/src/components/onboarding/TracesOnboarding";
+import {
+  getTracingTabs,
+  TRACING_TABS,
+  useTracingTabLocalStorage,
+} from "@/src/features/navigation/utils/tracing-tabs";
 
 export default function Traces() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
+  const [, setActiveTab] = useTracingTabLocalStorage();
 
   // Check if the user has any traces
   const { data: hasAnyTrace, isLoading } = api.traces.hasAny.useQuery(
@@ -24,14 +31,23 @@ export default function Traces() {
 
   const showOnboarding = !isLoading && !hasAnyTrace;
 
+  // Update local storage when this page loads
+  React.useEffect(() => {
+    setActiveTab(TRACING_TABS.TRACES);
+  }, [setActiveTab]);
+
   return (
     <Page
       headerProps={{
-        title: "Traces",
+        title: "Tracing",
         help: {
           description:
             "A trace represents a single function/api invocation. Traces contain observations. See docs to learn more.",
           href: "https://langfuse.com/docs/tracing-data-model",
+        },
+        tabsProps: {
+          tabs: getTracingTabs(projectId),
+          activeTab: TRACING_TABS.TRACES,
         },
       }}
       scrollable={showOnboarding}

--- a/web/src/pages/project/[projectId]/widgets/index.tsx
+++ b/web/src/pages/project/[projectId]/widgets/index.tsx
@@ -6,11 +6,9 @@ import { ActionButton } from "@/src/components/ActionButton";
 import { PlusIcon } from "lucide-react";
 import { DashboardWidgetTable } from "@/src/features/widgets";
 import {
-  TabsBar,
-  TabsBarList,
-  TabsBarTrigger,
-} from "@/src/components/ui/tabs-bar";
-import Link from "next/link";
+  getDashboardTabs,
+  DASHBOARD_TABS,
+} from "@/src/features/navigation/utils/dashboard-tabs";
 
 export default function Widgets() {
   const router = useRouter();
@@ -29,18 +27,10 @@ export default function Widgets() {
           description: "Manage and create widgets for your dashboard.",
           href: "https://langfuse.com/docs/analytics/custom-dashboards",
         },
-        tabsComponent: (
-          <TabsBar value="widgets">
-            <TabsBarList>
-              <TabsBarTrigger value="dashboards" asChild>
-                <Link href={`/project/${projectId}/dashboards`}>
-                  Dashboards
-                </Link>
-              </TabsBarTrigger>
-              <TabsBarTrigger value="widgets">Widgets</TabsBarTrigger>
-            </TabsBarList>
-          </TabsBar>
-        ),
+        tabsProps: {
+          tabs: getDashboardTabs(projectId),
+          activeTab: DASHBOARD_TABS.WIDGETS,
+        },
         actionButtonsRight: (
           <ActionButton
             icon={<PlusIcon className="h-4 w-4" aria-hidden="true" />}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Restructured main navigation with grouped navigation items and replaced old tab components with a new `tabsProps` structure across multiple pages.
> 
>   - **Navigation Restructure**:
>     - Introduced `processNavigation` in `utilities/routes.ts` to handle navigation item processing and grouping by `RouteSection` and `RouteGroup`.
>     - Updated `layout.tsx` to use `processNavigation` for navigation processing.
>     - Modified `app-sidebar.tsx` and `nav-main.tsx` to support grouped navigation items.
>   - **Tabs Replacement**:
>     - Replaced `tabsComponent` with `tabsProps` in `page-header.tsx`.
>     - Updated pages like `evaluators.tsx`, `templates.tsx`, `dashboards/index.tsx`, `datasets/[datasetId]/index.tsx`, `observations.tsx`, `prompts/metrics.tsx`, `traces.tsx`, and `widgets/index.tsx` to use `tabsProps`.
>   - **Route Definitions**:
>     - Added `RouteSection` and `RouteGroup` enums in `routes.tsx` for better navigation organization.
>     - Updated `ROUTES` in `routes.tsx` to include `section` and `group` properties.
>   - **Miscellaneous**:
>     - Added utility functions for generating tab definitions in `dashboard-tabs.ts`, `dataset-tabs.ts`, `evals-tabs.ts`, `prompt-tabs.ts`, and `tracing-tabs.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1987337d780bc390306bc8dba5f77c15f15dc14c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->