### PR TITLE
build: setup slack alerts on failing CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -492,10 +492,10 @@ jobs:
         working-directory: .
       - name: Notify Slack
         uses: ravsamhq/notify-slack-action@v2
-        if: always()
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         with:
           status: ${{ job.status }}
-          notify_when: "success,failure,cancelled,warnings,skipped"
+          notify_when: "failure"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -490,6 +490,14 @@ jobs:
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1
         working-directory: .
+      - name: Notify Slack
+        uses: ravsamhq/notify-slack-action@v2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notify_when: "success,failure,cancelled,warnings,skipped"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   push-docker-image:
     needs: all-ci-passed


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds Slack notifications for failed CI/CD builds in `.github/workflows/pipeline.yml`.
> 
>   - **CI/CD Pipeline**:
>     - Adds Slack notification step in `.github/workflows/pipeline.yml` using `ravsamhq/notify-slack-action@v2`.
>     - Triggers on `push` events to `main` branch or tags, notifying only on failure.
>     - Uses `SLACK_WEBHOOK_URL` from secrets for authentication.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0d461481e044fc4d3e7d9e3106a9d51e27556b8a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->