### PR TITLE
chore: only show 10 traces for evals

### DIFF
--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -134,6 +134,7 @@ export type TracesTableProps = {
   hideControls?: boolean;
   externalFilterState?: FilterState;
   externalDateRange?: TableDateRange;
+  limitRows?: number;
 };
 
 export default function TracesTable({
@@ -143,6 +144,7 @@ export default function TracesTable({
   hideControls = false,
   externalFilterState,
   externalDateRange,
+  limitRows,
 }: TracesTableProps) {
   const utils = api.useUtils();
   const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
@@ -246,8 +248,8 @@ export default function TracesTable({
     ...tracesAllCountFilter,
     searchQuery: searchQuery,
     searchType: searchType,
-    page: paginationState.pageIndex,
-    limit: paginationState.pageSize,
+    page: limitRows ? 0 : paginationState.pageIndex,
+    limit: limitRows ?? paginationState.pageSize,
     orderBy: orderByState,
   };
 
@@ -1193,11 +1195,15 @@ export default function TracesTable({
                   data: rows,
                 }
         }
-        pagination={{
-          totalCount,
-          onChange: setPaginationState,
-          state: paginationState,
-        }}
+        pagination={
+          limitRows
+            ? undefined
+            : {
+                totalCount,
+                onChange: setPaginationState,
+                state: paginationState,
+              }
+        }
         setOrderBy={setOrderByState}
         orderBy={orderByState}
         rowSelection={selectedRows}

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -116,6 +116,7 @@ const TracesPreview = ({
             hideControls
             externalFilterState={filterState}
             externalDateRange={dateRange}
+            limitRows={10}
           />
         </Suspense>
       </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Limit `TracesTable` to display only 10 rows in `TracesPreview` by adding a `limitRows` prop and adjusting pagination logic.
> 
>   - **Behavior**:
>     - Add `limitRows` prop to `TracesTable` in `traces.tsx` to limit the number of displayed rows.
>     - Set `limitRows` to 10 in `TracesPreview` in `inner-evaluator-form.tsx` to show only 10 traces.
>   - **Pagination**:
>     - Modify pagination logic in `traces.tsx` to disable pagination when `limitRows` is set.
>     - Adjust `page` and `limit` parameters in `tracesAllQueryFilter` based on `limitRows`.
>   - **UI**:
>     - Hide pagination controls in `DataTable` when `limitRows` is set in `traces.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2075e9ae65bdd56b8bf8a80ce7ca3fe54c1b771f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->