### PR TITLE
perf: skip FINAL for traces all route without metrics

### DIFF
--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -84,10 +84,9 @@ export const generateTracesForPublicApi = async ({
       SELECT
         trace_id,
         project_id,
-        sum(total_cost) as total_cost,
-        date_diff('millisecond', least(min(start_time), min(end_time)), greatest(max(start_time), max(end_time))) as latency_milliseconds,
-        groupArray(id) as observation_ids
-      FROM observations FINAL
+         ${includeMetrics ? "sum(total_cost) as total_cost, date_diff('millisecond', least(min(start_time), min(end_time)), greatest(max(start_time), max(end_time))) as latency_milliseconds, " : ""}
+        groupUniqArray(id) as observation_ids
+      FROM observations ${includeMetrics ? "FINAL" : ""}
       WHERE project_id = {projectId: String}
       ${timeFilter ? `AND start_time >= {cteTimeFilter: DateTime64(3)} - ${TRACE_TO_OBSERVATIONS_INTERVAL}` : ""}
       ${environmentFilter.length() > 0 ? `AND ${appliedEnvironmentFilter.query}` : ""}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize `generateTracesForPublicApi` in `traces.ts` by conditionally skipping `FINAL` in SQL queries when metrics are not included.
> 
>   - **Performance Optimization**:
>     - In `generateTracesForPublicApi` in `traces.ts`, skip `FINAL` keyword in SQL query when `includeMetrics` is false.
>     - Use `groupUniqArray` instead of `groupArray` for `observation_ids` when `includeMetrics` is false.
>   - **SQL Query Changes**:
>     - Conditional inclusion of `sum(total_cost)` and `latency_milliseconds` in `SELECT` clause based on `includeMetrics`.
>     - Conditional use of `FINAL` in `FROM observations` clause based on `includeMetrics`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 64e0598859f120940f7d5a088e838fba676a0256. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->