### PR TITLE
fix(trace-detail): better contrast for selected span

### DIFF
--- a/web/src/components/trace/TraceTree.tsx
+++ b/web/src/components/trace/TraceTree.tsx
@@ -198,8 +198,8 @@ const TreeNodeComponent = ({
       <CommandItem
         value={`${node.name} ${node.type} ${node.id}`}
         className={cn(
-          "relative flex w-full rounded-md px-0 hover:rounded-lg hover:bg-muted/50",
-          currentNodeId === node.id && "bg-muted/40",
+          "relative flex w-full rounded-md px-0 hover:rounded-lg",
+          currentNodeId === node.id && "bg-muted/60 hover:bg-muted/60",
         )}
         style={{
           paddingTop: 0,
@@ -257,7 +257,10 @@ const TreeNodeComponent = ({
 
           {/* Node content */}
           <div
-            className="flex min-w-0 flex-1 items-start gap-2 py-1"
+            className={cn(
+              "flex min-w-0 flex-1 items-start gap-2 py-1",
+              currentNodeId !== node.id && "rounded-md hover:bg-muted/40",
+            )}
             ref={currentNodeRef}
           >
             {/* Icon */}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve visual contrast for selected spans in `TraceTree.tsx` by adjusting background and hover colors in `TreeNodeComponent`.
> 
>   - **Visual Contrast**:
>     - In `TreeNodeComponent`, change background color for selected nodes to `bg-muted/60` and hover state to `hover:bg-muted/60` for better contrast.
>     - Add hover effect `hover:bg-muted/40` for non-selected nodes in `TreeNodeComponent`.
>   - **Misc**:
>     - Remove redundant hover styling `hover:rounded-lg` from `CommandItem` in `TreeNodeComponent`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 83aa32eed8a8469e420d5757cefb1ab0b48bbd4c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->