### PR TITLE
feat(annotation): add POST queue API

### DIFF
--- a/fern/apis/server/definition/annotation-queues.yml
+++ b/fern/apis/server/definition/annotation-queues.yml
@@ -22,6 +22,13 @@ service:
             docs: limit of items per page
       response: PaginatedAnnotationQueues
 
+    createQueue:
+      docs: Create an annotation queue
+      method: POST
+      path: /annotation-queues
+      request: CreateAnnotationQueueRequest
+      response: AnnotationQueue
+
     getQueue:
       docs: Get an annotation queue by ID
       method: GET
@@ -167,6 +174,12 @@ types:
     properties:
       data: list<AnnotationQueueItem>
       meta: pagination.MetaResponse
+
+  CreateAnnotationQueueRequest:
+    properties:
+      name: string
+      description: optional<string>
+      scoreConfigIds: list<string>
 
   CreateAnnotationQueueItemRequest:
     properties:

--- a/packages/shared/src/server/test-utils/org-factory.ts
+++ b/packages/shared/src/server/test-utils/org-factory.ts
@@ -15,6 +15,7 @@ export function createBasicAuthHeader(
 
 export type CreateOrgProjectAndApiKeyOptions = {
   projectId?: string;
+  plan?: "Team" | "Hobby" | "Core" | "Pro" | "Enterprise";
 };
 export const createOrgProjectAndApiKey = async (
   props?: CreateOrgProjectAndApiKeyOptions,
@@ -25,7 +26,7 @@ export const createOrgProjectAndApiKey = async (
       id: v4(),
       name: v4(),
       cloudConfig: CloudConfigSchema.parse({
-        plan: "Team",
+        plan: props?.plan ?? "Team",
       }),
     },
   });

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -79,6 +79,52 @@ paths:
               schema: {}
       security:
         - BasicAuth: []
+    post:
+      description: Create an annotation queue
+      operationId: annotationQueues_createQueue
+      tags:
+        - AnnotationQueues
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnnotationQueue'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAnnotationQueueRequest'
   /api/public/annotation-queues/{queueId}:
     get:
       description: Get an annotation queue by ID
@@ -3254,7 +3300,7 @@ paths:
       parameters:
         - name: filter
           in: query
-          description: Filter expression (e.g. userName eq 'value')
+          description: Filter expression (e.g. userName eq "value")
           required: false
           schema:
             type: string
@@ -4459,6 +4505,22 @@ components:
       required:
         - data
         - meta
+    CreateAnnotationQueueRequest:
+      title: CreateAnnotationQueueRequest
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        scoreConfigIds:
+          type: array
+          items:
+            type: string
+      required:
+        - name
+        - scoreConfigIds
     CreateAnnotationQueueItemRequest:
       title: CreateAnnotationQueueItemRequest
       type: object

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -80,6 +80,39 @@
         },
         {
           "_type": "endpoint",
+          "name": "Create Queue",
+          "request": {
+            "description": "Create an annotation queue",
+            "url": {
+              "raw": "{{baseUrl}}/api/public/annotation-queues",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "public",
+                "annotation-queues"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "header": [],
+            "method": "POST",
+            "auth": null,
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"example\",\n    \"description\": \"example\",\n    \"scoreConfigIds\": [\n        \"example\"\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": []
+        },
+        {
+          "_type": "endpoint",
           "name": "Get Queue",
           "request": {
             "description": "Get an annotation queue by ID",

--- a/web/src/features/public-api/types/annotation-queues.ts
+++ b/web/src/features/public-api/types/annotation-queues.ts
@@ -57,6 +57,17 @@ export const GetAnnotationQueuesResponse = z
   })
   .strict();
 
+// POST /annotation-queues
+export const CreateAnnotationQueueBody = z
+  .object({
+    name: z.string(),
+    description: z.string().nullable(),
+    scoreConfigIds: z.array(z.string()).min(1),
+  })
+  .strict();
+
+export const CreateAnnotationQueueResponse = AnnotationQueueSchema;
+
 // GET /annotation-queues/:queueId
 export const GetAnnotationQueueByIdQuery = z
   .object({

--- a/web/src/pages/api/public/annotation-queues/index.ts
+++ b/web/src/pages/api/public/annotation-queues/index.ts
@@ -94,9 +94,12 @@ export default withMiddlewares({
           id: { in: body.scoreConfigIds },
           projectId: auth.scope.projectId,
         },
+        select: {
+          id: true,
+        },
       });
-
-      if (scoreConfigs.length !== body.scoreConfigIds.length) {
+      const scoreConfigIdSet = new Set(scoreConfigs.map((config) => config.id));
+      if (body.scoreConfigIds.some((id) => !scoreConfigIdSet.has(id))) {
         throw new InvalidRequestError(
           "At least one of the score config IDs cannot be found for the given project.",
         );

--- a/web/src/pages/api/public/annotation-queues/index.ts
+++ b/web/src/pages/api/public/annotation-queues/index.ts
@@ -92,6 +92,7 @@ export default withMiddlewares({
       const scoreConfigs = await prisma.scoreConfig.findMany({
         where: {
           id: { in: body.scoreConfigIds },
+          projectId: auth.scope.projectId,
         },
       });
 
@@ -110,7 +111,14 @@ export default withMiddlewares({
         },
       });
 
-      return queue;
+      return {
+        id: queue.id,
+        name: queue.name,
+        description: queue.description,
+        scoreConfigIds: queue.scoreConfigIds,
+        createdAt: queue.createdAt,
+        updatedAt: queue.updatedAt,
+      };
     },
   }),
 });

--- a/web/src/pages/api/public/annotation-queues/index.ts
+++ b/web/src/pages/api/public/annotation-queues/index.ts
@@ -2,12 +2,14 @@ import { prisma } from "@langfuse/shared/src/db";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import {
+  CreateAnnotationQueueBody,
+  CreateAnnotationQueueResponse,
   GetAnnotationQueuesQuery,
   GetAnnotationQueuesResponse,
 } from "@/src/features/public-api/types/annotation-queues";
+import { InvalidRequestError, MethodNotAllowedError } from "@langfuse/shared";
 
 export default withMiddlewares({
-  // NOTE: Post API requires entitlement check
   GET: createAuthedProjectAPIRoute({
     name: "Get annotation queues",
     querySchema: GetAnnotationQueuesQuery,
@@ -52,6 +54,63 @@ export default withMiddlewares({
           totalPages: Math.ceil(totalItems / query.limit),
         },
       };
+    },
+  }),
+
+  POST: createAuthedProjectAPIRoute({
+    name: "Create annotation queue",
+    bodySchema: CreateAnnotationQueueBody,
+    responseSchema: CreateAnnotationQueueResponse,
+    fn: async ({ body, auth }) => {
+      // entitlement check
+      if (auth.scope.plan === "cloud:hobby") {
+        if (
+          (await prisma.annotationQueue.count({
+            where: {
+              projectId: auth.scope.projectId,
+            },
+          })) >= 1
+        ) {
+          throw new MethodNotAllowedError(
+            "Maximum number of annotation queues reached on Hobby plan.",
+          );
+        }
+      }
+
+      const existingQueue = await prisma.annotationQueue.findFirst({
+        where: {
+          projectId: auth.scope.projectId,
+          name: body.name,
+        },
+      });
+
+      if (existingQueue) {
+        throw new InvalidRequestError("A queue with this name already exists.");
+      }
+
+      // verify the score configs exist
+      const scoreConfigs = await prisma.scoreConfig.findMany({
+        where: {
+          id: { in: body.scoreConfigIds },
+        },
+      });
+
+      if (scoreConfigs.length !== body.scoreConfigIds.length) {
+        throw new InvalidRequestError(
+          "At least one of the score config IDs cannot be found for the given project.",
+        );
+      }
+
+      const queue = await prisma.annotationQueue.create({
+        data: {
+          projectId: auth.scope.projectId,
+          name: body.name,
+          description: body.description,
+          scoreConfigIds: body.scoreConfigIds,
+        },
+      });
+
+      return queue;
     },
   }),
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add POST API endpoint to create annotation queues with validation and entitlement checks, including tests and Postman collection update.
> 
>   - **API Changes**:
>     - Added `createQueue` POST endpoint in `annotation-queues.yml` to create annotation queues.
>     - Endpoint path: `/annotation-queues`, request: `CreateAnnotationQueueRequest`, response: `AnnotationQueue`.
>     - Added `CreateAnnotationQueueRequest` type with `name`, `description`, and `scoreConfigIds`.
>   - **Implementation**:
>     - In `index.ts`, added POST route for creating annotation queues with entitlement checks for Hobby plan.
>     - Validates unique queue name and existence of `scoreConfigIds`.
>   - **Tests**:
>     - Added tests in `annotation-queues-api.servertest.ts` for creating queues, including validation for duplicate names, missing `scoreConfigIds`, and plan restrictions.
>   - **Misc**:
>     - Updated Postman collection in `collection.json` to include the new POST endpoint.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8240899c130862fd753edfd6569e8b4023764793. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->