### PR TITLE
feat(annotation-queues): add support for batch adding observations to annotation queues

### DIFF
--- a/packages/shared/src/features/batchAction/types.ts
+++ b/packages/shared/src/features/batchAction/types.ts
@@ -15,6 +15,7 @@ const ActionIdSchema = z.enum([
   "trace-delete",
   "trace-add-to-annotation-queue",
   "session-add-to-annotation-queue",
+  "observation-add-to-annotation-queue",
 ]);
 
 export type ActionId = z.infer<typeof ActionIdSchema>;

--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -126,6 +126,15 @@ export const BatchActionProcessingEventSchema = z.discriminatedUnion(
       type: z.enum(BatchActionType),
     }),
     z.object({
+      actionId: z.literal("observation-add-to-annotation-queue"),
+      projectId: z.string(),
+      query: BatchActionQuerySchema,
+      tableName: z.enum(BatchTableNames),
+      cutoffCreatedAt: z.date(),
+      targetId: z.string().optional(),
+      type: z.enum(BatchActionType),
+    }),
+    z.object({
       actionId: z.literal("eval-create"),
       targetObject: z.enum(["trace", "dataset"]),
       configId: z.string(),

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -1,7 +1,7 @@
 import { api } from "@/src/utils/api";
 import { DataTable } from "@/src/components/table/data-table";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { TokenUsageBadge } from "@/src/components/token-usage-badge";
 import { NumberParam, useQueryParams, withDefault } from "use-query-params";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
@@ -15,6 +15,8 @@ import {
   BatchExportTableName,
   type ObservationType,
   TableViewPresetTableName,
+  AnnotationQueueObjectType,
+  BatchActionType,
 } from "@langfuse/shared";
 import { cn } from "@/src/utils/tailwind";
 import { LevelColors } from "@/src/components/level-colors";
@@ -43,7 +45,7 @@ import {
   convertSelectedEnvironmentsToFilter,
 } from "@/src/hooks/use-environment-filter";
 import { Badge } from "@/src/components/ui/badge";
-import { type Row } from "@tanstack/react-table";
+import { type RowSelectionState, type Row } from "@tanstack/react-table";
 import TableIdOrName from "@/src/components/table/table-id";
 import { ItemBadge } from "@/src/components/ItemBadge";
 import { Skeleton } from "@/src/components/ui/skeleton";
@@ -55,6 +57,11 @@ import { useTableViewManager } from "@/src/components/table/table-view-presets/h
 import { useRouter } from "next/router";
 import { useFullTextSearch } from "@/src/components/table/use-cases/useFullTextSearch";
 import { type PeekViewProps } from "@/src/components/table/peek/hooks/usePeekView";
+import { TableSelectionManager } from "@/src/features/table/components/TableSelectionManager";
+import { useSelectAll } from "@/src/features/table/hooks/useSelectAll";
+import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
+import { TableActionMenu } from "@/src/features/table/components/TableActionMenu";
+import { type TableAction } from "@/src/features/table/types";
 
 export type ObservationsTableRow = {
   // Shown by default
@@ -117,9 +124,11 @@ export default function ObservationsTable({
   const { viewId } = router.query;
 
   const { setDetailPageList } = useDetailPageLists();
-
+  const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
   const { searchQuery, searchType, setSearchQuery, setSearchType } =
     useFullTextSearch();
+
+  const { selectAll, setSelectAll } = useSelectAll(projectId, "observations");
 
   const [paginationState, setPaginationState] = useQueryParams({
     pageIndex: withDefault(NumberParam, 0),
@@ -272,6 +281,19 @@ export default function ObservationsTable({
     },
   );
 
+  const addToQueueMutation = api.annotationQueueItems.createMany.useMutation({
+    onSuccess: (data) => {
+      showSuccessToast({
+        title: "Observations added to queue",
+        description: `Selected observations will be added to queue "${data.queueName}". This may take a minute.`,
+        link: {
+          href: `/project/${projectId}/annotation-queues/${data.queueId}`,
+          text: `View queue "${data.queueName}"`,
+        },
+      });
+    },
+  });
+
   useEffect(() => {
     if (generations.isSuccess) {
       setDetailPageList(
@@ -302,7 +324,54 @@ export default function ObservationsTable({
     );
   };
 
+  const { selectActionColumn } = TableSelectionManager<ObservationsTableRow>({
+    projectId,
+    tableName: "observations",
+    setSelectedRows,
+  });
+
+  const handleAddToAnnotationQueue = async ({
+    projectId,
+    targetId,
+  }: {
+    projectId: string;
+    targetId: string;
+  }) => {
+    const selectedGenerationIds = Object.keys(selectedRows).filter(
+      (generationId) =>
+        generations.data?.generations.map((g) => g.id).includes(generationId),
+    );
+
+    await addToQueueMutation.mutateAsync({
+      projectId,
+      objectIds: selectedGenerationIds,
+      objectType: AnnotationQueueObjectType.OBSERVATION,
+      queueId: targetId,
+      isBatchAction: selectAll,
+      query: {
+        filter: filterState,
+        orderBy: orderByState,
+      },
+    });
+    setSelectedRows({});
+  };
+
+  const tableActions: TableAction[] = [
+    {
+      id: "observation-add-to-annotation-queue",
+      type: BatchActionType.Create,
+      label: "Add to Annotation Queue",
+      description: "Add selected observations to an annotation queue.",
+      targetLabel: "Annotation Queue",
+      execute: handleAddToAnnotationQueue,
+      accessCheck: {
+        scope: "annotationQueues:CUD",
+      },
+    },
+  ];
+
   const columns: LangfuseColumnDef<ObservationsTableRow>[] = [
+    selectActionColumn,
     {
       accessorKey: "startTime",
       id: "startTime",
@@ -975,7 +1044,7 @@ export default function ObservationsTable({
         setRowHeight={setRowHeight}
         selectedOption={selectedOption}
         setDateRangeAndOption={setDateRangeAndOption}
-        actionButtons={
+        actionButtons={[
           <BatchExportTableButton
             {...{
               projectId,
@@ -986,12 +1055,36 @@ export default function ObservationsTable({
             }}
             tableName={BatchExportTableName.Observations}
             key="batchExport"
-          />
-        }
+          />,
+          Object.keys(selectedRows).filter((generationId) =>
+            generations.data?.generations
+              .map((g) => g.id)
+              .includes(generationId),
+          ).length > 0 ? (
+            <TableActionMenu
+              key="observations-multi-select-actions"
+              projectId={projectId}
+              actions={tableActions}
+              tableName={BatchExportTableName.Observations}
+            />
+          ) : null,
+        ]}
         environmentFilter={{
           values: selectedEnvironments,
           onValueChange: setSelectedEnvironments,
           options: environmentOptions.map((env) => ({ value: env })),
+        }}
+        multiSelect={{
+          selectAll,
+          setSelectAll,
+          selectedRowIds: Object.keys(selectedRows).filter((generationId) =>
+            generations.data?.generations
+              .map((g) => g.id)
+              .includes(generationId),
+          ),
+          setRowSelection: setSelectedRows,
+          totalCount,
+          ...paginationState,
         }}
       />
       <DataTable
@@ -1018,6 +1111,8 @@ export default function ObservationsTable({
           onChange: setPaginationState,
           state: paginationState,
         }}
+        rowSelection={selectedRows}
+        setRowSelection={setSelectedRows}
         setOrderBy={setOrderByState}
         orderBy={orderByState}
         columnOrder={columnOrder}

--- a/web/src/features/annotation-queues/server/annotationQueueItems.ts
+++ b/web/src/features/annotation-queues/server/annotationQueueItems.ts
@@ -34,7 +34,7 @@ const isItemLocked = (item: AnnotationQueueItem) => {
 };
 
 const MAP_OBJECT_TYPE_TO_ACTION_PROPS: Record<
-  "TRACE" | "SESSION",
+  AnnotationQueueObjectType,
   { actionId: ActionId; tableName: BatchTableNames }
 > = {
   [AnnotationQueueObjectType.TRACE]: {
@@ -44,6 +44,10 @@ const MAP_OBJECT_TYPE_TO_ACTION_PROPS: Record<
   [AnnotationQueueObjectType.SESSION]: {
     actionId: "session-add-to-annotation-queue",
     tableName: BatchExportTableName.Sessions,
+  },
+  [AnnotationQueueObjectType.OBSERVATION]: {
+    actionId: "observation-add-to-annotation-queue",
+    tableName: BatchExportTableName.Observations,
   },
 };
 

--- a/web/src/features/table/components/targetOptionsQueryMap.tsx
+++ b/web/src/features/table/components/targetOptionsQueryMap.tsx
@@ -4,4 +4,6 @@ export const targetOptionsQueryMap = {
   "trace-add-to-annotation-queue": api.annotationQueues.allNamesAndIds.useQuery,
   "session-add-to-annotation-queue":
     api.annotationQueues.allNamesAndIds.useQuery,
+  "observation-add-to-annotation-queue":
+    api.annotationQueues.allNamesAndIds.useQuery,
 } as const;

--- a/worker/src/features/batchAction/handleBatchActionJob.ts
+++ b/worker/src/features/batchAction/handleBatchActionJob.ts
@@ -20,6 +20,7 @@ import { processClickhouseTraceDelete } from "../traces/processClickhouseTraceDe
 import { env } from "../../env";
 import { Job } from "bullmq";
 import {
+  processAddObservationsToQueue,
   processAddSessionsToQueue,
   processAddTracesToQueue,
 } from "./processAddToQueue";
@@ -63,6 +64,14 @@ async function processActionChunk(
 
       case "session-add-to-annotation-queue":
         await processAddSessionsToQueue(
+          projectId,
+          chunkIds,
+          targetId as string,
+        );
+        break;
+
+      case "observation-add-to-annotation-queue":
+        await processAddObservationsToQueue(
           projectId,
           chunkIds,
           targetId as string,
@@ -145,6 +154,7 @@ export const handleBatchActionJob = async (
     actionId === "trace-delete" ||
     actionId === "trace-add-to-annotation-queue" ||
     actionId === "session-add-to-annotation-queue" ||
+    actionId === "observation-add-to-annotation-queue" ||
     actionId === "score-delete"
   ) {
     const { projectId, tableName, query, cutoffCreatedAt, targetId, type } =

--- a/worker/src/features/batchAction/processAddToQueue.ts
+++ b/worker/src/features/batchAction/processAddToQueue.ts
@@ -92,3 +92,29 @@ export const processAddSessionsToQueue = async (
     throw e;
   }
 };
+
+export const processAddObservationsToQueue = async (
+  projectId: string,
+  observationIds: string[],
+  targetId: string,
+) => {
+  logger.info(
+    `Adding observations ${JSON.stringify(observationIds)} to annotation queue ${targetId} in project ${projectId}`,
+  );
+
+  try {
+    await addToQueue({
+      projectId,
+      objectIds: observationIds,
+      objectType: AnnotationQueueObjectType.OBSERVATION,
+      targetId,
+    });
+  } catch (e) {
+    logger.error(
+      `Error adding observations ${JSON.stringify(observationIds)} to annotation queue ${targetId} in project ${projectId}`,
+      e,
+    );
+    traceException(e);
+    throw e;
+  }
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for batch adding observations to annotation queues, including schema updates, server-side logic, and UI components.
> 
>   - **Behavior**:
>     - Add support for `observation-add-to-annotation-queue` in `BatchActionProcessingEventSchema` in `queues.ts`.
>     - Implement `processAddObservationsToQueue` in `processAddToQueue.ts` to handle adding observations to queues.
>     - Update `handleBatchActionJob` in `handleBatchActionJob.ts` to process `observation-add-to-annotation-queue` actions.
>   - **UI Components**:
>     - Add `handleAddToAnnotationQueue` function in `observations.tsx` to handle UI interactions for adding observations to queues.
>     - Update `ObservationsTable` in `observations.tsx` to include batch action menu for observations.
>   - **Misc**:
>     - Add `observation-add-to-annotation-queue` to `ActionIdSchema` in `types.ts`.
>     - Update `MAP_OBJECT_TYPE_TO_ACTION_PROPS` in `annotationQueueItems.ts` to include observation support.
>     - Add `observation-add-to-annotation-queue` to `targetOptionsQueryMap.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 20fa6855e17f363c0d84ee9164578c08de9241e3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->