### PR TITLE
chore: adjust getSessionsTable query for AMTs

### DIFF
--- a/packages/shared/src/server/services/sessions-ui-table-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-service.ts
@@ -239,12 +239,10 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
   const query = `
         WITH deduplicated_traces AS (
           SELECT * EXCEPT input, output, metadata
-          FROM __TRACE_TABLE__ t
+          FROM __TRACE_TABLE__ t FINAL
           WHERE t.session_id IS NOT NULL 
             AND t.project_id = {projectId: String}
             ${singleTraceFilter?.query ? ` AND ${singleTraceFilter.query}` : ""}
-            ORDER BY event_ts DESC
-            LIMIT 1 BY id, project_id
         ),
         deduplicated_observations AS (
             SELECT * 

--- a/worker/src/services/IngestionService/README.md
+++ b/worker/src/services/IngestionService/README.md
@@ -147,6 +147,7 @@ CREATE TABLE traces_all_amt
     `updated_at`         SimpleAggregateFunction(max, DateTime64(3)),
 
     -- Indexes
+    INDEX idx_trace_id id TYPE bloom_filter(0.001) GRANULARITY 1,
     INDEX idx_user_id user_id TYPE bloom_filter(0.001) GRANULARITY 1,
     INDEX idx_session_id session_id TYPE bloom_filter(0.001) GRANULARITY 1,
     INDEX idx_name name TYPE bloom_filter(0.001) GRANULARITY 1,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimizes `getSessionsTable` query by removing ordering and limit clauses, and adds an index to `traces_all_amt`.
> 
>   - **Query Optimization**:
>     - In `sessions-ui-table-service.ts`, removed `ORDER BY event_ts DESC` and `LIMIT 1 BY id, project_id` from `deduplicated_traces` CTE.
>   - **Index Addition**:
>     - Added `INDEX idx_trace_id id TYPE bloom_filter(0.001) GRANULARITY 1` to `traces_all_amt` in `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ce9be056a7b9b363b7bdc44ab047a387b52d09f0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->