### PR TITLE
fix(pretty-json-view): prevent infinite recursion and optimize child row processing

### DIFF
--- a/web/src/components/table/utils/jsonExpansionUtils.ts
+++ b/web/src/components/table/utils/jsonExpansionUtils.ts
@@ -13,6 +13,10 @@ export function getRowChildren(row: JsonTableRow): JsonTableRow[] {
     return row.subRows;
   }
   if (row.rawChildData) {
+    // Prevent infinite recursion by limiting depth; 25 levels of nesting should make a reasonable assumption
+    if (row.level > 25) {
+      return [];
+    }
     return transformJsonToTableData(
       row.rawChildData,
       row.key,

--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -225,6 +225,7 @@ function findOptimalExpansionLevel(
     rows: JsonTableRow[],
     currentLevel: number,
     cumulativeCount: number,
+    visitedData = new WeakSet(),
   ): number {
     const rowsAtThisLevel = rows.length;
     const newCumulativeCount = cumulativeCount + rowsAtThisLevel;
@@ -240,8 +241,21 @@ function findOptimalExpansionLevel(
 
     // Get all children for next level
     const childRows: JsonTableRow[] = [];
+
     for (const row of rows) {
-      if (row.hasChildren) {
+      if (row.hasChildren && row.rawChildData) {
+        if (typeof row.rawChildData !== "object" || row.rawChildData === null) {
+          continue; // Skip non-objects
+        }
+
+        // Skip if we've already processed this exact data to prevent cycles
+        if (visitedData.has(row.rawChildData)) {
+          continue;
+        }
+
+        // Mark data as visited
+        visitedData.add(row.rawChildData);
+
         const children = getRowChildren(row);
         childRows.push(...children);
       }
@@ -255,6 +269,7 @@ function findOptimalExpansionLevel(
       childRows,
       currentLevel + 1,
       newCumulativeCount,
+      visitedData,
     );
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevents infinite recursion and optimizes child row processing in JSON views by limiting recursion depth and adding cycle detection.
> 
>   - **Behavior**:
>     - Prevents infinite recursion in `getRowChildren()` by limiting depth to 25 levels in `jsonExpansionUtils.ts`.
>     - Optimizes `findOptimalExpansionLevel()` in `PrettyJsonView.tsx` by adding cycle detection using `WeakSet` to track visited data.
>   - **Functions**:
>     - Updates `findOptimalExpansionLevel()` in `PrettyJsonView.tsx` to skip non-object `rawChildData` and prevent processing cycles.
>     - Modifies `getRowChildren()` in `jsonExpansionUtils.ts` to return an empty array if recursion depth exceeds 25.
>   - **Misc**:
>     - Adds `visitedData` parameter to `findOptimalExpansionLevel()` and its recursive calls in `PrettyJsonView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for dc7266f73cc570fc17bff2101be90b2bfb0d56fb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->