### PR TITLE
chore: add linter rule for react icons

### DIFF
--- a/web/.eslintrc.js
+++ b/web/.eslintrc.js
@@ -11,9 +11,13 @@ module.exports = {
       {
         patterns: [
           {
-            group: ["react-icons", "react-icons/*"],
+            group: [
+              "react-icons",
+              "react-icons/!(si|tb)",
+              "react-icons/!(si|tb)/*",
+            ],
             message:
-              "react-icons import not allowed. Please use lucide-react instead.",
+              "Only react-icons/si and react-icons/tb are allowed. Please use lucide-react for other icons.",
           },
         ],
       },

--- a/web/.eslintrc.js
+++ b/web/.eslintrc.js
@@ -5,4 +5,29 @@ module.exports = {
   parserOptions: {
     project: true,
   },
+  rules: {
+    "no-restricted-imports": [
+      "error",
+      {
+        patterns: [
+          {
+            group: ["react-icons", "react-icons/*"],
+            message:
+              "react-icons import not allowed. Please use lucide-react instead.",
+          },
+        ],
+      },
+    ],
+  },
+  overrides: [
+    {
+      files: [
+        "src/components/nav/support-menu-dropdown.tsx",
+        "src/pages/auth/sign-in.tsx",
+      ],
+      rules: {
+        "no-restricted-imports": "off",
+      },
+    },
+  ],
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add linter rule to restrict `react-icons` imports except `si` and `tb`, with exceptions for two files.
> 
>   - **Linter Rule**:
>     - Adds `no-restricted-imports` rule in `.eslintrc.js` to restrict `react-icons` imports except `react-icons/si` and `react-icons/tb`.
>     - Provides a message to use `lucide-react` for other icons.
>   - **Overrides**:
>     - Disables `no-restricted-imports` rule for `src/components/nav/support-menu-dropdown.tsx` and `src/pages/auth/sign-in.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 71bc09c2963743ace64c63941cf835cca593a9a0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->