### PR TITLE
chore: re-enable focus-refetching for data tables

### DIFF
--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -265,8 +265,12 @@ export default function ObservationsTable({
     orderBy: orderByState,
   };
 
-  const generations = api.generations.all.useQuery(getAllPayload);
-  const totalCountQuery = api.generations.countAll.useQuery(getCountPayload);
+  const generations = api.generations.all.useQuery(getAllPayload, {
+    refetchOnWindowFocus: true,
+  });
+  const totalCountQuery = api.generations.countAll.useQuery(getCountPayload, {
+    refetchOnWindowFocus: true,
+  });
 
   const totalCount = totalCountQuery.data?.totalCount ?? null;
 

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -171,8 +171,12 @@ export default function SessionsTable({
     limit: paginationState.pageSize,
   };
 
-  const sessions = api.sessions.all.useQuery(payloadGetAll);
-  const sessionCountQuery = api.sessions.countAll.useQuery(payloadCount);
+  const sessions = api.sessions.all.useQuery(payloadGetAll, {
+    refetchOnWindowFocus: true,
+  });
+  const sessionCountQuery = api.sessions.countAll.useQuery(payloadCount, {
+    refetchOnWindowFocus: true,
+  });
 
   const addToQueueMutation = api.annotationQueueItems.createMany.useMutation({
     onSuccess: (data) => {
@@ -202,6 +206,7 @@ export default function SessionsTable({
     },
     {
       enabled: sessions.data !== undefined,
+      refetchOnWindowFocus: true,
     },
   );
 

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -256,7 +256,7 @@ export default function TracesTable({
   const traces = api.traces.all.useQuery(tracesAllQueryFilter, {
     enabled: environmentFilterOptions.data !== undefined,
     refetchOnMount: false,
-    refetchOnWindowFocus: false,
+    refetchOnWindowFocus: true,
   });
 
   const traceMetrics = api.traces.metrics.useQuery(
@@ -268,7 +268,7 @@ export default function TracesTable({
     {
       enabled: traces.data !== undefined,
       refetchOnMount: false,
-      refetchOnWindowFocus: false,
+      refetchOnWindowFocus: true,
     },
   );
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/01c1b724-6a7d-4a2d-baeb-55c1865a008b

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Re-enables `refetchOnWindowFocus` for data fetching in `observations.tsx`, `sessions.tsx`, and `traces.tsx` to keep data up-to-date on window focus.
> 
>   - **Behavior**:
>     - Re-enables `refetchOnWindowFocus: true` for data fetching in `observations.tsx`, `sessions.tsx`, and `traces.tsx`.
>     - Affects queries: `api.generations.all.useQuery`, `api.generations.countAll.useQuery`, `api.sessions.all.useQuery`, `api.sessions.countAll.useQuery`, `api.traces.all.useQuery`, and `api.traces.metrics.useQuery`.
>   - **Components**:
>     - `ObservationsTable`, `SessionsTable`, and `TracesTable` now refetch data on window focus.
>   - **Misc**:
>     - Ensures data is up-to-date without manual refreshes when window regains focus.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9abfe07672b5a84e7db5b9fad9cb6a8ff38ef641. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->