### PR TITLE
chore: record AMT duration distribution

### DIFF
--- a/packages/shared/src/server/clickhouse/measureAndReturn.ts
+++ b/packages/shared/src/server/clickhouse/measureAndReturn.ts
@@ -1,4 +1,4 @@
-import { instrumentAsync } from "../instrumentation";
+import { instrumentAsync, recordDistribution } from "../instrumentation";
 import * as opentelemetry from "@opentelemetry/api";
 import { env } from "../../env";
 import { logger } from "../logger";
@@ -68,6 +68,14 @@ export const measureAndReturn = async <T, Y>(args: {
         currentSpan?.setAttribute(
           "langfuse.experiment.amts.execution-time-difference",
           durationDifference,
+        );
+
+        recordDistribution(
+          "langfuse.experiment.amts.duration_difference_distribution",
+          durationDifference,
+          {
+            operation: args.operationName,
+          },
         );
 
         if (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `recordDistribution` in `measureAndReturn` to log execution duration differences.
> 
>   - **Functionality**:
>     - Adds `recordDistribution` call in `measureAndReturn` in `measureAndReturn.ts` to log duration differences between `existingExecution` and `newExecution`.
>     - Records distribution under `langfuse.experiment.amts.duration_difference_distribution` with `operationName` as a tag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 808f4cb13b9dc623768ffc65a26a956a8caa790e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->