### PR TITLE
fix(trace): show linebreaks in only text markdown view

### DIFF
--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -123,7 +123,7 @@ function MarkdownRenderer({
     return (
       <MemoizedReactMarkdown
         className={cn(
-          "space-y-2 overflow-x-auto break-words text-sm",
+          "space-y-2 overflow-x-auto whitespace-pre-wrap break-words text-sm",
           className,
         )}
         remarkPlugins={[remarkGfm]}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `whitespace-pre-wrap` to `MarkdownRenderer` in `MarkdownViewer.tsx` to preserve line breaks in text markdown view.
> 
>   - **Behavior**:
>     - In `MarkdownRenderer` in `MarkdownViewer.tsx`, added `whitespace-pre-wrap` to CSS classes to preserve line breaks in text markdown view.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for aeaf758ddfacf864798659b01510c4fd27ef5fc7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->