### PR TITLE
fix: drop unused redis reference in evalService

### DIFF
--- a/packages/config-eslint/library.js
+++ b/packages/config-eslint/library.js
@@ -41,6 +41,14 @@ module.exports = {
       // https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
       rules: {
         "no-undef": "off",
+        "no-restricted-globals": [
+          "error",
+          {
+            name: "redis",
+            message:
+              "Import redis explicitly from '@langfuse/shared/src/server' instead of using global.",
+          },
+        ],
       },
     },
   ],

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -747,31 +747,29 @@ export const evaluate = async ({
       },
     ]);
 
-    if (redis) {
-      const shardingKey = `${event.projectId}-${scoreId}`;
-      const queue = IngestionQueue.getInstance({ shardingKey });
-      if (!queue) {
-        throw new Error("Ingestion queue not available");
-      }
-      await queue.add(QueueJobs.IngestionJob, {
-        id: randomUUID(),
-        timestamp: new Date(),
-        name: QueueJobs.IngestionJob as const,
-        payload: {
-          data: {
-            type: eventTypes.SCORE_CREATE,
-            eventBodyId: scoreId,
-            fileKey: eventId,
-          },
-          authCheck: {
-            validKey: true,
-            scope: {
-              projectId: event.projectId,
-            },
+    const shardingKey = `${event.projectId}-${scoreId}`;
+    const queue = IngestionQueue.getInstance({ shardingKey });
+    if (!queue) {
+      throw new Error("Ingestion queue not available");
+    }
+    await queue.add(QueueJobs.IngestionJob, {
+      id: randomUUID(),
+      timestamp: new Date(),
+      name: QueueJobs.IngestionJob as const,
+      payload: {
+        data: {
+          type: eventTypes.SCORE_CREATE,
+          eventBodyId: scoreId,
+          fileKey: eventId,
+        },
+        authCheck: {
+          validKey: true,
+          scope: {
+            projectId: event.projectId,
           },
         },
-      });
-    }
+      },
+    });
   } catch (e) {
     logger.error(`Failed to add score into IngestionQueue: ${e}`, e);
     traceException(e);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes unused `redis` reference from `evalService.ts` and adds ESLint rule to restrict global `redis` usage.
> 
>   - **Behavior**:
>     - Removes unused `redis` reference in `evaluate()` in `evalService.ts`.
>     - Adds ESLint rule in `library.js` to restrict global `redis` usage, suggesting explicit import from `@langfuse/shared/src/server`.
>   - **Misc**:
>     - Removes conditional `redis` check and related logic in `evaluate()` in `evalService.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b94a35173dabbb524ac72f71d1255acccae26e80. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->