### PR TITLE
fix: use different env variable in worker to construct links

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -20,7 +20,6 @@ CLICKHOUSE_CLUSTER_ENABLED="false"
 # NEXTAUTH_SECRET=""
 NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="secret"
-BASE_URL="http://localhost:3000"
 
 # Langfuse Cloud Environment
 NEXT_PUBLIC_LANGFUSE_CLOUD_REGION="DEV"

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -20,6 +20,7 @@ CLICKHOUSE_CLUSTER_ENABLED="false"
 # NEXTAUTH_SECRET=""
 NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="secret"
+BASE_URL="http://localhost:3000"
 
 # Langfuse Cloud Environment
 NEXT_PUBLIC_LANGFUSE_CLOUD_REGION="DEV"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     ports:
       - 127.0.0.1:3030:3030
     environment: &langfuse-worker-env
+      NEXTAUTH_URL: http://localhost:3000
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres # CHANGEME
       SALT: "mysalt" # CHANGEME
       ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000" # CHANGEME: generate via `openssl rand -hex 32`
@@ -73,7 +74,6 @@ services:
       - 3000:3000
     environment:
       <<: *langfuse-worker-env
-      NEXTAUTH_URL: http://localhost:3000
       NEXTAUTH_SECRET: mysecret # CHANGEME
       LANGFUSE_INIT_ORG_ID: ${LANGFUSE_INIT_ORG_ID:-}
       LANGFUSE_INIT_ORG_NAME: ${LANGFUSE_INIT_ORG_NAME:-}

--- a/worker/src/__tests__/slack-message-builder.test.ts
+++ b/worker/src/__tests__/slack-message-builder.test.ts
@@ -168,16 +168,11 @@ describe("SlackMessageBuilder", () => {
     });
 
     it("should generate correct URLs for different environments", () => {
-      const expectedUrl =
-        process.env.NODE_ENV === "test"
-          ? "https://staging.langfuse.com"
-          : process.env.NODE_ENV === "production"
-            ? "https://cloud.langfuse.com"
-            : "https://localhost:3000";
-
       let blocks =
         SlackMessageBuilder.buildPromptVersionMessage(mockPromptPayload);
-      expect(blocks[4].elements[0].url).toContain(expectedUrl);
+      expect(blocks[4].elements[0].url).toContain(
+        "http://localhost:3000/project/project-456/prompts/test-prompt?version=2",
+      );
     });
   });
 

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -14,7 +14,7 @@ const EnvSchema = z.object({
     .max(65536, `options.port should be >= 0 and < 65536`)
     .default(3030),
 
-  BASE_URL: z.string().default("http://localhost:3000"),
+  NEXTAUTH_URL: z.string().default("http://localhost:3000"),
 
   LANGFUSE_CACHE_AUTOMATIONS_ENABLED: z.enum(["true", "false"]).default("true"),
   LANGFUSE_CACHE_AUTOMATIONS_TTL_SECONDS: z.coerce.number().default(60),

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -14,6 +14,8 @@ const EnvSchema = z.object({
     .max(65536, `options.port should be >= 0 and < 65536`)
     .default(3030),
 
+  BASE_URL: z.string().default("http://localhost:3000"),
+
   LANGFUSE_CACHE_AUTOMATIONS_ENABLED: z.enum(["true", "false"]).default("true"),
   LANGFUSE_CACHE_AUTOMATIONS_TTL_SECONDS: z.coerce.number().default(60),
   LANGFUSE_S3_BATCH_EXPORT_ENABLED: z.enum(["true", "false"]).default("false"),

--- a/worker/src/features/slack/slackMessageBuilder.ts
+++ b/worker/src/features/slack/slackMessageBuilder.ts
@@ -15,14 +15,6 @@ export class SlackMessageBuilder {
     // Determine action emoji and color
     const actionConfig = this.getActionConfig(action);
 
-    // generate url base
-    const urlBase =
-      env.NODE_ENV === "development"
-        ? "https://localhost:3000"
-        : env.NODE_ENV === "test"
-          ? "https://staging.langfuse.com"
-          : "https://cloud.langfuse.com";
-
     // Build the main message blocks
     const blocks = [
       // Header block with emoji and action
@@ -87,7 +79,7 @@ export class SlackMessageBuilder {
               text: "View Prompt",
               emoji: true,
             },
-            url: `${urlBase}/project/${prompt.projectId}/prompts/${encodeURIComponent(prompt.name)}?version=${prompt.version}`,
+            url: `${env.BASE_URL}/project/${prompt.projectId}/prompts/${encodeURIComponent(prompt.name)}?version=${prompt.version}`,
             style: "primary",
           },
         ],

--- a/worker/src/features/slack/slackMessageBuilder.ts
+++ b/worker/src/features/slack/slackMessageBuilder.ts
@@ -79,7 +79,7 @@ export class SlackMessageBuilder {
               text: "View Prompt",
               emoji: true,
             },
-            url: `${env.BASE_URL}/project/${prompt.projectId}/prompts/${encodeURIComponent(prompt.name)}?version=${prompt.version}`,
+            url: `${env.NEXTAUTH_URL}/project/${prompt.projectId}/prompts/${encodeURIComponent(prompt.name)}?version=${prompt.version}`,
             style: "primary",
           },
         ],


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Introduces a new env variable for the worker to construct links.
Using the NODE_ENV is not sufficient because of multiple prod environments.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `BASE_URL` environment variable for URL construction in Slack messages, replacing `NODE_ENV` based logic.
> 
>   - **Environment Variables**:
>     - Add `BASE_URL` to `.env.dev.example` and `worker/src/env.ts` for constructing links.
>   - **Slack Message Builder**:
>     - Replace `NODE_ENV` based URL construction with `BASE_URL` in `SlackMessageBuilder` class in `slackMessageBuilder.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c5396080f21d28eb5f6d7b309c26bca19183db7a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->