### PR TITLE
chore: fix eval event envelope timestmp

### DIFF
--- a/worker/src/features/utils/retry-handler.ts
+++ b/worker/src/features/utils/retry-handler.ts
@@ -112,7 +112,7 @@ export async function handleRetryableError(
         {
           name: config.jobName,
           id: randomUUID(),
-          timestamp: job.data.timestamp,
+          timestamp: new Date(),
           payload: job.data.payload,
           retryBaggage: retryBaggage,
         },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `handleRetryableError()` in `retry-handler.ts` to set retry job timestamp to current date.
> 
>   - **Behavior**:
>     - In `handleRetryableError()` in `retry-handler.ts`, change `timestamp` to `new Date()` when adding a retry job to the queue.
>     - Ensures retry job timestamp reflects current time, not original job time.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8dbc9908b7345ff293cd6f3c616a2875c65b410b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->