### PR TITLE
chore(dataset-run-items): adjust converter for background migration 

### DIFF
--- a/packages/shared/src/server/repositories/definitions.ts
+++ b/packages/shared/src/server/repositories/definitions.ts
@@ -365,13 +365,14 @@ export const convertPostgresDatasetRunItemToInsert = (
     dataset_run_name: datasetRunItem.dataset_run_name,
     dataset_run_description: datasetRunItem.dataset_run_description,
     dataset_run_metadata:
-      typeof datasetRunItem.dataset_run_metadata === "string" ||
-      typeof datasetRunItem.dataset_run_metadata === "number" ||
-      typeof datasetRunItem.dataset_run_metadata === "boolean"
+      typeof datasetRunItem.dataset_run_metadata === "string"
         ? { metadata: datasetRunItem.dataset_run_metadata }
         : Array.isArray(datasetRunItem.dataset_run_metadata)
           ? { metadata: datasetRunItem.dataset_run_metadata }
-          : (datasetRunItem.dataset_run_metadata ?? {}),
+          : typeof datasetRunItem.dataset_run_metadata === "object" ||
+              datasetRunItem.dataset_run_metadata === null
+            ? (datasetRunItem.dataset_run_metadata ?? {})
+            : { metadata: datasetRunItem.dataset_run_metadata },
     dataset_run_created_at: datasetRunItem.dataset_run_created_at?.getTime(),
     // denormalized item data
     dataset_item_input: JSON.stringify(datasetRunItem.dataset_item_input),
@@ -379,13 +380,14 @@ export const convertPostgresDatasetRunItemToInsert = (
       datasetRunItem.dataset_item_expected_output,
     ),
     dataset_item_metadata:
-      typeof datasetRunItem.dataset_item_metadata === "string" ||
-      typeof datasetRunItem.dataset_item_metadata === "number" ||
-      typeof datasetRunItem.dataset_item_metadata === "boolean"
+      typeof datasetRunItem.dataset_item_metadata === "string"
         ? { metadata: datasetRunItem.dataset_item_metadata }
         : Array.isArray(datasetRunItem.dataset_item_metadata)
           ? { metadata: datasetRunItem.dataset_item_metadata }
-          : (datasetRunItem.dataset_item_metadata ?? {}),
+          : typeof datasetRunItem.dataset_item_metadata === "object" ||
+              datasetRunItem.dataset_item_metadata === null
+            ? (datasetRunItem.dataset_item_metadata ?? {})
+            : { metadata: datasetRunItem.dataset_item_metadata },
     event_ts: datasetRunItem.created_at?.getTime(),
     is_deleted: 0,
   };

--- a/packages/shared/src/server/repositories/definitions.ts
+++ b/packages/shared/src/server/repositories/definitions.ts
@@ -365,7 +365,9 @@ export const convertPostgresDatasetRunItemToInsert = (
     dataset_run_name: datasetRunItem.dataset_run_name,
     dataset_run_description: datasetRunItem.dataset_run_description,
     dataset_run_metadata:
-      typeof datasetRunItem.dataset_run_metadata === "string"
+      typeof datasetRunItem.dataset_run_metadata === "string" ||
+      typeof datasetRunItem.dataset_run_metadata === "number" ||
+      typeof datasetRunItem.dataset_run_metadata === "boolean"
         ? { metadata: datasetRunItem.dataset_run_metadata }
         : Array.isArray(datasetRunItem.dataset_run_metadata)
           ? { metadata: datasetRunItem.dataset_run_metadata }
@@ -377,7 +379,9 @@ export const convertPostgresDatasetRunItemToInsert = (
       datasetRunItem.dataset_item_expected_output,
     ),
     dataset_item_metadata:
-      typeof datasetRunItem.dataset_item_metadata === "string"
+      typeof datasetRunItem.dataset_item_metadata === "string" ||
+      typeof datasetRunItem.dataset_item_metadata === "number" ||
+      typeof datasetRunItem.dataset_item_metadata === "boolean"
         ? { metadata: datasetRunItem.dataset_item_metadata }
         : Array.isArray(datasetRunItem.dataset_item_metadata)
           ? { metadata: datasetRunItem.dataset_item_metadata }

--- a/packages/shared/src/server/repositories/definitions.ts
+++ b/packages/shared/src/server/repositories/definitions.ts
@@ -365,14 +365,13 @@ export const convertPostgresDatasetRunItemToInsert = (
     dataset_run_name: datasetRunItem.dataset_run_name,
     dataset_run_description: datasetRunItem.dataset_run_description,
     dataset_run_metadata:
-      typeof datasetRunItem.dataset_run_metadata === "string"
+      typeof datasetRunItem.dataset_run_metadata === "string" ||
+      typeof datasetRunItem.dataset_run_metadata === "number" ||
+      typeof datasetRunItem.dataset_run_metadata === "boolean"
         ? { metadata: datasetRunItem.dataset_run_metadata }
         : Array.isArray(datasetRunItem.dataset_run_metadata)
           ? { metadata: datasetRunItem.dataset_run_metadata }
-          : typeof datasetRunItem.dataset_run_metadata === "object" ||
-              datasetRunItem.dataset_run_metadata === null
-            ? (datasetRunItem.dataset_run_metadata ?? {})
-            : { metadata: datasetRunItem.dataset_run_metadata },
+          : (datasetRunItem.dataset_run_metadata ?? {}),
     dataset_run_created_at: datasetRunItem.dataset_run_created_at?.getTime(),
     // denormalized item data
     dataset_item_input: JSON.stringify(datasetRunItem.dataset_item_input),
@@ -380,14 +379,13 @@ export const convertPostgresDatasetRunItemToInsert = (
       datasetRunItem.dataset_item_expected_output,
     ),
     dataset_item_metadata:
-      typeof datasetRunItem.dataset_item_metadata === "string"
+      typeof datasetRunItem.dataset_item_metadata === "string" ||
+      typeof datasetRunItem.dataset_item_metadata === "number" ||
+      typeof datasetRunItem.dataset_item_metadata === "boolean"
         ? { metadata: datasetRunItem.dataset_item_metadata }
         : Array.isArray(datasetRunItem.dataset_item_metadata)
           ? { metadata: datasetRunItem.dataset_item_metadata }
-          : typeof datasetRunItem.dataset_item_metadata === "object" ||
-              datasetRunItem.dataset_item_metadata === null
-            ? (datasetRunItem.dataset_item_metadata ?? {})
-            : { metadata: datasetRunItem.dataset_item_metadata },
+          : (datasetRunItem.dataset_item_metadata ?? {}),
     event_ts: datasetRunItem.created_at?.getTime(),
     is_deleted: 0,
   };

--- a/packages/shared/src/server/repositories/definitions.ts
+++ b/packages/shared/src/server/repositories/definitions.ts
@@ -355,31 +355,33 @@ export const convertPostgresDatasetRunItemToInsert = (
     project_id: datasetRunItem.project_id,
     dataset_run_id: datasetRunItem.dataset_run_id,
     dataset_item_id: datasetRunItem.dataset_item_id,
+    dataset_id: datasetRunItem.dataset_id,
     trace_id: datasetRunItem.trace_id,
     observation_id: datasetRunItem.observation_id,
     error: datasetRunItem.error,
     created_at: datasetRunItem.created_at?.getTime(),
     updated_at: datasetRunItem.updated_at?.getTime(),
     // denormalized run data
-    dataset_run_created_at: datasetRunItem.dataset_run_created_at?.getTime(),
-    dataset_id: datasetRunItem.dataset_id,
     dataset_run_name: datasetRunItem.dataset_run_name,
     dataset_run_description: datasetRunItem.dataset_run_description,
     dataset_run_metadata:
       typeof datasetRunItem.dataset_run_metadata === "string"
-        ? { dataset_run_metadata: datasetRunItem.dataset_run_metadata }
+        ? { metadata: datasetRunItem.dataset_run_metadata }
         : Array.isArray(datasetRunItem.dataset_run_metadata)
-          ? { dataset_run_metadata: datasetRunItem.dataset_run_metadata }
-          : datasetRunItem.dataset_run_metadata,
+          ? { metadata: datasetRunItem.dataset_run_metadata }
+          : (datasetRunItem.dataset_run_metadata ?? {}),
+    dataset_run_created_at: datasetRunItem.dataset_run_created_at?.getTime(),
     // denormalized item data
-    dataset_item_input: datasetRunItem.dataset_item_input,
-    dataset_item_expected_output: datasetRunItem.dataset_item_expected_output,
+    dataset_item_input: JSON.stringify(datasetRunItem.dataset_item_input),
+    dataset_item_expected_output: JSON.stringify(
+      datasetRunItem.dataset_item_expected_output,
+    ),
     dataset_item_metadata:
       typeof datasetRunItem.dataset_item_metadata === "string"
-        ? { dataset_item_metadata: datasetRunItem.dataset_item_metadata }
+        ? { metadata: datasetRunItem.dataset_item_metadata }
         : Array.isArray(datasetRunItem.dataset_item_metadata)
-          ? { dataset_item_metadata: datasetRunItem.dataset_item_metadata }
-          : datasetRunItem.dataset_item_metadata,
+          ? { metadata: datasetRunItem.dataset_item_metadata }
+          : (datasetRunItem.dataset_item_metadata ?? {}),
     event_ts: datasetRunItem.created_at?.getTime(),
     is_deleted: 0,
   };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `convertPostgresDatasetRunItemToInsert` to handle additional data types and JSON stringify fields for background migration.
> 
>   - **Functionality**:
>     - Update `convertPostgresDatasetRunItemToInsert` in `definitions.ts` to handle `number` and `boolean` types for `dataset_run_metadata` and `dataset_item_metadata`.
>     - Ensure `dataset_item_input` and `dataset_item_expected_output` are JSON stringified.
>   - **Misc**:
>     - Reorder `dataset_run_created_at` in `convertPostgresDatasetRunItemToInsert` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e55bf16f478e6db18ebf780f9078f60d716ec3e7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->