### PR TITLE
fix(auth): honor NEXT_PUBLIC_BASE_PATH in password reset verification

### DIFF
--- a/web/src/features/auth-credentials/components/ResetPasswordButton.tsx
+++ b/web/src/features/auth-credentials/components/ResetPasswordButton.tsx
@@ -66,7 +66,7 @@ export function RequestResetPasswordEmailButton({
       const callback = encodeURIComponent(
         `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/auth/reset-password`,
       );
-      const url = `/api/auth/callback/email?email=${formattedEmail}&token=${formattedCode}&callbackUrl=${callback}`;
+      const url = `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/auth/callback/email?email=${formattedEmail}&token=${formattedCode}&callbackUrl=${callback}`;
       window.location.href = url;
     } catch (error) {
       console.error("Error verifying code:", error);


### PR DESCRIPTION
Fixes #8368
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `ResetPasswordButton.tsx` to honor `NEXT_PUBLIC_BASE_PATH` in password reset verification URL.
> 
>   - **Behavior**:
>     - Modify URL construction in `handleVerify` in `ResetPasswordButton.tsx` to prepend `NEXT_PUBLIC_BASE_PATH` to `/api/auth/callback/email`.
>     - Ensures password reset verification URL honors `NEXT_PUBLIC_BASE_PATH` environment variable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c84d14a3237ebe73b628aae673e91a14c6599397. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->