### PR TITLE
docs: improve api reference for llm-connections api

### DIFF
--- a/fern/apis/server/definition/llm-connections.yml
+++ b/fern/apis/server/definition/llm-connections.yml
@@ -22,7 +22,7 @@ service:
       response: PaginatedLlmConnections
     upsert:
       method: PUT
-      docs: Create or update an LLM connection (upsert)
+      docs: Create or update an LLM connection. The connection is upserted on provider.
       path: /llm-connections
       request: UpsertLlmConnectionRequest
       response: LlmConnection
@@ -34,7 +34,7 @@ types:
       id: string
       provider:
         type: string
-        docs: Provider name (e.g., 'openai', 'anthropic')
+        docs: Provider name (e.g., 'openai', 'my-gateway'). Must be unique in project, used for upserting.
       adapter:
         type: string
         docs: The adapter used to interface with the LLM
@@ -66,7 +66,7 @@ types:
     properties:
       provider:
         type: string
-        docs: Provider name (e.g., 'openai', 'anthropic'). Must be unique in project.
+        docs: Provider name (e.g., 'openai', 'my-gateway'). Must be unique in project, used for upserting.
       adapter:
         type: LlmAdapter
         docs: The adapter used to interface with the LLM

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -1477,7 +1477,9 @@ paths:
       security:
         - BasicAuth: []
     put:
-      description: Create or update an LLM connection (upsert)
+      description: >-
+        Create or update an LLM connection. The connection is upserted on
+        provider.
       operationId: llmConnections_upsert
       tags:
         - LlmConnections
@@ -6335,7 +6337,9 @@ components:
           type: string
         provider:
           type: string
-          description: Provider name (e.g., 'openai', 'anthropic')
+          description: >-
+            Provider name (e.g., 'openai', 'my-gateway'). Must be unique in
+            project, used for upserting.
         adapter:
           type: string
           description: The adapter used to interface with the LLM
@@ -6397,13 +6401,15 @@ components:
       properties:
         provider:
           type: string
-          description: Provider name (e.g., 'openai', 'anthropic')
+          description: >-
+            Provider name (e.g., 'openai', 'my-gateway'). Must be unique in
+            project, used for upserting.
         adapter:
           $ref: '#/components/schemas/LlmAdapter'
           description: The adapter used to interface with the LLM
         secretKey:
           type: string
-          description: Secret key for the LLM API
+          description: Secret key for the LLM API.
         baseURL:
           type: string
           nullable: true
@@ -6417,16 +6423,13 @@ components:
         withDefaultModels:
           type: boolean
           nullable: true
-          description: Whether to include default models
+          description: Whether to include default models. Default is true.
         extraHeaders:
           type: object
           additionalProperties:
             type: string
           nullable: true
           description: Extra headers to send with requests
-        config:
-          nullable: true
-          description: Additional configuration specific to the adapter
       required:
         - provider
         - adapter

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -1174,7 +1174,7 @@
           "_type": "endpoint",
           "name": "Upsert",
           "request": {
-            "description": "Create or update an LLM connection (upsert)",
+            "description": "Create or update an LLM connection. The connection is upserted on provider.",
             "url": {
               "raw": "{{baseUrl}}/api/public/llm-connections",
               "host": [
@@ -1193,7 +1193,7 @@
             "auth": null,
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"provider\": \"example\",\n    \"adapter\": \"anthropic\",\n    \"secretKey\": \"example\",\n    \"baseURL\": \"example\",\n    \"customModels\": [\n        \"example\"\n    ],\n    \"withDefaultModels\": true,\n    \"extraHeaders\": {\n        \"example\": \"example\"\n    },\n    \"config\": \"UNKNOWN\"\n}",
+              "raw": "{\n    \"provider\": \"example\",\n    \"adapter\": \"anthropic\",\n    \"secretKey\": \"example\",\n    \"baseURL\": \"example\",\n    \"customModels\": [\n        \"example\"\n    ],\n    \"withDefaultModels\": true,\n    \"extraHeaders\": {\n        \"example\": \"example\"\n    }\n}",
               "options": {
                 "raw": {
                   "language": "json"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improved documentation for LLM connections API, clarifying upsert behavior and provider field usage.
> 
>   - **Documentation Updates**:
>     - Updated `upsert` method description in `llm-connections.yml` and `openapi.yml` to clarify that the connection is upserted on provider.
>     - Enhanced `provider` field documentation in `llm-connections.yml` and `openapi.yml` to specify uniqueness and usage for upserting.
>     - Added default behavior description for `withDefaultModels` in `openapi.yml`.
>   - **Postman Collection**:
>     - Updated `Upsert` endpoint description in `collection.json` to match new documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for abea44b515944499e78e15c165b47f9bad74c7a4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->