### PR TITLE
perf: parallelize S3 and clickhouse deletions for data retention

### DIFF
--- a/packages/shared/src/server/data-deletion/ingestionFileDeletion.ts
+++ b/packages/shared/src/server/data-deletion/ingestionFileDeletion.ts
@@ -88,7 +88,7 @@ async function removeIngestionEventsFromS3AndDeleteClickhouseRefs(p: {
   );
   await softDeleteInClickhouse(blobStorageRefs);
   logger.info(
-    `Deleted batch ${batch} of size ${blobStorageRefs.length} for ${projectId} of deleting s3 refs`,
+    `Deleted last batch ${batch} of size ${blobStorageRefs.length} for ${projectId} of deleting s3 refs`,
   );
 }
 

--- a/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
+++ b/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
@@ -56,22 +56,21 @@ export const handleDataRetentionProcessingJob = async (job: Job) => {
     );
   }
 
-  await removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject(
-    projectId,
-    cutoffDate,
-  );
-
   // Delete ClickHouse (TTL / Delete Queries)
   logger.info(
-    `[Data Retention] Deleting ClickHouse data older than ${retention} days for project ${projectId}`,
+    `[Data Retention] Deleting ClickHouse and S3 data older than ${retention} days for project ${projectId}`,
   );
   await Promise.all([
+    removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject(
+      projectId,
+      cutoffDate,
+    ),
     deleteTracesOlderThanDays(projectId, cutoffDate),
     deleteObservationsOlderThanDays(projectId, cutoffDate),
     deleteScoresOlderThanDays(projectId, cutoffDate),
   ]);
   logger.info(
-    `[Data Retention] Deleted ClickHouse data older than ${retention} days for project ${projectId}`,
+    `[Data Retention] Deleted ClickHouse and S3 data older than ${retention} days for project ${projectId}`,
   );
 
   // Set S3 Lifecycle for deletion (Future)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Parallelizes S3 and ClickHouse deletions in data retention processing for improved performance and updates logging to reflect combined operations.
> 
>   - **Performance**:
>     - Parallelizes S3 and ClickHouse deletions in `handleDataRetentionProcessingJob` by using `Promise.all`.
>     - Updates `removeIngestionEventsFromS3AndDeleteClickhouseRefs` to log the last batch deletion in `ingestionFileDeletion.ts`.
>   - **Logging**:
>     - Updates log messages in `handleDataRetentionProcessingJob` to indicate combined deletion of ClickHouse and S3 data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 12697c5c6c4464d28317d68380b162bc5bd8aee9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->