### PR TITLE
fix(json-table): render links clickable

### DIFF
--- a/packages/shared/src/utils/zod.ts
+++ b/packages/shared/src/utils/zod.ts
@@ -80,7 +80,7 @@ export const paginationMetaResponseZod = z.object({
   totalPages: z.number().int().nonnegative(),
 });
 
-const urlRegex = /https?:\/\/[^\s/$.?#].[^\s]*/i;
+export const urlRegex = /https?:\/\/[^\s/$.?#].[^\s]*/i;
 export const noUrlCheck = (value: string) => !urlRegex.test(value);
 
 export const NonEmptyString = z.string().min(1);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> URLs in JSON strings are now clickable links in `PrettyJsonView.tsx`, using a shared `urlRegex`.
> 
>   - **Behavior**:
>     - URLs in JSON strings are now rendered as clickable links in `PrettyJsonView.tsx`.
>     - Links open in a new tab and prevent row expansion on click.
>   - **Utilities**:
>     - Export `urlRegex` from `zod.ts` for use in other modules.
>   - **Functions**:
>     - Add `renderStringWithLinks()` in `PrettyJsonView.tsx` to split strings by URLs and render them as links.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 578cbed4e2ccfae198ea810fe08b01df1b8712fe. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->