### PR TITLE
chore: Remove add window button and its imports

### DIFF
--- a/web/src/features/playground/page/index.tsx
+++ b/web/src/features/playground/page/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { Button } from "@/src/components/ui/button";
-import { Plus, Play, Loader2 } from "lucide-react";
+import { Play, Loader2 } from "lucide-react";
 import { ResetPlaygroundButton } from "@/src/features/playground/page/components/ResetPlaygroundButton";
 import { useWindowCoordination } from "@/src/features/playground/page/hooks/useWindowCoordination";
 import { usePersistedWindowIds } from "@/src/features/playground/page/hooks/usePersistedWindowIds";
@@ -108,8 +108,6 @@ export default function PlaygroundPage() {
     ? getExecutionStatus() ||
       `Executing ${windowIds.length} window${windowIds.length === 1 ? "" : "s"}`
     : getExecutionStatus();
-  const isAddWindowDisabled =
-    windowIds.length >= MULTI_WINDOW_CONFIG.MAX_WINDOWS;
   const isRunAllDisabled = globalIsExecutingAll;
 
   const windowState: MultiWindowState = {
@@ -148,18 +146,6 @@ export default function PlaygroundPage() {
                 </>
               )}
             </div>
-
-            {/* Add Window Button - Hidden on mobile */}
-            <Button
-              variant="outline"
-              onClick={() => addWindow()}
-              disabled={isAddWindowDisabled}
-              className="hidden flex-shrink-0 gap-1 md:flex"
-              title="Add a new playground window"
-            >
-              <Plus className="h-3 w-3" />
-              <span className="hidden lg:inline">Add Window</span>
-            </Button>
 
             {/* Multi-Window Controls - Hidden on mobile */}
             <Button

--- a/web/src/features/playground/page/index.tsx
+++ b/web/src/features/playground/page/index.tsx
@@ -5,10 +5,7 @@ import { ResetPlaygroundButton } from "@/src/features/playground/page/components
 import { useWindowCoordination } from "@/src/features/playground/page/hooks/useWindowCoordination";
 import { usePersistedWindowIds } from "@/src/features/playground/page/hooks/usePersistedWindowIds";
 import useCommandEnter from "@/src/features/playground/page/hooks/useCommandEnter";
-import {
-  MULTI_WINDOW_CONFIG,
-  type MultiWindowState,
-} from "@/src/features/playground/page/types";
+import { type MultiWindowState } from "@/src/features/playground/page/types";
 import Page from "@/src/components/layouts/page";
 import MultiWindowPlayground from "@/src/features/playground/page/components/MultiWindowPlayground";
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove 'Add Window' button and related imports from `PlaygroundPage`.
> 
>   - **UI Changes**:
>     - Remove 'Add Window' button from `PlaygroundPage`.
>     - Remove `Plus` icon import from `lucide-react`.
>   - **State Management**:
>     - Remove `isAddWindowDisabled` logic from `PlaygroundPage`.
>   - **Imports**:
>     - Remove `MULTI_WINDOW_CONFIG` import from `types`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a19154473e218f61e30aa8b1cf488b93baec4b65. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->