### PR TITLE
perf: truncate IO in table overviews and skip internal JSON parse on TRPC

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -58,6 +58,7 @@ export * from "./logger";
 export * from "./headerPropagation";
 export * from "./queries";
 export * from "./repositories";
+export * from "./utils/rendering";
 export * from "./redis/evalExecutionQueue";
 export * from "./services/sessions-ui-table-service";
 export * from "./services/datasets-ui-table-service";

--- a/packages/shared/src/server/repositories/observations_converters.ts
+++ b/packages/shared/src/server/repositories/observations_converters.ts
@@ -1,15 +1,20 @@
 import { parseClickhouseUTCDateTimeFormat } from "./clickhouse";
 import { ObservationRecordReadType } from "./definitions";
-import { parseJsonPrioritised } from "../../utils/json";
 import {
   Observation,
   ObservationLevelType,
   ObservationType,
 } from "../../domain";
 import { parseMetadataCHRecordToDomain } from "../utils/metadata_conversion";
+import {
+  RenderingProps,
+  DEFAULT_RENDERING_PROPS,
+  applyInputOutputRendering,
+} from "../utils/rendering";
 
 export const convertObservation = (
   record: ObservationRecordReadType,
+  renderingProps: RenderingProps = DEFAULT_RENDERING_PROPS,
 ): Observation => {
   const reducedCostDetails = reduceUsageOrCostDetails(record.cost_details);
   const reducedUsageDetails = reduceUsageOrCostDetails(record.usage_details);
@@ -30,10 +35,8 @@ export const convertObservation = (
     level: record.level as ObservationLevelType,
     statusMessage: record.status_message ?? null,
     version: record.version ?? null,
-    input: record.input ? (parseJsonPrioritised(record.input) ?? null) : null,
-    output: record.output
-      ? (parseJsonPrioritised(record.output) ?? null)
-      : null,
+    input: applyInputOutputRendering(record.input, renderingProps),
+    output: applyInputOutputRendering(record.output, renderingProps),
     modelParameters: record.model_parameters
       ? (JSON.parse(record.model_parameters) ?? null)
       : null,

--- a/packages/shared/src/server/utils/rendering.ts
+++ b/packages/shared/src/server/utils/rendering.ts
@@ -1,0 +1,58 @@
+import { JsonNested } from "../../utils/zod";
+import { parseJsonPrioritised } from "../../utils/json";
+import { env } from "../../env";
+
+/**
+ * Rendering properties used to control how data is processed and returned
+ * in tRPC routes and repository functions.
+ */
+export interface RenderingProps {
+  /**
+   * Whether to truncate input/output fields to a specific character limit
+   */
+  truncated: boolean;
+
+  /**
+   * Whether to skip JSON parsing of input/output fields and return them as raw strings.
+   * This is useful when the client will handle JSON parsing to avoid double parsing.
+   */
+  shouldJsonParse: boolean;
+}
+
+/**
+ * Default rendering properties
+ */
+export const DEFAULT_RENDERING_PROPS: RenderingProps = {
+  truncated: false,
+  shouldJsonParse: true,
+};
+
+/**
+ * Transform input/output fields based on rendering properties.
+ */
+export const applyInputOutputRendering = (
+  io: string | null | undefined,
+  renderingProps: RenderingProps,
+): JsonNested | string | null => {
+  if (!io) return null;
+  let result: JsonNested | string = io;
+
+  if (
+    renderingProps.truncated &&
+    io.length > env.LANGFUSE_SERVER_SIDE_IO_CHAR_LIMIT
+  ) {
+    result =
+      io.slice(0, env.LANGFUSE_SERVER_SIDE_IO_CHAR_LIMIT) + "\n...[truncated]";
+  }
+
+  if (
+    renderingProps.truncated &&
+    io.length === env.LANGFUSE_SERVER_SIDE_IO_CHAR_LIMIT
+  ) {
+    result = io + "\n...[truncated]";
+  }
+
+  return renderingProps.shouldJsonParse
+    ? (parseJsonPrioritised(result) ?? null)
+    : result;
+};

--- a/web/src/__tests__/async/traces-trpc.servertest.ts
+++ b/web/src/__tests__/async/traces-trpc.servertest.ts
@@ -70,8 +70,8 @@ describe("traces trpc", () => {
       expect(traceRes?.name).toEqual(trace.name);
       expect(traceRes?.timestamp).toEqual(new Date(trace.timestamp));
       expect(traceRes?.tags?.sort()).toEqual(trace.tags?.sort());
-      expect(traceRes?.input).toEqual(trace.input);
-      expect(traceRes?.output).toEqual(trace.output);
+      expect(traceRes?.input).toBeNull();
+      expect(traceRes?.output).toBeNull();
       expect(traceRes?.userId).toEqual(trace.user_id);
       expect(traceRes?.sessionId).toEqual(trace.session_id);
     });

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -1146,6 +1146,7 @@ const GenerationsDynamicCell = ({
       traceId,
       projectId,
       startTime,
+      truncated: true,
     },
     {
       enabled: typeof traceId === "string" && typeof observationId === "string",

--- a/web/src/features/public-api/server/observations.ts
+++ b/web/src/features/public-api/server/observations.ts
@@ -103,7 +103,7 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
         params: input.params,
         tags: { ...input.tags, experiment_amt: "original" },
       });
-      return result.map(convertObservation);
+      return result.map((r) => convertObservation(r));
     },
     newExecution: async (input) => {
       const result = await queryClickhouse<ObservationRecordReadType>({
@@ -111,7 +111,7 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
         params: input.params,
         tags: { ...input.tags, experiment_amt: "new" },
       });
-      return result.map(convertObservation);
+      return result.map((r) => convertObservation(r));
     },
   });
 };

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -10,7 +10,10 @@ import {
   getTimeframesTracesAMT,
   measureAndReturn,
 } from "@langfuse/shared/src/server";
-import { type OrderByState } from "@langfuse/shared";
+import {
+  type OrderByState,
+  DEFAULT_RENDERING_PROPS,
+} from "@langfuse/shared/src/server";
 import { snakeCase } from "lodash";
 import {
   TRACE_FIELD_GROUPS,
@@ -266,7 +269,7 @@ export const generateTracesForPublicApi = async ({
 
   return result.map((trace) => {
     return {
-      ...convertClickhouseToDomain(trace, false),
+      ...convertClickhouseToDomain(trace, DEFAULT_RENDERING_PROPS),
       // Conditionally include additional fields based on request
       ...(includeObservations && { observations: trace.observations ?? null }),
       ...(includeScores && { scores: trace.scores ?? null }),

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -3,6 +3,7 @@ import {
   convertDateToClickhouseDateTime,
   queryClickhouse,
   TRACE_TO_OBSERVATIONS_INTERVAL,
+  DEFAULT_RENDERING_PROPS,
   orderByToClickhouseSql,
   type DateTimeFilter,
   convertClickhouseToDomain,
@@ -10,10 +11,7 @@ import {
   getTimeframesTracesAMT,
   measureAndReturn,
 } from "@langfuse/shared/src/server";
-import {
-  type OrderByState,
-  DEFAULT_RENDERING_PROPS,
-} from "@langfuse/shared/src/server";
+import { type OrderByState } from "@langfuse/shared";
 import { snakeCase } from "lodash";
 import {
   TRACE_FIELD_GROUPS,

--- a/web/src/server/api/routers/observations.ts
+++ b/web/src/server/api/routers/observations.ts
@@ -15,6 +15,7 @@ export const observationsRouter = createTRPCRouter({
         traceId: z.string(), // required for protectedGetTraceProcedure
         projectId: z.string(), // required for protectedGetTraceProcedure
         startTime: z.date().nullish(),
+        truncated: z.boolean().default(false), // used to truncate the input and output
       }),
     )
     .query(async ({ input }) => {
@@ -25,6 +26,10 @@ export const observationsRouter = createTRPCRouter({
           fetchWithInputOutput: true,
           traceId: input.traceId,
           startTime: input.startTime ?? undefined,
+          renderingProps: {
+            truncated: input.truncated,
+            shouldJsonParse: false,
+          },
         });
         if (!obs) {
           throw new TRPCError({
@@ -34,8 +39,8 @@ export const observationsRouter = createTRPCRouter({
         }
         return {
           ...obs,
-          input: obs.input != null ? JSON.stringify(obs.input) : null,
-          output: obs.output != null ? JSON.stringify(obs.output) : null,
+          input: obs.input as string,
+          output: obs.output as string,
           metadata: obs.metadata != null ? JSON.stringify(obs.metadata) : null,
           internalModel: obs?.internalModelId,
         };

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -207,11 +207,11 @@ export const traceRouter = createTRPCRouter({
     .query(async ({ ctx }) => {
       return {
         ...ctx.trace,
+        input: ctx.trace.input as string,
+        output: ctx.trace.output as string,
         metadata: ctx.trace.metadata
           ? JSON.stringify(ctx.trace.metadata)
           : undefined,
-        input: ctx.trace.input ? JSON.stringify(ctx.trace.input) : undefined,
-        output: ctx.trace.output ? JSON.stringify(ctx.trace.output) : undefined,
       };
     }),
   byIdWithObservationsAndScores: protectedGetTraceProcedure

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -384,7 +384,10 @@ const enforceTraceAccess = t.middleware(async ({ ctx, rawInput, next }) => {
     projectId,
     timestamp: timestamp ?? undefined,
     fromTimestamp: fromTimestamp ?? undefined,
-    truncated: result.data.truncated,
+    renderingProps: {
+      truncated: result.data.truncated,
+      shouldJsonParse: false, // we do not want to parse the input/output for tRPC
+    },
   });
 
   if (!trace) {


### PR DESCRIPTION
Extends on https://github.com/langfuse/langfuse/pull/8326
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances performance by introducing rendering properties to control input/output truncation and JSON parsing in observation and trace handling.
> 
>   - **Behavior**:
>     - Introduces `RenderingProps` in `rendering.ts` to control truncation and JSON parsing of input/output fields.
>     - Updates `getObservationById` and `getTraceById` to use `RenderingProps` for truncation and parsing control.
>     - Modifies `convertObservation` and `convertClickhouseToDomain` to apply rendering properties.
>   - **Repositories**:
>     - Updates `observations.ts` and `traces.ts` to handle `RenderingProps` in queries.
>     - Adjusts SQL queries to conditionally truncate input/output fields based on `RenderingProps`.
>   - **API**:
>     - Updates `observations.ts` and `traces.ts` routers to accept `truncated` flag and apply `RenderingProps`.
>     - Modifies `traces-trpc.servertest.ts` to expect null input/output when truncated.
>   - **Components**:
>     - Updates `observations.tsx` to pass `truncated: true` to `GenerationsDynamicCell`.
>   - **Misc**:
>     - Exports `rendering` utilities in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f3e17085796e7d94055be6a5e3ec6c996ae10d09. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->