### PR TITLE
chore: migrate additional session routes to new AMTs

### DIFF
--- a/web/src/__tests__/async/sessions-trpc.servertest.ts
+++ b/web/src/__tests__/async/sessions-trpc.servertest.ts
@@ -52,7 +52,7 @@ describe("traces trpc", () => {
   const ctx = createInnerTRPCContext({ session });
   const caller = appRouter.createCaller({ ...ctx, prisma });
 
-  describe("sessions.byId", () => {
+  describe("sessions.byIdWithScores", () => {
     it("access private session", async () => {
       const sessionId = randomUUID();
 
@@ -92,7 +92,7 @@ describe("traces trpc", () => {
 
       await createObservationsCh([observation, observation2, observation3]);
 
-      const sessionRes = await caller.sessions.byId({
+      const sessionRes = await caller.sessions.byIdWithScores({
         projectId,
         sessionId,
       });

--- a/web/src/__tests__/async/sessions-trpc.servertest.ts
+++ b/web/src/__tests__/async/sessions-trpc.servertest.ts
@@ -105,6 +105,7 @@ describe("traces trpc", () => {
         environment: "default",
         bookmarked: false,
         public: false,
+        scores: [],
         traces: expect.arrayContaining([
           expect.objectContaining({
             id: trace.id,

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -44,7 +44,7 @@ import {
   QueueJobs,
   getScoreMetadataById,
   deleteScores,
-  traceWithSessionIdExists,
+  getTracesIdentifierForSession,
 } from "@langfuse/shared/src/server";
 import { v4 } from "uuid";
 import { throwIfNoEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
@@ -306,11 +306,11 @@ export const scoresRouter = createTRPCRouter({
         }
       } else if (inflatedParams.sessionId) {
         // We consider no longer writing all sessions into postgres, hence we should search for traces with the session id
-        const isSessionReferenced = await traceWithSessionIdExists(
+        const traceIdentifiers = await getTracesIdentifierForSession(
           input.projectId,
           inflatedParams.sessionId,
         );
-        if (!isSessionReferenced) {
+        if (traceIdentifiers.length === 0) {
           logger.error(
             `No trace referencing session with id ${inflatedParams.sessionId} in project ${input.projectId} in Clickhouse`,
           );

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -359,20 +359,6 @@ export const sessionRouter = createTRPCRouter({
         });
       }
     }),
-  byId: protectedGetSessionProcedure
-    .input(
-      z.object({
-        projectId: z.string(),
-        sessionId: z.string(),
-      }),
-    )
-    .query(async ({ input, ctx }) => {
-      return await handleGetSessionById({
-        sessionId: input.sessionId,
-        projectId: input.projectId,
-        ctx,
-      });
-    }),
   byIdWithScores: protectedGetSessionProcedure
     .input(
       z.object({

--- a/worker/src/services/IngestionService/README.md
+++ b/worker/src/services/IngestionService/README.md
@@ -478,9 +478,9 @@ This checklist documents all references and invocations to the `traces` table gr
 - [x] **getTracesByIds()** - `packages/shared/src/server/repositories/traces.ts:233-264`
 
 ### 2. Session-Based Queries
-- [ ] **getTracesBySessionId()** - `packages/shared/src/server/repositories/traces.ts:266-304`
-- [ ] **getTracesIdentifierForSession()** - `packages/shared/src/server/repositories/traces.ts:642-688`
-- [ ] **traceWithSessionIdExists()** - `packages/shared/src/server/repositories/traces.ts:1143-1170`
+- [x] **getTracesBySessionId()** - `packages/shared/src/server/repositories/traces.ts:266-304`
+- [x] **getTracesIdentifierForSession()** - `packages/shared/src/server/repositories/traces.ts:642-688`
+- [x] **traceWithSessionIdExists()** - `packages/shared/src/server/repositories/traces.ts:1143-1170`
 
 ### 3. Existence Checks
 - [x] **checkTraceExists()** - `packages/shared/src/server/repositories/traces.ts:73-210`
@@ -493,7 +493,7 @@ This checklist documents all references and invocations to the `traces` table gr
 - [ ] **getTracesGroupedByTags()** - `packages/shared/src/server/repositories/traces.ts:605-640`
 - [ ] **getTotalUserCount()** - `packages/shared/src/server/repositories/traces.ts:789-827`
 - [ ] **getUserMetrics()** - `packages/shared/src/server/repositories/traces.ts:829-978`
-- [ ] **getTracesTableGeneric()** - `packages/shared/src/server/services/traces-ui-table-service.ts:207++`
+- [x] **getTracesTableGeneric()** - `packages/shared/src/server/services/traces-ui-table-service.ts:207++`
 - [ ] **getSessionsTableGeneric()** - `packages/shared/src/server/services/sessions-ui-table-service.ts:121++`)
 - [x] **generateTracesForPublicApi()** - `web/src/features/public-api/server/traces.ts:36++`
 

--- a/worker/src/services/IngestionService/README.md
+++ b/worker/src/services/IngestionService/README.md
@@ -480,7 +480,6 @@ This checklist documents all references and invocations to the `traces` table gr
 ### 2. Session-Based Queries
 - [x] **getTracesBySessionId()** - `packages/shared/src/server/repositories/traces.ts:266-304`
 - [x] **getTracesIdentifierForSession()** - `packages/shared/src/server/repositories/traces.ts:642-688`
-- [x] **traceWithSessionIdExists()** - `packages/shared/src/server/repositories/traces.ts:1143-1170`
 
 ### 3. Existence Checks
 - [x] **checkTraceExists()** - `packages/shared/src/server/repositories/traces.ts:73-210`


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Migrate session routes to use new AggregatingMergeTrees (AMTs) for trace data, updating queries, tests, and documentation accordingly.
> 
>   - **Behavior**:
>     - Migrate `getTracesBySessionId` and `getTracesIdentifierForSession` in `traces.ts` to use new AMTs for trace data.
>     - Remove `traceWithSessionIdExists` function from `traces.ts`.
>     - Update `sessions.byId` to `sessions.byIdWithScores` in `sessions-trpc.servertest.ts`.
>   - **Tests**:
>     - Update test descriptions and calls in `sessions-trpc.servertest.ts` to reflect new session route `byIdWithScores`.
>   - **Documentation**:
>     - Update `IngestionService/README.md` to mark `getTracesBySessionId` and `getTracesIdentifierForSession` as migrated to AMTs.
>   - **Misc**:
>     - Rename `sessions.byId` to `sessions.byIdWithScores` in `sessions.ts` and `scores.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 14a7ecdd6fedfe30d6d4809e1f740c73fd23212c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->