### PR TITLE
refactor: break up SlackService and move to web/worker packages

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -73,8 +73,6 @@
     "@prisma/client": "^6.10.1",
     "@react-email/components": "^0.1.0",
     "@react-email/render": "^1.1.2",
-    "@slack/oauth": "^2.6.0",
-    "@slack/web-api": "^7.0.0",
     "@types/bcryptjs": "^2.4.6",
     "axios": "^1.8.2",
     "bcryptjs": "^2.4.3",

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -65,7 +65,6 @@ export * from "./services/DashboardService";
 export * from "./services/TableViewService";
 export * from "./services/DefaultEvaluationModelService";
 export * from "./clickhouse/measureAndReturn";
-export * from "./services/SlackService";
 
 export * from "./data-deletion/ingestionFileDeletion";
 export * from "./s3";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,12 +187,6 @@ importers:
       '@react-email/render':
         specifier: ^1.1.2
         version: 1.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@slack/oauth':
-        specifier: ^2.6.0
-        version: 2.6.3
-      '@slack/web-api':
-        specifier: ^7.0.0
-        version: 7.9.3
       '@types/bcryptjs':
         specifier: ^2.4.6
         version: 2.4.6

--- a/web/src/__tests__/async/slack-integration.servertest.ts
+++ b/web/src/__tests__/async/slack-integration.servertest.ts
@@ -7,11 +7,15 @@ import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 
 // Mock SlackService
-jest.mock("../../server/services/SlackService", () => ({
-  SlackService: {
-    getInstance: jest.fn(),
-  },
-}));
+jest.mock("../../server/services/SlackService", () => {
+  const actual = jest.requireActual("../../server/services/SlackService");
+  return {
+    ...actual,
+    SlackService: {
+      getInstance: jest.fn(),
+    },
+  };
+});
 
 const __orgIds: string[] = [];
 let mockSlackService: any;

--- a/web/src/__tests__/async/slack-integration.servertest.ts
+++ b/web/src/__tests__/async/slack-integration.servertest.ts
@@ -7,15 +7,11 @@ import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 
 // Mock SlackService
-jest.mock("@langfuse/shared/src/server", () => {
-  const actual = jest.requireActual("@langfuse/shared/src/server");
-  return {
-    ...actual,
-    SlackService: {
-      getInstance: jest.fn(),
-    },
-  };
-});
+jest.mock("../../server/services/SlackService", () => ({
+  SlackService: {
+    getInstance: jest.fn(),
+  },
+}));
 
 const __orgIds: string[] = [];
 let mockSlackService: any;
@@ -72,7 +68,7 @@ const prepare = async () => {
 describe("Slack Integration", () => {
   beforeAll(async () => {
     // Import mocked SlackService
-    const { SlackService } = await import("@langfuse/shared/src/server");
+    const { SlackService } = await import("../../server/services/SlackService");
 
     // Create mock service instance
     mockSlackService = {
@@ -295,12 +291,14 @@ describe("Slack Integration", () => {
         });
 
         // Verify SlackService was called with proper parameters
-        expect(mockSlackService.sendMessage).toHaveBeenCalledWith({
-          client: expect.any(Object),
-          channelId: "C123456",
-          blocks: expect.any(Array),
-          text: "Test message from Langfuse",
-        });
+        expect(mockSlackService.sendMessage).toHaveBeenCalledWith(
+          expect.any(Object),
+          {
+            channelId: "C123456",
+            blocks: expect.any(Array),
+            text: "Test message from Langfuse",
+          },
+        );
 
         // 🔒 CRITICAL: Ensure no bot token is exposed in test results
         expect(JSON.stringify(result)).not.toContain("xoxb-test-token");

--- a/web/src/features/slack/server/oauth-handlers.ts
+++ b/web/src/features/slack/server/oauth-handlers.ts
@@ -2,7 +2,7 @@ import { type NextApiRequest, type NextApiResponse } from "next";
 import {
   SlackService,
   parseSlackInstallationMetadata,
-} from "@langfuse/shared/src/server";
+} from "@/src/server/services/SlackService";
 import { logger } from "@langfuse/shared/src/server";
 import { env } from "@/src/env.mjs";
 

--- a/web/src/features/slack/server/router.ts
+++ b/web/src/features/slack/server/router.ts
@@ -3,7 +3,7 @@ import {
   protectedProjectProcedure,
 } from "@/src/server/api/trpc";
 import { z } from "zod/v4";
-import { SlackService } from "@langfuse/shared/src/server";
+import { SlackService } from "@/src/server/services/SlackService";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { logger } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
@@ -282,8 +282,7 @@ export const slackRouter = createTRPCRouter({
           },
         ];
 
-        const result = await SlackService.getInstance().sendMessage({
-          client,
+        const result = await SlackService.getInstance().sendMessage(client, {
           channelId: input.channelId,
           blocks: testBlocks,
           text: "Test message from Langfuse",

--- a/worker/src/queues/webhooks.ts
+++ b/worker/src/queues/webhooks.ts
@@ -18,9 +18,9 @@ import {
   getActionByIdWithSecrets,
   getActionById,
   getConsecutiveAutomationFailures,
-  SlackService,
   logger,
 } from "@langfuse/shared/src/server";
+import { SlackService } from "../services/SlackService";
 import { Processor, Job } from "bullmq";
 import { backOff } from "exponential-backoff";
 import { env } from "../env";
@@ -388,8 +388,7 @@ async function executeSlackAction({
       await SlackService.getInstance().getWebClientForProject(projectId);
 
     // Send message
-    const sendResult = await SlackService.getInstance().sendMessage({
-      client,
+    const sendResult = await SlackService.getInstance().sendMessage(client, {
       channelId: slackConfig.channelId,
       blocks,
       text: "Langfuse Notification",

--- a/worker/src/services/SlackService.ts
+++ b/worker/src/services/SlackService.ts
@@ -1,0 +1,133 @@
+/**
+ * Slack Integration Service for Worker Package
+ *
+ * Handles message sending functionality for background job processing.
+ * Includes only messaging capabilities, no OAuth functionality.
+ */
+
+import { WebClient } from "@slack/web-api";
+import { logger } from "@langfuse/shared/src/server";
+import { prisma } from "@langfuse/shared/src/db";
+import { decrypt } from "@langfuse/shared/encryption";
+// Types for Slack integration
+export interface SlackMessageParams {
+  channelId: string;
+  blocks: any[];
+  text?: string;
+}
+
+export interface SlackMessageResponse {
+  messageTs: string;
+  channel: string;
+}
+
+/**
+ * Slack Service Class for Worker Package
+ *
+ * Simplified service focused on message sending for automation workflows.
+ * Does not include OAuth functionality to minimize bundle size.
+ */
+export class SlackService {
+  private static instance: SlackService | null = null;
+
+  private constructor() {
+    // No InstallProvider needed for worker
+  }
+
+  /**
+   * Get singleton instance of SlackService
+   */
+  static getInstance(): SlackService {
+    if (!SlackService.instance) {
+      SlackService.instance = new SlackService();
+    }
+    return SlackService.instance;
+  }
+
+  /**
+   * Get WebClient for a specific project
+   */
+  async getWebClientForProject(projectId: string): Promise<WebClient> {
+    try {
+      logger.debug("Getting WebClient for project", { projectId });
+
+      const integration = await prisma.slackIntegration.findUnique({
+        where: { projectId },
+      });
+
+      if (!integration) {
+        throw new Error(`No integration found for project ${projectId}`);
+      }
+
+      const decryptedToken = decrypt(integration.botToken);
+      const client = new WebClient(decryptedToken);
+
+      logger.debug("Created WebClient for project", { projectId });
+
+      return client;
+    } catch (error) {
+      logger.error("Failed to create WebClient for project", {
+        error,
+        projectId,
+      });
+      throw new Error(
+        `Failed to create WebClient: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+    }
+  }
+
+  /**
+   * Send a message to a Slack channel
+   */
+  async sendMessage(
+    client: WebClient,
+    params: SlackMessageParams,
+  ): Promise<SlackMessageResponse> {
+    try {
+      const result = await client.chat.postMessage({
+        channel: params.channelId,
+        blocks: params.blocks,
+        text: params.text || "Langfuse Notification",
+        unfurl_links: false,
+        unfurl_media: false,
+      });
+
+      if (!result.ok) {
+        throw new Error(`Failed to send message: ${result.error}`);
+      }
+
+      const response = {
+        messageTs: result.ts!,
+        channel: result.channel!,
+      };
+
+      logger.info("Message sent successfully to Slack", {
+        channel: params.channelId,
+        messageTs: response.messageTs,
+      });
+
+      return response;
+    } catch (error) {
+      logger.error("Failed to send message", {
+        error,
+        channelId: params.channelId,
+      });
+      throw new Error(
+        `Failed to send message: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+    }
+  }
+
+  /**
+   * Validate a WebClient instance
+   */
+  async validateClient(client: WebClient): Promise<boolean> {
+    try {
+      const result = await client.auth.test();
+      return result.ok || false;
+    } catch (error) {
+      logger.warn("Client validation failed", { error });
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Breaks up SlackService and moves the relevant parts into web/worker packages respectively.
Completely removes dependencies from shared package.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor SlackService by splitting it into web and worker packages, removing shared dependencies, and updating related imports and tests.
> 
>   - **Refactor SlackService**:
>     - Split `SlackService` into `web/src/server/services/SlackService.ts` and `worker/src/services/SlackService.ts`.
>     - `web/SlackService` handles OAuth and integration management.
>     - `worker/SlackService` handles message sending only.
>   - **Dependency Removal**:
>     - Removed `@slack/oauth` and `@slack/web-api` from `packages/shared/package.json`.
>     - Removed `SlackService` export from `shared/src/server/index.ts`.
>   - **Import Updates**:
>     - Updated imports in `web/src/__tests__/async/slack-integration.servertest.ts`, `web/src/features/slack/server/oauth-handlers.ts`, `web/src/features/slack/server/router.ts`, `worker/src/__tests__/slack-processor.test.ts`, and `worker/src/queues/webhooks.ts` to use new `SlackService` paths.
>   - **Function Changes**:
>     - Changed `sendMessage` function signature to accept `WebClient` as a separate parameter in both `SlackService` implementations.
>     - Removed `client` from `SlackMessageParams` interface in both `SlackService` implementations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 60e8f45342b5f7772a155ea77e1ff90f1b4a704d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->