### PR TITLE
build: add always() condition to run notifications on failure

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -492,7 +492,7 @@ jobs:
         working-directory: .
       - name: Notify Slack
         uses: ravsamhq/notify-slack-action@v2
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+        if: always() && github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         with:
           status: ${{ job.status }}
           notify_when: "failure"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `always()` condition to Slack notification step in `pipeline.yml` to ensure notifications are sent on job failure.
> 
>   - **Notifications**:
>     - Adds `always()` condition to Slack notification step in `.github/workflows/pipeline.yml` to ensure notifications are sent on job failure.
>     - Affects the `Notify Slack` step for `push` events on `main` branch or tags.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 36501421df30336803b9cd42cc8f4eea4157894e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->