### PR TITLE
fix: Unclustered migrations scripts should not have any 'ON CLUSTER' instructions

### DIFF
--- a/packages/shared/clickhouse/migrations/unclustered/0006_add_user_id_index.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0006_add_user_id_index.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE traces ON CLUSTER default DROP INDEX IF EXISTS idx_user_id;
+ALTER TABLE traces DROP INDEX IF EXISTS idx_user_id;


### PR DESCRIPTION
## What does this PR do?

Bug fix the script in the unclustered folder to remove the 'ON CLUSTER default' line which is not valid for unclustered ClickHouse instances

Fixes # (issue)

None but can raise separately

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `ON CLUSTER default` from `ALTER TABLE` in `0006_add_user_id_index.down.sql` for unclustered ClickHouse.
> 
>   - **Bug Fix**:
>     - Removes `ON CLUSTER default` from `ALTER TABLE` statement in `0006_add_user_id_index.down.sql` for unclustered ClickHouse instances.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 98c496cf4e9b9aac17c136eba3c1efdf0abcb1d5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->