### PR TITLE
fix: calculate correct traces table count

### DIFF
--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -492,7 +492,7 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
       let sqlSelect: string;
       switch (select) {
         case "count":
-          sqlSelect = "count(*) as count";
+          sqlSelect = "uniq(t.id) as count";
           break;
         case "metrics":
           sqlSelect = `
@@ -565,7 +565,7 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
         WHERE t.project_id = {projectId: String}
         ${tracesFilterRes ? `AND ${tracesFilterRes.query}` : ""}
         ${search.query}
-        GROUP BY project_id, id
+        ${select !== "count" ? "GROUP BY project_id, id" : ""}
         ${chOrderBy}
         ${limit !== undefined && page !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
       `;

--- a/web/src/__tests__/async/repositories/trace-repository.servertest.ts
+++ b/web/src/__tests__/async/repositories/trace-repository.servertest.ts
@@ -71,8 +71,14 @@ describe("Clickhouse Traces Repository Test", () => {
     expect(result.input).toEqual(JSON.parse(trace.input ?? "{}"));
     expect(result.output).toEqual("regular string");
     expect(result.metadata).toEqual(trace.metadata);
-    expect(result.createdAt).toEqual(new Date(trace.created_at));
-    expect(result.updatedAt).toEqual(new Date(trace.updated_at));
+    expect(result.createdAt.getTime()).toBeCloseTo(
+      new Date(trace.created_at).getTime(),
+      -2, // Up to 50ms precision
+    );
+    expect(result.updatedAt.getTime()).toBeCloseTo(
+      new Date(trace.updated_at).getTime(),
+      -2, // Up to 50ms precision
+    );
   });
 
   it("should find a trace if no timestamp is provided", async () => {

--- a/web/src/__tests__/async/traces-trpc.servertest.ts
+++ b/web/src/__tests__/async/traces-trpc.servertest.ts
@@ -199,6 +199,42 @@ describe("traces trpc", () => {
     });
   });
 
+  describe("traces.countAll", () => {
+    it("count traces correctly", async () => {
+      await createTracesCh(
+        Array(120)
+          .fill(0)
+          .map(() =>
+            createTrace({
+              project_id: projectId,
+            }),
+          ),
+      );
+
+      const traces = await caller.traces.countAll({
+        projectId,
+        filter: [
+          {
+            column: "timestamp",
+            type: "datetime",
+            operator: ">=",
+            value: new Date(new Date().getTime() - 1000).toISOString(),
+          },
+        ],
+        searchQuery: null,
+        searchType: ["id"],
+        page: 0,
+        limit: 50,
+        orderBy: {
+          column: "timestamp",
+          order: "DESC",
+        },
+      });
+
+      expect(traces.totalCount).toBe(120);
+    });
+  });
+
   describe("traces.byId", () => {
     it("access private trace", async () => {
       const trace = createTrace({

--- a/web/src/__tests__/async/traces-trpc.servertest.ts
+++ b/web/src/__tests__/async/traces-trpc.servertest.ts
@@ -207,6 +207,7 @@ describe("traces trpc", () => {
           .map(() =>
             createTrace({
               project_id: projectId,
+              tags: ["count-test"],
             }),
           ),
       );
@@ -219,6 +220,12 @@ describe("traces trpc", () => {
             type: "datetime",
             operator: ">=",
             value: new Date(new Date().getTime() - 1000).toISOString(),
+          },
+          {
+            column: "tags",
+            operator: "any of",
+            value: ["count-test"],
+            type: "arrayOptions",
           },
         ],
         searchQuery: null,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes trace count calculation by using `uniq(t.id)` in `getTracesTableGeneric()` and updates tests for timestamp precision and trace counting.
> 
>   - **Behavior**:
>     - Fixes trace count calculation in `getTracesTableGeneric()` in `traces-ui-table-service.ts` by using `uniq(t.id)` instead of `count(*)`.
>     - Removes `GROUP BY` clause for count queries in `getTracesTableGeneric()`.
>   - **Tests**:
>     - Updates `trace-repository.servertest.ts` to use `toBeCloseTo` for timestamp precision checks.
>     - Adds test case in `traces-trpc.servertest.ts` to verify correct trace count with specific filters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3b4fc37045d15ff438049eae2064eff2d23b14ae. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->