### PR TITLE
chore(dataset-run-items): sunset dual-write phase; do not fall back on PG in CH execution path 

### DIFF
--- a/packages/shared/src/server/dataset-run-items/datasetExecution.ts
+++ b/packages/shared/src/server/dataset-run-items/datasetExecution.ts
@@ -52,10 +52,11 @@ export async function executeWithDatasetRunItemsStrategy<TInput, TOutput>({
       const postgresResult = await postgresExecution(input);
 
       try {
-        await clickhouseExecution(input);
+        const clickhouseResult = await clickhouseExecution(input);
         logger.debug("Successfully wrote to both PostgreSQL and ClickHouse", {
           operation: `dataset_run_items_${operationType}`,
         });
+        return clickhouseResult;
       } catch (error) {
         logger.error("ClickHouse write failed during dual-write phase", {
           error: error instanceof Error ? error.message : String(error),

--- a/packages/shared/src/server/dataset-run-items/datasetExecution.ts
+++ b/packages/shared/src/server/dataset-run-items/datasetExecution.ts
@@ -48,24 +48,8 @@ export async function executeWithDatasetRunItemsStrategy<TInput, TOutput>({
   if (operationType === DatasetRunItemsOperationType.WRITE) {
     // For write operations, implement dual-write strategy
     if (strategy.shouldWriteToClickHouse) {
-      // Dual-write phase: write to both databases
-      const postgresResult = await postgresExecution(input);
-
-      try {
-        const clickhouseResult = await clickhouseExecution(input);
-        logger.debug("Successfully wrote to both PostgreSQL and ClickHouse", {
-          operation: `dataset_run_items_${operationType}`,
-        });
-        return clickhouseResult;
-      } catch (error) {
-        logger.error("ClickHouse write failed during dual-write phase", {
-          error: error instanceof Error ? error.message : String(error),
-          operation: `dataset_run_items_${operationType}`,
-        });
-        // Continue with PostgreSQL result since it succeeded
-      }
-
-      return postgresResult;
+      // Write only to ClickHouse
+      return await clickhouseExecution(input);
     } else {
       // Write only to PostgreSQL
       return await postgresExecution(input);
@@ -75,20 +59,10 @@ export async function executeWithDatasetRunItemsStrategy<TInput, TOutput>({
     const shouldExecuteClickhouse = strategy.shouldReadFromClickHouse;
 
     if (shouldExecuteClickhouse) {
-      try {
-        return await clickhouseExecution(input);
-      } catch (error) {
-        logger.error(
-          "ClickHouse execution failed, falling back to PostgreSQL",
-          {
-            error: error instanceof Error ? error.message : String(error),
-            operation: `dataset_run_items_${operationType}`,
-          },
-        );
-        // Fallback to PostgreSQL for reliability
-        return await postgresExecution(input);
-      }
+      // Read from ClickHouse
+      return await clickhouseExecution(input);
     } else {
+      // Read from PostgreSQL
       return await postgresExecution(input);
     }
   }

--- a/packages/shared/src/server/dataset-run-items/datasetExecution.ts
+++ b/packages/shared/src/server/dataset-run-items/datasetExecution.ts
@@ -1,5 +1,4 @@
 import { env } from "../../env";
-import { logger } from "../../server/logger";
 import {
   DatasetRunItemsExecutionStrategy,
   DatasetRunItemsOperationType,

--- a/packages/shared/src/server/llm/testModelCall.ts
+++ b/packages/shared/src/server/llm/testModelCall.ts
@@ -22,7 +22,7 @@ export const testModelCall = async ({
   apiKey: z.infer<typeof LLMApiKeySchema>;
   prompt?: string;
   modelConfig?: ModelConfig | null;
-}): Promise<void> => {
+}) => {
   (
     await fetchLLMCompletion({
       streaming: false,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove dual-write strategy and PostgreSQL fallback in `datasetExecution.ts`, focusing on ClickHouse operations.
> 
>   - **Behavior**:
>     - Remove dual-write strategy in `executeWithDatasetRunItemsStrategy()` in `datasetExecution.ts`. Now writes only to ClickHouse if `shouldWriteToClickHouse` is true.
>     - Remove fallback to PostgreSQL for reads in `executeWithDatasetRunItemsStrategy()` in `datasetExecution.ts`. Now reads only from ClickHouse if `shouldReadFromClickHouse` is true.
>   - **Misc**:
>     - Remove unused `logger` import in `datasetExecution.ts`.
>     - Change function signature in `testModelCall.ts` to remove `Promise<void>` return type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 59bb7b627b9110611df2f29be40f94ac47eb8ba1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->