### PR TITLE
chore(datasets): fix flaky test

### DIFF
--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -23,6 +23,7 @@ import {
 } from "@/src/features/datasets/server/service";
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
 import { isPresent } from "@langfuse/shared";
+import waitForExpect from "wait-for-expect";
 
 const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
 
@@ -241,90 +242,96 @@ describe("Fetch datasets for UI presentation", () => {
     const limit = 10;
     const page = 0;
 
-    // Get all runs from PostgreSQL and merge with ClickHouse metrics to maintain consistent count
-    const [runsWithMetrics, allRunsBasicInfo] = await Promise.all([
-      // Get runs that have metrics (only runs with dataset_run_items_rmt)
-      getDatasetRunsTableMetricsCh({
-        projectId: projectId,
-        datasetId: datasetId,
-        limit: limit,
-        offset: page * limit,
-      }),
-      // Get basic info for all runs to ensure we return all runs, even those without dataset_run_items_rmt
-      prisma.datasetRuns.findMany({
-        where: {
-          datasetId: datasetId,
+    let allRuns: any[] = [];
+    let firstRun: any | undefined;
+
+    await waitForExpect(async () => {
+      // Get all runs from PostgreSQL and merge with ClickHouse metrics to maintain consistent count
+      const [runsWithMetrics, allRunsBasicInfo] = await Promise.all([
+        // Get runs that have metrics (only runs with dataset_run_items_rmt)
+        getDatasetRunsTableMetricsCh({
           projectId: projectId,
-        },
-        select: {
-          id: true,
-          name: true,
-          description: true,
-          metadata: true,
-          createdAt: true,
-          datasetId: true,
-          projectId: true,
-        },
-        take: limit,
-        skip: page * limit,
-        orderBy: {
-          createdAt: "desc",
-        },
-      }),
-    ]);
+          datasetId: datasetId,
+          limit: limit,
+          offset: page * limit,
+        }),
+        // Get basic info for all runs to ensure we return all runs, even those without dataset_run_items_rmt
+        prisma.datasetRuns.findMany({
+          where: {
+            datasetId: datasetId,
+            projectId: projectId,
+          },
+          select: {
+            id: true,
+            name: true,
+            description: true,
+            metadata: true,
+            createdAt: true,
+            datasetId: true,
+            projectId: true,
+          },
+          take: limit,
+          skip: page * limit,
+          orderBy: {
+            createdAt: "desc",
+          },
+        }),
+      ]);
 
-    // Create lookup map for runs that have metrics
-    const metricsLookup = new Map<string, DatasetRunsMetrics>(
-      runsWithMetrics.map((run) => [run.id, run]),
-    );
+      // Create lookup map for runs that have metrics
+      const metricsLookup = new Map<string, DatasetRunsMetrics>(
+        runsWithMetrics.map((run) => [run.id, run]),
+      );
 
-    // Only fetch scores for runs that have metrics (runs without dataset_run_items_rmt won't have trace scores)
-    const runsWithMetricsIds = runsWithMetrics.map((run) => run.id);
-    const [traceScores, runScores] = await Promise.all([
-      runsWithMetricsIds.length > 0
-        ? getTraceScoresForDatasetRuns(projectId, runsWithMetricsIds)
-        : [],
-      getScoresForDatasetRuns({
-        projectId: projectId,
-        runIds: allRunsBasicInfo.map((run) => run.id),
-        includeHasMetadata: true,
-        excludeMetadata: false,
-      }),
-    ]);
+      // Only fetch scores for runs that have metrics (runs without dataset_run_items_rmt won't have trace scores)
+      const runsWithMetricsIds = runsWithMetrics.map((run) => run.id);
+      const [traceScores, runScores] = await Promise.all([
+        runsWithMetricsIds.length > 0
+          ? getTraceScoresForDatasetRuns(projectId, runsWithMetricsIds)
+          : [],
+        getScoresForDatasetRuns({
+          projectId: projectId,
+          runIds: allRunsBasicInfo.map((run) => run.id),
+          includeHasMetadata: true,
+          excludeMetadata: false,
+        }),
+      ]);
 
-    // Merge all runs: use metrics where available, defaults otherwise
-    const allRuns = allRunsBasicInfo.map((run) => {
-      const metrics = metricsLookup.get(run.id);
+      // Merge all runs: use metrics where available, defaults otherwise
+      const runs = allRunsBasicInfo.map((run) => {
+        const metrics = metricsLookup.get(run.id);
 
-      return {
-        ...run,
-        // Use ClickHouse metrics if available, otherwise use defaults for runs without dataset_run_items_rmt
-        countRunItems: metrics?.countRunItems ?? 0,
-        avgTotalCost: metrics?.avgTotalCost ?? null,
-        avgLatency: metrics?.avgLatency ?? null,
-        scores: aggregateScores(
-          traceScores.filter((s) => s.datasetRunId === run.id),
-        ),
-        runScores: aggregateScores(
-          runScores.filter((s) => s.datasetRunId === run.id),
-        ),
-      };
+        return {
+          ...run,
+          // Use ClickHouse metrics if available, otherwise use defaults for runs without dataset_run_items_rmt
+          countRunItems: metrics?.countRunItems ?? 0,
+          avgTotalCost: metrics?.avgTotalCost ?? null,
+          avgLatency: metrics?.avgLatency ?? null,
+          scores: aggregateScores(
+            traceScores.filter((s) => s.datasetRunId === run.id),
+          ),
+          runScores: aggregateScores(
+            runScores.filter((s) => s.datasetRunId === run.id),
+          ),
+        };
+      });
+
+      allRuns = runs;
+      expect(allRuns).toHaveLength(2);
+
+      firstRun = allRuns.find((run) => run.id === datasetRunId);
+      expect(firstRun).toBeDefined();
+      if (!firstRun) {
+        throw new Error("first run is not defined");
+      }
+      expect(firstRun.id).toEqual(datasetRunId);
+
+      expect(firstRun.description).toBeNull();
+      expect(firstRun.metadata).toEqual({});
+
+      expect(firstRun.avgLatency).toBeGreaterThanOrEqual(10800);
+      expect(firstRun.avgTotalCost?.toString()).toStrictEqual("275");
     });
-
-    expect(allRuns).toHaveLength(2);
-
-    const firstRun = allRuns.find((run) => run.id === datasetRunId);
-    expect(firstRun).toBeDefined();
-    if (!firstRun) {
-      throw new Error("first run is not defined");
-    }
-    expect(firstRun.id).toEqual(datasetRunId);
-
-    expect(firstRun.description).toBeNull();
-    expect(firstRun.metadata).toEqual({});
-
-    expect(firstRun.avgLatency).toBeGreaterThanOrEqual(10800);
-    expect(firstRun.avgTotalCost?.toString()).toStrictEqual("275");
 
     const expectedObject = {
       [`${scoreName.replaceAll("-", "_")}-API-NUMERIC`]: {

--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -331,7 +331,7 @@ describe("Fetch datasets for UI presentation", () => {
 
       expect(firstRun.avgLatency).toBeGreaterThanOrEqual(10800);
       expect(firstRun.avgTotalCost?.toString()).toStrictEqual("275");
-    });
+    }, 90000);
 
     const expectedObject = {
       [`${scoreName.replaceAll("-", "_")}-API-NUMERIC`]: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduced `wait-for-expect` in `dataset-service.servertest.ts` to handle flaky test by retrying assertions until they pass or timeout.
> 
>   - **Test Stability**:
>     - Introduced `wait-for-expect` in `dataset-service.servertest.ts` to handle flaky test by retrying assertions until they pass or timeout.
>     - Wrapped test logic in `waitForExpect` with a 90-second timeout to ensure conditions are met before proceeding.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 020a59f6a52ec4b3f1055b79bfef63e32c1dbb08. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->