### PR TITLE
perf: replace prisma upsert with raw query

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -1,6 +1,5 @@
 import { Cluster, Redis } from "ioredis";
 import { v4 } from "uuid";
-import { Prisma } from "@prisma/client";
 import {
   LangfuseNotFoundError,
   Model,

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -1,6 +1,5 @@
 import { Cluster, Redis } from "ioredis";
 import { v4 } from "uuid";
-import { Prisma } from "@prisma/client";
 import { Model, Price, PrismaClient, Prompt } from "@langfuse/shared";
 import {
   ClickhouseClientType,

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -300,33 +300,21 @@ export class IngestionService {
     // If the trace has a sessionId, we upsert the corresponding session into Postgres.
     if (finalTraceRecord.session_id) {
       try {
-        await this.prisma.traceSession.upsert({
-          where: {
-            id_projectId: {
-              id: finalTraceRecord.session_id,
-              projectId,
-            },
-          },
-          create: {
-            id: finalTraceRecord.session_id,
-            projectId,
-            environment: finalTraceRecord.environment,
-          },
-          update: {
-            environment: finalTraceRecord.environment,
-          },
-        });
+        await this.prisma.$executeRaw`
+          INSERT INTO trace_sessions (id, project_id, environment, created_at, updated_at)
+          VALUES (${finalTraceRecord.session_id}, ${projectId}, ${finalTraceRecord.environment}, NOW(), NOW())
+          ON CONFLICT (id, project_id) 
+          DO UPDATE SET 
+            environment = EXCLUDED.environment,
+            updated_at = NOW()
+          WHERE trace_sessions.environment IS DISTINCT FROM EXCLUDED.environment
+        `;
       } catch (e) {
-        if (
-          e instanceof Prisma.PrismaClientKnownRequestError &&
-          e.code === "P2002"
-        ) {
-          logger.warn(
-            `Failed to upsert session. Session ${finalTraceRecord.session_id} in project ${projectId} already exists`,
-          );
-        } else {
-          throw e;
-        }
+        logger.error(
+          `Failed to upsert session ${finalTraceRecord.session_id}`,
+          e,
+        );
+        throw e;
       }
     }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replaces Prisma upsert with raw SQL query for `trace_sessions` in `IngestionService`, improving performance and updating error handling.
> 
>   - **Performance**:
>     - Replaces Prisma `upsert` with raw SQL query in `IngestionService` for `trace_sessions` table.
>     - Raw query uses `INSERT ... ON CONFLICT` for upsert logic, updating `environment` and `updated_at` if `environment` differs.
>   - **Error Handling**:
>     - Removes specific handling for `PrismaClientKnownRequestError` with code `P2002`.
>     - Logs errors with `logger.error` and rethrows them.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fc15adf43610e11eb6df30b997b69ce2ac90c410. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->