### PR TITLE
chore: include boolean scores in the reference of scores-numeric

### DIFF
--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -458,7 +458,7 @@ const scoreBaseDimensions: DimensionsDeclarationType = {
 export const scoresNumericView: ViewDeclarationType = {
   name: "scores_numeric",
   description:
-    "Scores are flexible objects that are used for evaluations. This view contains numeric scores.",
+    "Scores are flexible objects that are used for evaluations. This view contains numeric and boolean scores.",
   dimensions: {
     ...scoreBaseDimensions,
     id: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `scoresNumericView` description in `dataModel.ts` to include boolean scores.
> 
>   - **Description Update**:
>     - Update `scoresNumericView` description in `dataModel.ts` to include boolean scores alongside numeric scores.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9d1fa4915e69c19c9fead6fec4ea495c795d2bc2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->