### PR TITLE
fix: fallback to auto for falsy region value in blob storage integration

### DIFF
--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -214,7 +214,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
       maxTimestamp,
       bucketName: blobStorageIntegration.bucketName,
       endpoint: blobStorageIntegration.endpoint,
-      region: blobStorageIntegration.region ?? "auto",
+      region: blobStorageIntegration.region || "auto",
       accessKeyId: blobStorageIntegration.accessKeyId || undefined,
       secretAccessKey: blobStorageIntegration.secretAccessKey
         ? decrypt(blobStorageIntegration.secretAccessKey)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix fallback to "auto" for falsy region values in `handleBlobStorageIntegrationProjectJob`.
> 
>   - **Behavior**:
>     - In `handleBlobStorageIntegrationProjectJob`, change `region: blobStorageIntegration.region ?? "auto"` to `region: blobStorageIntegration.region || "auto"` to ensure falsy values default to "auto".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 78f9f6902014dd8c0b461d47f773c9ef7ddb471d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->