### PR TITLE
fix(pagination): allow limit zero again

### DIFF
--- a/packages/shared/src/utils/zod.ts
+++ b/packages/shared/src/utils/zod.ts
@@ -45,7 +45,7 @@ export const paginationZod = {
   ),
   limit: z.preprocess(
     (x) => (x === "" ? undefined : x),
-    z.coerce.number().positive().lte(100).default(50),
+    z.coerce.number().nonnegative().lte(100).default(50),
   ),
 };
 

--- a/web/src/__tests__/async/llm-connections-api.servertest.ts
+++ b/web/src/__tests__/async/llm-connections-api.servertest.ts
@@ -210,15 +210,6 @@ describe("/api/public/llm-connections API Endpoints", () => {
     });
 
     it("should return 400 for invalid query parameters", async () => {
-      // Test invalid limit (0)
-      const invalidLimitResponse = await makeAPICall(
-        "GET",
-        "/api/public/llm-connections?page=1&limit=0",
-        undefined,
-        auth,
-      );
-      expect(invalidLimitResponse.status).toBe(400);
-
       // Test negative page
       const negativePageResponse = await makeAPICall(
         "GET",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Allow `limit` to be zero in pagination by updating validation in `zod.ts` and removing related test case.
> 
>   - **Behavior**:
>     - Allow `limit` to be zero in `paginationZod` in `zod.ts` by changing validation from `positive` to `nonnegative`.
>   - **Tests**:
>     - Remove test case for `limit=0` returning 400 in `llm-connections-api.servertest.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ccd97eb8b13bd613e1c8e133577bc02521202d71. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->