### PR TITLE
feat(llm-connections): populate gcp region in update form

### DIFF
--- a/web/src/features/llm-api-key/server/router.ts
+++ b/web/src/features/llm-api-key/server/router.ts
@@ -289,6 +289,7 @@ export const llmApiKeyRouter = createTRPCRouter({
               customModels: true,
               withDefaultModels: true,
               extraHeaderKeys: true,
+              config: true,
             },
             where: {
               projectId: input.projectId,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->

The form was already updating the GCP region but the current value wasn't shown in the update dialog.

Fixes #8313

> [!IMPORTANT]
> Adds `config` field to the `select` statement in `llmApiKeyRouter`'s `all` query in `router.ts`.
> 
>   - **Behavior**:
>     - Adds `config: true` to the `select` statement in the `all` query of `llmApiKeyRouter` in `router.ts`, enabling the inclusion of the `config` field in query results.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3fcb45548d6237bc0536d1cfb75299c4fc89a33b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->