### PR TITLE
chore: add AMT based analytics view

### DIFF
--- a/packages/shared/clickhouse/migrations/clustered/0024_analytics_traces_amt.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0024_analytics_traces_amt.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS analytics_traces_amt ON CLUSTER default;

--- a/packages/shared/clickhouse/migrations/clustered/0024_analytics_traces_amt.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0024_analytics_traces_amt.up.sql
@@ -1,0 +1,26 @@
+CREATE VIEW analytics_traces_amt ON CLUSTER default AS
+SELECT
+    project_id,
+    toStartOfHour(argMaxMerge(timestamp)) AS hour,
+    uniq(id) AS countTraces,
+    max(argMaxMerge(user_id) IS NOT NULL) AS hasUsers,
+    max(argMaxMerge(session_id) IS NOT NULL) AS hasSessions,
+    max(if(argMaxMerge(environment) != 'default', 1, 0)) AS hasEnvironments,
+    max(length(groupUniqArrayArrayMerge(tags)) > 0) AS hasTags,
+    -- Enhanced analytics from AMT data
+    max(length(maxMapMerge(metadata)) > 0) AS hasMetadata,
+    max(argMaxMerge(version) IS NOT NULL) AS hasVersions,
+    max(argMaxMerge(release) IS NOT NULL) AS hasReleases,
+    max(argMaxMerge(bookmarked) IS NOT NULL AND argMaxMerge(bookmarked) = true) AS hasBookmarked,
+    max(argMaxMerge(public) IS NOT NULL AND argMaxMerge(public) = true) AS hasPublic,
+    max(length(groupUniqArrayArrayMerge(observation_ids)) > 0) AS hasObservations,
+    max(length(groupUniqArrayArrayMerge(score_ids)) > 0) AS hasScores,
+    -- Cost and usage aggregations
+    sumMapMerge(cost_details) AS totalCostDetails,
+    sumMapMerge(usage_details) AS totalUsageDetails
+FROM
+    traces_all_amt
+WHERE toStartOfHour(argMaxMerge(timestamp)) <= toStartOfHour(subtractHours(now(), 1))
+GROUP BY
+    project_id,
+    hour;

--- a/packages/shared/clickhouse/migrations/clustered/0024_analytics_traces_amt.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0024_analytics_traces_amt.up.sql
@@ -1,26 +1,15 @@
 CREATE VIEW analytics_traces_amt ON CLUSTER default AS
 SELECT
     project_id,
-    toStartOfHour(argMaxMerge(timestamp)) AS hour,
+    toStartOfHour(start_time) AS hour,
     uniq(id) AS countTraces,
-    max(argMaxMerge(user_id) IS NOT NULL) AS hasUsers,
-    max(argMaxMerge(session_id) IS NOT NULL) AS hasSessions,
-    max(if(argMaxMerge(environment) != 'default', 1, 0)) AS hasEnvironments,
-    max(length(groupUniqArrayArrayMerge(tags)) > 0) AS hasTags,
-    -- Enhanced analytics from AMT data
-    max(length(maxMapMerge(metadata)) > 0) AS hasMetadata,
-    max(argMaxMerge(version) IS NOT NULL) AS hasVersions,
-    max(argMaxMerge(release) IS NOT NULL) AS hasReleases,
-    max(argMaxMerge(bookmarked) IS NOT NULL AND argMaxMerge(bookmarked) = true) AS hasBookmarked,
-    max(argMaxMerge(public) IS NOT NULL AND argMaxMerge(public) = true) AS hasPublic,
-    max(length(groupUniqArrayArrayMerge(observation_ids)) > 0) AS hasObservations,
-    max(length(groupUniqArrayArrayMerge(score_ids)) > 0) AS hasScores,
-    -- Cost and usage aggregations
-    sumMapMerge(cost_details) AS totalCostDetails,
-    sumMapMerge(usage_details) AS totalUsageDetails
+    max(user_id IS NOT NULL) AS hasUsers,
+    max(session_id IS NOT NULL) AS hasSessions,
+    max(if(environment != 'default', 1, 0)) AS hasEnvironments,
+    max(length(tags) > 0) AS hasTags
 FROM
     traces_all_amt
-WHERE toStartOfHour(argMaxMerge(timestamp)) <= toStartOfHour(subtractHours(now(), 1))
+WHERE toStartOfHour(start_time) <= toStartOfHour(subtractHours(now(), 1))
 GROUP BY
     project_id,
     hour;

--- a/packages/shared/clickhouse/migrations/unclustered/0024_analytics_traces_amt.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0024_analytics_traces_amt.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS analytics_traces_amt;

--- a/packages/shared/clickhouse/migrations/unclustered/0024_analytics_traces_amt.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0024_analytics_traces_amt.up.sql
@@ -1,26 +1,15 @@
 CREATE VIEW analytics_traces_amt AS
 SELECT
     project_id,
-    toStartOfHour(argMaxMerge(timestamp)) AS hour,
+    toStartOfHour(start_time) AS hour,
     uniq(id) AS countTraces,
-    max(argMaxMerge(user_id) IS NOT NULL) AS hasUsers,
-    max(argMaxMerge(session_id) IS NOT NULL) AS hasSessions,
-    max(if(argMaxMerge(environment) != 'default', 1, 0)) AS hasEnvironments,
-    max(length(groupUniqArrayArrayMerge(tags)) > 0) AS hasTags,
-    -- Enhanced analytics from AMT data
-    max(length(maxMapMerge(metadata)) > 0) AS hasMetadata,
-    max(argMaxMerge(version) IS NOT NULL) AS hasVersions,
-    max(argMaxMerge(release) IS NOT NULL) AS hasReleases,
-    max(argMaxMerge(bookmarked) IS NOT NULL AND argMaxMerge(bookmarked) = true) AS hasBookmarked,
-    max(argMaxMerge(public) IS NOT NULL AND argMaxMerge(public) = true) AS hasPublic,
-    max(length(groupUniqArrayArrayMerge(observation_ids)) > 0) AS hasObservations,
-    max(length(groupUniqArrayArrayMerge(score_ids)) > 0) AS hasScores,
-    -- Cost and usage aggregations
-    sumMapMerge(cost_details) AS totalCostDetails,
-    sumMapMerge(usage_details) AS totalUsageDetails
+    max(user_id IS NOT NULL) AS hasUsers,
+    max(session_id IS NOT NULL) AS hasSessions,
+    max(if(environment != 'default', 1, 0)) AS hasEnvironments,
+    max(length(tags) > 0) AS hasTags
 FROM
     traces_all_amt
-WHERE toStartOfHour(argMaxMerge(timestamp)) <= toStartOfHour(subtractHours(now(), 1))
+WHERE toStartOfHour(start_time) <= toStartOfHour(subtractHours(now(), 1))
 GROUP BY
     project_id,
     hour;

--- a/packages/shared/clickhouse/migrations/unclustered/0024_analytics_traces_amt.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0024_analytics_traces_amt.up.sql
@@ -1,0 +1,26 @@
+CREATE VIEW analytics_traces_amt AS
+SELECT
+    project_id,
+    toStartOfHour(argMaxMerge(timestamp)) AS hour,
+    uniq(id) AS countTraces,
+    max(argMaxMerge(user_id) IS NOT NULL) AS hasUsers,
+    max(argMaxMerge(session_id) IS NOT NULL) AS hasSessions,
+    max(if(argMaxMerge(environment) != 'default', 1, 0)) AS hasEnvironments,
+    max(length(groupUniqArrayArrayMerge(tags)) > 0) AS hasTags,
+    -- Enhanced analytics from AMT data
+    max(length(maxMapMerge(metadata)) > 0) AS hasMetadata,
+    max(argMaxMerge(version) IS NOT NULL) AS hasVersions,
+    max(argMaxMerge(release) IS NOT NULL) AS hasReleases,
+    max(argMaxMerge(bookmarked) IS NOT NULL AND argMaxMerge(bookmarked) = true) AS hasBookmarked,
+    max(argMaxMerge(public) IS NOT NULL AND argMaxMerge(public) = true) AS hasPublic,
+    max(length(groupUniqArrayArrayMerge(observation_ids)) > 0) AS hasObservations,
+    max(length(groupUniqArrayArrayMerge(score_ids)) > 0) AS hasScores,
+    -- Cost and usage aggregations
+    sumMapMerge(cost_details) AS totalCostDetails,
+    sumMapMerge(usage_details) AS totalUsageDetails
+FROM
+    traces_all_amt
+WHERE toStartOfHour(argMaxMerge(timestamp)) <= toStartOfHour(subtractHours(now(), 1))
+GROUP BY
+    project_id,
+    hour;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `analytics_traces_amt` view for aggregated trace analytics in ClickHouse with new migration files.
> 
>   - **New View**:
>     - Adds `analytics_traces_amt` view in `0024_analytics_traces_amt.up.sql` for both clustered and unclustered setups.
>     - Aggregates data from `traces_all_amt` by `project_id` and hour.
>     - Calculates `countTraces`, `hasUsers`, `hasSessions`, `hasEnvironments`, and `hasTags`.
>   - **Migrations**:
>     - `0024_analytics_traces_amt.up.sql` and `0024_analytics_traces_amt.down.sql` added for both clustered and unclustered setups.
>     - `DROP VIEW IF EXISTS` used in `.down.sql` files to remove the view.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 842f42910c9a0c55b4773eb21a738167f9958567. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->