### PR TITLE
chore(datasets): show edit in three dot table menu

### DIFF
--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
 import { useQueryParams, withDefault, NumberParam } from "use-query-params";
-import { Archive, ListTree, MoreVertical, Trash2 } from "lucide-react";
+import { Archive, ListTree, MoreVertical, Pen, Trash2 } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import { type DatasetItem, DatasetStatus, type Prisma } from "@langfuse/shared";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
@@ -30,6 +30,7 @@ import { UploadDatasetCsv } from "@/src/features/datasets/components/UploadDatas
 import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 import { BatchExportTableButton } from "@/src/components/BatchExportTableButton";
 import { BatchExportTableName } from "@langfuse/shared";
+import { useRouter } from "next/router";
 
 type RowData = {
   id: string;
@@ -62,6 +63,7 @@ export function DatasetItemsTable({
     pageIndex: withDefault(NumberParam, 0),
     pageSize: withDefault(NumberParam, 50),
   });
+  const router = useRouter();
 
   const [rowHeight, setRowHeight] = useRowHeightLocalStorage(
     "datasetItems",
@@ -230,6 +232,7 @@ export function DatasetItemsTable({
             <DropdownMenuContent align="end">
               <DropdownMenuLabel>Actions</DropdownMenuLabel>
               <DropdownMenuItem
+                key="archive"
                 disabled={!hasAccess}
                 onClick={() => {
                   capture("dataset_item:archive_toggle", {
@@ -253,6 +256,20 @@ export function DatasetItemsTable({
                 {status === DatasetStatus.ARCHIVED ? "Unarchive" : "Archive"}
               </DropdownMenuItem>
               <DropdownMenuItem
+                key="edit"
+                disabled={!hasAccess}
+                onClick={() => {
+                  // navigate to the item detail page
+                  void router.push(
+                    `/project/${projectId}/datasets/${datasetId}/items/${id}`,
+                  );
+                }}
+              >
+                <Pen className="mr-2 h-4 w-4" />
+                Edit
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                key="delete"
                 disabled={!hasAccess}
                 className="text-destructive"
                 onClick={() => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds 'Edit' option to `DatasetItemsTable` dropdown menu, allowing navigation to item detail page.
> 
>   - **Behavior**:
>     - Adds 'Edit' option to the dropdown menu in `DatasetItemsTable`.
>     - Navigates to item detail page on click using `router.push()`.
>   - **Icons**:
>     - Imports `Pen` icon from `lucide-react` for the 'Edit' option.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2da51e6fc6425994c2b7c133746a6d6053b6022d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->