### PR TITLE
feat(tracing): map openinference, openai to new observation types

### DIFF
--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -1097,7 +1097,60 @@ describe("OTel Resource Span Mapping", () => {
       expect(langfuseEvents).toHaveLength(2);
     });
 
-    it("should interpret openinference LLM calls as a generation", async () => {
+    it.each([
+      ["CHAIN", "chain-create"],
+      ["RETRIEVER", "retriever-create"],
+      ["LLM", "generation-create"],
+      ["EMBEDDING", "embedding-create"],
+      ["AGENT", "agent-create"],
+      ["TOOL", "tool-create"],
+      ["GUARDRAIL", "guardrail-create"],
+      ["EVALUATOR", "evaluator-create"],
+      ["", "span-create"],
+      ["UnknownKind", "span-create"],
+    ])(
+      "should map OpenInference %s span kind to %s event",
+      async (spanKind, expectedEventType) => {
+        const resourceSpan = {
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  ...defaultSpanProps,
+                  attributes: [
+                    {
+                      key: "openinference.span.kind",
+                      value: { stringValue: spanKind },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        // When
+        const langfuseEvents = await convertOtelSpanToIngestionEvent(
+          resourceSpan,
+          new Set(),
+        );
+
+        // Then
+        expect(langfuseEvents).toHaveLength(2); // Should create trace + observation
+        expect(
+          langfuseEvents.some((event) => event.type === expectedEventType),
+        ).toBe(true);
+
+        // Verify the observation has the correct type
+        const observationEvent = langfuseEvents.find(
+          (event) =>
+            event.type.endsWith("-create") && event.type !== "trace-create",
+        );
+        expect(observationEvent?.type).toBe(expectedEventType);
+      },
+    );
+
+    it("should prioritize OpenInference over model-based detection", async () => {
       const resourceSpan = {
         scopeSpans: [
           {
@@ -1107,7 +1160,11 @@ describe("OTel Resource Span Mapping", () => {
                 attributes: [
                   {
                     key: "openinference.span.kind",
-                    value: { stringValue: "LLM" },
+                    value: { stringValue: "TOOL" }, // Should be tool-create
+                  },
+                  {
+                    key: "gen_ai.request.model", // Would normally trigger generation
+                    value: { stringValue: "gpt-4" },
                   },
                 ],
               },
@@ -1123,10 +1180,117 @@ describe("OTel Resource Span Mapping", () => {
       );
 
       // Then
-      // Check that we create a generation
+      expect(langfuseEvents).toHaveLength(2);
+      // Should be tool-create, NOT generation-create (OpenInference takes priority)
+      expect(langfuseEvents.some((event) => event.type === "tool-create")).toBe(
+        true,
+      );
       expect(
         langfuseEvents.some((event) => event.type === "generation-create"),
+      ).toBe(false);
+    });
+
+    it("should trust Langfuse type over OpenInference or model detection", async () => {
+      const resourceSpan = {
+        scopeSpans: [
+          {
+            spans: [
+              {
+                ...defaultSpanProps,
+                attributes: [
+                  // Explicit Langfuse type (should always win)
+                  {
+                    key: "langfuse.observation.type",
+                    value: { stringValue: "span" },
+                  },
+                  // OpenInference span kind
+                  {
+                    key: "openinference.span.kind",
+                    value: { stringValue: "Agent" },
+                  },
+                  // Model indicators
+                  {
+                    key: "gen_ai.request.model",
+                    value: { stringValue: "gpt-4" },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      // When
+      const langfuseEvents = await convertOtelSpanToIngestionEvent(
+        resourceSpan,
+        new Set(),
+      );
+
+      // Then
+      expect(langfuseEvents).toHaveLength(2);
+      // Explicit Langfuse type should always win over inferred types
+      expect(langfuseEvents.some((event) => event.type === "span-create")).toBe(
+        true,
+      );
+      expect(
+        langfuseEvents.some((event) => event.type === "agent-create"),
+      ).toBe(false);
+      expect(
+        langfuseEvents.some((event) => event.type === "generation-create"),
+      ).toBe(false);
+    });
+
+    it("should trust OpenInference over model detection but keep model attributes", async () => {
+      const resourceSpan = {
+        scopeSpans: [
+          {
+            spans: [
+              {
+                ...defaultSpanProps,
+                attributes: [
+                  // OpenInference span kind (should take priority over model detection)
+                  {
+                    key: "openinference.span.kind",
+                    value: { stringValue: "RETRIEVER" },
+                  },
+                  // Model indicators (would be fallback)
+                  {
+                    key: "gen_ai.request.model",
+                    value: { stringValue: "text-embedding-ada-002" },
+                  },
+                  {
+                    key: "gen_ai.usage.input_tokens",
+                    value: { intValue: { low: 50, high: 0, unsigned: false } },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      // When
+      const langfuseEvents = await convertOtelSpanToIngestionEvent(
+        resourceSpan,
+        new Set(),
+      );
+
+      // Then
+      expect(langfuseEvents).toHaveLength(2);
+      // OpenInference should win over model detection
+      expect(
+        langfuseEvents.some((event) => event.type === "retriever-create"),
       ).toBe(true);
+      expect(
+        langfuseEvents.some((event) => event.type === "generation-create"),
+      ).toBe(false);
+
+      // Should still extract model and usage info
+      const retrieverEvent = langfuseEvents.find(
+        (event) => event.type === "retriever-create",
+      );
+      expect(retrieverEvent?.body.model).toBe("text-embedding-ada-002");
+      expect(retrieverEvent?.body.usageDetails.input).toBe(50);
     });
 
     it("should use logfire.msg as span name", async () => {
@@ -3473,6 +3637,71 @@ describe("OTel Resource Span Mapping", () => {
       expect(generationEvents.length).toBe(1);
       expect(generationEvents[0].body.name).toBe("test-llm-call");
       expect(generationEvents[0].body.model).toBe("gpt-4");
+    });
+
+    it("should default to span-create when no mapper can handle the attributes", async () => {
+      const otelSpans = [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [
+            {
+              scope: { name: "test-scope" },
+              spans: [
+                {
+                  traceId: {
+                    data: [
+                      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+                    ],
+                  },
+                  spanId: {
+                    data: [1, 2, 3, 4, 5, 6, 7, 8],
+                  },
+                  name: "unknown-operation",
+                  startTimeUnixNano: 1000000000,
+                  endTimeUnixNano: 2000000000,
+                  attributes: [
+                    // No openinference.span.kind, no model indicators, no explicit type
+                    {
+                      key: "custom.attribute",
+                      value: { stringValue: "some-value" },
+                    },
+                    {
+                      key: "service.name",
+                      value: { stringValue: "my-service" },
+                    },
+                    {
+                      key: "operation.type",
+                      value: { stringValue: "unknown" },
+                    },
+                  ],
+                  status: {},
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const events = await convertOtelSpanToIngestionEvent(
+        otelSpans[0],
+        new Set(),
+        publicKey,
+      );
+
+      // Should create a span-create event (default when no mapping found)
+      const spanEvents = events.filter((e) => e.type === "span-create");
+      expect(spanEvents.length).toBe(1);
+      expect(spanEvents[0].body.name).toBe("unknown-operation");
+
+      // Should not create any generation-create or other typed events
+      const nonSpanEvents = events.filter(
+        (e) => e.type !== "span-create" && e.type !== "trace-create",
+      );
+      expect(nonSpanEvents.length).toBe(0);
+
+      // Should still create a trace
+      const traceEvents = events.filter((e) => e.type === "trace-create");
+      expect(traceEvents.length).toBe(1);
     });
   });
 });

--- a/web/src/features/otel/server/ObservationTypeMapper.ts
+++ b/web/src/features/otel/server/ObservationTypeMapper.ts
@@ -1,0 +1,182 @@
+import { LangfuseOtelSpanAttributes } from "./attributes";
+import { ObservationType, ObservationTypeDomain } from "@langfuse/shared";
+
+type LangfuseObservationType = keyof typeof ObservationType;
+
+/**
+ * Interface for mapping span attributes to Langfuse observation types.
+ */
+export interface ObservationTypeMapper {
+  readonly name: string;
+  readonly priority: number; // Lower numbers = higher priority
+  canMap(attributes: Record<string, unknown>): boolean;
+  mapToObservationType(
+    attributes: Record<string, unknown>,
+  ): LangfuseObservationType | null;
+}
+
+/**
+ * Simple mapper for direct attribute key-value mappings.
+ */
+export class SimpleAttributeMapper implements ObservationTypeMapper {
+  constructor(
+    public readonly name: string,
+    public readonly priority: number,
+    private readonly attributeKey: string,
+    private readonly mappings: Record<string, string>,
+  ) {}
+
+  canMap(attributes: Record<string, unknown>): boolean {
+    return (
+      this.attributeKey in attributes && attributes[this.attributeKey] != null
+    );
+  }
+
+  mapToObservationType(
+    attributes: Record<string, unknown>,
+  ): LangfuseObservationType | null {
+    const value = attributes[this.attributeKey] as string;
+    const mappedType = this.mappings[value];
+
+    if (
+      mappedType &&
+      ObservationTypeDomain.safeParse(mappedType.toUpperCase()).success
+    ) {
+      return mappedType as LangfuseObservationType;
+    }
+
+    return null;
+  }
+}
+
+/**
+ * Mapper allowing for conditional logic, multiple attribute checks
+ */
+export class CustomAttributeMapper implements ObservationTypeMapper {
+  constructor(
+    public readonly name: string,
+    public readonly priority: number,
+    private readonly canMapFn: (attributes: Record<string, unknown>) => boolean,
+    private readonly mapFn: (
+      attributes: Record<string, unknown>,
+    ) => LangfuseObservationType | null,
+  ) {}
+
+  canMap(attributes: Record<string, unknown>): boolean {
+    return this.canMapFn(attributes);
+  }
+
+  mapToObservationType(
+    attributes: Record<string, unknown>,
+  ): LangfuseObservationType | null {
+    const result = this.mapFn(attributes);
+
+    if (
+      result &&
+      ObservationTypeDomain.safeParse(result.toUpperCase()).success
+    ) {
+      return result;
+    }
+
+    return null;
+  }
+}
+
+/**
+ * Registry to manage observation type mappers with a unified interface to map
+ * span attributes to observation types.
+ *
+ * Mappers are evaluated in priority order (lower number = higher priority).
+ *
+ * **NOTE**: This is the constructor to modify if you want to add new mappings.
+ */
+export class ObservationTypeMapperRegistry {
+  private readonly mappers: ObservationTypeMapper[] = [
+    new SimpleAttributeMapper("OpenInference", 1, "openinference.span.kind", {
+      CHAIN: "CHAIN",
+      RETRIEVER: "RETRIEVER",
+      LLM: "GENERATION",
+      EMBEDDING: "EMBEDDING",
+      AGENT: "AGENT",
+      TOOL: "TOOL",
+      GUARDRAIL: "GUARDRAIL",
+      EVALUATOR: "EVALUATOR",
+    }),
+
+    new CustomAttributeMapper(
+      "ModelBased",
+      2,
+      (attributes) => {
+        const modelKeys = [
+          LangfuseOtelSpanAttributes.OBSERVATION_MODEL,
+          "gen_ai.request.model",
+          "gen_ai.response.model",
+          "llm.model_name",
+          "model",
+        ];
+        return modelKeys.some((key) => attributes[key] != null);
+      },
+      () => "GENERATION",
+    ),
+  ];
+
+  private sortedMappersCache: ObservationTypeMapper[] | null = null;
+
+  /**
+   * Get mappers sorted by priority from cache.
+   */
+  private getSortedMappers(): ObservationTypeMapper[] {
+    if (!this.sortedMappersCache) {
+      this.sortedMappersCache = [...this.mappers].sort(
+        (a, b) => a.priority - b.priority,
+      );
+    }
+    return this.sortedMappersCache;
+  }
+
+  /**
+   * Maps span attributes to a Langfuse observation type.
+   * Returns null if no mapper can handle the attributes.
+   *
+   * @param attributes - The span attributes to analyze
+   * @returns The mapped observation type or null if no mapping found
+   */
+  mapToObservationType(
+    attributes: Record<string, unknown>,
+  ): LangfuseObservationType | null {
+    const sortedMappers = this.getSortedMappers();
+
+    for (const mapper of sortedMappers) {
+      if (mapper.canMap(attributes)) {
+        const result = mapper.mapToObservationType(attributes);
+        if (result) {
+          return result;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Returns a copy of mappers (for debugging)
+   */
+  getMappers(): ReadonlyArray<ObservationTypeMapper> {
+    return [...this.mappers];
+  }
+
+  /**
+   * Add a new mapper to the registry.
+   * Invalidates the sorted mappers cache.
+   */
+  addMapper(mapper: ObservationTypeMapper): void {
+    this.mappers.push(mapper);
+    this.sortedMappersCache = null;
+  }
+}
+
+/**
+ * Langfuse Mapping Registry containing the default mappings to be used.
+ */
+export const defaultObservationTypeMapperRegistry =
+  new ObservationTypeMapperRegistry();

--- a/web/src/features/otel/server/ObservationTypeMapper.ts
+++ b/web/src/features/otel/server/ObservationTypeMapper.ts
@@ -1,21 +1,95 @@
 import { LangfuseOtelSpanAttributes } from "./attributes";
-import type { ObservationType } from "@langfuse/shared";
-import { ObservationTypeDomain } from "@langfuse/shared";
+import { type ObservationType, ObservationTypeDomain } from "@langfuse/shared";
 
 type LangfuseObservationType = keyof typeof ObservationType;
 
+interface ObservationTypeMapper {
+  readonly name: string;
+  readonly priority: number; // Lower numbers = higher priority
+  canMap(attributes: Record<string, unknown>): boolean;
+  mapToObservationType(
+    attributes: Record<string, unknown>,
+  ): LangfuseObservationType | null;
+}
+
 /**
- * Configuration for OpenTelemetry attribute mapping to Langfuse observation types.
- *
- * To add new mappings, simply add entries to the MAPPING_CONFIG object below.
- * Each entry specifies what attribute to look for and how to map its values.
+ * Simple mapper for direct attribute key-value mappings.
  */
-const MAPPING_CONFIG = {
-  // OpenInference span kinds
-  openinference: {
-    attributeKey: "openinference.span.kind",
-    valueMapping: {
-      // SEEN_VALUE: LANGFUSE_OBSERVATION_TYPE
+class SimpleAttributeMapper implements ObservationTypeMapper {
+  constructor(
+    public readonly name: string,
+    public readonly priority: number,
+    private readonly attributeKey: string,
+    private readonly mappings: Record<string, string>,
+  ) {}
+
+  canMap(attributes: Record<string, unknown>): boolean {
+    return (
+      this.attributeKey in attributes && attributes[this.attributeKey] != null
+    );
+  }
+
+  mapToObservationType(
+    attributes: Record<string, unknown>,
+  ): LangfuseObservationType | null {
+    const value = attributes[this.attributeKey] as string;
+    const mappedType = this.mappings[value];
+
+    if (
+      mappedType &&
+      ObservationTypeDomain.safeParse(mappedType.toUpperCase()).success
+    ) {
+      return mappedType as LangfuseObservationType;
+    }
+
+    return null;
+  }
+}
+
+/**
+ * Mapper allowing for conditional logic, multiple attribute checks
+ */
+class CustomAttributeMapper implements ObservationTypeMapper {
+  constructor(
+    public readonly name: string,
+    public readonly priority: number,
+    private readonly canMapFn: (attributes: Record<string, unknown>) => boolean,
+    private readonly mapFn: (
+      attributes: Record<string, unknown>,
+    ) => LangfuseObservationType | null,
+  ) {}
+
+  canMap(attributes: Record<string, unknown>): boolean {
+    return this.canMapFn(attributes);
+  }
+
+  mapToObservationType(
+    attributes: Record<string, unknown>,
+  ): LangfuseObservationType | null {
+    const result = this.mapFn(attributes);
+
+    if (
+      result &&
+      ObservationTypeDomain.safeParse(result.toUpperCase()).success
+    ) {
+      return result;
+    }
+
+    return null;
+  }
+}
+
+/**
+ * Registry to manage observation type mappers with a unified interface to map
+ * span attributes to observation types.
+ *
+ * Mappers are evaluated in priority order (lower number = higher priority).
+ *
+ * **NOTE**: This is the constructor to modify if you want to add new mappings.
+ */
+class ObservationTypeMapperRegistry {
+  private readonly mappers: ObservationTypeMapper[] = [
+    new SimpleAttributeMapper("OpenInference", 1, "openinference.span.kind", {
       CHAIN: "CHAIN",
       RETRIEVER: "RETRIEVER",
       LLM: "GENERATION",
@@ -24,109 +98,64 @@ const MAPPING_CONFIG = {
       TOOL: "TOOL",
       GUARDRAIL: "GUARDRAIL",
       EVALUATOR: "EVALUATOR",
-    } as const,
-    priority: 1,
-  },
+    }),
 
-  // Model-based generation detection
-  modelBased: {
-    attributeKeys: [
-      LangfuseOtelSpanAttributes.OBSERVATION_MODEL,
-      "gen_ai.request.model",
-      "gen_ai.response.model",
-      "llm.model_name",
-      "model",
-    ],
-    defaultMapping: "GENERATION" as const,
-    priority: 2,
-  },
-} as const;
+    new CustomAttributeMapper(
+      "ModelBased",
+      2,
+      (attributes) => {
+        const modelKeys = [
+          LangfuseOtelSpanAttributes.OBSERVATION_MODEL,
+          "gen_ai.request.model",
+          "gen_ai.response.model",
+          "llm.model_name",
+          "model",
+        ];
+        return modelKeys.some((key) => attributes[key] != null);
+      },
+      () => "GENERATION",
+    ),
+  ];
 
-/**
- * Langfuse Mapping Registry - automatically built from MAPPING_CONFIG above.
- */
-export const defaultObservationTypeMapperRegistry =
-  new (class ObservationTypeMapperRegistry {
-    private readonly mappers = [
-      // Simple attribute-value mappers from config
-      ...Object.entries(MAPPING_CONFIG)
-        .filter(
-          (entry): entry is [string, typeof MAPPING_CONFIG.openinference] =>
-            "valueMapping" in entry[1],
-        )
-        .map(([name, config]) => ({
-          name: name.charAt(0).toUpperCase() + name.slice(1),
-          priority: config.priority,
-          canMap: (attributes: Record<string, unknown>) =>
-            config.attributeKey in attributes &&
-            attributes[config.attributeKey] != null,
-          mapToObservationType: (
-            attributes: Record<string, unknown>,
-          ): LangfuseObservationType | null => {
-            const value = attributes[config.attributeKey] as string;
-            const mappedType =
-              config.valueMapping[value as keyof typeof config.valueMapping];
+  private sortedMappersCache: ObservationTypeMapper[] | null = null;
 
-            if (
-              mappedType &&
-              ObservationTypeDomain.safeParse(mappedType.toUpperCase()).success
-            ) {
-              return mappedType as LangfuseObservationType;
-            }
-            return null;
-          },
-        })),
-
-      // Multi-attribute matchers from config
-      ...Object.entries(MAPPING_CONFIG)
-        .filter(
-          (entry): entry is [string, typeof MAPPING_CONFIG.modelBased] =>
-            "attributeKeys" in entry[1],
-        )
-        .map(([name, config]) => ({
-          name: name.charAt(0).toUpperCase() + name.slice(1),
-          priority: config.priority,
-          canMap: (attributes: Record<string, unknown>) =>
-            config.attributeKeys.some((key) => attributes[key] != null),
-          mapToObservationType: (): LangfuseObservationType | null =>
-            config.defaultMapping,
-        })),
-    ];
-
-    private sortedMappersCache: typeof this.mappers | null = null;
-
-    private getSortedMappers() {
-      if (!this.sortedMappersCache) {
-        this.sortedMappersCache = [...this.mappers].sort(
-          (a, b) => a.priority - b.priority,
-        );
-      }
-      return this.sortedMappersCache;
+  private getSortedMappers(): ObservationTypeMapper[] {
+    if (!this.sortedMappersCache) {
+      this.sortedMappersCache = [...this.mappers].sort(
+        (a, b) => a.priority - b.priority,
+      );
     }
+    return this.sortedMappersCache;
+  }
 
-    mapToObservationType(
-      attributes: Record<string, unknown>,
-    ): LangfuseObservationType | null {
-      const sortedMappers = this.getSortedMappers();
+  /**
+   * Maps span attributes to a Langfuse observation type.
+   * Returns null if no mapper can handle the attributes.
+   */
+  mapToObservationType(
+    attributes: Record<string, unknown>,
+  ): LangfuseObservationType | null {
+    const sortedMappers = this.getSortedMappers();
 
-      for (const mapper of sortedMappers) {
-        if (mapper.canMap(attributes)) {
-          const result = mapper.mapToObservationType(attributes);
-          if (result) {
-            return result;
-          }
+    for (const mapper of sortedMappers) {
+      if (mapper.canMap(attributes)) {
+        const result = mapper.mapToObservationType(attributes);
+        if (result) {
+          return result;
         }
       }
-
-      return null;
     }
 
-    getMappers() {
-      return [...this.mappers];
-    }
+    return null;
+  }
 
-    addMapper(mapper: (typeof this.mappers)[0]): void {
-      this.mappers.push(mapper);
-      this.sortedMappersCache = null;
-    }
-  })();
+  getMappersForDebugging(): ReadonlyArray<ObservationTypeMapper> {
+    return [...this.mappers];
+  }
+}
+
+/**
+ * Langfuse Mapping Registry containing the default mappings to be used.
+ */
+export const defaultObservationTypeMapperRegistry =
+  new ObservationTypeMapperRegistry();

--- a/web/src/features/otel/server/ObservationTypeMapper.ts
+++ b/web/src/features/otel/server/ObservationTypeMapper.ts
@@ -100,9 +100,25 @@ class ObservationTypeMapperRegistry {
       EVALUATOR: "EVALUATOR",
     }),
 
+    new SimpleAttributeMapper(
+      "OTel_GenAI_Operation",
+      2,
+      "gen_ai.operation.name",
+      {
+        chat: "GENERATION",
+        completion: "GENERATION",
+        generate_content: "GENERATION",
+        generate: "GENERATION",
+        embeddings: "EMBEDDING",
+        invoke_agent: "AGENT",
+        create_agent: "AGENT",
+        execute_tool: "TOOL",
+      },
+    ),
+
     new CustomAttributeMapper(
       "ModelBased",
-      2,
+      3,
       (attributes) => {
         const modelKeys = [
           LangfuseOtelSpanAttributes.OBSERVATION_MODEL,

--- a/web/src/features/otel/server/ObservationTypeMapper.ts
+++ b/web/src/features/otel/server/ObservationTypeMapper.ts
@@ -87,7 +87,7 @@ class CustomAttributeMapper implements ObservationTypeMapper {
  *
  * **NOTE**: This is the constructor to modify if you want to add new mappings.
  */
-class ObservationTypeMapperRegistry {
+export class ObservationTypeMapperRegistry {
   private readonly mappers: ObservationTypeMapper[] = [
     new SimpleAttributeMapper("OpenInference", 1, "openinference.span.kind", {
       CHAIN: "CHAIN",
@@ -169,9 +169,3 @@ class ObservationTypeMapperRegistry {
     return [...this.mappers];
   }
 }
-
-/**
- * Langfuse Mapping Registry containing the default mappings to be used.
- */
-export const defaultObservationTypeMapperRegistry =
-  new ObservationTypeMapperRegistry();

--- a/web/src/features/otel/server/OtelIngestionProcessor.ts
+++ b/web/src/features/otel/server/OtelIngestionProcessor.ts
@@ -16,7 +16,7 @@ import {
 } from "@langfuse/shared/src/server";
 
 import { LangfuseOtelSpanAttributes } from "./attributes";
-import { defaultObservationTypeMapperRegistry } from "./ObservationTypeMapper";
+import { ObservationTypeMapperRegistry } from "./ObservationTypeMapper";
 
 // Type definitions for internal processor state
 interface TraceState {
@@ -85,6 +85,8 @@ interface ResourceSpan {
     }>;
   }>;
 }
+
+const observationTypeMapper = new ObservationTypeMapperRegistry();
 
 /**
  * Processor class that encapsulates all logic for converting OpenTelemetry
@@ -645,8 +647,7 @@ export class OtelIngestionProcessor {
 
     // If no explicit observation type, try mapping from various frameworks
     if (!observationType) {
-      const mappedType =
-        defaultObservationTypeMapperRegistry.mapToObservationType(attributes);
+      const mappedType = observationTypeMapper.mapToObservationType(attributes);
       if (mappedType) {
         observationType = mappedType.toLowerCase();
       }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces a new mapping system for OpenTelemetry spans to Langfuse observation types, using `ObservationTypeMapperRegistry` to prioritize explicit types and handle various span conversion cases.
> 
>   - **Mapping System**:
>     - Introduces `ObservationTypeMapperRegistry` in `ObservationTypeMapper.ts` to map OpenTelemetry span attributes to Langfuse observation types.
>     - Supports mapping for `openinference.span.kind`, `gen_ai.operation.name`, and model-based attributes.
>     - Prioritizes explicit `langfuse.observation.type` over inferred types.
>   - **Processor Updates**:
>     - Updates `OtelIngestionProcessor` in `OtelIngestionProcessor.ts` to use `ObservationTypeMapperRegistry` for determining observation types.
>     - Handles cases where no explicit type is provided, defaulting to `span-create`.
>   - **Tests**:
>     - Adds tests in `otelMapping.servertest.ts` to verify mapping logic and prioritization.
>     - Tests cover scenarios for OpenInference, OTel GenAI, and model-based detection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a5e42bdb87202a2ea7815d295770e72d6a3fb74a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->