### PR TITLE
fix: check that value is defined before accessing length in ClickhouseWriter

### DIFF
--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -196,7 +196,7 @@ export class ClickhouseWriter {
       const metadata = record.metadata;
       const truncatedMetadata: Record<string, string> = {};
       for (const [key, value] of Object.entries(metadata)) {
-        if (value.length > maxFieldSize) {
+        if (value && value.length > maxFieldSize) {
           truncatedMetadata[key] = truncateField(value) || "";
           logger.info(
             `Truncated oversized metadata for record ${record.id} of type ${tableName} and key ${key}`,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes potential error in `ClickhouseWriter` by checking if `value` is defined before accessing its length.
> 
>   - **Bug Fix**:
>     - In `ClickhouseWriter` class, `truncateOversizedRecord` method now checks if `value` is defined before accessing `value.length` to prevent errors when `value` is `undefined` or `null`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 99dcba69a8981eeeb4c4a33c9663dc88cdf7e61d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->