### PR TITLE
fix(playground): use playground with tool calls form langgraph traces

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -192,11 +192,12 @@ export async function fetchLLMCompletion(
       )
         return new SystemMessage(safeContent);
 
-      if (message.type === ChatMessageType.ToolResult)
+      if (message.type === ChatMessageType.ToolResult) {
         return new ToolMessage({
           content: safeContent,
           tool_call_id: message.toolCallId,
         });
+      }
 
       return new AIMessage({
         content: safeContent,

--- a/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -243,7 +243,8 @@ const isLangchainToolDefinitionMessage = (
 
 const transformToPlaygroundMessage = (
   message: z.infer<typeof ParsedChatMessageListSchema>[0],
-): ChatMessage | PlaceholderMessage => {
+  allMessages?: z.infer<typeof ParsedChatMessageListSchema>,
+): ChatMessage | PlaceholderMessage | null => {
   // Return placeholder messages as-is
   if (isPlaceholder(message)) {
     return message;
@@ -281,11 +282,47 @@ const transformToPlaygroundMessage = (
 
     return playgroundMessage;
   } else if (regularMessage.role === "tool") {
+    // First check if tool_call_id is already provided
+    let toolCallId = (regularMessage as any).tool_call_id;
+
+    // Try to infer if tool_call_id is missing or empty (eg langgraph case)
+    if (!toolCallId && allMessages && regularMessage._originalRole) {
+      // Find all assistant messages with tool calls, most recent first
+      const assistantMessages = allMessages
+        .filter(
+          (msg): msg is Exclude<typeof msg, PlaceholderMessage> =>
+            !isPlaceholder(msg) &&
+            msg.role === "assistant" &&
+            !!(msg.tool_calls || msg.additional_kwargs?.tool_calls),
+        )
+        .reverse();
+
+      // Look for the first matching tool call by name
+      for (const prevMessage of assistantMessages) {
+        const toolCalls =
+          prevMessage.tool_calls ??
+          prevMessage.additional_kwargs?.tool_calls ??
+          [];
+
+        const matchingCall = toolCalls.find((tc) => {
+          if ("function" in tc) {
+            return tc.function.name === regularMessage._originalRole;
+          }
+          return tc.name === regularMessage._originalRole;
+        });
+
+        if (matchingCall && matchingCall.id) {
+          toolCallId = matchingCall.id;
+          break;
+        }
+      }
+    }
+
     const playgroundMessage: ChatMessage = {
       role: ChatMessageRole.Tool,
       content,
       type: ChatMessageType.ToolResult,
-      toolCallId: regularMessage.tool_call_id ?? "",
+      toolCallId: toolCallId || "",
     };
 
     return playgroundMessage;
@@ -323,9 +360,21 @@ const parsePrompt = (
     const parsedMessages =
       ParsedChatMessageListSchema.safeParse(normalizedMessages);
 
-    return parsedMessages.success
-      ? { messages: parsedMessages.data.map(transformToPlaygroundMessage) }
-      : null;
+    if (!parsedMessages.success) {
+      return null;
+    }
+
+    try {
+      return {
+        messages: parsedMessages.data
+          .map((msg) => transformToPlaygroundMessage(msg, parsedMessages.data))
+          .filter(
+            (msg): msg is ChatMessage | PlaceholderMessage => msg !== null,
+          ),
+      };
+    } catch (error) {
+      return null;
+    }
   } else {
     const promptString = prompt.resolvedPrompt;
 
@@ -403,15 +452,27 @@ const parseGeneration = (
     const parsedMessages =
       ParsedChatMessageListSchema.safeParse(normalizedMessages);
 
-    if (parsedMessages.success)
+    if (!parsedMessages.success) {
+      return null;
+    }
+
+    try {
+      const filteredMessages = parsedMessages.data.filter(
+        (m) => !isLangchainToolDefinitionMessage(m),
+      );
       return {
-        messages: parsedMessages.data
-          .filter((m) => !isLangchainToolDefinitionMessage(m))
-          .map(transformToPlaygroundMessage),
+        messages: filteredMessages
+          .map((msg) => transformToPlaygroundMessage(msg, filteredMessages))
+          .filter(
+            (msg): msg is ChatMessage | PlaceholderMessage => msg !== null,
+          ),
         modelParams,
         tools,
         structuredOutputSchema,
       };
+    } catch (error) {
+      return null;
+    }
   }
 
   if (typeof input === "object" && "messages" in input) {
@@ -424,15 +485,27 @@ const parseGeneration = (
     const parsedMessages =
       ParsedChatMessageListSchema.safeParse(normalizedMessages);
 
-    if (parsedMessages.success)
+    if (!parsedMessages.success) {
+      return null;
+    }
+
+    try {
+      const filteredMessages = parsedMessages.data.filter(
+        (m) => !isLangchainToolDefinitionMessage(m),
+      );
       return {
-        messages: parsedMessages.data
-          .filter((m) => !isLangchainToolDefinitionMessage(m))
-          .map(transformToPlaygroundMessage),
+        messages: filteredMessages
+          .map((msg) => transformToPlaygroundMessage(msg, filteredMessages))
+          .filter(
+            (msg): msg is ChatMessage | PlaceholderMessage => msg !== null,
+          ),
         modelParams,
         tools,
         structuredOutputSchema,
       };
+    } catch (error) {
+      return null;
+    }
   }
 
   return null;

--- a/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -282,7 +282,6 @@ const transformToPlaygroundMessage = (
 
     return playgroundMessage;
   } else if (regularMessage.role === "tool") {
-    // First check if tool_call_id is already provided
     let toolCallId = (regularMessage as any).tool_call_id;
 
     // Try to infer if tool_call_id is missing or empty (eg langgraph case)
@@ -364,17 +363,11 @@ const parsePrompt = (
       return null;
     }
 
-    try {
-      return {
-        messages: parsedMessages.data
-          .map((msg) => transformToPlaygroundMessage(msg, parsedMessages.data))
-          .filter(
-            (msg): msg is ChatMessage | PlaceholderMessage => msg !== null,
-          ),
-      };
-    } catch (error) {
-      return null;
-    }
+    return {
+      messages: parsedMessages.data
+        .map((msg) => transformToPlaygroundMessage(msg, parsedMessages.data))
+        .filter((msg): msg is ChatMessage | PlaceholderMessage => msg !== null),
+    };
   } else {
     const promptString = prompt.resolvedPrompt;
 
@@ -456,23 +449,17 @@ const parseGeneration = (
       return null;
     }
 
-    try {
-      const filteredMessages = parsedMessages.data.filter(
-        (m) => !isLangchainToolDefinitionMessage(m),
-      );
-      return {
-        messages: filteredMessages
-          .map((msg) => transformToPlaygroundMessage(msg, filteredMessages))
-          .filter(
-            (msg): msg is ChatMessage | PlaceholderMessage => msg !== null,
-          ),
-        modelParams,
-        tools,
-        structuredOutputSchema,
-      };
-    } catch (error) {
-      return null;
-    }
+    const filteredMessages = parsedMessages.data.filter(
+      (m) => !isLangchainToolDefinitionMessage(m),
+    );
+    return {
+      messages: filteredMessages
+        .map((msg) => transformToPlaygroundMessage(msg, filteredMessages))
+        .filter((msg): msg is ChatMessage | PlaceholderMessage => msg !== null),
+      modelParams,
+      tools,
+      structuredOutputSchema,
+    };
   }
 
   if (typeof input === "object" && "messages" in input) {
@@ -489,23 +476,17 @@ const parseGeneration = (
       return null;
     }
 
-    try {
-      const filteredMessages = parsedMessages.data.filter(
-        (m) => !isLangchainToolDefinitionMessage(m),
-      );
-      return {
-        messages: filteredMessages
-          .map((msg) => transformToPlaygroundMessage(msg, filteredMessages))
-          .filter(
-            (msg): msg is ChatMessage | PlaceholderMessage => msg !== null,
-          ),
-        modelParams,
-        tools,
-        structuredOutputSchema,
-      };
-    } catch (error) {
-      return null;
-    }
+    const filteredMessages = parsedMessages.data.filter(
+      (m) => !isLangchainToolDefinitionMessage(m),
+    );
+    return {
+      messages: filteredMessages
+        .map((msg) => transformToPlaygroundMessage(msg, filteredMessages))
+        .filter((msg): msg is ChatMessage | PlaceholderMessage => msg !== null),
+      modelParams,
+      tools,
+      structuredOutputSchema,
+    };
   }
 
   return null;

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -616,7 +616,6 @@ async function* getChatCompletionStream(
     return;
   }
 
-  // If messages contain tool results, we include tools in the request
   const hasToolResults = messages.some(
     (msg) => msg.type === ChatMessageType.ToolResult,
   );
@@ -677,7 +676,6 @@ async function getChatCompletionNonStreaming(
     throw new Error("Project ID is not set");
   }
 
-  // If messages contain tool results, we include tools in the request
   const hasToolResults = messages.some(
     (msg) => msg.type === ChatMessageType.ToolResult,
   );

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -539,6 +539,7 @@ async function getChatCompletionWithTools(
     tools,
     streaming,
   });
+
   const result = await fetch(
     `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/chatCompletion`,
     {
@@ -615,12 +616,21 @@ async function* getChatCompletionStream(
     return;
   }
 
+  // If messages contain tool results, we include tools in the request
+  const hasToolResults = messages.some(
+    (msg) => msg.type === ChatMessageType.ToolResult,
+  );
+
   const body = JSON.stringify({
     projectId,
     messages,
     modelParams: getFinalModelParams(modelParams),
     streaming: true,
+    // Include empty tools array if there are tool result messages to ensure processing
+    // E.g. if tool call was picked up through traces but not defined
+    ...(hasToolResults && { tools: [] }),
   });
+
   const result = await fetch(
     `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/chatCompletion`,
     {
@@ -667,11 +677,19 @@ async function getChatCompletionNonStreaming(
     throw new Error("Project ID is not set");
   }
 
+  // If messages contain tool results, we include tools in the request
+  const hasToolResults = messages.some(
+    (msg) => msg.type === ChatMessageType.ToolResult,
+  );
+
   const body = JSON.stringify({
     projectId,
     messages,
     modelParams: getFinalModelParams(modelParams),
     streaming: false,
+    // Include empty tools array if there are tool result messages to ensure processing
+    // E.g. if tool call was picked up through traces but not defined
+    ...(hasToolResults && { tools: [] }),
   });
 
   const result = await fetch(

--- a/web/src/features/playground/server/chatCompletionHandler.ts
+++ b/web/src/features/playground/server/chatCompletionHandler.ts
@@ -58,15 +58,54 @@ export default async function chatCompletionHandler(req: NextRequest) {
       config: parsedKey.data.config,
     };
 
-    if ((tools && tools.length > 0) || structuredOutputSchema) {
-      const { completion } = await fetchLLMCompletion({
+    // Handle structured output as special case
+    if (structuredOutputSchema) {
+      const result = await fetchLLMCompletion({
         ...fetchLLMCompletionParams,
         streaming: false,
-        tools: tools ?? [],
         structuredOutputSchema,
       });
+      return NextResponse.json(result.completion);
+    }
 
-      return NextResponse.json(completion);
+    // If messages contain tool results, we include tools in the request
+    const hasToolResults = messages.some((msg) => msg.type === "tool-result");
+
+    if ((tools && tools.length > 0) || hasToolResults) {
+      // Fix empty tool_call_id values by mapping to langgraph IDs
+      const fixedMessages = messages.map((msg) => {
+        if (
+          msg.type === "tool-result" &&
+          (!msg.toolCallId || msg.toolCallId === "")
+        ) {
+          const assistantMessages = messages
+            .filter((m) => m.type === "assistant-tool-call" && m.toolCalls)
+            .reverse();
+
+          // Find the first matching tool call by name
+          for (const prevMsg of assistantMessages) {
+            const matchingToolCall = prevMsg.toolCalls.find(
+              (tc) => tc.name === (msg as any)._originalRole,
+            );
+            if (matchingToolCall && matchingToolCall.id) {
+              return {
+                ...msg,
+                toolCallId: matchingToolCall.id,
+              };
+            }
+          }
+        }
+
+        return msg;
+      });
+
+      const result = await (fetchLLMCompletion as any)({
+        ...fetchLLMCompletionParams,
+        messages: fixedMessages,
+        streaming: false,
+        tools: tools ?? [],
+      });
+      return NextResponse.json(result.completion);
     }
 
     if (streaming) {

--- a/web/src/features/playground/server/chatCompletionHandler.ts
+++ b/web/src/features/playground/server/chatCompletionHandler.ts
@@ -82,9 +82,10 @@ export default async function chatCompletionHandler(req: NextRequest) {
             .reverse();
 
           // Find the first matching tool call by name
+          // Note: using 'as any' because we filtered for assistant-tool-call messages above
           for (const prevMsg of assistantMessages) {
-            const matchingToolCall = prevMsg.toolCalls.find(
-              (tc) => tc.name === (msg as any)._originalRole,
+            const matchingToolCall = (prevMsg as any).toolCalls.find(
+              (tc: any) => tc.name === (msg as any)._originalRole,
             );
             if (matchingToolCall && matchingToolCall.id) {
               return {

--- a/web/src/features/playground/server/chatCompletionHandler.ts
+++ b/web/src/features/playground/server/chatCompletionHandler.ts
@@ -58,7 +58,6 @@ export default async function chatCompletionHandler(req: NextRequest) {
       config: parsedKey.data.config,
     };
 
-    // Handle structured output as special case
     if (structuredOutputSchema) {
       const result = await fetchLLMCompletion({
         ...fetchLLMCompletionParams,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances playground tool call handling by inferring missing tool call IDs and improves error handling in message parsing.
> 
>   - **Behavior**:
>     - In `fetchLLMCompletion.ts`, added braces to `if` statement for `ToolResult` type to ensure proper block execution.
>     - In `JumpToPlaygroundButton.tsx`, `transformToPlaygroundMessage` now infers `tool_call_id` if missing, by matching with previous assistant messages.
>     - In `index.tsx`, `getChatCompletionStream` and `getChatCompletionNonStreaming` include empty tools array if tool results are present.
>     - In `chatCompletionHandler.ts`, fixes empty `tool_call_id` by mapping to LangGraph IDs if missing.
>   - **Error Handling**:
>     - In `parsePrompt` and `parseGeneration`, added try-catch blocks to handle parsing errors gracefully.
>   - **Misc**:
>     - Minor formatting changes and added comments for clarity in `index.tsx` and `JumpToPlaygroundButton.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0e71ade27c019a61eb316593ae9ff2a191bc4119. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->