### PR TITLE
feat(model-prices): match cross-region inference profile for claude via bedrock

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1004,9 +1004,9 @@
   {
     "id": "clxt0n0m60000pumz1j5b7zsf",
     "model_name": "claude-3-5-sonnet-20240620",
-    "match_pattern": "(?i)^(claude-3-5-sonnet-20240620|anthropic\\.claude-3-5-sonnet-20240620-v1:0|claude-3-5-sonnet@20240620)$",
+    "match_pattern": "(?i)^(claude-3-5-sonnet-20240620|(eu\\.|us\\.)?anthropic\\.claude-3-5-sonnet-20240620-v1:0|claude-3-5-sonnet@20240620)$",
     "created_at": "2024-06-25T11:47:24.475Z",
-    "updated_at": "2024-12-03T12:20:59.000Z",
+    "updated_at": "2025-07-16T14:56:27.501Z",
     "prices": {
       "input": 3e-6,
       "input_tokens": 3e-6,
@@ -1148,9 +1148,9 @@
   {
     "id": "cm2krz1uf000208jjg5653iud",
     "model_name": "claude-3.5-sonnet-20241022",
-    "match_pattern": "(?i)^(claude-3-5-sonnet-20241022|anthropic\\.claude-3-5-sonnet-20241022-v2:0|claude-3-5-sonnet-V2@20241022)$",
+    "match_pattern": "(?i)^(claude-3-5-sonnet-20241022|(eu\\.|us\\.)?anthropic\\.claude-3-5-sonnet-20241022-v2:0|claude-3-5-sonnet-V2@20241022)$",
     "created_at": "2024-10-22T18:48:01.676Z",
-    "updated_at": "2024-12-03T12:21:10.000Z",
+    "updated_at": "2025-07-16T14:56:27.501Z",
     "prices": {
       "input": 3e-6,
       "input_tokens": 3e-6,
@@ -1186,9 +1186,9 @@
   {
     "id": "cm34aq60d000207ml0j1h31ar",
     "model_name": "claude-3-5-haiku-20241022",
-    "match_pattern": "(?i)^(claude-3-5-haiku-20241022|anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
+    "match_pattern": "(?i)^(claude-3-5-haiku-20241022|(eu\\.|us\\.)?anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
     "created_at": "2024-11-05T10:30:50.566Z",
-    "updated_at": "2024-12-03T12:24:24.000Z",
+    "updated_at": "2025-07-16T14:56:27.501Z",
     "prices": {
       "input": 0.8e-6,
       "input_tokens": 0.8e-6,
@@ -1446,9 +1446,9 @@
   {
     "id": "cm7ka7561000108js3t9tb3at",
     "model_name": "claude-3.7-sonnet-20250219",
-    "match_pattern": "(?i)^(claude-3.7-sonnet-20250219|anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
+    "match_pattern": "(?i)^(claude-3.7-sonnet-20250219|(eu\\.|us\\.)?anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
     "created_at": "2025-02-25T09:35:39.000Z",
-    "updated_at": "2025-02-27T12:07:29.000Z",
+    "updated_at": "2025-07-16T14:51:47.025Z",
     "prices": {
       "input": 3e-6,
       "input_tokens": 3e-6,
@@ -1736,9 +1736,9 @@
   {
     "id": "cmazmkzlm00000djp1e1qe4k4",
     "model_name": "claude-sonnet-4-20250514",
-    "match_pattern": "(?i)^(claude-sonnet-4-20250514|anthropic\\.claude-sonnet-4-20250514-v1:0|claude-sonnet-4-V1@20250514|claude-sonnet-4@20250514)$",
+    "match_pattern": "(?i)^(claude-sonnet-4-20250514|(eu\\.|us\\.)?anthropic\\.claude-sonnet-4-20250514-v1:0|claude-sonnet-4-V1@20250514|claude-sonnet-4@20250514)$",
     "created_at": "2025-05-22T17:09:02.131Z",
-    "updated_at": "2025-05-26T23:09:02.131Z",
+    "updated_at": "2025-07-16T14:56:27.501Z",
     "prices": {
       "input": 3e-6,
       "input_tokens": 3e-6,
@@ -1774,9 +1774,9 @@
   {
     "id": "cmazmlm2p00020djpa9s64jw5",
     "model_name": "claude-opus-4-20250514",
-    "match_pattern": "(?i)^(claude-opus-4-20250514|anthropic\\.claude-opus-4-20250514-v1:0|claude-opus-4@20250514)$",
+    "match_pattern": "(?i)^(claude-opus-4-20250514|(eu\\.|us\\.)?anthropic\\.claude-opus-4-20250514-v1:0|claude-opus-4@20250514)$",
     "created_at": "2025-05-22T17:09:02.131Z",
-    "updated_at": "2025-05-22T17:09:02.131Z",
+    "updated_at": "2025-07-16T14:56:27.501Z",
     "prices": {
       "input": 15e-6,
       "input_tokens": 15e-6,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updated `match_pattern` in `default-model-prices.json` for several Claude models to support optional region prefixes, enabling cross-region inference profiles.
> 
>   - **Behavior**:
>     - Updated `match_pattern` for models `claude-3-5-sonnet-20240620`, `claude-3.5-sonnet-20241022`, `claude-3-5-haiku-20241022`, `claude-3.7-sonnet-20250219`, `claude-sonnet-4-20250514`, and `claude-opus-4-20250514` in `default-model-prices.json` to include optional `eu.` or `us.` prefixes.
>     - This change allows matching of model names with or without region prefixes, supporting cross-region inference profiles.
>   - **Misc**:
>     - Updated `updated_at` timestamps for the affected models to `2025-07-16T14:56:27.501Z` or `2025-07-16T14:51:47.025Z`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 561b4dd052fb9f17bebb1ba6aef17e84da608558. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->