### PR TITLE
fix(otel): override span observation types if generation-like attributes present

### DIFF
--- a/web/src/features/otel/server/OtelIngestionProcessor.ts
+++ b/web/src/features/otel/server/OtelIngestionProcessor.ts
@@ -645,6 +645,27 @@ export class OtelIngestionProcessor {
       LangfuseOtelSpanAttributes.OBSERVATION_TYPE
     ] as string;
 
+    // If generation-like attributes are set even though observation type is span, override to 'generation'
+    // Issue: https://github.com/langfuse/langfuse/issues/8682
+    // Affected SDK versions: Python SDK <= 3.3.0
+    const hasGenerationAttributes = Object.keys(attributes).some((key) => {
+      const generationKeys: LangfuseOtelSpanAttributes[] = [
+        LangfuseOtelSpanAttributes.OBSERVATION_MODEL,
+        LangfuseOtelSpanAttributes.OBSERVATION_COST_DETAILS,
+        LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS,
+        LangfuseOtelSpanAttributes.OBSERVATION_COMPLETION_START_TIME,
+        LangfuseOtelSpanAttributes.OBSERVATION_MODEL_PARAMETERS,
+        LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_NAME,
+        LangfuseOtelSpanAttributes.OBSERVATION_PROMPT_VERSION,
+      ];
+
+      return generationKeys.includes(key as any);
+    });
+
+    if (observationType === "span" && hasGenerationAttributes) {
+      observationType = "generation";
+    }
+
     // If no explicit observation type, try mapping from various frameworks
     if (!observationType) {
       const mappedType = observationTypeMapper.mapToObservationType(attributes);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Overrides observation type to 'generation' for spans with 'span' type but generation-like attributes in `OtelIngestionProcessor.ts`, with tests added in `otelMapping.servertest.ts`.
> 
>   - **Behavior**:
>     - Overrides observation type to 'generation' if 'span' type has generation-like attributes in `OtelIngestionProcessor.ts`.
>     - Affects spans with attributes like `OBSERVATION_MODEL`, `OBSERVATION_COST_DETAILS`, etc.
>   - **Tests**:
>     - Adds test in `otelMapping.servertest.ts` to verify observation type override behavior.
>     - Ensures spans with generation-like attributes are processed as 'generation-create' events.
>   - **Misc**:
>     - No changes to existing functionality outside of the specific override logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for be0e00055482dc74c1d594dfc8590f765b69a3fa. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->