### PR TITLE
fix(members-table): update table column visibility and order logic based on project context

### DIFF
--- a/web/src/features/rbac/components/MembersTable.tsx
+++ b/web/src/features/rbac/components/MembersTable.tsx
@@ -309,10 +309,13 @@ export function MembersTable({
   ];
 
   const [columnVisibility, setColumnVisibility] =
-    useColumnVisibility<MembersTableRow>("membersColumnVisibility", columns);
+    useColumnVisibility<MembersTableRow>(
+      project ? "membersColumnVisibilityProject" : "membersColumnVisibilityOrg",
+      columns,
+    );
 
   const [columnOrder, setColumnOrder] = useColumnOrder<MembersTableRow>(
-    "membersColumnOrder",
+    project ? "membersColumnOrderProject" : "membersColumnOrderOrg",
     columns,
   );
 
@@ -362,7 +365,7 @@ export function MembersTable({
       {showSettingsCard ? (
         <SettingsTableCard>
           <DataTable
-            tableName={"members"}
+            tableName={project ? "projectMembers" : "orgMembers"}
             columns={columns}
             data={
               members.isLoading
@@ -394,7 +397,7 @@ export function MembersTable({
         </SettingsTableCard>
       ) : (
         <DataTable
-          tableName={"members"}
+          tableName={project ? "projectMembers" : "orgMembers"}
           columns={columns}
           data={
             members.isLoading


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `MembersTable` to handle column visibility and order based on project or organization context.
> 
>   - **Behavior**:
>     - Update `columnVisibility` and `columnOrder` keys in `MembersTable` to use `membersColumnVisibilityProject` and `membersColumnOrderProject` if `project` is defined, otherwise use `membersColumnVisibilityOrg` and `membersColumnOrderOrg`.
>     - Change `tableName` in `DataTable` to `projectMembers` if `project` is defined, otherwise use `orgMembers`.
>   - **Files**:
>     - Modifications in `MembersTable.tsx` to handle project-specific and organization-specific logic for table column visibility and order.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 39690dd9f1ed9d4f06f93b48ef4b82469907fba6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->