### PR TITLE
chore: adjust sampling metric

### DIFF
--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -280,21 +280,19 @@ export const processEventBatch = async (
       });
 
       if (!isSampled) {
-        recordIncrement(
-          "langfuse.ingestion.sampling.events_out",
-          eventData.data.length,
-          { projectId: authCheck.scope.projectId ?? "<not set>" },
-        );
+        recordIncrement("langfuse.ingestion.sampling", eventData.data.length, {
+          projectId: authCheck.scope.projectId ?? "<not set>",
+          sampling_decision: "out",
+        });
 
         return;
       }
 
       if (isSamplingConfigured) {
-        recordIncrement(
-          "langfuse.ingestion.sampling.events_in",
-          eventData.data.length,
-          { projectId: authCheck.scope.projectId ?? "<not set>" },
-        );
+        recordIncrement("langfuse.ingestion.sampling", eventData.data.length, {
+          projectId: authCheck.scope.projectId ?? "<not set>",
+          sampling_decision: "in",
+        });
       }
 
       return queue


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Consolidate sampling metrics in `processEventBatch.ts` by using a single metric with a `sampling_decision` tag.
> 
>   - **Metrics**:
>     - Consolidate `recordIncrement` calls for sampling metrics in `processEventBatch`.
>     - Use `langfuse.ingestion.sampling` with `sampling_decision` tag instead of separate `events_in` and `events_out` metrics.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 57cb127a019790f1c01366b86b6b3e90ac4cbea2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->