### PR TITLE
fix(trace-detail): remove unnecessary z-indexes

### DIFF
--- a/web/src/components/trace/TraceTree.tsx
+++ b/web/src/components/trace/TraceTree.tsx
@@ -185,7 +185,7 @@ const UnmemoizedTreeNodeComponent = ({
         <div className="flex w-full pl-2">
           {/* Tree structure indicators */}
           {indentationLevel > 0 && (
-            <div className="z-20 flex flex-shrink-0">
+            <div className="flex flex-shrink-0">
               {/* Vertical lines for ancestor levels */}
               {Array.from({ length: indentationLevel - 1 }, (_, i) => (
                 <div key={i} className="relative w-6">
@@ -197,7 +197,7 @@ const UnmemoizedTreeNodeComponent = ({
               {/* Branch indicator for current level */}
               <div className="relative w-6">
                 <div
-                  className="absolute left-3 z-10 w-px bg-border"
+                  className="absolute left-3 w-px bg-border"
                   style={{
                     top: 0,
                     bottom: isLastSibling ? "calc(100% - 12px)" : "12px",
@@ -240,7 +240,7 @@ const UnmemoizedTreeNodeComponent = ({
               setCurrentNodeId(node.type === "TRACE" ? undefined : node.id)
             }
             className={cn(
-              "peer relative z-20 flex min-w-0 flex-1 items-center rounded-md py-1.5 pl-0 pr-2 text-left",
+              "peer relative flex min-w-0 flex-1 items-center rounded-md py-1.5 pl-0 pr-2 text-left",
             )}
             ref={currentNodeRef}
           >
@@ -259,7 +259,7 @@ const UnmemoizedTreeNodeComponent = ({
 
           {/* Expand/Collapse button */}
           {node.children.length > 0 && (
-            <div className="z-20 flex items-center justify-end py-1 pr-2">
+            <div className="flex items-center justify-end py-1 pr-2">
               <Button
                 size="icon"
                 variant="ghost"


### PR DESCRIPTION
Fixes tooltips z-index issue.



> [!IMPORTANT]
> Remove unnecessary `z-index` properties from div elements in `UnmemoizedTreeNodeComponent` in `TraceTree.tsx`.
> 
>   - **CSS Changes**:
>     - Removed `z-index` from div elements in `UnmemoizedTreeNodeComponent` in `TraceTree.tsx`.
>     - Affected elements include tree structure indicators, branch indicators, and expand/collapse buttons.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8dcdedee023c28c4d062a93ab4764efe218af7c6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->