### PR TITLE
fix(metrics): convert latency from milliseconds to seconds for accurate display

### DIFF
--- a/web/src/pages/project/[projectId]/prompts/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/metrics.tsx
@@ -199,7 +199,8 @@ export default function PromptVersionTable({
         }
 
         return !!latency ? (
-          <span>{formatIntervalSeconds(latency, 3)}</span>
+          // latency is in milliseconds, divide by 1000 to get seconds
+          <span>{formatIntervalSeconds(latency / 1000, 3)}</span>
         ) : undefined;
       },
       enableHiding: true,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Converts `medianLatency` from milliseconds to seconds in `PromptVersionTable` for accurate display.
> 
>   - **Behavior**:
>     - Converts `medianLatency` from milliseconds to seconds in `PromptVersionTable` in `metrics.tsx` for accurate display.
>     - Uses `formatIntervalSeconds(latency / 1000, 3)` to format latency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5b0616b2366002919a8845cef0d854e8a62a31a7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->