### PR TITLE
chore: add missing blob-storage export entitlement

### DIFF
--- a/web/src/features/entitlements/constants/entitlements.ts
+++ b/web/src/features/entitlements/constants/entitlements.ts
@@ -11,6 +11,7 @@ const entitlements = [
   "trace-deletion", // Not in use anymore, but necessary to use the TableAction type.
   "audit-logs",
   "data-retention",
+  "scheduled-blob-exports",
   "prompt-protected-labels",
   "admin-api",
 ] as const;
@@ -21,7 +22,10 @@ const cloudAllPlansEntitlements: Entitlement[] = [
   "trace-deletion",
 ];
 
-const selfHostedAllPlansEntitlements: Entitlement[] = ["trace-deletion"];
+const selfHostedAllPlansEntitlements: Entitlement[] = [
+  "trace-deletion",
+  "scheduled-blob-exports",
+];
 
 // Entitlement Limits: Limits on the number of resources that can be created/used
 const entitlementLimits = [
@@ -85,6 +89,7 @@ export const entitlementAccess: Record<
       "cloud-multi-tenant-sso",
       "prompt-protected-labels",
       "admin-api",
+      "scheduled-blob-exports",
     ],
     entitlementLimits: {
       "annotation-queue-count": false,
@@ -103,6 +108,7 @@ export const entitlementAccess: Record<
       "cloud-multi-tenant-sso",
       "prompt-protected-labels",
       "admin-api",
+      "scheduled-blob-exports",
     ],
     entitlementLimits: {
       "annotation-queue-count": false,

--- a/web/src/pages/project/[projectId]/settings/index.tsx
+++ b/web/src/pages/project/[projectId]/settings/index.tsx
@@ -247,6 +247,10 @@ const Integrations = (props: { projectId: string }) => {
     scope: "integrations:CRUD",
   });
 
+  const allowBlobStorageIntegration = useHasEntitlement(
+    "scheduled-blob-exports",
+  );
+
   return (
     <div>
       <Header title="Integrations" />
@@ -288,6 +292,7 @@ const Integrations = (props: { projectId: string }) => {
             <ActionButton
               variant="secondary"
               hasAccess={hasAccess}
+              hasEntitlement={allowBlobStorageIntegration}
               href={`/project/${props.projectId}/settings/integrations/blobstorage`}
             >
               Configure


### PR DESCRIPTION
Align entitlement config with https://langfuse.com/pricing.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `scheduled-blob-exports` entitlement and update UI to conditionally show blob storage integration based on this entitlement.
> 
>   - **Entitlements**:
>     - Add `scheduled-blob-exports` to `entitlements.ts` for both cloud and self-hosted plans.
>     - Update `cloud:team`, `cloud:enterprise`, and `self-hosted:enterprise` plans to include `scheduled-blob-exports`.
>   - **UI Changes**:
>     - In `index.tsx`, add `allowBlobStorageIntegration` using `useHasEntitlement` for `scheduled-blob-exports`.
>     - Modify `Integrations` component to conditionally enable blob storage configuration based on `allowBlobStorageIntegration`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d3690ac974579e718f5f3929e11952666547d183. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->