### PR TITLE
fix(dataset-run-items): CH execution for dataset-level evals

### DIFF
--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -442,8 +442,20 @@ export const getDatasetItemIdsByTraceIdCh = async (
   });
 };
 
-export const getDatasetRunItemsCountByDatasetIdCh = async (
+export const getDatasetRunItemsCountCh = async (
   opts: DatasetRunItemsTableQuery,
+): Promise<number> => {
+  const rows = await getDatasetRunItemsTableInternal<{ count: string }>({
+    ...opts,
+    select: "count",
+    tags: { kind: "list" },
+  });
+
+  return Number(rows[0]?.count);
+};
+
+export const getDatasetRunItemsCountByDatasetIdCh = async (
+  opts: DatasetRunItemsByDatasetIdQuery,
 ): Promise<number> => {
   const rows = await getDatasetRunItemsTableInternal<{ count: string }>({
     ...opts,

--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -22,7 +22,7 @@ import { ClickHouseClientConfigOptions } from "@clickhouse/client";
 type DatasetItemIdsByTraceIdQuery = {
   projectId: string;
   traceId: string;
-  // this filter needs to include a dataset_id filter
+  // this filter should include a dataset_id filter to search along primary key
   filter: FilterState;
 };
 

--- a/packages/shared/src/tableDefinitions/mapDatasetRunItemsTable.ts
+++ b/packages/shared/src/tableDefinitions/mapDatasetRunItemsTable.ts
@@ -25,4 +25,10 @@ export const datasetRunItemsTableUiColumnDefinitions: UiColumnMappings = [
     clickhouseTableName: "dataset_run_items_rmt",
     clickhouseSelect: 'dri."dataset_item_id"',
   },
+  {
+    uiTableName: "Dataset",
+    uiTableId: "datasetId",
+    clickhouseTableName: "dataset_run_items_rmt",
+    clickhouseSelect: 'dri."dataset_id"',
+  },
 ];

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -24,6 +24,9 @@ import {
   getScoresForTraces,
   tableColumnsToSqlFilterAndPrefix,
   getTraceIdentifiers,
+  executeWithDatasetRunItemsStrategy,
+  DatasetRunItemsOperationType,
+  getDatasetRunItemsCh,
 } from "@langfuse/shared/src/server";
 import Decimal from "decimal.js";
 import { env } from "../../env";
@@ -410,53 +413,108 @@ export const getDatabaseReadStream = async ({
     }
 
     case "dataset_run_items": {
-      return new DatabaseReadStream<unknown>(
-        async (pageSize: number, offset: number) => {
-          const condition = tableColumnsToSqlFilterAndPrefix(
-            filter ?? [],
-            evalDatasetFormFilterCols,
-            "dataset_items",
+      return await executeWithDatasetRunItemsStrategy({
+        input: {},
+        operationType: DatasetRunItemsOperationType.READ,
+        postgresExecution: async () => {
+          return new DatabaseReadStream<unknown>(
+            async (pageSize: number, offset: number) => {
+              const condition = tableColumnsToSqlFilterAndPrefix(
+                filter ?? [],
+                evalDatasetFormFilterCols,
+                "dataset_items",
+              );
+
+              const items = await prisma.$queryRaw<
+                Array<{
+                  id: string;
+                  project_id: string;
+                  dataset_item_id: string;
+                  trace_id: string;
+                  observation_id: string | null;
+                  created_at: Date;
+                  updated_at: Date;
+                  dataset_name: string;
+                }>
+              >`
+                SELECT dri.*, d.name as dataset_name
+    
+                FROM dataset_run_items dri 
+                  JOIN dataset_items di ON dri.dataset_item_id = di.id AND dri.project_id = di.project_id 
+                  JOIN datasets d ON di.dataset_id = d.id AND d.project_id = dri.project_id
+                WHERE dri.project_id = ${projectId}
+                AND dri.created_at < ${cutoffCreatedAt}
+                ${condition}
+                ORDER BY dri.created_at DESC
+                LIMIT ${pageSize}
+                OFFSET ${offset}
+              `;
+
+              return items.map((item) => ({
+                id: item.id,
+                projectId: item.project_id,
+                datasetItemId: item.dataset_item_id,
+                traceId: item.trace_id,
+                observationId: item.observation_id,
+                createdAt: item.created_at,
+                updatedAt: item.updated_at,
+                datasetName: item.dataset_name,
+              }));
+            },
+            env.BATCH_EXPORT_PAGE_SIZE,
+            rowLimit,
           );
-
-          const items = await prisma.$queryRaw<
-            Array<{
-              id: string;
-              project_id: string;
-              dataset_item_id: string;
-              trace_id: string;
-              observation_id: string | null;
-              created_at: Date;
-              updated_at: Date;
-              dataset_name: string;
-            }>
-          >`
-            SELECT dri.*, d.name as dataset_name
-
-            FROM dataset_run_items dri 
-              JOIN dataset_items di ON dri.dataset_item_id = di.id AND dri.project_id = di.project_id 
-              JOIN datasets d ON di.dataset_id = d.id AND d.project_id = dri.project_id
-            WHERE dri.project_id = ${projectId}
-            AND dri.created_at < ${cutoffCreatedAt}
-            ${condition}
-            ORDER BY dri.created_at DESC
-            LIMIT ${pageSize}
-            OFFSET ${offset}
-          `;
-
-          return items.map((item) => ({
-            id: item.id,
-            projectId: item.project_id,
-            datasetItemId: item.dataset_item_id,
-            traceId: item.trace_id,
-            observationId: item.observation_id,
-            createdAt: item.created_at,
-            updatedAt: item.updated_at,
-            datasetName: item.dataset_name,
-          }));
         },
-        env.BATCH_EXPORT_PAGE_SIZE,
-        rowLimit,
-      );
+        clickhouseExecution: async () => {
+          return new DatabaseReadStream<unknown>(
+            async (pageSize: number, offset: number) => {
+              const items = await getDatasetRunItemsCh({
+                projectId,
+                filter: filter
+                  ? [...filter, createdAtCutoffFilter]
+                  : [createdAtCutoffFilter],
+                limit: pageSize,
+                orderBy: {
+                  column: "createdAt",
+                  order: "DESC",
+                },
+                offset,
+                clickhouseConfigs,
+              });
+
+              // fetch all project dataset names
+              const datasets = await prisma.dataset.findMany({
+                where: {
+                  projectId,
+                },
+                select: {
+                  id: true,
+                  name: true,
+                },
+              });
+
+              return items.map((item) => {
+                const datasetName = datasets.find(
+                  (d) => d.id === item.datasetId,
+                )?.name;
+
+                return {
+                  id: item.id,
+                  projectId: item.projectId,
+                  datasetItemId: item.datasetItemId,
+                  traceId: item.traceId,
+                  observationId: item.observationId,
+                  createdAt: item.createdAt,
+                  updatedAt: item.updatedAt,
+                  datasetName: datasetName ?? "Unknown",
+                };
+              });
+            },
+            env.BATCH_EXPORT_PAGE_SIZE,
+            rowLimit,
+          );
+        },
+      });
     }
 
     case "dataset_items": {

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -28,6 +28,9 @@ import {
   InMemoryFilterService,
   recordIncrement,
   getCurrentSpan,
+  DatasetRunItemsOperationType,
+  executeWithDatasetRunItemsStrategy,
+  getDatasetItemIdsByTraceIdCh,
 } from "@langfuse/shared/src/server";
 import {
   mapTraceFilterColumn,
@@ -322,19 +325,33 @@ export const createEvalJobs = async ({
         `);
         datasetItem = datasetItems.shift();
       } else {
-        // Otherwise, try to find the dataset item id from datasetRunItems.
-        // Here, we can search for the traceId and projectId and should only get one result.
-        const datasetItems = await prisma.$queryRaw<
-          Array<{ id: string }>
-        >(Prisma.sql`
-          SELECT dataset_item_id as id
-          FROM dataset_run_items as dri
-          JOIN dataset_items as di ON di.id = dri.dataset_item_id AND di.project_id = ${event.projectId}
-          WHERE dri.project_id = ${event.projectId}
-            AND dri.trace_id = ${event.traceId}
-            ${condition}
-        `);
-        datasetItem = datasetItems.shift();
+        await executeWithDatasetRunItemsStrategy({
+          input: {},
+          operationType: DatasetRunItemsOperationType.READ,
+          postgresExecution: async () => {
+            // Otherwise, try to find the dataset item id from datasetRunItems.
+            // Here, we can search for the traceId and projectId and should only get one result.
+            const datasetItems = await prisma.$queryRaw<
+              Array<{ id: string }>
+            >(Prisma.sql`
+              SELECT dataset_item_id as id
+              FROM dataset_run_items as dri
+              JOIN dataset_items as di ON di.id = dri.dataset_item_id AND di.project_id = ${event.projectId}
+              WHERE dri.project_id = ${event.projectId}
+                AND dri.trace_id = ${event.traceId}
+                ${condition}
+            `);
+            datasetItem = datasetItems.shift();
+          },
+          clickhouseExecution: async () => {
+            const datasetItemIds = await getDatasetItemIdsByTraceIdCh({
+              projectId: event.projectId,
+              traceId: event.traceId,
+              filter: config.target_object === "dataset" ? validatedFilter : [],
+            });
+            datasetItem = datasetItemIds.shift();
+          },
+        });
       }
     }
 

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -325,7 +325,7 @@ export const createEvalJobs = async ({
         `);
         datasetItem = datasetItems.shift();
       } else {
-        await executeWithDatasetRunItemsStrategy({
+        datasetItem = await executeWithDatasetRunItemsStrategy({
           input: {},
           operationType: DatasetRunItemsOperationType.READ,
           postgresExecution: async () => {
@@ -341,7 +341,7 @@ export const createEvalJobs = async ({
                 AND dri.trace_id = ${event.traceId}
                 ${condition}
             `);
-            datasetItem = datasetItems.shift();
+            return datasetItems.shift();
           },
           clickhouseExecution: async () => {
             const datasetItemIds = await getDatasetItemIdsByTraceIdCh({
@@ -349,7 +349,7 @@ export const createEvalJobs = async ({
               traceId: event.traceId,
               filter: config.target_object === "dataset" ? validatedFilter : [],
             });
-            datasetItem = datasetItemIds.shift();
+            return datasetItemIds.shift();
           },
         });
       }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances dataset run item handling by integrating ClickHouse for dataset-level evaluations, updating queries and types, and modifying related functions across multiple files.
> 
>   - **Behavior**:
>     - Introduces ClickHouse integration for dataset-level evaluations in `dataset-run-items.ts`.
>     - Adds `getDatasetItemIdsByTraceIdCh` and modifies `getDatasetRunItemsCh` to support ClickHouse queries.
>     - Updates `getDatabaseReadStream` in `getDatabaseReadStream.ts` to handle dataset run items with ClickHouse.
>   - **Types and Queries**:
>     - Adds `DatasetItemIdsByTraceIdQuery` and `DatasetRunItemsByDatasetIdQuery` types in `dataset-run-items.ts`.
>     - Modifies `DatasetRunItemsTableQuery` to include optional `datasetId` and `clickhouseConfigs`.
>   - **Functions**:
>     - Renames `getDatasetRunItemsByDatasetIdCh` to `getDatasetRunItemsCh` in `dataset-run-items.ts`.
>     - Adds `getDatasetRunItemsCountByDatasetIdCh` in `dataset-run-items.ts`.
>   - **Misc**:
>     - Updates `datasetRunItemsTableUiColumnDefinitions` in `mapDatasetRunItemsTable.ts` to include `datasetId`.
>     - Modifies `dataset-router.ts` to use `executeWithDatasetRunItemsStrategy` for dataset item count queries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c1585ac3bace11243af47b97b2b2c0fffb45a590. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->