### PR TITLE
fix: add timeouts to webhooks

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -66,7 +66,5 @@ export * from "./clickhouse/measureAndReturn";
 export * from "./data-deletion/ingestionFileDeletion";
 export * from "./s3";
 
-export * from "./automations/webhooks";
-
 // test utils
 export * from "./test-utils";

--- a/worker/src/__tests__/webhooks.test.ts
+++ b/worker/src/__tests__/webhooks.test.ts
@@ -11,13 +11,13 @@ import { v4 } from "uuid";
 import {
   ActionExecutionStatus,
   JobConfigState,
+  JsonNested,
   PromptDomainSchema,
   WebhookActionConfigWithSecrets,
 } from "@langfuse/shared";
 import {
   WebhookInput,
   createOrgProjectAndApiKey,
-  executeWebhook,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import {
@@ -28,6 +28,7 @@ import {
 import { generateWebhookSecret } from "@langfuse/shared/encryption";
 import { setupServer } from "msw/node";
 import { http, HttpResponse } from "msw";
+import { executeWebhook } from "../queues/webhooks";
 
 // Mock webhook server for testing HTTP requests
 class WebhookTestServer {

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -16,7 +16,6 @@ import {
 } from "./queues/evalQueue";
 import { batchExportQueueProcessor } from "./queues/batchExportQueue";
 import { onShutdown } from "./utils/shutdown";
-
 import helmet from "helmet";
 import { cloudUsageMeteringQueueProcessor } from "./queues/cloudUsageMeteringQueue";
 import { WorkerManager } from "./queues/workerManager";

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -30,7 +30,6 @@ import {
   BlobStorageIntegrationQueue,
   DeadLetterRetryQueue,
   IngestionQueue,
-  webhookProcessor,
 } from "@langfuse/shared/src/server";
 import { env } from "./env";
 import { ingestionQueueProcessorBuilder } from "./queues/ingestionQueue";
@@ -56,6 +55,7 @@ import { batchActionQueueProcessor } from "./queues/batchActionQueue";
 import { scoreDeleteProcessor } from "./queues/scoreDelete";
 import { DlqRetryService } from "./services/dlq/dlqRetryService";
 import { entityChangeQueueProcessor } from "./queues/entityChangeQueue";
+import { webhookProcessor } from "./queues/webhooks";
 
 const app = express();
 

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -242,6 +242,7 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(5),
+  LANGFUSE_WEBHOOK_TIMEOUT_MS: z.coerce.number().positive().default(10000),
   LANGFUSE_ENTITY_CHANGE_QUEUE_PROCESSING_CONCURRENCY: z.coerce
     .number()
     .positive()

--- a/worker/src/queues/webhooks.ts
+++ b/worker/src/queues/webhooks.ts
@@ -1,24 +1,24 @@
-import { Job, Processor } from "bullmq";
-import { backOff } from "exponential-backoff";
 import {
-  ActionExecutionStatus,
-  JobConfigState,
-} from "../../../prisma/generated/types";
-import {
+  InternalServerError,
   PromptWebhookOutboundSchema,
   WebhookDefaultHeaders,
-} from "../../domain";
-import { prisma } from "../../db";
-import { TQueueJobTypes, QueueName, WebhookInput } from "../queues";
+  ActionExecutionStatus,
+  LangfuseNotFoundError,
+  JobConfigState,
+} from "@langfuse/shared";
+import { decrypt, createSignatureHeader } from "@langfuse/shared/encryption";
+import { prisma } from "@langfuse/shared/src/db";
 import {
-  getActionByIdWithSecrets,
+  TQueueJobTypes,
+  QueueName,
+  WebhookInput,
   getAutomationById,
+  getActionByIdWithSecrets,
   getConsecutiveAutomationFailures,
-} from "../repositories";
-import { logger } from "..";
-import { createSignatureHeader } from "../../encryption/signature";
-import { decrypt } from "../../encryption";
-import { InternalServerError, LangfuseNotFoundError } from "../../errors";
+  logger,
+} from "@langfuse/shared/src/server";
+import { Processor, Job } from "bullmq";
+import { backOff } from "exponential-backoff";
 
 export const webhookProcessor: Processor = async (
   job: Job<TQueueJobTypes[QueueName.WebhookQueue]>,

--- a/worker/src/queues/webhooks.ts
+++ b/worker/src/queues/webhooks.ts
@@ -19,6 +19,7 @@ import {
 } from "@langfuse/shared/src/server";
 import { Processor, Job } from "bullmq";
 import { backOff } from "exponential-backoff";
+import { env } from "../env";
 
 export const webhookProcessor: Processor = async (
   job: Job<TQueueJobTypes[QueueName.WebhookQueue]>,
@@ -132,22 +133,44 @@ export const executeWebhook = async (input: WebhookInput) => {
             webhookPayload,
           )} and headers ${JSON.stringify(requestHeaders)}`,
         );
-        const res = await fetch(webhookConfig.url, {
-          method: "POST",
-          body: webhookPayload,
-          headers: requestHeaders,
-        });
 
-        httpStatus = res.status;
-        responseBody = await res.text();
+        // Create AbortController for timeout
+        const abortController = new AbortController();
+        const timeoutId = setTimeout(() => {
+          abortController.abort();
+        }, env.LANGFUSE_WEBHOOK_TIMEOUT_MS);
 
-        if (res.status !== 200) {
-          logger.warn(
-            `Webhook does not return 200: failed with status ${res.status} for url ${webhookConfig.url} and project ${projectId}. Body: ${responseBody}`,
-          );
-          throw new Error(
-            `Webhook does not return 200: failed with status ${res.status} for url ${webhookConfig.url} and project ${projectId}`,
-          );
+        try {
+          const res = await fetch(webhookConfig.url, {
+            method: "POST",
+            body: webhookPayload,
+            headers: requestHeaders,
+            signal: abortController.signal,
+          });
+
+          httpStatus = res.status;
+          responseBody = await res.text();
+
+          if (res.status !== 200) {
+            logger.warn(
+              `Webhook does not return 200: failed with status ${res.status} for url ${webhookConfig.url} and project ${projectId}. Body: ${responseBody}`,
+            );
+            throw new Error(
+              `Webhook does not return 200: failed with status ${res.status} for url ${webhookConfig.url} and project ${projectId}`,
+            );
+          }
+        } catch (error) {
+          if (error instanceof Error && error.name === "AbortError") {
+            logger.warn(
+              `Webhook timeout after ${env.LANGFUSE_WEBHOOK_TIMEOUT_MS}ms for url ${webhookConfig.url} and project ${projectId}`,
+            );
+            throw new Error(
+              `Webhook timeout after ${env.LANGFUSE_WEBHOOK_TIMEOUT_MS}ms for url ${webhookConfig.url} and project ${projectId}`,
+            );
+          }
+          throw error;
+        } finally {
+          clearTimeout(timeoutId);
         }
       },
       {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a timeout to webhook executions and refactors webhook processing logic, moving it to a new location and updating related imports.
> 
>   - **Behavior**:
>     - Adds timeout to webhook executions in `executeWebhook()` in `webhooks.ts` using `AbortController` with a default of 10000ms.
>     - Handles timeout errors by logging and throwing a specific error message.
>   - **Refactoring**:
>     - Moves `webhooks.ts` from `packages/shared/src/server/automations` to `worker/src/queues`.
>     - Updates imports in `webhooks.test.ts` and `app.ts` to reflect new location.
>   - **Environment**:
>     - Adds `LANGFUSE_WEBHOOK_TIMEOUT_MS` to `env.ts` with a default value of 10000ms.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7c6fcf6ad05a8dd7cda6d5cff82a918b76c6f59f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->