### PR TITLE
fix(dataset-run-items): set trace creation default to PG for self-hosters

### DIFF
--- a/worker/src/__tests__/experimentsService.test.ts
+++ b/worker/src/__tests__/experimentsService.test.ts
@@ -588,7 +588,26 @@ describe("create experiment job calls with langfuse server side tracing", async 
     await createExperimentJobPostgres({ event: mockEvent });
 
     // Verify callLLM was called with correct trace parameters
-    expect(callLLM).toHaveBeenCalledTimes(0);
+    expect(callLLM).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Array),
+      expect.any(Object),
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({
+        environment: PROMPT_EXPERIMENT_ENVIRONMENT,
+        traceName: expect.stringMatching(/^dataset-run-item-/),
+        traceId: expect.any(String),
+        projectId: mockEvent.projectId,
+        authCheck: expect.objectContaining({
+          validKey: true,
+          scope: expect.objectContaining({
+            projectId: mockEvent.projectId,
+            accessLevel: "project",
+          }),
+        }),
+      }),
+    );
   });
 });
 

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -264,7 +264,7 @@ const EnvSchema = z.object({
   LANGFUSE_DELETE_BATCH_SIZE: z.coerce.number().positive().default(2000),
   LANGFUSE_EXPERIMENT_DATASET_RUN_ITEMS_TRACE_SOURCE_CH: z
     .enum(["true", "false"])
-    .default("true"),
+    .default("false"),
 });
 
 export const env: z.infer<typeof EnvSchema> =


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default trace creation source to Postgres for self-hosters and update test to verify correct parameters in `experimentsService.test.ts`.
> 
>   - **Environment Configuration**:
>     - Change default of `LANGFUSE_EXPERIMENT_DATASET_RUN_ITEMS_TRACE_SOURCE_CH` to `false` in `env.ts`.
>   - **Testing**:
>     - Update test in `experimentsService.test.ts` to verify `callLLM` is called with correct parameters, including `traceName`, `traceId`, and `authCheck`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e36f4d5152424d7a06cd15d4df180dcd970c055d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->