### PR TITLE
perf: allow concurrent insert operations on ClickHouse Writer

### DIFF
--- a/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
+++ b/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
@@ -210,19 +210,6 @@ describe("ClickhouseWriter", () => {
     expect(writer["queue"][TableName.Observations]).toHaveLength(0);
   });
 
-  it("should not flush when isIntervalFlushInProgress is true", async () => {
-    const mockInsert = vi
-      .spyOn(clickhouseClientMock, "insert")
-      .mockResolvedValue();
-    writer["isIntervalFlushInProgress"] = true;
-    writer.addToQueue(TableName.Traces, { id: "1", name: "test" });
-
-    await vi.advanceTimersByTimeAsync(writer.writeInterval);
-
-    expect(mockInsert).not.toHaveBeenCalled();
-    expect(writer["queue"][TableName.Traces]).toHaveLength(1);
-  });
-
   it("should set up interval correctly in start method", () => {
     const setIntervalSpy = vi.spyOn(global, "setInterval");
     writer["start"]();

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -28,15 +28,12 @@ export class ClickhouseWriter {
   maxAttempts: number;
   queue: ClickhouseQueue;
 
-  isIntervalFlushInProgress: boolean;
   intervalId: NodeJS.Timeout | null = null;
 
   private constructor() {
     this.batchSize = env.LANGFUSE_INGESTION_CLICKHOUSE_WRITE_BATCH_SIZE;
     this.writeInterval = env.LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS;
     this.maxAttempts = env.LANGFUSE_INGESTION_CLICKHOUSE_MAX_ATTEMPTS;
-
-    this.isIntervalFlushInProgress = false;
 
     this.queue = {
       [TableName.Traces]: [],
@@ -72,15 +69,9 @@ export class ClickhouseWriter {
     );
 
     this.intervalId = setInterval(() => {
-      if (this.isIntervalFlushInProgress) return;
-
-      this.isIntervalFlushInProgress = true;
-
       logger.debug("Flush interval elapsed, flushing all queues...");
 
-      this.flushAll().finally(() => {
-        this.isIntervalFlushInProgress = false;
-      });
+      this.flushAll().finally(() => {});
     }, this.writeInterval);
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes `isIntervalFlushInProgress` flag in `ClickhouseWriter` to allow concurrent flush operations, simplifying the code and improving performance.
> 
>   - **Behavior**:
>     - Removes `isIntervalFlushInProgress` flag from `ClickhouseWriter` to allow concurrent flush operations.
>     - Simplifies `setInterval` logic in `ClickhouseWriter` by removing checks for ongoing flush operations.
>   - **Misc**:
>     - Minor refactoring in `ClickhouseWriter` to remove unused code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d8d3ca508a84368f4b49a09b35a239b39fb4f8b7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->