### PR TITLE
chore(dataset-run-items): add background migration for DRI

### DIFF
--- a/packages/shared/prisma/migrations/20250731100100_add_dataset_run_items_pg_to_ch_background_migration/migration.sql
+++ b/packages/shared/prisma/migrations/20250731100100_add_dataset_run_items_pg_to_ch_background_migration/migration.sql
@@ -1,0 +1,2 @@
+INSERT INTO background_migrations (id, name, script, args)
+VALUES ('8d47f91b-3e5c-4a26-9f85-c12d6e4b9a3d', '20250731_1001_migrate_dataset_run_items_pg_to_ch', 'migrateDatasetRunItemsFromPostgresToClickhouse', '{}');


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a background migration to move dataset run items from Postgres to Clickhouse.
> 
>   - **Migration**:
>     - Adds a new background migration in `migration.sql` to move dataset run items from Postgres to Clickhouse.
>     - Inserts entry into `background_migrations` table with ID `8d47f91b-3e5c-4a26-9f85-c12d6e4b9a3d`, name `20250731_1001_migrate_dataset_run_items_pg_to_ch`, and script `migrateDatasetRunItemsFromPostgresToClickhouse`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 94aa1be65ed7fbd93102a5f87a71630c6d1a80dd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->