### PR TITLE
fix(onboarding): only show org onboarding for Cloud and more UX touches

### DIFF
--- a/web/src/features/onboarding/components/OnboardingSurvey.tsx
+++ b/web/src/features/onboarding/components/OnboardingSurvey.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect } from "react";
+import type { Path } from "react-hook-form";
 import { useRouter } from "next/router";
 import { Button } from "@/src/components/ui/button";
 import { Form } from "@/src/components/ui/form";
@@ -62,6 +63,20 @@ export function OnboardingSurvey() {
     form,
     onSubmit,
   ]);
+
+  // Auto-focus the first form control of the current step
+  useEffect(() => {
+    if (!currentQuestion?.id) return;
+    const field = currentQuestion.id as Path<SurveyFormData>;
+    const raf = requestAnimationFrame(() => {
+      try {
+        form.setFocus(field, { shouldSelect: true });
+      } catch {
+        // ignore if the control cannot be focused
+      }
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [currentQuestion?.id, form]);
 
   const handleSkip = () => {
     if (isLastStep) {

--- a/web/src/features/onboarding/components/OnboardingSurvey.tsx
+++ b/web/src/features/onboarding/components/OnboardingSurvey.tsx
@@ -78,7 +78,42 @@ export function OnboardingSurvey() {
     return () => cancelAnimationFrame(raf);
   }, [currentQuestion?.id, form]);
 
-  const handleSkip = () => {
+  // Determine labeling/behavior of the primary (right) button
+  const roleValue = form.watch("role");
+  const signupReasonValue = form.watch("signupReason");
+  const referralSourceValue = form.watch("referralSource");
+
+  const currentFieldId = currentQuestion?.id as
+    | keyof SurveyFormData
+    | undefined;
+  const currentValue = currentFieldId
+    ? form.watch(currentFieldId as Path<SurveyFormData>)
+    : undefined;
+
+  const isEmpty = (v: unknown) =>
+    v == null || (typeof v === "string" && v.trim() === "");
+  const allFields = {
+    role: roleValue,
+    signupReason: signupReasonValue,
+    referralSource: referralSourceValue,
+  } as const;
+
+  const currentEmpty = isEmpty(currentValue);
+  const otherTwoEmpty = Object.entries(allFields)
+    .filter(([key]) => key !== currentFieldId)
+    .every(([, v]) => isEmpty(v));
+  // showSkip: ghost button labeled "Skip" when skipping is the intended action
+  const showSkip = isLastStep ? currentEmpty && otherTwoEmpty : currentEmpty;
+
+  const handleSkipButton = () => {
+    if (isLastStep) {
+      void router.push("/");
+    } else {
+      goNext();
+    }
+  };
+
+  const handleSubmitButton = () => {
     if (isLastStep) {
       form.handleSubmit(onSubmit)();
     } else {
@@ -110,14 +145,25 @@ export function OnboardingSurvey() {
             </div>
 
             <div className="flex flex-row-reverse items-center justify-between pt-6">
-              <Button
-                type="button"
-                onClick={handleSkip}
-                variant={isLastStep ? "default" : "ghost"}
-                className="w-20"
-              >
-                {isLastStep ? "Finish" : "Skip"}
-              </Button>
+              {showSkip ? (
+                <Button
+                  type="button"
+                  onClick={handleSkipButton}
+                  variant="ghost"
+                  className="w-20"
+                >
+                  Skip
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  onClick={handleSubmitButton}
+                  variant="default"
+                  className="w-20"
+                >
+                  {isLastStep ? "Finish" : "Next"}
+                </Button>
+              )}
 
               <div className="basis-[10rem] px-4">
                 <SurveyProgress

--- a/web/src/features/onboarding/components/SurveyStep.tsx
+++ b/web/src/features/onboarding/components/SurveyStep.tsx
@@ -55,6 +55,8 @@ export function SurveyStep({
             </FormLabel>
             <FormControl>
               <RadioGroup
+                name={field.name}
+                ref={field.ref}
                 onValueChange={(value) => {
                   field.onChange(value);
                   setTimeout(() => {

--- a/web/src/features/onboarding/components/SurveyStep.tsx
+++ b/web/src/features/onboarding/components/SurveyStep.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/src/components/ui/form";
 import { RadioGroup, RadioGroupItem } from "@/src/components/ui/radio-group";
 import { Textarea } from "@/src/components/ui/textarea";
+import { Input } from "@/src/components/ui/input";
 import { Label } from "@/src/components/ui/label";
 import type { Control, Path } from "react-hook-form";
 import type { SurveyQuestion, SurveyFormData } from "../lib/surveyTypes";
@@ -97,11 +98,15 @@ export function SurveyStep({
               {question.question}
             </FormLabel>
             <FormControl>
-              <Textarea
-                placeholder={question.placeholder}
-                className="min-h-[170px] resize-none"
-                {...field}
-              />
+              {question.id === "referralSource" ? (
+                <Input placeholder={question.placeholder} {...field} />
+              ) : (
+                <Textarea
+                  placeholder={question.placeholder}
+                  className="min-h-[170px] resize-none"
+                  {...field}
+                />
+              )}
             </FormControl>
             <FormMessage />
           </FormItem>

--- a/web/src/features/onboarding/lib/questions.ts
+++ b/web/src/features/onboarding/lib/questions.ts
@@ -31,8 +31,7 @@ export const SURVEY_QUESTIONS: SurveyQuestion[] = [
     id: "referralSource",
     type: "text",
     question: "Where did you hear about us?",
-    placeholder:
-      "We're curious to know how you discovered the project! Thanks for sharing.",
+    placeholder: "GitHub, X, Reddit, colleague etc.",
   },
 ];
 

--- a/web/src/features/organizations/components/NewOrganizationForm.tsx
+++ b/web/src/features/organizations/components/NewOrganizationForm.tsx
@@ -47,6 +47,8 @@ export const NewOrganizationForm = ({
     onError: (error) => form.setError("name", { message: error.message }),
   });
   const createSurveyMutation = api.surveys.create.useMutation();
+  const watchedType = form.watch("type");
+  const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 
   function onSubmit(values: z.infer<typeof organizationNameSchema>) {
     capture("organizations:new_form_submit");
@@ -84,9 +86,6 @@ export const NewOrganizationForm = ({
         console.error(error);
       });
   }
-
-  const watchedType = form.watch("type");
-  const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 
   // Clear size whenever type is not Company or Agency to avoid submitting hidden values
   useEffect(() => {

--- a/web/src/features/organizations/components/NewOrganizationForm.tsx
+++ b/web/src/features/organizations/components/NewOrganizationForm.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/src/components/ui/button";
+import { useEffect } from "react";
 import type * as z from "zod/v4";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
@@ -24,6 +25,7 @@ import { useSession } from "next-auth/react";
 import { organizationNameSchema } from "@/src/features/organizations/utils/organizationNameSchema";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { SurveyName } from "@prisma/client";
+import { env } from "@/src/env.mjs";
 
 export const NewOrganizationForm = ({
   onSuccess,
@@ -36,7 +38,7 @@ export const NewOrganizationForm = ({
     resolver: zodResolver(organizationNameSchema),
     defaultValues: {
       name: "",
-      type: undefined,
+      type: "Personal",
       size: undefined,
     },
   });
@@ -53,8 +55,8 @@ export const NewOrganizationForm = ({
         name: values.name,
       })
       .then(async (org) => {
-        // Submit survey with organization data if type is provided
-        if (values.type) {
+        // Submit survey with organization data only on Cloud and if type is provided
+        if (isCloud && values.type) {
           const surveyResponse: Record<string, string> = {
             type: values.type,
           };
@@ -84,6 +86,14 @@ export const NewOrganizationForm = ({
   }
 
   const watchedType = form.watch("type");
+  const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
+
+  // Clear size whenever type is not Company or Agency to avoid submitting hidden values
+  useEffect(() => {
+    if (watchedType !== "Company" && watchedType !== "Agency") {
+      form.setValue("size", undefined);
+    }
+  }, [watchedType, form]);
 
   return (
     <Form {...form}>
@@ -110,67 +120,74 @@ export const NewOrganizationForm = ({
             </FormItem>
           )}
         />
-        <FormField
-          control={form.control}
-          name="type"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Type</FormLabel>
-              <FormDescription>
-                What would best describe your organization?
-              </FormDescription>
-              <Select onValueChange={field.onChange} defaultValue={field.value}>
-                <FormControl>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select organization type" />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  <SelectItem value="Personal">Personal</SelectItem>
-                  <SelectItem value="Educational">Educational</SelectItem>
-                  <SelectItem value="Company">Company</SelectItem>
-                  <SelectItem value="Startup">Startup</SelectItem>
-                  <SelectItem value="Agency">Agency</SelectItem>
-                  <SelectItem value="N/A">N/A</SelectItem>
-                </SelectContent>
-              </Select>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        {(watchedType === "Company" ||
-          watchedType === "Startup" ||
-          watchedType === "Agency") && (
-          <FormField
-            control={form.control}
-            name="size"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>{watchedType} size</FormLabel>
-                <FormDescription>
-                  How many people are in your {watchedType}?
-                </FormDescription>
-                <Select
-                  onValueChange={field.onChange}
-                  defaultValue={field.value}
-                >
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select organization size" />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    <SelectItem value="1-10">1-10</SelectItem>
-                    <SelectItem value="10-49">10-49</SelectItem>
-                    <SelectItem value="50-99">50-99</SelectItem>
-                    <SelectItem value="100-299">100-299</SelectItem>
-                    <SelectItem value="More than 300">More than 300</SelectItem>
-                  </SelectContent>
-                </Select>
-                <FormMessage />
-              </FormItem>
+        {isCloud && (
+          <>
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Type</FormLabel>
+                  <FormDescription>
+                    What would best describe your organization?
+                  </FormDescription>
+                  <Select
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select organization type" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="Personal">Personal</SelectItem>
+                      <SelectItem value="Educational">Educational</SelectItem>
+                      <SelectItem value="Company">Company</SelectItem>
+                      <SelectItem value="Startup">Startup</SelectItem>
+                      <SelectItem value="Agency">Agency</SelectItem>
+                      <SelectItem value="N/A">N/A</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {(watchedType === "Company" || watchedType === "Agency") && (
+              <FormField
+                control={form.control}
+                name="size"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{watchedType} size</FormLabel>
+                    <FormDescription>
+                      How many people are in your {watchedType}?
+                    </FormDescription>
+                    <Select
+                      onValueChange={field.onChange}
+                      defaultValue={field.value}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select organization size" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="1-10">1-10</SelectItem>
+                        <SelectItem value="10-49">10-49</SelectItem>
+                        <SelectItem value="50-99">50-99</SelectItem>
+                        <SelectItem value="100-299">100-299</SelectItem>
+                        <SelectItem value="More than 300">
+                          More than 300
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             )}
-          />
+          </>
         )}
         <Button type="submit" loading={createOrgMutation.isLoading}>
           Create


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance onboarding UX with auto-focus, conditional button labeling, and cloud-specific behavior in survey and organization form components.
> 
>   - **Onboarding Survey**:
>     - Auto-focus on the first form control of the current step in `OnboardingSurvey.tsx`.
>     - Conditional button labeling in `OnboardingSurvey.tsx`: "Skip" or "Next/Finish" based on form state.
>     - Cmd/Ctrl+Enter submits the form on the "referralSource" step in `OnboardingSurvey.tsx`.
>   - **Survey Step**:
>     - `Input` used for "referralSource" question instead of `Textarea` in `SurveyStep.tsx`.
>   - **Organization Form**:
>     - Default organization type set to "Personal" in `NewOrganizationForm.tsx`.
>     - Organization type and size fields only shown for Cloud in `NewOrganizationForm.tsx`.
>     - Clears size field when type is not "Company" or "Agency" in `NewOrganizationForm.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6833a6e53529f5ea3629ca2dfb8111ab3f99348b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->