### PR TITLE
perf: truncate very large records on insertion

### DIFF
--- a/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
+++ b/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
@@ -17,6 +17,7 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
     logger: {
       info: vi.fn(),
       debug: vi.fn(),
+      warn: vi.fn(),
       error: vi.fn(),
     },
   };
@@ -341,5 +342,148 @@ describe("ClickhouseWriter", () => {
 
     expect(mockInsert).toHaveBeenCalledTimes(2);
     expect(writer["queue"][TableName.Traces]).toHaveLength(0);
+  });
+
+  describe("truncation logic", () => {
+    it("should truncate oversized input field", () => {
+      const largeInput = "a".repeat(2 * 1024 * 1024); // 2MB string
+      const record = {
+        id: "1",
+        input: largeInput,
+        output: "normal output",
+        metadata: { key: "value" },
+      } as any;
+
+      const truncatedRecord = writer["truncateOversizedRecord"](record);
+
+      expect(truncatedRecord.id).toBe("1");
+      expect((truncatedRecord as any).output).toBe("normal output");
+      expect((truncatedRecord as any).metadata).toEqual({ key: "value" });
+      expect((truncatedRecord as any).input).toContain(
+        "[TRUNCATED: Field exceeded size limit]",
+      );
+      expect((truncatedRecord as any).input.length).toBeLessThan(
+        largeInput.length,
+      );
+      expect((truncatedRecord as any).input).toMatch(
+        /^a+\[TRUNCATED: Field exceeded size limit]$/,
+      );
+    });
+
+    it("should truncate oversized output field", () => {
+      const largeOutput = "b".repeat(2 * 1024 * 1024); // 2MB string
+      const record = {
+        id: "1",
+        input: "normal input",
+        output: largeOutput,
+        metadata: { key: "value" },
+      };
+
+      const truncatedRecord = writer["truncateOversizedRecord"](record);
+
+      expect(truncatedRecord.id).toBe("1");
+      expect(truncatedRecord.input).toBe("normal input");
+      expect(truncatedRecord.metadata).toEqual({ key: "value" });
+      expect(truncatedRecord.output).toContain(
+        "[TRUNCATED: Field exceeded size limit]",
+      );
+      expect(truncatedRecord.output.length).toBeLessThan(largeOutput.length);
+      expect(truncatedRecord.output).toMatch(
+        /^b+\[TRUNCATED: Field exceeded size limit\]$/,
+      );
+    });
+
+    it("should truncate oversized metadata values", () => {
+      const largeMetadataValue = "c".repeat(2 * 1024 * 1024); // 2MB string
+      const record = {
+        id: "1",
+        input: "normal input",
+        output: "normal output",
+        metadata: {
+          normalKey: "normal value",
+          largeKey: largeMetadataValue,
+          anotherNormalKey: "another normal value",
+        },
+      };
+
+      const truncatedRecord = writer["truncateOversizedRecord"](record);
+
+      expect(truncatedRecord.id).toBe("1");
+      expect(truncatedRecord.input).toBe("normal input");
+      expect(truncatedRecord.output).toBe("normal output");
+      expect(truncatedRecord.metadata.normalKey).toBe("normal value");
+      expect(truncatedRecord.metadata.anotherNormalKey).toBe(
+        "another normal value",
+      );
+      expect(truncatedRecord.metadata.largeKey).toContain(
+        "[TRUNCATED: Field exceeded size limit]",
+      );
+      expect(truncatedRecord.metadata.largeKey.length).toBeLessThan(
+        largeMetadataValue.length,
+      );
+      expect(truncatedRecord.metadata.largeKey).toMatch(
+        /^c+\[TRUNCATED: Field exceeded size limit\]$/,
+      );
+    });
+
+    it("should not truncate normal-sized fields", () => {
+      const normalRecord = {
+        id: "1",
+        input: "normal input",
+        output: "normal output",
+        metadata: { key: "value" },
+      };
+
+      const truncatedRecord = writer["truncateOversizedRecord"](normalRecord);
+
+      expect(truncatedRecord).toEqual(normalRecord);
+    });
+
+    it("should handle size errors with truncation in retry logic", async () => {
+      const largeInput = "a".repeat(2 * 1024 * 1024); // 2MB string
+      const record = {
+        id: "1",
+        input: largeInput,
+        output: "normal output",
+      } as any;
+
+      const mockInsert = vi
+        .spyOn(clickhouseClientMock, "insert")
+        .mockRejectedValueOnce(
+          new Error(
+            "size of json object is extremely large and expected not greater than 1MB",
+          ),
+        )
+        .mockResolvedValueOnce();
+
+      writer.addToQueue(TableName.Traces, record);
+
+      await vi.advanceTimersByTimeAsync(writer.writeInterval);
+
+      expect(mockInsert).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("size of json object is extremely large"),
+      );
+
+      // Second attempt with truncated data
+      await vi.advanceTimersByTimeAsync(writer.writeInterval);
+
+      expect(mockInsert).toHaveBeenCalledTimes(2);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Truncating oversized records"),
+        expect.objectContaining({
+          attemptNumber: 1,
+          error:
+            "size of json object is extremely large and expected not greater than 1MB",
+        }),
+      );
+      expect(writer["queue"][TableName.Traces]).toHaveLength(0);
+
+      // Verify that the second call used truncated data
+      const secondCallArgs = mockInsert.mock.calls[1][0];
+      expect(secondCallArgs.values[0].input).toContain(
+        "[TRUNCATED: Field exceeded size limit]",
+      );
+    });
   });
 });

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -124,6 +124,68 @@ export class ClickhouseWriter {
     return errorMessage.includes("socket hang up");
   }
 
+  private isSizeError(error: unknown): boolean {
+    if (!error || typeof error !== "object") return false;
+
+    const errorMessage = (error as Error).message?.toLowerCase() || "";
+
+    // Check for ClickHouse size errors
+    return (
+      errorMessage.includes("size of json object") &&
+      errorMessage.includes("extremely large") &&
+      errorMessage.includes("expected not greater than")
+    );
+  }
+
+  private truncateOversizedRecord<T extends TableName>(
+    record: RecordInsertType<T>,
+  ): RecordInsertType<T> {
+    const maxFieldSize = 1024 * 1024; // 1MB per field as safety margin
+    const truncationMessage = "[TRUNCATED: Field exceeded size limit]";
+
+    // Helper function to safely truncate string fields
+    const truncateField = (value: string | null | undefined): string | null => {
+      if (!value) return value || null;
+      if (value.length > maxFieldSize) {
+        return (
+          // Keep the first 500KB and append a truncation message
+          value.substring(0, 500 * 1024) + truncationMessage
+        );
+      }
+      return value;
+    };
+
+    // Truncate input field if present
+    if (
+      "input" in record &&
+      record.input &&
+      JSON.stringify(record.input).length > maxFieldSize
+    ) {
+      record.input = truncateField(record.input);
+    }
+
+    // Truncate output field if present
+    if (
+      "output" in record &&
+      record.output &&
+      JSON.stringify(record.output).length > maxFieldSize
+    ) {
+      record.output = truncateField(record.output);
+    }
+
+    // Truncate metadata field if present
+    if ("metadata" in record && record.metadata) {
+      const metadata = record.metadata;
+      const truncatedMetadata: Record<string, string> = {};
+      for (const [key, value] of Object.entries(metadata)) {
+        truncatedMetadata[key] = truncateField(value) || "";
+      }
+      record.metadata = truncatedMetadata;
+    }
+
+    return record;
+  }
+
   private async flush<T extends TableName>(tableName: T, fullQueue = false) {
     const entityQueue = this.queue[tableName];
     if (entityQueue.length === 0) return;
@@ -151,17 +213,22 @@ export class ClickhouseWriter {
     try {
       const processingStartTime = Date.now();
 
+      let recordsToWrite = queueItems.map((item) => item.data);
+      let hasBeenTruncated = false;
+
       await backOff(
         async () =>
           this.writeToClickhouse({
             table: tableName,
-            records: queueItems.map((item) => item.data),
+            records: recordsToWrite,
           }),
         {
           numOfAttempts: env.LANGFUSE_INGESTION_CLICKHOUSE_MAX_ATTEMPTS,
           retry: (error: Error, attemptNumber: number) => {
-            const shouldRetry = this.isRetryableError(error);
-            if (shouldRetry) {
+            const isRetryable = this.isRetryableError(error);
+            const isSizeError = this.isSizeError(error);
+
+            if (isRetryable) {
               logger.warn(
                 `ClickHouse Writer failed with retryable error for ${tableName} (attempt ${attemptNumber}/${env.LANGFUSE_INGESTION_CLICKHOUSE_MAX_ATTEMPTS}): ${error.message}`,
                 {
@@ -173,6 +240,28 @@ export class ClickhouseWriter {
                 "retry.attempt": attemptNumber,
                 "retry.error": error.message,
               });
+              return true;
+            } else if (isSizeError && !hasBeenTruncated) {
+              logger.warn(
+                `ClickHouse Writer failed with size error for ${tableName} (attempt ${attemptNumber}/${env.LANGFUSE_INGESTION_CLICKHOUSE_MAX_ATTEMPTS}): Truncating oversized records and retrying`,
+                {
+                  error: error.message,
+                  attemptNumber,
+                },
+              );
+
+              // Truncate oversized records
+              recordsToWrite = recordsToWrite.map((record) =>
+                this.truncateOversizedRecord(record),
+              );
+              hasBeenTruncated = true;
+
+              currentSpan?.addEvent("clickhouse-query-truncate-retry", {
+                "retry.attempt": attemptNumber,
+                "retry.error": error.message,
+                truncated: true,
+              });
+              return true;
             } else {
               logger.error(
                 `ClickHouse query failed with non-retryable error: ${error.message}`,
@@ -180,8 +269,8 @@ export class ClickhouseWriter {
                   error: error.message,
                 },
               );
+              return false;
             }
-            return shouldRetry;
           },
           startingDelay: 100,
           timeMultiple: 1,

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -159,7 +159,7 @@ export class ClickhouseWriter {
     if (
       "input" in record &&
       record.input &&
-      JSON.stringify(record.input).length > maxFieldSize
+      record.input.length > maxFieldSize
     ) {
       record.input = truncateField(record.input);
     }
@@ -168,7 +168,7 @@ export class ClickhouseWriter {
     if (
       "output" in record &&
       record.output &&
-      JSON.stringify(record.output).length > maxFieldSize
+      record.output.length > maxFieldSize
     ) {
       record.output = truncateField(record.output);
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces truncation for oversized records in `ClickhouseWriter` to handle size errors, with tests ensuring correct behavior.
> 
>   - **Behavior**:
>     - Adds `truncateOversizedRecord()` in `index.ts` to truncate fields exceeding 1MB, appending "[TRUNCATED: Field exceeded size limit]".
>     - Modifies `flush()` in `index.ts` to retry with truncated records on size errors.
>     - Updates retry logic to handle size errors specifically, logging warnings and retrying with truncated data.
>   - **Tests**:
>     - Adds tests in `ClickhouseWriter.unit.test.ts` for truncating oversized `input`, `output`, and `metadata` fields.
>     - Tests retry logic with truncation on size errors, ensuring records are truncated and retried correctly.
>     - Verifies normal-sized records remain unchanged.
>   - **Misc**:
>     - Adds `warn` logger mock in `ClickhouseWriter.unit.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a616cba44dd598d621f51cf54c41d9905b490b7a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->