### PR TITLE
fix(playground): enable jumpt to playground for gemini

### DIFF
--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -125,6 +125,7 @@ export enum ChatMessageType {
   AssistantText = "assistant-text",
   AssistantToolCall = "assistant-tool-call",
   ToolResult = "tool-result",
+  ModelText = "model-text",
   PublicAPICreated = "public-api-created",
   Placeholder = "placeholder",
 }
@@ -156,6 +157,13 @@ export const AssistantTextMessageSchema = z.object({
   content: z.string(),
 });
 export type AssistantTextMessage = z.infer<typeof AssistantTextMessageSchema>;
+
+export const ModelMessageSchema = z.object({
+  type: z.literal(ChatMessageType.ModelText),
+  role: z.literal(ChatMessageRole.Model),
+  content: z.string(),
+});
+export type ModelMessage = z.infer<typeof ModelMessageSchema>;
 
 export const AssistantToolCallMessageSchema = z.object({
   type: z.literal(ChatMessageType.AssistantToolCall),
@@ -194,6 +202,7 @@ export const ChatMessageSchema = z.union([
   AssistantTextMessageSchema,
   AssistantToolCallMessageSchema,
   ToolResultMessageSchema,
+  ModelMessageSchema,
   z
     .object({
       role: z.union([ChatMessageDefaultRoleSchema, z.string()]), // Users may ingest any string as role via API/SDK

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -113,6 +113,7 @@ export enum ChatMessageRole {
   User = "user",
   Assistant = "assistant",
   Tool = "tool",
+  Model = "model", // Google Gemini assistant format
 }
 
 // Thought: should placeholder not semantically be part of this, because it can be

--- a/web/src/components/ChatMessages/ChatMessageComponent.tsx
+++ b/web/src/components/ChatMessages/ChatMessageComponent.tsx
@@ -156,6 +156,12 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
             role: nextRole,
             type: ChatMessageType.System,
           });
+        } else if (nextRole === ChatMessageRole.Model) {
+          replaceMessage(message.id, {
+            content: message.content,
+            role: nextRole,
+            type: ChatMessageType.AssistantText,
+          });
         } else {
           const exhaustiveCheck: never = nextRole;
           console.error(`Unhandled role: ${exhaustiveCheck}`);

--- a/web/src/components/ChatMessages/ChatMessageComponent.tsx
+++ b/web/src/components/ChatMessages/ChatMessageComponent.tsx
@@ -160,7 +160,7 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
           replaceMessage(message.id, {
             content: message.content,
             role: nextRole,
-            type: ChatMessageType.AssistantText,
+            type: ChatMessageType.ModelText,
           });
         } else {
           const exhaustiveCheck: never = nextRole;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enable jump to playground for Google Gemini by adding new message roles and types, and updating message normalization and handling logic.
> 
>   - **Behavior**:
>     - Adds `Model` role and `ModelText` type to `ChatMessageRole` and `ChatMessageType` enums in `types.ts` for Google Gemini.
>     - Updates `normalizeLangGraphMessage()` in `JumpToPlaygroundButton.tsx` to convert `model` role to `assistant` and `parts` field to `content`.
>     - Modifies `ChatMessageComponent.tsx` to handle `Model` role in `replaceMessage()` logic.
>   - **Schemas**:
>     - Adds `ModelMessageSchema` to `types.ts` for validating messages with `ModelText` type.
>     - Updates `ChatMessageSchema` in `types.ts` to include `ModelMessageSchema`.
>   - **Misc**:
>     - Updates `parsePrompt()` and `parseGeneration()` in `JumpToPlaygroundButton.tsx` to handle new message formats.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 72fbdac5f548234577e156e846980d731140a9cf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->