### PR TITLE
chore: fix date parsing for eval retries

### DIFF
--- a/worker/src/features/utils/retry-handler.ts
+++ b/worker/src/features/utils/retry-handler.ts
@@ -79,7 +79,9 @@ export async function handleRetryableError(
 
       const retryBaggage: RetryBaggage | undefined = job.data.retryBaggage
         ? {
-            originalJobTimestamp: job.data.retryBaggage.originalJobTimestamp,
+            originalJobTimestamp: new Date(
+              job.data.retryBaggage.originalJobTimestamp,
+            ),
             attempt: job.data.retryBaggage.attempt + 1,
           }
         : undefined;
@@ -98,7 +100,7 @@ export async function handleRetryableError(
         // Record delay distribution per queue
         recordDistribution(
           `${convertQueueNameToMetricName(config.queueName)}.total_retry_delay_ms`,
-          new Date().getTime() - retryBaggage.originalJobTimestamp.getTime(),
+          new Date().getTime() - retryBaggage.originalJobTimestamp.getTime(), // this is the total delay
           {
             queue: config.queueName,
             unit: "milliseconds",
@@ -107,7 +109,7 @@ export async function handleRetryableError(
       }
 
       logger.info(
-        `Job ${jobId} is rate limited. Retrying in ${delay}ms. Attempt: ${retryBaggage?.attempt}. Total delay: ${retryBaggage ? new Date().getTime() - retryBaggage?.originalJobTimestamp.getTime() : "unavailable"}ms.`,
+        `Job ${jobId} is rate limited. Retrying in ${delay}ms. Attempt: ${retryBaggage?.attempt}. Total delay: ${retryBaggage ? new Date().getTime() - new Date(retryBaggage?.originalJobTimestamp).getTime() : "unavailable"}ms.`,
       );
 
       await config.queue?.add(

--- a/worker/src/features/utils/retry-handler.ts
+++ b/worker/src/features/utils/retry-handler.ts
@@ -100,7 +100,8 @@ export async function handleRetryableError(
         // Record delay distribution per queue
         recordDistribution(
           `${convertQueueNameToMetricName(config.queueName)}.total_retry_delay_ms`,
-          new Date().getTime() - retryBaggage.originalJobTimestamp.getTime(), // this is the total delay
+          new Date().getTime() -
+            new Date(retryBaggage.originalJobTimestamp).getTime(), // this is the total delay
           {
             queue: config.queueName,
             unit: "milliseconds",

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -84,7 +84,6 @@ export const evalJobExecutorQueueProcessor = async (
   try {
     logger.info("Executing Evaluation Execution Job", job.data);
     await evaluate({ event: job.data.payload });
-
     return true;
   } catch (e) {
     // If the job fails with a 429, we want to retry it unless it's older than 24h.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix date parsing in `handleRetryableError()` by converting timestamps to `Date` objects in `retry-handler.ts`.
> 
>   - **Date Parsing Fixes**:
>     - Convert `originalJobTimestamp` to `Date` object in `handleRetryableError()` in `retry-handler.ts`.
>     - Ensure `originalJobTimestamp` is a `Date` object when calculating `total_retry_delay_ms` in `retry-handler.ts`.
>     - Update logging in `handleRetryableError()` to use `Date` object for `originalJobTimestamp`.
>   - **Misc**:
>     - Remove unnecessary newline in `evalJobExecutorQueueProcessor` in `evalQueue.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8c47c167f187f60452233d39b7a6efcb96e8d042. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->