### PR TITLE
fix(evals): update trace deletion logic to remove job executions directly

### DIFF
--- a/worker/src/features/traces/processPostgresTraceDelete.ts
+++ b/worker/src/features/traces/processPostgresTraceDelete.ts
@@ -9,26 +9,12 @@ export const processPostgresTraceDelete = async (
     `Deleting traces ${JSON.stringify(traceIds)} in project ${projectId} from Postgres`,
   );
   try {
-    await prisma.jobExecution.updateMany({
+    await prisma.jobExecution.deleteMany({
       where: {
         jobInputTraceId: {
           in: traceIds,
         },
         projectId: projectId,
-      },
-      data: {
-        jobInputTraceId: {
-          set: null,
-        },
-        jobInputObservationId: {
-          set: null,
-        },
-        status: {
-          set: "CANCELLED",
-        },
-        error: {
-          set: "Job execution cancelled. User deleted to be evaluated trace.",
-        },
       },
     });
   } catch (e) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `processPostgresTraceDelete` now directly deletes job executions instead of updating them, simplifying trace deletion logic.
> 
>   - **Behavior**:
>     - `processPostgresTraceDelete` in `processPostgresTraceDelete.ts` now directly deletes job executions instead of updating them.
>     - Removes logic that set job execution fields to null and status to "CANCELLED".
>   - **Error Handling**:
>     - Retains error logging and exception tracing for failed deletions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2a9c2e4b4159fc68a320505c3f0c063e9f1368d0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->