### PR TITLE
docs(dataset-runs-ui): rename `experiments` to `dataset runs` across ui

### DIFF
--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -509,7 +509,7 @@ export const InnerEvaluatorForm = (props: {
                           value="dataset"
                           disabled={props.disabled || props.mode === "edit"}
                         >
-                          Experiment runs
+                          Dataset runs
                         </TabsTrigger>
                       </TabsList>
                     </Tabs>

--- a/web/src/features/evals/components/template-selector.tsx
+++ b/web/src/features/evals/components/template-selector.tsx
@@ -222,7 +222,7 @@ export const TemplateSelector = ({
                             )}
                             {isInactive && (
                               <div
-                                title="The evaluator has been used in the past but is currently paused. It will not run in this experiment. You can reactivate it if you wish"
+                                title="The evaluator has been used in the past but is currently paused. It will not run in this dataset run. You can reactivate it if you wish"
                                 className="ml-2 text-xs text-muted-foreground"
                               >
                                 Paused
@@ -297,7 +297,7 @@ export const TemplateSelector = ({
                           )}
                           {isInactive && (
                             <div
-                              title="The evaluator has been used in the past but is currently paused. It will not run in this experiment. You can reactivate it if you wish"
+                              title="The evaluator has been used in the past but is currently paused. It will not run in this dataset run. You can reactivate it if you wish"
                               className="ml-2 text-xs text-muted-foreground"
                             >
                               Paused

--- a/web/src/features/evals/components/template-selector.tsx
+++ b/web/src/features/evals/components/template-selector.tsx
@@ -222,7 +222,7 @@ export const TemplateSelector = ({
                             )}
                             {isInactive && (
                               <div
-                                title="The evaluator has been used in the past but is currently paused. It will not run in this dataset run. You can reactivate it if you wish"
+                                title="The evaluator has been used in the past but is currently paused. It will not run against outputs created in this dataset run. You can reactivate it if you wish"
                                 className="ml-2 text-xs text-muted-foreground"
                               >
                                 Paused
@@ -297,7 +297,7 @@ export const TemplateSelector = ({
                           )}
                           {isInactive && (
                             <div
-                              title="The evaluator has been used in the past but is currently paused. It will not run in this dataset run. You can reactivate it if you wish"
+                              title="The evaluator has been used in the past but is currently paused. It will not run against outputs created in this dataset run. You can reactivate it if you wish"
                               className="ml-2 text-xs text-muted-foreground"
                             >
                               Paused

--- a/web/src/features/experiments/components/CreateExperimentsForm.tsx
+++ b/web/src/features/experiments/components/CreateExperimentsForm.tsx
@@ -98,10 +98,10 @@ export const CreateExperimentsForm = ({
     return (
       <>
         <DialogHeader>
-          <DialogTitle>Run Experiment on Dataset</DialogTitle>
+          <DialogTitle>Start Dataset Run</DialogTitle>
           <DialogDescription>
-            Experiments allow to test iterations of your application or prompt
-            on a dataset. Learn more about datasets and experiments{" "}
+            Dataset runs allow to test iterations of your application or prompt
+            on a dataset. Learn more about dataset runs{" "}
             <Link
               href="https://langfuse.com/docs/evaluation/dataset-runs/datasets"
               target="_blank"
@@ -118,7 +118,7 @@ export const CreateExperimentsForm = ({
               <CardHeader>
                 <CardTitle className="flex items-center gap-2 text-lg">
                   <Wand2 className="size-4" />
-                  Prompt Experiment
+                  via User Interface
                 </CardTitle>
                 <CardDescription>
                   Test single prompts and model configurations via Langfuse UI
@@ -136,7 +136,7 @@ export const CreateExperimentsForm = ({
                   className="w-full"
                   onClick={() => setShowPromptForm(true)}
                 >
-                  Create
+                  Configure
                 </Button>
                 <Button
                   variant="outline"
@@ -157,15 +157,15 @@ export const CreateExperimentsForm = ({
               <CardHeader>
                 <CardTitle className="flex items-center gap-2 text-lg">
                   <Code2 className="size-4" />
-                  Custom Experiment
+                  via SDK / API
                 </CardTitle>
                 <CardDescription>
-                  Run any experiment via the Langfuse SDKs
+                  Start any dataset run via the Langfuse SDKs
                 </CardDescription>
               </CardHeader>
               <CardContent>
                 <ul className="list-disc space-y-2 pl-4 text-sm text-muted-foreground">
-                  <li>Full control over experiment execution</li>
+                  <li>Full control over dataset run execution</li>
                   <li>Custom evaluation logic</li>
                   <li>Integration with your codebase</li>
                 </ul>
@@ -207,7 +207,7 @@ export const CreateExperimentsForm = ({
                 {!existingRemoteExperiment.data && (
                   <Button
                     variant="outline"
-                    title="Set up remote experiment in UI trigger"
+                    title="Set up remote dataset run in UI trigger"
                     className="h-8 w-8 flex-shrink-0"
                     size="icon"
                     onClick={() => setShowRemoteExperimentUpsertForm(true)}

--- a/web/src/features/experiments/components/PromptExperimentsForm.tsx
+++ b/web/src/features/experiments/components/PromptExperimentsForm.tsx
@@ -208,7 +208,7 @@ export const PromptExperimentsForm = ({
     onSuccess: handleExperimentSuccess ?? (() => {}),
     onError: (error) => {
       showErrorToast(
-        error.message || "Failed to trigger experiment run",
+        error.message || "Failed to trigger dataset run",
         "Please try again.",
       );
     },
@@ -273,9 +273,9 @@ export const PromptExperimentsForm = ({
             ← Back
           </Button>
         )}
-        <DialogTitle>New Prompt Experiment</DialogTitle>
+        <DialogTitle>New Dataset Run</DialogTitle>
         <DialogDescription>
-          Create an experiment to test a prompt version on a dataset. See{" "}
+          Start a dataset run to test a prompt version on a dataset. See{" "}
           <Link
             href="https://langfuse.com/docs/evaluation/dataset-runs/native-run"
             target="_blank"
@@ -294,7 +294,7 @@ export const PromptExperimentsForm = ({
               name="name"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Experiment name (optional)</FormLabel>
+                  <FormLabel>Dataset run name (optional)</FormLabel>
                   <FormControl>
                     <Input {...field} type="string" />
                   </FormControl>
@@ -560,7 +560,7 @@ export const PromptExperimentsForm = ({
               <FormItem>
                 <FormLabel>Evaluators</FormLabel>
                 <FormDescription>
-                  Will run against your experiment results.
+                  Will run against the LLM outputs
                 </FormDescription>
                 <TemplateSelector
                   projectId={projectId}
@@ -639,7 +639,7 @@ export const PromptExperimentsForm = ({
                         ))}
                       </ul>
                       Items missing all required variables and placeholders will
-                      be excluded from the experiment.
+                      be excluded from the dataset run.
                     </div>
                   </CardHeader>
                 </Card>
@@ -658,7 +658,7 @@ export const PromptExperimentsForm = ({
                 }
                 loading={form.formState.isSubmitting}
               >
-                Create
+                Start
               </Button>
             </div>
           </DialogFooter>

--- a/web/src/features/experiments/components/RemoteExperimentTriggerModal.tsx
+++ b/web/src/features/experiments/components/RemoteExperimentTriggerModal.tsx
@@ -72,21 +72,21 @@ export const RemoteExperimentTriggerModal = ({
       onSuccess: (data) => {
         if (data.success) {
           showSuccessToast({
-            title: "Experiment started",
-            description: "Your experiment may take a few minutes to complete.",
+            title: "Dataset run started",
+            description: "Your dataset run may take a few minutes to complete.",
           });
         } else {
           showErrorToast(
-            "Failed to start experiment",
-            "Please try again or check your remote experiment configuration.",
+            "Failed to start dataset run",
+            "Please try again or check your remote dataset run configuration.",
           );
         }
         setShowTriggerModal(false);
       },
       onError: (error) => {
         showErrorToast(
-          error.message || "Failed to start experiment",
-          "Please try again or check your remote experiment configuration.",
+          error.message || "Failed to start dataset run",
+          "Please try again or check your remote dataset run configuration.",
         );
       },
     });
@@ -124,7 +124,7 @@ export const RemoteExperimentTriggerModal = ({
         >
           ← Back
         </Button>
-        <DialogTitle>Run remote experiment</DialogTitle>
+        <DialogTitle>Run remote dataset run</DialogTitle>
         <DialogDescription>
           This action will send the following information to{" "}
           <strong>{remoteExperimentConfig.url}</strong>.
@@ -142,8 +142,8 @@ export const RemoteExperimentTriggerModal = ({
                   <FormItem>
                     <FormLabel>Config</FormLabel>
                     <FormDescription>
-                      Confirm the config you want to send to the remote
-                      experiment URL along with the{" "}
+                      Confirm the config you want to send to the remote dataset
+                      run URL along with the{" "}
                       <strong>{dataset.data?.name}</strong> dataset information.
                     </FormDescription>
                     <FormControl>

--- a/web/src/features/experiments/components/RemoteExperimentUpsertForm.tsx
+++ b/web/src/features/experiments/components/RemoteExperimentUpsertForm.tsx
@@ -97,13 +97,13 @@ export const RemoteExperimentUpsertForm = ({
         showSuccessToast({
           title: "Deleted successfully",
           description:
-            "The remote experiment trigger has been removed from this dataset.",
+            "The remote dataset run trigger has been removed from this dataset.",
         });
         setShowRemoteExperimentUpsertForm(false);
       },
       onError: (error) => {
         showErrorToast(
-          error.message || "Failed to delete remote experiment trigger",
+          error.message || "Failed to delete remote dataset run trigger",
           "Please try again.",
         );
       },
@@ -131,7 +131,9 @@ export const RemoteExperimentUpsertForm = ({
 
   const handleDelete = () => {
     if (
-      confirm("Are you sure you want to delete this remote experiment trigger?")
+      confirm(
+        "Are you sure you want to delete this remote dataset run trigger?",
+      )
     ) {
       deleteRemoteExperimentMutation.mutate({
         projectId,
@@ -160,11 +162,11 @@ export const RemoteExperimentUpsertForm = ({
         </Button>
         <DialogTitle>
           {existingRemoteExperiment
-            ? "Edit remote experiment trigger"
-            : "Set up remote experiment trigger in UI"}
+            ? "Edit remote dataset run trigger"
+            : "Set up remote dataset run trigger in UI"}
         </DialogTitle>
         <DialogDescription>
-          Enable your team to run custom experiments on dataset{" "}
+          Enable your team to run custom dataset runs on dataset{" "}
           <strong>
             {dataset.isSuccess ? (
               <>&quot;{dataset.data?.name}&quot;</>
@@ -172,9 +174,9 @@ export const RemoteExperimentUpsertForm = ({
               <Loader2 className="inline h-4 w-4 animate-spin" />
             )}
           </strong>
-          . Configure a webhook URL to trigger remote custom experiments from
+          . Configure a webhook URL to trigger remote custom dataset runs from
           UI. We will send dataset info (name, id) and config to your service,
-          which can run experiments and post results to Langfuse.
+          which can run against the dataset and post results to Langfuse.
         </DialogDescription>
       </DialogHeader>
 
@@ -188,7 +190,7 @@ export const RemoteExperimentUpsertForm = ({
                 <FormItem>
                   <FormLabel>URL</FormLabel>
                   <FormDescription>
-                    The URL that will be called when the remote experiment is
+                    The URL that will be called when the remote dataset run is
                     triggered.
                   </FormDescription>
                   <FormControl>
@@ -209,9 +211,9 @@ export const RemoteExperimentUpsertForm = ({
                 <FormItem>
                   <FormLabel>Default config</FormLabel>
                   <FormDescription>
-                    Set a default config that will be sent to the remote
-                    experiment URL. This can be modified when running the
-                    experiment. View docs for more details.
+                    Set a default config that will be sent to the remote dataset
+                    run URL. This can be modified before starting a new run.
+                    View docs for more details.
                   </FormDescription>
                   <CodeMirrorEditor
                     value={field.value}

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -197,10 +197,10 @@ export const PromptDetail = ({
     void utils.datasets.baseRunDataByDatasetId.invalidate();
     void utils.datasets.runsByDatasetId.invalidate();
     showSuccessToast({
-      title: "Experiment run triggered successfully",
-      description: "Waiting for experiment to complete...",
+      title: "Dataset run triggered successfully",
+      description: "Waiting for dataset run to complete...",
       link: {
-        text: "View experiment",
+        text: "View dataset run",
         href: `/project/${projectId}/datasets/${data.datasetId}/compare?runs=${data.runId}`,
       },
     });
@@ -410,7 +410,7 @@ export const PromptDetail = ({
                       >
                         <FlaskConical className="h-4 w-4" />
                         <span className="hidden md:ml-2 md:inline">
-                          Experiment
+                          Dataset run
                         </span>
                       </Button>
                     </DialogTrigger>

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
@@ -193,7 +193,7 @@ export default function DatasetCompare() {
                   onClick={() => capture("dataset_run:new_form_open")}
                 >
                   <FlaskConical className="h-4 w-4" />
-                  <span className="ml-2 hidden md:block">New experiment</span>
+                  <span className="ml-2 hidden md:block">New dataset run</span>
                 </Button>
               </DialogTrigger>
               <DialogContent className="max-h-[90vh] overflow-y-auto">
@@ -258,12 +258,12 @@ export default function DatasetCompare() {
           />
         </div>
         <SidePanel
-          mobileTitle="Compare Experiments"
-          id="compare-experiments"
+          mobileTitle="Compare Dataset Runs"
+          id="compare-dataset-runs"
           scrollable={false}
         >
           <SidePanelHeader>
-            <SidePanelTitle>Compare Experiments</SidePanelTitle>
+            <SidePanelTitle>Compare Dataset Runs</SidePanelTitle>
           </SidePanelHeader>
           <SidePanelContent className="overflow-y-auto p-1">
             <div className="w-full space-y-4">

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
@@ -85,10 +85,10 @@ export default function Dataset() {
     void utils.datasets.runsByDatasetId.invalidate();
     void utils.datasets.baseRunDataByDatasetId.invalidate();
     showSuccessToast({
-      title: "Experiment run triggered successfully",
-      description: "Waiting for experiment to complete...",
+      title: "Dataset run triggered successfully",
+      description: "Waiting for dataset run to complete...",
       link: {
-        text: "View experiment",
+        text: "View dataset run",
         href: `/project/${projectId}/datasets/${data.datasetId}/compare?runs=${data.runId}`,
       },
     });
@@ -178,7 +178,7 @@ export default function Dataset() {
                   onClick={() => capture("dataset_run:new_form_open")}
                 >
                   <FlaskConical className="h-4 w-4" />
-                  <span className="ml-2 hidden md:block">New experiment</span>
+                  <span className="ml-2 hidden md:block">New dataset run</span>
                 </Button>
               </DialogTrigger>
               <DialogContent className="max-h-[90vh] overflow-y-auto">

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId].tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId].tsx
@@ -143,8 +143,8 @@ export default function Dataset() {
                       </h4>
                       <p className="text-sm text-muted-foreground">
                         {item.data.status === DatasetStatus.ACTIVE
-                          ? "Archiving an item will exclude it from new experiment runs."
-                          : "Unarchiving an item will include it back in new experiment runs."}
+                          ? "Archiving an item will exclude it from new dataset runs."
+                          : "Unarchiving an item will include it back in new dataset runs."}
                       </p>
                     </div>
                     <Button


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Renamed 'experiments' to 'dataset runs' across UI components for consistency.
> 
>   - **UI Changes**:
>     - Rename "Experiment runs" to "Dataset runs" in `inner-evaluator-form.tsx`.
>     - Update tooltips in `template-selector.tsx` to reflect "dataset run" terminology.
>     - Change "Run Experiment on Dataset" to "Start Dataset Run" in `CreateExperimentsForm.tsx`.
>     - Update button labels and descriptions in `PromptExperimentsForm.tsx` to use "Dataset Run".
>     - Modify success and error messages in `RemoteExperimentTriggerModal.tsx` to use "Dataset run".
>     - Update dialog titles and descriptions in `RemoteExperimentUpsertForm.tsx` to "Dataset run".
>     - Change success toast messages in `prompt-detail.tsx` to "Dataset run".
>     - Update button labels and side panel titles in `compare.tsx` and `index.tsx` to "Dataset run".
>     - Modify archive status messages in `items/[itemId].tsx` to "Dataset run".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 84602f3a5a5bf7f51654a713e5a0bfed5b1a8528. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->