### PR TITLE
chore: correctly parse input and output on traces_mt ingestion

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -445,11 +445,14 @@ export class IngestionService {
     if (
       env.LANGFUSE_EXPERIMENT_INSERT_INTO_AGGREGATING_MERGE_TREES === "true"
     ) {
-      traceRecords
-        .map(convertTraceToTraceMt)
-        .forEach((r) =>
-          this.clickHouseWriter.addToQueue(TableName.TracesMt, r),
-        );
+      traceRecords.map(convertTraceToTraceMt).forEach((r) =>
+        this.clickHouseWriter.addToQueue(TableName.TracesMt, {
+          ...r,
+          // We need to re-add input and output here as they were excluded in a previous mapping step
+          input: finalTraceRecord.input ?? "",
+          output: finalTraceRecord.output ?? "",
+        }),
+      );
     }
 
     // Add trace into trace upsert queue for eval processing

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -78,6 +78,8 @@ describe("Ingestion end-to-end tests", () => {
           name: traceName,
           timestamp,
           environment,
+          input: "foo",
+          output: "bar",
         },
       },
     ];
@@ -102,8 +104,8 @@ describe("Ingestion end-to-end tests", () => {
     expect(trace.public).toBe(false);
     expect(trace.bookmarked).toBe(false);
     expect(trace.tags).toEqual([]);
-    expect(["", null]).toContain(trace.input);
-    expect(["", null]).toContain(trace.output);
+    expect(trace.input).toBe("foo");
+    expect(trace.output).toBe("bar");
     expect(trace.session_id).toBeNull();
     expect(trace.timestamp).toBe(timestamp);
   });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes input/output field handling in trace ingestion for `TracesMt` table and updates tests to verify this behavior.
> 
>   - **Behavior**:
>     - Fixes handling of `input` and `output` fields in `processTraceEventList()` in `index.ts` by ensuring they are included in the final trace record for `TracesMt` table.
>     - Updates `IngestionService.integration.test.ts` to verify correct ingestion of `input` and `output` fields in trace records.
>   - **Tests**:
>     - Modifies test case in `IngestionService.integration.test.ts` to check that `input` and `output` fields are correctly set to "foo" and "bar" respectively.
>     - Ensures that trace records in tests reflect the changes to input/output handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 53289c6133a9f7906b5148d2eee6f2fb2025941b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->