### PR TITLE
fix(evals): ensure default model supports langfuse evals at set up

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -14,6 +14,7 @@ export * from "./llm/fetchLLMCompletion";
 export * from "./llm/utils";
 export * from "./llm/types";
 export * from "./llm/compileChatMessages";
+export * from "./llm/testModelCall";
 export * from "./utils/DatabaseReadStream";
 export * from "./utils/transforms";
 export * from "./clickhouse/client";

--- a/packages/shared/src/server/llm/testModelCall.ts
+++ b/packages/shared/src/server/llm/testModelCall.ts
@@ -1,0 +1,52 @@
+import { z as zodV3 } from "zod/v3";
+import {
+  ChatMessageRole,
+  ChatMessageType,
+  LLMApiKeySchema,
+  type ModelConfig,
+} from "./types";
+import { decrypt } from "../../encryption";
+import { fetchLLMCompletion } from "./fetchLLMCompletion";
+import { decryptAndParseExtraHeaders } from "./utils";
+import z from "zod/v4";
+
+export const testModelCall = async ({
+  provider,
+  model,
+  apiKey,
+  prompt,
+  modelConfig,
+}: {
+  provider: string;
+  model: string;
+  apiKey: z.infer<typeof LLMApiKeySchema>;
+  prompt?: string;
+  modelConfig?: ModelConfig | null;
+}): Promise<void> => {
+  (
+    await fetchLLMCompletion({
+      streaming: false,
+      apiKey: decrypt(apiKey.secretKey), // decrypt the secret key
+      extraHeaders: decryptAndParseExtraHeaders(apiKey.extraHeaders),
+      baseURL: apiKey.baseURL ?? undefined,
+      messages: [
+        {
+          role: ChatMessageRole.User,
+          content: prompt ?? "mock content",
+          type: ChatMessageType.User,
+        },
+      ],
+      modelParams: {
+        provider: provider,
+        model: model,
+        adapter: apiKey.adapter,
+        ...modelConfig,
+      },
+      structuredOutputSchema: zodV3.object({
+        score: zodV3.string(),
+        reasoning: zodV3.string(),
+      }),
+      config: apiKey.config,
+    })
+  ).completion;
+};

--- a/packages/shared/src/server/services/DefaultEvaluationModelService/DefaultEvalModelService.ts
+++ b/packages/shared/src/server/services/DefaultEvaluationModelService/DefaultEvalModelService.ts
@@ -63,8 +63,9 @@ export class DefaultEvalModelService {
         });
       }
     } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
       throw new ForbiddenError(
-        "Selected model is not supported for evaluations. Test tool call failed.",
+        `Model configuration not valid for evaluation. ${message}`,
       );
     }
 

--- a/web/src/features/evals/pages/default-evaluation-model.tsx
+++ b/web/src/features/evals/pages/default-evaluation-model.tsx
@@ -223,7 +223,10 @@ function UpdateButton({
           Update
         </Button>
       </PopoverTrigger>
-      <PopoverContent onClick={(e) => e.stopPropagation()}>
+      <PopoverContent
+        onClick={(e) => e.stopPropagation()}
+        className="w-fit max-w-[500px]"
+      >
         <h2 className="text-md mb-3 font-semibold">Please confirm</h2>
         <p className="mb-3 text-sm">
           Updating the default model will impact any currently running

--- a/web/src/features/evals/pages/default-evaluation-model.tsx
+++ b/web/src/features/evals/pages/default-evaluation-model.tsx
@@ -69,21 +69,17 @@ export default function DefaultEvaluationModelPage() {
     });
 
   const executeUpsertMutation = () => {
-    try {
-      upsertDefaultModel({
-        projectId,
-        provider: modelParams.provider.value,
-        adapter: modelParams.adapter.value,
-        model: modelParams.model.value,
-        modelParams: {
-          max_tokens: modelParams.max_tokens.value,
-          temperature: modelParams.temperature.value,
-          top_p: modelParams.top_p.value,
-        },
-      });
-    } catch (error) {
-      return Promise.reject(error);
-    }
+    upsertDefaultModel({
+      projectId,
+      provider: modelParams.provider.value,
+      adapter: modelParams.adapter.value,
+      model: modelParams.model.value,
+      modelParams: {
+        max_tokens: modelParams.max_tokens.value,
+        temperature: modelParams.temperature.value,
+        top_p: modelParams.top_p.value,
+      },
+    });
     setIsEditing(false);
   };
 

--- a/web/src/features/evals/server/defaultEvalModelRouter.ts
+++ b/web/src/features/evals/server/defaultEvalModelRouter.ts
@@ -43,7 +43,7 @@ export const defaultEvalModelRouter = createTRPCRouter({
       });
 
       try {
-        return DefaultEvalModelService.upsertDefaultModel(input);
+        return await DefaultEvalModelService.upsertDefaultModel(input);
       } catch (error) {
         if (error instanceof InvalidRequestError) {
           throw new TRPCError({ code: "BAD_REQUEST", message: error.message });

--- a/web/src/features/evals/server/defaultEvalModelRouter.ts
+++ b/web/src/features/evals/server/defaultEvalModelRouter.ts
@@ -5,6 +5,7 @@ import {
 } from "@/src/server/api/trpc";
 import { z } from "zod/v4";
 import {
+  ForbiddenError,
   InvalidRequestError,
   LangfuseNotFoundError,
   ZodModelConfig,
@@ -48,6 +49,8 @@ export const defaultEvalModelRouter = createTRPCRouter({
           throw new TRPCError({ code: "BAD_REQUEST", message: error.message });
         } else if (error instanceof LangfuseNotFoundError) {
           throw new TRPCError({ code: "NOT_FOUND", message: error.message });
+        } else if (error instanceof ForbiddenError) {
+          throw new TRPCError({ code: "FORBIDDEN", message: error.message });
         }
         throw error;
       }

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -813,12 +813,10 @@ export const evalRouter = createTRPCRouter({
           prompt: input.prompt,
         });
       } catch (err) {
-        logger.error(err);
-
+        const message = err instanceof Error ? err.message : "Unknown error";
         throw new TRPCError({
           code: "PRECONDITION_FAILED",
-          message:
-            "Selected model is not supported for evaluations. Test tool call failed.",
+          message: `Model configuration not valid for evaluation. ${message}`,
         });
       }
 

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -1,5 +1,4 @@
 import { z } from "zod/v4";
-import { z as zodV3 } from "zod/v3";
 import {
   createTRPCRouter,
   protectedProjectProcedure,
@@ -11,7 +10,6 @@ import {
   ZodModelConfig,
   singleFilter,
   variableMapping,
-  ChatMessageRole,
   paginationZod,
   type JobConfiguration,
   JobType,
@@ -21,19 +19,16 @@ import {
   orderBy,
   jsonSchema,
 } from "@langfuse/shared";
-import { decrypt } from "@langfuse/shared/encryption";
 import {
-  decryptAndParseExtraHeaders,
-  fetchLLMCompletion,
   getQueue,
   getScoresByIds,
   logger,
   QueueName,
   QueueJobs,
-  ChatMessageType,
   tableColumnsToSqlFilterAndPrefix,
   orderByToPrismaSql,
   DefaultEvalModelService,
+  testModelCall,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 import { EvalReferencedEvaluators } from "@/src/features/evals/types";
@@ -808,38 +803,15 @@ export const evalRouter = createTRPCRouter({
         });
       }
 
-      const matchingLLMKey = modelConfig.config.apiKey;
-
-      // Make a test structured output call to validate the LLM key
       try {
-        (
-          await fetchLLMCompletion({
-            streaming: false,
-            apiKey: decrypt(matchingLLMKey.secretKey), // decrypt the secret key
-            extraHeaders: decryptAndParseExtraHeaders(
-              matchingLLMKey.extraHeaders,
-            ),
-            baseURL: matchingLLMKey.baseURL ?? undefined,
-            messages: [
-              {
-                role: ChatMessageRole.User,
-                content: input.prompt,
-                type: ChatMessageType.User,
-              },
-            ],
-            modelParams: {
-              provider: modelConfig.config.provider,
-              model: modelConfig.config.model,
-              adapter: matchingLLMKey.adapter,
-              ...input.modelParams,
-            },
-            structuredOutputSchema: zodV3.object({
-              score: zodV3.string(),
-              reasoning: zodV3.string(),
-            }),
-            config: matchingLLMKey.config,
-          })
-        ).completion;
+        // Make a test structured output call to validate the LLM key
+        await testModelCall({
+          provider: modelConfig.config.provider,
+          model: modelConfig.config.model,
+          apiKey: modelConfig.config.apiKey,
+          modelConfig: input.modelParams,
+          prompt: input.prompt,
+        });
       } catch (err) {
         logger.error(err);
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `testModelCall` for LLM API key validation and integrates it into model configuration processes with enhanced error handling and UI feedback.
> 
>   - **Behavior**:
>     - Adds `testModelCall` function in `testModelCall.ts` to validate LLM API keys by making a test structured output call.
>     - Integrates `testModelCall` into `DefaultEvalModelService` to validate model configurations before upserting.
>     - Updates `default-evaluation-model.tsx` to handle errors from `testModelCall` and display them in the UI.
>   - **Error Handling**:
>     - Adds `ForbiddenError` handling in `defaultEvalModelRouter.ts` and `router.ts` for invalid model configurations.
>     - Updates `upsertDefaultModel` mutation in `defaultEvalModelRouter.ts` to catch and throw `ForbiddenError`.
>   - **UI Changes**:
>     - Adds `formError` state in `default-evaluation-model.tsx` to display error messages from model validation.
>     - Modifies dialog behavior to reset errors when closed in `default-evaluation-model.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7b801abd05f4eadfdcc775ba750e5676653d41d4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->