### PR TITLE
chore: allow whitelisting which AMTs can be used

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -158,6 +158,12 @@ const EnvSchema = z.object({
   LANGFUSE_EXPERIMENT_INSERT_INTO_AGGREGATING_MERGE_TREES: z
     .enum(["true", "false"])
     .default("false"),
+  LANGFUSE_EXPERIMENT_WHITELISTED_AMT_TABLES: z
+    .string()
+    .optional()
+    .transform((s) =>
+      s ? s.split(",").map((s) => s.toLowerCase().trim()) : [],
+    ),
   LANGFUSE_INGESTION_PROCESSING_SAMPLED_PROJECTS: z
     .string()
     .optional()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `LANGFUSE_EXPERIMENT_WHITELISTED_AMT_TABLES` to whitelist AMT tables in `getTimeframesTracesAMT`.
> 
>   - **Environment**:
>     - Adds `LANGFUSE_EXPERIMENT_WHITELISTED_AMT_TABLES` to `env.ts`, allowing a comma-separated list of whitelisted AMT tables.
>   - **Functionality**:
>     - Updates `getTimeframesTracesAMT` in `traces.ts` to use `LANGFUSE_EXPERIMENT_WHITELISTED_AMT_TABLES` for selecting AMT tables.
>     - Falls back to `TracesAllAMT` if no timestamp is provided or if the selected table is not whitelisted.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ca0ec8cd58ae6d8c01801bb8875fcbd5dbb0997e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->