### PR TITLE
perf: reduce expensive joins for default case on metrics/daily route

### DIFF
--- a/web/src/features/public-api/server/dailyMetrics.ts
+++ b/web/src/features/public-api/server/dailyMetrics.ts
@@ -36,22 +36,23 @@ export const generateDailyMetrics = async (props: QueryType) => {
       (f.operator === ">=" || f.operator === ">"),
   ) as DateTimeFilter | undefined;
 
+  // If there is any other filter than fromTimestamp, we just merge the traces table to be on the safe side.
+  const hasNonTimestampsFilter = timeFilter && filter.length() > 1;
+
   const query = `
     WITH model_usage AS (
       SELECT
         toDate(o.start_time) as date,
         o.provided_model_name as model,
         count(o.id) as countObservations,
-        count(distinct t.id) as countTraces,
+        count(distinct o.trace_id) as countTraces,
         sum(arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'input') > 0, o.usage_details)))) as inputUsage,
         sum(arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'output') > 0, o.usage_details)))) as outputUsage,
         sumMap(o.usage_details)['total'] as totalUsage,
         sum(coalesce(o.total_cost, 0)) as totalCost
-      FROM __TRACE_TABLE__ t FINAL
-      LEFT JOIN observations o FINAL on o.trace_id = t.id AND o.project_id = t.project_id
+      FROM observations o FINAL ${hasNonTimestampsFilter ? " LEFT JOIN __TRACE_TABLE__ t FINAL on o.trace_id = t.id AND o.project_id = t.project_id" : ""}
       WHERE o.project_id = {projectId: String} 
-      AND t.project_id = {projectId: String}
-      ${filter.length() > 0 ? `AND ${appliedFilter.query}` : ""}
+      ${hasNonTimestampsFilter ? `AND t.project_id = {projectId: String} AND ${appliedFilter.query}` : ""}
       ${timeFilter ? `AND start_time >= {cteTimeFilter: DateTime64(3)} - ${TRACE_TO_OBSERVATIONS_INTERVAL}` : ""}
       GROUP BY date, model
     ), daily_model_usage AS (

--- a/web/src/features/public-api/server/dailyMetrics.ts
+++ b/web/src/features/public-api/server/dailyMetrics.ts
@@ -36,7 +36,7 @@ export const generateDailyMetrics = async (props: QueryType) => {
       (f.operator === ">=" || f.operator === ">"),
   ) as DateTimeFilter | undefined;
 
-  // If there is any other filter than fromTimestamp, we just merge the traces table to be on the safe side.
+  // If there is any other filter than fromTimestamp, we join the traces table to be on the safe side.
   const hasNonTimestampsFilter = timeFilter && filter.length() > 1;
 
   const query = `

--- a/web/src/features/public-api/server/dailyMetrics.ts
+++ b/web/src/features/public-api/server/dailyMetrics.ts
@@ -37,7 +37,8 @@ export const generateDailyMetrics = async (props: QueryType) => {
   ) as DateTimeFilter | undefined;
 
   // If there is any other filter than fromTimestamp, we join the traces table to be on the safe side.
-  const hasNonTimestampsFilter = timeFilter && filter.length() > 1;
+  const hasNonTimestampsFilter =
+    (timeFilter && filter.length() > 1) || (!timeFilter && filter.length() > 0);
 
   const query = `
     WITH model_usage AS (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimize `generateDailyMetrics` in `dailyMetrics.ts` by conditionally joining `traces` table based on filters, reducing unnecessary joins.
> 
>   - **Performance Optimization**:
>     - In `generateDailyMetrics` in `dailyMetrics.ts`, conditionally join `traces` table only if non-timestamp filters are present, reducing unnecessary joins.
>     - Modify SQL query to count distinct `trace_id` instead of `t.id` for `countTraces`.
>   - **Logic Changes**:
>     - Introduce `hasNonTimestampsFilter` to determine if `traces` table join is needed based on filters.
>     - Adjust query conditions to reflect the new join logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 85e84b28c37f51eb8cd9dfff41632ba5bc0c1569. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->