### PR TITLE
chore: add TERM env to cursor dockerfile

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -49,6 +49,7 @@ RUN pnpm store path > /dev/null && \
 USER ubuntu
 WORKDIR /home/ubuntu
 ENV HOME=/home/ubuntu
+ENV TERM=xterm-256color
 
 # Container starts with a bash shell ready for hacking.
 CMD ["bash"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `TERM` environment variable to `.cursor/Dockerfile` for terminal compatibility.
> 
>   - **Environment**:
>     - Add `ENV TERM=xterm-256color` to `.cursor/Dockerfile` to ensure terminal compatibility with 256 colors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f161964d3a8526333b9c520da6a7869c072a5b68. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->