### PR TITLE
feat: allow viewing api keys and header values in LLM Connection settings

### DIFF
--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -424,7 +424,11 @@ export function CreateLLMApiKeyForm({
                   </FormDescription>
 
                   <FormControl>
-                    <Input {...field} placeholder="default" />
+                    <Input
+                      {...field}
+                      placeholder="default"
+                      data-1p-ignore="true"
+                    />
                   </FormControl>
 
                   <FormMessage />
@@ -442,7 +446,7 @@ export function CreateLLMApiKeyForm({
                   <FormItem>
                     <FormLabel>AWS Region</FormLabel>
                     <FormControl>
-                      <Input {...field} />
+                      <Input {...field} data-1p-ignore="true" />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -560,6 +564,7 @@ export function CreateLLMApiKeyForm({
                   <FormControl>
                     <PasswordInput
                       {...field}
+                      autoComplete="off"
                       placeholder={
                         mode === "update"
                           ? existingKey?.displaySecretKey
@@ -659,7 +664,7 @@ export function CreateLLMApiKeyForm({
             name="withDefaultModels"
             render={({ field }) => (
               <FormItem>
-                <span className="row flex">
+                <span className="row flex items-center gap-4">
                   <span className="flex-1">
                     <FormLabel>Enable default models</FormLabel>
                     <FormDescription>

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -604,7 +604,7 @@ export function CreateLLMApiKeyForm({
                   <FormLabel>Extra Headers</FormLabel>
                   <FormDescription>
                     Optional additional HTTP headers to include with requests
-                    towards LLM provider. All header values stored encrypted{" "}
+                    towards LLM provider. All header values are stored encrypted{" "}
                     {isLangfuseCloud ? "on our servers" : "in your database"}.
                   </FormDescription>
 

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -163,15 +163,17 @@ export function CreateLLMApiKeyForm({
         ? {
             adapter: existingKey.adapter as LLMAdapter,
             provider: existingKey.provider,
-            secretKey: "",
+            secretKey: existingKey.secretKey ?? "",
             baseURL:
               existingKey.baseURL ??
               getCustomizedBaseURL(existingKey.adapter as LLMAdapter),
             withDefaultModels: existingKey.withDefaultModels,
             customModels: existingKey.customModels.map((value) => ({ value })),
-            extraHeaders:
-              existingKey.extraHeaderKeys?.map((key) => ({ key, value: "" })) ??
-              [],
+            extraHeaders: existingKey.extraHeaders
+              ? Object.entries(existingKey.extraHeaders).map(
+                  ([key, value]) => ({ key, value }),
+                )
+              : [],
             vertexAILocation:
               existingKey.adapter === LLMAdapter.VertexAI && existingKey.config
                 ? ((existingKey.config as VertexAIConfig).location ?? "")
@@ -618,8 +620,8 @@ export function CreateLLMApiKeyForm({
                         {...form.register(`extraHeaders.${index}.value`)}
                         placeholder={
                           mode === "update" &&
-                          existingKey?.extraHeaderKeys &&
-                          existingKey.extraHeaderKeys[index]
+                          existingKey?.extraHeaders &&
+                          Object.keys(existingKey.extraHeaders)[index]
                             ? "***"
                             : "Header value"
                         }

--- a/web/src/features/public-api/components/LLMApiKeyList.tsx
+++ b/web/src/features/public-api/components/LLMApiKeyList.tsx
@@ -115,12 +115,7 @@ export function LlmApiKeyList(props: { projectId: string }) {
                   <TableCell>
                     <div className="flex space-x-2">
                       <UpdateLLMApiKeyDialog
-                        apiKey={{
-                          ...apiKey,
-                          secretKey: apiKey.displaySecretKey,
-                          extraHeaders: apiKey.extraHeaderKeys.join(","),
-                          config: apiKey.config ?? null,
-                        }}
+                        apiKey={apiKey}
                         projectId={props.projectId}
                       />
                       <DeleteApiKeyButton

--- a/web/src/features/public-api/components/LLMApiKeyList.tsx
+++ b/web/src/features/public-api/components/LLMApiKeyList.tsx
@@ -72,9 +72,6 @@ export function LlmApiKeyList(props: { projectId: string }) {
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead className="hidden text-primary md:table-cell">
-                Created
-              </TableHead>
               <TableHead className="text-primary md:table-cell">
                 Provider
               </TableHead>
@@ -104,9 +101,6 @@ export function LlmApiKeyList(props: { projectId: string }) {
                   key={apiKey.id}
                   className="hover:bg-primary-foreground"
                 >
-                  <TableCell className="hidden md:table-cell">
-                    {apiKey.createdAt.toLocaleDateString()}
-                  </TableCell>
                   <TableCell className="font-mono">{apiKey.provider}</TableCell>
                   <TableCell className="font-mono">{apiKey.adapter}</TableCell>
                   <TableCell className="max-w-md overflow-auto font-mono">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Decrypt and display API keys and header values in LLM Connection settings, updating forms and tables accordingly.
> 
>   - **Behavior**:
>     - Decrypts `secretKey` and `extraHeaders` in `llmApiKeyRouter` in `router.ts` for display.
>     - Updates `CreateLLMApiKeyForm.tsx` to show decrypted `secretKey` and `extraHeaders` in forms.
>     - Modifies `LLMApiKeyList.tsx` to display `extraHeaderKeys` if present.
>   - **Schema**:
>     - Extends `LLMApiKeySchema` in `router.ts` to include `extraHeaders` as an object.
>   - **UI**:
>     - Adds `data-1p-ignore="true"` to `Input` fields in `CreateLLMApiKeyForm.tsx` to prevent autofill.
>     - Removes "Created" column from `LLMApiKeyList.tsx` table.
>   - **Misc**:
>     - Fixes placeholder and description text in `CreateLLMApiKeyForm.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 14494416872ace038118e89ebe318dd091e66e35. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->