### PR TITLE
fix: check projectMembers:read for trpc members.byProjectId

### DIFF
--- a/web/src/features/rbac/server/membersRouter.ts
+++ b/web/src/features/rbac/server/membersRouter.ts
@@ -702,6 +702,12 @@ export const membersRouter = createTRPCRouter({
       }),
     )
     .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "projectMembers:read",
+      });
+
       const searchFilter = buildUserSearchFilter(input.searchQuery);
 
       const filterCondition: FilterState =


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a `projectMembers:read` permission check to the `byProjectId` query in `membersRouter.ts`.
> 
>   - **Behavior**:
>     - Adds a permission check in `byProjectId` query in `membersRouter.ts` to ensure `projectMembers:read` scope is required for accessing project members.
>   - **Functions**:
>     - Uses `throwIfNoProjectAccess` to enforce the new permission check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for eae4bbf165c7e72a6b50fc756794d102e3d448bc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->