### PR TITLE
Allow whitespace in variable reference for readability + trim before validation

### DIFF
--- a/web/src/components/editor/CodeMirrorEditor.tsx
+++ b/web/src/components/editor/CodeMirrorEditor.tsx
@@ -39,7 +39,8 @@ const promptLanguage = StreamLanguage.define({
       stream.skipTo("}}") || stream.skipToEnd();
       const content = stream.string.slice(start, stream.pos);
       stream.match("}}");
-      return isValidVariableName(content) ? "variable" : "error";
+      // Trim whitespace before validation to allow spacing for readability
+      return isValidVariableName(content.trim()) ? "variable" : "error";
     }
     stream.next();
     return null;
@@ -74,14 +75,16 @@ const promptLinter = linter((view) => {
   // Check variable format
   for (const match of content.matchAll(MUSTACHE_REGEX)) {
     const variable = match[1];
-    if (!variable || variable.trim() === "") {
+    // Trim whitespace to check if variable is empty
+    const trimmedVariable = variable.trim();
+    if (!trimmedVariable) {
       diagnostics.push({
         from: match.index,
         to: match.index + match[0].length,
         severity: "error",
         message: "Empty variable is not allowed",
       });
-    } else if (!isValidVariableName(variable)) {
+    } else if (!isValidVariableName(trimmedVariable)) {
       diagnostics.push({
         from: match.index,
         to: match.index + match[0].length,


### PR DESCRIPTION
## What does this PR do?

This PR allows whitespace between mustache brackets and variable names in the prompt editor for better readability. Users can now write variables as `{{ variable_name }}` in addition to the compact format `{{variable_name}}`.

The change modifies the prompt editor's syntax highlighter and linter to trim whitespace before validating variable names, while keeping the actual text as typed by the user. This is purely a UI/UX improvement that doesn't affect how variables are processed in the backend.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`npm run lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked if new and existing unit tests pass locally with my changes

## Implementation Details

Modified `web/src/components/editor/CodeMirrorEditor.tsx`:
1. Updated `promptLanguage` syntax highlighter to trim whitespace before validation
2. Updated `promptLinter` to trim whitespace when checking variable validity

This allows both formats to work seamlessly:
- `{{variable_name}}` - compact format
- `{{ variable_name }}` - readable format with spaces
<!-- ELLIPSIS_HIDDEN -->

## [Open Discussion Link](https://github.com/orgs/langfuse/discussions/7951)

----

> [!IMPORTANT]
> Allows whitespace in mustache variable references in `CodeMirrorEditor.tsx` for better readability, supporting both `{{variable_name}}` and `{{ variable_name }}` formats.
> 
>   - **Behavior**:
>     - Allows whitespace in mustache variable references in `CodeMirrorEditor.tsx` for readability.
>     - Supports both `{{variable_name}}` and `{{ variable_name }}` formats.
>   - **Implementation**:
>     - Updates `promptLanguage` syntax highlighter to trim whitespace before validation.
>     - Updates `promptLinter` to trim whitespace when checking variable validity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f86ce7f0130f83161be74b220191899ee3acc4a6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->