### PR TITLE
chore: add operation_name tag to AMT query experiments

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -783,6 +783,7 @@ const getObservationsTableInternal = async <T>(
         type: "observation",
         projectId,
         kind: opts.select,
+        operation_name: "getObservationsTableInternal",
       },
     },
     existingExecution: async (input) => {

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -966,6 +966,7 @@ const getScoresUiGeneric = async <T>(props: {
         type: "score",
         projectId,
         select: props.select,
+        operation_name: "getScoresUiGeneric",
       },
     },
     existingExecution: async (input) => {

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -166,6 +166,7 @@ export const checkTraceExists = async ({
         type: "trace",
         kind: "exists",
         projectId,
+        operation_name: "checkTraceExists",
       },
       timestamp: timestamp ?? exactTimestamp,
     },
@@ -295,6 +296,7 @@ export const getTracesByIds = async (
         type: "trace",
         kind: "byId",
         projectId,
+        operation_name: "getTracesByIds",
       },
       clickhouseConfigs,
     },
@@ -376,6 +378,7 @@ export const getTracesBySessionId = async (
         type: "trace",
         kind: "list",
         projectId,
+        operation_name: "getTracesBySessionId",
       },
       timestamp,
     },
@@ -451,6 +454,7 @@ export const hasAnyTrace = async (projectId: string) => {
         type: "trace",
         kind: "hasAny",
         projectId,
+        operation_name: "hasAnyTrace",
       },
     },
     existingExecution: async (input) => {
@@ -511,6 +515,7 @@ export const getTraceCountsByProjectInCreationInterval = async ({
         feature: "tracing",
         type: "trace",
         kind: "analytic",
+        operation_name: "getTraceCountsByProjectInCreationInterval",
       },
       timestamp: start,
     },
@@ -585,6 +590,7 @@ export const getTraceCountOfProjectsSinceCreationDate = async ({
         feature: "tracing",
         type: "trace",
         kind: "analytic",
+        operation_name: "getTraceCountOfProjectsSinceCreationDate",
       },
       timestamp: start,
     },
@@ -663,6 +669,7 @@ export const getTraceById = async ({
         type: "trace",
         kind: "byId",
         projectId,
+        operation_name: "getTraceById",
       },
     },
     existingExecution: (input) => {
@@ -760,6 +767,7 @@ export const getTracesGroupedByName = async (
         type: "trace",
         kind: "analytic",
         projectId,
+        operation_name: "getTracesGroupedByName",
       },
     },
     existingExecution: async (input) => {
@@ -857,6 +865,7 @@ export const getTracesGroupedByUsers = async (
         type: "trace",
         kind: "analytic",
         projectId,
+        operation_name: "getTracesGroupedByUsers",
       },
     },
     existingExecution: async (input) => {
@@ -950,6 +959,7 @@ export const getTracesGroupedByTags = async (props: GroupedTracesQueryProp) => {
         type: "trace",
         kind: "analytic",
         projectId,
+        operation_name: "getTracesGroupedByTags",
       },
     },
     existingExecution: async (input) => {
@@ -1013,6 +1023,7 @@ export const getTracesIdentifierForSession = async (
         type: "trace",
         kind: "list",
         projectId,
+        operation_name: "getTracesIdentifierForSession",
       },
     },
     existingExecution: (input) => {
@@ -1166,6 +1177,7 @@ export const hasAnyUser = async (projectId: string) => {
         type: "user",
         kind: "hasAny",
         projectId,
+        operation_name: "hasAnyUser",
       },
     },
     existingExecution: async (input) => {
@@ -1240,6 +1252,7 @@ export const getTotalUserCount = async (
         type: "trace",
         kind: "analytic",
         projectId,
+        operation_name: "getTotalUserCount",
       },
     },
     existingExecution: async (input) => {
@@ -1396,6 +1409,7 @@ export const getUserMetrics = async (
         type: "trace",
         kind: "analytic",
         projectId,
+        operation_name: "getUserMetrics",
       },
     },
     existingExecution: async (input) => {
@@ -1621,6 +1635,7 @@ export const getTracesByIdsForAnyProject = async (traceIds: string[]) => {
         feature: "tracing",
         type: "trace",
         kind: "list",
+        operation_name: "getTracesByIdsForAnyProject",
       },
     },
     existingExecution: async (input) => {

--- a/packages/shared/src/server/services/sessions-ui-table-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-service.ts
@@ -399,6 +399,7 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
         feature: "tracing",
         type: "sessions-table",
         projectId,
+        operation_name: "getSessionsTableGeneric",
       },
     },
     existingExecution: async (input) => {

--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -480,6 +480,7 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
           type: "traces-table",
           projectId,
           experiment_amt: "original",
+          operation_name: "getTracesTableGeneric",
         },
         clickhouseConfigs,
       });
@@ -590,6 +591,7 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
           type: "traces-table",
           projectId,
           experiment_amt: "new",
+          operation_name: "getTracesTableGeneric",
         },
         clickhouseConfigs,
       });

--- a/web/src/features/public-api/server/observations.ts
+++ b/web/src/features/public-api/server/observations.ts
@@ -94,6 +94,7 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
         feature: "tracing",
         type: "observation",
         projectId: props.projectId,
+        operation_name: "generateObservationsForPublicApi",
       },
     },
     existingExecution: async (input) => {
@@ -138,6 +139,7 @@ export const getObservationsCountForPublicApi = async (props: QueryType) => {
         feature: "tracing",
         type: "observation",
         projectId: props.projectId,
+        operation_name: "getObservationsCountForPublicApi",
       },
     },
     existingExecution: async (input) => {

--- a/web/src/features/public-api/server/scores.ts
+++ b/web/src/features/public-api/server/scores.ts
@@ -120,6 +120,7 @@ export const _handleGenerateScoresForPublicApi = async ({
         type: "score",
         projectId: props.projectId,
         scoreScope,
+        operation_name: "_handleGenerateScoresForPublicApi",
       },
     },
     existingExecution: async (input) => {
@@ -237,6 +238,7 @@ export const _handleGetScoresCountForPublicApi = async ({
         type: "score",
         projectId: props.projectId,
         scoreScope,
+        operation_name: "_handleGetScoresCountForPublicApi",
       },
     },
     existingExecution: async (input) => {

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -136,6 +136,7 @@ export const generateTracesForPublicApi = async ({
         type: "trace",
         kind: "public-api",
         projectId: props.projectId,
+        operation_name: "getTracesForPublicApi",
       },
       fromTimestamp: timeFilter?.value ?? undefined,
     },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `operation_name` tag to various functions for enhanced observability and logging across observations, scores, traces, and sessions.
> 
>   - **Observations**:
>     - Add `operation_name` tag to `getObservationsTableInternal` in `observations.ts`.
>     - Add `operation_name` tag to `generateObservationsForPublicApi` and `getObservationsCountForPublicApi` in `observations.ts`.
>   - **Scores**:
>     - Add `operation_name` tag to `getScoresUiGeneric` in `scores.ts`.
>     - Add `operation_name` tag to `_handleGenerateScoresForPublicApi` and `_handleGetScoresCountForPublicApi` in `scores.ts`.
>   - **Traces**:
>     - Add `operation_name` tag to `checkTraceExists`, `getTracesByIds`, `getTracesBySessionId`, `hasAnyTrace`, `getTraceCountsByProjectInCreationInterval`, `getTraceCountOfProjectsSinceCreationDate`, `getTraceById`, `getTracesGroupedByName`, `getTracesGroupedByUsers`, `getTracesGroupedByTags`, `getTracesIdentifierForSession`, `getTracesByIdsForAnyProject`, `hasAnyUser`, `getTotalUserCount`, `getUserMetrics` in `traces.ts`.
>     - Add `operation_name` tag to `generateTracesForPublicApi` and `getTracesCountForPublicApi` in `traces.ts`.
>   - **Sessions**:
>     - Add `operation_name` tag to `getSessionsTableGeneric` in `sessions-ui-table-service.ts`.
>   - **Misc**:
>     - Add `operation_name` tag to `getTracesTableGeneric` in `traces-ui-table-service.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b2020a036b7bdb3c2544a3928f38269571783c72. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->