### PR TITLE
fix(datasets-table): don't table render json here

### DIFF
--- a/web/src/components/grouped-score-badge.tsx
+++ b/web/src/components/grouped-score-badge.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/src/components/ui/hover-card";
 import { type LastUserScore, type APIScoreV2 } from "@langfuse/shared";
 import { BracesIcon, MessageCircleMoreIcon } from "lucide-react";
-import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
+import { JSONView } from "@/src/components/ui/CodeJsonViewer";
 
 const partitionScores = <T extends APIScoreV2 | LastUserScore>(
   scores: Record<string, T[]>,
@@ -74,11 +74,7 @@ const ScoreGroupBadge = <T extends APIScoreV2 | LastUserScore>({
                   <BracesIcon className="mb-[0.0625rem] !size-3" />
                 </HoverCardTrigger>
                 <HoverCardContent className="max-h-[50dvh] overflow-y-auto whitespace-normal break-normal rounded-md border-none p-0">
-                  <PrettyJsonView
-                    codeClassName="!rounded-md"
-                    json={s.metadata}
-                    currentView="pretty"
-                  />
+                  <JSONView codeClassName="!rounded-md" json={s.metadata} />
                 </HoverCardContent>
               </HoverCard>
             )}

--- a/web/src/components/scores-table-cell.tsx
+++ b/web/src/components/scores-table-cell.tsx
@@ -11,7 +11,7 @@ import {
 import { numberFormatter } from "@/src/utils/numbers";
 import { cn } from "@/src/utils/tailwind";
 import { BracesIcon, MessageCircleMore } from "lucide-react";
-import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
+import { JSONView } from "@/src/components/ui/CodeJsonViewer";
 import { api } from "@/src/utils/api";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 import { Skeleton } from "@/src/components/ui/skeleton";
@@ -161,11 +161,7 @@ function AggregateScoreMetadataPeek({
       </HoverCardTrigger>
       <HoverCardContent className="overflow-hidden whitespace-normal break-normal rounded-md border-none p-0">
         {metadataLoaded ? (
-          <PrettyJsonView
-            codeClassName="!rounded-md"
-            json={metadata}
-            currentView="pretty"
-          />
+          <JSONView codeClassName="!rounded-md" json={metadata} />
         ) : (
           <Skeleton className="h-12 w-full" />
         )}

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -19,7 +19,6 @@ import { useMarkdownContext } from "@/src/features/theming/useMarkdownContext";
 import { type MediaReturnType } from "@/src/features/media/validation";
 import { LangfuseMediaView } from "@/src/components/ui/LangfuseMediaView";
 import { MarkdownJsonViewHeader } from "@/src/components/ui/MarkdownJsonView";
-import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
 import { renderContentWithPromptButtons } from "@/src/features/prompts/components/renderContentWithPromptButtons";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
 
@@ -328,7 +327,7 @@ export const IOTableCell = ({
         </div>
       ) : shouldTruncate ? (
         <div className="ph-no-capture grid h-full grid-cols-1">
-          <PrettyJsonView
+          <JSONView
             json={
               stringifiedJson.slice(0, IO_TABLE_CHAR_LIMIT) +
               `...[truncated ${stringifiedJson.length - IO_TABLE_CHAR_LIMIT} characters]`
@@ -336,14 +335,13 @@ export const IOTableCell = ({
             className={cn("h-full w-full self-stretch rounded-sm", className)}
             codeClassName="py-1 px-2 min-h-0 h-full overflow-y-auto"
             collapseStringsAfterLength={null} // in table, show full strings as row height is fixed
-            currentView="json"
           />
           <div className="text-xs text-muted-foreground">
             Content was truncated.
           </div>
         </div>
       ) : (
-        <PrettyJsonView
+        <JSONView
           json={data}
           className={cn(
             "ph-no-capture h-full w-full self-stretch rounded-sm",
@@ -351,7 +349,6 @@ export const IOTableCell = ({
           )}
           codeClassName="py-1 px-2 min-h-0 h-full overflow-y-auto"
           collapseStringsAfterLength={null} // in table, show full strings as row height is fixed
-          currentView="pretty"
         />
       )}
     </>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `PrettyJsonView` with `JSONView` for JSON rendering in `grouped-score-badge.tsx` and `scores-table-cell.tsx`.
> 
>   - **Components**:
>     - Replace `PrettyJsonView` with `JSONView` in `grouped-score-badge.tsx` and `scores-table-cell.tsx` for rendering JSON metadata.
>   - **UI**:
>     - `JSONView` in `CodeJsonViewer.tsx` now handles JSON rendering, removing the `currentView` prop previously used in `PrettyJsonView`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b449e98f962ed79b2b86a607d8253e80d72e56b7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->