### PR TITLE
perf: stream new records to clickhouse in writer

### DIFF
--- a/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
+++ b/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
@@ -344,12 +344,12 @@ describe("ClickhouseWriter", () => {
     await vi.advanceTimersByTimeAsync(writer.writeInterval);
 
     expect(mockInsert).toHaveBeenCalledTimes(1);
-    expect(mockInsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        values: expect.arrayContaining(
-          new Array(partialQueueSize).fill(expect.any(Object)),
-        ),
-      }),
+    const streamValues = await mockInsert.mock.calls[0][0].values.toArray();
+    expect(streamValues).toHaveLength(partialQueueSize);
+    expect(streamValues).toEqual(
+      expect.arrayContaining(
+        new Array(partialQueueSize).fill(expect.any(Object)),
+      ),
     );
     expect(writer["queue"][TableName.Traces]).toHaveLength(0);
   });
@@ -518,8 +518,8 @@ describe("ClickhouseWriter", () => {
       expect(writer["queue"][TableName.Traces]).toHaveLength(0);
 
       // Verify that the second call used truncated data
-      const secondCallArgs = mockInsert.mock.calls[1][0];
-      expect(secondCallArgs.values[0].input).toContain(
+      const secondCallArgs = await mockInsert.mock.calls[1][0].values.toArray();
+      expect(secondCallArgs[0].input).toContain(
         "[TRUNCATED: Field exceeded size limit]",
       );
     });

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -12,6 +12,7 @@ import {
   TraceNullRecordInsertType,
   DatasetRunItemRecordInsertType,
 } from "@langfuse/shared/src/server";
+import { Readable } from "stream";
 
 import { env } from "../../env";
 import { logger } from "@langfuse/shared/src/server";
@@ -379,7 +380,7 @@ export class ClickhouseWriter {
       .insert({
         table: params.table,
         format: "JSONEachRow",
-        values: params.records,
+        values: Readable.from(params.records),
         clickhouse_settings: {
           log_comment: JSON.stringify({ feature: "ingestion" }),
         },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimize ClickhouseWriter by streaming records using Node.js streams and update tests for streaming behavior.
> 
>   - **Behavior**:
>     - `writeToClickhouse` in `index.ts` now streams records using `Readable.from()` for efficient data handling.
>     - Updates error handling to retry on size errors by truncating records and retrying.
>   - **Tests**:
>     - Updates `ClickhouseWriter.unit.test.ts` to verify streaming behavior with `toArray()` on mock calls.
>     - Ensures tests handle truncated data correctly after retries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0ba83419c36ec89bc147be0325325bd040fccf1f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->