### PR TITLE
fix(ui): hide separator of demo badge when sidebar is collapsed & make envlabel dismissable onClick

### DIFF
--- a/web/src/components/EnvLabel.tsx
+++ b/web/src/components/EnvLabel.tsx
@@ -1,15 +1,18 @@
 import { env } from "@/src/env.mjs";
 import { cn } from "@/src/utils/tailwind";
 import { useSession } from "next-auth/react";
+import { useState } from "react";
 
 export const EnvLabel = ({ className }: { className?: string }) => {
+  const [isHidden, setIsHidden] = useState(false);
   const session = useSession();
   if (!env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) return null;
   if (!session.data?.user?.email?.endsWith("@langfuse.com")) return null;
+  if (isHidden) return null;
   return (
     <div
       className={cn(
-        "flex items-center gap-1 self-stretch whitespace-nowrap rounded-md px-1 py-0.5 text-xs",
+        "flex cursor-pointer items-center gap-1 self-stretch whitespace-nowrap rounded-md px-1 py-0.5 text-xs",
         env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "STAGING"
           ? "bg-light-blue text-dark-blue"
           : env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "DEV"
@@ -17,6 +20,7 @@ export const EnvLabel = ({ className }: { className?: string }) => {
             : "bg-light-red text-dark-red",
         className,
       )}
+      onClick={() => setIsHidden(true)}
     >
       {["EU", "US", "HIPAA"].includes(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION)
         ? `PROD-${env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION}`

--- a/web/src/components/nav/app-sidebar.tsx
+++ b/web/src/components/nav/app-sidebar.tsx
@@ -70,12 +70,19 @@ const DemoBadge = () => {
   const router = useRouter();
   const routerProjectId = router.query.projectId as string | undefined;
 
-  return env.NEXT_PUBLIC_DEMO_ORG_ID &&
-    env.NEXT_PUBLIC_DEMO_PROJECT_ID &&
-    routerProjectId === env.NEXT_PUBLIC_DEMO_PROJECT_ID &&
-    Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) ? (
-    <div className="flex border-b px-3 py-2">
-      <Alert className="rounded-md bg-light-yellow group-data-[collapsible=icon]:hidden">
+  if (
+    !(
+      env.NEXT_PUBLIC_DEMO_ORG_ID &&
+      env.NEXT_PUBLIC_DEMO_PROJECT_ID &&
+      routerProjectId === env.NEXT_PUBLIC_DEMO_PROJECT_ID &&
+      Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION)
+    )
+  )
+    return null;
+
+  return (
+    <div className="flex border-b px-3 py-2 group-data-[collapsible=icon]:hidden">
+      <Alert className="rounded-md bg-light-yellow">
         <AlertDescription className="overflow-hidden text-ellipsis whitespace-nowrap text-xs">
           View-only{" "}
           <Link
@@ -88,5 +95,5 @@ const DemoBadge = () => {
         </AlertDescription>
       </Alert>
     </div>
-  ) : null;
+  );
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `EnvLabel` to be dismissable on click and adjust `DemoBadge` visibility when sidebar is collapsed.
> 
>   - **EnvLabel**:
>     - Added `useState` to manage visibility in `EnvLabel` in `EnvLabel.tsx`.
>     - `EnvLabel` is now dismissable on click by setting `isHidden` state.
>   - **DemoBadge**:
>     - Adjusted `DemoBadge` in `app-sidebar.tsx` to hide when sidebar is collapsed using `group-data-[collapsible=icon]:hidden` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ef20e2c132182f71a875dfae97a42b1465257399. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->