### PR TITLE
fix(blob-storage): disable auto container check for Azure buckets for costsavings

### DIFF
--- a/.env.dev-azure.example
+++ b/.env.dev-azure.example
@@ -68,6 +68,7 @@ LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE=true
 LANGFUSE_S3_EVENT_UPLOAD_PREFIX=events/
 
 LANGFUSE_USE_AZURE_BLOB=true
+LANGFUSE_AZURE_SKIP_CONTAINER_CHECK=false
 
 # Set during docker build of application
 # Used to disable environment verification at build time

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -92,6 +92,9 @@ const EnvSchema = z.object({
   LANGFUSE_S3_MEDIA_UPLOAD_SSE: z.enum(["AES256", "aws:kms"]).optional(),
   LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID: z.string().optional(),
   LANGFUSE_USE_AZURE_BLOB: z.enum(["true", "false"]).default("false"),
+  LANGFUSE_AZURE_SKIP_CONTAINER_CHECK: z
+    .enum(["true", "false"])
+    .default("true"),
   LANGFUSE_USE_GOOGLE_CLOUD_STORAGE: z.enum(["true", "false"]).default("false"),
   LANGFUSE_GOOGLE_CLOUD_STORAGE_CREDENTIALS: z.string().optional(),
   STRIPE_SECRET_KEY: z.string().optional(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces `LANGFUSE_AZURE_SKIP_CONTAINER_CHECK` to skip Azure Blob Storage container checks by default for cost savings.
> 
>   - **Behavior**:
>     - Introduces `LANGFUSE_AZURE_SKIP_CONTAINER_CHECK` environment variable to control Azure Blob Storage container existence checks.
>     - Default behavior skips container checks for cost savings.
>   - **Code Changes**:
>     - Updates `createContainerIfNotExists()` in `AzureBlobStorageService` to respect `LANGFUSE_AZURE_SKIP_CONTAINER_CHECK`.
>     - Adds `LANGFUSE_AZURE_SKIP_CONTAINER_CHECK` to `EnvSchema` in `env.ts` with default `true`.
>   - **Configuration**:
>     - Adds `LANGFUSE_AZURE_SKIP_CONTAINER_CHECK=false` to `.env.dev-azure.example`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6ea4f77c1ab11de17de361f8335d6a262bad38e9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->