### PR TITLE
fix(sessions): allow filter combination of environment and session_id

### DIFF
--- a/packages/shared/src/server/services/sessions-ui-table-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-service.ts
@@ -195,16 +195,14 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
     );
   }
 
-  const additionalSingleTraceFilter = tracesFilter.find(
-    (f) =>
-      f.field === "bookmarked" ||
-      f.field === "session_id" ||
-      f.field === "environment",
-  );
-
-  if (additionalSingleTraceFilter) {
-    filters.push(additionalSingleTraceFilter);
-  }
+  tracesFilter
+    .filter(
+      (f) =>
+        f.field === "bookmarked" ||
+        f.field === "session_id" ||
+        f.field === "environment",
+    )
+    .forEach((f) => filters.push(f));
 
   const singleTraceFilter =
     filters.length > 0 ? new FilterList(filters).apply() : undefined;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Allow multiple filters for `session_id` and `environment` in `getSessionsTableGeneric` and add test for mismatched environment filtering.
> 
>   - **Behavior**:
>     - Modify `getSessionsTableGeneric` in `sessions-ui-table-service.ts` to allow multiple filters for `session_id` and `environment`.
>     - Add test in `sessions-trpc.servertest.ts` to verify filtering by `session_id` and mismatched `environment` returns empty.
>   - **Tests**:
>     - Add test case in `sessions-trpc.servertest.ts` for filtering by `session_id` and `environment`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b1a737b7af0abbf239a9411d2acd86ca6cd55fe2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->