### PR TITLE
fix: set slack redirect uri specifically per environment

### DIFF
--- a/web/src/features/slack/server/oauth-handlers.ts
+++ b/web/src/features/slack/server/oauth-handlers.ts
@@ -4,6 +4,7 @@ import {
   parseSlackInstallationMetadata,
 } from "@langfuse/shared/src/server";
 import { logger } from "@langfuse/shared/src/server";
+import { env } from "@/src/env.mjs";
 
 /**
  * SlackOAuthHandlers
@@ -25,12 +26,22 @@ export async function handleInstallPath(
     // 1. Generate the OAuth URL with proper state parameter
     // 2. Set session cookies for state validation
     // 3. Render the installation page with "Add to Slack" button
+    const installOptions = {
+      scopes: ["channels:read", "chat:write", "chat:write.public"],
+      metadata: JSON.stringify({ projectId: projectId }),
+      redirectUri: `${env.NEXTAUTH_URL}/api/public/slack/oauth`,
+    };
+
+    // hack because nextjs dev server suppurt for https is experimental
+    if (env.NODE_ENV === "development") {
+      installOptions.redirectUri = installOptions.redirectUri?.replace(
+        "http://",
+        "https://",
+      );
+    }
     return await SlackService.getInstance()
       .getInstaller()
-      .handleInstallPath(req, res, undefined, {
-        scopes: ["channels:read", "chat:write", "chat:write.public"],
-        metadata: JSON.stringify({ projectId: projectId }),
-      });
+      .handleInstallPath(req, res, undefined, installOptions);
   } catch (error) {
     logger.error("Install path handler failed", { error, projectId });
     throw error;
@@ -67,7 +78,7 @@ export async function handleCallback(
 
         failure: async (error) => {
           logger.error("OAuth callback failed", { error: error.message });
-          throw error;
+          res.status(500).json({ message: "Internal server error" });
         },
       });
   } catch (error) {

--- a/web/src/features/slack/server/oauth-handlers.ts
+++ b/web/src/features/slack/server/oauth-handlers.ts
@@ -32,7 +32,7 @@ export async function handleInstallPath(
       redirectUri: `${env.NEXTAUTH_URL}/api/public/slack/oauth`,
     };
 
-    // hack because nextjs dev server suppurt for https is experimental
+    // hack because nextjs dev server support for https is experimental
     if (env.NODE_ENV === "development") {
       installOptions.redirectUri = installOptions.redirectUri?.replace(
         "http://",

--- a/web/src/pages/api/public/slack/install/index.ts
+++ b/web/src/pages/api/public/slack/install/index.ts
@@ -31,11 +31,6 @@ export default async function handler(
     return await handleInstallPath(req, res, projectId);
   } catch (error) {
     logger.error("Install handler failed", { error });
-
-    // Fallback response for unexpected errors
-    return res.status(500).json({
-      error: "Internal server error",
-      message: "Failed to handle Slack installation request",
-    });
+    return res.status(500).json({ message: "Internal server error" });
   }
 }

--- a/web/src/pages/api/public/slack/oauth/index.ts
+++ b/web/src/pages/api/public/slack/oauth/index.ts
@@ -23,8 +23,6 @@ export default async function handler(
     return await handleCallback(req, res);
   } catch (error) {
     logger.error("OAuth callback handler failed", { error });
-
-    // Fallback redirect on unexpected errors
-    return res.redirect("/settings/slack?error=unexpected_error");
+    return res.status(500).json({ message: "Internal server error" });
   }
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Sets the Slack redirect uri for each environment specifically and fixes an uncaught exception problem in the oauth handler

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets Slack redirect URI per environment and improves error handling in OAuth handlers.
> 
>   - **Behavior**:
>     - Sets Slack redirect URI per environment in `handleInstallPath()` in `oauth-handlers.ts`.
>     - Adjusts redirect URI to use `https` in development mode.
>     - Replaces uncaught exceptions with `500` error responses in `handleCallback()` in `oauth-handlers.ts`.
>   - **API Handlers**:
>     - Updates error handling in `install/index.ts` and `oauth/index.ts` to return consistent `500` error responses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3ed641e951dd8d856e52b455c53e2d8291a730b5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->