### PR TITLE
chore: add projectId to eval processing spans

### DIFF
--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -27,6 +27,7 @@ import {
   getObservationForTraceIdByName,
   InMemoryFilterService,
   recordIncrement,
+  getCurrentSpan,
 } from "@langfuse/shared/src/server";
 import {
   mapTraceFilterColumn,
@@ -159,6 +160,11 @@ export const createEvalJobs = async ({
   jobTimestamp: Date;
   enforcedJobTimeScope?: JobTimeScope;
 }) => {
+  const span = getCurrentSpan();
+  if (span) {
+    span.setAttribute("messaging.bullmq.job.input.projectId", event.projectId);
+  }
+
   // Fetch all configs for a given project. Those may be dataset or trace configs.
   let configsQuery = kyselyPrisma.$kysely
     .selectFrom("job_configurations")
@@ -471,6 +477,11 @@ export const evaluate = async ({
 }: {
   event: z.infer<typeof EvalExecutionEvent>;
 }) => {
+  const span = getCurrentSpan();
+  if (span) {
+    span.setAttribute("messaging.bullmq.job.input.projectId", event.projectId);
+  }
+
   logger.debug(
     `Evaluating job ${event.jobExecutionId} for project ${event.projectId}`,
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `projectId` to spans in `createEvalJobs()` and `evaluate()` in `evalService.ts` for enhanced traceability.
> 
>   - **Behavior**:
>     - Add `projectId` to spans in `createEvalJobs()` and `evaluate()` in `evalService.ts` using `getCurrentSpan()`.
>   - **Misc**:
>     - Import `getCurrentSpan` from `@langfuse/shared/src/server` in `evalService.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1f6c7b934c6de1396aa4592b0b965b8c21247c38. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->