### PR TITLE
chore: patch docs for ingestion replay

### DIFF
--- a/worker/src/scripts/replayIngestionEvents/README.md
+++ b/worker/src/scripts/replayIngestionEvents/README.md
@@ -35,12 +35,13 @@ Create a suitable .env file in your repository root with Redis connection settin
 ```
 # Relevant
 REDIS_CONNECTION_STRING=redis://:myredissecret@127.0.0.1:6379
+LANGFUSE_S3_EVENT_UPLOAD_BUCKET=<bucket-name>
 
 # Necessary for parsing the file and starting the script
-LANGFUSE_S3_EVENT_UPLOAD_BUCKET=langfuse
 CLICKHOUSE_URL=http://localhost:8123
 CLICKHOUSE_USER=clickhouse
 CLICKHOUSE_PASSWORD=clickhouse
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
 ```
 
 ## 3. Execute the migration

--- a/worker/src/scripts/replayIngestionEvents/s3-ingestion-event-replay.ts
+++ b/worker/src/scripts/replayIngestionEvents/s3-ingestion-event-replay.ts
@@ -420,7 +420,7 @@ async function ingestEventsToQueue(jsonPath: string): Promise<void> {
           try {
             // List versions to find the delete marker
             const listCommand = new ListObjectVersionsCommand({
-              Bucket: env.LANGFUSE_S3_CORE_DATA_UPLOAD_BUCKET,
+              Bucket: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
               Prefix: keyValue,
             });
 
@@ -434,7 +434,7 @@ async function ingestEventsToQueue(jsonPath: string): Promise<void> {
 
             if (deleteMarker) {
               const deleteCommand = new DeleteObjectCommand({
-                Bucket: env.LANGFUSE_S3_CORE_DATA_UPLOAD_BUCKET,
+                Bucket: env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
                 Key: keyValue,
                 VersionId: deleteMarker.VersionId,
               });

--- a/worker/src/scripts/replayIngestionEvents/s3-ingestion-event-replay.ts
+++ b/worker/src/scripts/replayIngestionEvents/s3-ingestion-event-replay.ts
@@ -42,7 +42,13 @@ interface Stats {
   processingTimeMs: number;
 }
 
-const client = new S3Client();
+const client = new S3Client({
+  requestHandler: {
+    httpsAgent: {
+      maxSockets: 300,
+    },
+  },
+});
 
 interface JsonOutputItem {
   useS3EventStore: true;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update S3 bucket environment variable and add `DATABASE_URL` in documentation for ingestion replay.
> 
>   - **Environment Variables**:
>     - Update `LANGFUSE_S3_EVENT_UPLOAD_BUCKET` in `README.md` and `s3-ingestion-event-replay.ts` to replace `LANGFUSE_S3_CORE_DATA_UPLOAD_BUCKET`.
>   - **Documentation**:
>     - Add `DATABASE_URL` to `.env` example in `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4fb70dd9457c49bf5ae68e8d809944302817afd4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->