### PR TITLE
perf: use uniq instead of count for prompt metrics call

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1158,8 +1158,8 @@ export const getObservationsWithPromptName = async (
   promptNames: string[],
 ) => {
   const query = `
-  SELECT count(*) as count, prompt_name
-  FROM observations FINAL
+  SELECT uniq(id) as count, prompt_name
+  FROM observations
   WHERE project_id = {projectId: String}
   AND prompt_name IN ({promptNames: Array(String)})
   AND prompt_name IS NOT NULL


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize `getObservationsWithPromptName` by using `uniq(id)` instead of `count(*)` for better performance.
> 
>   - **Performance Optimization**:
>     - In `getObservationsWithPromptName`, replace `count(*)` with `uniq(id)` to count unique observation IDs, improving query performance by reducing data processing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8a1a9c2ce5b2b0df5b26b72f687416884f7b5404. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->