### PR TITLE
chore: add dataset-run-items tables to clickhouse

### DIFF
--- a/packages/shared/clickhouse/migrations/clustered/0022_dataset_run_items.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0022_dataset_run_items.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE dataset_run_items ON CLUSTER default;

--- a/packages/shared/clickhouse/migrations/clustered/0022_dataset_run_items.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0022_dataset_run_items.up.sql
@@ -1,0 +1,36 @@
+CREATE TABLE dataset_run_items ON CLUSTER default (
+    -- primary identifiers
+    `id` String,
+    `project_id` String,
+    `dataset_run_id` String,
+    `dataset_item_id` String,
+    `dataset_id` String,
+    `trace_id` String,
+    `observation_id` Nullable(String),
+
+    -- error field
+    `error` Nullable(String),
+
+     -- timestamps
+    `created_at` DateTime64(3) DEFAULT now(),
+    `updated_at` DateTime64(3) DEFAULT now(),
+
+    -- denormalized immutable dataset run fields
+    `dataset_run_name` String,
+    `dataset_run_description` Nullable(String),
+    `dataset_run_metadata` Map(LowCardinality(String), String),
+    `dataset_run_created_at` DateTime64(3),
+
+    -- denormalized dataset item fields (mutable, but snapshots are relevant)
+    `dataset_item_input` Nullable(String) CODEC(ZSTD(3)), -- json
+    `dataset_item_expected_output` Nullable(String) CODEC(ZSTD(3)), -- json
+    `dataset_item_metadata` Map(LowCardinality(String), String),
+
+    -- clickhouse engine fields
+    `event_ts` DateTime64(3),
+    `is_deleted` UInt8,
+
+    -- For dataset item lookups
+    INDEX idx_dataset_item dataset_item_id TYPE bloom_filter(0.001) GRANULARITY 1,
+) ENGINE = ReplacingMergeTree(event_ts, is_deleted)
+ORDER BY (project_id, dataset_id, dataset_run_id, id);

--- a/packages/shared/clickhouse/migrations/unclustered/0022_dataset_run_items.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0022_dataset_run_items.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE dataset_run_items;

--- a/packages/shared/clickhouse/migrations/unclustered/0022_dataset_run_items.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0022_dataset_run_items.up.sql
@@ -1,0 +1,36 @@
+CREATE TABLE dataset_run_items (
+    -- primary identifiers
+    `id` String,
+    `project_id` String,
+    `dataset_run_id` String,
+    `dataset_item_id` String,
+    `dataset_id` String,
+    `trace_id` String,
+    `observation_id` Nullable(String),
+
+    -- error field
+    `error` Nullable(String),
+
+     -- timestamps
+    `created_at` DateTime64(3) DEFAULT now(),
+    `updated_at` DateTime64(3) DEFAULT now(),
+
+    -- denormalized immutable dataset run fields
+    `dataset_run_name` String,
+    `dataset_run_description` Nullable(String),
+    `dataset_run_metadata` Map(LowCardinality(String), String),
+    `dataset_run_created_at` DateTime64(3),
+
+    -- denormalized dataset item fields (mutable, but snapshots are relevant)
+    `dataset_item_input` Nullable(String) CODEC(ZSTD(3)), -- json
+    `dataset_item_expected_output` Nullable(String) CODEC(ZSTD(3)), -- json
+    `dataset_item_metadata` Map(LowCardinality(String), String),
+
+    -- clickhouse engine fields
+    `event_ts` DateTime64(3),
+    `is_deleted` UInt8,
+
+    -- For dataset item lookups
+    INDEX idx_dataset_item dataset_item_id TYPE bloom_filter(0.001) GRANULARITY 1,
+) ENGINE = ReplacingMergeTree(event_ts, is_deleted)
+ORDER BY (project_id, dataset_id, dataset_run_id, id);

--- a/worker/src/services/IngestionService/README.md
+++ b/worker/src/services/IngestionService/README.md
@@ -1,55 +1,5 @@
 # IngestionService
 
-## Experimental Setup for Dataset Run Items
-
-Warn: Do not apply on your own as this is highly experimental and may change anytime.
-
-We have a new dataset run item table that is used to store dataset run items. We enable experiments on cloud to verify expected behavior.
-It requires the following table schema to be applied on the database instance:
-
-```sql
--- up migration
-CREATE TABLE dataset_run_items (
-    -- primary identifiers
-    `id` String,
-    `project_id` String,
-    `dataset_run_id` String,
-    `dataset_item_id` String,
-    `dataset_id` String,
-    `trace_id` String,
-    `observation_id` Nullable(String),
-
-    -- error field
-    `error` Nullable(String),
-
-     -- timestamps
-    `created_at` DateTime64(3) DEFAULT now(),
-    `updated_at` DateTime64(3) DEFAULT now(),
-
-    -- denormalized immutable dataset run fields
-    `dataset_run_name` String,
-    `dataset_run_description` Nullable(String),
-    `dataset_run_metadata` Map(LowCardinality(String), String),
-    `dataset_run_created_at` DateTime64(3),
-
-    -- denormalized dataset item fields (mutable, but snapshots are relevant)
-    `dataset_item_input` Nullable(String) CODEC(ZSTD(3)), -- json
-    `dataset_item_expected_output` Nullable(String) CODEC(ZSTD(3)), -- json
-    `dataset_item_metadata` Map(LowCardinality(String), String),
-
-    -- clickhouse engine fields
-    `event_ts` DateTime64(3),
-    `is_deleted` UInt8,
-
-    -- For dataset item lookups
-    INDEX idx_dataset_item dataset_item_id TYPE bloom_filter(0.001) GRANULARITY 1,
-) ENGINE = ReplacingMergeTree(event_ts, is_deleted)
-ORDER BY (project_id, dataset_id, dataset_run_id, id);
-
--- down migration
-DROP TABLE dataset_run_items;
-```
-
 ## Experimental Setup with AggregatingMergeTrees
 
 Warn: Do not apply on your own as this is highly experimental and may change anytime.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add ClickHouse migrations for `dataset_run_items` table and update README by removing experimental setup instructions.
> 
>   - **ClickHouse Migrations**:
>     - Add `dataset_run_items` table creation in `0022_dataset_run_items.up.sql` for both clustered and unclustered setups.
>     - Define schema with fields for identifiers, error, timestamps, denormalized dataset run fields, and dataset item fields.
>     - Add `dataset_run_items` table drop in `0022_dataset_run_items.down.sql` for both clustered and unclustered setups.
>   - **Documentation**:
>     - Remove experimental setup instructions for `dataset_run_items` from `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e24f74fc0885bd9fb56840f502756c822dcffa27. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->