### PR TITLE
fix(ingestion): cached model not found

### DIFF
--- a/packages/shared/src/server/ingestion/modelMatch.ts
+++ b/packages/shared/src/server/ingestion/modelMatch.ts
@@ -83,7 +83,7 @@ const getModelFromRedis = async (
     if (redisModel) {
       recordIncrement("langfuse.model_match.cache_hit", 1);
       if (redisModel === NOT_FOUND_TOKEN) {
-        return null;
+        return NOT_FOUND_TOKEN;
       }
       const model = redisModelToPrismaModel(redisModel);
       return model;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `getModelFromRedis` to return `NOT_FOUND_TOKEN` instead of `null` for cache misses in `modelMatch.ts`.
> 
>   - **Behavior**:
>     - Change return value in `getModelFromRedis` in `modelMatch.ts` to return `NOT_FOUND_TOKEN` instead of `null` when model is not found in Redis cache.
>     - Affects handling of cache misses in `findModel` function, ensuring consistent use of `NOT_FOUND_TOKEN`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3b905b3e5b7fe2615ff9db495d42337f16332f13. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->