### PR TITLE
fix(sessions): align duration unit with UI

### DIFF
--- a/packages/shared/src/server/services/sessions-ui-table-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-service.ts
@@ -288,7 +288,7 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
             sum(o.obs_count) as total_observations,
             -- Use minIf, because ClickHouse fills 1970-01-01 on left joins. We assume that no
             -- LLM session started on that date so this behaviour should yield better results.
-            date_diff('millisecond', minIf(min_start_time, min_start_time > '1970-01-01'), max(max_end_time)) as duration,
+            date_diff('second', minIf(min_start_time, min_start_time > '1970-01-01'), max(max_end_time)) as duration,
             sumMap(o.sum_usage_details) as session_usage_details,
             sumMap(o.sum_cost_details) as session_cost_details,
             arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'input') > 0, sumMap(o.sum_cost_details)))) as session_input_cost,

--- a/web/src/__tests__/async/sessions-ui-table.servertest.ts
+++ b/web/src/__tests__/async/sessions-ui-table.servertest.ts
@@ -383,7 +383,6 @@ describe("trpc.sessions", () => {
 
     expect(sessions[0]).toBeDefined();
     expect(sessions[0]?.trace_count).toBe(2);
-    expect(parseInt(sessions[0]?.duration as any)).toBeGreaterThan(995);
-    expect(parseInt(sessions[0]?.duration as any)).toBeLessThan(1005);
+    expect(parseInt(sessions[0]?.duration as any)).toBe(1);
   });
 });

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -281,7 +281,7 @@ export const sessionRouter = createTRPCRouter({
           environment: s.trace_environment,
           trace_count: Number(s.trace_count),
           total_observations: Number(s.total_observations),
-          sessionDuration: Number(s.duration) / 1000,
+          sessionDuration: Number(s.duration),
           inputCost: new Decimal(s.session_input_cost),
           outputCost: new Decimal(s.session_output_cost),
           totalCost: new Decimal(s.session_total_cost),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change session duration unit from milliseconds to seconds in ClickHouse query and update related tests and API logic.
> 
>   - **Behavior**:
>     - Change `date_diff` unit from 'millisecond' to 'second' in `getSessionsTableGeneric()` in `sessions-ui-table-service.ts`.
>     - Update test expectation for `duration` in `sessions-ui-table.servertest.ts` to reflect new unit.
>   - **API**:
>     - Remove division by 1000 for `sessionDuration` in `sessionRouter` in `sessions.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 004f7004264f1c6d0f43f762aab2b04d2bda956d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->