### PR TITLE
fix(annotation-queues): remove unnecessary refetchOnMount option and ensure current item type is defined

### DIFF
--- a/web/src/features/annotation-queues/components/AnnotationQueuesItem.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueuesItem.tsx
@@ -49,7 +49,7 @@ export const AnnotationQueuesItem = ({
       itemId: itemId as string,
       queueId: annotationQueueId,
     },
-    { enabled: !!itemId, refetchOnMount: false },
+    { enabled: !!itemId },
   );
 
   const [view, setView] = useSessionStorage<"hideTree" | "showTree">(
@@ -58,6 +58,7 @@ export const AnnotationQueuesItem = ({
   );
 
   const isSessionItem =
+    !!currentItemType.data &&
     currentItemType.data === AnnotationQueueObjectType.SESSION;
   const isDetailedViewDisabled = isSessionItem;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `refetchOnMount` option and ensure `currentItemType.data` is defined in `AnnotationQueuesItem.tsx`.
> 
>   - **Behavior**:
>     - Removed `refetchOnMount: false` option from `currentItemType` query in `AnnotationQueuesItem.tsx`.
>     - Added check for `currentItemType.data` to ensure item type is defined before comparison in `AnnotationQueuesItem.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 51335db4cf9c7328dc6bdea2fd4ae08bc5be5327. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->