### PR TITLE
chore: optimize queries for session AMT accesses

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -1052,10 +1052,11 @@ export const getTracesIdentifierForSession = async (
           start_time as timestamp,
           project_id,
           environment
-        FROM traces_all_amt FINAL
+        FROM traces_all_amt
         WHERE (project_id = {projectId: String})
         AND (session_id = {sessionId: String})
-        ORDER BY start_time ASC;
+        ORDER BY start_time ASC
+        LIMIT 1 BY id, project_id;
       `;
 
       return queryClickhouse<{

--- a/packages/shared/src/server/services/sessions-ui-table-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-service.ts
@@ -237,10 +237,11 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
   const query = `
         WITH deduplicated_traces AS (
           SELECT * EXCEPT input, output, metadata
-          FROM __TRACE_TABLE__ t FINAL
+          FROM __TRACE_TABLE__ t
           WHERE t.session_id IS NOT NULL 
             AND t.project_id = {projectId: String}
             ${singleTraceFilter?.query ? ` AND ${singleTraceFilter.query}` : ""}
+            LIMIT 1 BY id, project_id
         ),
         deduplicated_observations AS (
             SELECT * 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize session AMT queries by removing `FINAL` and using `LIMIT 1 BY id, project_id` for deduplication in `traces.ts` and `sessions-ui-table-service.ts`.
> 
>   - **Query Optimization**:
>     - Removed `FINAL` keyword and added `LIMIT 1 BY id, project_id` in `getTracesIdentifierForSession` in `traces.ts` and `getSessionsTableGeneric` in `sessions-ui-table-service.ts` to optimize deduplication.
>   - **Behavior**:
>     - Queries now deduplicate results using `LIMIT 1 BY id, project_id` instead of `FINAL`, improving performance.
>     - Affects session and trace retrieval queries, ensuring only unique entries are processed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c52a005b59fac80fc3f8195fd91600c07fe87ec0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->