### PR TITLE
feat: allow opt-out of blob-storage-file-log for lifecycle policed buckets

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -156,6 +156,9 @@ OTEL_SERVICE_NAME="langfuse"
 # LANGFUSE_S3_EVENT_UPLOAD_REGION=
 # LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID=
 # LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY=
+# Whether to use blob_storage_file_log table to manage blob storage events
+# Can be set to `false` if `event` entities are managed using lifecycle policies in the blob storage bucket.
+LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG=true
 
 # Automated provisioning of default resources
 # LANGFUSE_INIT_ORG_ID=org-id

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -103,6 +103,10 @@ const EnvSchema = z.object({
   LANGFUSE_GOOGLE_CLOUD_STORAGE_CREDENTIALS: z.string().optional(),
   STRIPE_SECRET_KEY: z.string().optional(),
 
+  LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG: z
+    .enum(["true", "false"])
+    .default("true"),
+
   LANGFUSE_S3_LIST_MAX_KEYS: z.coerce.number().positive().default(200),
   LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED: z
     .enum(["true", "false"])

--- a/packages/shared/src/server/repositories/blobStorageLog.ts
+++ b/packages/shared/src/server/repositories/blobStorageLog.ts
@@ -185,7 +185,7 @@ export const insertIntoS3RefsTableFromEventLog = async (
 ) => {
   const query = `
     INSERT INTO blob_storage_file_log
-    SELECT 
+    SELECT
       id,
       project_id,
       entity_type,
@@ -239,10 +239,10 @@ export const findS3RefsByPrimaryKey = async (primaryKey: {
   bucket_path: string;
 }) => {
   const query = `
-    SELECT * 
-    FROM blob_storage_file_log 
-    WHERE project_id = {project_id: String} 
-      AND entity_type = {entity_type: String} 
+    SELECT *
+    FROM blob_storage_file_log
+    WHERE project_id = {project_id: String}
+      AND entity_type = {entity_type: String}
       AND entity_id = {entity_id: String}
       AND bucket_path = {bucket_path: String}
   `;

--- a/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
+++ b/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
@@ -61,10 +61,12 @@ export const handleDataRetentionProcessingJob = async (job: Job) => {
     `[Data Retention] Deleting ClickHouse and S3 data older than ${retention} days for project ${projectId}`,
   );
   await Promise.all([
-    removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject(
-      projectId,
-      cutoffDate,
-    ),
+    env.LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG === "true"
+      ? removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject(
+          projectId,
+          cutoffDate,
+        )
+      : Promise.resolve(),
     deleteTracesOlderThanDays(projectId, cutoffDate),
     deleteObservationsOlderThanDays(projectId, cutoffDate),
     deleteScoresOlderThanDays(projectId, cutoffDate),

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -132,6 +132,10 @@ const EnvSchema = z.object({
     .enum(["true", "false"])
     .default("false"),
 
+  LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG: z
+    .enum(["true", "false"])
+    .default("true"),
+
   // Flags to toggle queue consumers on or off.
   QUEUE_CONSUMER_CLOUD_USAGE_METERING_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])

--- a/worker/src/features/scores/processClickhouseScoreDelete.ts
+++ b/worker/src/features/scores/processClickhouseScoreDelete.ts
@@ -4,22 +4,26 @@ import {
   traceException,
   deleteIngestionEventsFromS3AndClickhouseForScores,
 } from "@langfuse/shared/src/server";
+import { env } from "../../env";
 
 export const processClickhouseScoreDelete = async (
   projectId: string,
   scoreIds: string[],
 ) => {
   logger.info(
-    `Deleting scores ${JSON.stringify(scoreIds)} in project ${projectId} from Clickhouse`,
+    `Deleting scores ${JSON.stringify(scoreIds)} in project ${projectId} from Clickhouse and S3`,
   );
 
-  await deleteIngestionEventsFromS3AndClickhouseForScores({
-    projectId,
-    scoreIds,
-  });
-
   try {
-    await deleteScores(projectId, scoreIds);
+    await Promise.all([
+      env.LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG === "true"
+        ? deleteIngestionEventsFromS3AndClickhouseForScores({
+            projectId,
+            scoreIds,
+          })
+        : Promise.resolve(),
+      await deleteScores(projectId, scoreIds),
+    ]);
   } catch (e) {
     logger.error(
       `Error deleting scores ${JSON.stringify(scoreIds)} in project ${projectId} from Clickhouse`,

--- a/worker/src/features/scores/processClickhouseScoreDelete.ts
+++ b/worker/src/features/scores/processClickhouseScoreDelete.ts
@@ -22,7 +22,7 @@ export const processClickhouseScoreDelete = async (
             scoreIds,
           })
         : Promise.resolve(),
-      await deleteScores(projectId, scoreIds),
+      deleteScores(projectId, scoreIds),
     ]);
   } catch (e) {
     logger.error(

--- a/worker/src/features/traces/processClickhouseTraceDelete.ts
+++ b/worker/src/features/traces/processClickhouseTraceDelete.ts
@@ -143,13 +143,14 @@ export const processClickhouseTraceDelete = async (
 
   await deleteMediaItemsForTraces(projectId, traceIds);
 
-  await removeIngestionEventsFromS3AndDeleteClickhouseRefsForTraces({
-    projectId,
-    traceIds,
-  });
-
   try {
     await Promise.all([
+      env.LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG === "true"
+        ? removeIngestionEventsFromS3AndDeleteClickhouseRefsForTraces({
+            projectId,
+            traceIds,
+          })
+        : Promise.resolve(),
       deleteTraces(projectId, traceIds),
       deleteObservationsByTraceIds(projectId, traceIds),
       deleteScoresByTraceIds(projectId, traceIds),

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -56,7 +56,11 @@ export const ingestionQueueProcessorBuilder = (
       // We write the new file into the ClickHouse event log to keep track for retention and deletions
       const clickhouseWriter = ClickhouseWriter.getInstance();
 
-      if (job.data.payload.data.fileKey && job.data.payload.data.fileKey) {
+      if (
+        env.LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG === "true" &&
+        job.data.payload.data.fileKey &&
+        job.data.payload.data.fileKey
+      ) {
         const fileName = `${job.data.payload.data.fileKey}.json`;
         clickhouseWriter.addToQueue(TableName.BlobStorageFileLog, {
           id: randomUUID(),

--- a/worker/src/queues/projectDelete.ts
+++ b/worker/src/queues/projectDelete.ts
@@ -79,18 +79,18 @@ export const projectDeleteProcessor: Processor = async (
     // No need to delete from table as this will be done below via Prisma
   }
 
-  logger.info(`Deleting S3 event logs for ${projectId} in org ${orgId}`);
-
-  // Remove event files from S3
-  await removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject(
-    projectId,
-    undefined,
+  logger.info(
+    `Deleting ClickHouse and S3 data for ${projectId} in org ${orgId}`,
   );
-
-  logger.info(`Deleting ClickHouse data for ${projectId} in org ${orgId}`);
 
   // Delete project data from ClickHouse first
   await Promise.all([
+    env.LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG === "true"
+      ? removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject(
+          projectId,
+          undefined,
+        )
+      : Promise.resolve(),
     deleteTracesByProjectId(projectId),
     deleteObservationsByProjectId(projectId),
     deleteScoresByProjectId(projectId),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG` to allow opting out of using `blob_storage_file_log` for event management, with conditional logic across various modules.
> 
>   - **Feature**:
>     - Introduces `LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG` environment variable to opt-out of using `blob_storage_file_log` for managing blob storage events.
>     - Defaults to `true`, allowing existing behavior unless explicitly set to `false`.
>   - **Behavior**:
>     - Conditional logic added in `upsertClickhouse()` in `clickhouse.ts` to skip inserting into `blob_storage_file_log` if the variable is `false`.
>     - Similar conditional checks added in `processClickhouseScoreDelete()`, `processClickhouseTraceDelete()`, `handleDataRetentionProcessingJob()`, and `projectDeleteProcessor` to skip related operations.
>   - **Environment**:
>     - Updates in `env.ts` files to include the new environment variable with default value `true`.
>     - `.env.prod.example` updated to document the new variable.
>   - **Misc**:
>     - Minor formatting changes in `blobStorageLog.ts` and `clickhouse.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0d216aacc0045b3617f868191ae6c3632ac1230e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->