### PR TITLE
feat(evaluator-form): add tooltips for evaluator usage and target in edit mode

### DIFF
--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -69,6 +69,12 @@ import {
 import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { DialogBody, DialogFooter } from "@/src/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/src/components/ui/tooltip";
+import { InfoIcon } from "lucide-react";
 
 // Lazy load TracesTable
 const TracesTable = lazy(
@@ -505,14 +511,34 @@ export const InnerEvaluatorForm = (props: {
                               : "dataset run items"}
                           </label>
                           {field.value.includes("EXISTING") &&
-                            props.mode !== "edit" &&
-                            !props.disabled && (
+                            !props.disabled &&
+                            (props.mode === "edit" ? (
+                              <Tooltip>
+                                <TooltipTrigger>
+                                  <InfoIcon className="size-3 text-muted-foreground" />
+                                </TooltipTrigger>
+                                <TooltipContent className="max-w-[300px] p-2">
+                                  <span className="leading-4">
+                                    You may only run this evaluator on existing{" "}
+                                    {form.watch("target") === "trace"
+                                      ? "traces"
+                                      : "dataset run items"}{" "}
+                                    once. Set up a new evaluator to re-run on
+                                    existing{" "}
+                                    {form.watch("target") === "trace"
+                                      ? "traces"
+                                      : "dataset run items"}
+                                    .
+                                  </span>
+                                </TooltipContent>
+                              </Tooltip>
+                            ) : (
                               <ExecutionCountTooltip
                                 projectId={props.projectId}
                                 item={form.watch("target")}
                                 filter={form.watch("filter")}
                               />
-                            )}
+                            ))}
                         </div>
                       </div>
                     </div>

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -562,8 +562,8 @@ export const InnerEvaluatorForm = (props: {
                         </TooltipTrigger>
                         <TooltipContent className="max-w-[200px] p-2">
                           <span className="leading-4">
-                            An evaluator's target data may only be configured at
-                            creation.
+                            An evaluator&apos;s target data may only be
+                            configured at creation.
                           </span>
                         </TooltipContent>
                       </Tooltip>

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -519,7 +519,7 @@ export const InnerEvaluatorForm = (props: {
                                 </TooltipTrigger>
                                 <TooltipContent className="max-w-[300px] p-2">
                                   <span className="leading-4">
-                                    You may only run this evaluator on existing{" "}
+                                    This evaluator has already run on existing{" "}
                                     {form.watch("target") === "trace"
                                       ? "traces"
                                       : "dataset run items"}{" "}
@@ -553,7 +553,22 @@ export const InnerEvaluatorForm = (props: {
               name="target"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Target data</FormLabel>
+                  <FormLabel>
+                    Target data{" "}
+                    {props.mode === "edit" && (
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <InfoIcon className="size-3 text-muted-foreground" />
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-[200px] p-2">
+                          <span className="leading-4">
+                            An evaluator's target data may only be configured at
+                            creation.
+                          </span>
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                  </FormLabel>
                   <FormControl>
                     <Tabs
                       defaultValue="trace"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add tooltips to `InnerEvaluatorForm` for evaluator usage and target data in edit mode to enhance user understanding.
> 
>   - **UI Enhancements**:
>     - Add `Tooltip` components to `InnerEvaluatorForm` in `inner-evaluator-form.tsx` for evaluator usage and target data in edit mode.
>     - Tooltips provide information on existing evaluator runs and target data configuration restrictions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fc6a0ab2aca75d311eb5ce83b515ff7fe16fbb54. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->