### PR TITLE
chore: add clickhouse and postgres review guide

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,3 +1,14 @@
 # Code Review Instructions
 
-TODO
+## Database Migrations
+
+### ClickHouse
+
+- ClickHouse migrations in the `packages/shared/clickhouse/migrations/clustered` directory should include `ON CLUSTER default` and should use `Replicated` merge tree table types.
+  - E.g. `ReplacingMergeTree` is likely an error while `ReplicatedReplacingMergeTree` would be correct in most cases.
+- ClickHouse migrations in the `packages/shared/clickhouse/migrations/unclustered` directory must not include `ON CLUSTER` statements and must not use `Replicated` merge tree table types.
+- Migrations in `packages/shared/clickhouse/migrations/clustered` should match their counterparts in `packages/shared/clickhouse/migrations/unclustered` aside from the restrictions listed above.
+
+### Postgres
+
+- Most `schema.prisma` changes should produce a change in `packages/shared/prisma/migrations`.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds ClickHouse and Postgres database migration review guidelines to `REVIEW.md`.
> 
>   - **ClickHouse Migrations**:
>     - `clustered` directory: Must include `ON CLUSTER default` and use `Replicated` merge tree table types (e.g., `ReplicatedReplacingMergeTree`).
>     - `unclustered` directory: Must not include `ON CLUSTER` and must not use `Replicated` merge tree table types.
>     - Migrations in `clustered` should match `unclustered` counterparts, except for the above restrictions.
>   - **Postgres Migrations**:
>     - Changes in `schema.prisma` should result in changes in `packages/shared/prisma/migrations`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 65b95cc3618d132a8e0368401b18d5bc27af8092. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->