### PR TITLE
Fix number env vars not coercing string -> number for LANGFUSE_INIT_PROJECT_RETENTION, more

### DIFF
--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -249,7 +249,7 @@ export const env = createEnv({
     LANGFUSE_INIT_ORG_CLOUD_PLAN: z.string().optional(), // for use in CI
     LANGFUSE_INIT_PROJECT_ID: z.string().optional(),
     LANGFUSE_INIT_PROJECT_NAME: z.string().optional(),
-    LANGFUSE_INIT_PROJECT_RETENTION: z.number().int().gte(3).optional(),
+    LANGFUSE_INIT_PROJECT_RETENTION: z.coerce.number().int().gte(3).optional(),
     LANGFUSE_INIT_PROJECT_PUBLIC_KEY: z.string().optional(),
     LANGFUSE_INIT_PROJECT_SECRET_KEY: z.string().optional(),
     LANGFUSE_INIT_USER_EMAIL: z
@@ -257,7 +257,7 @@ export const env = createEnv({
       .optional(),
     LANGFUSE_INIT_USER_NAME: z.string().optional(),
     LANGFUSE_INIT_USER_PASSWORD: z.string().optional(),
-    LANGFUSE_MAX_HISTORIC_EVAL_CREATION_LIMIT: z
+    LANGFUSE_MAX_HISTORIC_EVAL_CREATION_LIMIT: z.coerce
       .number()
       .positive()
       .default(50_000),


### PR DESCRIPTION
## What does this PR do?

This PR fixes config of the LANGFUSE_INIT_PROJECT_RETENTION and LANGFUSE_MAX_HISTORIC_EVAL_CREATION_LIMIT via env.
`coerce` was missing on both env vars. It seems all other `number()` envs use this, so it was probably an oversight that it was not added.


When setting up retention in our chart, Langfuse fails to validate the env var LANGFUSE_INIT_PROJECT_RETENTION when configured in `additionalEnv` as follows:
```
additionalEnv:
  - name: LANGFUSE_INIT_PROJECT_RETENTION
    value: "14"
```
Langfuse logs these errors when attempting to start:
```
Error: An error occurred while loading instrumentation hook: Invalid environment variables
LANGFUSE_INIT_PROJECT_RETENTION: [ 'Expected number, received string' ]
```

Note that setting the value unquoted results in a parsing error in helm:
```
✗ Helm upgrade failed for release langfuse/langfuse with chart langfuse@1.3.1: failed to create resource: Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal number into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```

While in here, I found that `LANGFUSE_MAX_HISTORIC_EVAL_CREATION_LIMIT` will suffer from the same issue, so I've also fixed that.

## Type of change

- [x] Bug fix 

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes environment variable coercion for `LANGFUSE_INIT_PROJECT_RETENTION` and `LANGFUSE_MAX_HISTORIC_EVAL_CREATION_LIMIT` in `web/src/env.mjs`.
> 
>   - **Bug Fix**:
>     - Add `z.coerce` to `LANGFUSE_INIT_PROJECT_RETENTION` and `LANGFUSE_MAX_HISTORIC_EVAL_CREATION_LIMIT` in `web/src/env.mjs` to coerce strings to numbers.
>     - Fixes validation error: "Expected number, received string" for `LANGFUSE_INIT_PROJECT_RETENTION` when set via Helm with quotes.
>     - Prevents parsing error in Helm when setting `LANGFUSE_INIT_PROJECT_RETENTION` without quotes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b9e86a3dd1f5be8fd729356381c7a4e9926355c6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->