### PR TITLE
chore: skip unavailable shards in traces AMT background migration

### DIFF
--- a/worker/src/backgroundMigrations/migrateTracesToTracesAMTs.ts
+++ b/worker/src/backgroundMigrations/migrateTracesToTracesAMTs.ts
@@ -35,6 +35,7 @@ async function checkQueryExists(
       SELECT COUNT(*) > 0 AS exists
       FROM ${queryLogTable}
       WHERE query_id = '${queryId}'
+      ${env.CLICKHOUSE_CLUSTER_ENABLED === "true" ? " SETTINGS skip_unavailable_shards = 1 " : ""}
     `,
     format: "JSONEachRow",
   });
@@ -60,6 +61,7 @@ async function checkCompletedQuery(
       FROM ${queryLogTable}
       WHERE query_id = '${queryId}' AND type != 'QueryStart'
       LIMIT 1
+      ${env.CLICKHOUSE_CLUSTER_ENABLED === "true" ? " SETTINGS skip_unavailable_shards = 1 " : ""}
     `,
     format: "JSONEachRow",
   });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add setting to skip unavailable shards in ClickHouse queries for traces AMT migration when cluster is enabled.
> 
>   - **Behavior**:
>     - Add `SETTINGS skip_unavailable_shards = 1` to queries in `checkQueryExists()` and `checkCompletedQuery()` when `CLICKHOUSE_CLUSTER_ENABLED` is `true`.
>   - **Functions**:
>     - Modify `checkQueryExists()` and `checkCompletedQuery()` in `migrateTracesToTracesAMTs.ts` to include shard skipping setting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for afc337ede3b9057f8c9e98afe6fe395d9f1da6e0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->