### PR TITLE
fix: implement a recursive version of getChannels

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -199,6 +199,14 @@ const EnvSchema = z.object({
   SLACK_CLIENT_ID: z.string().optional(),
   SLACK_CLIENT_SECRET: z.string().optional(),
   SLACK_STATE_SECRET: z.string().optional(),
+  SLACK_FETCH_LIMIT: z
+    .number()
+    .positive()
+    .optional()
+    .default(1_000)
+    .describe(
+      "How many records should be fetched from Slack, before we give up",
+    ),
   HTTPS_PROXY: z.string().optional(),
 
   LANGFUSE_SERVER_SIDE_IO_CHAR_LIMIT: z.coerce

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -273,11 +273,6 @@ export const env = createEnv({
     SLACK_CLIENT_ID: z.string().optional(),
     SLACK_CLIENT_SECRET: z.string().optional(),
     SLACK_STATE_SECRET: z.string().optional(),
-    SLACK_FETCH_LIMIT: z
-      .number({ description: "How many records should be fetched from Slack, before we give up" })
-      .positive()
-      .optional()
-      .default(1_000),
   },
 
   /**
@@ -548,7 +543,6 @@ export const env = createEnv({
     SLACK_CLIENT_ID: process.env.SLACK_CLIENT_ID,
     SLACK_CLIENT_SECRET: process.env.SLACK_CLIENT_SECRET,
     SLACK_STATE_SECRET: process.env.SLACK_STATE_SECRET,
-    SLACK_FETCH_LIMIT: process.env.SLACK_FETCH_LIMIT,
   },
   // Skip validation in Docker builds
   // DOCKER_BUILD is set in Dockerfile

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -273,6 +273,11 @@ export const env = createEnv({
     SLACK_CLIENT_ID: z.string().optional(),
     SLACK_CLIENT_SECRET: z.string().optional(),
     SLACK_STATE_SECRET: z.string().optional(),
+    SLACK_FETCH_LIMIT: z
+      .number({ description: "How many records should be fetched from Slack, before we give up" })
+      .positive()
+      .optional()
+      .default(1_000),
   },
 
   /**
@@ -543,6 +548,7 @@ export const env = createEnv({
     SLACK_CLIENT_ID: process.env.SLACK_CLIENT_ID,
     SLACK_CLIENT_SECRET: process.env.SLACK_CLIENT_SECRET,
     SLACK_STATE_SECRET: process.env.SLACK_STATE_SECRET,
+    SLACK_FETCH_LIMIT: process.env.SLACK_FETCH_LIMIT,
   },
   // Skip validation in Docker builds
   // DOCKER_BUILD is set in Dockerfile


### PR DESCRIPTION
## What does this PR do?

SlackService.getChannels only fetched 200 channels, which after filtering might get even less. This doesn't work for large organizations, as there are usually more than 200 active channels, with possibly more archived (which counted into the limit)

Related discussion https://github.com/orgs/langfuse/discussions/8359

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->
- I haven't added tests that prove my fix is effective or that my feature works

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implements recursive channel fetching in `SlackService` to handle Slack API pagination and retrieve all channels.
> 
>   - **Behavior**:
>     - Implements `getChannelsRecursive()` in `SlackService.ts` to fetch all channels using Slack API's cursor-based pagination.
>     - Updates `getChannels()` to use `getChannelsRecursive()` for complete channel retrieval.
>   - **Error Handling**:
>     - Logs errors in `getChannelsRecursive()` if channel fetching fails.
>     - Throws detailed errors in `getChannelsRecursive()` and `getChannels()` for better debugging.
>   - **Logging**:
>     - Adds debug logging in `getChannels()` to log the number of channels retrieved.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d9e0a7ea9ede4796fd0dca43581e6a9e67b56934. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->