### PR TITLE
fix(evals): redirect and pull data for latest template version post template edit

### DIFF
--- a/web/src/features/evals/components/eval-template-detail.tsx
+++ b/web/src/features/evals/components/eval-template-detail.tsx
@@ -33,9 +33,6 @@ export const EvalTemplateDetail = () => {
   const templateId = router.query.id as string;
 
   const [isEditing, setIsEditing] = useState(false);
-  const [selectedTemplate, setSelectedTemplate] = useState<EvalTemplate | null>(
-    null,
-  );
 
   // get the current template by id
   const template = api.evals.templateById.useQuery({
@@ -58,15 +55,7 @@ export const EvalTemplateDetail = () => {
     },
   );
 
-  // Set the selected template when data is loaded
-  React.useEffect(() => {
-    if (template.data && !selectedTemplate) {
-      setSelectedTemplate(template.data);
-    }
-  }, [template.data, selectedTemplate]);
-
   const handleTemplateSelect = (newTemplate: EvalTemplate) => {
-    setSelectedTemplate(newTemplate);
     // Update URL without full page reload
     router.push(
       `/project/${projectId}/evals/templates/${newTemplate.id}`,
@@ -75,13 +64,10 @@ export const EvalTemplateDetail = () => {
     );
   };
 
-  // Get the appropriate template to display
-  const displayTemplate = selectedTemplate || template.data;
-
   return (
     <Page
       headerProps={{
-        title: `${displayTemplate?.name || ""}`,
+        title: `${template.data?.name ?? ""}`,
         itemType: "EVALUATOR",
         breadcrumb: [
           {
@@ -95,7 +81,7 @@ export const EvalTemplateDetail = () => {
               projectId={projectId}
               isEditing={isEditing}
               setIsEditing={setIsEditing}
-              isCustom={!!displayTemplate?.projectId}
+              isCustom={!!template.data?.projectId}
             />
 
             {/* TODO: moved to LFE-4573 */}
@@ -114,14 +100,14 @@ export const EvalTemplateDetail = () => {
         ),
       }}
     >
-      {allTemplates.isLoading || !allTemplates.data || !displayTemplate ? (
+      {allTemplates.isLoading || !allTemplates.data || !template.data ? (
         <div className="p-3">Loading...</div>
       ) : isEditing ? (
         <div className="overflow-y-auto p-3 pt-1">
           <EvalTemplateForm
             useDialog={false}
             projectId={projectId}
-            existingEvalTemplate={displayTemplate}
+            existingEvalTemplate={template.data}
             isEditing={isEditing}
             setIsEditing={setIsEditing}
           />
@@ -132,7 +118,7 @@ export const EvalTemplateDetail = () => {
             <EvalTemplateForm
               useDialog={false}
               projectId={projectId}
-              existingEvalTemplate={displayTemplate}
+              existingEvalTemplate={template.data}
               isEditing={isEditing}
               setIsEditing={setIsEditing}
             />
@@ -150,7 +136,7 @@ export const EvalTemplateDetail = () => {
                     <div
                       key={template.id}
                       className={`flex cursor-pointer flex-col rounded-md px-2 py-1.5 hover:bg-accent ${
-                        template.id === displayTemplate.id ? "bg-accent" : ""
+                        template.id === templateId ? "bg-accent" : ""
                       }`}
                       onClick={() => handleTemplateSelect(template)}
                     >

--- a/web/src/features/evals/components/evaluator-selector.tsx
+++ b/web/src/features/evals/components/evaluator-selector.tsx
@@ -58,6 +58,12 @@ export function EvaluatorSelector({
     },
   );
 
+  // Ensure per-name arrays are sorted by createdAt ascending so last is latest
+  const sortByCreatedAt = (arr: EvalTemplate[]) =>
+    arr.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  Object.values(groupedTemplates.custom).forEach(sortByCreatedAt);
+  Object.values(groupedTemplates.langfuse).forEach(sortByCreatedAt);
+
   // Filter templates based on search
   const filteredTemplates = {
     langfuse: Object.entries(groupedTemplates.langfuse)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplified template version handling in `eval-template-detail.tsx` and ensured latest version display in `evaluator-selector.tsx`.
> 
>   - **Behavior**:
>     - Removed `selectedTemplate` state in `eval-template-detail.tsx`, directly using `template.data` for current template display and selection.
>     - Updated `handleTemplateSelect` to update URL with the latest template version.
>   - **Sorting**:
>     - Added sorting by `createdAt` in `evaluator-selector.tsx` to ensure latest template version is displayed.
>   - **UI**:
>     - Updated UI components in `eval-template-detail.tsx` to reflect changes in template selection logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e6366ba0bac1fc4d022d76f6bdda2908d6f9eecb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->