### PR TITLE
chore(dataset-run-items): remove PG execution fallbacks

### DIFF
--- a/packages/shared/src/server/dataset-run-items/datasetExecution.ts
+++ b/packages/shared/src/server/dataset-run-items/datasetExecution.ts
@@ -71,23 +71,8 @@ export async function executeWithDatasetRunItemsStrategy<TInput, TOutput>({
       return await postgresExecution(input);
     }
   } else {
-    // For read operations, rely on the strategy
-    const shouldExecuteClickhouse = strategy.shouldReadFromClickHouse;
-
-    if (shouldExecuteClickhouse) {
-      try {
-        return await clickhouseExecution(input);
-      } catch (error) {
-        logger.error(
-          "ClickHouse execution failed, falling back to PostgreSQL",
-          {
-            error: error instanceof Error ? error.message : String(error),
-            operation: `dataset_run_items_${operationType}`,
-          },
-        );
-        // Fallback to PostgreSQL for reliability
-        return await postgresExecution(input);
-      }
+    if (strategy.shouldReadFromClickHouse) {
+      return await clickhouseExecution(input);
     } else {
       // Read from PostgreSQL
       return await postgresExecution(input);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove PostgreSQL fallback for ClickHouse read failures in `executeWithDatasetRunItemsStrategy` in `datasetExecution.ts`.
> 
>   - **Behavior**:
>     - Removes fallback to PostgreSQL for read operations in `executeWithDatasetRunItemsStrategy` in `datasetExecution.ts`.
>     - Now, if `strategy.shouldReadFromClickHouse` is true, it only attempts ClickHouse execution without fallback.
>   - **Logging**:
>     - Eliminates error logging for ClickHouse read failures in `datasetExecution.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f102e70d99fb503750dfd102941563dea9633807. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->