### PR TITLE
fix: reinstate ability to remove tags from prompts

### DIFF
--- a/web/src/features/tag/components/TagInput.tsx
+++ b/web/src/features/tag/components/TagInput.tsx
@@ -1,50 +1,79 @@
 import React from "react";
 import { cn } from "@/src/utils/tailwind";
+import { X } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import { Command as CommandPrimitive } from "cmdk";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 type TagInputProps = React.ComponentPropsWithoutRef<
   typeof CommandPrimitive.Input
 > & {
   selectedTags: string[];
   setSelectedTags?: (tags: string[]) => void;
+  allowTagRemoval?: boolean;
 };
 
 export const TagInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
   TagInputProps
->(({ className, selectedTags, ...props }, ref) => {
-  return (
-    <div
-      className="flex flex-wrap items-center overflow-auto rounded-lg border px-2"
-      cmdk-input-wrapper=""
-    >
-      {selectedTags.length > 0 && (
-        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 pt-2">
-          {selectedTags.map((tag: string) => (
-            <Button
-              key={tag}
-              variant="tertiary"
-              size="icon-sm"
-              disabled
-              className="cursor-default"
-            >
-              {tag}
-            </Button>
-          ))}
-        </div>
-      )}
-      <CommandPrimitive.Input
-        ref={ref}
-        className={cn(
-          "placeholder:muted-foreground flex h-8 w-full rounded-md border-transparent bg-transparent px-1 text-sm outline-none focus:border-0 focus:border-none focus:border-transparent focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50",
-          className,
+>(
+  (
+    {
+      className,
+      selectedTags,
+      setSelectedTags,
+      allowTagRemoval = false,
+      ...props
+    },
+    ref,
+  ) => {
+    const capture = usePostHogClientCapture();
+
+    const removeTag = (tagToRemove: string) => {
+      if (setSelectedTags && allowTagRemoval) {
+        setSelectedTags(selectedTags.filter((t) => t !== tagToRemove));
+        capture("tag:remove_tag", {
+          name: tagToRemove,
+        });
+      }
+    };
+
+    return (
+      <div
+        className="flex flex-wrap items-center overflow-auto rounded-lg border px-2"
+        cmdk-input-wrapper=""
+      >
+        {selectedTags.length > 0 && (
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 pt-2">
+            {selectedTags.map((tag: string) => (
+              <Button
+                key={tag}
+                variant="tertiary"
+                size="icon-sm"
+                disabled={!allowTagRemoval}
+                className={
+                  allowTagRemoval ? "cursor-pointer" : "cursor-default"
+                }
+                onClick={allowTagRemoval ? () => removeTag(tag) : undefined}
+              >
+                {tag}
+                {allowTagRemoval && <X className="ml-1 h-3 w-3" />}
+              </Button>
+            ))}
+          </div>
         )}
-        autoFocus
-        {...props}
-      />
-    </div>
-  );
-});
+        <CommandPrimitive.Input
+          ref={ref}
+          className={cn(
+            "placeholder:muted-foreground flex h-8 w-full rounded-md border-transparent bg-transparent px-1 text-sm outline-none focus:border-0 focus:border-none focus:border-transparent focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50",
+            className,
+          )}
+          autoFocus
+          {...props}
+        />
+      </div>
+    );
+  },
+);
 
 TagInput.displayName = CommandPrimitive.Input.displayName;

--- a/web/src/features/tag/components/TagManager.tsx
+++ b/web/src/features/tag/components/TagManager.tsx
@@ -22,6 +22,7 @@ type TagManagerProps = {
   mutateTags: (value: string[]) => void;
   className?: string;
   isTableCell?: boolean;
+  allowTagRemoval?: boolean;
 };
 
 const TagManager = ({
@@ -33,6 +34,7 @@ const TagManager = ({
   mutateTags,
   className,
   isTableCell = false,
+  allowTagRemoval = true,
 }: TagManagerProps) => {
   const {
     selectedTags,
@@ -114,6 +116,7 @@ const TagManager = ({
             onValueChange={setInputValue}
             selectedTags={selectedTags}
             setSelectedTags={setSelectedTags}
+            allowTagRemoval={allowTagRemoval}
           />
           <CommandList>
             <CommandGroup

--- a/web/src/features/tag/components/TagPromptDetailsPopover.tsx
+++ b/web/src/features/tag/components/TagPromptDetailsPopover.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { api } from "@/src/utils/api";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { type RouterOutput } from "@/src/utils/types";
-import TagManager from "@/src/features/tag/components/TagMananger";
+import TagManager from "@/src/features/tag/components/TagManager";
 import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
 
 type TagPromptDetailsPopoverProps = {

--- a/web/src/features/tag/components/TagPromptPopover.tsx
+++ b/web/src/features/tag/components/TagPromptPopover.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { api } from "@/src/utils/api";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { type RouterOutput, type RouterInput } from "@/src/utils/types";
-import TagManager from "@/src/features/tag/components/TagMananger";
+import TagManager from "@/src/features/tag/components/TagManager";
 import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
 
 type TagPromptPopverProps = {

--- a/web/src/features/tag/components/TagTraceDetailsPopover.tsx
+++ b/web/src/features/tag/components/TagTraceDetailsPopover.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { api } from "@/src/utils/api";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { type RouterOutput } from "@/src/utils/types";
-import TagManager from "@/src/features/tag/components/TagMananger";
+import TagManager from "@/src/features/tag/components/TagManager";
 import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
 
 type TagTraceDetailsPopoverProps = {
@@ -85,6 +85,7 @@ export function TagTraceDetailsPopover({
       isLoading={isLoading}
       mutateTags={mutateTags}
       className={className}
+      allowTagRemoval={false}
     />
   );
 }

--- a/web/src/features/tag/components/TagTracePopver.tsx
+++ b/web/src/features/tag/components/TagTracePopver.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { api } from "@/src/utils/api";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { type RouterOutput, type RouterInput } from "@/src/utils/types";
-import TagManager from "@/src/features/tag/components/TagMananger";
+import TagManager from "@/src/features/tag/components/TagManager";
 import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
 
 type TagTracePopoverProps = {
@@ -75,6 +75,7 @@ export function TagTracePopover({
       mutateTags={mutateTags}
       className={className}
       isTableCell
+      allowTagRemoval={false}
     />
   );
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reinstates tag removal functionality in `TagInput` and `TagManager` components, adds `allowTagRemoval` prop, and fixes a file name typo.
> 
>   - **Behavior**:
>     - Reinstates tag removal in `TagInput.tsx` by adding `allowTagRemoval` prop.
>     - Updates `removeTag` function to handle tag removal and log events.
>     - Adds `allowTagRemoval` prop to `TagManager` in `TagManager.tsx`.
>   - **File Renames**:
>     - Renames `TagMananger.tsx` to `TagManager.tsx`.
>   - **Components**:
>     - Updates `TagPromptDetailsPopover.tsx`, `TagPromptPopover.tsx`, `TagTraceDetailsPopover.tsx`, and `TagTracePopover.tsx` to use `allowTagRemoval` prop.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6aac8fd25e29709ebf80904b5484b9d333e099c4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->