### PR TITLE
chore: improve webhook retries

### DIFF
--- a/packages/shared/src/domain/automations.ts
+++ b/packages/shared/src/domain/automations.ts
@@ -58,6 +58,7 @@ export const WebhookActionConfigSchema = z.object({
   apiVersion: AvailableWebhookApiSchema,
   secretKey: z.string(),
   displaySecretKey: z.string(),
+  lastFailingExecutionId: z.string().nullable().optional(),
 });
 
 export const SafeWebhookActionConfigSchema = WebhookActionConfigSchema.omit({

--- a/packages/shared/src/domain/automations.ts
+++ b/packages/shared/src/domain/automations.ts
@@ -58,7 +58,7 @@ export const WebhookActionConfigSchema = z.object({
   apiVersion: AvailableWebhookApiSchema,
   secretKey: z.string(),
   displaySecretKey: z.string(),
-  lastFailingExecutionId: z.string().nullable().optional(),
+  lastFailingExecutionId: z.string().nullish(),
 });
 
 export const SafeWebhookActionConfigSchema = WebhookActionConfigSchema.omit({

--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -103,10 +103,7 @@ type ProcessEventBatchOptions = {
  */
 export const processEventBatch = async (
   input: unknown[],
-  scope: {
-    orgId?: string;
-    projectId: string;
-  },
+  authCheck: AuthHeaderValidVerificationResult,
   options: ProcessEventBatchOptions = {},
 ): Promise<{
   successes: { id: string; status: number }[];

--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -103,7 +103,10 @@ type ProcessEventBatchOptions = {
  */
 export const processEventBatch = async (
   input: unknown[],
-  authCheck: AuthHeaderValidVerificationResult,
+  scope: {
+    orgId?: string;
+    projectId: string;
+  },
   options: ProcessEventBatchOptions = {},
 ): Promise<{
   successes: { id: string; status: number }[];

--- a/packages/shared/src/server/repositories/automation-repository.ts
+++ b/packages/shared/src/server/repositories/automation-repository.ts
@@ -39,9 +39,7 @@ export const getActionByIdWithSecrets = async ({
 
   // Decrypt secret headers for webhook execution using new structure
   const decryptedHeaders = config.requestHeaders
-    ? decryptSecretHeaders(
-        mergeHeaders(config.headers || {}, config.requestHeaders),
-      )
+    ? decryptSecretHeaders(mergeHeaders(config.headers, config.requestHeaders))
     : config.headers
       ? Object.entries(config.headers).reduce(
           (acc, [key, value]) => {

--- a/packages/shared/src/server/repositories/automation-repository.ts
+++ b/packages/shared/src/server/repositories/automation-repository.ts
@@ -158,6 +158,7 @@ const convertActionToDomain = (action: Action): ActionDomain => {
       displayHeaders: getDisplayHeaders(config),
       apiVersion: config.apiVersion,
       displaySecretKey: config.displaySecretKey,
+      lastFailingExecutionId: config.lastFailingExecutionId,
     } as SafeWebhookActionConfig,
   };
 };

--- a/packages/shared/src/server/repositories/automation-repository.ts
+++ b/packages/shared/src/server/repositories/automation-repository.ts
@@ -2,6 +2,7 @@ import {
   Action,
   ActionExecutionStatus,
   JobConfigState,
+  Prisma,
   prisma,
   Trigger,
 } from "../../db";
@@ -247,7 +248,7 @@ export const getConsecutiveAutomationFailures = async ({
     .config as WebhookActionConfigWithSecrets;
 
   // Build where clause - if lastFailingExecutionId is set, only consider executions newer than it
-  const whereClause: any = {
+  const whereClause: Prisma.AutomationExecutionWhereInput = {
     triggerId,
     actionId,
     projectId,

--- a/web/src/__tests__/async/automations-trpc.servertest.ts
+++ b/web/src/__tests__/async/automations-trpc.servertest.ts
@@ -1826,7 +1826,7 @@ describe("automations trpc", () => {
       });
 
       // Create failed executions that occurred BEFORE the lastFailingExecutionId
-      const oldFailedExecution = await prisma.automationExecution.create({
+      await prisma.automationExecution.create({
         data: {
           id: "some-failing-execution-id",
           automationId: automation.id,

--- a/web/src/__tests__/async/automations-trpc.servertest.ts
+++ b/web/src/__tests__/async/automations-trpc.servertest.ts
@@ -1780,6 +1780,199 @@ describe("automations trpc", () => {
 
       expect(response.count).toBe(3);
     });
+
+    it("should return 0 consecutive failures when lastFailingExecutionId is set", async () => {
+      const { project, caller } = await prepare();
+
+      // Create automation
+      const trigger = await prisma.trigger.create({
+        data: {
+          id: v4(),
+          projectId: project.id,
+          eventSource: "prompt",
+          eventActions: ["created"],
+          filter: [],
+          status: JobConfigState.INACTIVE, // Disabled due to failures
+        },
+      });
+
+      const { secretKey, displaySecretKey } = generateWebhookSecret();
+      const action = await prisma.action.create({
+        data: {
+          id: v4(),
+          projectId: project.id,
+          type: "WEBHOOK",
+          config: {
+            type: "WEBHOOK",
+            url: "https://example.com/webhook",
+            requestHeaders: {
+              "Content-Type": { secret: false, value: "application/json" },
+            },
+            apiVersion: { prompt: "v1" },
+            secretKey: encrypt(secretKey),
+            displaySecretKey,
+            lastFailingExecutionId: "some-failing-execution-id", // This simulates a webhook that was disabled
+          },
+        },
+      });
+
+      const automation = await prisma.automation.create({
+        data: {
+          projectId: project.id,
+          triggerId: trigger.id,
+          actionId: action.id,
+          name: "Test Automation",
+        },
+      });
+
+      // Create failed executions that occurred BEFORE the lastFailingExecutionId
+      const oldFailedExecution = await prisma.automationExecution.create({
+        data: {
+          id: "some-failing-execution-id",
+          automationId: automation.id,
+          projectId: project.id,
+          triggerId: trigger.id,
+          actionId: action.id,
+          status: ActionExecutionStatus.ERROR,
+          sourceId: v4(),
+          input: { iteration: 0 },
+          error: "Old failure",
+          createdAt: new Date(Date.now() - 60000), // 1 minute ago
+        },
+      });
+
+      // Create more failed executions that occurred BEFORE the lastFailingExecutionId
+      for (let i = 1; i < 5; i++) {
+        await prisma.automationExecution.create({
+          data: {
+            id: v4(),
+            automationId: automation.id,
+            projectId: project.id,
+            triggerId: trigger.id,
+            actionId: action.id,
+            status: ActionExecutionStatus.ERROR,
+            sourceId: v4(),
+            input: { iteration: i },
+            error: `Old failure ${i}`,
+            createdAt: new Date(Date.now() - (60000 + i * 1000)), // Before the lastFailingExecutionId
+          },
+        });
+      }
+
+      const response = await caller.automations.getCountOfConsecutiveFailures({
+        projectId: project.id,
+        automationId: automation.id,
+      });
+
+      // Should return 0 because all failures occurred before the lastFailingExecutionId
+      expect(response.count).toBe(0);
+    });
+
+    it("should count failures after lastFailingExecutionId correctly", async () => {
+      const { project, caller } = await prepare();
+
+      // Create automation
+      const trigger = await prisma.trigger.create({
+        data: {
+          id: v4(),
+          projectId: project.id,
+          eventSource: "prompt",
+          eventActions: ["created"],
+          filter: [],
+          status: JobConfigState.ACTIVE,
+        },
+      });
+
+      const { secretKey, displaySecretKey } = generateWebhookSecret();
+      const lastFailingExecutionId = v4();
+      const action = await prisma.action.create({
+        data: {
+          id: v4(),
+          projectId: project.id,
+          type: "WEBHOOK",
+          config: {
+            type: "WEBHOOK",
+            url: "https://example.com/webhook",
+            requestHeaders: {
+              "Content-Type": { secret: false, value: "application/json" },
+            },
+            apiVersion: { prompt: "v1" },
+            secretKey: encrypt(secretKey),
+            displaySecretKey,
+            lastFailingExecutionId,
+          },
+        },
+      });
+
+      const automation = await prisma.automation.create({
+        data: {
+          projectId: project.id,
+          triggerId: trigger.id,
+          actionId: action.id,
+          name: "Test Automation",
+        },
+      });
+
+      // Create the lastFailingExecution
+      await prisma.automationExecution.create({
+        data: {
+          id: lastFailingExecutionId,
+          automationId: automation.id,
+          projectId: project.id,
+          triggerId: trigger.id,
+          actionId: action.id,
+          status: ActionExecutionStatus.ERROR,
+          sourceId: v4(),
+          input: { iteration: 0 },
+          error: "Last failing execution",
+          createdAt: new Date(Date.now() - 60000), // 1 minute ago
+        },
+      });
+
+      // Create old failures that should be ignored
+      for (let i = 0; i < 3; i++) {
+        await prisma.automationExecution.create({
+          data: {
+            id: v4(),
+            automationId: automation.id,
+            projectId: project.id,
+            triggerId: trigger.id,
+            actionId: action.id,
+            status: ActionExecutionStatus.ERROR,
+            sourceId: v4(),
+            input: { iteration: i },
+            error: `Old failure ${i}`,
+            createdAt: new Date(Date.now() - (120000 + i * 1000)), // Before the lastFailingExecutionId
+          },
+        });
+      }
+
+      // Create new failures AFTER the lastFailingExecutionId
+      for (let i = 0; i < 2; i++) {
+        await prisma.automationExecution.create({
+          data: {
+            id: v4(),
+            automationId: automation.id,
+            projectId: project.id,
+            triggerId: trigger.id,
+            actionId: action.id,
+            status: ActionExecutionStatus.ERROR,
+            sourceId: v4(),
+            input: { iteration: i },
+            error: `New failure ${i}`,
+            createdAt: new Date(Date.now() - (30000 - i * 1000)), // After the lastFailingExecutionId
+          },
+        });
+      }
+
+      const response = await caller.automations.getCountOfConsecutiveFailures({
+        projectId: project.id,
+        automationId: automation.id,
+      });
+
+      // Should return 2 because only the 2 new failures after lastFailingExecutionId should be counted
+      expect(response.count).toBe(2);
+    });
   });
 
   describe("automations.regenerateWebhookSecret", () => {

--- a/web/src/features/automations/server/router.ts
+++ b/web/src/features/automations/server/router.ts
@@ -320,7 +320,6 @@ export const automationsRouter = createTRPCRouter({
       };
     }),
 
-  // Update an existing automation
   updateAutomation: protectedProjectProcedure
     .input(UpdateAutomationInputSchema)
     .mutation(async ({ ctx, input }) => {
@@ -389,7 +388,6 @@ export const automationsRouter = createTRPCRouter({
             },
           });
 
-          // Get the updated automation
           const automation = await tx.automation.findFirst({
             where: {
               id: input.automationId,

--- a/web/src/features/automations/server/webhookHelpers.ts
+++ b/web/src/features/automations/server/webhookHelpers.ts
@@ -14,7 +14,6 @@ import {
   mergeHeaders,
   createDisplayHeaders,
   encryptSecretHeaders,
-  logger,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 

--- a/web/src/features/automations/server/webhookHelpers.ts
+++ b/web/src/features/automations/server/webhookHelpers.ts
@@ -14,6 +14,7 @@ import {
   mergeHeaders,
   createDisplayHeaders,
   encryptSecretHeaders,
+  logger,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 
@@ -23,16 +24,6 @@ interface WebhookConfigOptions {
   projectId: string;
 }
 
-/**
- * Processes webhook action configuration by:
- * 1. Merging legacy headers with new requestHeaders
- * 2. Handling header removal (headers not in input are removed)
- * 3. Preserving existing values when empty values are submitted
- * 4. Encrypting secret headers based on secret flag
- * 5. Generating display values for secret headers
- * 6. Generating or preserving webhook secrets
- * 7. Encrypting secrets for storage
- */
 export async function processWebhookActionConfig({
   actionConfig,
   actionId,
@@ -60,7 +51,7 @@ export async function processWebhookActionConfig({
     actionConfig,
     existingAction?.config as WebhookActionConfigWithSecrets | undefined,
   );
-
+  logger.info(`finalActionConfig ${JSON.stringify(finalActionConfig)}`);
   return {
     finalActionConfig: {
       ...finalActionConfig,
@@ -156,6 +147,7 @@ function processWebhookHeaders(
     displayHeaders: createDisplayHeaders(finalRequestHeaders),
     secretKey: "", // will be overwritten by the caller
     displaySecretKey: "", // will be overwritten by the caller
+    lastFailingExecutionId: existingConfig?.lastFailingExecutionId,
   };
 }
 

--- a/web/src/features/automations/server/webhookHelpers.ts
+++ b/web/src/features/automations/server/webhookHelpers.ts
@@ -51,7 +51,6 @@ export async function processWebhookActionConfig({
     actionConfig,
     existingAction?.config as WebhookActionConfigWithSecrets | undefined,
   );
-  logger.info(`finalActionConfig ${JSON.stringify(finalActionConfig)}`);
   return {
     finalActionConfig: {
       ...finalActionConfig,

--- a/worker/package.json
+++ b/worker/package.json
@@ -8,7 +8,7 @@
     "node": "20"
   },
   "scripts": {
-    "test": "dotenv -e ../.env -- vitest run --reporter=basic --pool=forks --poolOptions.forks.singleFork=true",
+    "test": "dotenv -e ../.env -- vitest run --pool=forks --poolOptions.forks.singleFork=true",
     "coverage": "vitest run --coverage",
     "start": "dotenv -e ../.env -- node dist/index.js",
     "build": "tsc",

--- a/worker/src/__tests__/webhooks.test.ts
+++ b/worker/src/__tests__/webhooks.test.ts
@@ -974,7 +974,7 @@ describe("Webhook Integration Tests", () => {
       }
 
       // Set a lastFailingExecutionId in the action config
-      const lastFailingExecutionId = "test-failing-execution-id";
+      const lastFailingExecutionId = v4();
       await prisma.action.update({
         where: { id: actionId },
         data: {

--- a/worker/src/__tests__/webhooks.test.ts
+++ b/worker/src/__tests__/webhooks.test.ts
@@ -18,6 +18,7 @@ import {
 import {
   WebhookInput,
   createOrgProjectAndApiKey,
+  getActionByIdWithSecrets,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import {
@@ -1023,8 +1024,9 @@ describe("Webhook Integration Tests", () => {
           where: { id: promptId },
         });
 
-        const action = await prisma.action.findUnique({
-          where: { id: actionId },
+        const action = await getActionByIdWithSecrets({
+          projectId,
+          actionId,
         });
 
         if (!action) {
@@ -1035,8 +1037,6 @@ describe("Webhook Integration Tests", () => {
         await prisma.action.update({
           where: { id: actionId },
           data: {
-            projectId,
-            type: "WEBHOOK",
             config: {
               ...(action.config as WebhookActionConfigWithSecrets),
               url: "https://webhook-error.example.com/test",

--- a/worker/src/__tests__/webhooks.test.ts
+++ b/worker/src/__tests__/webhooks.test.ts
@@ -421,7 +421,7 @@ describe("Webhook Integration Tests", () => {
       });
     });
 
-    it("should disable trigger after 5 consecutive failures", async () => {
+    it("should disable trigger after 5 consecutive failures and store lastFailingExecutionId", async () => {
       const fullPrompt = await prisma.prompt.findUnique({
         where: { id: promptId },
       });
@@ -497,6 +497,14 @@ describe("Webhook Integration Tests", () => {
         where: { id: triggerId },
       });
       expect(trigger?.status).toBe(JobConfigState.INACTIVE);
+
+      // Verify lastFailingExecutionId was stored in action config
+      const updatedAction = await prisma.action.findUnique({
+        where: { id: actionId },
+      });
+      const config = updatedAction?.config as any;
+      expect(config.lastFailingExecutionId).toBeDefined();
+      expect(typeof config.lastFailingExecutionId).toBe("string");
     });
 
     it("should execute webhook with secret headers correctly", async () => {
@@ -951,5 +959,201 @@ describe("Webhook Integration Tests", () => {
       });
       expect(execution).toBeNull();
     });
+
+    it("should reset failure count correctly with lastFailingExecutionId", async () => {
+      const fullPrompt = await prisma.prompt.findUnique({
+        where: { id: promptId },
+      });
+
+      const action = await prisma.action.findUnique({
+        where: { id: actionId },
+      });
+
+      if (!action) {
+        throw new Error("Action not found");
+      }
+
+      // Set a lastFailingExecutionId in the action config
+      const lastFailingExecutionId = "test-failing-execution-id";
+      await prisma.action.update({
+        where: { id: actionId },
+        data: {
+          config: {
+            ...(action.config as WebhookActionConfigWithSecrets),
+            lastFailingExecutionId,
+          },
+        },
+      });
+
+      // Create the execution that matches the lastFailingExecutionId
+      await prisma.automationExecution.create({
+        data: {
+          id: lastFailingExecutionId,
+          projectId,
+          triggerId,
+          automationId,
+          actionId,
+          status: ActionExecutionStatus.ERROR,
+          sourceId: v4(),
+          input: { test: "old failing execution" },
+          error: "Old failure",
+          createdAt: new Date(Date.now() - 60000), // 1 minute ago
+        },
+      });
+
+      // Import the function to test it directly
+      const { getConsecutiveAutomationFailures } = await import(
+        "@langfuse/shared/src/server"
+      );
+
+      // Check that consecutive failures is 0 since there are no executions after the lastFailingExecutionId
+      const failures = await getConsecutiveAutomationFailures({
+        automationId,
+        projectId,
+      });
+
+      expect(failures).toBe(0);
+    });
+
+    it(
+      "should reset failure count when webhook is re-enabled after being disabled",
+      { timeout: 20000 },
+      async () => {
+        const fullPrompt = await prisma.prompt.findUnique({
+          where: { id: promptId },
+        });
+
+        const action = await prisma.action.findUnique({
+          where: { id: actionId },
+        });
+
+        if (!action) {
+          throw new Error("Action not found");
+        }
+
+        // Update action to point to error endpoint
+        await prisma.action.update({
+          where: { id: actionId },
+          data: {
+            projectId,
+            type: "WEBHOOK",
+            config: {
+              ...(action.config as WebhookActionConfigWithSecrets),
+              url: "https://webhook-error.example.com/test",
+            },
+          },
+        });
+
+        const executionIds: string[] = [];
+
+        // Execute webhook 5 times to trigger disable
+        for (let i = 0; i < 5; i++) {
+          const executionId = v4();
+          executionIds.push(executionId);
+
+          await prisma.automationExecution.create({
+            data: {
+              id: executionId,
+              projectId,
+              triggerId,
+              automationId,
+              actionId,
+              status: ActionExecutionStatus.PENDING,
+              sourceId: v4(),
+              input: {
+                promptName: "test-prompt",
+                promptVersion: 1,
+                action: "created",
+                type: "prompt-version",
+              },
+            },
+          });
+
+          const webhookInput: WebhookInput = {
+            projectId,
+            automationId,
+            executionId,
+            payload: {
+              prompt: PromptDomainSchema.parse(fullPrompt),
+              action: "created",
+              type: "prompt-version",
+            },
+          };
+
+          await executeWebhook(webhookInput);
+        }
+
+        // Verify trigger was disabled and lastFailingExecutionId was stored
+        const trigger = await prisma.trigger.findUnique({
+          where: { id: triggerId },
+        });
+        expect(trigger?.status).toBe(JobConfigState.INACTIVE);
+
+        const actionAfterDisable = await prisma.action.findUnique({
+          where: { id: actionId },
+        });
+        const configAfterDisable = actionAfterDisable?.config as any;
+        expect(configAfterDisable.lastFailingExecutionId).toBe(executionIds[4]);
+
+        // Re-enable the trigger (simulates user action)
+        await prisma.trigger.update({
+          where: { id: triggerId },
+          data: { status: JobConfigState.ACTIVE },
+        });
+
+        // Create 5 more failing executions to trigger disable again
+        const newExecutionIds: string[] = [];
+        for (let i = 0; i < 5; i++) {
+          const newExecutionId = v4();
+          newExecutionIds.push(newExecutionId);
+
+          await prisma.automationExecution.create({
+            data: {
+              id: newExecutionId,
+              projectId,
+              triggerId,
+              automationId,
+              actionId,
+              status: ActionExecutionStatus.PENDING,
+              sourceId: v4(),
+              input: {
+                promptName: "test-prompt",
+                promptVersion: 1,
+                action: "created",
+                type: "prompt-version",
+              },
+            },
+          });
+
+          const newWebhookInput: WebhookInput = {
+            projectId,
+            automationId,
+            executionId: newExecutionId,
+            payload: {
+              prompt: PromptDomainSchema.parse(fullPrompt),
+              action: "created",
+              type: "prompt-version",
+            },
+          };
+
+          await executeWebhook(newWebhookInput);
+        }
+
+        // Verify trigger was disabled again and lastFailingExecutionId was updated
+        const triggerAfterSecondDisable = await prisma.trigger.findUnique({
+          where: { id: triggerId },
+        });
+        expect(triggerAfterSecondDisable?.status).toBe(JobConfigState.INACTIVE);
+
+        const actionAfterSecondDisable = await prisma.action.findUnique({
+          where: { id: actionId },
+        });
+        const configAfterSecondDisable =
+          actionAfterSecondDisable?.config as any;
+        expect(configAfterSecondDisable.lastFailingExecutionId).toBe(
+          newExecutionIds[4],
+        );
+      },
+    );
   });
 });

--- a/worker/src/queues/webhooks.ts
+++ b/worker/src/queues/webhooks.ts
@@ -272,7 +272,7 @@ export const executeWebhook = async (input: WebhookInput) => {
         });
 
         // Update action config to store the failing execution ID
-        const actionConfig = automation.action.config as any;
+        const actionConfig = automation.action.config;
         await tx.action.update({
           where: { id: automation.action.id, projectId },
           data: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves webhook retries by tracking consecutive failures and disabling triggers after 5 failures, with tests added for verification.
> 
>   - **Behavior**:
>     - Adds `lastFailingExecutionId` to `WebhookActionConfigSchema` in `automations.ts` to track last failing execution.
>     - Updates `getConsecutiveAutomationFailures()` in `automation-repository.ts` to consider `lastFailingExecutionId` for counting failures.
>     - Modifies `executeWebhook()` in `webhooks.ts` to disable triggers after 5 consecutive failures and update `lastFailingExecutionId`.
>   - **Tests**:
>     - Adds tests in `automations-trpc.servertest.ts` and `webhooks.test.ts` to verify behavior when `lastFailingExecutionId` is set and when triggers are disabled after consecutive failures.
>   - **Misc**:
>     - Removes comment lines in `router.ts` and `webhookHelpers.ts`.
>     - Updates `test` script in `package.json` to remove `--reporter=basic`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8e622ed53d0027b6c47807ba37bab52d5b785d9e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->