### PR TITLE
fix(markdown): don't break after list item number

### DIFF
--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -88,13 +88,12 @@ const isChecklist = (children: ReactNode) =>
 
 const transformListItemChildren = (children: ReactNode) =>
   Children.map(children, (child) =>
-    isTextElement(child) ? (
-      <div className="mb-1 inline-flex">
-        {createElement(child.type, { ...child.props })}
-      </div>
-    ) : (
-      child
-    ),
+    isTextElement(child)
+      ? createElement("span", {
+          ...child.props,
+          className: cn(child.props.className, "mb-1"),
+        })
+      : child,
   );
 
 const isImageNode = (node?: ReactMarkdownNode): boolean =>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes list item number rendering in `MarkdownViewer.tsx` by using `span` instead of `div` in `transformListItemChildren`, preventing line breaks after numbers.
> 
>   - **Behavior**:
>     - Fixes list item number rendering in `MarkdownViewer.tsx` by using `span` instead of `div` in `transformListItemChildren`.
>     - Prevents line break after list item numbers in ordered lists.
>   - **Functions**:
>     - Updates `transformListItemChildren` to wrap text elements in `span` with `mb-1` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 09c8e1c54707dc6f1e604e802a52194c5a207627. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->