### PR TITLE
chore: migrate analytic routes to new AMTs

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -600,39 +600,77 @@ export const getTracesGroupedByName = async (
     ? new FilterList(chFilter).apply()
     : undefined;
 
-  // We mainly use queries like this to retrieve filter options.
-  // Therefore, we can skip final as some inaccuracy in count is acceptable.
-  const query = `
-      select
-        name as name,
-        count(*) as count
-      from traces t FINAL
-      WHERE t.project_id = {projectId: String}
-      AND t.name IS NOT NULL
-      ${timestampFilterRes?.query ? `AND ${timestampFilterRes.query}` : ""}
-      GROUP BY name
-      ORDER BY count(*) desc
-      LIMIT 1000;
-    `;
+  // Extract the timestamp from filter for AMT table selection
+  const fromTimestamp = timestampFilter?.find(
+    (f) =>
+      f.column === "timestamp" && (f.operator === ">=" || f.operator === ">"),
+  )?.value as Date | undefined;
 
-  const rows = await queryClickhouse<{
-    name: string;
-    count: string;
-  }>({
-    query: query,
-    params: {
-      projectId: projectId,
-      ...(timestampFilterRes ? timestampFilterRes.params : {}),
+  return measureAndReturn({
+    operationName: "getTracesGroupedByName",
+    projectId,
+    input: {
+      params: {
+        projectId,
+        ...(timestampFilterRes ? timestampFilterRes.params : {}),
+      },
+      tags: {
+        feature: "tracing",
+        type: "trace",
+        kind: "analytic",
+        projectId,
+      },
+      timestamp: fromTimestamp,
     },
-    tags: {
-      feature: "tracing",
-      type: "trace",
-      kind: "analytic",
-      projectId,
+    existingExecution: async (input) => {
+      // We mainly use queries like this to retrieve filter options.
+      // Therefore, we can skip final as some inaccuracy in count is acceptable.
+      const query = `
+        select
+          name as name,
+          count(*) as count
+        from traces t FINAL
+        WHERE t.project_id = {projectId: String}
+        AND t.name IS NOT NULL
+        ${timestampFilterRes?.query ? `AND ${timestampFilterRes.query}` : ""}
+        GROUP BY name
+        ORDER BY count(*) desc
+        LIMIT 1000;
+      `;
+
+      return queryClickhouse<{
+        name: string;
+        count: string;
+      }>({
+        query,
+        params: input.params,
+        tags: input.tags,
+      });
+    },
+    newExecution: async (input) => {
+      const traceAmt = getTimeframesTracesAMT(input.timestamp);
+      const query = `
+        select
+          name as name,
+          count(*) as count
+        from ${traceAmt} t
+        WHERE t.project_id = {projectId: String}
+        AND t.name IS NOT NULL
+        GROUP BY name
+        ORDER BY count(*) desc
+        LIMIT 1000;
+      `;
+
+      return queryClickhouse<{
+        name: string;
+        count: string;
+      }>({
+        query,
+        params: input.params,
+        tags: input.tags,
+      });
     },
   });
-
-  return rows;
 };
 
 export const getTracesGroupedByUsers = async (
@@ -657,44 +695,85 @@ export const getTracesGroupedByUsers = async (
   const tracesFilterRes = tracesFilter.apply();
   const search = clickhouseSearchCondition(searchQuery, undefined, "t");
 
-  // We mainly use queries like this to retrieve filter options.
-  // Therefore, we can skip final as some inaccuracy in count is acceptable.
-  const query = `
-      select
-        user_id as user,
-        count(*) as count
-      from traces t
-      WHERE t.project_id = {projectId: String}
-      AND t.user_id IS NOT NULL
-      AND t.user_id != ''
-      ${tracesFilterRes?.query ? `AND ${tracesFilterRes.query}` : ""}
-      ${search.query}
-      GROUP BY user
-      ORDER BY count desc
-      ${limit !== undefined && offset !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
-  `;
+  // Extract the timestamp from filter for AMT table selection
+  const fromTimestamp = filter?.find(
+    (f) =>
+      f.column === "timestamp" && (f.operator === ">=" || f.operator === ">"),
+  )?.value as Date | undefined;
 
-  const rows = await queryClickhouse<{
-    user: string;
-    count: string;
-  }>({
-    query: query,
-    params: {
-      limit,
-      offset,
-      projectId,
-      ...(tracesFilterRes ? tracesFilterRes.params : {}),
-      ...(searchQuery ? search.params : {}),
+  return measureAndReturn({
+    operationName: "getTracesGroupedByUsers",
+    projectId,
+    input: {
+      params: {
+        limit,
+        offset,
+        projectId,
+        ...(tracesFilterRes ? tracesFilterRes.params : {}),
+        ...(searchQuery ? search.params : {}),
+      },
+      tags: {
+        feature: "tracing",
+        type: "trace",
+        kind: "analytic",
+        projectId,
+      },
+      timestamp: fromTimestamp,
     },
-    tags: {
-      feature: "tracing",
-      type: "trace",
-      kind: "analytic",
-      projectId,
+    existingExecution: async (input) => {
+      // We mainly use queries like this to retrieve filter options.
+      // Therefore, we can skip final as some inaccuracy in count is acceptable.
+      const query = `
+        select
+          user_id as user,
+          count(*) as count
+        from traces t
+        WHERE t.project_id = {projectId: String}
+        AND t.user_id IS NOT NULL
+        AND t.user_id != ''
+        ${tracesFilterRes?.query ? `AND ${tracesFilterRes.query}` : ""}
+        ${search.query}
+        GROUP BY user
+        ORDER BY count desc
+        ${limit !== undefined && offset !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
+      `;
+
+      return queryClickhouse<{
+        user: string;
+        count: string;
+      }>({
+        query,
+        params: input.params,
+        tags: input.tags,
+      });
+    },
+    newExecution: async (input) => {
+      const traceAmt = getTimeframesTracesAMT(input.timestamp);
+      const query = `
+        select
+          user_id as user,
+          count(*) as count
+        from ${traceAmt} t
+        WHERE t.project_id = {projectId: String}
+        AND t.user_id IS NOT NULL
+        AND t.user_id != ''
+        ${tracesFilterRes?.query ? `AND ${tracesFilterRes.query}` : ""}
+        ${search.query}
+        GROUP BY user
+        ORDER BY count desc
+        ${limit !== undefined && offset !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
+      `;
+
+      return queryClickhouse<{
+        user: string;
+        count: string;
+      }>({
+        query,
+        params: input.params,
+        tags: input.tags,
+      });
     },
   });
-
-  return rows;
 };
 
 export type GroupedTracesQueryProp = {
@@ -713,31 +792,64 @@ export const getTracesGroupedByTags = async (props: GroupedTracesQueryProp) => {
 
   const filterRes = new FilterList(chFilter).apply();
 
-  const query = `
-    select distinct(arrayJoin(tags)) as value
-    from traces t
-    WHERE t.project_id = {projectId: String}
-    ${filterRes?.query ? `AND ${filterRes.query}` : ""}
-    LIMIT 1000;
-  `;
+  // Extract the timestamp from filter for AMT table selection
+  const fromTimestamp = filter?.find(
+    (f) =>
+      f.column === "timestamp" && (f.operator === ">=" || f.operator === ">"),
+  )?.value as Date | undefined;
 
-  const rows = await queryClickhouse<{
-    value: string;
-  }>({
-    query: query,
-    params: {
-      projectId: projectId,
-      ...(filterRes ? filterRes.params : {}),
+  return measureAndReturn({
+    operationName: "getTracesGroupedByTags",
+    projectId,
+    input: {
+      params: {
+        projectId,
+        ...(filterRes ? filterRes.params : {}),
+      },
+      tags: {
+        feature: "tracing",
+        type: "trace",
+        kind: "analytic",
+        projectId,
+      },
+      timestamp: fromTimestamp,
     },
-    tags: {
-      feature: "tracing",
-      type: "trace",
-      kind: "analytic",
-      projectId,
+    existingExecution: async (input) => {
+      const query = `
+        select distinct(arrayJoin(tags)) as value
+        from traces t
+        WHERE t.project_id = {projectId: String}
+        ${filterRes?.query ? `AND ${filterRes.query}` : ""}
+        LIMIT 1000;
+      `;
+
+      return queryClickhouse<{
+        value: string;
+      }>({
+        query,
+        params: input.params,
+        tags: input.tags,
+      });
+    },
+    newExecution: async (input) => {
+      const traceAmt = getTimeframesTracesAMT(input.timestamp);
+      const query = `
+        select distinct(arrayJoin(tags)) as value
+        from ${traceAmt} t
+        WHERE t.project_id = {projectId: String}
+        ${filterRes?.query ? `AND ${filterRes.query}` : ""}
+        LIMIT 1000;
+      `;
+
+      return queryClickhouse<{
+        value: string;
+      }>({
+        query,
+        params: input.params,
+        tags: input.tags,
+      });
     },
   });
-
-  return rows;
 };
 
 export const getTracesIdentifierForSession = async (
@@ -862,29 +974,59 @@ export const deleteTracesByProjectId = async (projectId: string) => {
 };
 
 export const hasAnyUser = async (projectId: string) => {
-  const query = `
-    SELECT 1
-    FROM traces
-    WHERE project_id = {projectId: String}
-    AND user_id IS NOT NULL
-    AND user_id != ''
-    LIMIT 1
-  `;
-
-  const rows = await queryClickhouse<{ 1: number }>({
-    query,
-    params: {
+  return measureAndReturn({
+    operationName: "hasAnyUser",
+    projectId,
+    input: {
       projectId,
+      tags: {
+        feature: "tracing",
+        type: "user",
+        kind: "hasAny",
+        projectId,
+      },
     },
-    tags: {
-      feature: "tracing",
-      type: "user",
-      kind: "hasAny",
-      projectId,
+    existingExecution: async (input) => {
+      const query = `
+        SELECT 1
+        FROM traces
+        WHERE project_id = {projectId: String}
+        AND user_id IS NOT NULL
+        AND user_id != ''
+        LIMIT 1
+      `;
+
+      const rows = await queryClickhouse<{ 1: number }>({
+        query,
+        params: {
+          projectId: input.projectId,
+        },
+        tags: input.tags,
+      });
+
+      return rows.length > 0;
+    },
+    newExecution: async (input) => {
+      const query = `
+        SELECT 1
+        FROM traces_all_amt
+        WHERE project_id = {projectId: String}
+        AND user_id IS NOT NULL
+        AND user_id != ''
+        LIMIT 1
+      `;
+
+      const rows = await queryClickhouse<{ 1: number }>({
+        query,
+        params: {
+          projectId: input.projectId,
+        },
+        tags: input.tags,
+      });
+
+      return rows.length > 0;
     },
   });
-
-  return rows.length > 0;
 };
 
 export const getTotalUserCount = async (
@@ -903,26 +1045,60 @@ export const getTotalUserCount = async (
   const tracesFilterRes = tracesFilter.apply();
   const search = clickhouseSearchCondition(searchQuery, undefined, "t");
 
-  const query = `
-    SELECT COUNT(DISTINCT t.user_id) AS totalCount
-    FROM traces t
-    WHERE ${tracesFilterRes.query}
-    ${search.query}
-    AND t.user_id IS NOT NULL
-    AND t.user_id != ''
-  `;
+  // Extract the timestamp from filter for AMT table selection
+  const fromTimestamp = filter?.find(
+    (f) =>
+      f.column === "timestamp" && (f.operator === ">=" || f.operator === ">"),
+  )?.value as Date | undefined;
 
-  return queryClickhouse({
-    query,
-    params: {
-      ...tracesFilterRes.params,
-      ...search.params,
+  return measureAndReturn({
+    operationName: "getTotalUserCount",
+    projectId,
+    input: {
+      params: {
+        ...tracesFilterRes.params,
+        ...search.params,
+      },
+      tags: {
+        feature: "tracing",
+        type: "trace",
+        kind: "analytic",
+        projectId,
+      },
+      timestamp: fromTimestamp,
     },
-    tags: {
-      feature: "tracing",
-      type: "trace",
-      kind: "analytic",
-      projectId,
+    existingExecution: async (input) => {
+      const query = `
+        SELECT COUNT(DISTINCT t.user_id) AS totalCount
+        FROM traces t
+        WHERE ${tracesFilterRes.query}
+        ${search.query}
+        AND t.user_id IS NOT NULL
+        AND t.user_id != ''
+      `;
+
+      return queryClickhouse({
+        query,
+        params: input.params,
+        tags: input.tags,
+      });
+    },
+    newExecution: async (input) => {
+      const traceAmt = getTimeframesTracesAMT(input.timestamp);
+      const query = `
+        SELECT COUNT(DISTINCT t.user_id) AS totalCount
+        FROM ${traceAmt} t
+        WHERE ${tracesFilterRes.query}
+        ${search.query}
+        AND t.user_id IS NOT NULL
+        AND t.user_id != ''
+      `;
+
+      return queryClickhouse({
+        query,
+        params: input.params,
+        tags: input.tags,
+      });
     },
   });
 };

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -694,12 +694,6 @@ export const getTracesGroupedByUsers = async (
   const tracesFilterRes = tracesFilter.apply();
   const search = clickhouseSearchCondition(searchQuery, undefined, "t");
 
-  // Extract the timestamp from filter for AMT table selection
-  const fromTimestamp = filter?.find(
-    (f) =>
-      f.column === "timestamp" && (f.operator === ">=" || f.operator === ">"),
-  )?.value as Date | undefined;
-
   return measureAndReturn({
     operationName: "getTracesGroupedByUsers",
     projectId,
@@ -717,7 +711,6 @@ export const getTracesGroupedByUsers = async (
         kind: "analytic",
         projectId,
       },
-      timestamp: fromTimestamp,
     },
     existingExecution: async (input) => {
       // We mainly use queries like this to retrieve filter options.
@@ -747,7 +740,13 @@ export const getTracesGroupedByUsers = async (
       });
     },
     newExecution: async (input) => {
-      const traceAmt = getTimeframesTracesAMT(input.timestamp);
+      // Extract the timestamp from filter for AMT table selection
+      const fromTimestamp = filter?.find(
+        (f) =>
+          f.column === "timestamp" &&
+          (f.operator === ">=" || f.operator === ">"),
+      )?.value as Date | undefined;
+      const traceAmt = getTimeframesTracesAMT(fromTimestamp);
       const query = `
         select
           user_id as user,
@@ -791,12 +790,6 @@ export const getTracesGroupedByTags = async (props: GroupedTracesQueryProp) => {
 
   const filterRes = new FilterList(chFilter).apply();
 
-  // Extract the timestamp from filter for AMT table selection
-  const fromTimestamp = filter?.find(
-    (f) =>
-      f.column === "timestamp" && (f.operator === ">=" || f.operator === ">"),
-  )?.value as Date | undefined;
-
   return measureAndReturn({
     operationName: "getTracesGroupedByTags",
     projectId,
@@ -811,7 +804,6 @@ export const getTracesGroupedByTags = async (props: GroupedTracesQueryProp) => {
         kind: "analytic",
         projectId,
       },
-      timestamp: fromTimestamp,
     },
     existingExecution: async (input) => {
       const query = `
@@ -831,7 +823,13 @@ export const getTracesGroupedByTags = async (props: GroupedTracesQueryProp) => {
       });
     },
     newExecution: async (input) => {
-      const traceAmt = getTimeframesTracesAMT(input.timestamp);
+      // Extract the timestamp from filter for AMT table selection
+      const fromTimestamp = filter?.find(
+        (f) =>
+          f.column === "timestamp" &&
+          (f.operator === ">=" || f.operator === ">"),
+      )?.value as Date | undefined;
+      const traceAmt = getTimeframesTracesAMT(fromTimestamp);
       const query = `
         select distinct(arrayJoin(tags)) as value
         from ${traceAmt} t

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -600,12 +600,6 @@ export const getTracesGroupedByName = async (
     ? new FilterList(chFilter).apply()
     : undefined;
 
-  // Extract the timestamp from filter for AMT table selection
-  const fromTimestamp = timestampFilter?.find(
-    (f) =>
-      f.column === "timestamp" && (f.operator === ">=" || f.operator === ">"),
-  )?.value as Date | undefined;
-
   return measureAndReturn({
     operationName: "getTracesGroupedByName",
     projectId,
@@ -620,7 +614,6 @@ export const getTracesGroupedByName = async (
         kind: "analytic",
         projectId,
       },
-      timestamp: fromTimestamp,
     },
     existingExecution: async (input) => {
       // We mainly use queries like this to retrieve filter options.
@@ -648,7 +641,13 @@ export const getTracesGroupedByName = async (
       });
     },
     newExecution: async (input) => {
-      const traceAmt = getTimeframesTracesAMT(input.timestamp);
+      // Extract the timestamp from filter for AMT table selection
+      const fromTimestamp = timestampFilter?.find(
+        (f) =>
+          f.column === "timestamp" &&
+          (f.operator === ">=" || f.operator === ">"),
+      )?.value as Date | undefined;
+      const traceAmt = getTimeframesTracesAMT(fromTimestamp);
       const query = `
         select
           name as name,

--- a/worker/src/services/IngestionService/README.md
+++ b/worker/src/services/IngestionService/README.md
@@ -485,13 +485,13 @@ This checklist documents all references and invocations to the `traces` table gr
 ### 3. Existence Checks
 - [x] **checkTraceExists()** - `packages/shared/src/server/repositories/traces.ts:73-210`
 - [x] **hasAnyTrace()** - `packages/shared/src/server/repositories/traces.ts:306-356`
-- [ ] **hasAnyUser()** - `packages/shared/src/server/repositories/traces.ts:763-787`
+- [x] **hasAnyUser()** - `packages/shared/src/server/repositories/traces.ts:763-787`
 
 ### 4. Aggregation and Analytics Queries
-- [ ] **getTracesGroupedByName()** - `packages/shared/src/server/repositories/traces.ts:489-535`
-- [ ] **getTracesGroupedByUsers()** - `packages/shared/src/server/repositories/traces.ts:537-597`
-- [ ] **getTracesGroupedByTags()** - `packages/shared/src/server/repositories/traces.ts:605-640`
-- [ ] **getTotalUserCount()** - `packages/shared/src/server/repositories/traces.ts:789-827`
+- [x] **getTracesGroupedByName()** - `packages/shared/src/server/repositories/traces.ts:489-535`
+- [x] **getTracesGroupedByUsers()** - `packages/shared/src/server/repositories/traces.ts:537-597`
+- [x] **getTracesGroupedByTags()** - `packages/shared/src/server/repositories/traces.ts:605-640`
+- [x] **getTotalUserCount()** - `packages/shared/src/server/repositories/traces.ts:789-827`
 - [ ] **getUserMetrics()** - `packages/shared/src/server/repositories/traces.ts:829-978`
 - [ ] **getTracesTableGeneric()** - `packages/shared/src/server/services/traces-ui-table-service.ts:207++`
 - [ ] **getSessionsTableGeneric()** - `packages/shared/src/server/services/sessions-ui-table-service.ts:121++`)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Migrate analytic routes in `traces.ts` to use new AMTs for improved performance and update `README.md` accordingly.
> 
>   - **Behavior**:
>     - Migrate analytic routes in `traces.ts` to use new AMTs (`traces_7d_amt`, `traces_30d_amt`, `traces_all_amt`) based on timestamp filters.
>     - Functions `getTracesGroupedByName`, `getTracesGroupedByUsers`, `getTracesGroupedByTags`, `getTotalUserCount`, and `hasAnyUser` now select AMT tables based on `fromTimestamp`.
>   - **Functions**:
>     - `measureAndReturn` utility used for execution path selection in `traces.ts` functions.
>     - `getTimeframesTracesAMT` determines appropriate AMT table based on timestamp.
>   - **Documentation**:
>     - Update `README.md` in `IngestionService` to mark functions as migrated to AMTs.
>     - Checklist updated to reflect changes in `traces.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ca549bcbdae3a636a72b044fe0820b8ca9b37d72. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->