### PR TITLE
feat(otel): add parsing for Vercel AI SDK

### DIFF
--- a/web/src/components/trace/BreakdownToolTip.tsx
+++ b/web/src/components/trace/BreakdownToolTip.tsx
@@ -171,6 +171,12 @@ const OtherSection = ({ details, isCost, formatValue }: OtherSectionProps) => {
 
   if (otherEntries.length === 0) return null;
 
+  const otherTotal = otherEntries.reduce((acc, val) => {
+    if (typeof val[1] !== "number") return acc;
+
+    return acc + (val[1] ?? 0);
+  }, 0);
+
   return (
     <div className="flex flex-col gap-2">
       <div className="flex justify-between border-b pb-2">
@@ -178,7 +184,7 @@ const OtherSection = ({ details, isCost, formatValue }: OtherSectionProps) => {
           {isCost ? "Other cost" : "Other usage"}
         </span>
         <span className="text-right font-mono text-xs font-medium">
-          {formatValue(details.total ?? 0)}
+          {formatValue(otherTotal)}
         </span>
       </div>
       {otherEntries.map(([key, value]) => (

--- a/web/src/features/otel/server/OtelIngestionProcessor.ts
+++ b/web/src/features/otel/server/OtelIngestionProcessor.ts
@@ -1473,14 +1473,15 @@ export class OtelIngestionProcessor {
 
     // Vercel AI SDK
     try {
-      if ("ai.response.msToFirstChunk" in attributes && startTimeISO) {
-        const msToFirstChunk = Math.ceil(
-          Number(attributes["ai.response.msToFirstChunk"]),
-        );
+      const msToFirstChunk =
+        attributes["ai.response.msToFirstChunk"] ??
+        attributes["ai.stream.msToFirstChunk"];
+      if (msToFirstChunk && startTimeISO) {
+        const msToFirstChunkNumber = Math.ceil(Number(msToFirstChunk));
 
         const startTimeUnix = new Date(startTimeISO).getTime();
 
-        return new Date(startTimeUnix + msToFirstChunk).toISOString();
+        return new Date(startTimeUnix + msToFirstChunkNumber).toISOString();
       }
     } catch {}
 

--- a/web/src/features/otel/server/OtelIngestionProcessor.ts
+++ b/web/src/features/otel/server/OtelIngestionProcessor.ts
@@ -445,6 +445,8 @@ export class OtelIngestionProcessor {
       environment: this.extractEnvironment(attributes, resourceAttributes),
     };
 
+    const instrumentationScopeName = scopeSpan?.scope?.name as string;
+
     // Create full trace for root spans or spans with trace updates
     if (isRootSpan) {
       trace = {
@@ -477,7 +479,12 @@ export class OtelIngestionProcessor {
         public: this.isTracePublic(attributes),
         tags: this.extractTags(attributes),
         environment: this.extractEnvironment(attributes, resourceAttributes),
-        ...this.extractInputAndOutput(span?.events ?? [], attributes, "trace"),
+        ...this.extractInputAndOutput({
+          events: span?.events ?? [],
+          attributes,
+          domain: "trace",
+          instrumentationScopeName,
+        }),
       };
     }
 
@@ -562,6 +569,8 @@ export class OtelIngestionProcessor {
       endTimeISO,
     } = params;
 
+    const instrumentationScopeName = scopeSpan?.scope?.name;
+
     const observation = {
       id: this.parseId(span.spanId?.data ?? span.spanId),
       traceId,
@@ -570,7 +579,10 @@ export class OtelIngestionProcessor {
       startTime: startTimeISO,
       endTime: endTimeISO,
       environment: this.extractEnvironment(attributes, resourceAttributes),
-      completionStartTime: this.extractCompletionStartTime(attributes),
+      completionStartTime: this.extractCompletionStartTime(
+        attributes,
+        startTimeISO,
+      ),
       metadata: {
         ...resourceAttributeMetadata,
         ...spanAttributeMetadata,
@@ -591,25 +603,35 @@ export class OtelIngestionProcessor {
         attributes[LangfuseOtelSpanAttributes.VERSION] ??
         resourceAttributes?.["service.version"] ??
         null,
-      modelParameters: this.extractModelParameters(attributes) as any,
+      modelParameters: this.extractModelParameters(
+        attributes,
+        instrumentationScopeName,
+      ) as any,
       model: this.extractModelName(attributes),
       promptName:
         attributes?.[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME] ??
         attributes["langfuse.prompt.name"] ??
+        this.parseLangfusePromptFromAISDK(attributes)?.name ??
         null,
       promptVersion:
         attributes?.[LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION] ??
         attributes["langfuse.prompt.version"] ??
+        this.parseLangfusePromptFromAISDK(attributes)?.version ??
         null,
       usageDetails: this.extractUsageDetails(
         attributes,
         isLangfuseSDKSpans,
+        instrumentationScopeName,
       ) as any,
       costDetails: this.extractCostDetails(
         attributes,
         isLangfuseSDKSpans,
       ) as any,
-      ...this.extractInputAndOutput(span?.events ?? [], attributes),
+      ...this.extractInputAndOutput({
+        events: span?.events ?? [],
+        attributes,
+        instrumentationScopeName,
+      }),
     };
 
     const isGeneration =
@@ -665,12 +687,17 @@ export class OtelIngestionProcessor {
       LangfuseOtelSpanAttributes.TRACE_TAGS,
       LangfuseOtelSpanAttributes.TRACE_COMPAT_USER_ID,
       LangfuseOtelSpanAttributes.TRACE_COMPAT_SESSION_ID,
+      // OpenAI and Langchain integrations
       `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langfuse_user_id`,
       `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langfuse_session_id`,
       `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langfuse_tags`,
       `${LangfuseOtelSpanAttributes.TRACE_METADATA}.langfuse_session_id`,
       `${LangfuseOtelSpanAttributes.TRACE_METADATA}.langfuse_user_id`,
       `${LangfuseOtelSpanAttributes.TRACE_METADATA}.langfuse_tags`,
+      // Vercel AI SDK
+      `ai.telemetry.metadata.sessionId`,
+      `ai.telemetry.metadata.userId`,
+      `ai.telemetry.metadata.tags`,
     ].some((traceAttribute) => Boolean(attributes[traceAttribute]));
 
     const attributeKeys = Object.keys(attributes);
@@ -774,11 +801,14 @@ export class OtelIngestionProcessor {
     }
   }
 
-  private extractInputAndOutput(
-    events: any[],
-    attributes: Record<string, unknown>,
-    domain?: "trace" | "observation",
-  ): { input: any; output: any } {
+  private extractInputAndOutput(params: {
+    events: any[];
+    attributes: Record<string, unknown>;
+    instrumentationScopeName: string;
+    domain?: "trace" | "observation";
+  }): { input: any; output: any } {
+    const { instrumentationScopeName, events, attributes, domain } = params;
+
     let input = null;
     let output = null;
 
@@ -793,6 +823,37 @@ export class OtelIngestionProcessor {
         : attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT];
 
     if (input != null || output != null) {
+      return { input, output };
+    }
+
+    // Vercel AI SDK
+    if (instrumentationScopeName === "ai") {
+      input =
+        "ai.prompt.messages" in attributes
+          ? attributes["ai.prompt.messages"]
+          : "ai.prompt" in attributes
+            ? attributes["ai.prompt"]
+            : "ai.toolCall.args" in attributes
+              ? attributes["ai.toolCall.args"]
+              : undefined;
+
+      output =
+        "ai.response.text" in attributes
+          ? attributes["ai.response.text"]
+          : "ai.result.text" in attributes // Legacy support for ai SDK versions < 4.0.0
+            ? attributes["ai.result.text"]
+            : "ai.toolCall.result" in attributes
+              ? attributes["ai.toolCall.result"]
+              : "ai.response.object" in attributes
+                ? attributes["ai.response.object"]
+                : "ai.result.object" in attributes // Legacy support for ai SDK versions < 4.0.0
+                  ? attributes["ai.result.object"]
+                  : "ai.response.toolCalls" in attributes
+                    ? attributes["ai.response.toolCalls"]
+                    : "ai.result.toolCalls" in attributes // Legacy support for ai SDK versions < 4.0.0
+                      ? attributes["ai.result.toolCalls"]
+                      : undefined;
+
       return { input, output };
     }
 
@@ -874,8 +935,16 @@ export class OtelIngestionProcessor {
           return acc;
         }, {}) ?? {};
 
-      const { input: eventInput } = this.extractInputAndOutput([], input);
-      const { output: eventOutput } = this.extractInputAndOutput([], output);
+      const { input: eventInput } = this.extractInputAndOutput({
+        events: [],
+        attributes: input,
+        instrumentationScopeName,
+      });
+      const { output: eventOutput } = this.extractInputAndOutput({
+        events: [],
+        attributes: output,
+        instrumentationScopeName,
+      });
       return { input: eventInput || input, output: eventOutput || output };
     }
 
@@ -1008,6 +1077,18 @@ export class OtelIngestionProcessor {
       }
     }
 
+    // Vercel AI SDK
+    const functionIdAttribute = "ai.telemetry.functionId";
+    const operationIdAttribute = "ai.operationId";
+
+    if (operationIdAttribute in attributes) {
+      const prefix = attributes[functionIdAttribute]
+        ? attributes[functionIdAttribute] + ":"
+        : "";
+
+      return prefix + attributes[operationIdAttribute];
+    }
+
     return spanName;
   }
 
@@ -1015,7 +1096,7 @@ export class OtelIngestionProcessor {
     attributes: Record<string, unknown>,
     domain: "trace" | "observation",
   ): Record<string, unknown> {
-    let metadata: Record<string, unknown> = {};
+    let topLevelMetadata: Record<string, unknown> = {};
 
     const metadataKeyPrefix =
       domain === "observation"
@@ -1028,9 +1109,12 @@ export class OtelIngestionProcessor {
     if (langfuseMetadataAttribute) {
       try {
         if (typeof langfuseMetadataAttribute === "string") {
-          metadata = JSON.parse(langfuseMetadataAttribute as string);
+          topLevelMetadata = JSON.parse(langfuseMetadataAttribute as string);
         } else if (typeof langfuseMetadataAttribute === "object") {
-          metadata = langfuseMetadataAttribute as Record<string, unknown>;
+          topLevelMetadata = langfuseMetadataAttribute as Record<
+            string,
+            unknown
+          >;
         }
       } catch (e) {
         // Continue with nested metadata extraction
@@ -1040,16 +1124,33 @@ export class OtelIngestionProcessor {
     const langfuseMetadata: Record<string, unknown> = {};
 
     for (const [key, value] of Object.entries(attributes)) {
-      for (const prefix of [metadataKeyPrefix, "langfuse.metadata"]) {
-        if (key.startsWith(`${prefix}.`)) {
+      for (const prefix of [
+        metadataKeyPrefix,
+        "langfuse.metadata",
+        "ai.telemetry.metadata",
+      ]) {
+        if (
+          key.startsWith(`${prefix}.`) &&
+          // Filter out the Vercel AI SDK trace attribute keys
+          ![
+            "ai.telemetry.metadata.userId",
+            "ai.telemetry.metadata.sessionId",
+            "ai.telemetry.metadata.tags",
+            "ai.telemetry.metadata.langfusePrompt",
+          ].includes(key)
+        ) {
           const newKey = key.replace(`${prefix}.`, "");
           langfuseMetadata[newKey] = value;
         }
       }
     }
 
+    // Vercel AI SDK
+    const tools =
+      "ai.prompt.tools" in attributes ? attributes["ai.prompt.tools"] : [];
+
     return {
-      ...metadata,
+      ...topLevelMetadata,
       ...langfuseMetadata,
     };
   }
@@ -1062,6 +1163,7 @@ export class OtelIngestionProcessor {
       "user.id",
       `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langfuse_user_id`,
       `${LangfuseOtelSpanAttributes.TRACE_METADATA}.langfuse_user_id`,
+      `ai.telemetry.metadata.userId`,
     ];
 
     for (const key of userIdKeys) {
@@ -1082,6 +1184,7 @@ export class OtelIngestionProcessor {
       "gen_ai.conversation.id",
       `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langfuse_session_id`,
       `${LangfuseOtelSpanAttributes.TRACE_METADATA}.langfuse_session_id`,
+      `ai.telemetry.metadata.sessionId`,
     ];
 
     for (const key of userIdKeys) {
@@ -1095,6 +1198,7 @@ export class OtelIngestionProcessor {
 
   private extractModelParameters(
     attributes: Record<string, unknown>,
+    instrumentationScopeName: string,
   ): Record<string, unknown> {
     if (attributes[LangfuseOtelSpanAttributes.OBSERVATION_MODEL_PARAMETERS]) {
       try {
@@ -1106,6 +1210,48 @@ export class OtelIngestionProcessor {
           ),
         );
       } catch {}
+    }
+
+    // Vercel AI SDK
+    if (instrumentationScopeName === "ai") {
+      return {
+        maxSteps:
+          "ai.settings.maxSteps" in attributes
+            ? (attributes["ai.settings.maxSteps"]?.toString() ?? null)
+            : null,
+        toolChoice:
+          "ai.prompt.toolChoice" in attributes
+            ? (attributes["ai.prompt.toolChoice"]?.toString() ?? null)
+            : null,
+        maxTokens:
+          "gen_ai.request.max_tokens" in attributes
+            ? (attributes["gen_ai.request.max_tokens"]?.toString() ?? null)
+            : null,
+        finishReason:
+          "gen_ai.response.finish_reasons" in attributes
+            ? (attributes["gen_ai.response.finish_reasons"]?.toString() ?? null)
+            : "gen_ai.finishReason" in attributes //  Legacy support for ai SDK versions < 4.0.0
+              ? (attributes["gen_ai.finishReason"]?.toString() ?? null)
+              : null,
+        system:
+          "gen_ai.system" in attributes
+            ? (attributes["gen_ai.system"]?.toString() ?? null)
+            : "ai.model.provider" in attributes
+              ? (attributes["ai.model.provider"]?.toString() ?? null)
+              : null,
+        maxRetries:
+          "ai.settings.maxRetries" in attributes
+            ? (attributes["ai.settings.maxRetries"]?.toString() ?? null)
+            : null,
+        mode:
+          "ai.settings.mode" in attributes
+            ? (attributes["ai.settings.mode"]?.toString() ?? null)
+            : null,
+        temperature:
+          "gen_ai.request.temperature" in attributes
+            ? (attributes["gen_ai.request.temperature"]?.toString() ?? null)
+            : null,
+      };
     }
 
     if (attributes["llm.invocation_parameters"]) {
@@ -1180,6 +1326,7 @@ export class OtelIngestionProcessor {
   private extractUsageDetails(
     attributes: Record<string, unknown>,
     isLangfuseSDKSpan: boolean,
+    instrumentationScopeName: string,
   ): Record<string, unknown> {
     if (isLangfuseSDKSpan) {
       try {
@@ -1188,6 +1335,71 @@ export class OtelIngestionProcessor {
             LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS
           ] as string,
         );
+      } catch {}
+    }
+
+    if (instrumentationScopeName === "ai") {
+      try {
+        const usageDetails: Record<string, number | undefined> = {
+          input:
+            "gen_ai.usage.prompt_tokens" in attributes // Backward compat, input_tokens used in latest ai SDK versions
+              ? parseInt(
+                  attributes["gen_ai.usage.prompt_tokens"]?.toString() ?? "0",
+                )
+              : "gen_ai.usage.input_tokens" in attributes
+                ? parseInt(
+                    attributes["gen_ai.usage.input_tokens"]?.toString() ?? "0",
+                  )
+                : undefined,
+
+          output:
+            "gen_ai.usage.completion_tokens" in attributes // Backward compat, output_tokens used in latest ai SDK versions
+              ? parseInt(
+                  attributes["gen_ai.usage.completion_tokens"]?.toString() ??
+                    "0",
+                )
+              : "gen_ai.usage.output_tokens" in attributes
+                ? parseInt(
+                    attributes["gen_ai.usage.output_tokens"]?.toString() ?? "0",
+                  )
+                : undefined,
+          total:
+            "ai.usage.tokens" in attributes
+              ? parseInt(attributes["ai.usage.tokens"]?.toString() ?? "0")
+              : undefined,
+        };
+
+        const providerMetadata = attributes["ai.response.providerMetadata"];
+        if (providerMetadata) {
+          const parsed = JSON.parse(providerMetadata as string);
+
+          if ("openai" in parsed) {
+            const openaiMetadata = parsed["openai"] as Record<string, number>;
+
+            usageDetails["input_cached_tokens"] =
+              openaiMetadata["cachedPromptTokens"];
+            usageDetails["accepted_prediction_tokens"] =
+              openaiMetadata["acceptedPredictionTokens"];
+            usageDetails["rejected_prediction_tokens"] =
+              openaiMetadata["rejectedPredictionTokens"];
+            usageDetails["output_reasoning_tokens"] =
+              openaiMetadata["reasoningTokens"];
+          }
+          // "ai.response.providerMetadata": "{\"anthropic\":{\"cacheCreationInputTokens\":0,\"cacheReadInputTokens\":0}}"
+          if ("anthropic" in parsed) {
+            const openaiMetadata = parsed["anthropic"] as Record<
+              string,
+              number
+            >;
+
+            usageDetails["input_cache_creation"] =
+              openaiMetadata["cacheCreationInputTokens"];
+            usageDetails["input_cache_read"] =
+              openaiMetadata["cacheReadInputTokens"];
+          }
+        }
+
+        return usageDetails;
       } catch {}
     }
 
@@ -1241,13 +1453,29 @@ export class OtelIngestionProcessor {
     return {};
   }
 
-  private extractCompletionStartTime(attributes: Record<string, unknown>) {
+  private extractCompletionStartTime(
+    attributes: Record<string, unknown>,
+    startTimeISO?: string,
+  ): string | null {
     try {
       return JSON.parse(
         attributes[
           LangfuseOtelSpanAttributes.OBSERVATION_COMPLETION_START_TIME
         ] as string,
       );
+    } catch {}
+
+    // Vercel AI SDK
+    try {
+      if ("ai.response.msToFirstChunk" in attributes && startTimeISO) {
+        const msToFirstChunk = Math.ceil(
+          Number(attributes["ai.response.msToFirstChunk"]),
+        );
+
+        const startTimeUnix = new Date(startTimeISO).getTime();
+
+        return new Date(startTimeUnix + msToFirstChunk).toISOString();
+      }
     } catch {}
 
     return null;
@@ -1260,7 +1488,10 @@ export class OtelIngestionProcessor {
       attributes[
         `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langfuse_tags`
       ] ||
-      attributes[`${LangfuseOtelSpanAttributes.TRACE_METADATA}.langfuse_tags`];
+      attributes[
+        `${LangfuseOtelSpanAttributes.TRACE_METADATA}.langfuse_tags`
+      ] ||
+      attributes["ai.telemetry.metadata.tags"];
 
     if (tagsValue === undefined || tagsValue === null) {
       return [];
@@ -1292,6 +1523,19 @@ export class OtelIngestionProcessor {
     return [];
   }
 
+  private parseLangfusePromptFromAISDK(
+    attributes: Record<string, unknown>,
+  ): { name: string; version: number } | undefined {
+    const aiSDKPrompt = attributes["ai.telemetry.metadata.langfusePrompt"];
+
+    if (!aiSDKPrompt) return;
+
+    try {
+      const parsed = JSON.parse(aiSDKPrompt as string);
+
+      return typeof parsed === "object" ? parsed : undefined;
+    } catch {}
+  }
   /**
    * Get a set of trace IDs that have been seen recently (from Redis cache).
    * Returns a Set of trace IDs that should not trigger new trace creation.

--- a/web/src/features/otel/server/OtelIngestionProcessor.ts
+++ b/web/src/features/otel/server/OtelIngestionProcessor.ts
@@ -1147,7 +1147,13 @@ export class OtelIngestionProcessor {
 
     // Vercel AI SDK
     const tools =
-      "ai.prompt.tools" in attributes ? attributes["ai.prompt.tools"] : [];
+      "ai.prompt.tools" in attributes
+        ? attributes["ai.prompt.tools"]
+        : undefined;
+
+    if (tools) {
+      langfuseMetadata["tools"] = tools;
+    }
 
     return {
       ...topLevelMetadata,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds support for parsing Vercel AI SDK data in `OtelIngestionProcessor`, including handling new attributes and extracting relevant information.
> 
>   - **Behavior**:
>     - Adds parsing for Vercel AI SDK in `OtelIngestionProcessor.ts`.
>     - Updates `extractInputAndOutput()` to handle Vercel AI SDK attributes like `ai.prompt.messages` and `ai.response.text`.
>     - Modifies `extractModelParameters()` to include Vercel AI SDK specific parameters such as `ai.settings.maxSteps` and `ai.settings.maxRetries`.
>     - Updates `extractUsageDetails()` to parse Vercel AI SDK usage details including `ai.usage.tokens`.
>     - Enhances `extractCompletionStartTime()` to calculate completion start time using `ai.response.msToFirstChunk`.
>     - Adjusts `extractMetadata()` to include Vercel AI SDK metadata while filtering out specific keys.
>     - Updates `extractTags()` to include tags from `ai.telemetry.metadata.tags`.
>     - Adds `parseLangfusePromptFromAISDK()` to parse prompt name and version from `ai.telemetry.metadata.langfusePrompt`.
>   - **Misc**:
>     - Fixes total calculation in `BreakdownToolTip.tsx` by using `otherTotal` instead of `details.total`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ab17c262388ae548c87d316b29931b240b2a1d7e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->