### PR TITLE
feat: use lazy materialization traces table

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -82,12 +82,12 @@ jobs:
           else
             BASE_SHA=$(git merge-base origin/main HEAD)
           fi
-          
+
           echo "Checking files changed from $BASE_SHA to HEAD"
-          
+
           # Get changed files
           CHANGED_FILES=$(git diff --name-only $BASE_SHA HEAD -- '*.js' '*.jsx' '*.ts' '*.tsx' '*.css' | tr '\n' ' ')
-          
+
           if [ -n "$CHANGED_FILES" ] && [ "$CHANGED_FILES" != " " ]; then
             echo "Files to check: $CHANGED_FILES"
             pnpm prettier --check --experimental-cli $CHANGED_FILES

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: docker.io/clickhouse/clickhouse-server:24.3
+    image: docker.io/clickhouse/clickhouse-server
     user: "101:101"
     environment:
       CLICKHOUSE_DB: default

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -181,6 +181,11 @@ const EnvSchema = z.object({
   SLACK_CLIENT_ID: z.string().optional(),
   SLACK_CLIENT_SECRET: z.string().optional(),
   SLACK_STATE_SECRET: z.string().optional(),
+
+  LANGFUSE_CLICKHOUSE_USE_LAZY_MATERIALIZATION: z
+    .enum(["true", "false"])
+    .default("true"),
+  LANGFUSE_DEFAULT_IO_TRUNCATION_LENGTH: z.coerce.number().default(10000), //~0.0095 MB
 });
 
 export const env: z.infer<typeof EnvSchema> =

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -184,7 +184,7 @@ const EnvSchema = z.object({
 
   LANGFUSE_CLICKHOUSE_USE_LAZY_MATERIALIZATION: z
     .enum(["true", "false"])
-    .default("true"),
+    .default("false"),
   LANGFUSE_DEFAULT_IO_TRUNCATION_LENGTH: z.coerce.number().default(10000), //~0.0095 MB
 });
 

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -616,8 +616,8 @@ const getObservationsTableInternal = async <T>(
     opts.select === "count"
       ? select
       : selectFullIOAndMetadata
-        ? `${select}, input, output, metadata`
-        : `${select}, left(input, ${env.LANGFUSE_DEFAULT_IO_TRUNCATION_LENGTH}) as "input", left(output, ${env.LANGFUSE_DEFAULT_IO_TRUNCATION_LENGTH}) as "output", metadata`;
+        ? `${select}, o.input, o.output, o.metadata`
+        : `${select}, left(o.input, ${env.LANGFUSE_DEFAULT_IO_TRUNCATION_LENGTH}) as "input", left(o.output, ${env.LANGFUSE_DEFAULT_IO_TRUNCATION_LENGTH}) as "output", o.metadata`;
 
   const timeFilter = filter.find(
     (f) =>

--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -401,7 +401,7 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
             t.public as public,
             left(t.input, ${env.LANGFUSE_DEFAULT_IO_TRUNCATION_LENGTH}) as "input",
             left(t.output, ${env.LANGFUSE_DEFAULT_IO_TRUNCATION_LENGTH}) as "output",
-            o.metadata as metadata`;
+            t.metadata as metadata`;
           break;
         case "identifiers":
           sqlSelect = `
@@ -538,7 +538,7 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
             finalizeAggregation(t.public) as public,
             left(t.input, ${env.LANGFUSE_DEFAULT_IO_TRUNCATION_LENGTH}) as "input",
             left(t.output, ${env.LANGFUSE_DEFAULT_IO_TRUNCATION_LENGTH}) as "output",
-            o.metadata as metadata`;
+            t.metadata as metadata`;
           break;
         case "identifiers":
           sqlSelect = `

--- a/web/src/__tests__/async/observations-trpc.servertest.ts
+++ b/web/src/__tests__/async/observations-trpc.servertest.ts
@@ -53,7 +53,7 @@ describe("traces trpc", () => {
     environment: {} as any,
   };
 
-  const ctx = createInnerTRPCContext({ session });
+  const ctx = createInnerTRPCContext({ session, headers: {} });
   const caller = appRouter.createCaller({ ...ctx, prisma });
 
   describe("generations.all", () => {

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -351,15 +351,11 @@ export default function ObservationsTable({
       id: "input",
       size: 300,
       cell: ({ row }) => {
-        const observationId: string = row.getValue("id");
-        const traceId: string = row.getValue("traceId");
+        const input = row.getValue("input");
         return (
-          <GenerationsDynamicCell
-            observationId={observationId}
-            traceId={traceId}
-            projectId={projectId}
-            startTime={row.getValue("startTime")}
-            col="input"
+          <MemoizedIOTableCell
+            isLoading={false}
+            data={input}
             singleLine={rowHeight === "s"}
           />
         );
@@ -372,15 +368,12 @@ export default function ObservationsTable({
       header: "Output",
       size: 300,
       cell: ({ row }) => {
-        const observationId: string = row.getValue("id");
-        const traceId: string = row.getValue("traceId");
+        const output = row.getValue("output");
         return (
-          <GenerationsDynamicCell
-            observationId={observationId}
-            traceId={traceId}
-            projectId={projectId}
-            startTime={row.getValue("startTime")}
-            col="output"
+          <MemoizedIOTableCell
+            isLoading={false}
+            data={output}
+            className={cn("bg-accent-light-green")}
             singleLine={rowHeight === "s"}
           />
         );
@@ -619,15 +612,11 @@ export default function ObservationsTable({
         href: "https://langfuse.com/docs/tracing-features/metadata",
       },
       cell: ({ row }) => {
-        const observationId: string = row.getValue("id");
-        const traceId: string = row.getValue("traceId");
+        const metadata = row.getValue("metadata");
         return (
-          <GenerationsDynamicCell
-            observationId={observationId}
-            traceId={traceId}
-            projectId={projectId}
-            startTime={row.getValue("startTime")}
-            col="metadata"
+          <MemoizedIOTableCell
+            isLoading={false}
+            data={metadata}
             singleLine={rowHeight === "s"}
           />
         );
@@ -940,6 +929,9 @@ export default function ObservationsTable({
             usageDetails: generation.usageDetails ?? {},
             costDetails: generation.costDetails ?? {},
             environment: generation.environment ?? undefined,
+            input: generation.input ?? undefined,
+            output: generation.output ?? undefined,
+            metadata: generation.metadata ?? undefined,
           };
         })
       : [];
@@ -1029,49 +1021,3 @@ export default function ObservationsTable({
     </>
   );
 }
-
-const GenerationsDynamicCell = ({
-  traceId,
-  observationId,
-  projectId,
-  startTime,
-  col,
-  singleLine = false,
-}: {
-  traceId: string;
-  observationId: string;
-  projectId: string;
-  startTime?: Date;
-  col: "input" | "output" | "metadata";
-  singleLine: boolean;
-}) => {
-  const observation = api.observations.byId.useQuery(
-    {
-      observationId,
-      traceId,
-      projectId,
-      startTime,
-    },
-    {
-      enabled: typeof traceId === "string" && typeof observationId === "string",
-      refetchOnMount: false, // prevents refetching loops
-      staleTime: 60 * 1000, // 1 minute
-    },
-  );
-
-  const data =
-    col === "output"
-      ? observation.data?.output
-      : col === "input"
-        ? observation.data?.input
-        : observation.data?.metadata;
-
-  return (
-    <MemoizedIOTableCell
-      isLoading={observation.isLoading}
-      data={data}
-      className={cn(col === "output" && "bg-accent-light-green")}
-      singleLine={singleLine}
-    />
-  );
-};

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -513,15 +513,11 @@ export default function TracesTable({
       id: "input",
       size: 400,
       cell: ({ row }) => {
-        const traceId: TracesTableRow["id"] = row.getValue("id");
-        const traceTimestamp: TracesTableRow["timestamp"] =
-          row.getValue("timestamp");
+        const input: TracesTableRow["input"] = row.getValue("input");
         return (
-          <TracesDynamicCell
-            traceId={traceId}
-            projectId={projectId}
-            timestamp={new Date(traceTimestamp)}
-            col="input"
+          <MemoizedIOTableCell
+            isLoading={false}
+            data={input}
             singleLine={rowHeight === "s"}
           />
         );
@@ -534,15 +530,12 @@ export default function TracesTable({
       id: "output",
       size: 400,
       cell: ({ row }) => {
-        const traceId: TracesTableRow["id"] = row.getValue("id");
-        const traceTimestamp: TracesTableRow["timestamp"] =
-          row.getValue("timestamp");
+        const output: TracesTableRow["output"] = row.getValue("output");
         return (
-          <TracesDynamicCell
-            traceId={traceId}
-            projectId={projectId}
-            timestamp={new Date(traceTimestamp)}
-            col="output"
+          <MemoizedIOTableCell
+            isLoading={false}
+            data={output}
+            className="bg-accent-light-green"
             singleLine={rowHeight === "s"}
           />
         );
@@ -697,15 +690,11 @@ export default function TracesTable({
         href: "https://langfuse.com/docs/tracing-features/metadata",
       },
       cell: ({ row }) => {
-        const traceId: TracesTableRow["id"] = row.getValue("id");
-        const traceTimestamp: TracesTableRow["timestamp"] =
-          row.getValue("timestamp");
+        const metadata: TracesTableRow["metadata"] = row.getValue("metadata");
         return (
-          <TracesDynamicCell
-            traceId={traceId}
-            projectId={projectId}
-            timestamp={new Date(traceTimestamp)}
-            col="metadata"
+          <MemoizedIOTableCell
+            isLoading={false}
+            data={metadata}
             singleLine={rowHeight === "s"}
           />
         );
@@ -1097,6 +1086,9 @@ export default function TracesTable({
               outputCost: trace.calculatedOutputCost ?? undefined,
             },
             totalCost: trace.calculatedTotalCost ?? undefined,
+            input: trace.input ?? undefined,
+            output: trace.output ?? undefined,
+            metadata: trace.metadata ?? undefined,
           };
         }) ?? [])
       : [];
@@ -1214,41 +1206,3 @@ export default function TracesTable({
     </>
   );
 }
-
-const TracesDynamicCell = ({
-  traceId,
-  projectId,
-  timestamp,
-  col,
-  singleLine = false,
-}: {
-  traceId: string;
-  projectId: string;
-  timestamp: Date;
-  col: "input" | "output" | "metadata";
-  singleLine?: boolean;
-}) => {
-  const trace = api.traces.byId.useQuery(
-    { traceId, projectId, timestamp },
-    {
-      refetchOnMount: false, // prevents refetching loops
-      staleTime: 60 * 1000, // 1 minute
-    },
-  );
-
-  const data =
-    col === "output"
-      ? trace.data?.output
-      : col === "input"
-        ? trace.data?.input
-        : trace.data?.metadata;
-
-  return (
-    <MemoizedIOTableCell
-      isLoading={trace.isLoading}
-      data={data}
-      className={cn(col === "output" && "bg-accent-light-green")}
-      singleLine={singleLine}
-    />
-  );
-};

--- a/web/src/server/api/routers/generations/db/getAllGenerationsSqlQuery.ts
+++ b/web/src/server/api/routers/generations/db/getAllGenerationsSqlQuery.ts
@@ -9,10 +9,8 @@ import {
 
 export async function getAllGenerations({
   input,
-  selectIOAndMetadata,
 }: {
   input: GetAllGenerationsInput;
-  selectIOAndMetadata: boolean;
 }) {
   const generations = await getObservationsTableWithModelData({
     projectId: input.projectId,
@@ -20,7 +18,7 @@ export async function getAllGenerations({
     orderBy: input.orderBy,
     searchQuery: input.searchQuery ?? undefined,
     searchType: input.searchType,
-    selectIOAndMetadata: selectIOAndMetadata,
+    selectFullIOAndMetadata: false,
     offset: input.page * input.limit,
     limit: input.limit,
   });

--- a/web/src/server/api/routers/generations/getAllQueries.ts
+++ b/web/src/server/api/routers/generations/getAllQueries.ts
@@ -17,7 +17,6 @@ export const getAllQueries = {
     .query(async ({ input }) => {
       const { generations } = await getAllGenerations({
         input,
-        selectIOAndMetadata: false,
       });
       return { generations };
     }),

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -249,7 +249,7 @@ export const getDatabaseReadStream = async ({
             searchQuery,
             searchType: searchType ?? ["id" as const],
             orderBy,
-            selectIOAndMetadata: true,
+            selectFullIOAndMetadata: true,
             clickhouseConfigs,
           });
           const scores = await getScoresForObservations({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhances ClickHouse query efficiency with lazy materialization and input/output truncation, refactors cell components, and updates environment configurations.
> 
>   - **Behavior**:
>     - Introduces lazy materialization for ClickHouse queries in `observations.ts` and `traces-ui-table-service.ts` controlled by `LANGFUSE_CLICKHOUSE_USE_LAZY_MATERIALIZATION`.
>     - Truncates `input` and `output` fields in `observations.ts` and `traces-ui-table-service.ts` using `LANGFUSE_DEFAULT_IO_TRUNCATION_LENGTH`.
>   - **Environment**:
>     - Adds `LANGFUSE_CLICKHOUSE_USE_LAZY_MATERIALIZATION` and `LANGFUSE_DEFAULT_IO_TRUNCATION_LENGTH` to `env.ts`.
>   - **Refactoring**:
>     - Renames `selectIOAndMetadata` to `selectFullIOAndMetadata` in `observations.ts` and `getAllGenerationsSqlQuery.ts`.
>     - Replaces `GenerationsDynamicCell` and `TracesDynamicCell` with `MemoizedIOTableCell` in `observations.tsx` and `traces.tsx`.
>   - **Testing**:
>     - Updates `observations-trpc.servertest.ts` to include headers in `createInnerTRPCContext`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0edfb61621df676ac790af1001aa3847f73eb28d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->