### PR TITLE
fix(json-view): store formatted/json preference in local storage

### DIFF
--- a/web/src/components/trace/IOPreview.tsx
+++ b/web/src/components/trace/IOPreview.tsx
@@ -15,6 +15,7 @@ import { MarkdownJsonView } from "@/src/components/ui/MarkdownJsonView";
 import { SubHeaderLabel } from "@/src/components/layouts/header";
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import useLocalStorage from "@/src/components/useLocalStorage";
 
 export const IOPreview: React.FC<{
   input?: Prisma.JsonValue;
@@ -47,9 +48,9 @@ export const IOPreview: React.FC<{
   onOutputExpansionChange,
   ...props
 }) => {
-  const [localCurrentView, setLocalCurrentView] = useState<"pretty" | "json">(
-    "pretty",
-  );
+  const [localCurrentView, setLocalCurrentView] = useLocalStorage<
+    "pretty" | "json"
+  >("jsonViewPreference", "pretty");
   const selectedView = currentView ?? localCurrentView;
   const capture = usePostHogClientCapture();
   const input = deepParseJson(props.input);

--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -59,7 +59,10 @@ export const ObservationPreview = ({
     "view",
     withDefault(StringParam, "preview"),
   );
-  const [currentView, setCurrentView] = useState<"pretty" | "json">("pretty");
+  const [currentView, setCurrentView] = useLocalStorage<"pretty" | "json">(
+    "jsonViewPreference",
+    "pretty",
+  );
   const capture = usePostHogClientCapture();
   const [isPrettyViewAvailable, setIsPrettyViewAvailable] = useState(false);
   const [emptySelectedConfigIds, setEmptySelectedConfigIds] = useLocalStorage<

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -60,7 +60,10 @@ export const TracePreview = ({
     "view",
     withDefault(StringParam, "preview"),
   );
-  const [currentView, setCurrentView] = useState<"pretty" | "json">("pretty");
+  const [currentView, setCurrentView] = useLocalStorage<"pretty" | "json">(
+    "jsonViewPreference",
+    "pretty",
+  );
   const [isPrettyViewAvailable, setIsPrettyViewAvailable] = useState(false);
   const [emptySelectedConfigIds, setEmptySelectedConfigIds] = useLocalStorage<
     string[]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Store user's JSON view preference in local storage for `IOPreview`, `ObservationPreview`, and `TracePreview`.
> 
>   - **Behavior**:
>     - Store user's view preference ("pretty" or "json") in local storage using `useLocalStorage` in `IOPreview`, `ObservationPreview`, and `TracePreview`.
>     - Default view is "pretty" if no preference is stored.
>   - **Components**:
>     - Replace `useState` with `useLocalStorage` for `currentView` in `IOPreview`, `ObservationPreview`, and `TracePreview`.
>     - Update `Tabs` to use `setLocalCurrentView` for view changes in `IOPreview`.
>   - **Misc**:
>     - Import `useLocalStorage` in `IOPreview.tsx`, `ObservationPreview.tsx`, and `TracePreview.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b6e4f52f99c781be58049a8683e1db1f001102e5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->