### PR TITLE
chore(datasets-csv-upload): no longer nest column values if single valid json object

### DIFF
--- a/web/src/features/datasets/lib/csvHelpers.ts
+++ b/web/src/features/datasets/lib/csvHelpers.ts
@@ -214,6 +214,15 @@ export function parseColumns(
   headerMap: Map<string, number>,
 ): Prisma.JsonValue {
   if (columnNames.length === 0) return null;
+
+  // Single column: do not nest columns into json objects
+  if (columnNames.length === 1) {
+    const col = columnNames[0];
+    const rawValue = row[headerMap.get(col)!];
+    return parseValue(rawValue);
+  }
+
+  // Multiple columns: nest columns into json objects
   return Object.fromEntries(
     columnNames.map((col) => [col, parseValue(row[headerMap.get(col)!])]),
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `parseColumns` to return single-column CSV data as a direct value instead of a nested JSON object.
> 
>   - **Behavior**:
>     - In `parseColumns` function, single-column CSV data is no longer nested into JSON objects.
>     - For single-column, returns parsed value directly instead of an object.
>     - Multi-column behavior remains unchanged, nesting values into JSON objects.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 932321d3410e71aaba02ecd68a7ab4002eddc511. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->