### PR TITLE
chore(evaluator-form): prevent form submission on Enter key press; hide controls in preview

### DIFF
--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -453,10 +453,10 @@ export default function TracesTable({
   const enableSorting = !hideControls;
 
   const columns: LangfuseColumnDef<TracesTableRow>[] = [
-    selectActionColumn,
     ...(hideControls
       ? []
       : [
+          selectActionColumn,
           {
             accessorKey: "bookmarked",
             header: undefined,
@@ -998,12 +998,12 @@ export default function TracesTable({
 
   const [columnVisibility, setColumnVisibility] =
     useColumnVisibility<TracesTableRow>(
-      `traceColumnVisibility-${projectId}${hideControls ? "-hideControls" : "-showControls"}`,
+      `traceColumnVisibility-${projectId}${hideControls ? "-hideControl" : "-showControls"}`,
       columns,
     );
 
   const [columnOrder, setColumnOrder] = useColumnOrder<TracesTableRow>(
-    `traceColumnOrder-${projectId}${hideControls ? "-hideControls" : "-showControls"}`,
+    `traceColumnOrder-${projectId}${hideControls ? "-hideControl" : "-showControls"}`,
     columns,
   );
 

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -1089,6 +1089,11 @@ export const InnerEvaluatorForm = (props: {
       <form
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         onSubmit={form.handleSubmit(onSubmit)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && e.target instanceof HTMLInputElement) {
+            e.preventDefault();
+          }
+        }}
         className="flex w-full flex-col gap-4"
       >
         {props.useDialog ? <DialogBody>{formBody}</DialogBody> : formBody}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Prevents form submission on Enter key press in `InnerEvaluatorForm` and adjusts column handling in `TracesTable`.
> 
>   - **Behavior**:
>     - Prevents form submission on Enter key press in `InnerEvaluatorForm` in `inner-evaluator-form.tsx` by adding an `onKeyDown` event handler.
>   - **Table Adjustments**:
>     - Moves `selectActionColumn` in `TracesTable` in `traces.tsx` to be conditionally included based on `hideControls`.
>     - Fixes typo in `traces.tsx` by changing `-hideControls` to `-hideControl` in `useColumnVisibility` and `useColumnOrder` keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6fc60273509f7d4aeb45201382d206df0e7c946e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->