### PR TITLE
feat(admin-api): add okta role assignment capabilities

### DIFF
--- a/web/src/pages/api/public/scim/Users/[id].ts
+++ b/web/src/pages/api/public/scim/Users/[id].ts
@@ -50,6 +50,10 @@ export default async function handler(
     });
   }
 
+  logger.info(
+    `Received request for /api/public/scim/Users/[id] with method ${req.method} for orgId ${authCheck.scope.orgId} and userId ${req.query.id}`,
+  );
+
   const orgMembership = await prisma.organizationMembership.findFirst({
     where: {
       orgId: authCheck.scope.orgId,

--- a/web/src/pages/api/public/scim/Users/index.ts
+++ b/web/src/pages/api/public/scim/Users/index.ts
@@ -5,6 +5,8 @@ import { logger, redis } from "@langfuse/shared/src/server";
 
 import { type NextApiRequest, type NextApiResponse } from "next";
 import { hashPassword } from "@/src/features/auth-credentials/lib/credentialsServerUtils";
+import { z } from "zod";
+import { Role } from "@langfuse/shared";
 
 export default async function handler(
   req: NextApiRequest,
@@ -49,6 +51,10 @@ export default async function handler(
       status: 403,
     });
   }
+
+  logger.info(
+    `Received request for /api/public/scim/Users with method ${req.method} for orgId ${authCheck.scope.orgId}`,
+  );
 
   if (req.method === "GET") {
     try {
@@ -147,7 +153,7 @@ export default async function handler(
         }
       }
 
-      const { userName, name, password, displayName } = req.body;
+      const { userName, name, password, displayName, roles } = req.body;
 
       if (!userName) {
         logger.warn("userName is required for SCIM user creation");
@@ -156,6 +162,24 @@ export default async function handler(
           detail: "userName is required",
           status: 400,
         });
+      }
+
+      let role: Role = "NONE";
+      if (roles && Array.isArray(roles) && roles.length > 0) {
+        const roleSchema = z.array(
+          z.enum(["OWNER", "ADMIN", "MEMBER", "VIEWER", "NONE"]),
+        );
+        const parsedRoles = roleSchema.safeParse(roles);
+        if (!parsedRoles.success) {
+          logger.warn("Invalid roles provided for SCIM user creation");
+          return res.status(400).json({
+            schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+            detail: `Invalid roles provided: ${JSON.stringify(roles)}, must be one of OWNER, ADMIN, MEMBER, VIEWER, NONE`,
+            status: 400,
+          });
+        }
+        // Use the first valid role
+        role = parsedRoles.data[0];
       }
 
       // Check if user already exists
@@ -195,7 +219,7 @@ export default async function handler(
         data: {
           userId: user.id,
           orgId: authCheck.scope.orgId,
-          role: "NONE",
+          role,
         },
       });
 

--- a/web/src/pages/api/public/scim/Users/index.ts
+++ b/web/src/pages/api/public/scim/Users/index.ts
@@ -6,7 +6,7 @@ import { logger, redis } from "@langfuse/shared/src/server";
 import { type NextApiRequest, type NextApiResponse } from "next";
 import { hashPassword } from "@/src/features/auth-credentials/lib/credentialsServerUtils";
 import { z } from "zod";
-import { Role } from "@langfuse/shared";
+import { type Role } from "@langfuse/shared";
 
 export default async function handler(
   req: NextApiRequest,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add role assignment to SCIM user creation and improve request logging in SCIM Users API.
> 
>   - **Role Assignment**:
>     - Added `roles` field handling in `POST` method in `Users/index.ts`.
>     - Validates roles using `zod` schema, supports roles: OWNER, ADMIN, MEMBER, VIEWER, NONE.
>     - Assigns first valid role to user during creation.
>   - **Logging**:
>     - Added logging for incoming requests in `Users/[id].ts` and `Users/index.ts`.
>   - **Misc**:
>     - Updated `organizationMembership.create` to use assigned role in `Users/index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7f668b4ec0c3cda1317e8a741f4b847fff38acd6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->