### PR TITLE
chore: remove ineffective pnpm configs

### DIFF
--- a/ee/package.json
+++ b/ee/package.json
@@ -45,10 +45,5 @@
     "ts-node": "^10.9.2",
     "tsc-watch": "^6.2.0",
     "typescript": "^5.4.5"
-  },
-  "pnpm": {
-    "overrides": {
-      "nanoid": "^3.3.8"
-    }
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -125,10 +125,5 @@
   "peerDependencies": {
     "@types/react": "~18.2.79",
     "react": "~18.2.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "nanoid": "^3.3.8"
-    }
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -201,11 +201,5 @@
   },
   "ct3aMetadata": {
     "initVersion": "7.13.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "nanoid": "^3.3.8",
-      "katex": "0.16.21"
-    }
   }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove ineffective `pnpm` overrides for `nanoid` and `katex` from `package.json` files.
> 
>   - **Configuration Removal**:
>     - Removed `pnpm` overrides for `nanoid` in `ee/package.json` and `packages/shared/package.json`.
>     - Removed `pnpm` overrides for `nanoid` and `katex` in `web/package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 38021c39bde57e126909d71483cf3f0bc9b42817. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->