### PR TITLE
feat(ui): improved demo app menu buttons and link from home to projectid/traces

### DIFF
--- a/web/src/components/nav/app-sidebar.tsx
+++ b/web/src/components/nav/app-sidebar.tsx
@@ -10,17 +10,24 @@ import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
   SidebarRail,
 } from "@/src/components/ui/sidebar";
 import { env } from "@/src/env.mjs";
 import { useRouter } from "next/router";
 import Link from "next/link";
-import { Alert, AlertDescription } from "@/src/components/ui/alert";
+
 import { LangfuseLogo } from "@/src/components/LangfuseLogo";
 import { SidebarNotifications } from "@/src/components/nav/sidebar-notifications";
 import { UsageTracker } from "@/src/ee/features/billing/components/UsageTracker";
 import { type RouteGroup } from "@/src/components/layouts/routes";
+import { ExternalLink, Grid2X2 } from "lucide-react";
 
 type AppSidebarProps = {
   navItems: {
@@ -81,19 +88,36 @@ const DemoBadge = () => {
     return null;
 
   return (
-    <div className="flex border-b px-3 py-2 group-data-[collapsible=icon]:hidden">
-      <Alert className="rounded-md bg-light-yellow">
-        <AlertDescription className="overflow-hidden text-ellipsis whitespace-nowrap text-xs">
-          View-only{" "}
-          <Link
-            href="https://langfuse.com/docs/demo"
-            target="_blank"
-            className="underline"
-          >
-            demo project
-          </Link>
-        </AlertDescription>
-      </Alert>
-    </div>
+    <SidebarGroup className="mb-1 border-b">
+      <SidebarGroupLabel>Demo Project (view only)</SidebarGroupLabel>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              asChild
+              tooltip="Use Demo App to create traces"
+              variant="cta"
+            >
+              <Link
+                href="https://langfuse.com/docs/demo"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <ExternalLink className="h-4 w-4" />
+                <span>Use Demo App</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild tooltip="Your Langfuse Organizations">
+              <Link href="/">
+                <Grid2X2 className="h-4 w-4" />
+                <span>Your Langfuse Orgs</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
   );
 };

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -450,7 +450,7 @@ const SidebarGroupLabel = React.forwardRef<
       ref={ref}
       data-sidebar="group-label"
       className={cn(
-        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-[margin,opa] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "flex h-8 shrink-0 items-center whitespace-nowrap rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-[margin,opa] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:hidden",
         className,
       )}
@@ -530,6 +530,7 @@ const sidebarMenuButtonVariants = cva(
         default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
         outline:
           "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+        cta: "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground active:bg-primary/80 active:text-primary-foreground",
       },
       size: {
         default: "h-8 text-sm",

--- a/web/src/features/organizations/components/ProjectOverview.tsx
+++ b/web/src/features/organizations/components/ProjectOverview.tsx
@@ -87,7 +87,7 @@ const DemoOrganizationTile = () => {
       </CardContent>
       <CardFooter>
         <Button asChild variant="secondary">
-          <Link href={`/project/${env.NEXT_PUBLIC_DEMO_PROJECT_ID}`}>
+          <Link href={`/project/${env.NEXT_PUBLIC_DEMO_PROJECT_ID}/traces`}>
             View Demo Project
           </Link>
         </Button>


### PR DESCRIPTION
before
<img width="538" height="400" alt="CleanShot 2025-08-19 at 20 02 36" src="https://github.com/user-attachments/assets/5d52f1ca-497a-4b4d-9cd4-8cb5cb8d5557" />

after
<img width="259" height="256" alt="image" src="https://github.com/user-attachments/assets/5c3f3855-3f6c-4a34-992a-a30e8ea2ec7f" />
