### PR TITLE
chore: expand logging for large entity truncation

### DIFF
--- a/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
+++ b/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
@@ -354,7 +354,10 @@ describe("ClickhouseWriter", () => {
         metadata: { key: "value" },
       } as any;
 
-      const truncatedRecord = writer["truncateOversizedRecord"](record);
+      const truncatedRecord = writer["truncateOversizedRecord"](
+        "traces",
+        record,
+      );
 
       expect(truncatedRecord.id).toBe("1");
       expect((truncatedRecord as any).output).toBe("normal output");
@@ -379,7 +382,10 @@ describe("ClickhouseWriter", () => {
         metadata: { key: "value" },
       };
 
-      const truncatedRecord = writer["truncateOversizedRecord"](record);
+      const truncatedRecord = writer["truncateOversizedRecord"](
+        "traces",
+        record,
+      );
 
       expect(truncatedRecord.id).toBe("1");
       expect(truncatedRecord.input).toBe("normal input");
@@ -406,7 +412,10 @@ describe("ClickhouseWriter", () => {
         },
       };
 
-      const truncatedRecord = writer["truncateOversizedRecord"](record);
+      const truncatedRecord = writer["truncateOversizedRecord"](
+        "traces",
+        record,
+      );
 
       expect(truncatedRecord.id).toBe("1");
       expect(truncatedRecord.input).toBe("normal input");
@@ -434,7 +443,10 @@ describe("ClickhouseWriter", () => {
         metadata: { key: "value" },
       };
 
-      const truncatedRecord = writer["truncateOversizedRecord"](normalRecord);
+      const truncatedRecord = writer["truncateOversizedRecord"](
+        "traces",
+        normalRecord,
+      );
 
       expect(truncatedRecord).toEqual(normalRecord);
     });

--- a/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
+++ b/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
@@ -355,7 +355,7 @@ describe("ClickhouseWriter", () => {
       } as any;
 
       const truncatedRecord = writer["truncateOversizedRecord"](
-        "traces",
+        TableName.Traces,
         record,
       );
 
@@ -383,7 +383,7 @@ describe("ClickhouseWriter", () => {
       };
 
       const truncatedRecord = writer["truncateOversizedRecord"](
-        "traces",
+        TableName.Traces,
         record,
       );
 
@@ -413,7 +413,7 @@ describe("ClickhouseWriter", () => {
       };
 
       const truncatedRecord = writer["truncateOversizedRecord"](
-        "traces",
+        TableName.Traces,
         record,
       );
 
@@ -444,7 +444,7 @@ describe("ClickhouseWriter", () => {
       };
 
       const truncatedRecord = writer["truncateOversizedRecord"](
-        "traces",
+        TableName.Traces,
         normalRecord,
       );
 

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -138,6 +138,7 @@ export class ClickhouseWriter {
   }
 
   private truncateOversizedRecord<T extends TableName>(
+    tableName: T,
     record: RecordInsertType<T>,
   ): RecordInsertType<T> {
     const maxFieldSize = 1024 * 1024; // 1MB per field as safety margin
@@ -162,6 +163,12 @@ export class ClickhouseWriter {
       record.input.length > maxFieldSize
     ) {
       record.input = truncateField(record.input);
+      logger.info(
+        `Truncated oversized input field for record ${record.id} of type ${tableName}`,
+        {
+          projectId: record.project_id,
+        },
+      );
     }
 
     // Truncate output field if present
@@ -171,6 +178,12 @@ export class ClickhouseWriter {
       record.output.length > maxFieldSize
     ) {
       record.output = truncateField(record.output);
+      logger.info(
+        `Truncated oversized output field for record ${record.id} of type ${tableName}`,
+        {
+          projectId: record.project_id,
+        },
+      );
     }
 
     // Truncate metadata field if present
@@ -178,7 +191,15 @@ export class ClickhouseWriter {
       const metadata = record.metadata;
       const truncatedMetadata: Record<string, string> = {};
       for (const [key, value] of Object.entries(metadata)) {
-        truncatedMetadata[key] = truncateField(value) || "";
+        if (value.length > maxFieldSize) {
+          truncatedMetadata[key] = truncateField(value) || "";
+          logger.info(
+            `Truncated oversized metadata for record ${record.metadata} of type ${tableName} and key ${key}`,
+            {
+              projectId: record.project_id,
+            },
+          );
+        }
       }
       record.metadata = truncatedMetadata;
     }
@@ -252,7 +273,7 @@ export class ClickhouseWriter {
 
               // Truncate oversized records
               recordsToWrite = recordsToWrite.map((record) =>
-                this.truncateOversizedRecord(record),
+                this.truncateOversizedRecord(tableName, record),
               );
               hasBeenTruncated = true;
 

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -199,6 +199,8 @@ export class ClickhouseWriter {
               projectId: record.project_id,
             },
           );
+        } else {
+          truncatedMetadata[key] = value;
         }
       }
       record.metadata = truncatedMetadata;

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -194,7 +194,7 @@ export class ClickhouseWriter {
         if (value.length > maxFieldSize) {
           truncatedMetadata[key] = truncateField(value) || "";
           logger.info(
-            `Truncated oversized metadata for record ${record.metadata} of type ${tableName} and key ${key}`,
+            `Truncated oversized metadata for record ${record.id} of type ${tableName} and key ${key}`,
             {
               projectId: record.project_id,
             },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Expand logging for truncation of large entities in `ClickhouseWriter` by adding logs for input, output, and metadata truncation.
> 
>   - **Behavior**:
>     - Adds logging in `truncateOversizedRecord` in `index.ts` for truncating input, output, and metadata fields.
>     - Updates `truncateOversizedRecord` calls in `ClickhouseWriter.unit.test.ts` to include `tableName` parameter.
>   - **Tests**:
>     - Verifies logging of truncation in `ClickhouseWriter.unit.test.ts` for input, output, and metadata fields.
>     - Updates test cases to reflect changes in method signature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f15c2838801add9841bec9539ad4caa348034039. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->