### PR TITLE
perf: avoid final modified for traces.countAll via uniq

### DIFF
--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -356,7 +356,8 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
       let sqlSelect: string;
       switch (select) {
         case "count":
-          sqlSelect = "uniq(t.id) as count";
+          // Using uniqExact here as we need the correct count to handle pagination right
+          sqlSelect = "uniqExact(t.id) as count";
           break;
         case "metrics":
           sqlSelect = `

--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -356,7 +356,7 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
       let sqlSelect: string;
       switch (select) {
         case "count":
-          sqlSelect = "count(*) as count";
+          sqlSelect = "uniq(t.id) as count";
           break;
         case "metrics":
           sqlSelect = `
@@ -447,8 +447,8 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
         ${observationsAndScoresCTE}        
 
         SELECT ${sqlSelect}
-        -- FINAL is used for non default ordering and count.
-        FROM traces t  ${["metrics", "rows", "identifiers"].includes(select) && defaultOrder ? "" : "FINAL"}
+        -- FINAL is used for non default ordering.
+        FROM traces t  ${defaultOrder || select === "count" ? "" : "FINAL"}
         ${select === "metrics" || requiresObservationsJoin ? `LEFT JOIN observations_stats o on o.project_id = t.project_id and o.trace_id = t.id` : ""}
         ${select === "metrics" || requiresScoresJoin ? `LEFT JOIN scores_avg s on s.project_id = t.project_id and s.trace_id = t.id` : ""}
         WHERE t.project_id = {projectId: String}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize trace counting by using `uniq(t.id)` and adjust `FINAL` keyword usage in `getTracesTableGeneric()` for better performance.
> 
>   - **Performance Optimization**:
>     - Change `count(*)` to `uniq(t.id)` for counting unique trace IDs in `getTracesTableGeneric()`.
>     - Modify `FINAL` keyword usage condition to avoid it when `defaultOrder` is true or `select` is "count" in `getTracesTableGeneric()`.
>   - **Files Affected**:
>     - `traces-ui-table-service.ts`
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bc1240f4806fb1cf62da7adada62f89f31c30a95. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->