### PR TITLE
fix(eval-service): selected observation type not handled in eval service

### DIFF
--- a/packages/shared/src/features/evals/types.ts
+++ b/packages/shared/src/features/evals/types.ts
@@ -59,6 +59,56 @@ const observationCols = [
 
 export const availableTraceEvalVariables = [
   {
+    id: "agent",
+    display: "Agent",
+    availableColumns: observationCols,
+  },
+  {
+    id: "chain",
+    display: "Chain",
+    availableColumns: observationCols,
+  },
+  {
+    id: "embedding",
+    display: "Embedding",
+    availableColumns: observationCols,
+  },
+  {
+    id: "evaluator",
+    display: "Evaluator",
+    availableColumns: observationCols,
+  },
+  {
+    id: "event",
+    display: "Event",
+    availableColumns: observationCols,
+  },
+  {
+    id: "generation",
+    display: "Generation",
+    availableColumns: observationCols,
+  },
+  {
+    id: "guardrail",
+    display: "Guardrail",
+    availableColumns: observationCols,
+  },
+  {
+    id: "retriever",
+    display: "Retriever",
+    availableColumns: observationCols,
+  },
+  {
+    id: "span",
+    display: "Span",
+    availableColumns: observationCols,
+  },
+  {
+    id: "tool",
+    display: "Tool",
+    availableColumns: observationCols,
+  },
+  {
     id: "trace",
     display: "Trace",
     availableColumns: [
@@ -71,56 +121,6 @@ export const availableTraceEvalVariables = [
       { name: "Input", id: "input", internal: 't."input"' },
       { name: "Output", id: "output", internal: 't."output"' },
     ],
-  },
-  {
-    id: "span",
-    display: "Span",
-    availableColumns: observationCols,
-  },
-  {
-    id: "generation",
-    display: "Generation",
-    availableColumns: observationCols,
-  },
-  {
-    id: "event",
-    display: "Event",
-    availableColumns: observationCols,
-  },
-  {
-    id: "agent",
-    display: "Agent",
-    availableColumns: observationCols,
-  },
-  {
-    id: "tool",
-    display: "Tool",
-    availableColumns: observationCols,
-  },
-  {
-    id: "chain",
-    display: "Chain",
-    availableColumns: observationCols,
-  },
-  {
-    id: "retriever",
-    display: "Retriever",
-    availableColumns: observationCols,
-  },
-  {
-    id: "evaluator",
-    display: "Evaluator",
-    availableColumns: observationCols,
-  },
-  {
-    id: "embedding",
-    display: "Embedding",
-    availableColumns: observationCols,
-  },
-  {
-    id: "guardrail",
-    display: "Guardrail",
-    availableColumns: observationCols,
   },
 ];
 

--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -1849,12 +1849,12 @@ describe("eval service tests", () => {
 
         expect(result).toEqual([
           {
-            value: '{"huhu": "This is a great prompt"}',
+            value: '{"huhu":"This is a great prompt"}',
             var: "input",
             environment: "production",
           },
           {
-            value: '{"haha": "This is a great response"}',
+            value: '{"haha":"This is a great response"}',
             var: "output",
             environment: "production",
           },

--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -2,6 +2,7 @@ import {
   ApiError,
   LLMAdapter,
   LangfuseNotFoundError,
+  ObservationType,
   variableMappingList,
 } from "@langfuse/shared";
 import { encrypt } from "@langfuse/shared/encryption";
@@ -1789,6 +1790,78 @@ describe("eval service tests", () => {
         },
       ]);
     }, 10_000);
+
+    test.each(
+      Object.values(ObservationType).filter(
+        (type) => !["SPAN", "EVENT", "GENERATION"].includes(type),
+      ),
+    )(
+      "extracts variables from a %s observation",
+      async (observationType) => {
+        const traceId = randomUUID();
+
+        await upsertTrace({
+          id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          user_id: "a",
+          input: JSON.stringify({ input: "This is a great prompt" }),
+          output: JSON.stringify({ output: "This is a great response" }),
+          timestamp: convertDateToClickhouseDateTime(new Date()),
+          created_at: convertDateToClickhouseDateTime(new Date()),
+          updated_at: convertDateToClickhouseDateTime(new Date()),
+        });
+
+        await upsertObservation({
+          id: randomUUID(),
+          trace_id: traceId,
+          project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          name: `great-${observationType.toLowerCase()}-name`,
+          type: observationType,
+          environment: "production",
+          input: JSON.stringify({ huhu: "This is a great prompt" }),
+          output: JSON.stringify({ haha: "This is a great response" }),
+          start_time: convertDateToClickhouseDateTime(new Date()),
+          created_at: convertDateToClickhouseDateTime(new Date()),
+          updated_at: convertDateToClickhouseDateTime(new Date()),
+        });
+
+        const variableMapping = variableMappingList.parse([
+          {
+            langfuseObject: observationType.toLowerCase(),
+            selectedColumnId: "input",
+            templateVariable: "input",
+            objectName: `great-${observationType.toLowerCase()}-name`,
+          },
+          {
+            langfuseObject: observationType.toLowerCase(),
+            selectedColumnId: "output",
+            templateVariable: "output",
+            objectName: `great-${observationType.toLowerCase()}-name`,
+          },
+        ]);
+
+        const result = await extractVariablesFromTracingData({
+          projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+          variables: ["input", "output"],
+          traceId: traceId,
+          variableMapping: variableMapping,
+        });
+
+        expect(result).toEqual([
+          {
+            value: '{"huhu": "This is a great prompt"}',
+            var: "input",
+            environment: "production",
+          },
+          {
+            value: '{"haha": "This is a great response"}',
+            var: "output",
+            environment: "production",
+          },
+        ]);
+      },
+      10_000,
+    );
   });
 
   test("requiresDatabaseLookup correctly identifies complex filters", () => {

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -862,7 +862,11 @@ export async function extractVariablesFromTracingData({
       continue;
     }
 
-    if (["generation", "span", "event"].includes(mapping.langfuseObject)) {
+    const observationTypes = availableTraceEvalVariables
+      .filter((obj) => obj.id !== "trace") // trace is handled separately above
+      .map((obj) => obj.id);
+
+    if (observationTypes.includes(mapping.langfuseObject)) {
       const safeInternalColumn = availableTraceEvalVariables
         .find((o) => o.id === mapping.langfuseObject)
         ?.availableColumns.find((col) => col.id === mapping.selectedColumnId);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes handling of observation types in `evalService.ts` and adds tests to ensure correct variable extraction for all observation types except `SPAN`, `EVENT`, and `GENERATION`.
> 
>   - **Behavior**:
>     - Fixes handling of observation types in `extractVariablesFromTracingData()` in `evalService.ts` by updating the logic to include all observation types except `trace`.
>     - Adds test cases in `evalService.test.ts` to verify variable extraction for all observation types except `SPAN`, `EVENT`, and `GENERATION`.
>   - **Misc**:
>     - Updates `availableTraceEvalVariables` in `types.ts` to reorder observation types and ensure correct column mapping.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b15b23d13ac837f6140a8ff3d5bd52960c73cb74. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->