### PR TITLE
chore: limit batch sizes of trace deletions

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -257,6 +257,7 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(2),
+  LANGFUSE_DELETE_BATCH_SIZE: z.coerce.number().default(2000),
 });
 
 export const env: z.infer<typeof EnvSchema> =

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -257,7 +257,7 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(2),
-  LANGFUSE_DELETE_BATCH_SIZE: z.coerce.number().default(2000),
+  LANGFUSE_DELETE_BATCH_SIZE: z.coerce.number().positive().default(2000),
 });
 
 export const env: z.infer<typeof EnvSchema> =


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Limits trace deletion batch size to 2000, configurable via `LANGFUSE_DELETE_BATCH_SIZE`, in `traceDelete.ts` and `env.ts`.
> 
>   - **Behavior**:
>     - Limits trace deletion batch size using `LANGFUSE_DELETE_BATCH_SIZE` in `traceDelete.ts`.
>     - Default batch size set to 2000 in `env.ts`.
>   - **Environment**:
>     - Adds `LANGFUSE_DELETE_BATCH_SIZE` to `EnvSchema` in `env.ts` with a default of 2000.
>   - **Trace Deletion**:
>     - Modifies `traceDeleteProcessor` in `traceDelete.ts` to use batch size limit for deletions.
>     - Updates span attributes to reflect batch size in `traceDelete.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for eaca583692673d223fce343dafee881df3ebb1a1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->