### PR TITLE
Add prompt version deletion endpoint and documentation

### DIFF
--- a/fern/apis/server/definition/prompt-version.yml
+++ b/fern/apis/server/definition/prompt-version.yml
@@ -25,3 +25,16 @@ service:
               type: list<string>
               docs: New labels for the prompt version. Labels are unique across versions. The "latest" label is reserved and managed by Langfuse.
       response: prompts.Prompt
+    
+    delete:
+      docs: Delete a specific prompt version
+      method: DELETE
+      path: /prompts/{name}/versions/{version}
+      path-parameters:
+        name:
+          type: string
+          docs: The name of the prompt
+        version:
+          type: integer
+          docs: Version of the prompt to delete
+      response: prompts.Prompt

--- a/web/src/__tests__/async/prompts.v2.servertest.ts
+++ b/web/src/__tests__/async/prompts.v2.servertest.ts
@@ -3038,6 +3038,1146 @@ describe("PATCH api/public/v2/prompts/[promptName]/versions/[version]", () => {
   });
 });
 
+describe("DELETE api/public/v2/prompts/[promptName]/versions/[version]", () => {
+  afterAll(async () => {
+    await disconnectQueues();
+  });
+
+  it("should delete a prompt version", async () => {
+    const { projectId: newProjectId, auth: newAuth } =
+      await createOrgProjectAndApiKey();
+
+    const originalPrompt = await prisma.prompt.create({
+      data: {
+        name: "prompt-to-delete",
+        projectId: newProjectId,
+        version: 1,
+        labels: ["test"],
+        createdBy: "user-test",
+        prompt: "prompt to delete",
+      },
+    });
+
+    const response = await makeAPICall(
+      "DELETE",
+      `${baseURI}/prompt-to-delete/versions/1`,
+      undefined,
+      newAuth,
+    );
+
+    expect(response.status).toBe(200);
+
+    // Verify prompt was deleted
+    const deletedPrompt = await prisma.prompt.findUnique({
+      where: {
+        id: originalPrompt.id,
+      },
+    });
+    expect(deletedPrompt).toBeNull();
+  });
+
+  it("should prevent deletion of prompt with protected labels", async () => {
+    const { projectId: newProjectId, auth: newAuth } =
+      await createOrgProjectAndApiKey();
+
+    // Create a protected label
+    await prisma.promptProtectedLabels.create({
+      data: {
+        projectId: newProjectId,
+        label: "protected",
+      },
+    });
+
+    const promptWithProtectedLabel = await prisma.prompt.create({
+      data: {
+        name: "protected-prompt",
+        projectId: newProjectId,
+        version: 1,
+        labels: ["protected"],
+        createdBy: "user-test",
+        prompt: "protected prompt",
+      },
+    });
+
+    const response = await makeAPICall(
+      "DELETE",
+      `${baseURI}/protected-prompt/versions/1`,
+      undefined,
+      newAuth,
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body).toMatchObject({
+      message: expect.stringContaining("protected label"),
+    });
+
+    // Verify prompt was not deleted
+    const existingPrompt = await prisma.prompt.findUnique({
+      where: {
+        id: promptWithProtectedLabel.id,
+      },
+    });
+    expect(existingPrompt).not.toBeNull();
+  });
+
+  it("should prevent deletion of prompt with dependencies", async () => {
+    const { projectId: newProjectId, auth: newAuth } =
+      await createOrgProjectAndApiKey();
+
+    // Create child prompt
+    const childPrompt = await prisma.prompt.create({
+      data: {
+        name: "child-prompt",
+        projectId: newProjectId,
+        version: 1,
+        labels: ["dependency"],
+        createdBy: "user-test",
+        prompt: "child prompt",
+      },
+    });
+
+    // Create parent prompt that depends on child
+    const parentPrompt = await prisma.prompt.create({
+      data: {
+        name: "parent-prompt",
+        projectId: newProjectId,
+        version: 1,
+        labels: ["test"],
+        createdBy: "user-test",
+        prompt: "parent with dependency: @@@langfusePrompt:name=child-prompt|label=dependency@@@",
+      },
+    });
+
+    // Create the dependency relationship
+    await prisma.promptDependency.create({
+      data: {
+        projectId: newProjectId,
+        parentId: parentPrompt.id,
+        childName: "child-prompt",
+        childLabel: "dependency",
+      },
+    });
+
+    const response = await makeAPICall(
+      "DELETE",
+      `${baseURI}/child-prompt/versions/1`,
+      undefined,
+      newAuth,
+    );
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({
+      message: expect.stringContaining("Other prompts are depending"),
+    });
+
+    // Verify child prompt was not deleted
+    const existingChild = await prisma.prompt.findUnique({
+      where: {
+        id: childPrompt.id,
+      },
+    });
+    expect(existingChild).not.toBeNull();
+  });
+
+  it("should return 404 for non-existing prompt", async () => {
+    const { auth: newAuth } = await createOrgProjectAndApiKey();
+
+    const response = await makeAPICall(
+      "DELETE",
+      `${baseURI}/non-existing-prompt/versions/1`,
+      undefined,
+      newAuth,
+    );
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("prompt composability", () => {
+  it("can create a prompt with dependencies linked via label", async () => {
+    const { projectId: newProjectId, auth: newAuth } =
+      await createOrgProjectAndApiKey();
+
+    // Create child prompt
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "child-prompt",
+        prompt: "I am a child prompt",
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    // Create parent prompt with dependency
+    const parentPromptContent =
+      "Parent prompt with dependency: @@@langfusePrompt:name=child-prompt|label=production@@@";
+    const response = await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "parent-prompt",
+        prompt: parentPromptContent,
+        type: "text",
+      },
+      newAuth,
+    );
+
+    expect(response.status).toBe(201);
+
+    // Verify dependency was created
+    const dependencies = await prisma.promptDependency.findMany({
+      where: {
+        projectId: newProjectId,
+        childName: "child-prompt",
+      },
+    });
+
+    expect(dependencies.length).toBe(1);
+    expect(dependencies[0].childLabel).toBe("production");
+
+    // Get the resolved prompt
+    const getResponse = await makeAPICall(
+      "GET",
+      `${baseURI}/parent-prompt?version=1`,
+      undefined,
+      newAuth,
+    );
+
+    expect(getResponse.status).toBe(200);
+    const responseBody = getResponse.body as unknown as Prompt;
+    const parsedPrompt = responseBody.prompt as string;
+
+    // Verify the resolution graph is returned with the correct structure
+    const parentId = responseBody.id;
+
+    expect(responseBody.resolutionGraph).toEqual({
+      root: {
+        name: "parent-prompt",
+        version: 1,
+        id: parentId,
+      },
+      dependencies: {
+        [parentId]: [
+          {
+            name: "child-prompt",
+            version: 1,
+            id: expect.any(String),
+          },
+        ],
+      },
+    });
+
+    // Verify the dependency was resolved correctly
+    expect(parsedPrompt).toBe(
+      "Parent prompt with dependency: I am a child prompt",
+    );
+
+    // Create another version of the child prompt with the same name and production label
+    // This will automatically strip the production label from the previous version
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "child-prompt",
+        prompt: "I am an updated child prompt",
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    // Get the resolved prompt again to check if it now uses the new version
+    const getResponseAfterUpdate = await makeAPICall(
+      "GET",
+      `${baseURI}/parent-prompt?version=1`,
+      undefined,
+      newAuth,
+    );
+
+    expect(getResponseAfterUpdate.status).toBe(200);
+    const responseBodyAfterUpdate =
+      getResponseAfterUpdate.body as unknown as Prompt;
+    const parsedPromptAfterUpdate = responseBodyAfterUpdate.prompt as string;
+
+    expect(parsedPromptAfterUpdate).toBe(
+      "Parent prompt with dependency: I am an updated child prompt",
+    );
+
+    expect(responseBodyAfterUpdate.resolutionGraph).toEqual({
+      root: {
+        name: "parent-prompt",
+        version: 1,
+        id: parentId,
+      },
+      dependencies: {
+        [parentId]: [
+          {
+            name: "child-prompt",
+            version: 2,
+            id: expect.any(String),
+          },
+        ],
+      },
+    });
+
+    const childPrompts = await prisma.prompt.findMany({
+      where: {
+        projectId: newProjectId,
+        name: "child-prompt",
+      },
+      orderBy: {
+        version: "asc",
+      },
+    });
+
+    expect(childPrompts.length).toBe(2);
+  });
+
+  it("resolves prompt dependencies correctly when linked via label", async () => {
+    const { auth: newAuth } = await createOrgProjectAndApiKey();
+
+    // Create child prompt
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "nested-child",
+        prompt: "I am a nested child",
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    // Create intermediate prompt with dependency
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "intermediate",
+        prompt:
+          "Intermediate with dependency: @@@langfusePrompt:name=nested-child|label=production@@@",
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    // Create parent prompt with dependency
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "nested-parent",
+        prompt:
+          "Parent with nested dependency: @@@langfusePrompt:name=intermediate|label=production@@@",
+        type: "text",
+      },
+      newAuth,
+    );
+
+    // Get the resolved prompt
+    const response = await makeAPICall(
+      "GET",
+      `${baseURI}/nested-parent?version=1`,
+      undefined,
+      newAuth,
+    );
+
+    expect(response.status).toBe(200);
+    const responseBody = response.body as unknown as Prompt;
+    expect(responseBody.prompt).toBe(
+      "Parent with nested dependency: Intermediate with dependency: I am a nested child",
+    );
+  });
+
+  it("resolves prompt dependencies correctly when linked via version", async () => {
+    const { auth: newAuth } = await createOrgProjectAndApiKey();
+
+    // Create child prompt with version
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "version-linked-child",
+        prompt: "I am version 3 of the child prompt",
+        type: "text",
+        version: 1,
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    // Create parent prompt with version-specific dependency
+    const parentPromptContent =
+      "Parent with version dependency: @@@langfusePrompt:name=version-linked-child|version=1@@@";
+
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "version-linked-parent",
+        prompt: parentPromptContent,
+        type: "text",
+      },
+      newAuth,
+    );
+
+    // Get the resolved prompt
+    const response = await makeAPICall(
+      "GET",
+      `${baseURI}/version-linked-parent?version=1`,
+      undefined,
+      newAuth,
+    );
+
+    expect(response.status).toBe(200);
+    const responseBody = response.body as unknown as Prompt;
+    expect(responseBody.prompt).toBe(
+      "Parent with version dependency: I am version 3 of the child prompt",
+    );
+    expect(responseBody.prompt).not.toContain("@@@langfusePrompt");
+  });
+
+  it("detects circular dependencies", async () => {
+    const { auth: newAuth } = await createOrgProjectAndApiKey();
+
+    // Create first prompt
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "circular-a",
+        prompt: "Prompt A without dependency",
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    // Create second prompt that depends on the first - this should be rejected due to circular dependency
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "circular-b",
+        prompt:
+          "Prompt B with dependency: @@@langfusePrompt:name=circular-a|label=production@@@",
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    const circularResponse = await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "circular-a",
+        prompt:
+          "Prompt A with dependency: @@@langfusePrompt:name=circular-b|label=production@@@",
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    // The second call should be rejected with a 400 error
+    expect(circularResponse.status).toBe(400);
+    const circularResponseBody = circularResponse.body as unknown as {
+      error: string;
+    };
+    expect(JSON.stringify(circularResponseBody)).toContain("circular");
+  });
+
+  it("handles deeply nested dependencies (3+ levels)", async () => {
+    //const { auth: newAuth } = await createOrgProjectAndApiKey();
+    const newAuth = undefined;
+
+    // Create level 3 (deepest) prompts
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "level-3-a",
+        prompt: "I am level 3 prompt A",
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "level-3-b",
+        prompt: "I am level 3 prompt B",
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    // Create level 2 prompt that depends on level 3 prompts
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "level-2",
+        prompt:
+          "Level 2 with dependencies: @@@langfusePrompt:name=level-3-a|label=production@@@ and @@@langfusePrompt:name=level-3-b|label=production@@@",
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    // Create level 1 prompt that depends on level 2
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "level-1",
+        prompt:
+          "Level 1 with dependency: @@@langfusePrompt:name=level-2|label=production@@@",
+        type: "text",
+      },
+      newAuth,
+    );
+
+    // Get the resolved prompt
+    const response = await makeAPICall(
+      "GET",
+      `${baseURI}/level-1?version=1`,
+      undefined,
+      newAuth,
+    );
+
+    expect(response.status).toBe(200);
+    const responseBody = response.body as unknown as Prompt;
+    expect(responseBody.prompt).toBe(
+      "Level 1 with dependency: Level 2 with dependencies: I am level 3 prompt A and I am level 3 prompt B",
+    );
+    expect(responseBody.prompt).not.toContain("@@@langfusePrompt");
+  });
+
+  it("handles multiple dependencies at the same level", async () => {
+    const { auth: newAuth } = await createOrgProjectAndApiKey();
+
+    // Create multiple child prompts
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "child-a",
+        prompt: "I am child prompt A",
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "child-b",
+        prompt: "I am child prompt B",
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "child-c",
+        prompt: "I am child prompt C",
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    // Create parent prompt with multiple dependencies
+    const parentPromptContent = `Parent prompt with multiple dependencies: First: @@@langfusePrompt:name=child-a|label=production@@@ Second: @@@langfusePrompt:name=child-b|label=production@@@ Third: @@@langfusePrompt:name=child-c|label=production@@@`;
+
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "multi-parent",
+        prompt: parentPromptContent,
+        type: "text",
+      },
+      newAuth,
+    );
+
+    // Get the resolved prompt
+    const response = await makeAPICall(
+      "GET",
+      `${baseURI}/multi-parent?version=1`,
+      undefined,
+      newAuth,
+    );
+
+    expect(response.status).toBe(200);
+    const responseBody = response.body as unknown as Prompt;
+    expect(responseBody.prompt).toBe(
+      "Parent prompt with multiple dependencies: First: I am child prompt A Second: I am child prompt B Third: I am child prompt C",
+    );
+    expect(responseBody.prompt).not.toContain("@@@langfusePrompt");
+  });
+
+  it("handles version-specific dependencies", async () => {
+    const { auth: newAuth } = await createOrgProjectAndApiKey();
+
+    // Create child prompt with multiple versions
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "versioned-child",
+        prompt: "I am version 1",
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "versioned-child",
+        prompt: "I am version 2",
+        type: "text",
+        version: 2,
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    // Create parent prompt with version-specific dependency
+    const parentPromptContent =
+      "Parent with version dependency: @@@langfusePrompt:name=versioned-child|version=1@@@";
+
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "version-parent",
+        prompt: parentPromptContent,
+        type: "text",
+      },
+      newAuth,
+    );
+
+    // Get the resolved prompt
+    const response = await makeAPICall(
+      "GET",
+      `${baseURI}/version-parent?version=1`,
+      undefined,
+      newAuth,
+    );
+
+    expect(response.status).toBe(200);
+    const responseBody = response.body as unknown as Prompt;
+    expect(responseBody.prompt).toBe(
+      "Parent with version dependency: I am version 1",
+    );
+    expect(responseBody.prompt).not.toContain("@@@langfusePrompt");
+  });
+
+  it("resolves prompt dependencies in chat prompts correctly", async () => {
+    const { auth: newAuth } = await createOrgProjectAndApiKey();
+
+    // Create child text prompt
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "chat-child-text",
+        prompt: "I am a text prompt used in a chat prompt",
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    // Create parent chat prompt with dependency
+    const chatPromptContent = [
+      { role: "system", content: "You are a helpful assistant" },
+      {
+        role: "user",
+        content:
+          "Here's some context: @@@langfusePrompt:name=chat-child-text|label=production@@@",
+      },
+    ];
+
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "chat-parent",
+        prompt: chatPromptContent,
+        type: "chat",
+      },
+      newAuth,
+    );
+
+    // Get the resolved prompt
+    const response = await makeAPICall(
+      "GET",
+      `${baseURI}/chat-parent?version=1`,
+      undefined,
+      newAuth,
+    );
+
+    expect(response.status).toBe(200);
+    const responseBody = response.body as unknown as Prompt;
+    expect(responseBody.prompt).toEqual([
+      { role: "system", content: "You are a helpful assistant" },
+      {
+        role: "user",
+        content:
+          "Here's some context: I am a text prompt used in a chat prompt",
+      },
+    ]);
+    expect(JSON.stringify(responseBody.prompt)).not.toContain(
+      "@@@langfusePrompt",
+    );
+  });
+
+  it("supports nested dependencies in chat prompts", async () => {
+    const { auth: newAuth } = await createOrgProjectAndApiKey();
+
+    // Create nested child text prompt
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "nested-child",
+        prompt: "I am a nested child prompt",
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    // Create intermediate text prompt with dependency
+    const intermediatePromptContent =
+      "Intermediate prompt with dependency: @@@langfusePrompt:name=nested-child|label=production@@@";
+
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "intermediate-prompt",
+        prompt: intermediatePromptContent,
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    // Create parent chat prompt with dependency to intermediate
+    const chatPromptContent = [
+      { role: "system", content: "You are a helpful assistant" },
+      {
+        role: "user",
+        content:
+          "Here's some context: @@@langfusePrompt:name=intermediate-prompt|label=production@@@",
+      },
+    ];
+
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "nested-chat-parent",
+        prompt: chatPromptContent,
+        type: "chat",
+      },
+      newAuth,
+    );
+
+    // Get the resolved prompt
+    const response = await makeAPICall(
+      "GET",
+      `${baseURI}/nested-chat-parent?version=1`,
+      undefined,
+      newAuth,
+    );
+
+    expect(response.status).toBe(200);
+    const responseBody = response.body as unknown as Prompt;
+    const parsedPrompt = responseBody.prompt;
+    expect(parsedPrompt).toEqual([
+      { role: "system", content: "You are a helpful assistant" },
+      {
+        role: "user",
+        content:
+          "Here's some context: Intermediate prompt with dependency: I am a nested child prompt",
+      },
+    ]);
+    expect(JSON.stringify(parsedPrompt)).not.toContain("@@@langfusePrompt");
+  });
+
+  it("should ignore invalid prompt tags", async () => {
+    const { auth: newAuth } = await createOrgProjectAndApiKey();
+
+    // Create a prompt with invalid dependency tags
+    const invalidTagPromptContent = JSON.stringify({
+      text: "This prompt has invalid tags: @@@langfusePrompt:invalid@@@, @@@langfusePrompt:name=missing-type@@@, @@@langfusePrompt:name=no-version-or-label@@@",
+    });
+
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "prompt-with-invalid-tags",
+        prompt: invalidTagPromptContent,
+        type: "text",
+      },
+      newAuth,
+    );
+
+    // Get the resolved prompt
+    const response = await makeAPICall(
+      "GET",
+      `${baseURI}/prompt-with-invalid-tags?version=1`,
+      undefined,
+      newAuth,
+    );
+
+    expect(response.status).toBe(200);
+    const responseBody = response.body as unknown as Prompt;
+    const parsedPrompt = JSON.parse(responseBody.prompt as string);
+
+    // The invalid tags should remain unchanged in the resolved prompt
+    expect(parsedPrompt.text).toContain("@@@langfusePrompt:invalid@@@");
+    expect(parsedPrompt.text).toContain(
+      "@@@langfusePrompt:name=missing-type@@@",
+    );
+    expect(parsedPrompt.text).toContain(
+      "@@@langfusePrompt:name=no-version-or-label@@@",
+    );
+  });
+
+  it("should handle duplicate dependency tags for the same prompt", async () => {
+    const { auth: newAuth } = await createOrgProjectAndApiKey();
+
+    // Create a parent prompt
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "parent-prompt",
+        prompt: "I am a parent prompt",
+        type: "text",
+      },
+      newAuth,
+    );
+
+    // Create a prompt with duplicate dependency tags
+    const duplicateTagsPromptContent =
+      "This prompt has duplicate tags: @@@langfusePrompt:name=parent-prompt|version=1@@@ and again @@@langfusePrompt:name=parent-prompt|version=1@@@";
+
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "prompt-with-duplicate-tags",
+        prompt: duplicateTagsPromptContent,
+        type: "text",
+      },
+      newAuth,
+    );
+
+    // Get the resolved prompt
+    const response = await makeAPICall(
+      "GET",
+      `${baseURI}/prompt-with-duplicate-tags?version=1`,
+      undefined,
+      newAuth,
+    );
+
+    expect(response.status).toBe(200);
+
+    const responseBody = response.body as unknown as Prompt;
+    const parsedPrompt = responseBody.prompt as string;
+
+    // The duplicate tags should be resolved to the same prompt
+    expect(parsedPrompt).toBe(
+      "This prompt has duplicate tags: I am a parent prompt and again I am a parent prompt",
+    );
+  });
+
+  it("should handle special characters in prompt names", async () => {
+    const { auth: newAuth } = await createOrgProjectAndApiKey();
+
+    // Create prompts with special characters in names
+    const specialCharPrompts = [
+      { name: "prompt-with-hyphens", prompt: "Hyphen content", type: "text" },
+      {
+        name: "prompt_with_underscores",
+        prompt: "Underscore content",
+        type: "text",
+      },
+      { name: "prompt.with.dots", prompt: "Dot content", type: "text" },
+      {
+        name: "prompt123WithNumbers",
+        prompt: "Number content",
+        type: "text",
+      },
+      { name: "prompt with spaces", prompt: "Space content", type: "text" },
+      { name: "prompt/with/slashes", prompt: "Slash content", type: "text" },
+    ];
+
+    // Create all the special character prompts
+    for (const promptData of specialCharPrompts) {
+      const response = await makeAPICall(
+        "POST",
+        baseURI,
+        promptData,
+        newAuth,
+      );
+      expect(response.status).toBe(201);
+    }
+
+    // Create a prompt that references all the special character prompts
+    const dependencyContent = `
+    Reference prompts with special chars:
+    @@@langfusePrompt:name=prompt-with-hyphens|version=1@@@
+    @@@langfusePrompt:name=prompt_with_underscores|version=1@@@
+    @@@langfusePrompt:name=prompt.with.dots|version=1@@@
+    @@@langfusePrompt:name=prompt123WithNumbers|version=1@@@
+    @@@langfusePrompt:name=prompt with spaces|version=1@@@
+    @@@langfusePrompt:name=prompt/with/slashes|version=1@@@
+  `;
+
+    await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "prompt-with-special-char-dependencies",
+        prompt: dependencyContent,
+        type: "text",
+      },
+      newAuth,
+    );
+
+    // Get the resolved prompt
+    const response = await makeAPICall(
+      "GET",
+      `${baseURI}/prompt-with-special-char-dependencies?version=1`,
+      undefined,
+      newAuth,
+    );
+
+    expect(response.status).toBe(200);
+    const responseBody = response.body as unknown as Prompt;
+    const parsedPrompt = responseBody.prompt as string;
+
+    // Verify the exact resolved prompt string
+    const expectedPrompt = `
+    Reference prompts with special chars:
+    Hyphen content
+    Underscore content
+    Dot content
+    Number content
+    Space content
+    Slash content
+  `;
+    expect(parsedPrompt).toBe(expectedPrompt);
+  }, 10_000);
+
+  it("should disallow a prompt that references itself", async () => {
+    const { auth } = await createOrgProjectAndApiKey();
+
+    // First, create the prompt without self-reference
+    const initialPromptName = "self-referencing-prompt";
+    const initialPromptContent = "This is the initial content";
+
+    const createResponse = await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: initialPromptName,
+        prompt: initialPromptContent,
+        type: "text",
+      },
+      auth,
+    );
+
+    expect(createResponse.status).toBe(201);
+
+    // Now try to update the prompt to include a reference to itself
+    const selfReferenceContent = `This prompt references itself:
+    @@@langfusePrompt:name=self-referencing-prompt|version=1@@@
+    And that's it!`;
+
+    const updateResponse = await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: initialPromptName,
+        prompt: selfReferenceContent,
+        type: "text",
+      },
+      auth,
+    );
+
+    // Expect the request to fail with a 400 Bad Request
+    expect(updateResponse.status).toBe(400);
+    // Check that the response contains an error about circular dependency
+    expect(JSON.stringify(updateResponse.body)).toContain(
+      "Circular dependency",
+    );
+  });
+
+  it("should return an error when a dependent prompt doesn't exist", async () => {
+    const { auth: newAuth } = await createOrgProjectAndApiKey();
+
+    // Create a prompt that references a non-existent prompt
+    const promptWithNonExistentDependency = `This prompt references a non-existent prompt:
+    @@@langfusePrompt:name=non-existent-prompt|version=1@@@
+    End of prompt.`;
+
+    // Create the prompt with the non-existent dependency
+    const createResponse = await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "prompt-with-missing-dependency",
+        prompt: promptWithNonExistentDependency,
+        type: "text",
+      },
+      newAuth,
+    );
+
+    // The creation should succeed as dependencies are resolved at retrieval time
+    expect(createResponse.status).toBe(400);
+
+    expect(JSON.stringify(createResponse.body)).toContain("not found");
+  });
+
+  it("should return an error when a dependent prompt exists but in a different project", async () => {
+    // Create two different organizations with their own projects
+    await createOrgProjectAndApiKey();
+    const { auth: auth2 } = await createOrgProjectAndApiKey();
+
+    // Create a prompt in the first project
+    const foreignProjectId = randomUUID();
+    await prisma.project.upsert({
+      where: { id: foreignProjectId },
+      update: {
+        name: "test-foreign-llm-app",
+        orgId: "seed-org-id",
+      },
+      create: {
+        id: foreignProjectId,
+        name: "test-foreign-llm-app",
+        orgId: "seed-org-id",
+      },
+    });
+    await prisma.prompt.create({
+      data: {
+        name: "cross-project-prompt",
+        prompt: "This prompt belongs to project 1",
+        type: "TEXT",
+        version: 1,
+        projectId: foreignProjectId,
+        createdBy: "test-user",
+      },
+    });
+
+    // Create a prompt in the second project that references the prompt from the first project
+    const promptWithCrossProjectDependency = `This prompt references a prompt from another project: @@@langfusePrompt:name=cross-project-prompt|version=1@@@ End of prompt.`;
+
+    // Create the prompt with the cross-project dependency
+    const createResponse = await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: "prompt-with-cross-project-dependency",
+        prompt: promptWithCrossProjectDependency,
+        type: "text",
+      },
+      auth2,
+    );
+
+    expect(createResponse.status).toBe(400);
+
+    expect(JSON.stringify(createResponse.body)).toContain("not found");
+
+    await prisma.project.delete({
+      where: { id: foreignProjectId },
+    });
+  });
+
+  it("should throw an error if MAX_PROMPT_NESTING_DEPTH is exceeded", async () => {
+    const { auth: newAuth } = await createOrgProjectAndApiKey();
+
+    // Create prompts with increasing depth
+    for (let i = MAX_PROMPT_NESTING_DEPTH; i >= 1; i--) {
+      const promptName = `depth-${i}`;
+      let promptContent = "";
+
+      if (i === MAX_PROMPT_NESTING_DEPTH) {
+        // The deepest prompt has no dependencies
+        promptContent = "I am the deepest prompt";
+      } else {
+        // Each prompt depends on the one deeper than it
+        promptContent = `Level ${i} with dependency: @@@langfusePrompt:name=depth-${i + 1}|label=production@@@`;
+      }
+
+      const response = await makeAPICall(
+        "POST",
+        baseURI,
+        {
+          name: promptName,
+          prompt: promptContent,
+          type: "text",
+          labels: ["production"],
+        },
+        newAuth,
+      );
+
+      expect(response.status).toBe(201);
+    }
+
+    // Try to create the depth-0 prompt which would exceed the max nesting depth
+    const promptName = "depth-0";
+    const promptContent = `Level 0 with dependency: @@@langfusePrompt:name=depth-1|label=production@@@`;
+
+    const createResponse = await makeAPICall(
+      "POST",
+      baseURI,
+      {
+        name: promptName,
+        prompt: promptContent,
+        type: "text",
+        labels: ["production"],
+      },
+      newAuth,
+    );
+
+    // Expect an error response
+    expect(createResponse.status).toBe(400);
+    expect(JSON.stringify(createResponse.body)).toContain(
+      "Maximum nesting depth exceeded",
+    );
+  }, 10_000);
+});
+
 const isPrompt = (x: unknown): x is Prompt => {
   if (typeof x !== "object" || x === null) return false;
   const prompt = x as Prompt;

--- a/web/src/features/prompts/server/handlers/promptVersionHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptVersionHandler.ts
@@ -1,16 +1,11 @@
 import { logger } from "@langfuse/shared/src/server";
 import { z } from "zod/v4";
-import { Prisma, LATEST_PROMPT_LABEL } from "@langfuse/shared";
-import { PromptService, redis } from "@langfuse/shared/src/server";
-import { ForbiddenError, LangfuseConflictError } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import { updatePrompt } from "@/src/features/prompts/server/actions/updatePrompts";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
-import { checkHasProtectedLabels } from "@/src/features/prompts/server/utils/checkHasProtectedLabels";
-import { promptChangeEventSourcing } from "@/src/features/prompts/server/promptChangeEventSourcing";
 
 const UpdatePromptBodySchema = z.object({
   newLabels: z
@@ -60,141 +55,30 @@ export const promptVersionHandler = withMiddlewares({
       const projectId = auth.scope.projectId;
       const version = Number(promptVersion);
 
-      // Find the prompt version to delete
-      const promptVersionToDelete = await prisma.prompt.findFirstOrThrow({
-        where: {
-          name: promptName as string,
-          version,
-          projectId,
-        },
-      });
+      const { validatePromptVersionDeletion } = await import("../utils/validatePromptVersionDeletion");
+      const { executePromptVersionDeletion } = await import("../utils/executePromptVersionDeletion");
 
-      const { name, labels } = promptVersionToDelete;
-
-      // Check if prompt has a protected label
-      const { hasProtectedLabels, protectedLabels } = await checkHasProtectedLabels({
+      // Validate the deletion (this will throw if not allowed)
+      const validationResult = await validatePromptVersionDeletion({
         prisma,
         projectId,
-        labelsToCheck: promptVersionToDelete.labels,
+        promptName: promptName as string,
+        version,
+        // No session provided, so it will use HTTP errors instead of TRPC errors
       });
 
-      if (hasProtectedLabels) {
-        throw new ForbiddenError(
-          `You don't have permission to delete a prompt with a protected label. Please contact your project admin for assistance.\n\n Protected labels are: ${protectedLabels.join(", ")}`,
-        );
-      }
-
-      // Check for dependencies if the prompt has labels
-      if (labels.length > 0) {
-        const dependents = await prisma.$queryRaw<
-          {
-            parent_name: string;
-            parent_version: number;
-            child_version: number;
-            child_label: string;
-          }[]
-        >`
-          SELECT
-            p."name" AS "parent_name",
-            p."version" AS "parent_version",
-            pd."child_version" AS "child_version",
-            pd."child_label" AS "child_label"
-          FROM
-            prompt_dependencies pd
-            INNER JOIN prompts p ON p.id = pd.parent_id
-          WHERE
-            p.project_id = ${projectId}
-            AND pd.project_id = ${projectId}
-            AND pd.child_name = ${name}
-            AND (
-              (pd."child_version" IS NOT NULL AND pd."child_version" = ${version})
-              OR
-              (pd."child_label" IS NOT NULL AND pd."child_label" IN (${Prisma.join(labels)}))
-            )
-          `;
-
-        if (dependents.length > 0) {
-          const dependencyMessages = dependents
-            .map(
-              (d) =>
-                `${d.parent_name} v${d.parent_version} depends on ${name} ${d.child_version ? `v${d.child_version}` : d.child_label}`,
-            )
-            .join("\n");
-
-          throw new LangfuseConflictError(
-            `Other prompts are depending on the prompt version you are trying to delete:\n\n${dependencyMessages}\n\nPlease delete the dependent prompts first.`,
-          );
-        }
-      }
-
-      // Audit log before deletion
-      await auditLog({
-        action: "delete",
-        resourceType: "prompt",
-        resourceId: promptVersionToDelete.id,
+      // Execute the deletion with all side effects
+      await executePromptVersionDeletion({
+        prisma,
         projectId,
         orgId: auth.scope.orgId,
         apiKeyId: auth.scope.apiKeyId,
-        before: promptVersionToDelete,
+        validationResult,
       });
 
-      const transaction = [
-        prisma.prompt.delete({
-          where: {
-            id: promptVersionToDelete.id,
-            projectId,
-          },
-        }),
-      ];
+      logger.info(`Prompt version deleted ${JSON.stringify(validationResult.promptVersionToDelete)}`);
 
-      // If the deleted prompt was the latest version, update the latest prompt
-      if (promptVersionToDelete.labels.includes(LATEST_PROMPT_LABEL)) {
-        const newLatestPrompt = await prisma.prompt.findFirst({
-          where: {
-            projectId,
-            name: name,
-            id: { not: promptVersionToDelete.id },
-          },
-          orderBy: [{ version: "desc" }],
-        });
-
-        if (newLatestPrompt) {
-          transaction.push(
-            prisma.prompt.update({
-              where: {
-                id: newLatestPrompt.id,
-                projectId,
-              },
-              data: {
-                labels: {
-                  push: LATEST_PROMPT_LABEL,
-                },
-              },
-            }),
-          );
-        }
-      }
-
-      // Lock and invalidate cache for _all_ versions and labels of the prompt
-      const promptService = new PromptService(prisma, redis);
-      await promptService.lockCache({ projectId, promptName: name });
-      await promptService.invalidateCache({ projectId, promptName: name });
-
-      // Execute transaction
-      await prisma.$transaction(transaction);
-
-      // Unlock cache
-      await promptService.unlockCache({ projectId, promptName: name });
-
-      // Trigger webhooks for prompt version deletion
-      await promptChangeEventSourcing(
-        await promptService.resolvePrompt(promptVersionToDelete),
-        "deleted",
-      );
-
-      logger.info(`Prompt version deleted ${JSON.stringify(promptVersionToDelete)}`);
-
-      return promptVersionToDelete;
+      return validationResult.promptVersionToDelete;
     },
   }),
 });

--- a/web/src/features/prompts/server/handlers/promptVersionHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptVersionHandler.ts
@@ -1,10 +1,16 @@
 import { logger } from "@langfuse/shared/src/server";
 import { z } from "zod/v4";
+import { Prisma, LATEST_PROMPT_LABEL } from "@langfuse/shared";
+import { PromptService, redis } from "@langfuse/shared/src/server";
+import { ForbiddenError, LangfuseConflictError } from "@langfuse/shared";
+import { prisma } from "@langfuse/shared/src/db";
 
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import { updatePrompt } from "@/src/features/prompts/server/actions/updatePrompts";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { checkHasProtectedLabels } from "@/src/features/prompts/server/utils/checkHasProtectedLabels";
+import { promptChangeEventSourcing } from "@/src/features/prompts/server/promptChangeEventSourcing";
 
 const UpdatePromptBodySchema = z.object({
   newLabels: z
@@ -43,6 +49,152 @@ export const promptVersionHandler = withMiddlewares({
       logger.info(`Prompt updated ${JSON.stringify(prompt)}`);
 
       return prompt;
+    },
+  }),
+  DELETE: createAuthedProjectAPIRoute({
+    name: "Delete Prompt Version",
+    bodySchema: z.void(),
+    responseSchema: z.any(),
+    fn: async ({ req, auth }) => {
+      const { promptName, promptVersion } = req.query;
+      const projectId = auth.scope.projectId;
+      const version = Number(promptVersion);
+
+      // Find the prompt version to delete
+      const promptVersionToDelete = await prisma.prompt.findFirstOrThrow({
+        where: {
+          name: promptName as string,
+          version,
+          projectId,
+        },
+      });
+
+      const { name, labels } = promptVersionToDelete;
+
+      // Check if prompt has a protected label
+      const { hasProtectedLabels, protectedLabels } = await checkHasProtectedLabels({
+        prisma,
+        projectId,
+        labelsToCheck: promptVersionToDelete.labels,
+      });
+
+      if (hasProtectedLabels) {
+        throw new ForbiddenError(
+          `You don't have permission to delete a prompt with a protected label. Please contact your project admin for assistance.\n\n Protected labels are: ${protectedLabels.join(", ")}`,
+        );
+      }
+
+      // Check for dependencies if the prompt has labels
+      if (labels.length > 0) {
+        const dependents = await prisma.$queryRaw<
+          {
+            parent_name: string;
+            parent_version: number;
+            child_version: number;
+            child_label: string;
+          }[]
+        >`
+          SELECT
+            p."name" AS "parent_name",
+            p."version" AS "parent_version",
+            pd."child_version" AS "child_version",
+            pd."child_label" AS "child_label"
+          FROM
+            prompt_dependencies pd
+            INNER JOIN prompts p ON p.id = pd.parent_id
+          WHERE
+            p.project_id = ${projectId}
+            AND pd.project_id = ${projectId}
+            AND pd.child_name = ${name}
+            AND (
+              (pd."child_version" IS NOT NULL AND pd."child_version" = ${version})
+              OR
+              (pd."child_label" IS NOT NULL AND pd."child_label" IN (${Prisma.join(labels)}))
+            )
+          `;
+
+        if (dependents.length > 0) {
+          const dependencyMessages = dependents
+            .map(
+              (d) =>
+                `${d.parent_name} v${d.parent_version} depends on ${name} ${d.child_version ? `v${d.child_version}` : d.child_label}`,
+            )
+            .join("\n");
+
+          throw new LangfuseConflictError(
+            `Other prompts are depending on the prompt version you are trying to delete:\n\n${dependencyMessages}\n\nPlease delete the dependent prompts first.`,
+          );
+        }
+      }
+
+      // Audit log before deletion
+      await auditLog({
+        action: "delete",
+        resourceType: "prompt",
+        resourceId: promptVersionToDelete.id,
+        projectId,
+        orgId: auth.scope.orgId,
+        apiKeyId: auth.scope.apiKeyId,
+        before: promptVersionToDelete,
+      });
+
+      const transaction = [
+        prisma.prompt.delete({
+          where: {
+            id: promptVersionToDelete.id,
+            projectId,
+          },
+        }),
+      ];
+
+      // If the deleted prompt was the latest version, update the latest prompt
+      if (promptVersionToDelete.labels.includes(LATEST_PROMPT_LABEL)) {
+        const newLatestPrompt = await prisma.prompt.findFirst({
+          where: {
+            projectId,
+            name: name,
+            id: { not: promptVersionToDelete.id },
+          },
+          orderBy: [{ version: "desc" }],
+        });
+
+        if (newLatestPrompt) {
+          transaction.push(
+            prisma.prompt.update({
+              where: {
+                id: newLatestPrompt.id,
+                projectId,
+              },
+              data: {
+                labels: {
+                  push: LATEST_PROMPT_LABEL,
+                },
+              },
+            }),
+          );
+        }
+      }
+
+      // Lock and invalidate cache for _all_ versions and labels of the prompt
+      const promptService = new PromptService(prisma, redis);
+      await promptService.lockCache({ projectId, promptName: name });
+      await promptService.invalidateCache({ projectId, promptName: name });
+
+      // Execute transaction
+      await prisma.$transaction(transaction);
+
+      // Unlock cache
+      await promptService.unlockCache({ projectId, promptName: name });
+
+      // Trigger webhooks for prompt version deletion
+      await promptChangeEventSourcing(
+        await promptService.resolvePrompt(promptVersionToDelete),
+        "deleted",
+      );
+
+      logger.info(`Prompt version deleted ${JSON.stringify(promptVersionToDelete)}`);
+
+      return promptVersionToDelete;
     },
   }),
 });

--- a/web/src/features/prompts/server/utils/executePromptVersionDeletion.ts
+++ b/web/src/features/prompts/server/utils/executePromptVersionDeletion.ts
@@ -1,0 +1,112 @@
+import { type PrismaClient, LATEST_PROMPT_LABEL } from "@langfuse/shared";
+import { PromptService, redis } from "@langfuse/shared/src/server";
+import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { promptChangeEventSourcing } from "@/src/features/prompts/server/promptChangeEventSourcing";
+import { type PromptVersionDeletionResult } from "./validatePromptVersionDeletion";
+
+export type ExecutePromptVersionDeletionParams = {
+  prisma: PrismaClient;
+  projectId: string;
+  orgId: string;
+  apiKeyId?: string;
+  sessionUserId?: string;
+  validationResult: PromptVersionDeletionResult;
+};
+
+/**
+ * Executes the prompt version deletion with all necessary side effects:
+ * - Audit logging
+ * - Cache management
+ * - Database transaction
+ * - Webhook events
+ * 
+ * This function is shared between TRPC and public API endpoints to ensure
+ * consistent behavior.
+ */
+export async function executePromptVersionDeletion(
+  params: ExecutePromptVersionDeletionParams,
+): Promise<void> {
+  const { 
+    prisma, 
+    projectId, 
+    orgId, 
+    apiKeyId, 
+    sessionUserId,
+    validationResult: { promptVersionToDelete, newLatestPrompt }
+  } = params;
+
+  const { name: promptName } = promptVersionToDelete;
+
+  // Audit log before deletion - use appropriate variant based on available auth info
+  if (apiKeyId) {
+    // API key variant
+    await auditLog({
+      action: "delete",
+      resourceType: "prompt",
+      resourceId: promptVersionToDelete.id,
+      apiKeyId,
+      orgId,
+      projectId,
+      before: promptVersionToDelete,
+    });
+  } else if (sessionUserId) {
+    // User session variant
+    await auditLog({
+      action: "delete",
+      resourceType: "prompt",
+      resourceId: promptVersionToDelete.id,
+      userId: sessionUserId,
+      orgId,
+      projectId,
+      before: promptVersionToDelete,
+    });
+  } else {
+    // Fallback - this shouldn't happen in normal operation
+    throw new Error("Either apiKeyId or sessionUserId must be provided for audit logging");
+  }
+
+  const transaction = [
+    prisma.prompt.delete({
+      where: {
+        id: promptVersionToDelete.id,
+        projectId,
+      },
+    }),
+  ];
+
+  // If the deleted prompt was the latest version, update the latest prompt
+  if (newLatestPrompt) {
+    transaction.push(
+      prisma.prompt.update({
+        where: {
+          id: newLatestPrompt.id,
+          projectId,
+        },
+        data: {
+          labels: {
+            push: LATEST_PROMPT_LABEL,
+          },
+        },
+      }),
+    );
+  }
+
+  // Lock and invalidate cache for _all_ versions and labels of the prompt
+  const promptService = new PromptService(prisma, redis);
+  await promptService.lockCache({ projectId, promptName });
+  await promptService.invalidateCache({ projectId, promptName });
+
+  try {
+    // Execute transaction
+    await prisma.$transaction(transaction);
+
+    // Trigger webhooks for prompt version deletion
+    await promptChangeEventSourcing(
+      await promptService.resolvePrompt(promptVersionToDelete),
+      "deleted",
+    );
+  } finally {
+    // Always unlock cache, even if transaction fails
+    await promptService.unlockCache({ projectId, promptName });
+  }
+}

--- a/web/src/features/prompts/server/utils/validatePromptVersionDeletion.ts
+++ b/web/src/features/prompts/server/utils/validatePromptVersionDeletion.ts
@@ -1,0 +1,153 @@
+import { type PrismaClient, Prisma, LATEST_PROMPT_LABEL, type Prompt } from "@langfuse/shared";
+import { ForbiddenError, LangfuseConflictError } from "@langfuse/shared";
+import { checkHasProtectedLabels } from "./checkHasProtectedLabels";
+import { type Session } from "next-auth";
+
+export type PromptVersionDeletionValidationParams = {
+  prisma: PrismaClient;
+  projectId: string;
+  promptName: string;
+  version: number;
+  /**
+   * Optional session for RBAC checks. If provided, will throw TRPCError.
+   * If not provided, will throw standard HTTP errors for API endpoints.
+   * This should be the full TRPC session object from protectedProjectProcedure.
+   */
+  session?: Session & {
+    user: {
+      id: string;
+      admin?: boolean;
+    };
+    orgId: string;
+    projectId: string;
+  };
+};
+
+export type PromptVersionDeletionResult = {
+  promptVersionToDelete: Prompt; // Use full Prompt type instead of partial
+  newLatestPrompt?: Prompt; // Use full Prompt type instead of partial
+};
+
+/**
+ * Validates whether a prompt version can be deleted and returns the prompt data.
+ * Throws appropriate errors if deletion is not allowed.
+ * 
+ * This function is shared between TRPC and public API endpoints to ensure
+ * consistent validation logic.
+ */
+export async function validatePromptVersionDeletion(
+  params: PromptVersionDeletionValidationParams,
+): Promise<PromptVersionDeletionResult> {
+  const { prisma, projectId, promptName, version, session } = params;
+
+  // Find the prompt version to delete
+  const promptVersionToDelete = await prisma.prompt.findFirstOrThrow({
+    where: {
+      name: promptName,
+      version,
+      projectId,
+    },
+  });
+
+  const { name, labels } = promptVersionToDelete;
+
+  // Check if prompt has a protected label
+  const { hasProtectedLabels, protectedLabels } = await checkHasProtectedLabels({
+    prisma,
+    projectId,
+    labelsToCheck: promptVersionToDelete.labels,
+  });
+
+  if (hasProtectedLabels) {
+    const errorMessage = `You don't have permission to delete a prompt with a protected label. Please contact your project admin for assistance.\n\n Protected labels are: ${protectedLabels.join(", ")}`;
+    
+    if (session) {
+      // For TRPC endpoints, we need to check RBAC and throw TRPCError
+      const { throwIfNoProjectAccess } = await import("@/src/features/rbac/utils/checkProjectAccess");
+      throwIfNoProjectAccess({
+        session,
+        projectId,
+        scope: "promptProtectedLabels:CUD",
+        forbiddenErrorMessage: errorMessage,
+      });
+    } else {
+      // For API endpoints, throw HTTP error
+      throw new ForbiddenError(errorMessage);
+    }
+  }
+
+  // Check for dependencies if the prompt has labels
+  if (labels.length > 0) {
+    const dependents = await prisma.$queryRaw<
+      {
+        parent_name: string;
+        parent_version: number;
+        child_version: number;
+        child_label: string;
+      }[]
+    >`
+      SELECT
+        p."name" AS "parent_name",
+        p."version" AS "parent_version",
+        pd."child_version" AS "child_version",
+        pd."child_label" AS "child_label"
+      FROM
+        prompt_dependencies pd
+        INNER JOIN prompts p ON p.id = pd.parent_id
+      WHERE
+        p.project_id = ${projectId}
+        AND pd.project_id = ${projectId}
+        AND pd.child_name = ${name}
+        AND (
+          (pd."child_version" IS NOT NULL AND pd."child_version" = ${version})
+          OR
+          (pd."child_label" IS NOT NULL AND pd."child_label" IN (${Prisma.join(labels)}))
+        )
+      `;
+
+    if (dependents.length > 0) {
+      const dependencyMessages = dependents
+        .map(
+          (d) =>
+            `${d.parent_name} v${d.parent_version} depends on ${name} ${d.child_version ? `v${d.child_version}` : d.child_label}`,
+        )
+        .join("\n");
+
+      const errorMessage = `Other prompts are depending on the prompt version you are trying to delete:\n\n${dependencyMessages}\n\nPlease delete the dependent prompts first.`;
+
+      if (session) {
+        // For TRPC endpoints, throw TRPCError
+        const { TRPCError } = await import("@trpc/server");
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: errorMessage,
+        });
+      } else {
+        // For API endpoints, throw HTTP error
+        throw new LangfuseConflictError(errorMessage);
+      }
+    }
+  }
+
+  // Find the new latest prompt if we're deleting the current latest
+  let newLatestPrompt: PromptVersionDeletionResult["newLatestPrompt"];
+  if (promptVersionToDelete.labels.includes(LATEST_PROMPT_LABEL)) {
+    const foundLatestPrompt = await prisma.prompt.findFirst({
+      where: {
+        projectId,
+        name: name,
+        id: { not: promptVersionToDelete.id },
+      },
+      orderBy: [{ version: "desc" }],
+    });
+
+    if (foundLatestPrompt) {
+      newLatestPrompt = foundLatestPrompt;
+    }
+  }
+
+  return {
+    promptVersionToDelete,
+    newLatestPrompt,
+  };
+}


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new `DELETE` endpoint at `/api/public/v2/prompts/{name}/versions/{version}` to allow for the deletion of specific prompt versions.

Key features include:
*   **Comprehensive Validation**: Implements the same robust checks as the UI's TRPC deletion logic, preventing deletion if:
    *   The prompt version has a protected label (returns 403 Forbidden).
    *   Other prompts depend on this version via composition (returns 409 Conflict).
*   **"Latest" Label Management**: Automatically reassigns the "latest" label to the next highest version if the deleted version was the current "latest".
*   **Cache Invalidation & Webhooks**: Ensures proper cache invalidation and triggers webhook events upon successful deletion.
*   **API Reference Integration**: The new endpoint is included in the Fern API definition to automatically generate API documentation.
*   **Audit Logging**: All deletion attempts are logged for compliance.
*   **Test Coverage**: Adds new tests to cover successful deletion, protected label checks, and dependency checks.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [x] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my PR needs changes to the documentation
- [x] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [x] I haven't added tests that prove my fix is effective or that my feature works
- [x] I haven't checked if new and existing unit tests pass locally with my changes

---
<a href="https://cursor.com/background-agent?bcId=bc-c2772aaf-9f2c-40cc-b545-118fb3469e6e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c2772aaf-9f2c-40cc-b545-118fb3469e6e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a DELETE endpoint for prompt version deletion with validation, cache management, and audit logging, including test coverage for various scenarios.
> 
>   - **New Endpoint**:
>     - Adds `DELETE /api/public/v2/prompts/{name}/versions/{version}` in `prompt-version.yml` for deleting specific prompt versions.
>   - **Validation**:
>     - Validates deletion in `validatePromptVersionDeletion.ts` to prevent deletion if prompt has protected labels or dependencies.
>   - **Execution**:
>     - Implements `executePromptVersionDeletion.ts` to handle deletion, cache invalidation, and webhook events.
>   - **Handlers**:
>     - Updates `promptVersionHandler.ts` to include DELETE logic.
>   - **Router**:
>     - Modifies `promptRouter.ts` to use new validation and execution functions.
>   - **Tests**:
>     - Adds tests in `prompts.v2.servertest.ts` for deletion scenarios including protected labels, dependencies, and non-existing prompts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e5f177ad5035c47cbd5d125f0f85c945c1a31767. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->