### PR TITLE
chore: add edit button to dataset items dot menu

### DIFF
--- a/web/src/features/datasets/components/DatasetActionButton.tsx
+++ b/web/src/features/datasets/components/DatasetActionButton.tsx
@@ -183,3 +183,5 @@ export const DatasetActionButton = forwardRef<
     </Dialog>
   );
 });
+
+DatasetActionButton.displayName = "DatasetActionButton";

--- a/web/src/features/datasets/components/DatasetActionButton.tsx
+++ b/web/src/features/datasets/components/DatasetActionButton.tsx
@@ -7,7 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/src/components/ui/dialog";
-import { useState } from "react";
+import { useState, forwardRef } from "react";
 import { DialogTrigger } from "@radix-ui/react-dialog";
 import { DatasetForm } from "@/src/features/datasets/components/DatasetForm";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
@@ -46,7 +46,10 @@ type DatasetActionButtonProps =
   | UpdateDatasetButtonProps
   | DeleteDatasetButtonProps;
 
-export const DatasetActionButton = (props: DatasetActionButtonProps) => {
+export const DatasetActionButton = forwardRef<
+  HTMLButtonElement,
+  DatasetActionButtonProps
+>((props, ref) => {
   const capture = usePostHogClientCapture();
   const [open, setOpen] = useState(false);
   const hasAccess = useHasProjectAccess({
@@ -60,6 +63,7 @@ export const DatasetActionButton = (props: DatasetActionButtonProps) => {
         {props.mode === "update" ? (
           props.icon ? (
             <Button
+              ref={ref}
               variant={props.variant || "outline"}
               size={props.size || "icon"}
               className={props.className}
@@ -74,6 +78,7 @@ export const DatasetActionButton = (props: DatasetActionButtonProps) => {
             </Button>
           ) : (
             <Button
+              ref={ref}
               variant={props.variant || "ghost"}
               size={props.size || "icon"}
               className={props.className}
@@ -95,6 +100,7 @@ export const DatasetActionButton = (props: DatasetActionButtonProps) => {
           )
         ) : props.mode === "delete" ? (
           <Button
+            ref={ref}
             variant={props.variant || "ghost"}
             size={props.size}
             className={props.className}
@@ -115,6 +121,7 @@ export const DatasetActionButton = (props: DatasetActionButtonProps) => {
           </Button>
         ) : (
           <Button
+            ref={ref}
             size={props.size}
             className={props.className}
             disabled={!hasAccess}
@@ -175,4 +182,4 @@ export const DatasetActionButton = (props: DatasetActionButtonProps) => {
       </DialogContent>
     </Dialog>
   );
-};
+});

--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -232,6 +232,7 @@ export function DatasetItemsTable({
             <DropdownMenuContent align="end">
               <DropdownMenuLabel>Actions</DropdownMenuLabel>
               <DropdownMenuItem
+                disabled={!hasAccess}
                 onClick={() => {
                   router.push(
                     `/project/${projectId}/datasets/${datasetId}/items/${id}`,

--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -2,6 +2,7 @@ import { DataTable } from "@/src/components/table/data-table";
 import TableLink from "@/src/components/table/table-link";
 import { api } from "@/src/utils/api";
 import { type RouterOutput } from "@/src/utils/types";
+import { useRouter } from "next/router";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -10,7 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
 import { useQueryParams, withDefault, NumberParam } from "use-query-params";
-import { Archive, ListTree, MoreVertical, Trash2 } from "lucide-react";
+import { Archive, Edit, ListTree, MoreVertical, Trash2 } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import { type DatasetItem, DatasetStatus, type Prisma } from "@langfuse/shared";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
@@ -53,6 +54,7 @@ export function DatasetItemsTable({
   datasetId: string;
   menuItems?: React.ReactNode;
 }) {
+  const router = useRouter();
   const { setDetailPageList } = useDetailPageLists();
   const utils = api.useUtils();
   const capture = usePostHogClientCapture();
@@ -229,6 +231,16 @@ export function DatasetItemsTable({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuLabel>Actions</DropdownMenuLabel>
+              <DropdownMenuItem
+                onClick={() => {
+                  router.push(
+                    `/project/${projectId}/datasets/${datasetId}/items/${id}`,
+                  );
+                }}
+              >
+                <Edit className="mr-2 h-4 w-4" />
+                Edit
+              </DropdownMenuItem>
               <DropdownMenuItem
                 disabled={!hasAccess}
                 onClick={() => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add "Edit" button to dataset items dropdown menu for navigation to edit page, with ref handling in `DatasetActionButton`.
> 
>   - **Behavior**:
>     - Adds an "Edit" button to the dropdown menu in `DatasetItemsTable.tsx`, allowing navigation to the edit page for a dataset item.
>     - Uses `useRouter` to handle navigation to the edit page.
>   - **Components**:
>     - Updates `DatasetActionButton` in `DatasetActionButton.tsx` to use `forwardRef` for button ref handling.
>     - Adds `ref` to `Button` components in `DatasetActionButton` for update, delete, and create modes.
>   - **Icons**:
>     - Imports `Edit` icon in `DatasetItemsTable.tsx` for the new edit menu item.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c2fa6e39ab52a8cae3d2f824f6561665a250e1e0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->