### PR TITLE
chore(dataset-run-items-rmt): add table with suffix, add background migration from postgres to clickhouse 

### DIFF
--- a/packages/shared/clickhouse/migrations/clustered/0024_dataset_run_items.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0024_dataset_run_items.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE dataset_run_items_rmt ON CLUSTER default;

--- a/packages/shared/clickhouse/migrations/clustered/0024_dataset_run_items.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0024_dataset_run_items.up.sql
@@ -1,0 +1,36 @@
+CREATE TABLE dataset_run_items_rmt ON CLUSTER default (
+    -- primary identifiers
+    `id` String,
+    `project_id` String,
+    `dataset_run_id` String,
+    `dataset_item_id` String,
+    `dataset_id` String,
+    `trace_id` String,
+    `observation_id` Nullable(String),
+
+    -- error field
+    `error` Nullable(String),
+
+     -- timestamps
+    `created_at` DateTime64(3) DEFAULT now(),
+    `updated_at` DateTime64(3) DEFAULT now(),
+
+    -- denormalized immutable dataset run fields
+    `dataset_run_name` String,
+    `dataset_run_description` Nullable(String),
+    `dataset_run_metadata` Map(LowCardinality(String), String),
+    `dataset_run_created_at` DateTime64(3),
+
+    -- denormalized dataset item fields (mutable, but snapshots are relevant)
+    `dataset_item_input` Nullable(String) CODEC(ZSTD(3)), -- json
+    `dataset_item_expected_output` Nullable(String) CODEC(ZSTD(3)), -- json
+    `dataset_item_metadata` Map(LowCardinality(String), String),
+
+    -- clickhouse engine fields
+    `event_ts` DateTime64(3),
+    `is_deleted` UInt8,
+
+    -- For dataset item lookups
+    INDEX idx_dataset_item dataset_item_id TYPE bloom_filter(0.001) GRANULARITY 1,
+) ENGINE = ReplicatedReplacingMergeTree(event_ts, is_deleted)
+ORDER BY (project_id, dataset_id, dataset_run_id, id);

--- a/packages/shared/clickhouse/migrations/unclustered/0024_dataset_run_items.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0024_dataset_run_items.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE dataset_run_items_rmt;

--- a/packages/shared/clickhouse/migrations/unclustered/0024_dataset_run_items.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0024_dataset_run_items.up.sql
@@ -1,0 +1,36 @@
+CREATE TABLE dataset_run_items_rmt (
+    -- primary identifiers
+    `id` String,
+    `project_id` String,
+    `dataset_run_id` String,
+    `dataset_item_id` String,
+    `dataset_id` String,
+    `trace_id` String,
+    `observation_id` Nullable(String),
+
+    -- error field
+    `error` Nullable(String),
+
+     -- timestamps
+    `created_at` DateTime64(3) DEFAULT now(),
+    `updated_at` DateTime64(3) DEFAULT now(),
+
+    -- denormalized immutable dataset run fields
+    `dataset_run_name` String,
+    `dataset_run_description` Nullable(String),
+    `dataset_run_metadata` Map(LowCardinality(String), String),
+    `dataset_run_created_at` DateTime64(3),
+
+    -- denormalized dataset item fields (mutable, but snapshots are relevant)
+    `dataset_item_input` Nullable(String) CODEC(ZSTD(3)), -- json
+    `dataset_item_expected_output` Nullable(String) CODEC(ZSTD(3)), -- json
+    `dataset_item_metadata` Map(LowCardinality(String), String),
+
+    -- clickhouse engine fields
+    `event_ts` DateTime64(3),
+    `is_deleted` UInt8,
+
+    -- For dataset item lookups
+    INDEX idx_dataset_item dataset_item_id TYPE bloom_filter(0.001) GRANULARITY 1,
+) ENGINE = ReplacingMergeTree(event_ts, is_deleted)
+ORDER BY (project_id, dataset_id, dataset_run_id, id);

--- a/packages/shared/prisma/migrations/20250814090100_remove_dataset_run_items_pg_to_ch_background_migration/migration.sql
+++ b/packages/shared/prisma/migrations/20250814090100_remove_dataset_run_items_pg_to_ch_background_migration/migration.sql
@@ -1,0 +1,1 @@
+DELETE FROM background_migrations WHERE id = '8d47f91b-3e5c-4a26-9f85-c12d6e4b9a3d';

--- a/packages/shared/prisma/migrations/20250814100100_add_dataset_run_items_rmt_pg_to_ch_background_migration copy/migration.sql
+++ b/packages/shared/prisma/migrations/20250814100100_add_dataset_run_items_rmt_pg_to_ch_background_migration copy/migration.sql
@@ -1,0 +1,2 @@
+INSERT INTO background_migrations (id, name, script, args)
+VALUES ('9f32e84c-7b1d-4f59-a803-d67ae5c9b2e8', '20250814_1001_migrate_dataset_run_items_rmt_pg_to_ch', 'migrateDatasetRunItemsFromPostgresToClickhouseRmt', '{}');

--- a/worker/src/backgroundMigrations/migrateDatasetRunItemsFromPostgresToClickhouse.ts
+++ b/worker/src/backgroundMigrations/migrateDatasetRunItemsFromPostgresToClickhouse.ts
@@ -1,26 +1,18 @@
 import { IBackgroundMigration } from "./IBackgroundMigration";
-import {
-  clickhouseClient,
-  convertPostgresDatasetRunItemToInsert,
-  logger,
-} from "@langfuse/shared/src/server";
-import { parseArgs } from "node:util";
-import { prisma, Prisma } from "@langfuse/shared/src/db";
+import { logger } from "@langfuse/shared/src/server";
 import { env } from "../env";
 
 // This is hard-coded in our migrations and uniquely identifies the row in background_migrations table
-const backgroundMigrationId = "8d47f91b-3e5c-4a26-9f85-c12d6e4b9a3d";
+// In this case it is not used as we will skip this migration and run the RMT migration instead
+// const backgroundMigrationId = "8d47f91b-3e5c-4a26-9f85-c12d6e4b9a3d";
 
 export default class MigrateDatasetRunItemsFromPostgresToClickhouse
   implements IBackgroundMigration
 {
-  private isAborted = false;
-  private isFinished = false;
-
-  async validate(
-    args: Record<string, unknown>,
-    attempts = 5,
-  ): Promise<{ valid: boolean; invalidReason: string | undefined }> {
+  async validate(): Promise<{
+    valid: boolean;
+    invalidReason: string | undefined;
+  }> {
     // Check if Clickhouse credentials are configured
     if (
       !env.CLICKHOUSE_URL ||
@@ -34,157 +26,13 @@ export default class MigrateDatasetRunItemsFromPostgresToClickhouse
       };
     }
 
-    // Check if ClickHouse dataset_run_items table exists
-    const tables = await clickhouseClient().query({
-      query: "SHOW TABLES",
-    });
-    const tableNames = (await tables.json()).data as { name: string }[];
-    if (!tableNames.some((r) => r.name === "dataset_run_items")) {
-      // Retry if the table does not exist as this may mean migrations are still pending
-      if (attempts > 0) {
-        logger.info(
-          `ClickHouse dataset_run_items table does not exist. Retrying in 10s...`,
-        );
-        return new Promise((resolve) => {
-          setTimeout(() => resolve(this.validate(args, attempts - 1)), 10_000);
-        });
-      }
-
-      // If all retries are exhausted, return as invalid
-      return {
-        valid: false,
-        invalidReason: "ClickHouse dataset_run_items table does not exist",
-      };
-    }
-
+    // Return true as we will skip this migration and run the RMT migration instead
     return { valid: true, invalidReason: undefined };
   }
 
-  async run(args: Record<string, unknown>): Promise<void> {
-    const start = Date.now();
+  async run(): Promise<void> {
     logger.info(
-      `Migrating dataset_run_items from postgres to clickhouse with ${JSON.stringify(args)}`,
-    );
-
-    // @ts-ignore
-    const initialMigrationState: { state: { maxDate: string | undefined } } =
-      await prisma.backgroundMigration.findUniqueOrThrow({
-        where: { id: backgroundMigrationId },
-        select: { state: true },
-      });
-
-    const maxRowsToProcess = Number(args.maxRowsToProcess ?? Infinity);
-    const batchSize = Number(args.batchSize ?? 1000);
-    const maxDate = initialMigrationState.state?.maxDate
-      ? new Date(initialMigrationState.state.maxDate)
-      : new Date((args.maxDate as string) ?? new Date());
-
-    await prisma.backgroundMigration.update({
-      where: { id: backgroundMigrationId },
-      data: { state: { maxDate } },
-    });
-
-    let processedRows = 0;
-    while (
-      !this.isAborted &&
-      !this.isFinished &&
-      processedRows < maxRowsToProcess
-    ) {
-      const fetchStart = Date.now();
-
-      // @ts-ignore
-      const migrationState: { state: { maxDate: string } } =
-        await prisma.backgroundMigration.findUniqueOrThrow({
-          where: { id: backgroundMigrationId },
-          select: { state: true },
-        });
-
-      const datasetRunItems = await prisma.$queryRaw<
-        Array<Record<string, any>>
-      >(Prisma.sql`
-        SELECT 
-          dri.id as id,
-          dri.project_id as project_id,
-          dri.dataset_run_id as dataset_run_id,
-          dri.dataset_item_id as dataset_item_id, 
-          dri.trace_id as trace_id,
-          dri.observation_id as observation_id,
-          dri.created_at as created_at,
-          dri.updated_at as updated_at,
-          
-          -- Denormalized dataset run fields
-          dr.name as dataset_run_name,
-          dr.description as dataset_run_description,
-          dr.metadata as dataset_run_metadata,
-          dr.created_at as dataset_run_created_at,
-          
-          -- Denormalized dataset item fields  
-          di.input as dataset_item_input,
-          di.expected_output as dataset_item_expected_output,
-          di.metadata as dataset_item_metadata,
-          
-          -- Dataset ID
-          d.id as dataset_id
-
-        FROM dataset_run_items dri
-        JOIN dataset_runs dr ON dri.dataset_run_id = dr.id
-        JOIN dataset_items di ON dri.dataset_item_id = di.id  
-        JOIN datasets d ON di.dataset_id = d.id
-        WHERE dri.created_at <= ${new Date(migrationState.state.maxDate)}
-        ORDER BY dri.created_at DESC
-        LIMIT ${batchSize};
-      `);
-      if (datasetRunItems.length === 0) {
-        logger.info("No more dataset_run_items to migrate. Exiting...");
-        break;
-      }
-
-      logger.info(
-        `Got ${datasetRunItems.length} records from Postgres in ${Date.now() - fetchStart}ms`,
-      );
-
-      const insertStart = Date.now();
-      await clickhouseClient().insert({
-        table: "dataset_run_items",
-        values: datasetRunItems.map(convertPostgresDatasetRunItemToInsert),
-        format: "JSONEachRow",
-      });
-
-      logger.info(
-        `Inserted ${datasetRunItems.length} dataset_run_items into Clickhouse in ${Date.now() - insertStart}ms`,
-      );
-
-      await prisma.backgroundMigration.update({
-        where: { id: backgroundMigrationId },
-        data: {
-          state: {
-            maxDate: new Date(
-              datasetRunItems[datasetRunItems.length - 1].created_at,
-            ),
-          },
-        },
-      });
-
-      if (datasetRunItems.length < batchSize) {
-        logger.info("No more dataset_run_items to migrate. Exiting...");
-        this.isFinished = true;
-      }
-
-      processedRows += datasetRunItems.length;
-      logger.info(
-        `Processed batch in ${Date.now() - fetchStart}ms. Oldest record in batch: ${new Date(datasetRunItems[datasetRunItems.length - 1].created_at).toISOString()}`,
-      );
-    }
-
-    if (this.isAborted) {
-      logger.info(
-        `Migration of traces from Postgres to Clickhouse aborted after processing ${processedRows} rows. Skipping cleanup.`,
-      );
-      return;
-    }
-
-    logger.info(
-      `Finished migration of traces from Postgres to Clickhouse in ${Date.now() - start}ms`,
+      `Migration of dataset_run_items from postgres to clickhouse skipped as we will run the RMT migration instead`,
     );
   }
 
@@ -192,26 +40,13 @@ export default class MigrateDatasetRunItemsFromPostgresToClickhouse
     logger.info(
       `Aborting migration of dataset run items from Postgres to clickhouse`,
     );
-    this.isAborted = true;
   }
 }
 
 async function main() {
-  const args = parseArgs({
-    options: {
-      batchSize: { type: "string", short: "b", default: "1000" },
-      maxRowsToProcess: { type: "string", short: "r", default: "Infinity" },
-      maxDate: {
-        type: "string",
-        short: "d",
-        default: new Date().toISOString(),
-      },
-    },
-  });
-
   const migration = new MigrateDatasetRunItemsFromPostgresToClickhouse();
-  await migration.validate(args.values);
-  await migration.run(args.values);
+  await migration.validate();
+  await migration.run();
 }
 
 // If the script is being executed directly (not imported), run the main function

--- a/worker/src/backgroundMigrations/migrateDatasetRunItemsFromPostgresToClickhouseRmt.ts
+++ b/worker/src/backgroundMigrations/migrateDatasetRunItemsFromPostgresToClickhouseRmt.ts
@@ -1,0 +1,227 @@
+import { IBackgroundMigration } from "./IBackgroundMigration";
+import {
+  clickhouseClient,
+  convertPostgresDatasetRunItemToInsert,
+  logger,
+} from "@langfuse/shared/src/server";
+import { parseArgs } from "node:util";
+import { prisma, Prisma } from "@langfuse/shared/src/db";
+import { env } from "../env";
+
+// This is hard-coded in our migrations and uniquely identifies the row in background_migrations table
+const backgroundMigrationId = "9f32e84c-7b1d-4f59-a803-d67ae5c9b2e8";
+
+export default class MigrateDatasetRunItemsFromPostgresToClickhouseRmt
+  implements IBackgroundMigration
+{
+  private isAborted = false;
+  private isFinished = false;
+
+  async validate(
+    args: Record<string, unknown>,
+    attempts = 5,
+  ): Promise<{ valid: boolean; invalidReason: string | undefined }> {
+    // Check if Clickhouse credentials are configured
+    if (
+      !env.CLICKHOUSE_URL ||
+      !env.CLICKHOUSE_USER ||
+      !env.CLICKHOUSE_PASSWORD
+    ) {
+      return {
+        valid: false,
+        invalidReason:
+          "Clickhouse credentials must be configured to perform migration",
+      };
+    }
+
+    // Check if ClickHouse dataset_run_items table exists
+    const tables = await clickhouseClient().query({
+      query: "SHOW TABLES",
+    });
+    const tableNames = (await tables.json()).data as { name: string }[];
+    if (!tableNames.some((r) => r.name === "dataset_run_items_rmt")) {
+      // Retry if the table does not exist as this may mean migrations are still pending
+      if (attempts > 0) {
+        logger.info(
+          `ClickHouse dataset_run_items table does not exist. Retrying in 10s...`,
+        );
+        return new Promise((resolve) => {
+          setTimeout(() => resolve(this.validate(args, attempts - 1)), 10_000);
+        });
+      }
+
+      // If all retries are exhausted, return as invalid
+      return {
+        valid: false,
+        invalidReason: "ClickHouse dataset_run_items table does not exist",
+      };
+    }
+
+    return { valid: true, invalidReason: undefined };
+  }
+
+  async run(args: Record<string, unknown>): Promise<void> {
+    const start = Date.now();
+    logger.info(
+      `Migrating dataset_run_items from postgres to clickhouse with ${JSON.stringify(args)}`,
+    );
+
+    // @ts-ignore
+    const initialMigrationState: { state: { maxDate: string | undefined } } =
+      await prisma.backgroundMigration.findUniqueOrThrow({
+        where: { id: backgroundMigrationId },
+        select: { state: true },
+      });
+
+    const maxRowsToProcess = Number(args.maxRowsToProcess ?? Infinity);
+    const batchSize = Number(args.batchSize ?? 1000);
+    const maxDate = initialMigrationState.state?.maxDate
+      ? new Date(initialMigrationState.state.maxDate)
+      : new Date((args.maxDate as string) ?? new Date());
+
+    await prisma.backgroundMigration.update({
+      where: { id: backgroundMigrationId },
+      data: { state: { maxDate } },
+    });
+
+    let processedRows = 0;
+    while (
+      !this.isAborted &&
+      !this.isFinished &&
+      processedRows < maxRowsToProcess
+    ) {
+      const fetchStart = Date.now();
+
+      // @ts-ignore
+      const migrationState: { state: { maxDate: string } } =
+        await prisma.backgroundMigration.findUniqueOrThrow({
+          where: { id: backgroundMigrationId },
+          select: { state: true },
+        });
+
+      const datasetRunItems = await prisma.$queryRaw<
+        Array<Record<string, any>>
+      >(Prisma.sql`
+        SELECT 
+          dri.id as id,
+          dri.project_id as project_id,
+          dri.dataset_run_id as dataset_run_id,
+          dri.dataset_item_id as dataset_item_id, 
+          dri.trace_id as trace_id,
+          dri.observation_id as observation_id,
+          dri.created_at as created_at,
+          dri.updated_at as updated_at,
+          
+          -- Denormalized dataset run fields
+          dr.name as dataset_run_name,
+          dr.description as dataset_run_description,
+          dr.metadata as dataset_run_metadata,
+          dr.created_at as dataset_run_created_at,
+          
+          -- Denormalized dataset item fields  
+          di.input as dataset_item_input,
+          di.expected_output as dataset_item_expected_output,
+          di.metadata as dataset_item_metadata,
+          
+          -- Dataset ID
+          d.id as dataset_id
+
+        FROM dataset_run_items dri
+        JOIN dataset_runs dr ON dri.dataset_run_id = dr.id
+        JOIN dataset_items di ON dri.dataset_item_id = di.id  
+        JOIN datasets d ON di.dataset_id = d.id
+        WHERE dri.created_at <= ${new Date(migrationState.state.maxDate)}
+        ORDER BY dri.created_at DESC
+        LIMIT ${batchSize};
+      `);
+      if (datasetRunItems.length === 0) {
+        logger.info("No more dataset_run_items to migrate. Exiting...");
+        break;
+      }
+
+      logger.info(
+        `Got ${datasetRunItems.length} records from Postgres in ${Date.now() - fetchStart}ms`,
+      );
+
+      const insertStart = Date.now();
+      await clickhouseClient().insert({
+        table: "dataset_run_items_rmt",
+        values: datasetRunItems.map(convertPostgresDatasetRunItemToInsert),
+        format: "JSONEachRow",
+      });
+
+      logger.info(
+        `Inserted ${datasetRunItems.length} dataset_run_items into Clickhouse in ${Date.now() - insertStart}ms`,
+      );
+
+      await prisma.backgroundMigration.update({
+        where: { id: backgroundMigrationId },
+        data: {
+          state: {
+            maxDate: new Date(
+              datasetRunItems[datasetRunItems.length - 1].created_at,
+            ),
+          },
+        },
+      });
+
+      if (datasetRunItems.length < batchSize) {
+        logger.info("No more dataset_run_items to migrate. Exiting...");
+        this.isFinished = true;
+      }
+
+      processedRows += datasetRunItems.length;
+      logger.info(
+        `Processed batch in ${Date.now() - fetchStart}ms. Oldest record in batch: ${new Date(datasetRunItems[datasetRunItems.length - 1].created_at).toISOString()}`,
+      );
+    }
+
+    if (this.isAborted) {
+      logger.info(
+        `Migration of dataset run items from Postgres to Clickhouse aborted after processing ${processedRows} rows. Skipping cleanup.`,
+      );
+      return;
+    }
+
+    logger.info(
+      `Finished migration of dataset run items from Postgres to Clickhouse in ${Date.now() - start}ms`,
+    );
+  }
+
+  async abort(): Promise<void> {
+    logger.info(
+      `Aborting migration of dataset run items from Postgres to clickhouse`,
+    );
+    this.isAborted = true;
+  }
+}
+
+async function main() {
+  const args = parseArgs({
+    options: {
+      batchSize: { type: "string", short: "b", default: "1000" },
+      maxRowsToProcess: { type: "string", short: "r", default: "Infinity" },
+      maxDate: {
+        type: "string",
+        short: "d",
+        default: new Date().toISOString(),
+      },
+    },
+  });
+
+  const migration = new MigrateDatasetRunItemsFromPostgresToClickhouseRmt();
+  await migration.validate(args.values);
+  await migration.run(args.values);
+}
+
+// If the script is being executed directly (not imported), run the main function
+if (require.main === module) {
+  main()
+    .then(() => {
+      process.exit(0);
+    })
+    .catch((error) => {
+      logger.error(`Migration execution failed: ${error}`, error);
+      process.exit(1); // Exit with an error code
+    });
+}

--- a/worker/src/backgroundMigrations/migrateDatasetRunItemsFromPostgresToClickhouseRmt.ts
+++ b/worker/src/backgroundMigrations/migrateDatasetRunItemsFromPostgresToClickhouseRmt.ts
@@ -34,16 +34,16 @@ export default class MigrateDatasetRunItemsFromPostgresToClickhouseRmt
       };
     }
 
-    // Check if ClickHouse dataset_run_items table exists
+    // Check if ClickHouse dataset_run_items_rmt table exists
     const tables = await clickhouseClient().query({
       query: "SHOW TABLES",
     });
     const tableNames = (await tables.json()).data as { name: string }[];
-    if (!tableNames.some((r) => r.name === "dataset_run_items_rmt")) {
+    if (!tableNames.some((r) => r.name === "dataset_run_items_rmt_rmt")) {
       // Retry if the table does not exist as this may mean migrations are still pending
       if (attempts > 0) {
         logger.info(
-          `ClickHouse dataset_run_items table does not exist. Retrying in 10s...`,
+          `ClickHouse dataset_run_items_rmt table does not exist. Retrying in 10s...`,
         );
         return new Promise((resolve) => {
           setTimeout(() => resolve(this.validate(args, attempts - 1)), 10_000);
@@ -53,7 +53,7 @@ export default class MigrateDatasetRunItemsFromPostgresToClickhouseRmt
       // If all retries are exhausted, return as invalid
       return {
         valid: false,
-        invalidReason: "ClickHouse dataset_run_items table does not exist",
+        invalidReason: "ClickHouse dataset_run_items_rmt table does not exist",
       };
     }
 
@@ -63,7 +63,7 @@ export default class MigrateDatasetRunItemsFromPostgresToClickhouseRmt
   async run(args: Record<string, unknown>): Promise<void> {
     const start = Date.now();
     logger.info(
-      `Migrating dataset_run_items from postgres to clickhouse with ${JSON.stringify(args)}`,
+      `Migrating dataset_run_items_rmt from postgres to clickhouse with ${JSON.stringify(args)}`,
     );
 
     // @ts-ignore
@@ -126,7 +126,7 @@ export default class MigrateDatasetRunItemsFromPostgresToClickhouseRmt
           -- Dataset ID
           d.id as dataset_id
 
-        FROM dataset_run_items dri
+        FROM dataset_run_items_rmt dri
         JOIN dataset_runs dr ON dri.dataset_run_id = dr.id
         JOIN dataset_items di ON dri.dataset_item_id = di.id  
         JOIN datasets d ON di.dataset_id = d.id
@@ -135,7 +135,7 @@ export default class MigrateDatasetRunItemsFromPostgresToClickhouseRmt
         LIMIT ${batchSize};
       `);
       if (datasetRunItems.length === 0) {
-        logger.info("No more dataset_run_items to migrate. Exiting...");
+        logger.info("No more dataset_run_items_rmt to migrate. Exiting...");
         break;
       }
 
@@ -145,13 +145,13 @@ export default class MigrateDatasetRunItemsFromPostgresToClickhouseRmt
 
       const insertStart = Date.now();
       await clickhouseClient().insert({
-        table: "dataset_run_items_rmt",
+        table: "dataset_run_items_rmt_rmt",
         values: datasetRunItems.map(convertPostgresDatasetRunItemToInsert),
         format: "JSONEachRow",
       });
 
       logger.info(
-        `Inserted ${datasetRunItems.length} dataset_run_items into Clickhouse in ${Date.now() - insertStart}ms`,
+        `Inserted ${datasetRunItems.length} dataset_run_items_rmt into Clickhouse in ${Date.now() - insertStart}ms`,
       );
 
       await prisma.backgroundMigration.update({
@@ -166,7 +166,7 @@ export default class MigrateDatasetRunItemsFromPostgresToClickhouseRmt
       });
 
       if (datasetRunItems.length < batchSize) {
-        logger.info("No more dataset_run_items to migrate. Exiting...");
+        logger.info("No more dataset_run_items_rmt to migrate. Exiting...");
         this.isFinished = true;
       }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `dataset_run_items_rmt` table and new background migration from Postgres to Clickhouse, removing old migration logic.
> 
>   - **Clickhouse Migrations**:
>     - Add `dataset_run_items_rmt` table creation in `0024_dataset_run_items.up.sql` for both clustered and unclustered setups.
>     - Add corresponding drop table commands in `0024_dataset_run_items.down.sql`.
>   - **Background Migrations**:
>     - Remove old migration entry in `20250814090100_remove_dataset_run_items_pg_to_ch_background_migration/migration.sql`.
>     - Add new migration entry in `20250814100100_add_dataset_run_items_rmt_pg_to_ch_background_migration copy/migration.sql`.
>     - Add `migrateDatasetRunItemsFromPostgresToClickhouseRmt.ts` to handle migration to `dataset_run_items_rmt`.
>     - Update `migrateDatasetRunItemsFromPostgresToClickhouse.ts` to skip old migration logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6fbecbdb2a644d10f49d68285e1ac75c72f6a8b7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->