### PR TITLE
fix: fail silently when /api/latest-releases returns invalid schema

### DIFF
--- a/web/src/server/api/routers/public.ts
+++ b/web/src/server/api/routers/public.ts
@@ -2,7 +2,6 @@ import { VERSION } from "@/src/constants/VERSION";
 import { env } from "@/src/env.mjs";
 import { createTRPCRouter, publicProcedure } from "@/src/server/api/trpc";
 import { logger } from "@langfuse/shared/src/server";
-import { TRPCError } from "@trpc/server";
 import { z } from "zod/v4";
 
 const versionSchema = z.string().regex(/^v\d+\.\d+\.\d+(?:[-+].+)?$/); // e.g. v1.2.3, v1.2.3-rc.1, v1.2.3+build.123
@@ -79,7 +78,7 @@ export const publicRouter = createTRPCRouter({
       );
       body = await response.json();
     } catch (error) {
-      logger.info(
+      logger.error(
         "[trpc.public.checkUpdate] failed to fetch latest-release api",
       );
       return null;
@@ -87,19 +86,22 @@ export const publicRouter = createTRPCRouter({
 
     const releases = ReleaseApiRes.safeParse(body);
     if (!releases.success) {
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message: "Release API response is invalid",
-      });
+      logger.error(
+        "[trpc.public.checkUpdate] Release API response is invalid, does not match schema",
+        {
+          error: releases.error,
+        },
+      );
+      return null;
     }
     const langfuseRelease = releases.data.find(
       (release) => release.repo === "langfuse/langfuse",
     );
     if (!langfuseRelease) {
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message: "Release API response is invalid",
-      });
+      logger.error(
+        "[trpc.public.checkUpdate] Release API response is invalid, does not contain langfuse/langfuse",
+      );
+      return null;
     }
 
     const updateType = compareVersions(VERSION, langfuseRelease.latestRelease);

--- a/web/src/server/api/routers/public.ts
+++ b/web/src/server/api/routers/public.ts
@@ -80,6 +80,9 @@ export const publicRouter = createTRPCRouter({
     } catch (error) {
       logger.error(
         "[trpc.public.checkUpdate] failed to fetch latest-release api",
+        {
+          error,
+        },
       );
       return null;
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> In `public.ts`, `checkUpdate` now logs errors and returns null instead of throwing exceptions for invalid API responses.
> 
>   - **Behavior**:
>     - In `public.ts`, `checkUpdate` now logs errors instead of throwing `TRPCError` when `/api/latest-releases` returns an invalid schema or missing `langfuse/langfuse` repo.
>     - Returns `null` if the API response is invalid or the specific repo is not found.
>   - **Logging**:
>     - Changes from `logger.info` to `logger.error` for failed fetch attempts and invalid schema responses in `checkUpdate`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for dcb094b99bd0749e7b4f781a483d525d184f9393. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->