### PR TITLE
chore(datasets): default to reading/writing CH

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -129,10 +129,10 @@ const EnvSchema = z.object({
   // Dataset Run Items Migration Environment Variables
   LANGFUSE_EXPERIMENT_DATASET_RUN_ITEMS_WRITE_CH: z
     .enum(["true", "false"])
-    .default("false"),
+    .default("true"),
   LANGFUSE_EXPERIMENT_DATASET_RUN_ITEMS_READ_CH: z
     .enum(["true", "false"])
-    .default("false"),
+    .default("true"),
   LANGFUSE_EXPERIMENT_COMPARE_READ_FROM_AGGREGATING_MERGE_TREES: z
     .enum(["true", "false"])
     .default("false"),

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -268,7 +268,7 @@ const EnvSchema = z.object({
   LANGFUSE_DELETE_BATCH_SIZE: z.coerce.number().positive().default(2000),
   LANGFUSE_EXPERIMENT_DATASET_RUN_ITEMS_TRACE_SOURCE_CH: z
     .enum(["true", "false"])
-    .default("false"),
+    .default("true"),
 });
 
 export const env: z.infer<typeof EnvSchema> =


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default environment variables to enable reading/writing to ClickHouse by default in `env.ts` files.
> 
>   - **Environment Variables**:
>     - In `packages/shared/src/env.ts`, change default of `LANGFUSE_EXPERIMENT_DATASET_RUN_ITEMS_WRITE_CH` and `LANGFUSE_EXPERIMENT_DATASET_RUN_ITEMS_READ_CH` to `true`.
>     - In `worker/src/env.ts`, change default of `LANGFUSE_EXPERIMENT_DATASET_RUN_ITEMS_TRACE_SOURCE_CH` to `true`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cdb62c8f4e99cb53aaf79ec5db2165ca47e82435. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->