### PR TITLE
chore(datasets-ui): prefix I/O with "Trace" on runs table in items detail view

### DIFF
--- a/web/src/features/datasets/components/DatasetRunItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsTable.tsx
@@ -181,7 +181,7 @@ export function DatasetRunItemsTable(
     { ...getScoreGroupColumnProps(isColumnLoading), columns: scoreColumns },
     {
       accessorKey: "input",
-      header: "Input",
+      header: `${"datasetItemId" in props ? "Trace" : ""} Input`,
       id: "input",
       size: 200,
       enableHiding: true,
@@ -202,7 +202,7 @@ export function DatasetRunItemsTable(
     },
     {
       accessorKey: "output",
-      header: "Output",
+      header: `${"datasetItemId" in props ? "Trace" : ""} Output`,
       id: "output",
       size: 200,
       enableHiding: true,

--- a/web/src/features/datasets/components/DatasetRunItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsTable.tsx
@@ -181,7 +181,7 @@ export function DatasetRunItemsTable(
     { ...getScoreGroupColumnProps(isColumnLoading), columns: scoreColumns },
     {
       accessorKey: "input",
-      header: `${"datasetItemId" in props ? "Trace" : ""} Input`,
+      header: `${"datasetItemId" in props ? "Trace Input" : "Input"}`,
       id: "input",
       size: 200,
       enableHiding: true,
@@ -202,7 +202,7 @@ export function DatasetRunItemsTable(
     },
     {
       accessorKey: "output",
-      header: `${"datasetItemId" in props ? "Trace" : ""} Output`,
+      header: `${"datasetItemId" in props ? "Trace Output" : "Output"}`,
       id: "output",
       size: 200,
       enableHiding: true,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Prefix 'Input' and 'Output' headers with 'Trace' in `DatasetRunItemsTable` if `datasetItemId` is present in props.
> 
>   - **UI Changes**:
>     - In `DatasetRunItemsTable.tsx`, prefix 'Input' and 'Output' headers with 'Trace' if `datasetItemId` is present in `props`.
>     - Affects `input` and `output` columns in the `DatasetRunItemsTable` component.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c5bb6d36b4d9d4652aa1c6bed0d3d5eb191fad32. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->