### PR TITLE
feat(api): add `DELETE /api/public/v2/prompts/{name}/versions/{version}`

### DIFF
--- a/fern/apis/server/definition/prompt-version.yml
+++ b/fern/apis/server/definition/prompt-version.yml
@@ -25,3 +25,20 @@ service:
               type: list<string>
               docs: New labels for the prompt version. Labels are unique across versions. The "latest" label is reserved and managed by Langfuse.
       response: prompts.Prompt
+    delete:
+      docs: Delete a specific prompt version
+      method: DELETE
+      path: /prompts/{name}/versions/{version}
+      path-parameters:
+        name:
+          type: string
+          docs: The name of the prompt
+        version:
+          type: integer
+          docs: Version of the prompt to delete
+      response: DeletePromptVersionResponse
+
+types:
+  DeletePromptVersionResponse:
+    properties:
+      message: string

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -2918,6 +2918,58 @@ paths:
                     Langfuse.
               required:
                 - newLabels
+    delete:
+      description: Delete a specific prompt version
+      operationId: promptVersion_delete
+      tags:
+        - PromptVersion
+      parameters:
+        - name: name
+          in: path
+          description: The name of the prompt
+          required: true
+          schema:
+            type: string
+        - name: version
+          in: path
+          description: Version of the prompt to delete
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletePromptVersionResponse'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
   /api/public/v2/prompts/{promptName}:
     get:
       description: Get a prompt
@@ -3254,7 +3306,7 @@ paths:
       parameters:
         - name: filter
           in: query
-          description: Filter expression (e.g. userName eq 'value')
+          description: Filter expression (e.g. userName eq "value")
           required: false
           schema:
             type: string
@@ -7023,6 +7075,14 @@ components:
           type: boolean
       required:
         - success
+    DeletePromptVersionResponse:
+      title: DeletePromptVersionResponse
+      type: object
+      properties:
+        message:
+          type: string
+      required:
+        - message
     PromptMetaListResponse:
       title: PromptMetaListResponse
       type: object

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -2171,6 +2171,46 @@
             }
           },
           "response": []
+        },
+        {
+          "_type": "endpoint",
+          "name": "Delete",
+          "request": {
+            "description": "Delete a specific prompt version",
+            "url": {
+              "raw": "{{baseUrl}}/api/public/v2/prompts/:name/versions/:version",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "public",
+                "v2",
+                "prompts",
+                ":name",
+                "versions",
+                ":version"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "key": "name",
+                  "value": "",
+                  "description": "The name of the prompt"
+                },
+                {
+                  "key": "version",
+                  "value": "",
+                  "description": "Version of the prompt to delete"
+                }
+              ]
+            },
+            "header": [],
+            "method": "DELETE",
+            "auth": null,
+            "body": null
+          },
+          "response": []
         }
       ]
     },

--- a/web/src/__tests__/async/prompts.v2.servertest.ts
+++ b/web/src/__tests__/async/prompts.v2.servertest.ts
@@ -3038,6 +3038,117 @@ describe("PATCH api/public/v2/prompts/[promptName]/versions/[version]", () => {
   });
 });
 
+describe("DELETE api/public/v2/prompts/[promptName]/versions/[version]", () => {
+  afterAll(async () => {
+    await disconnectQueues();
+  });
+
+  it("should delete a prompt version", async () => {
+    const { projectId, auth } = await createOrgProjectAndApiKey();
+    const promptName = `delete-me-${nanoid()}`;
+
+    const created = await prisma.prompt.create({
+      data: {
+        name: promptName,
+        prompt: "to be deleted",
+        labels: [],
+        version: 1,
+        projectId,
+        createdBy: "API",
+      },
+    });
+
+    const res = await makeAPICall(
+      "DELETE",
+      `${baseURI}/${encodeURIComponent(promptName)}/versions/1`,
+      undefined,
+      auth,
+    );
+
+    expect(res.status).toBe(200);
+    // @ts-expect-error
+    expect(res.body?.message).toContain("deleted");
+
+    const exists = await prisma.prompt.findUnique({
+      where: { id: created.id },
+    });
+    expect(exists).toBeNull();
+  });
+
+  it("should block delete if dependent prompts exist", async () => {
+    const { projectId, auth } = await createOrgProjectAndApiKey();
+    // child referenced by label
+    await prisma.prompt.create({
+      data: {
+        name: "child-for-delete",
+        prompt: "child",
+        labels: ["production"],
+        version: 1,
+        projectId,
+        createdBy: "API",
+      },
+    });
+    // parent referencing child via label to create dependency
+    const parent = await prisma.prompt.create({
+      data: {
+        name: "parent-for-delete",
+        prompt:
+          "uses child @@@langfusePrompt:name=child-for-delete|label=production@@@",
+        labels: [],
+        version: 1,
+        projectId,
+        createdBy: "API",
+      },
+    });
+
+    // Wire dependency row to mirror PromptService behavior at creation time
+    await prisma.promptDependency.create({
+      data: {
+        projectId,
+        parentId: parent.id,
+        childName: "child-for-delete",
+        childLabel: "production",
+      },
+    });
+
+    const res = await makeAPICall(
+      "DELETE",
+      `${baseURI}/child-for-delete/versions/1`,
+      undefined,
+      auth,
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it("should block delete if protected labels exist", async () => {
+    const { projectId, auth } = await createOrgProjectAndApiKey();
+    // mark label as protected
+    await prisma.promptProtectedLabels.create({
+      data: { projectId, label: "production" },
+    });
+    // create prompt carrying protected label
+    await prisma.prompt.create({
+      data: {
+        name: "protected-for-delete",
+        prompt: "content",
+        labels: ["production"],
+        version: 1,
+        projectId,
+        createdBy: "API",
+      },
+    });
+
+    const res = await makeAPICall(
+      "DELETE",
+      `${baseURI}/protected-for-delete/versions/1`,
+      undefined,
+      auth,
+    );
+
+    expect([401, 403]).toContain(res.status); // forbidden via protected label entitlement
+  });
+});
+
 const isPrompt = (x: unknown): x is Prompt => {
   if (typeof x !== "object" || x === null) return false;
   const prompt = x as Prompt;

--- a/web/src/features/prompts/server/actions/deletePromptVersion.ts
+++ b/web/src/features/prompts/server/actions/deletePromptVersion.ts
@@ -1,0 +1,164 @@
+import {
+  prisma as _prisma,
+  Prisma,
+  type PrismaClient,
+  type Prompt,
+} from "@langfuse/shared/src/db";
+import { redis, PromptService, logger } from "@langfuse/shared/src/server";
+import { TRPCError } from "@trpc/server";
+import { checkHasProtectedLabels } from "@/src/features/prompts/server/utils/checkHasProtectedLabels";
+import {
+  LATEST_PROMPT_LABEL,
+  ForbiddenError,
+  LangfuseNotFoundError,
+} from "@langfuse/shared";
+import { promptChangeEventSourcing } from "@/src/features/prompts/server/promptChangeEventSourcing";
+
+export type DeletePromptVersionParams = {
+  projectId: string;
+  promptVersionId: string;
+  prisma?: PrismaClient;
+  canDeleteProtectedLabel?: boolean;
+  onBeforeDelete?: (prompt: Prompt) => Promise<void> | void;
+  onAfterDelete?: (prompt: Prompt) => Promise<void> | void;
+};
+
+/**
+ * Deletes a prompt version with full safety checks and side-effects (audit log via callbacks, cache invalidation, webhooks).
+ */
+export async function deletePromptVersion(params: DeletePromptVersionParams) {
+  const prisma = params.prisma ?? _prisma;
+  const projectId = params.projectId;
+
+  // Resolve prompt version by id
+  const promptVersion = await prisma.prompt.findFirst({
+    where: { id: params.promptVersionId, projectId },
+  });
+
+  if (!promptVersion) {
+    throw new LangfuseNotFoundError("Prompt not found");
+  }
+
+  const { name: promptName, version, labels } = promptVersion;
+
+  // Protected label check
+  const { hasProtectedLabels, protectedLabels } = await checkHasProtectedLabels(
+    {
+      prisma,
+      projectId,
+      labelsToCheck: labels,
+    },
+  );
+
+  if (hasProtectedLabels && !params.canDeleteProtectedLabel) {
+    throw new ForbiddenError(
+      `You don't have permission to delete a prompt with a protected label. Please contact your project admin for assistance.\n\n Protected labels are: ${protectedLabels.join(", ")}`,
+    );
+  }
+
+  // Dependency check only needed if labels exist
+  if (labels.length > 0) {
+    const dependents = await prisma.$queryRaw<
+      {
+        parent_name: string;
+        parent_version: number;
+        child_version: number;
+        child_label: string;
+      }[]
+    >`
+      SELECT
+        p."name" AS "parent_name",
+        p."version" AS "parent_version",
+        pd."child_version" AS "child_version",
+        pd."child_label" AS "child_label"
+      FROM
+        prompt_dependencies pd
+        INNER JOIN prompts p ON p.id = pd.parent_id
+      WHERE
+        p.project_id = ${projectId}
+        AND pd.project_id = ${projectId}
+        AND pd.child_name = ${promptName}
+        AND (
+          (pd."child_version" IS NOT NULL AND pd."child_version" = ${version})
+          OR
+          (pd."child_label" IS NOT NULL AND pd."child_label" IN (${Prisma.join(labels)}))
+        )
+    `;
+
+    if (dependents.length > 0) {
+      const dependencyMessages = dependents
+        .map(
+          (d) =>
+            `${d.parent_name} v${d.parent_version} depends on ${promptName} ${d.child_version ? `v${d.child_version}` : d.child_label}`,
+        )
+        .join("\n");
+
+      throw new TRPCError({
+        code: "CONFLICT",
+        message: `Other prompts are depending on the prompt version you are trying to delete:\n\n${dependencyMessages}\n\nPlease delete the dependent prompts first.`,
+      });
+    }
+  }
+
+  // Allow caller to audit before deletion
+  if (params.onBeforeDelete) await params.onBeforeDelete(promptVersion);
+
+  const promptService = new PromptService(prisma, redis);
+
+  try {
+    // Lock and invalidate cache for all versions/labels of the prompt
+    await promptService.lockCache({ projectId, promptName });
+    await promptService.invalidateCache({ projectId, promptName });
+
+    const transaction: Array<ReturnType<PrismaClient["$executeRaw"]> | any> = [
+      prisma.prompt.delete({
+        where: { id: promptVersion.id, projectId },
+      }),
+    ];
+
+    // If deleted version carried the "latest" label, move it to the next latest
+    if (promptVersion.labels.includes(LATEST_PROMPT_LABEL)) {
+      const newLatestPrompt = await prisma.prompt.findFirst({
+        where: {
+          projectId,
+          name: promptName,
+          id: { not: promptVersion.id },
+        },
+        orderBy: [{ version: "desc" }],
+      });
+
+      if (newLatestPrompt) {
+        transaction.push(
+          prisma.prompt.update({
+            where: { id: newLatestPrompt.id, projectId },
+            data: { labels: { push: LATEST_PROMPT_LABEL } },
+          }),
+        );
+      }
+    }
+
+    // Execute transaction
+    await prisma.$transaction(transaction);
+
+    // Unlock cache
+    await promptService.unlockCache({ projectId, promptName });
+
+    // Trigger webhooks for prompt version deletion
+    await promptChangeEventSourcing(
+      await promptService.resolvePrompt(promptVersion),
+      "deleted",
+    );
+
+    // Allow caller to audit after deletion
+    if (params.onAfterDelete) await params.onAfterDelete(promptVersion);
+  } catch (e) {
+    logger.error(e);
+    // Always attempt to unlock cache
+    try {
+      await promptService.unlockCache({ projectId, promptName });
+    } catch {}
+    throw e;
+  }
+
+  return { id: promptVersion.id };
+}

--- a/web/src/features/prompts/server/handlers/promptVersionHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptVersionHandler.ts
@@ -4,29 +4,33 @@ import { z } from "zod/v4";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import { updatePrompt } from "@/src/features/prompts/server/actions/updatePrompts";
+import { deletePromptVersion } from "@/src/features/prompts/server/actions/deletePromptVersion";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { prisma } from "@langfuse/shared/src/db";
+import { LangfuseNotFoundError } from "@langfuse/shared";
+import {
+  PatchPromptVersionV2Query,
+  PatchPromptVersionV2Body,
+  DeletePromptVersionV2Query,
+  DeletePromptVersionV2Response,
+} from "@/src/features/public-api/types/prompts";
 
-const UpdatePromptBodySchema = z.object({
-  newLabels: z
-    .array(z.string())
-    .refine((labels) => !labels.includes("latest"), {
-      message: "Label 'latest' is always assigned to the latest prompt version",
-    }),
-});
+// kept in types/prompts
 
 export const promptVersionHandler = withMiddlewares({
   PATCH: createAuthedProjectAPIRoute({
     name: "Update Prompt",
-    bodySchema: UpdatePromptBodySchema,
+    querySchema: PatchPromptVersionV2Query,
+    bodySchema: PatchPromptVersionV2Body,
     responseSchema: z.any(),
-    fn: async ({ body, req, auth }) => {
-      const { newLabels } = UpdatePromptBodySchema.parse(body);
-      const { promptName, promptVersion } = req.query;
+    fn: async ({ body, query, auth }) => {
+      const { newLabels } = body;
+      const { promptName, promptVersion } = query;
 
       const prompt = await updatePrompt({
-        promptName: promptName as string,
+        promptName: promptName,
         projectId: auth.scope.projectId,
-        promptVersion: Number(promptVersion),
+        promptVersion: promptVersion,
         newLabels,
       });
 
@@ -43,6 +47,45 @@ export const promptVersionHandler = withMiddlewares({
       logger.info(`Prompt updated ${JSON.stringify(prompt)}`);
 
       return prompt;
+    },
+  }),
+  DELETE: createAuthedProjectAPIRoute({
+    name: "Delete Prompt Version",
+    querySchema: DeletePromptVersionV2Query,
+    responseSchema: DeletePromptVersionV2Response,
+    fn: async ({ query, auth }) => {
+      const { promptName, promptVersion } = query;
+
+      // Look up id by name+version for the public endpoint
+      const toDelete = await prisma.prompt.findFirst({
+        where: {
+          projectId: auth.scope.projectId,
+          name: promptName,
+          version: promptVersion,
+        },
+      });
+
+      if (!toDelete) {
+        throw new LangfuseNotFoundError("Prompt not found");
+      }
+
+      await deletePromptVersion({
+        projectId: auth.scope.projectId,
+        promptVersionId: toDelete.id,
+        onBeforeDelete: async (prompt) => {
+          await auditLog({
+            apiKeyId: auth.scope.apiKeyId,
+            orgId: auth.scope.orgId,
+            projectId: auth.scope.projectId,
+            resourceType: "prompt",
+            resourceId: prompt.id,
+            action: "delete",
+            before: prompt,
+          });
+        },
+      });
+
+      return { message: "Prompt version deleted successfully" };
     },
   }),
 });

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -36,6 +36,7 @@ import {
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
 import { TRPCError } from "@trpc/server";
 import { promptChangeEventSourcing } from "@/src/features/prompts/server/promptChangeEventSourcing";
+import { deletePromptVersion as deletePromptVersionAction } from "@/src/features/prompts/server/actions/deletePromptVersion";
 
 const buildPromptSearchFilter = (
   searchQuery: string | undefined | null,
@@ -557,138 +558,24 @@ export const promptRouter = createTRPCRouter({
           scope: "prompts:CUD",
         });
 
-        const promptVersion = await ctx.prisma.prompt.findFirstOrThrow({
-          where: {
-            id: input.promptVersionId,
-            projectId,
+        await deletePromptVersionAction({
+          projectId,
+          promptVersionId: input.promptVersionId,
+          prisma: ctx.prisma,
+          canDeleteProtectedLabel: true,
+          onBeforeDelete: async (prompt) => {
+            await auditLog(
+              {
+                session: ctx.session,
+                resourceType: "prompt",
+                resourceId: prompt.id,
+                action: "delete",
+                before: prompt,
+              },
+              ctx.prisma,
+            );
           },
         });
-        const { name: promptName, version, labels } = promptVersion;
-
-        // Check if prompt has a protected label
-        const { hasProtectedLabels, protectedLabels } =
-          await checkHasProtectedLabels({
-            prisma: ctx.prisma,
-            projectId: input.projectId,
-            labelsToCheck: promptVersion.labels,
-          });
-
-        if (hasProtectedLabels) {
-          throwIfNoProjectAccess({
-            session: ctx.session,
-            projectId: input.projectId,
-            scope: "promptProtectedLabels:CUD",
-            forbiddenErrorMessage: `You don't have permission to delete a prompt with a protected label. Please contact your project admin for assistance.\n\n Protected labels are: ${protectedLabels.join(", ")}`,
-          });
-        }
-
-        if (labels.length > 0) {
-          const dependents = await ctx.prisma.$queryRaw<
-            {
-              parent_name: string;
-              parent_version: number;
-              child_version: number;
-              child_label: string;
-            }[]
-          >`
-            SELECT
-              p."name" AS "parent_name",
-              p."version" AS "parent_version",
-              pd."child_version" AS "child_version",
-              pd."child_label" AS "child_label"
-            FROM
-              prompt_dependencies pd
-              INNER JOIN prompts p ON p.id = pd.parent_id
-            WHERE
-              p.project_id = ${projectId}
-              AND pd.project_id = ${projectId}
-              AND pd.child_name = ${promptName}
-              AND (
-                (pd."child_version" IS NOT NULL AND pd."child_version" = ${version})
-                OR
-                (pd."child_label" IS NOT NULL AND pd."child_label" IN (${Prisma.join(labels)}))
-              )
-            `;
-
-          if (dependents.length > 0) {
-            const dependencyMessages = dependents
-              .map(
-                (d) =>
-                  `${d.parent_name} v${d.parent_version} depends on ${promptName} ${d.child_version ? `v${d.child_version}` : d.child_label}`,
-              )
-              .join("\n");
-
-            throw new TRPCError({
-              code: "CONFLICT",
-              message: `Other prompts are depending on the prompt version you are trying to delete:\n\n${dependencyMessages}\n\nPlease delete the dependent prompts first.`,
-            });
-          }
-        }
-
-        await auditLog(
-          {
-            session: ctx.session,
-            resourceType: "prompt",
-            resourceId: input.promptVersionId,
-            action: "delete",
-            before: promptVersion,
-          },
-          ctx.prisma,
-        );
-
-        const transaction = [
-          ctx.prisma.prompt.delete({
-            where: {
-              id: input.promptVersionId,
-              projectId,
-            },
-          }),
-        ];
-
-        // If the deleted prompt was the latest version, update the latest prompt
-        if (promptVersion.labels.includes(LATEST_PROMPT_LABEL)) {
-          const newLatestPrompt = await ctx.prisma.prompt.findFirst({
-            where: {
-              projectId,
-              name: promptName,
-              id: { not: input.promptVersionId },
-            },
-            orderBy: [{ version: "desc" }],
-          });
-
-          if (newLatestPrompt) {
-            transaction.push(
-              ctx.prisma.prompt.update({
-                where: {
-                  id: newLatestPrompt.id,
-                  projectId: input.projectId,
-                },
-                data: {
-                  labels: {
-                    push: LATEST_PROMPT_LABEL,
-                  },
-                },
-              }),
-            );
-          }
-        }
-
-        // Lock and invalidate cache for _all_ versions and labels of the prompt
-        const promptService = new PromptService(ctx.prisma, redis);
-        await promptService.lockCache({ projectId, promptName });
-        await promptService.invalidateCache({ projectId, promptName });
-
-        // Execute transaction
-        await ctx.prisma.$transaction(transaction);
-
-        // Unlock cache
-        await promptService.unlockCache({ projectId, promptName });
-
-        // Trigger webhooks for prompt version deletion
-        await promptChangeEventSourcing(
-          await promptService.resolvePrompt(promptVersion),
-          "deleted",
-        );
       } catch (e) {
         logger.error(e);
         throw e;

--- a/web/src/features/public-api/types/prompts.ts
+++ b/web/src/features/public-api/types/prompts.ts
@@ -1,0 +1,37 @@
+import { z } from "zod/v4";
+import { PromptSchema, queryStringZod } from "@langfuse/shared";
+
+// PATCH /api/public/v2/prompts/{promptName}/versions/{promptVersion}
+export const PatchPromptVersionV2Query = z
+  .object({
+    promptName: queryStringZod,
+    promptVersion: z.coerce.number(),
+  })
+  .strict();
+
+export const PatchPromptVersionV2Body = z
+  .object({
+    newLabels: z
+      .array(z.string())
+      .refine((labels) => !labels.includes("latest"), {
+        message:
+          "Label 'latest' is always assigned to the latest prompt version",
+      }),
+  })
+  .strict();
+
+export const PatchPromptVersionV2Response = PromptSchema;
+
+// DELETE /api/public/v2/prompts/{promptName}/versions/{promptVersion}
+export const DeletePromptVersionV2Query = z
+  .object({
+    promptName: queryStringZod,
+    promptVersion: z.coerce.number(),
+  })
+  .strict();
+
+export const DeletePromptVersionV2Response = z
+  .object({
+    message: z.string(),
+  })
+  .strict();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `DELETE /api/public/v2/prompts/{name}/versions/{version}` endpoint with dependency and protected label checks, including tests and documentation updates.
> 
>   - **API Endpoint**:
>     - Adds `DELETE /api/public/v2/prompts/{name}/versions/{version}` to `prompt-version.yml` and `openapi.yml`.
>     - Handles deletion of specific prompt versions with checks for dependencies and protected labels.
>   - **Functionality**:
>     - Implements `deletePromptVersion()` in `deletePromptVersion.ts` with safety checks and side-effects.
>     - Updates `promptVersionHandler.ts` to handle DELETE requests using `deletePromptVersion()`.
>   - **Testing**:
>     - Adds tests in `prompts.v2.servertest.ts` for successful deletion, dependency conflict, and protected label scenarios.
>   - **Miscellaneous**:
>     - Updates Postman collection in `collection.json` to include the new DELETE endpoint.
>     - Defines `DeletePromptVersionV2Query` and `DeletePromptVersionV2Response` in `types/prompts.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a89280f2ac5afb46edcae1c39281b82d771ec614. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->