### PR TITLE
fix(sessions): infer session env from trace

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -310,8 +310,11 @@ export class IngestionService {
           create: {
             id: finalTraceRecord.session_id,
             projectId,
+            environment: finalTraceRecord.environment,
           },
-          update: {},
+          update: {
+            environment: finalTraceRecord.environment,
+          },
         });
       } catch (e) {
         if (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `IngestionService`, `processTraceEventList` now infers and updates session environment from trace data during `traceSession.upsert`.
> 
>   - **Behavior**:
>     - In `IngestionService`, `processTraceEventList` now includes `environment` in `create` and `update` operations for `traceSession.upsert`.
>     - Ensures session environment is inferred from trace data.
>   - **Misc**:
>     - Removed empty `update` object in `traceSession.upsert` call.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 559a19cbffb706fe0a5e2eb7a87509d29650ba75. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->