### PR TITLE
chore: add sessions type for annotation queue

### DIFF
--- a/packages/shared/prisma/generated/types.ts
+++ b/packages/shared/prisma/generated/types.ts
@@ -55,6 +55,7 @@ export type AnnotationQueueStatus =
 export const AnnotationQueueObjectType = {
   TRACE: "TRACE",
   OBSERVATION: "OBSERVATION",
+  SESSION: "SESSION",
 } as const;
 export type AnnotationQueueObjectType =
   (typeof AnnotationQueueObjectType)[keyof typeof AnnotationQueueObjectType];

--- a/packages/shared/prisma/migrations/20250724160133_add_session_object_type_annoation_queue_items/migration.sql
+++ b/packages/shared/prisma/migrations/20250724160133_add_session_object_type_annoation_queue_items/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "AnnotationQueueObjectType" ADD VALUE 'SESSION';

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -539,6 +539,7 @@ enum AnnotationQueueStatus {
 enum AnnotationQueueObjectType {
   TRACE
   OBSERVATION
+  SESSION
 }
 
 model CronJobs {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `SESSION` type to `AnnotationQueueObjectType` enum in TypeScript, Prisma schema, and database migration.
> 
>   - **Enums**:
>     - Add `SESSION` to `AnnotationQueueObjectType` in `types.ts` and `schema.prisma`.
>   - **Database**:
>     - New migration `20250724160133_add_session_object_type_annoation_queue_items/migration.sql` to add `SESSION` to `AnnotationQueueObjectType` enum in the database.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8ae8a15da36e22dabfef9f79f332ba607a7df3db. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->