### PR TITLE
fix(annotation): mobile responsivness behaviour

### DIFF
--- a/web/src/components/ItemBadge.tsx
+++ b/web/src/components/ItemBadge.tsx
@@ -99,12 +99,16 @@ export function ItemBadge({
       variant="outline"
       title={label}
       className={cn(
-        "flex max-w-fit items-center gap-1 border-2 bg-background px-1",
+        "flex max-w-fit items-center gap-1 overflow-hidden whitespace-nowrap border-2 bg-background px-1",
         isSmall && "h-4",
       )}
     >
       <Icon className={iconClass} />
-      {showLabel && <span>{label.replace(/_/g, " ")}</span>}
+      {showLabel && (
+        <span className="truncate" title={label.replace(/_/g, " ")}>
+          {label.replace(/_/g, " ")}
+        </span>
+      )}
     </Badge>
   );
 }

--- a/web/src/features/annotation-queues/components/shared/AnnotationProcessingLayout.tsx
+++ b/web/src/features/annotation-queues/components/shared/AnnotationProcessingLayout.tsx
@@ -20,27 +20,40 @@ export const AnnotationProcessingLayout: React.FC<
   );
 
   return (
-    <ResizablePanelGroup
-      direction="horizontal"
-      className="h-full overflow-hidden"
-      onLayout={(sizes) => {
-        setPanelSize(sizes[0]);
-      }}
-    >
-      <ResizablePanel
-        className="col-span-1 h-full !overflow-y-auto rounded-md border"
-        minSize={30}
-        defaultSize={panelSize}
-      >
-        {leftPanel}
-      </ResizablePanel>
-      <ResizableHandle withHandle className="ml-4 bg-transparent" />
-      <ResizablePanel
-        className="col-span-1 h-full md:flex md:flex-col md:overflow-hidden"
-        minSize={30}
-      >
-        {rightPanel}
-      </ResizablePanel>
-    </ResizablePanelGroup>
+    <>
+      {/* Mobile: Vertical stack without resizing */}
+      <div className="flex h-full flex-col gap-2 overflow-hidden md:hidden">
+        <div className="h-1/2 overflow-y-auto rounded-md border">
+          {leftPanel}
+        </div>
+        <div className="flex h-1/2 flex-col overflow-hidden">{rightPanel}</div>
+      </div>
+
+      {/* Desktop: Horizontal resizable panels */}
+      <div className="hidden h-full md:block">
+        <ResizablePanelGroup
+          direction="horizontal"
+          className="h-full overflow-hidden"
+          onLayout={(sizes) => {
+            setPanelSize(sizes[0]);
+          }}
+        >
+          <ResizablePanel
+            className="col-span-1 h-full !overflow-y-auto rounded-md border"
+            minSize={30}
+            defaultSize={panelSize}
+          >
+            {leftPanel}
+          </ResizablePanel>
+          <ResizableHandle withHandle className="ml-4 bg-transparent" />
+          <ResizablePanel
+            className="col-span-1 flex h-full flex-col overflow-hidden"
+            minSize={30}
+          >
+            {rightPanel}
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
+    </>
   );
 };

--- a/web/src/features/annotation-queues/components/shared/AnnotationProcessingLayout.tsx
+++ b/web/src/features/annotation-queues/components/shared/AnnotationProcessingLayout.tsx
@@ -30,7 +30,7 @@ export const AnnotationProcessingLayout: React.FC<
       </div>
 
       {/* Desktop: Horizontal resizable panels */}
-      <div className="hidden h-full md:block">
+      <div className="hidden max-h-full min-h-0 overflow-hidden md:block">
         <ResizablePanelGroup
           direction="horizontal"
           className="h-full overflow-hidden"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves mobile responsiveness for `ItemBadge` and `AnnotationProcessingLayout` by handling text overflow and adapting layout based on screen size.
> 
>   - **ItemBadge.tsx**:
>     - Added `overflow-hidden` and `whitespace-nowrap` to prevent text overflow.
>     - Wrapped label in a `span` with `truncate` class for better text handling.
>   - **AnnotationProcessingLayout.tsx**:
>     - Introduced separate layouts for mobile and desktop.
>     - Mobile: Uses vertical stack layout without resizing.
>     - Desktop: Maintains horizontal resizable panels.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bb97c1ba4ddb88516fcf742ef26c82bf36d9d541. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->