### PR TITLE
chore: disable usage alert configuration temporarily

### DIFF
--- a/web/src/features/entitlements/constants/entitlements.ts
+++ b/web/src/features/entitlements/constants/entitlements.ts
@@ -62,7 +62,8 @@ export const entitlementAccess: Record<
     },
   },
   "cloud:core": {
-    entitlements: [...cloudAllPlansEntitlements, "cloud-usage-alerts"],
+    // TODO: Update Stripe Webhooks when enabling this again.
+    entitlements: [...cloudAllPlansEntitlements], // , "cloud-usage-alerts"],
     entitlementLimits: {
       "organization-member-count": false,
       "data-access-days": 90,
@@ -72,7 +73,7 @@ export const entitlementAccess: Record<
     },
   },
   "cloud:pro": {
-    entitlements: [...cloudAllPlansEntitlements, "cloud-usage-alerts"],
+    entitlements: [...cloudAllPlansEntitlements], // "cloud-usage-alerts"],
     entitlementLimits: {
       "annotation-queue-count": false,
       "organization-member-count": false,
@@ -91,7 +92,7 @@ export const entitlementAccess: Record<
       "prompt-protected-labels",
       "admin-api",
       "scheduled-blob-exports",
-      "cloud-usage-alerts",
+      // "cloud-usage-alerts",
     ],
     entitlementLimits: {
       "annotation-queue-count": false,
@@ -111,7 +112,7 @@ export const entitlementAccess: Record<
       "prompt-protected-labels",
       "admin-api",
       "scheduled-blob-exports",
-      "cloud-usage-alerts",
+      // "cloud-usage-alerts",
     ],
     entitlementLimits: {
       "annotation-queue-count": false,


### PR DESCRIPTION
As Stripe billing alerts do not behave in their documented way, we are temporarily disabling their invocation and the configuration. See the note in https://langfuse.com/docs/administration/usage-alerts.

Alerts so far are often false-positive as they consider the _entire_ usage history instead of the current billing period.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Temporarily disables `cloud-usage-alerts` entitlement in `entitlements.ts` for multiple plans due to false-positive alerts.
> 
>   - **Behavior**:
>     - Temporarily disables `cloud-usage-alerts` entitlement in `entitlementAccess` for `cloud:core`, `cloud:pro`, `cloud:team`, and `cloud:enterprise` plans in `entitlements.ts`.
>     - Alerts were often false-positive due to considering entire usage history instead of current billing period.
>   - **Comments**:
>     - Added TODO comment to update Stripe Webhooks when re-enabling `cloud-usage-alerts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8be217fa42e361d3f96a6920d272808776987066. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->