### PR TITLE
fix(llm-connections): ensure dialog remains open when switching tabs

### DIFF
--- a/web/src/components/ModelParameters/index.tsx
+++ b/web/src/components/ModelParameters/index.tsx
@@ -61,6 +61,9 @@ export const ModelParameters: React.FC<ModelParamsContext> = ({
   const [modelSettingsOpen, setModelSettingsOpen] = useState(false);
   const [modelSettingsUsed, setModelSettingsUsed] = useState(false);
 
+  const [createLlmApiKeyDialogOpen, setCreateLlmApiKeyDialogOpen] =
+    useState(false);
+
   useEffect(() => {
     const hasEnabledModelSetting = Object.keys(modelParams).some(
       (key) =>
@@ -88,7 +91,10 @@ export const ModelParameters: React.FC<ModelParamsContext> = ({
           </div>
         )}
         <p className="text-xs">No LLM API key set in project. </p>
-        <CreateLLMApiKeyDialog />
+        <CreateLLMApiKeyDialog
+          open={createLlmApiKeyDialogOpen}
+          setOpen={setCreateLlmApiKeyDialogOpen}
+        />
       </div>
     );
   }
@@ -204,7 +210,10 @@ export const ModelParameters: React.FC<ModelParamsContext> = ({
                   </SelectItem>
                 ))}
                 <SelectSeparator />
-                <CreateLLMApiKeyDialog />
+                <CreateLLMApiKeyDialog
+                  open={createLlmApiKeyDialogOpen}
+                  setOpen={setCreateLlmApiKeyDialogOpen}
+                />
               </SelectContent>
             </Select>
             {modelParamsDescription ? (
@@ -304,6 +313,9 @@ const ModelParamsSelect = ({
   modelParamsDescription,
   layout = "vertical",
 }: ModelParamsSelectProps) => {
+  const [createLlmApiKeyDialogOpen, setCreateLlmApiKeyDialogOpen] =
+    useState(false);
+
   // Compact layout - simplified, space-efficient (no individual labels)
   if (layout === "compact") {
     return (
@@ -328,7 +340,10 @@ const ModelParamsSelect = ({
               </SelectItem>
             ))}
             <SelectSeparator />
-            <CreateLLMApiKeyDialog />
+            <CreateLLMApiKeyDialog
+              open={createLlmApiKeyDialogOpen}
+              setOpen={setCreateLlmApiKeyDialogOpen}
+            />
           </SelectContent>
         </Select>
         {modelParamsDescription ? (
@@ -374,7 +389,10 @@ const ModelParamsSelect = ({
               </SelectItem>
             ))}
             <SelectSeparator />
-            <CreateLLMApiKeyDialog />
+            <CreateLLMApiKeyDialog
+              open={createLlmApiKeyDialogOpen}
+              setOpen={setCreateLlmApiKeyDialogOpen}
+            />
           </SelectContent>
         </Select>
         {modelParamsDescription ? (

--- a/web/src/features/public-api/components/CreateLLMApiKeyDialog.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyDialog.tsx
@@ -1,6 +1,4 @@
 import { PlusIcon } from "lucide-react";
-import { useState } from "react";
-
 import { Button } from "@/src/components/ui/button";
 import {
   Dialog,

--- a/web/src/features/public-api/components/CreateLLMApiKeyDialog.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyDialog.tsx
@@ -14,9 +14,14 @@ import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 import { useUiCustomization } from "@/src/ee/features/ui-customization/useUiCustomization";
 import { CreateLLMApiKeyForm } from "@/src/features/public-api/components/CreateLLMApiKeyForm";
 
-export function CreateLLMApiKeyDialog() {
+export function CreateLLMApiKeyDialog({
+  open,
+  setOpen,
+}: {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}) {
   const projectId = useProjectIdFromURL();
-  const [open, setOpen] = useState(false);
   const hasAccess = useHasProjectAccess({
     projectId,
     scope: "llmApiKeys:create",

--- a/web/src/features/public-api/components/LLMApiKeyList.tsx
+++ b/web/src/features/public-api/components/LLMApiKeyList.tsx
@@ -29,6 +29,7 @@ import { UpdateLLMApiKeyDialog } from "./UpdateLLMApiKeyDialog";
 
 export function LlmApiKeyList(props: { projectId: string }) {
   const [editingKeyId, setEditingKeyId] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
 
   const hasAccess = useHasProjectAccess({
     projectId: props.projectId,
@@ -148,7 +149,7 @@ export function LlmApiKeyList(props: { projectId: string }) {
           </TableBody>
         </Table>
       </Card>
-      <CreateLLMApiKeyDialog />
+      <CreateLLMApiKeyDialog open={open} setOpen={setOpen} />
     </div>
   );
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Ensure `CreateLLMApiKeyDialog` remains open when switching tabs by managing its open state externally.
> 
>   - **Behavior**:
>     - `CreateLLMApiKeyDialog` now accepts `open` and `setOpen` props to control its open state externally in `index.tsx`, `CreateLLMApiKeyDialog.tsx`, and `LLMApiKeyList.tsx`.
>     - Ensures dialog remains open when switching tabs by managing state in parent components.
>   - **Components**:
>     - `CreateLLMApiKeyDialog` modified to use external state for open/close control.
>     - Updated `ModelParameters` and `LlmApiKeyList` to manage dialog state and pass it to `CreateLLMApiKeyDialog`.
>   - **Misc**:
>     - Removed internal state management from `CreateLLMApiKeyDialog`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 84aeda0febea700105634208794482978f2fe30f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->