### PR TITLE
fix: Coerce SLACK_FETCH_LIMIT to number

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -199,7 +199,7 @@ const EnvSchema = z.object({
   SLACK_CLIENT_ID: z.string().optional(),
   SLACK_CLIENT_SECRET: z.string().optional(),
   SLACK_STATE_SECRET: z.string().optional(),
-  SLACK_FETCH_LIMIT: z
+  SLACK_FETCH_LIMIT: z.coerce
     .number()
     .positive()
     .optional()


### PR DESCRIPTION
## What does this PR do?

You can't pass numbers as Kubernetes env variables, so we need to coerce from strings.

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Coerce `SLACK_FETCH_LIMIT` to a number in `env.ts` to handle Kubernetes string environment variables.
> 
>   - **Behavior**:
>     - Coerce `SLACK_FETCH_LIMIT` to a number in `env.ts` to handle Kubernetes string environment variables.
>   - **Misc**:
>     - No other changes or new features introduced.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d86d66c5f1e986baf6cd8a44512bbe4cbbd8f025. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->