### PR TITLE
fix: explicit observation types should be respected

### DIFF
--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -3347,5 +3347,133 @@ describe("OTel Resource Span Mapping", () => {
       expect(spanEvents.length).toBe(1);
       expect(spanEvents[0].body.name).toBe("test-span");
     });
+
+    it("should respect explicit observation types", async () => {
+      // Test that explicit observation types (agent, evaluator, etc.) are respected
+      // even when spans have generation-like properties (e.g., model names)
+      const observationTypes = [
+        { type: "agent", expectedEventType: "agent-create" },
+        { type: "evaluator", expectedEventType: "evaluator-create" },
+        { type: "tool", expectedEventType: "tool-create" },
+        { type: "retriever", expectedEventType: "retriever-create" },
+        { type: "embedding", expectedEventType: "embedding-create" },
+        { type: "guardrail", expectedEventType: "guardrail-create" },
+        { type: "generation", expectedEventType: "generation-create" },
+      ];
+
+      for (const { type, expectedEventType } of observationTypes) {
+        const otelSpans = [
+          {
+            resource: { attributes: [] },
+            scopeSpans: [
+              {
+                scope: { name: "test-scope" },
+                spans: [
+                  {
+                    traceId: {
+                      data: [
+                        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+                      ],
+                    },
+                    spanId: { data: [1, 2, 3, 4, 5, 6, 7, 8] },
+                    name: `test-${type}`,
+                    startTimeUnixNano: 1000000000,
+                    endTimeUnixNano: 2000000000,
+                    attributes: [
+                      {
+                        key: "langfuse.observation.type",
+                        value: { stringValue: type },
+                      },
+                      // Add model name to trigger generation heuristic
+                      {
+                        key: "langfuse.observation.model.name",
+                        value: { stringValue: "gpt-4" },
+                      },
+                      // Add other generation-like properties
+                      {
+                        key: "gen_ai.request.model",
+                        value: { stringValue: "gpt-4" },
+                      },
+                      {
+                        key: "openinference.span.kind",
+                        value: { stringValue: "LLM" },
+                      },
+                    ],
+                    status: {},
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        const events = await convertOtelSpanToIngestionEvent(
+          otelSpans[0],
+          new Set(),
+          publicKey,
+        );
+
+        // Should create the specific observation type, NOT generation-create
+        const observationEvents = events.filter(
+          (e) => e.type === expectedEventType,
+        );
+        const generationEvents = events.filter(
+          (e) => e.type === "generation-create",
+        );
+
+        expect(observationEvents.length).toBe(1);
+        expect(generationEvents.length).toBe(0);
+        expect(observationEvents[0].body.name).toBe(`test-${type}`);
+        expect(observationEvents[0].body.model).toBe("gpt-4");
+      }
+    });
+
+    it("should fall back to generation-create for model names without explicit type", async () => {
+      // Ensure model name heuristic still works when no explicit type is provided
+      const otelSpans = [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [
+            {
+              scope: { name: "test-scope" },
+              spans: [
+                {
+                  traceId: {
+                    data: [
+                      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+                    ],
+                  },
+                  spanId: { data: [1, 2, 3, 4, 5, 6, 7, 8] },
+                  name: "test-llm-call",
+                  startTimeUnixNano: 1000000000,
+                  endTimeUnixNano: 2000000000,
+                  attributes: [
+                    // No explicit observation type
+                    {
+                      key: "langfuse.observation.model.name",
+                      value: { stringValue: "gpt-4" },
+                    },
+                  ],
+                  status: {},
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const events = await convertOtelSpanToIngestionEvent(
+        otelSpans[0],
+        new Set(),
+        publicKey,
+      );
+
+      const generationEvents = events.filter(
+        (e) => e.type === "generation-create",
+      );
+      expect(generationEvents.length).toBe(1);
+      expect(generationEvents[0].body.name).toBe("test-llm-call");
+      expect(generationEvents[0].body.model).toBe("gpt-4");
+    });
   });
 });

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -3358,7 +3358,6 @@ describe("OTel Resource Span Mapping", () => {
         { type: "retriever", expectedEventType: "retriever-create" },
         { type: "embedding", expectedEventType: "embedding-create" },
         { type: "guardrail", expectedEventType: "guardrail-create" },
-        { type: "generation", expectedEventType: "generation-create" },
       ];
 
       for (const { type, expectedEventType } of observationTypes) {

--- a/web/src/features/otel/server/OtelIngestionProcessor.ts
+++ b/web/src/features/otel/server/OtelIngestionProcessor.ts
@@ -652,10 +652,10 @@ export class OtelIngestionProcessor {
       ObservationTypeDomain.safeParse(observationType.toUpperCase()).success;
 
     const getIngestionEventType = (): string => {
-      if (isGeneration) return "generation-create";
       if (isKnownObservationType) {
         return `${observationType.toLowerCase()}-create`;
       }
+      if (isGeneration) return "generation-create";
       return "span-create";
     };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> This PR ensures explicit observation types are prioritized over generation heuristics in OpenTelemetry span processing, with updated tests to verify this behavior.
> 
>   - **Behavior**:
>     - `OtelIngestionProcessor.ts`: Prioritizes explicit observation types over generation heuristics in `createObservationEvent()`.
>     - Falls back to `generation-create` if no explicit type is provided and model name heuristic applies.
>   - **Tests**:
>     - `otelMapping.servertest.ts`: Adds tests to verify explicit observation types are respected and generation fallback works.
>     - Tests include cases for `agent`, `evaluator`, `tool`, `retriever`, `embedding`, and `guardrail` types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6e5abb557992279c55ba034f3c25bf3890c91baf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->