### PR TITLE
chore: expose email_from_address and smtp_connection_url in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
       REDIS_TLS_CA: ${REDIS_TLS_CA:-/certs/ca.crt}
       REDIS_TLS_CERT: ${REDIS_TLS_CERT:-/certs/redis.crt}
       REDIS_TLS_KEY: ${REDIS_TLS_KEY:-/certs/redis.key}
+      EMAIL_FROM_ADDRESS: ${EMAIL_FROM_ADDRESS:-}
+      SMTP_CONNECTION_URL: ${SMTP_CONNECTION_URL:-}
 
   langfuse-web:
     image: docker.io/langfuse/langfuse:3


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/8017
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Expose `EMAIL_FROM_ADDRESS` and `SMTP_CONNECTION_URL` in `docker-compose.yml` for `langfuse-worker` and `langfuse-web`.
> 
>   - **Configuration**:
>     - Expose `EMAIL_FROM_ADDRESS` and `SMTP_CONNECTION_URL` as environment variables in `docker-compose.yml` for `langfuse-worker` and `langfuse-web` services.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9feac7cc8d163cb699a695df2b48d138b4dbbfc6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->