### PR TITLE
perf: import react-icons from one sub path

### DIFF
--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -12,9 +12,15 @@ import {
 import { Input } from "@/src/components/ui/input";
 import { env } from "@/src/env.mjs";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { FcGoogle } from "react-icons/fc";
-import { FaGithub, FaGitlab } from "react-icons/fa";
-import { SiOkta, SiAuth0, SiAmazoncognito, SiKeycloak } from "react-icons/si";
+import {
+  SiOkta,
+  SiAuth0,
+  SiAmazoncognito,
+  SiKeycloak,
+  SiGoogle,
+  SiGitlab,
+  SiGithub,
+} from "react-icons/si";
 import { TbBrandAzure, TbBrandOauth } from "react-icons/tb";
 import { signIn } from "next-auth/react";
 import Head from "next/head";
@@ -184,7 +190,7 @@ export function SSOButtons({
               variant="secondary"
               loading={providerSigningIn === "google"}
             >
-              <FcGoogle className="mr-3" size={18} />
+              <SiGoogle className="mr-3" size={18} />
               Google
             </Button>
           )}
@@ -194,7 +200,7 @@ export function SSOButtons({
               variant="secondary"
               loading={providerSigningIn === "github"}
             >
-              <FaGithub className="mr-3" size={18} />
+              <SiGithub className="mr-3" size={18} />
               GitHub
             </Button>
           )}
@@ -204,7 +210,7 @@ export function SSOButtons({
               variant="secondary"
               loading={providerSigningIn === "github-enterprise"}
             >
-              <FaGithub className="mr-3" size={18} />
+              <SiGithub className="mr-3" size={18} />
               GitHub Enterprise
             </Button>
           )}
@@ -214,7 +220,7 @@ export function SSOButtons({
               variant="secondary"
               loading={providerSigningIn === "gitlab"}
             >
-              <FaGitlab className="mr-3" size={18} />
+              <SiGitlab className="mr-3" size={18} />
               Gitlab
             </Button>
           )}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize `react-icons` imports in `sign-in.tsx` by consolidating them under a single sub-path for improved performance.
> 
>   - **Imports**:
>     - Consolidate `react-icons` imports in `sign-in.tsx` to use a single sub-path `react-icons/si` for `SiOkta`, `SiAuth0`, `SiAmazoncognito`, `SiKeycloak`, `SiGoogle`, `SiGitlab`, and `SiGithub`.
>     - Replace `FcGoogle` with `SiGoogle` and `FaGithub`, `FaGitlab` with `SiGithub`, `SiGitlab` respectively in `SSOButtons` component.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6565221930411a45440d7dd3973187a652b85a5a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->