### PR TITLE
feat(tracing): map vercel AI sdk observation types

### DIFF
--- a/web/src/features/otel/server/ObservationTypeMapper.ts
+++ b/web/src/features/otel/server/ObservationTypeMapper.ts
@@ -116,9 +116,25 @@ export class ObservationTypeMapperRegistry {
       },
     ),
 
+    new SimpleAttributeMapper("Vercel_AI_SDK_Operation", 3, "operation.name", {
+      "ai.generateText": "GENERATION",
+      "ai.generateText.doGenerate": "GENERATION",
+      "ai.streamText": "GENERATION",
+      "ai.streamText.doStream": "GENERATION",
+      "ai.generateObject": "GENERATION",
+      "ai.generateObject.doGenerate": "GENERATION",
+      "ai.streamObject": "GENERATION",
+      "ai.streamObject.doStream": "GENERATION",
+      "ai.embed": "EMBEDDING",
+      "ai.embed.doEmbed": "EMBEDDING",
+      "ai.embedMany": "EMBEDDING",
+      "ai.embedMany.doEmbed": "EMBEDDING",
+      "ai.toolCall": "TOOL",
+    }),
+
     new CustomAttributeMapper(
       "ModelBased",
-      3,
+      4,
       (attributes) => {
         const modelKeys = [
           LangfuseOtelSpanAttributes.OBSERVATION_MODEL,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add mappings for Vercel AI SDK operations to observation types in `ObservationTypeMapperRegistry` and verify with tests.
> 
>   - **Mappings**:
>     - Add `Vercel_AI_SDK_Operation` mapping in `ObservationTypeMapperRegistry` for operations like `ai.generateText`, `ai.streamText`, `ai.embed`, and `ai.toolCall` to observation types `GENERATION`, `EMBEDDING`, and `TOOL`.
>   - **Tests**:
>     - Add test cases in `otelMapping.servertest.ts` to verify mapping of Vercel AI SDK operations to correct observation types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 92e3bbbe946a04d9ffc20df6fb80e42f98cf9770. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->