### PR TITLE
chore: limit traces to trace AMT migration to only write into traces_all_amt

### DIFF
--- a/worker/src/backgroundMigrations/migrateTracesToTracesAMTs.ts
+++ b/worker/src/backgroundMigrations/migrateTracesToTracesAMTs.ts
@@ -341,8 +341,6 @@ export default class MigrateTracesToTracesAMTs implements IBackgroundMigration {
             updated_at
           FROM traces t
           WHERE toYYYYMM(t.timestamp) = ${currentMonth}
-          -- order by project_id, toDate(t.timestamp), t.event_ts desc
-          -- limit 1 by project_id, id
         `
         : `
           INSERT INTO ${targetTable}

--- a/worker/src/backgroundMigrations/migrateTracesToTracesAMTs.ts
+++ b/worker/src/backgroundMigrations/migrateTracesToTracesAMTs.ts
@@ -302,47 +302,8 @@ export default class MigrateTracesToTracesAMTs implements IBackgroundMigration {
         ? "traces_all_amt"
         : "traces_null";
 
-      const query = targetTracesAllAmtOnly
-        ? `
-        INSERT INTO traces_all_amt
-        SELECT 
-          -- Identifiers
-          project_id,
-          id,
-          timestamp as start_time,
-          null as end_time,
-          name,
-          
-          -- Metadata properties
-          metadata,
-          user_id,
-          session_id,
-          tags,
-          version, 
-          release,
-          
-          -- UI Properties
-          bookmarked,
-          public,
-          
-          -- Aggregations
-          [] as observation_ids,
-          [] as score_ids,
-          map() as cost_details,
-          map() as usage_details,
-          
-          -- Input/Output
-          input,
-          output,
-          
-          created_at,
-          updated_at,
-          event_ts
-        FROM traces
-        WHERE toYYYYMM(timestamp) = ${currentMonth}
-      `
-        : `
-        INSERT INTO traces_null
+      const query = `
+        INSERT INTO ${targetTable}
         SELECT 
           -- Identifiers
           project_id,

--- a/worker/src/backgroundMigrations/migrateTracesToTracesAMTs.ts
+++ b/worker/src/backgroundMigrations/migrateTracesToTracesAMTs.ts
@@ -334,15 +334,15 @@ export default class MigrateTracesToTracesAMTs implements IBackgroundMigration {
             map() as usage_details,
 
             -- Input/Output
-            arrayReduce('argMaxState', [coalesce(input, '')], [event_ts]) as input,
-            arrayReduce('argMaxState', [coalesce(output, '')], [event_ts]) as output,
+            arrayReduce('argMaxState', [coalesce(input, '')], [if(coalesce(input, '') <> '', event_ts, toDateTime64(0, 3))]) as input,
+            arrayReduce('argMaxState', [coalesce(output, '')], [if(coalesce(output, '') <> '', event_ts, toDateTime64(0, 3))]) as output,
 
             created_at,
             updated_at
           FROM traces t
           WHERE toYYYYMM(t.timestamp) = ${currentMonth}
-          order by project_id, toDate(t.timestamp), t.event_ts desc
-          limit 1 by project_id, id
+          -- order by project_id, toDate(t.timestamp), t.event_ts desc
+          -- limit 1 by project_id, id
         `
         : `
           INSERT INTO ${targetTable}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `targetTracesAllAmtOnly` flag to control whether traces migrate to `traces_all_amt` or `traces_null` in `migrateTracesToTracesAMTs.ts`.
> 
>   - **Behavior**:
>     - Adds `targetTracesAllAmtOnly` flag to `MigrationState` in `migrateTracesToTracesAMTs.ts` to control target table for migration.
>     - If `targetTracesAllAmtOnly` is true, traces are migrated to `traces_all_amt` instead of `traces_null`.
>     - Default behavior remains migrating to `traces_null` unless flag is set.
>   - **Logging**:
>     - Updates log messages in `executeLongRunningQuery()` and `run()` to reflect target table based on `targetTracesAllAmtOnly` flag.
>   - **Query Logic**:
>     - Modifies query construction in `run()` to conditionally target `traces_all_amt` or `traces_null` based on `targetTracesAllAmtOnly`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c2c0af85a43ab0fad03087e37ad3232d595542a3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->