### PR TITLE
perf: add metadata indexes on observations table

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -8,7 +8,7 @@
   - E.g. `ReplacingMergeTree` is likely an error while `ReplicatedReplacingMergeTree` would be correct in most cases.
 - ClickHouse migrations in the `packages/shared/clickhouse/migrations/unclustered` directory must not include `ON CLUSTER` statements and must not use `Replicated` merge tree table types.
 - Migrations in `packages/shared/clickhouse/migrations/clustered` should match their counterparts in `packages/shared/clickhouse/migrations/unclustered` aside from the restrictions listed above.
-- When adding new indexes on ClickHouse, ensure that there is a corresponding `MATERIALIZE INDEX` statement in the same migration. The materialization must use `SETTINGS mutations_sync = 2`.
+- When adding new indexes on ClickHouse, ensure that there is a corresponding `MATERIALIZE INDEX` statement in the same migration. The materialization can use `SETTINGS mutations_sync = 2` if they operate on smaller tables, but may timeout otherwise.
 
 ### Postgres
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -8,6 +8,7 @@
   - E.g. `ReplacingMergeTree` is likely an error while `ReplicatedReplacingMergeTree` would be correct in most cases.
 - ClickHouse migrations in the `packages/shared/clickhouse/migrations/unclustered` directory must not include `ON CLUSTER` statements and must not use `Replicated` merge tree table types.
 - Migrations in `packages/shared/clickhouse/migrations/clustered` should match their counterparts in `packages/shared/clickhouse/migrations/unclustered` aside from the restrictions listed above.
+- When adding new indexes on ClickHouse, ensure that there is a corresponding `MATERIALIZE INDEX` statement in the same migration. The materialization must use `SETTINGS mutations_sync = 2`.
 
 ### Postgres
 

--- a/packages/shared/clickhouse/migrations/clustered/0025_add_observations_metadata_indexes.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0025_add_observations_metadata_indexes.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE observations ON CLUSTER default DROP INDEX IF EXISTS idx_res_metadata_value;
+ALTER TABLE observations ON CLUSTER default DROP INDEX IF EXISTS idx_res_metadata_key;

--- a/packages/shared/clickhouse/migrations/clustered/0025_add_observations_metadata_indexes.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0025_add_observations_metadata_indexes.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE observations ON CLUSTER default ADD INDEX IF NOT EXISTS idx_res_metadata_key mapKeys(metadata) TYPE bloom_filter(0.01) GRANULARITY 1;
+ALTER TABLE observations ON CLUSTER default ADD INDEX IF NOT EXISTS idx_res_metadata_value mapValues(metadata) TYPE bloom_filter(0.01) GRANULARITY 1;
+ALTER TABLE observations ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_res_metadata_key;
+ALTER TABLE observations ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_res_metadata_value;

--- a/packages/shared/clickhouse/migrations/clustered/0025_add_observations_metadata_indexes.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0025_add_observations_metadata_indexes.up.sql
@@ -1,4 +1,4 @@
 ALTER TABLE observations ON CLUSTER default ADD INDEX IF NOT EXISTS idx_res_metadata_key mapKeys(metadata) TYPE bloom_filter(0.01) GRANULARITY 1;
 ALTER TABLE observations ON CLUSTER default ADD INDEX IF NOT EXISTS idx_res_metadata_value mapValues(metadata) TYPE bloom_filter(0.01) GRANULARITY 1;
-ALTER TABLE observations ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_res_metadata_key SETTINGS mutations_sync = 2;
-ALTER TABLE observations ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_res_metadata_value SETTINGS mutations_sync = 2;
+ALTER TABLE observations ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_res_metadata_key;
+ALTER TABLE observations ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_res_metadata_value;

--- a/packages/shared/clickhouse/migrations/clustered/0025_add_observations_metadata_indexes.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0025_add_observations_metadata_indexes.up.sql
@@ -1,4 +1,4 @@
 ALTER TABLE observations ON CLUSTER default ADD INDEX IF NOT EXISTS idx_res_metadata_key mapKeys(metadata) TYPE bloom_filter(0.01) GRANULARITY 1;
 ALTER TABLE observations ON CLUSTER default ADD INDEX IF NOT EXISTS idx_res_metadata_value mapValues(metadata) TYPE bloom_filter(0.01) GRANULARITY 1;
-ALTER TABLE observations ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_res_metadata_key;
-ALTER TABLE observations ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_res_metadata_value;
+ALTER TABLE observations ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_res_metadata_key SETTINGS mutations_sync = 2;
+ALTER TABLE observations ON CLUSTER default MATERIALIZE INDEX IF EXISTS idx_res_metadata_value SETTINGS mutations_sync = 2;

--- a/packages/shared/clickhouse/migrations/unclustered/0025_add_observations_metadata_indexes.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0025_add_observations_metadata_indexes.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE observations DROP INDEX IF EXISTS idx_res_metadata_value;
+ALTER TABLE observations DROP INDEX IF EXISTS idx_res_metadata_key;

--- a/packages/shared/clickhouse/migrations/unclustered/0025_add_observations_metadata_indexes.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0025_add_observations_metadata_indexes.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE observations ADD INDEX IF NOT EXISTS idx_res_metadata_key mapKeys(metadata) TYPE bloom_filter(0.01) GRANULARITY 1;
+ALTER TABLE observations ADD INDEX IF NOT EXISTS idx_res_metadata_value mapValues(metadata) TYPE bloom_filter(0.01) GRANULARITY 1;
+ALTER TABLE observations MATERIALIZE INDEX IF EXISTS idx_res_metadata_key;
+ALTER TABLE observations MATERIALIZE INDEX IF EXISTS idx_res_metadata_value;

--- a/packages/shared/clickhouse/migrations/unclustered/0025_add_observations_metadata_indexes.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0025_add_observations_metadata_indexes.up.sql
@@ -1,4 +1,4 @@
 ALTER TABLE observations ADD INDEX IF NOT EXISTS idx_res_metadata_key mapKeys(metadata) TYPE bloom_filter(0.01) GRANULARITY 1;
 ALTER TABLE observations ADD INDEX IF NOT EXISTS idx_res_metadata_value mapValues(metadata) TYPE bloom_filter(0.01) GRANULARITY 1;
-ALTER TABLE observations MATERIALIZE INDEX IF EXISTS idx_res_metadata_key SETTINGS mutations_sync = 2;
-ALTER TABLE observations MATERIALIZE INDEX IF EXISTS idx_res_metadata_value SETTINGS mutations_sync = 2;
+ALTER TABLE observations MATERIALIZE INDEX IF EXISTS idx_res_metadata_key;
+ALTER TABLE observations MATERIALIZE INDEX IF EXISTS idx_res_metadata_value;

--- a/packages/shared/clickhouse/migrations/unclustered/0025_add_observations_metadata_indexes.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0025_add_observations_metadata_indexes.up.sql
@@ -1,4 +1,4 @@
 ALTER TABLE observations ADD INDEX IF NOT EXISTS idx_res_metadata_key mapKeys(metadata) TYPE bloom_filter(0.01) GRANULARITY 1;
 ALTER TABLE observations ADD INDEX IF NOT EXISTS idx_res_metadata_value mapValues(metadata) TYPE bloom_filter(0.01) GRANULARITY 1;
-ALTER TABLE observations MATERIALIZE INDEX IF EXISTS idx_res_metadata_key;
-ALTER TABLE observations MATERIALIZE INDEX IF EXISTS idx_res_metadata_value;
+ALTER TABLE observations MATERIALIZE INDEX IF EXISTS idx_res_metadata_key SETTINGS mutations_sync = 2;
+ALTER TABLE observations MATERIALIZE INDEX IF EXISTS idx_res_metadata_value SETTINGS mutations_sync = 2;


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/8361

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add and materialize metadata indexes on `observations` table in ClickHouse migrations for both clustered and unclustered setups.
> 
>   - **ClickHouse Migrations**:
>     - Add `idx_res_metadata_key` and `idx_res_metadata_value` indexes to `observations` table in `0025_add_observations_metadata_indexes.up.sql` for both clustered and unclustered.
>     - Materialize the new indexes in the same migration files.
>     - Drop the indexes in `0025_add_observations_metadata_indexes.down.sql` for both clustered and unclustered.
>   - **Review Guidelines**:
>     - Update `REVIEW.md` to include instructions for materializing indexes when added.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6de0d3c0f6f84f4869114e5947419d67fafad37f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->