### PR TITLE
fix(layout): highlight nav items when viewing child routes

### DIFF
--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -119,6 +119,19 @@ export default function Layout(props: PropsWithChildren) {
   // project info based on projectId in the URL
   const { project, organization } = useQueryProjectOrOrganization();
 
+  // Helper function for precise path matching
+  const isPathActive = (routePath: string, currentPath: string): boolean => {
+    // Exact match
+    if (currentPath === routePath) return true;
+
+    // Only allow prefix matching if the route ends with a specific page (not just project root)
+    // This prevents /project/123 from matching /project/123/datasets
+    const isRoot = routePath.split("/").length <= 3;
+    if (isRoot) return false;
+
+    return currentPath.startsWith(routePath + "/");
+  };
+
   const mapNavigation = (route: Route): NavigationItem | null => {
     // Project-level routes
     if (!routerProjectId && route.pathname.includes("[projectId]")) return null;
@@ -196,7 +209,7 @@ export default function Layout(props: PropsWithChildren) {
     return {
       ...route,
       url: url,
-      isActive: router.pathname === route.pathname,
+      isActive: isPathActive(route.pathname, router.pathname),
       items:
         items.length > 0
           ? (items as NavigationItem[]) // does not include null due to filter


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `isPathActive` function in `layout.tsx` to improve navigation item highlighting by matching child routes.
> 
>   - **Behavior**:
>     - Adds `isPathActive` function in `layout.tsx` to improve navigation item highlighting by matching child routes.
>     - Ensures exact match or prefix match only if route ends with a specific page, preventing incorrect root path matches.
>   - **Navigation**:
>     - Updates `isActive` property in `mapNavigation` to use `isPathActive` for determining active navigation items.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4011f83d09d097ef82f74795f770fc293f164f8a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->