### PR TITLE
perf: initialize clickhouse skip read map on startup

### DIFF
--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -33,6 +33,8 @@ import {
 import { env } from "./env";
 import { ingestionQueueProcessorBuilder } from "./queues/ingestionQueue";
 import { BackgroundMigrationManager } from "./backgroundMigrations/backgroundMigrationManager";
+import { prisma } from "@langfuse/shared/src/db";
+import { ClickhouseReadSkipCache } from "./utils/clickhouseReadSkipCache";
 import { experimentCreateQueueProcessor } from "./queues/experimentQueue";
 import { traceDeleteProcessor } from "./queues/traceDelete";
 import { projectDeleteProcessor } from "./queues/projectDelete";
@@ -78,6 +80,13 @@ if (env.LANGFUSE_ENABLE_BACKGROUND_MIGRATIONS === "true") {
     logger.error("Error running background migrations", err);
   });
 }
+
+// Initialize ClickhouseReadSkipCache on container start
+ClickhouseReadSkipCache.getInstance(prisma)
+  .initialize()
+  .catch((err) => {
+    logger.error("Error initializing ClickhouseReadSkipCache", err);
+  });
 
 if (env.QUEUE_CONSUMER_TRACE_UPSERT_QUEUE_IS_ENABLED === "true") {
   WorkerManager.register(

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -848,9 +848,9 @@ export class IngestionService {
     };
   }) {
     if (
-      await ClickhouseReadSkipCache.getInstance().shouldSkipClickHouseRead(
-        params.projectId,
-      )
+      await ClickhouseReadSkipCache.getInstance(
+        this.prisma,
+      ).shouldSkipClickHouseRead(params.projectId)
     ) {
       recordIncrement("langfuse.ingestion.clickhouse_read_for_update", 1, {
         skipped: "true",

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -1,13 +1,7 @@
 import { Cluster, Redis } from "ioredis";
 import { v4 } from "uuid";
 import { Prisma } from "@prisma/client";
-import {
-  LangfuseNotFoundError,
-  Model,
-  Price,
-  PrismaClient,
-  Prompt,
-} from "@langfuse/shared";
+import { Model, Price, PrismaClient, Prompt } from "@langfuse/shared";
 import {
   ClickhouseClientType,
   convertDateToClickhouseDateTime,

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -1960,22 +1960,6 @@ describe("Ingestion end-to-end tests", () => {
     expect(trace.user_id).toBe("user-1");
   });
 
-  it("should skip clickhouse read for recently created projects", async () => {
-    const projectId = randomUUID();
-    await prisma.project.create({
-      data: {
-        id: projectId,
-        name: randomUUID(),
-        orgId: "seed-org-id",
-      },
-    });
-    const shouldSkip = await ingestionService.shouldSkipClickHouseRead(
-      projectId,
-      "2024-01-01", // Use some date in the past
-    );
-    expect(shouldSkip).toBe(true);
-  });
-
   [
     {
       inputs: [{ a: "a" }, { b: "b" }],

--- a/worker/src/utils/clickhouseReadSkipCache.ts
+++ b/worker/src/utils/clickhouseReadSkipCache.ts
@@ -1,0 +1,173 @@
+import { PrismaClient, LangfuseNotFoundError } from "@langfuse/shared";
+import { logger } from "@langfuse/shared/src/server";
+import { env } from "../env";
+
+export class ClickhouseReadSkipCache {
+  private static instance: ClickhouseReadSkipCache | null = null;
+  private projectSkipMap = new Map<string, boolean>();
+  private initialized = false;
+  private initializing = false;
+  private initPromise: Promise<void> | null = null;
+  private prisma: PrismaClient;
+
+  private constructor(prisma: PrismaClient) {
+    this.prisma = prisma;
+  }
+
+  public static getInstance(prisma?: PrismaClient): ClickhouseReadSkipCache {
+    if (!ClickhouseReadSkipCache.instance) {
+      if (!prisma) {
+        throw new Error("PrismaClient is required for first initialization");
+      }
+      ClickhouseReadSkipCache.instance = new ClickhouseReadSkipCache(prisma);
+    }
+    return ClickhouseReadSkipCache.instance;
+  }
+
+  public async initialize(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+
+    if (this.initializing) {
+      if (this.initPromise) {
+        await this.initPromise;
+      }
+      return;
+    }
+
+    this.initializing = true;
+    this.initPromise = this.performInitialization();
+
+    try {
+      await this.initPromise;
+      this.initialized = true;
+    } catch (error) {
+      this.initializing = false;
+      this.initPromise = null;
+      throw error;
+    }
+  }
+
+  private async performInitialization(): Promise<void> {
+    if (!env.LANGFUSE_SKIP_INGESTION_CLICKHOUSE_READ_MIN_PROJECT_CREATE_DATE) {
+      logger.info(
+        "No min project create date set, ClickhouseReadSkipCache will not pre-populate",
+      );
+      return;
+    }
+
+    const cutoffDate = new Date(
+      env.LANGFUSE_SKIP_INGESTION_CLICKHOUSE_READ_MIN_PROJECT_CREATE_DATE,
+    );
+
+    logger.info(
+      `Initializing ClickhouseReadSkipCache with cutoff date: ${cutoffDate.toISOString()}`,
+    );
+
+    try {
+      const projects = await this.prisma.project.findMany({
+        where: {
+          deletedAt: null,
+        },
+        select: {
+          id: true,
+          createdAt: true,
+        },
+      });
+
+      let skipCount = 0;
+      let noSkipCount = 0;
+
+      for (const project of projects) {
+        const shouldSkip = project.createdAt >= cutoffDate;
+        this.projectSkipMap.set(project.id, shouldSkip);
+
+        if (shouldSkip) {
+          skipCount++;
+        } else {
+          noSkipCount++;
+        }
+      }
+
+      logger.debug(
+        `ClickhouseReadSkipCache initialized with ${projects.length} projects (${skipCount} will skip, ${noSkipCount} will not skip)`,
+      );
+    } catch (error) {
+      logger.error("Failed to initialize ClickhouseReadSkipCache", error);
+      throw error;
+    }
+  }
+
+  public async shouldSkipClickHouseRead(
+    projectId: string,
+    minProjectCreateDate?: string,
+  ): Promise<boolean> {
+    // Check explicit project ID list first
+    if (
+      env.LANGFUSE_SKIP_INGESTION_CLICKHOUSE_READ_PROJECT_IDS &&
+      env.LANGFUSE_SKIP_INGESTION_CLICKHOUSE_READ_PROJECT_IDS.split(
+        ",",
+      ).includes(projectId)
+    ) {
+      return true;
+    }
+
+    // If no cutoff date configuration, don't skip
+    if (
+      !env.LANGFUSE_SKIP_INGESTION_CLICKHOUSE_READ_MIN_PROJECT_CREATE_DATE &&
+      !minProjectCreateDate
+    ) {
+      return false;
+    }
+
+    // Ensure the cache is initialized
+    if (!this.initialized) {
+      await this.initialize();
+    }
+
+    // Check if we have the project in our cache
+    if (this.projectSkipMap.has(projectId)) {
+      return this.projectSkipMap.get(projectId) ?? false;
+    }
+
+    // If not in cache, we need to fetch the project
+    logger.debug(`Project ${projectId} not in cache, fetching from database`);
+
+    try {
+      const project = await this.prisma.project.findFirst({
+        where: {
+          id: projectId,
+          deletedAt: null,
+        },
+        select: {
+          id: true,
+          createdAt: true,
+        },
+      });
+
+      if (!project) {
+        throw new LangfuseNotFoundError(`Project ${projectId} not found`);
+      }
+
+      const cutoffDate = new Date(
+        env.LANGFUSE_SKIP_INGESTION_CLICKHOUSE_READ_MIN_PROJECT_CREATE_DATE ??
+          minProjectCreateDate ??
+          new Date(), // Fallback to today. Should never apply.
+      );
+
+      const shouldSkip = project.createdAt >= cutoffDate;
+
+      // Cache the result for future use
+      this.projectSkipMap.set(projectId, shouldSkip);
+
+      return shouldSkip;
+    } catch (error) {
+      logger.error(
+        `Failed to fetch project ${projectId} for ClickHouse skip check`,
+        error,
+      );
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduce `ClickhouseReadSkipCache` to manage skipping Clickhouse reads based on project creation dates, initialized on startup.
> 
>   - **Behavior**:
>     - Initialize `ClickhouseReadSkipCache` on startup in `app.ts`.
>     - Use `ClickhouseReadSkipCache` in `IngestionService` to determine if Clickhouse reads should be skipped based on project creation date.
>   - **Cache Implementation**:
>     - New `ClickhouseReadSkipCache` class in `clickhouseReadSkipCache.ts` manages project skip logic.
>     - Caches project skip status based on environment variable `LANGFUSE_SKIP_INGESTION_CLICKHOUSE_READ_MIN_PROJECT_CREATE_DATE`.
>   - **Code Removal**:
>     - Remove `shouldSkipClickHouseRead` logic from `IngestionService`.
>     - Remove related test `should skip clickhouse read for recently created projects` from `IngestionService.integration.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b93ee556476a7e295b715bf2b2cc5862958ed4ef. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->