### PR TITLE
fix(prompts): commitMessage error handling in NewPromptForm

### DIFF
--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -90,7 +90,7 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
     name: initialPrompt?.name ?? (folderPath ? `${folderPath}/` : ""),
     config: JSON.stringify(initialPrompt?.config?.valueOf(), null, 2) || "{}",
     isActive: !Boolean(initialPrompt),
-    commitMessage: initialPrompt?.commitMessage ?? undefined,
+    commitMessage: undefined,
   };
 
   const form = useForm({

--- a/web/src/features/prompts/components/NewPromptForm/validation.ts
+++ b/web/src/features/prompts/components/NewPromptForm/validation.ts
@@ -18,8 +18,8 @@ const NewPromptBaseSchema = z.object({
   commitMessage: z
     .string()
     .trim()
-    .min(1)
     .max(COMMIT_MESSAGE_MAX_LENGTH)
+    .transform((val) => (val === "" ? undefined : val))
     .optional(),
 });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix error handling for `commitMessage` in `NewPromptForm` by setting default to `undefined` and transforming empty strings in validation.
> 
>   - **Behavior**:
>     - Set default `commitMessage` to `undefined` in `NewPromptForm` in `index.tsx`.
>     - Transform empty `commitMessage` strings to `undefined` in `validation.ts` using `zod`.
>   - **Validation**:
>     - Remove `.min(1)` constraint from `commitMessage` in `NewPromptBaseSchema` in `validation.ts`.
>     - Add transformation to handle empty strings for `commitMessage` in `validation.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e3c41b6aef96ab5d499e9235bfa4be0b70b3f293. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->