### PR TITLE
fix(playground): scroll variables if many are present

### DIFF
--- a/web/src/features/playground/page/components/MessagePlaceholders.tsx
+++ b/web/src/features/playground/page/components/MessagePlaceholders.tsx
@@ -9,33 +9,37 @@ export const MessagePlaceholders = () => {
   return (
     <div className="flex h-full flex-col">
       <p className="font-semibold">Message Placeholders</p>
-      {messagePlaceholders.length === 0 ? (
-        <div className="mt-4 text-xs">
-          <p className="mb-2">No message placeholders defined.</p>
-          <p>
-            Placeholders can be used to e.g. inject message histories into
-            prompts.
-          </p>
-        </div>
-      ) : (
-        <div className="h-full overflow-auto">
-          {messagePlaceholders
-            .slice()
-            .sort((a, b) => {
-              if (a.isUsed && !b.isUsed) return -1;
-              if (!a.isUsed && b.isUsed) return 1;
-              return a.name.localeCompare(b.name);
-            })
-            .map((placeholder, index) => (
-              <div key={placeholder.name}>
-                <MessagePlaceholderComponent messagePlaceholder={placeholder} />
-                {index !== messagePlaceholders.length - 1 && (
-                  <Divider className="my-2 text-muted-foreground" />
-                )}
-              </div>
-            ))}
-        </div>
-      )}
+      <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
+        {messagePlaceholders.length === 0 ? (
+          <div className="mt-4 text-xs">
+            <p className="mb-2">No message placeholders defined.</p>
+            <p>
+              Placeholders can be used to e.g. inject message histories into
+              prompts.
+            </p>
+          </div>
+        ) : (
+          <>
+            {messagePlaceholders
+              .slice()
+              .sort((a, b) => {
+                if (a.isUsed && !b.isUsed) return -1;
+                if (!a.isUsed && b.isUsed) return 1;
+                return a.name.localeCompare(b.name);
+              })
+              .map((placeholder, index) => (
+                <div key={placeholder.name}>
+                  <MessagePlaceholderComponent
+                    messagePlaceholder={placeholder}
+                  />
+                  {index !== messagePlaceholders.length - 1 && (
+                    <Divider className="my-2 text-muted-foreground" />
+                  )}
+                </div>
+              ))}
+          </>
+        )}
+      </div>
     </div>
   );
 };

--- a/web/src/features/playground/page/components/Variables.tsx
+++ b/web/src/features/playground/page/components/Variables.tsx
@@ -17,25 +17,20 @@ export const Variables = () => {
   const renderVariables = () => (
     <div className="h-full overflow-auto">
       {promptVariables
+        .slice()
         .sort((a, b) => {
           if (a.isUsed && !b.isUsed) return -1;
           if (!a.isUsed && b.isUsed) return 1;
-
           return a.name.localeCompare(b.name);
         })
-        .map((promptVariable, index) => {
-          return (
-            <>
-              <PromptVariableComponent
-                promptVariable={promptVariable}
-                key={promptVariable.name}
-              />
-              {index !== promptVariables.length - 1 ? (
-                <Divider className="my-2 text-muted-foreground" />
-              ) : null}
-            </>
-          );
-        })}
+        .map((promptVariable, index) => (
+          <div key={promptVariable.name}>
+            <PromptVariableComponent promptVariable={promptVariable} />
+            {index !== promptVariables.length - 1 && (
+              <Divider className="my-2 text-muted-foreground" />
+            )}
+          </div>
+        ))}
     </div>
   );
 

--- a/web/src/features/playground/page/components/Variables.tsx
+++ b/web/src/features/playground/page/components/Variables.tsx
@@ -15,7 +15,7 @@ export const Variables = () => {
     </div>
   );
   const renderVariables = () => (
-    <div className="h-full overflow-auto">
+    <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
       {promptVariables
         .slice()
         .sort((a, b) => {

--- a/web/src/features/playground/page/playground.tsx
+++ b/web/src/features/playground/page/playground.tsx
@@ -15,7 +15,7 @@ export default function Playground() {
         <Messages {...playgroundContext} />
       </div>
       <div className="max-h-full min-h-0 basis-1/4 pr-2">
-        <div className="flex h-full flex-col gap-4 overflow-auto">
+        <div className="flex h-full flex-col gap-4">
           <div className="mb-4 flex-shrink-0 overflow-y-auto">
             <ModelParameters {...playgroundContext} />
           </div>
@@ -25,9 +25,11 @@ export default function Playground() {
           <div className="mb-4 flex-shrink-0">
             <StructuredOutputSchemaSection />
           </div>
-          <div className="flex-grow overflow-y-auto">
-            <div className="space-y-6">
+          <div className="flex min-h-0 flex-1 flex-col gap-6">
+            <div className="min-h-0 flex-1">
               <Variables />
+            </div>
+            <div className="min-h-0 flex-1">
               <MessagePlaceholders />
             </div>
           </div>


### PR DESCRIPTION
fixes LFE-5419
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix scrolling for `Variables` and `MessagePlaceholders` components to handle many items in the playground UI.
> 
>   - **Behavior**:
>     - Adjusts scrolling behavior for `Variables` and `MessagePlaceholders` components to handle many items.
>     - Uses `min-h-0 flex-1 overflow-y-auto overflow-x-hidden` for scrollable areas in `Variables.tsx` and `MessagePlaceholders.tsx`.
>   - **Layout**:
>     - Updates layout in `playground.tsx` to ensure proper scrolling and spacing for `Variables` and `MessagePlaceholders` sections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 781c94054112cb68b9ee5c047966b8573d8f3f6a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->