### PR TITLE
fix(dataset-run-items): fix pagination for consistent ordering across sources

### DIFF
--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -22,7 +22,7 @@ type DatasetRunItemsTableQuery = {
   projectId: string;
   datasetId: string;
   filter: FilterState;
-  orderBy?: OrderByState;
+  orderBy?: OrderByState | OrderByState[];
   limit?: number;
   offset?: number;
 };
@@ -294,7 +294,11 @@ const getDatasetRunItemsTableInternal = async <T>(
 
   // Add user ordering if provided
   if (orderBy) {
-    orderByArray.push(orderBy);
+    if (Array.isArray(orderBy)) {
+      orderByArray.push(...orderBy);
+    } else {
+      orderByArray.push(orderBy);
+    }
   }
 
   // Add event_ts DESC for row queries (for deduplication)

--- a/packages/shared/src/tableDefinitions/mapDatasetRunItemsTable.ts
+++ b/packages/shared/src/tableDefinitions/mapDatasetRunItemsTable.ts
@@ -19,4 +19,10 @@ export const datasetRunItemsTableUiColumnDefinitions: UiColumnMappings = [
     clickhouseTableName: "dataset_run_items",
     clickhouseSelect: 'dri."event_ts"',
   },
+  {
+    uiTableName: "Dataset Item ID",
+    uiTableId: "datasetItemId",
+    clickhouseTableName: "dataset_run_items",
+    clickhouseSelect: 'dri."dataset_item_id"',
+  },
 ];

--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -490,7 +490,7 @@ export function DatasetRunsTable(props: {
       avgLatency: item.avgLatency ?? 0,
       avgTotalCost: item.avgTotalCost
         ? usdFormatter(item.avgTotalCost.toNumber())
-        : undefined,
+        : usdFormatter(0),
       runItemScores: item.scores
         ? verifyAndPrefixScoreDataAgainstKeys(
             scoreKeysAndProps,

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -1200,10 +1200,16 @@ export const datasetRouter = createTRPCRouter({
               projectId: queryInput.projectId,
               datasetId: finalDatasetId,
               filter,
-              orderBy: {
-                column: "createdAt",
-                order: "DESC",
-              },
+              // ensure consistent ordering with datasets.baseDatasetItemByDatasetId
+              // CH run items are created in reverse order as postgres execution path
+              // can be refactored once we switch to CH only implementation
+              orderBy: [
+                {
+                  column: "createdAt",
+                  order: "ASC",
+                },
+                { column: "datasetItemId", order: "DESC" },
+              ],
               limit: queryInput.limit,
               offset: queryInput.page * queryInput.limit,
             }),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix pagination and ordering for dataset run items to ensure consistent ordering across sources, with backend and UI adjustments.
> 
>   - **Ordering and Pagination**:
>     - Updated `orderBy` in `DatasetRunItemsTableQuery` in `dataset-run-items.ts` to accept an array for multiple ordering criteria.
>     - Modified `getDatasetRunItemsTableInternal()` in `dataset-run-items.ts` to handle array-based `orderBy` for consistent ordering.
>     - Adjusted `orderBy` in `dataset-router.ts` to ensure consistent ordering with `baseDatasetItemByDatasetId`.
>   - **UI Adjustments**:
>     - Added `datasetItemId` column to `datasetRunItemsTableUiColumnDefinitions` in `mapDatasetRunItemsTable.ts`.
>     - Updated `avgTotalCost` default formatting in `DatasetRunsTable.tsx` to use `usdFormatter(0)` when undefined.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 24f564c55faefa6cf5197577d898adcf9c3ff054. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->