### PR TITLE
feat(llm-connections): default credential provider chain for Bedrock when self-hosted

### DIFF
--- a/packages/shared/src/interfaces/customLLMProviderConfigSchemas.ts
+++ b/packages/shared/src/interfaces/customLLMProviderConfigSchemas.ts
@@ -1,5 +1,9 @@
 import { z } from "zod/v4";
 
+// Sentinel value for Bedrock default credential provider chain
+export const BEDROCK_USE_DEFAULT_CREDENTIALS =
+  "__BEDROCK_DEFAULT_CREDENTIALS__";
+
 export const BedrockConfigSchema = z.object({ region: z.string() });
 export type BedrockConfig = z.infer<typeof BedrockConfigSchema>;
 

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -23,6 +23,7 @@ import GCPServiceAccountKeySchema, {
   BedrockConfigSchema,
   BedrockCredentialSchema,
   VertexAIConfigSchema,
+  BEDROCK_USE_DEFAULT_CREDENTIALS,
 } from "../../interfaces/customLLMProviderConfigSchemas";
 import { processEventBatch } from "../ingestion/processEventBatch";
 import { logger } from "../logger";
@@ -264,7 +265,11 @@ export async function fetchLLMCompletion(
     });
   } else if (modelParams.adapter === LLMAdapter.Bedrock) {
     const { region } = BedrockConfigSchema.parse(config);
-    const credentials = BedrockCredentialSchema.parse(JSON.parse(apiKey));
+    // Handle both explicit credentials and default provider chain
+    const credentials =
+      apiKey === BEDROCK_USE_DEFAULT_CREDENTIALS
+        ? undefined // undefined = use AWS SDK default credential provider chain
+        : BedrockCredentialSchema.parse(JSON.parse(apiKey));
 
     chatModel = new ChatBedrockConverse({
       model: modelParams.model,

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -19,6 +19,7 @@ import {
 } from "@langchain/core/output_parsers";
 import { IterableReadableStream } from "@langchain/core/utils/stream";
 import { ChatOpenAI, AzureChatOpenAI } from "@langchain/openai";
+import { env } from "../../env";
 import GCPServiceAccountKeySchema, {
   BedrockConfigSchema,
   BedrockCredentialSchema,
@@ -41,6 +42,8 @@ import {
 } from "./types";
 import { CallbackHandler } from "langfuse-langchain";
 import type { BaseCallbackHandler } from "@langchain/core/callbacks/base";
+
+const isLangfuseCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 
 type ProcessTracedEvents = () => Promise<void>;
 
@@ -267,7 +270,7 @@ export async function fetchLLMCompletion(
     const { region } = BedrockConfigSchema.parse(config);
     // Handle both explicit credentials and default provider chain
     const credentials =
-      apiKey === BEDROCK_USE_DEFAULT_CREDENTIALS
+      apiKey === BEDROCK_USE_DEFAULT_CREDENTIALS && !isLangfuseCloud
         ? undefined // undefined = use AWS SDK default credential provider chain
         : BedrockCredentialSchema.parse(JSON.parse(apiKey));
 

--- a/web/src/features/llm-api-key/server/router.ts
+++ b/web/src/features/llm-api-key/server/router.ts
@@ -18,6 +18,7 @@ import {
   GCPServiceAccountKeySchema,
   BedrockConfigSchema,
   VertexAIConfigSchema,
+  BEDROCK_USE_DEFAULT_CREDENTIALS,
 } from "@langfuse/shared";
 import { encrypt, decrypt } from "@langfuse/shared/encryption";
 import {
@@ -31,6 +32,9 @@ import { env } from "@/src/env.mjs";
 import { TRPCError } from "@trpc/server";
 
 export function getDisplaySecretKey(secretKey: string) {
+  if (secretKey === BEDROCK_USE_DEFAULT_CREDENTIALS) {
+    return "Default AWS credentials";
+  }
   return secretKey.endsWith('"}')
     ? "..." + secretKey.slice(-6, -2)
     : "..." + secretKey.slice(-4);
@@ -124,6 +128,21 @@ export const llmApiKeyRouter = createTRPCRouter({
           projectId: input.projectId,
           scope: "llmApiKeys:create",
         });
+
+        // Validate that default credentials sentinel is only allowed for Bedrock in self-hosted deployments
+        if (input.secretKey === BEDROCK_USE_DEFAULT_CREDENTIALS) {
+          const isLangfuseCloud = Boolean(
+            env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
+          );
+
+          if (isLangfuseCloud || input.adapter !== LLMAdapter.Bedrock) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message:
+                "Default credentials are only allowed for Bedrock in self-hosted deployments.",
+            });
+          }
+        }
 
         if (!env.ENCRYPTION_KEY) {
           if (env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
@@ -406,6 +425,21 @@ export const llmApiKeyRouter = createTRPCRouter({
             code: "BAD_REQUEST",
             message: "Provider and adapter cannot be changed",
           });
+        }
+
+        // Validate that default credentials sentinel is only allowed for Bedrock in self-hosted deployments
+        if (input.secretKey === BEDROCK_USE_DEFAULT_CREDENTIALS) {
+          const isLangfuseCloud = Boolean(
+            env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
+          );
+
+          if (isLangfuseCloud || input.adapter !== LLMAdapter.Bedrock) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message:
+                "Default credentials are only allowed for Bedrock in self-hosted deployments.",
+            });
+          }
         }
 
         // Ensure we delete extra headers if they existed before and were removed

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -38,6 +38,8 @@ import { DialogFooter } from "@/src/components/ui/dialog";
 import { DialogBody } from "@/src/components/ui/dialog";
 import { env } from "@/src/env.mjs";
 
+const isLangfuseCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
+
 const createFormSchema = (mode: "create" | "update") =>
   z
     .object({
@@ -67,8 +69,6 @@ const createFormSchema = (mode: "create" | "update") =>
     })
     .refine(
       (data) => {
-        const isLangfuseCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
-
         if (data.adapter !== LLMAdapter.Bedrock) return true;
 
         // For cloud deployments, AWS credentials are required
@@ -82,7 +82,7 @@ const createFormSchema = (mode: "create" | "update") =>
         return data.awsRegion;
       },
       {
-        message: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION)
+        message: isLangfuseCloud
           ? "AWS credentials are required for Bedrock"
           : "AWS region is required.",
         path: ["adapter"],
@@ -210,8 +210,6 @@ export function CreateLLMApiKeyForm({
     if (mode !== "update") return false;
     return ["provider", "adapter"].includes(fieldName);
   };
-
-  const isLangfuseCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     if (!projectId) return console.error("No project ID found.");
@@ -532,7 +530,7 @@ export function CreateLLMApiKeyForm({
                 <FormItem>
                   <FormLabel>API Key</FormLabel>
                   <FormDescription>
-                    {env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
+                    {isLangfuseCloud
                       ? "Your API keys are stored encrypted on our servers."
                       : "Your API keys are stored encrypted in your database."}
                   </FormDescription>
@@ -607,10 +605,7 @@ export function CreateLLMApiKeyForm({
                   <FormDescription>
                     Optional additional HTTP headers to include with requests
                     towards LLM provider. All header values stored encrypted{" "}
-                    {env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
-                      ? "on our servers"
-                      : "in your database"}
-                    .
+                    {isLangfuseCloud ? "on our servers" : "in your database"}.
                   </FormDescription>
 
                   {headerFields.map((header, index) => (

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -6,6 +6,7 @@ import {
   type VertexAIConfig,
   LLMAdapter,
   type LlmApiKeys,
+  BEDROCK_USE_DEFAULT_CREDENTIALS,
 } from "@langfuse/shared";
 import { PlusIcon, TrashIcon } from "lucide-react";
 import { z } from "zod/v4";
@@ -65,11 +66,25 @@ const createFormSchema = (mode: "create" | "update") =>
       path: ["withDefaultModels"],
     })
     .refine(
-      (data) =>
-        data.adapter !== LLMAdapter.Bedrock ||
-        (data.awsAccessKeyId && data.awsSecretAccessKey && data.awsRegion),
+      (data) => {
+        const isLangfuseCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
+
+        if (data.adapter !== LLMAdapter.Bedrock) return true;
+
+        // For cloud deployments, AWS credentials are required
+        if (isLangfuseCloud) {
+          return (
+            data.awsAccessKeyId && data.awsSecretAccessKey && data.awsRegion
+          );
+        }
+
+        // For self-hosted deployments, only region is required
+        return data.awsRegion;
+      },
       {
-        message: "AWS credentials are required when using Bedrock adapter.",
+        message: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION)
+          ? "AWS credentials are required for Bedrock"
+          : "AWS region is required.",
         path: ["adapter"],
       },
     )
@@ -196,6 +211,8 @@ export function CreateLLMApiKeyForm({
     return ["provider", "adapter"].includes(fieldName);
   };
 
+  const isLangfuseCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
+
   async function onSubmit(values: z.infer<typeof formSchema>) {
     if (!projectId) return console.error("No project ID found.");
 
@@ -224,11 +241,19 @@ export function CreateLLMApiKeyForm({
     let config: BedrockConfig | VertexAIConfig | undefined;
 
     if (currentAdapter === LLMAdapter.Bedrock) {
-      const credentials: BedrockCredential = {
-        accessKeyId: values.awsAccessKeyId ?? "",
-        secretAccessKey: values.awsSecretAccessKey ?? "",
-      };
-      secretKey = JSON.stringify(credentials);
+      // For self-hosted deployments, allow empty credentials to use default provider chain
+      if (
+        !isLangfuseCloud &&
+        (!values.awsAccessKeyId || !values.awsSecretAccessKey)
+      ) {
+        secretKey = BEDROCK_USE_DEFAULT_CREDENTIALS;
+      } else {
+        const credentials: BedrockCredential = {
+          accessKeyId: values.awsAccessKeyId ?? "",
+          secretAccessKey: values.awsSecretAccessKey ?? "",
+        };
+        secretKey = JSON.stringify(credentials);
+      }
 
       config = {
         region: values.awsRegion ?? "",
@@ -428,10 +453,19 @@ export function CreateLLMApiKeyForm({
                 name="awsAccessKeyId"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>AWS Access Key ID</FormLabel>
+                    <FormLabel>
+                      AWS Access Key ID
+                      {!isLangfuseCloud && (
+                        <span className="font-normal text-muted-foreground">
+                          {" "}
+                          (optional)
+                        </span>
+                      )}
+                    </FormLabel>
                     <FormDescription>
-                      These should be long-lived credentials for an AWS user
-                      with `bedrock:InvokeModel` permission.
+                      {isLangfuseCloud
+                        ? "These should be long-lived credentials for an AWS user with `bedrock:InvokeModel` permission."
+                        : "For self-hosted deployments, AWS credentials are optional. When omitted, authentication will use the AWS SDK default credential provider chain."}
                     </FormDescription>
                     <FormControl>
                       <Input {...field} />
@@ -445,7 +479,15 @@ export function CreateLLMApiKeyForm({
                 name="awsSecretAccessKey"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>AWS Secret Access Key</FormLabel>
+                    <FormLabel>
+                      AWS Secret Access Key
+                      {!isLangfuseCloud && (
+                        <span className="font-normal text-muted-foreground">
+                          {" "}
+                          (optional)
+                        </span>
+                      )}
+                    </FormLabel>
                     <FormControl>
                       <PasswordInput {...field} />
                     </FormControl>
@@ -453,6 +495,34 @@ export function CreateLLMApiKeyForm({
                   </FormItem>
                 )}
               />
+              {!isLangfuseCloud && (
+                <div className="space-y-2 border-l-2 border-blue-200 pl-4 text-sm text-muted-foreground">
+                  <p>
+                    <strong>Default credential provider chain:</strong> When AWS
+                    credentials are omitted, the system will automatically check
+                    for credentials in this order:
+                  </p>
+                  <ul className="ml-2 list-inside list-disc space-y-1">
+                    <li>
+                      Environment variables (AWS_ACCESS_KEY_ID,
+                      AWS_SECRET_ACCESS_KEY)
+                    </li>
+                    <li>AWS credentials file (~/.aws/credentials)</li>
+                    <li>IAM roles for EC2 instances</li>
+                    <li>IAM roles for ECS tasks</li>
+                  </ul>
+                  <p>
+                    <a
+                      href="https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 underline hover:text-blue-800"
+                    >
+                      Learn more about AWS credential providers →
+                    </a>
+                  </p>
+                </div>
+              )}
             </>
           ) : (
             <FormField


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds support for using AWS default credential provider chain for Bedrock in self-hosted deployments, with validation and UI updates.
> 
>   - **Behavior**:
>     - Introduces `BEDROCK_USE_DEFAULT_CREDENTIALS` sentinel value in `customLLMProviderConfigSchemas.ts` for using AWS default credential provider chain.
>     - Updates `fetchLLMCompletion()` in `fetchLLMCompletion.ts` to handle `BEDROCK_USE_DEFAULT_CREDENTIALS` for Bedrock adapter.
>     - Validates in `router.ts` that `BEDROCK_USE_DEFAULT_CREDENTIALS` is only allowed for Bedrock in self-hosted deployments.
>   - **UI**:
>     - Updates `CreateLLMApiKeyForm.tsx` to allow optional AWS credentials for Bedrock when self-hosted, displaying relevant information and validation messages.
>     - Adds description of AWS default credential provider chain in `CreateLLMApiKeyForm.tsx` for self-hosted deployments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 903e64ca2e9d40324d8ee624dc38f6511ca338fb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->