### PR TITLE
chore: adjust stalled settings for eval execution queue

### DIFF
--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -195,6 +195,13 @@ if (env.QUEUE_CONSUMER_EVAL_EXECUTION_QUEUE_IS_ENABLED === "true") {
     evalJobExecutorQueueProcessor,
     {
       concurrency: env.LANGFUSE_EVAL_EXECUTION_WORKER_CONCURRENCY,
+      // The default lockDuration is 30s and the lockRenewTime 1/2 of that.
+      // We set it to 60s to reduce the number of lock renewals and also be less sensitive to high CPU wait times.
+      // We also update the stalledInterval check to 120s from 30s default to perform the check less frequently.
+      // Finally, we set the maxStalledCount to 3 (default 1) to perform repeated attempts on stalled jobs.
+      lockDuration: 60000, // 60 seconds
+      stalledInterval: 120000, // 120 seconds
+      maxStalledCount: 3,
     },
   );
 }

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -100,6 +100,13 @@ export class WorkerManager {
       {
         connection: redisInstance,
         prefix: getQueuePrefix(queueName),
+        // The default lockDuration is 30s and the lockRenewTime 1/2 of that.
+        // We set it to 60s to reduce the number of lock renewals and also be less sensitive to high CPU wait times.
+        // We also update the stalledInterval check to 120s from 30s default to perform the check less frequently.
+        // Finally, we set the maxStalledCount to 3 perform repeated attempts on stalled jobs.
+        lockDuration: 60000, // 60 seconds
+        stalledInterval: 120000, // 120 seconds
+        maxStalledCount: 3,
         ...additionalOptions,
       },
     );

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -100,13 +100,6 @@ export class WorkerManager {
       {
         connection: redisInstance,
         prefix: getQueuePrefix(queueName),
-        // The default lockDuration is 30s and the lockRenewTime 1/2 of that.
-        // We set it to 60s to reduce the number of lock renewals and also be less sensitive to high CPU wait times.
-        // We also update the stalledInterval check to 120s from 30s default to perform the check less frequently.
-        // Finally, we set the maxStalledCount to 3 perform repeated attempts on stalled jobs.
-        lockDuration: 60000, // 60 seconds
-        stalledInterval: 120000, // 120 seconds
-        maxStalledCount: 3,
         ...additionalOptions,
       },
     );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjust `EvaluationExecution` queue settings in `worker/src/app.ts` to improve performance and reliability by increasing lock duration, stalled interval, and max stalled count.
> 
>   - **Queue Settings Adjustments**:
>     - In `worker/src/app.ts`, adjust `EvaluationExecution` queue settings:
>       - Increase `lockDuration` to 60 seconds.
>       - Increase `stalledInterval` to 120 seconds.
>       - Increase `maxStalledCount` to 3.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6e3f54c58432ed6f6354a27fd2bdf99171802971. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->