### PR TITLE
fix(dataset-items): ensure deterministic ordering given pagination for GET dataset items api

### DIFF
--- a/web/src/pages/api/public/dataset-items/index.ts
+++ b/web/src/pages/api/public/dataset-items/index.ts
@@ -148,9 +148,7 @@ export default withMiddlewares({
           },
           take: limit,
           skip: (page - 1) * limit,
-          orderBy: {
-            createdAt: "desc",
-          },
+          orderBy: [{ createdAt: "desc" }, { id: "asc" }],
           include: {
             dataset: {
               select: {

--- a/web/src/pages/api/public/datasets/[name]/index.ts
+++ b/web/src/pages/api/public/datasets/[name]/index.ts
@@ -28,9 +28,7 @@ export default withMiddlewares({
             where: {
               status: "ACTIVE",
             },
-            orderBy: {
-              createdAt: "desc",
-            },
+            orderBy: [{ createdAt: "desc" }, { id: "asc" }],
           },
           datasetRuns: {
             select: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Ensure deterministic ordering for `GET` dataset items and datasets by adding secondary sort key `id` ascending.
> 
>   - **Behavior**:
>     - Ensures deterministic ordering for `GET` requests in `index.ts` and `[name]/index.ts` by adding secondary sort key `id` ascending to existing `createdAt` descending order.
>   - **Files Affected**:
>     - `index.ts`: Modifies `orderBy` clause in `GET` dataset items API.
>     - `[name]/index.ts`: Modifies `orderBy` clause in `GET` dataset API.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d5142ef0a72eed10b424ab7bb5306d9770be0e7e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->