### PR TITLE
chore(tracing): consistently use thousands separator

### DIFF
--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -10,7 +10,7 @@ import { api } from "@/src/utils/api";
 import { IOPreview } from "@/src/components/trace/IOPreview";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import Link from "next/link";
-import { usdFormatter } from "@/src/utils/numbers";
+import { usdFormatter, formatTokenCounts } from "@/src/utils/numbers";
 import { withDefault, StringParam, useQueryParam } from "use-query-params";
 import ScoresTable from "@/src/components/table/use-cases/scores";
 import { JumpToPlaygroundButton } from "@/src/features/playground/page/components/JumpToPlaygroundButton";
@@ -274,9 +274,12 @@ export const ObservationPreview = ({
                         className="flex items-center gap-1"
                       >
                         <span>
-                          {preloadedObservation.inputUsage} prompt →{" "}
-                          {preloadedObservation.outputUsage} completion (∑{" "}
-                          {preloadedObservation.totalUsage})
+                          {formatTokenCounts(
+                            preloadedObservation.inputUsage,
+                            preloadedObservation.outputUsage,
+                            preloadedObservation.totalUsage,
+                            true,
+                          )}
                         </span>
                         <InfoIcon className="h-3 w-3" />
                       </Badge>

--- a/web/src/components/trace/SpanItem.tsx
+++ b/web/src/components/trace/SpanItem.tsx
@@ -5,7 +5,7 @@ import { LevelColors } from "@/src/components/level-colors";
 import { CommentCountIcon } from "@/src/features/comments/CommentCountIcon";
 import { cn } from "@/src/utils/tailwind";
 import { formatIntervalSeconds } from "@/src/utils/dates";
-import { usdFormatter } from "@/src/utils/numbers";
+import { usdFormatter, formatTokenCounts } from "@/src/utils/numbers";
 import {
   calculateDisplayTotalCost,
   heatMapTextColor,
@@ -127,7 +127,11 @@ export const SpanItem: React.FC<SpanItemProps> = ({
               ) : null}
               {node.inputUsage || node.outputUsage || node.totalUsage ? (
                 <span className="text-xs text-muted-foreground">
-                  {node.inputUsage} → {node.outputUsage} (∑ {node.totalUsage})
+                  {formatTokenCounts(
+                    node.inputUsage,
+                    node.outputUsage,
+                    node.totalUsage,
+                  )}
                 </span>
               ) : null}
               {totalCost ? (

--- a/web/src/utils/numbers.ts
+++ b/web/src/utils/numbers.ts
@@ -40,6 +40,7 @@ export const numberFormatter = (
 ) => {
   return Intl.NumberFormat("en-US", {
     notation: "standard",
+    useGrouping: true,
     minimumFractionDigits: fractionDigits ?? 2,
     maximumFractionDigits: fractionDigits ?? 2,
   }).format(number ?? 0);
@@ -71,6 +72,19 @@ export const usdFormatter = (
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumfractiondigits
     maximumFractionDigits,
   }).format(numberToFormat ?? 0);
+};
+
+export const formatTokenCounts = (
+  inputUsage?: number | null,
+  outputUsage?: number | null,
+  totalUsage?: number | null,
+  showLabels = false,
+): string => {
+  if (!inputUsage && !outputUsage && !totalUsage) return "";
+
+  return showLabels
+    ? `${numberFormatter(inputUsage ?? 0, 0)} prompt → ${numberFormatter(outputUsage ?? 0, 0)} completion (∑ ${numberFormatter(totalUsage ?? 0, 0)})`
+    : `${numberFormatter(inputUsage ?? 0, 0)} → ${numberFormatter(outputUsage ?? 0, 0)} (∑ ${numberFormatter(totalUsage ?? 0, 0)})`;
 };
 
 export function randomIntFromInterval(min: number, max: number) {


### PR DESCRIPTION
<img width="279" height="40" alt="thousands separators" src="https://github.com/user-attachments/assets/72878016-0d6b-437b-8389-d323edb87e9a" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces `formatTokenCounts` for consistent thousands separator in token counts across `ObservationPreview.tsx` and `SpanItem.tsx`.
> 
>   - **Behavior**:
>     - Introduces `formatTokenCounts` in `numbers.ts` to format token counts with thousands separator.
>     - Replaces inline token count formatting with `formatTokenCounts` in `ObservationPreview.tsx` and `SpanItem.tsx`.
>   - **Formatting**:
>     - `numberFormatter` in `numbers.ts` updated to use `useGrouping: true` for thousands separator.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 683e3cb0cbee127e8d7529f188e4ef62cb9ea58c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->