### PR TITLE
fix(evals): display final status in peek view

### DIFF
--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -50,7 +50,7 @@ export const PeekViewEvaluatorConfigDetail = ({
           <span className="max-h-fit text-lg font-medium">Configuration</span>
           <div className="flex items-center gap-2">
             <StatusBadge
-              type={evalConfig.status.toLowerCase()}
+              type={evalConfig.finalStatus.toLowerCase()}
               isLive
               className="max-h-8"
             />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `StatusBadge` to use `evalConfig.finalStatus` in `peek-evaluator-config-detail.tsx`.
> 
>   - **Behavior**:
>     - Change `StatusBadge` in `peek-evaluator-config-detail.tsx` to use `evalConfig.finalStatus` instead of `evalConfig.status` for displaying status.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for dc5f031ff2d3d47a3439397ec2c2f5a579fec750. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->