### PR TITLE
chore: add env to move short-term reads to AMTs

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -148,6 +148,9 @@ const EnvSchema = z.object({
   LANGFUSE_EXPERIMENT_RETURN_NEW_RESULT: z
     .enum(["true", "false"])
     .default("false"),
+  LANGFUSE_EXPERIMENT_RETURN_NEW_RESULT_SHORT_TERM: z
+    .enum(["true", "false"])
+    .default("false"),
   LANGFUSE_EXPERIMENT_INSERT_INTO_AGGREGATING_MERGE_TREES: z
     .enum(["true", "false"])
     .default("false"),

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -764,6 +764,7 @@ const getObservationsTableInternal = async <T>(
   return measureAndReturn({
     operationName: "getObservationsTableInternal",
     projectId,
+    minStartTime: (timeFilter?.value as Date) || undefined,
     input: {
       params: {
         ...appliedScoresFilter.params,

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -146,6 +146,7 @@ export const checkTraceExists = async ({
   return measureAndReturn({
     operationName: "checkTraceExists",
     projectId,
+    minStartTime: timestamp ?? exactTimestamp,
     input: {
       params: {
         projectId,
@@ -366,6 +367,7 @@ export const getTracesBySessionId = async (
   const records = await measureAndReturn({
     operationName: "getTracesBySessionId",
     projectId,
+    minStartTime: timestamp,
     input: {
       params: {
         sessionIds,
@@ -509,6 +511,7 @@ export const getTraceCountsByProjectInCreationInterval = async ({
   return measureAndReturn({
     operationName: "getTraceCountsByProjectInCreationInterval",
     projectId: "__CROSS_PROJECT__",
+    minStartTime: start,
     input: {
       params: {
         start: convertDateToClickhouseDateTime(start),
@@ -584,6 +587,7 @@ export const getTraceCountOfProjectsSinceCreationDate = async ({
   return measureAndReturn({
     operationName: "getTraceCountOfProjectsSinceCreationDate",
     projectId: "__CROSS_PROJECT__",
+    minStartTime: start,
     input: {
       params: {
         projectIds,
@@ -658,6 +662,7 @@ export const getTraceById = async ({
   const records = await measureAndReturn({
     operationName: "getTraceById",
     projectId,
+    minStartTime: fromTimestamp ?? timestamp,
     input: {
       params: {
         traceId,
@@ -782,6 +787,10 @@ export const getTracesGroupedByName = async (
   return measureAndReturn({
     operationName: "getTracesGroupedByName",
     projectId,
+    minStartTime: timestampFilter?.find(
+      (f) =>
+        f.column === "timestamp" && (f.operator === ">=" || f.operator === ">"),
+    )?.value as Date | undefined,
     input: {
       params: {
         projectId,
@@ -877,6 +886,10 @@ export const getTracesGroupedByUsers = async (
   return measureAndReturn({
     operationName: "getTracesGroupedByUsers",
     projectId,
+    minStartTime: filter?.find(
+      (f) =>
+        f.column === "timestamp" && (f.operator === ">=" || f.operator === ">"),
+    )?.value as Date | undefined,
     input: {
       params: {
         limit,
@@ -974,6 +987,10 @@ export const getTracesGroupedByTags = async (props: GroupedTracesQueryProp) => {
   return measureAndReturn({
     operationName: "getTracesGroupedByTags",
     projectId,
+    minStartTime: filter?.find(
+      (f) =>
+        f.column === "timestamp" && (f.operator === ">=" || f.operator === ">"),
+    )?.value as Date | undefined,
     input: {
       params: {
         projectId,
@@ -1270,19 +1287,6 @@ export const deleteTracesOlderThanDays = async (
           },
           tags: input.tags,
         }),
-        // Delete from traces_null
-        commandClickhouse({
-          query: `
-            DELETE FROM traces_null
-            WHERE project_id = {projectId: String}
-            AND start_time < {cutoffDate: DateTime64(3)};
-          `,
-          params: input.params,
-          clickhouseConfigs: {
-            request_timeout: env.LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS,
-          },
-          tags: input.tags,
-        }),
         // Delete from traces_all_amt
         commandClickhouse({
           query: `
@@ -1499,6 +1503,10 @@ export const getTotalUserCount = async (
   return measureAndReturn({
     operationName: "getTotalUserCount",
     projectId,
+    minStartTime: filter?.find(
+      (f) =>
+        f.column === "timestamp" && (f.operator === ">=" || f.operator === ">"),
+    )?.value as Date | undefined,
     input: {
       params: {
         ...tracesFilterRes.params,
@@ -1648,6 +1656,10 @@ export const getUserMetrics = async (
   return measureAndReturn({
     operationName: "getUserMetrics",
     projectId,
+    minStartTime: filter?.find(
+      (f) =>
+        f.column === "timestamp" && (f.operator === ">=" || f.operator === ">"),
+    )?.value as Date | undefined,
     input: {
       params: {
         projectId,

--- a/packages/shared/src/server/services/sessions-ui-table-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-service.ts
@@ -378,6 +378,11 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
   return measureAndReturn({
     operationName: "getSessionsTableGeneric",
     projectId,
+    minStartTime: filter?.find(
+      (f) =>
+        f.column === "min_timestamp" &&
+        (f.operator === ">=" || f.operator === ">"),
+    )?.value as Date | undefined,
     input: {
       params: {
         projectId,

--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -350,6 +350,7 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
   return measureAndReturn({
     operationName: "getTracesTableGeneric",
     projectId: props.projectId,
+    minStartTime: select !== "metrics" ? timeStampFilter?.value : undefined,
     input: props,
     existingExecution: async (props) => {
       let sqlSelect: string;

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -116,6 +116,7 @@ export const generateTracesForPublicApi = async ({
   const result = await measureAndReturn({
     operationName: "getTracesForPublicApi",
     projectId: props.projectId,
+    minStartTime: timeFilter?.value,
     input: {
       params: {
         ...appliedEnvironmentFilter.params,

--- a/web/src/features/query/server/queryExecutor.ts
+++ b/web/src/features/query/server/queryExecutor.ts
@@ -48,6 +48,7 @@ export async function executeQuery(
   return measureAndReturn({
     operationName: "executeQuery",
     projectId,
+    minStartTime: new Date(query.fromTimestamp),
     input: {
       query: compiledQuery,
       params: parameters,
@@ -73,11 +74,7 @@ export async function executeQuery(
       });
     },
     newExecution: async (input) => {
-      const fromDate = input.fromTimestamp
-        ? new Date(input.fromTimestamp)
-        : undefined;
-      const traceTable = getTimeframesTracesAMT(fromDate);
-
+      const traceTable = getTimeframesTracesAMT(new Date(input.fromTimestamp));
       return queryClickhouse<Record<string, unknown>>({
         query: input.query.replaceAll("traces", traceTable),
         params: input.params,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `LANGFUSE_EXPERIMENT_RETURN_NEW_RESULT_SHORT_TERM` for short-term read handling using AMTs and update `measureAndReturn` and related functions to support it.
> 
>   - **Environment**:
>     - Add `LANGFUSE_EXPERIMENT_RETURN_NEW_RESULT_SHORT_TERM` to `env.ts` for short-term read handling.
>   - **Functionality**:
>     - Update `measureAndReturn` in `measureAndReturn.ts` to handle short-term reads using AMTs if `LANGFUSE_EXPERIMENT_RETURN_NEW_RESULT_SHORT_TERM` is "true" and `minStartTime` is within 30 days.
>     - Modify `getObservationsTableInternal`, `checkTraceExists`, `getTracesBySessionId`, `getTraceCountsByProjectInCreationInterval`, `getTraceCountOfProjectsSinceCreationDate`, `getTracesGroupedByName`, `getTracesGroupedByUsers`, `getTracesGroupedByTags`, `getTotalUserCount`, `getUserMetrics`, `getSessionsTableGeneric`, `getTracesTableGeneric`, `generateTracesForPublicApi`, and `executeQuery` to pass `minStartTime` to `measureAndReturn`.
>   - **Misc**:
>     - Remove deletion from `traces_null` in `deleteTracesOlderThanDays` in `observations.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d662ed91946236aa23df612f308e62f816007fda. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->