### PR TITLE
perf: increase clickhouse timeouts for blob storage exports

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -193,6 +193,12 @@ const EnvSchema = z.object({
     .int()
     .positive()
     .default(1_000),
+
+  LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(600_000), // 10 minutes
 });
 
 export const env: z.infer<typeof EnvSchema> =

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1486,6 +1486,9 @@ export const getObservationsForBlobStorageExport = function (
       kind: "analytic",
       projectId,
     },
+    clickhouseConfigs: {
+      request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
+    },
   });
 
   return records;
@@ -1544,7 +1547,7 @@ export const getGenerationsForPostHog = async function* (
       projectId,
     },
     clickhouseConfigs: {
-      request_timeout: 300_000, // 5 minutes
+      request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
       clickhouse_settings: {
         join_algorithm: "grace_hash",
         grace_hash_join_initial_buckets: "32",

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1386,6 +1386,9 @@ export const getScoresForBlobStorageExport = function (
       kind: "analytic",
       projectId,
     },
+    clickhouseConfigs: {
+      request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
+    },
   });
 
   return records;
@@ -1437,7 +1440,7 @@ export const getScoresForPostHog = async function* (
       projectId,
     },
     clickhouseConfigs: {
-      request_timeout: 300_000, // 5 minutes
+      request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
       clickhouse_settings: {
         join_algorithm: "grace_hash",
         grace_hash_join_initial_buckets: "32",

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -1782,6 +1782,9 @@ export const getTracesForBlobStorageExport = function (
       kind: "analytic",
       projectId,
     },
+    clickhouseConfigs: {
+      request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
+    },
   });
 };
 
@@ -1838,7 +1841,7 @@ export const getTracesForPostHog = async function* (
       projectId,
     },
     clickhouseConfigs: {
-      request_timeout: 300_000, // 5 minutes
+      request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
       clickhouse_settings: {
         join_algorithm: "grace_hash",
         grace_hash_join_initial_buckets: "32",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase ClickHouse data export request timeout to 10 minutes for blob storage and PostHog exports, configurable via `LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS`.
> 
>   - **Behavior**:
>     - Increase ClickHouse data export request timeout to 10 minutes in `getObservationsForBlobStorageExport()`, `getGenerationsForPostHog()` in `observations.ts`, `getScoresForBlobStorageExport()`, `getScoresForPostHog()` in `scores.ts`, and `getTracesForBlobStorageExport()`, `getTracesForPostHog()` in `traces.ts`.
>     - Timeout is now configurable via `LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS` in `env.ts`.
>   - **Configuration**:
>     - Add `LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS` to `EnvSchema` in `env.ts` with a default of 600,000 ms (10 minutes).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 322f554feedbff45332c95fd070a943ff27c3de9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->