### PR TITLE
Revert "perf: stream new records to clickhouse in writer (#8421)"

### DIFF
--- a/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
+++ b/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
@@ -344,12 +344,12 @@ describe("ClickhouseWriter", () => {
     await vi.advanceTimersByTimeAsync(writer.writeInterval);
 
     expect(mockInsert).toHaveBeenCalledTimes(1);
-    const streamValues = await mockInsert.mock.calls[0][0].values.toArray();
-    expect(streamValues).toHaveLength(partialQueueSize);
-    expect(streamValues).toEqual(
-      expect.arrayContaining(
-        new Array(partialQueueSize).fill(expect.any(Object)),
-      ),
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        values: expect.arrayContaining(
+          new Array(partialQueueSize).fill(expect.any(Object)),
+        ),
+      }),
     );
     expect(writer["queue"][TableName.Traces]).toHaveLength(0);
   });
@@ -518,8 +518,8 @@ describe("ClickhouseWriter", () => {
       expect(writer["queue"][TableName.Traces]).toHaveLength(0);
 
       // Verify that the second call used truncated data
-      const secondCallArgs = await mockInsert.mock.calls[1][0].values.toArray();
-      expect(secondCallArgs[0].input).toContain(
+      const secondCallArgs = mockInsert.mock.calls[1][0];
+      expect(secondCallArgs.values[0].input).toContain(
         "[TRUNCATED: Field exceeded size limit]",
       );
     });

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -12,7 +12,6 @@ import {
   TraceNullRecordInsertType,
   DatasetRunItemRecordInsertType,
 } from "@langfuse/shared/src/server";
-import { Readable } from "stream";
 
 import { env } from "../../env";
 import { logger } from "@langfuse/shared/src/server";
@@ -380,7 +379,7 @@ export class ClickhouseWriter {
       .insert({
         table: params.table,
         format: "JSONEachRow",
-        values: Readable.from(params.records),
+        values: params.records,
         clickhouse_settings: {
           log_comment: JSON.stringify({ feature: "ingestion" }),
         },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reverts streaming records to Clickhouse using `Readable.from()` and updates tests to reflect this change.
> 
>   - **Behavior**:
>     - Reverts streaming records to Clickhouse using `Readable.from()` in `index.ts`.
>     - Changes `values` parameter in `writeToClickhouse()` to use direct array instead of stream.
>   - **Tests**:
>     - Updates `ClickhouseWriter.unit.test.ts` to reflect changes in `mockInsert` calls, removing `toArray()` and adjusting expectations accordingly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2df03036a18d4a9c6f803a8fdc4765178944b482. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->