### PR TITLE
chore(dataset-run-items): add env variable for trace creation

### DIFF
--- a/worker/src/__tests__/experimentsService.test.ts
+++ b/worker/src/__tests__/experimentsService.test.ts
@@ -588,26 +588,7 @@ describe("create experiment job calls with langfuse server side tracing", async 
     await createExperimentJobPostgres({ event: mockEvent });
 
     // Verify callLLM was called with correct trace parameters
-    expect(callLLM).not.toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.any(Array),
-      expect.any(Object),
-      expect.any(String),
-      expect.any(String),
-      expect.objectContaining({
-        environment: PROMPT_EXPERIMENT_ENVIRONMENT,
-        traceName: expect.stringMatching(/^dataset-run-item-/),
-        traceId: expect.any(String),
-        projectId: mockEvent.projectId,
-        authCheck: expect.objectContaining({
-          validKey: true,
-          scope: expect.objectContaining({
-            projectId: mockEvent.projectId,
-            accessLevel: "project",
-          }),
-        }),
-      }),
-    );
+    expect(callLLM).toHaveBeenCalledTimes(0);
   });
 });
 

--- a/worker/src/__tests__/experimentsService.test.ts
+++ b/worker/src/__tests__/experimentsService.test.ts
@@ -588,7 +588,7 @@ describe("create experiment job calls with langfuse server side tracing", async 
     await createExperimentJobPostgres({ event: mockEvent });
 
     // Verify callLLM was called with correct trace parameters
-    expect(callLLM).toHaveBeenCalledWith(
+    expect(callLLM).not.toHaveBeenCalledWith(
       expect.any(Object),
       expect.any(Array),
       expect.any(Object),

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -262,6 +262,9 @@ const EnvSchema = z.object({
     .positive()
     .default(2),
   LANGFUSE_DELETE_BATCH_SIZE: z.coerce.number().positive().default(2000),
+  LANGFUSE_EXPERIMENT_DATASET_RUN_ITEMS_TRACE_SOURCE_CH: z
+    .enum(["true", "false"])
+    .default("false"),
 });
 
 export const env: z.infer<typeof EnvSchema> =

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -264,7 +264,7 @@ const EnvSchema = z.object({
   LANGFUSE_DELETE_BATCH_SIZE: z.coerce.number().positive().default(2000),
   LANGFUSE_EXPERIMENT_DATASET_RUN_ITEMS_TRACE_SOURCE_CH: z
     .enum(["true", "false"])
-    .default("false"),
+    .default("true"),
 });
 
 export const env: z.infer<typeof EnvSchema> =

--- a/worker/src/features/experiments/utils.ts
+++ b/worker/src/features/experiments/utils.ts
@@ -29,6 +29,7 @@ import {
 import { kyselyPrisma, prisma } from "@langfuse/shared/src/db";
 import z from "zod/v4";
 import { createHash } from "crypto";
+import { env } from "../../env";
 
 export enum TraceExecutionSource {
   // eslint-disable-next-line no-unused-vars
@@ -52,7 +53,10 @@ export enum TraceExecutionSource {
  *
  */
 export const shouldCreateTrace = (source: TraceExecutionSource) => {
-  return source === TraceExecutionSource.CLICKHOUSE;
+  if (env.LANGFUSE_EXPERIMENT_DATASET_RUN_ITEMS_TRACE_SOURCE_CH === "true") {
+    return source === TraceExecutionSource.CLICKHOUSE;
+  }
+  return source === TraceExecutionSource.POSTGRES;
 };
 
 /**


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `LANGFUSE_EXPERIMENT_DATASET_RUN_ITEMS_TRACE_SOURCE_CH` env variable to control trace creation source and update related test.
> 
>   - **Environment Variable**:
>     - Add `LANGFUSE_EXPERIMENT_DATASET_RUN_ITEMS_TRACE_SOURCE_CH` to `env.ts` to control trace creation source.
>   - **Functionality**:
>     - Update `shouldCreateTrace` in `utils.ts` to use `LANGFUSE_EXPERIMENT_DATASET_RUN_ITEMS_TRACE_SOURCE_CH` to determine trace source.
>   - **Testing**:
>     - Modify test in `experimentsService.test.ts` to expect `callLLM` to be called zero times, reflecting the new trace creation logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7ab4910bed1ce074e2ec81fa2f7f428fb7045f4c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->