### PR TITLE
chore: fix output box for playground

### DIFF
--- a/web/src/features/playground/page/components/GenerationOutput.tsx
+++ b/web/src/features/playground/page/components/GenerationOutput.tsx
@@ -88,25 +88,29 @@ export const GenerationOutput = () => {
     ) : null;
 
   return (
-    <div className="relative h-full overflow-auto">
+    <div className="relative h-full">
       <div
-        className="h-full overflow-auto rounded-lg bg-muted p-4"
+        className="h-full overflow-auto rounded-lg bg-muted"
         ref={scrollAreaRef}
       >
-        <div className="mb-4 flex w-full items-center">
-          <p className="flex-1 text-xs font-semibold">Output</p>
-          {copyButton}
+        <div className="sticky top-0 z-10 bg-muted p-3">
+          <div className="flex w-full items-center">
+            <p className="flex-1 text-xs font-semibold">Output</p>
+            {copyButton}
+          </div>
         </div>
-        <pre className="whitespace-break-spaces break-words text-xs">
-          {isJson ? outputJson : output}
-        </pre>
-        {outputToolCalls.length > 0
-          ? outputToolCalls.map((toolCall) => (
-              <div className="mt-4" key={toolCall.id}>
-                <ToolCallCard toolCall={toolCall} />
-              </div>
-            ))
-          : null}
+        <div className="px-4">
+          <pre className="whitespace-break-spaces break-words text-xs">
+            {isJson ? outputJson : output}
+          </pre>
+          {outputToolCalls.length > 0
+            ? outputToolCalls.map((toolCall) => (
+                <div className="mt-4" key={toolCall.id}>
+                  <ToolCallCard toolCall={toolCall} />
+                </div>
+              ))
+            : null}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make header sticky in `GenerationOutput.tsx` to improve output box usability in the playground.
> 
>   - **UI Improvements**:
>     - Made the header sticky in `GenerationOutput.tsx` to keep the output label and buttons visible during scrolling.
>     - Removed redundant padding from the output container to streamline the layout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7e5eb26f39b4a32c2ef48ae4cdab7a2f4ce1be90. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->