### PR TITLE
feat: add level filter param to observations api

### DIFF
--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -33,7 +33,7 @@ service:
           type: optional<string>
           traceId: optional<string>
           level:
-            type: optional<string>
+            type: optional<commons.ObservationLevel>
             docs: Optional filter for observations with a specific level (e.g. "DEBUG", "DEFAULT", "WARNING", "ERROR").
           parentObservationId: optional<string>
           environment:

--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -32,6 +32,9 @@ service:
           userId: optional<string>
           type: optional<string>
           traceId: optional<string>
+          level:
+            type: optional<string>
+            docs: Optional filter for observations with a specific level (e.g. "DEBUG", "DEFAULT", "WARNING", "ERROR").
           parentObservationId: optional<string>
           environment:
             type: optional<string>

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -1942,6 +1942,15 @@ paths:
           schema:
             type: string
             nullable: true
+        - name: level
+          in: query
+          description: >-
+            Optional filter for observations with a specific level (e.g.
+            "DEBUG", "DEFAULT", "WARNING", "ERROR").
+          required: false
+          schema:
+            $ref: '#/components/schemas/ObservationLevel'
+            nullable: true
         - name: parentObservationId
           in: query
           required: false

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -1462,7 +1462,7 @@
           "request": {
             "description": "Get a list of observations",
             "url": {
-              "raw": "{{baseUrl}}/api/public/observations?page=&limit=&name=&userId=&type=&traceId=&parentObservationId=&environment=&fromStartTime=&toStartTime=&version=",
+              "raw": "{{baseUrl}}/api/public/observations?page=&limit=&name=&userId=&type=&traceId=&level=&parentObservationId=&environment=&fromStartTime=&toStartTime=&version=",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1501,6 +1501,11 @@
                   "key": "traceId",
                   "value": "",
                   "description": null
+                },
+                {
+                  "key": "level",
+                  "value": "",
+                  "description": "Optional filter for observations with a specific level (e.g. \"DEBUG\", \"DEFAULT\", \"WARNING\", \"ERROR\")."
                 },
                 {
                   "key": "parentObservationId",

--- a/web/src/__tests__/async/observations-api.servertest.ts
+++ b/web/src/__tests__/async/observations-api.servertest.ts
@@ -1,0 +1,282 @@
+import {
+  createObservation,
+  createTrace,
+  createTracesCh,
+} from "@langfuse/shared/src/server";
+import { createObservationsCh } from "@langfuse/shared/src/server";
+import { makeZodVerifiedAPICall } from "@/src/__tests__/test-utils";
+import { GetObservationsV1Response } from "@/src/features/public-api/types/observations";
+import { randomUUID } from "crypto";
+
+const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
+
+describe("/api/public/observations API Endpoint", () => {
+  describe("GET /api/public/observations", () => {
+    it("should fetch all observations with basic data structure", async () => {
+      const traceId = randomUUID();
+      const timestamp = new Date();
+
+      // Create a trace first
+      const createdTrace = createTrace({
+        id: traceId,
+        name: "test-trace",
+        user_id: "user-1",
+        timestamp: timestamp.getTime(),
+        project_id: projectId,
+        metadata: { testKey: "testValue" },
+        release: "1.0.0",
+        version: "2.0.0",
+      });
+
+      // Create multiple observations with different types and levels
+      const observations = [
+        createObservation({
+          id: randomUUID(),
+          trace_id: traceId,
+          project_id: projectId,
+          name: "generation-observation",
+          type: "GENERATION",
+          level: "DEFAULT",
+          start_time: timestamp.getTime(),
+          end_time: timestamp.getTime() + 1000,
+          input: "What is the capital of France?",
+          output: "The capital of France is Paris.",
+          provided_model_name: "gpt-4",
+        }),
+        createObservation({
+          id: randomUUID(),
+          trace_id: traceId,
+          project_id: projectId,
+          name: "span-observation",
+          type: "SPAN",
+          level: "DEBUG",
+          start_time: timestamp.getTime() + 500,
+          end_time: timestamp.getTime() + 2000,
+          input: "Processing request",
+          output: "Request processed successfully",
+        }),
+        createObservation({
+          id: randomUUID(),
+          trace_id: traceId,
+          project_id: projectId,
+          name: "event-observation",
+          type: "EVENT",
+          level: "WARNING",
+          start_time: timestamp.getTime() + 1500,
+          input: "User action recorded",
+          metadata: { eventType: "click", target: "submit-button" },
+        }),
+      ];
+
+      await createTracesCh([createdTrace]);
+      await createObservationsCh(observations);
+
+      const response = await makeZodVerifiedAPICall(
+        GetObservationsV1Response,
+        "GET",
+        "/api/public/observations",
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toBeDefined();
+      expect(response.body.meta).toBeDefined();
+      expect(response.body.meta.totalItems).toBeGreaterThanOrEqual(3);
+      expect(response.body.data.length).toBeGreaterThanOrEqual(3);
+
+      // Find our created observations in the response
+      const createdObservations = response.body.data.filter(
+        (obs) => obs.traceId === traceId,
+      );
+      expect(createdObservations.length).toBe(3);
+
+      // Verify data structure and content
+      const generationObs = createdObservations.find(
+        (obs) => obs.type === "GENERATION",
+      );
+      expect(generationObs).toBeDefined();
+      expect(generationObs?.name).toBe("generation-observation");
+      expect(generationObs?.level).toBe("DEFAULT");
+      expect(generationObs?.input).toBe("What is the capital of France?");
+      expect(generationObs?.output).toBe("The capital of France is Paris.");
+      expect(generationObs?.model).toBe("gpt-4");
+      expect(generationObs?.projectId).toBe(projectId);
+      expect(generationObs?.traceId).toBe(traceId);
+
+      const spanObs = createdObservations.find((obs) => obs.type === "SPAN");
+      expect(spanObs).toBeDefined();
+      expect(spanObs?.name).toBe("span-observation");
+      expect(spanObs?.level).toBe("DEBUG");
+      expect(spanObs?.input).toBe("Processing request");
+      expect(spanObs?.output).toBe("Request processed successfully");
+
+      const eventObs = createdObservations.find((obs) => obs.type === "EVENT");
+      expect(eventObs).toBeDefined();
+      expect(eventObs?.name).toBe("event-observation");
+      expect(eventObs?.level).toBe("WARNING");
+      expect(eventObs?.input).toBe("User action recorded");
+      expect(eventObs?.metadata).toEqual({
+        eventType: "click",
+        target: "submit-button",
+      });
+    });
+
+    it("should filter observations by level parameter", async () => {
+      const traceId = randomUUID();
+      const timestamp = new Date();
+
+      // Create a trace
+      const createdTrace = createTrace({
+        id: traceId,
+        project_id: projectId,
+        timestamp: timestamp.getTime(),
+      });
+
+      // Create observations with different levels
+      const observations = [
+        createObservation({
+          id: randomUUID(),
+          trace_id: traceId,
+          project_id: projectId,
+          name: "debug-observation",
+          type: "EVENT",
+          level: "DEBUG",
+          start_time: timestamp.getTime(),
+          input: "Debug information",
+          output: "Debug output",
+        }),
+        createObservation({
+          id: randomUUID(),
+          trace_id: traceId,
+          project_id: projectId,
+          name: "default-observation",
+          type: "GENERATION",
+          level: "DEFAULT",
+          start_time: timestamp.getTime() + 1000,
+          input: "Regular operation",
+          output: "Operation completed",
+        }),
+        createObservation({
+          id: randomUUID(),
+          trace_id: traceId,
+          project_id: projectId,
+          name: "warning-observation",
+          type: "SPAN",
+          level: "WARNING",
+          start_time: timestamp.getTime() + 2000,
+          input: "Warning condition detected",
+          output: "Warning handled",
+        }),
+        createObservation({
+          id: randomUUID(),
+          trace_id: traceId,
+          project_id: projectId,
+          name: "error-observation",
+          type: "EVENT",
+          level: "ERROR",
+          start_time: timestamp.getTime() + 3000,
+          input: "Error occurred",
+          output: "Error logged",
+        }),
+      ];
+
+      await createTracesCh([createdTrace]);
+      await createObservationsCh(observations);
+
+      // Test filtering by DEBUG level
+      const debugResponse = await makeZodVerifiedAPICall(
+        GetObservationsV1Response,
+        "GET",
+        `/api/public/observations?traceId=${traceId}&level=DEBUG`,
+      );
+
+      expect(debugResponse.body.data.length).toBe(1);
+      expect(debugResponse.body.data[0]?.level).toBe("DEBUG");
+      expect(debugResponse.body.data[0]?.name).toBe("debug-observation");
+      expect(debugResponse.body.data[0]?.input).toBe("Debug information");
+
+      // Test filtering by DEFAULT level
+      const defaultResponse = await makeZodVerifiedAPICall(
+        GetObservationsV1Response,
+        "GET",
+        `/api/public/observations?traceId=${traceId}&level=DEFAULT`,
+      );
+
+      expect(defaultResponse.body.data.length).toBe(1);
+      expect(defaultResponse.body.data[0]?.level).toBe("DEFAULT");
+      expect(defaultResponse.body.data[0]?.name).toBe("default-observation");
+      expect(defaultResponse.body.data[0]?.type).toBe("GENERATION");
+
+      // Test filtering by WARNING level
+      const warningResponse = await makeZodVerifiedAPICall(
+        GetObservationsV1Response,
+        "GET",
+        `/api/public/observations?traceId=${traceId}&level=WARNING`,
+      );
+
+      expect(warningResponse.body.data.length).toBe(1);
+      expect(warningResponse.body.data[0]?.level).toBe("WARNING");
+      expect(warningResponse.body.data[0]?.name).toBe("warning-observation");
+      expect(warningResponse.body.data[0]?.type).toBe("SPAN");
+
+      // Test filtering by ERROR level
+      const errorResponse = await makeZodVerifiedAPICall(
+        GetObservationsV1Response,
+        "GET",
+        `/api/public/observations?traceId=${traceId}&level=ERROR`,
+      );
+
+      expect(errorResponse.body.data.length).toBe(1);
+      expect(errorResponse.body.data[0]?.level).toBe("ERROR");
+      expect(errorResponse.body.data[0]?.name).toBe("error-observation");
+      expect(errorResponse.body.data[0]?.input).toBe("Error occurred");
+    });
+
+    it("should return empty results when filtering by level with no matches", async () => {
+      const traceId = randomUUID();
+      const timestamp = new Date();
+
+      // Create a trace
+      const createdTrace = createTrace({
+        id: traceId,
+        project_id: projectId,
+        timestamp: timestamp.getTime(),
+      });
+
+      // Create observations with only DEFAULT level
+      const observations = [
+        createObservation({
+          id: randomUUID(),
+          trace_id: traceId,
+          project_id: projectId,
+          name: "default-observation-1",
+          type: "EVENT",
+          level: "DEFAULT",
+          start_time: timestamp.getTime(),
+        }),
+        createObservation({
+          id: randomUUID(),
+          trace_id: traceId,
+          project_id: projectId,
+          name: "default-observation-2",
+          type: "GENERATION",
+          level: "DEFAULT",
+          start_time: timestamp.getTime() + 1000,
+        }),
+      ];
+
+      await createTracesCh([createdTrace]);
+      await createObservationsCh(observations);
+
+      // Test filtering by ERROR level (should return no results)
+      const errorResponse = await makeZodVerifiedAPICall(
+        GetObservationsV1Response,
+        "GET",
+        `/api/public/observations?traceId=${traceId}&level=ERROR`,
+      );
+
+      expect(errorResponse.body.data.length).toBe(0);
+      expect(errorResponse.body.meta.totalItems).toBe(0);
+      expect(errorResponse.body.meta.totalPages).toBe(0);
+    });
+  });
+});

--- a/web/src/__tests__/async/observations-api.servertest.ts
+++ b/web/src/__tests__/async/observations-api.servertest.ts
@@ -118,7 +118,7 @@ describe("/api/public/observations API Endpoint", () => {
         eventType: "click",
         target: "submit-button",
       });
-    });
+    }, 15_000);
 
     it("should filter observations by level parameter", async () => {
       const traceId = randomUUID();

--- a/web/src/features/public-api/server/observations.ts
+++ b/web/src/features/public-api/server/observations.ts
@@ -135,6 +135,13 @@ const filterParams = [
     clickhousePrefix: "o",
   },
   {
+    id: "level",
+    clickhouseSelect: "level",
+    filterType: "StringFilter",
+    clickhouseTable: "observations",
+    clickhousePrefix: "o",
+  },
+  {
     id: "type",
     clickhouseSelect: "type",
     filterType: "StringFilter",

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -1,5 +1,6 @@
 import {
   type Observation,
+  ObservationLevel,
   paginationMetaResponseZod,
   publicApiPaginationZod,
 } from "@langfuse/shared";
@@ -159,6 +160,7 @@ export const GetObservationsV1Query = z.object({
   type: ObservationType.nullish(),
   name: z.string().nullish(),
   userId: z.string().nullish(),
+  level: z.enum(ObservationLevel).nullish(),
   traceId: z.string().nullish(),
   version: z.string().nullish(),
   parentObservationId: z.string().nullish(),

--- a/web/src/pages/api/public/observations/index.ts
+++ b/web/src/pages/api/public/observations/index.ts
@@ -25,6 +25,7 @@ export default withMiddlewares({
         limit: query.limit ?? undefined,
         traceId: query.traceId ?? undefined,
         userId: query.userId ?? undefined,
+        level: query.level ?? undefined,
         name: query.name ?? undefined,
         type: query.type ?? undefined,
         environment: query.environment ?? undefined,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `level` filter to observations API for filtering by observation level, update API specs, and add tests.
> 
>   - **API Changes**:
>     - Add `level` filter parameter to `observations.yml` for filtering observations by level (e.g., "DEBUG", "DEFAULT", "WARNING", "ERROR").
>     - Update `openapi.yml` to include `level` as a query parameter for the observations endpoint.
>     - Modify `collection.json` to include `level` in the request URL for observations.
>   - **Backend**:
>     - Update `observations.ts` to handle `level` filter in `generateObservationsForPublicApi()` and `getObservationsCountForPublicApi()`.
>     - Add `level` to `filterParams` in `observations.ts`.
>   - **Testing**:
>     - Add tests in `observations-api.servertest.ts` to verify filtering by `level` parameter, including cases with no matches.
>   - **Types**:
>     - Update `GetObservationsV1Query` in `observations.ts` to include `level` as an optional filter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a848571df20c5b108b1f40bc927fc8b16034730d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->