### PR TITLE
fix(trace-view): render new lines in json table view

### DIFF
--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -284,7 +284,7 @@ const ValueCell = memo(({ row }: { row: Row<JsonTableRow> }) => {
     switch (type) {
       case "string":
         return (
-          <span className="text-green-600 dark:text-green-400">
+          <span className="whitespace-pre-line text-green-600 dark:text-green-400">
             &quot;{String(value)}&quot;
           </span>
         );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modifies `ValueCell` in `PrettyJsonView.tsx` to render JSON string values with preserved new lines using `whitespace-pre-line`.
> 
>   - **UI Rendering**:
>     - In `PrettyJsonView.tsx`, modifies `ValueCell` to render JSON string values with `whitespace-pre-line` to preserve new lines.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b601bb4542049705b51e0b5fd038850ec89f8a06. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->