### PR TITLE
chore(ingestions): add s3 download size hist and span attribute

### DIFF
--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -154,9 +154,13 @@ export const ingestionQueueProcessorBuilder = (
         const file = await s3Client.download(filePath);
         const fileSize = file.length;
 
-        recordHistogram("langfuse.ingestion.s3_file_download_size_bytes", fileSize, {
-          skippedS3List: "true",
-        });
+        recordHistogram(
+          "langfuse.ingestion.s3_file_download_size_bytes",
+          fileSize,
+          {
+            skippedS3List: "true",
+          },
+        );
         totalS3DownloadSizeBytes += fileSize;
 
         const parsedFile = JSON.parse(file);
@@ -170,9 +174,13 @@ export const ingestionQueueProcessorBuilder = (
           const file = await s3Client.download(fileRef.file);
           const fileSize = file.length;
 
-          recordHistogram("langfuse.ingestion.s3_file_download_size_bytes", fileSize, {
-            skippedS3List: "false",
-          });
+          recordHistogram(
+            "langfuse.ingestion.s3_file_download_size_bytes",
+            fileSize,
+            {
+              skippedS3List: "false",
+            },
+          );
           totalS3DownloadSizeBytes += fileSize;
 
           const parsedFile = JSON.parse(file);

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -157,7 +157,7 @@ export const ingestionQueueProcessorBuilder = (
         recordHistogram("langfuse.ingestion.s3DownloadSizeBytes", fileSize, {
           skippedS3List: "true",
         });
-        totalS3DownloadSizeBytes += file.length;
+        totalS3DownloadSizeBytes += fileSize;
 
         const parsedFile = JSON.parse(file);
         events.push(...(Array.isArray(parsedFile) ? parsedFile : [parsedFile]));
@@ -173,7 +173,7 @@ export const ingestionQueueProcessorBuilder = (
           recordHistogram("langfuse.ingestion.s3DownloadSizeBytes", fileSize, {
             skippedS3List: "false",
           });
-          totalS3DownloadSizeBytes += file.length;
+          totalS3DownloadSizeBytes += fileSize;
 
           const parsedFile = JSON.parse(file);
           return Array.isArray(parsedFile) ? parsedFile : [parsedFile];

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -170,7 +170,7 @@ export const ingestionQueueProcessorBuilder = (
           const file = await s3Client.download(fileRef.file);
           const fileSize = file.length;
 
-          recordHistogram("langfuse.ingestion.s3DownloadSizeBytes", fileSize, {
+          recordHistogram("langfuse.ingestion.s3_file_download_size_bytes", fileSize, {
             skippedS3List: "false",
           });
           totalS3DownloadSizeBytes += fileSize;

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -9,6 +9,7 @@ import {
   logger,
   QueueName,
   recordDistribution,
+  recordHistogram,
   recordIncrement,
   redis,
   TQueueJobTypes,
@@ -143,12 +144,21 @@ export const ingestionQueueProcessorBuilder = (
 
       const s3Prefix = `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${job.data.payload.authCheck.scope.projectId}/${clickhouseEntityType}/${job.data.payload.data.eventBodyId}/`;
 
+      let totalS3DownloadSizeBytes = 0;
+
       if (shouldSkipS3List) {
         // Direct file download - skip S3 list operation
         const filePath = `${s3Prefix}${job.data.payload.data.fileKey}.json`;
         eventFiles = [{ file: filePath, createdAt: new Date() }];
 
         const file = await s3Client.download(filePath);
+        const fileSize = file.length;
+
+        recordHistogram("langfuse.ingestion.s3DownloadSizeBytes", fileSize, {
+          skippedS3List: "true",
+        });
+        totalS3DownloadSizeBytes += file.length;
+
         const parsedFile = JSON.parse(file);
         events.push(...(Array.isArray(parsedFile) ? parsedFile : [parsedFile]));
       } else {
@@ -158,6 +168,13 @@ export const ingestionQueueProcessorBuilder = (
         // If a user has 5k events, this will likely take 100 seconds.
         const downloadAndParseFile = async (fileRef: { file: string }) => {
           const file = await s3Client.download(fileRef.file);
+          const fileSize = file.length;
+
+          recordHistogram("langfuse.ingestion.s3DownloadSizeBytes", fileSize, {
+            skippedS3List: "false",
+          });
+          totalS3DownloadSizeBytes += file.length;
+
           const parsedFile = JSON.parse(file);
           return Array.isArray(parsedFile) ? parsedFile : [parsedFile];
         };
@@ -184,6 +201,10 @@ export const ingestionQueueProcessorBuilder = (
         eventFiles.length,
       );
       span?.setAttribute("langfuse.ingestion.event.kind", clickhouseEntityType);
+      span?.setAttribute(
+        "langfuse.ingestion.event.totalS3DownloadSizeBytes",
+        totalS3DownloadSizeBytes,
+      );
 
       const firstS3WriteTime =
         eventFiles

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -202,7 +202,7 @@ export const ingestionQueueProcessorBuilder = (
       );
       span?.setAttribute("langfuse.ingestion.event.kind", clickhouseEntityType);
       span?.setAttribute(
-        "langfuse.ingestion.event.totalS3DownloadSizeBytes",
+        "langfuse.ingestion.s3_all_files_download_size_bytes",
         totalS3DownloadSizeBytes,
       );
 

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -154,7 +154,7 @@ export const ingestionQueueProcessorBuilder = (
         const file = await s3Client.download(filePath);
         const fileSize = file.length;
 
-        recordHistogram("langfuse.ingestion.s3DownloadSizeBytes", fileSize, {
+        recordHistogram("langfuse.ingestion.s3_file_download_size_bytes", fileSize, {
           skippedS3List: "true",
         });
         totalS3DownloadSizeBytes += fileSize;

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -154,13 +154,9 @@ export const ingestionQueueProcessorBuilder = (
         const file = await s3Client.download(filePath);
         const fileSize = file.length;
 
-        recordHistogram(
-          "langfuse.ingestion.s3_file_download_size_bytes",
-          fileSize,
-          {
-            skippedS3List: "true",
-          },
-        );
+        recordHistogram("langfuse.ingestion.s3_file_size_bytes", fileSize, {
+          skippedS3List: "true",
+        });
         totalS3DownloadSizeBytes += fileSize;
 
         const parsedFile = JSON.parse(file);
@@ -174,13 +170,9 @@ export const ingestionQueueProcessorBuilder = (
           const file = await s3Client.download(fileRef.file);
           const fileSize = file.length;
 
-          recordHistogram(
-            "langfuse.ingestion.s3_file_download_size_bytes",
-            fileSize,
-            {
-              skippedS3List: "false",
-            },
-          );
+          recordHistogram("langfuse.ingestion.s3_file_size_bytes", fileSize, {
+            skippedS3List: "false",
+          });
           totalS3DownloadSizeBytes += fileSize;
 
           const parsedFile = JSON.parse(file);
@@ -210,7 +202,7 @@ export const ingestionQueueProcessorBuilder = (
       );
       span?.setAttribute("langfuse.ingestion.event.kind", clickhouseEntityType);
       span?.setAttribute(
-        "langfuse.ingestion.s3_all_files_download_size_bytes",
+        "langfuse.ingestion.s3_all_files_size_bytes",
         totalS3DownloadSizeBytes,
       );
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds S3 download size tracking and span attribute updates in `ingestionQueueProcessorBuilder`.
> 
>   - **Behavior**:
>     - Adds `recordHistogram` calls in `ingestionQueueProcessorBuilder` to track S3 file download sizes, distinguishing between skipped and non-skipped S3 list operations.
>     - Updates span attributes to include `langfuse.ingestion.s3_all_files_size_bytes` for total S3 download size.
>   - **Functions**:
>     - Modifies `ingestionQueueProcessorBuilder` in `ingestionQueue.ts` to include new histogram recording and span attribute setting.
>   - **Misc**:
>     - Adds `totalS3DownloadSizeBytes` variable to accumulate total download size.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ade0ea6229a5c1562fb9c787d8c17a3ebc11f3ed. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->