### PR TITLE
feat(peek-evaluator-config): add edit mode functionality

### DIFF
--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -14,6 +14,12 @@ import { LangfuseIcon } from "@/src/components/LangfuseLogo";
 import { UserCircle2Icon } from "lucide-react";
 import { StatusBadge } from "@/src/components/layouts/status-badge";
 import { DeactivateEvalConfig } from "@/src/features/evals/components/deactivate-config";
+import { Switch } from "@/src/components/ui/switch";
+import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { useState } from "react";
+import { cn } from "@/src/utils/tailwind";
+import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
+import { api } from "@/src/utils/api";
 
 export const PeekViewEvaluatorConfigDetail = ({
   projectId,
@@ -23,11 +29,15 @@ export const PeekViewEvaluatorConfigDetail = ({
   row?: EvaluatorDataRow;
 }) => {
   const { peekId } = usePeekState();
+  const [isEditMode, setIsEditMode] = useState(false);
+  const utils = api.useUtils();
 
   const { data: evalConfig } = usePeekEvalConfigData({
     jobConfigurationId: peekId,
     projectId,
   });
+
+  const hasAccess = useHasProjectAccess({ projectId, scope: "evalJob:CUD" });
 
   if (!evalConfig) {
     return <Skeleton className="h-full w-full" />;
@@ -36,8 +46,8 @@ export const PeekViewEvaluatorConfigDetail = ({
   return (
     <div className="grid h-full flex-1 grid-rows-[auto,auto,1fr] gap-2 overflow-hidden p-3 contain-layout">
       <div className="flex items-center justify-between">
-        <span className="max-h-fit text-lg font-medium">Configuration</span>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-row items-center gap-2">
+          <span className="max-h-fit text-lg font-medium">Configuration</span>
           <div className="flex items-center gap-2">
             <StatusBadge
               type={evalConfig.status.toLowerCase()}
@@ -49,7 +59,22 @@ export const PeekViewEvaluatorConfigDetail = ({
               evalConfig={evalConfig}
             />
           </div>
-          <span className="text-sm text-muted-foreground">View Only</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span
+            className={cn("text-sm", isEditMode ? "" : "text-muted-foreground")}
+          >
+            Edit Mode
+          </span>
+          <Switch
+            disabled={
+              !hasAccess ||
+              (evalConfig?.timeScope?.length === 1 &&
+                evalConfig.timeScope[0] === "EXISTING")
+            }
+            checked={isEditMode}
+            onCheckedChange={setIsEditMode}
+          />
         </div>
       </div>
       <CardDescription className="flex items-center text-sm">
@@ -76,7 +101,7 @@ export const PeekViewEvaluatorConfigDetail = ({
       </CardDescription>
       <div className="flex max-h-full w-full flex-col items-start justify-between space-y-2 overflow-y-auto pb-4">
         <EvaluatorForm
-          key={evalConfig?.id}
+          key={`${evalConfig?.id}-${evalConfig?.updatedAt}-${isEditMode}`}
           projectId={projectId}
           evalTemplates={
             evalConfig?.evalTemplate ? [evalConfig.evalTemplate] : []
@@ -89,9 +114,18 @@ export const PeekViewEvaluatorConfigDetail = ({
                 }
               : undefined
           }
-          disabled={true}
+          mode="edit"
+          disabled={!isEditMode}
           shouldWrapVariables={true}
           useDialog={false}
+          onFormSuccess={() => {
+            setIsEditMode(false);
+            utils.evals.invalidate();
+            showSuccessToast({
+              title: "Running Evaluator updated",
+              description: "The evaluator configuration has been updated.",
+            });
+          }}
         />
       </div>
     </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds edit mode to `PeekViewEvaluatorConfigDetail`, allowing users with access to modify evaluator configurations.
> 
>   - **Edit Mode Functionality**:
>     - Adds `isEditMode` state to `PeekViewEvaluatorConfigDetail` to toggle edit mode.
>     - Introduces `Switch` component to enable/disable edit mode based on `hasAccess` and `evalConfig.timeScope` conditions.
>   - **EvaluatorForm Updates**:
>     - Changes `EvaluatorForm` key to include `isEditMode` state.
>     - Sets `EvaluatorForm` `mode` to "edit" and `disabled` to `!isEditMode`.
>     - Adds `onFormSuccess` callback to reset edit mode, invalidate cache, and show success toast.
>   - **Access Control**:
>     - Uses `useHasProjectAccess` to determine edit mode availability based on `projectId` and `scope`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2c6d64f7a4196923a1a63cedca2c8613c548e2fe. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->