### PR TITLE
chore(ui): reorder version menu items

### DIFF
--- a/web/src/components/VersionLabel.tsx
+++ b/web/src/components/VersionLabel.tsx
@@ -122,29 +122,23 @@ export const VersionLabel = ({ className }: { className?: string }) => {
             <DropdownMenuSeparator />
           </>
         )}
-        <DropdownMenuItem asChild>
-          <Link
-            href="https://github.com/langfuse/langfuse/releases"
-            target="_blank"
-          >
-            <Github size={16} className="mr-2" />
-            Releases
-          </Link>
-        </DropdownMenuItem>
         {!isLangfuseCloud && (
-          <DropdownMenuItem asChild>
-            <Link href="/background-migrations">
-              <ArrowUp10 size={16} className="mr-2" />
-              Background Migrations
-              {showBackgroundMigrationStatus && (
-                <StatusBadge
-                  type={backgroundMigrationStatus.data?.status.toLowerCase()}
-                  showText={false}
-                  className="bg-transparent"
-                />
-              )}
-            </Link>
-          </DropdownMenuItem>
+          <>
+            <DropdownMenuItem asChild>
+              <Link href="/background-migrations">
+                <ArrowUp10 size={16} className="mr-2" />
+                Background Migrations
+                {showBackgroundMigrationStatus && (
+                  <StatusBadge
+                    type={backgroundMigrationStatus.data?.status.toLowerCase()}
+                    showText={false}
+                    className="bg-transparent"
+                  />
+                )}
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
         )}
         <DropdownMenuItem asChild>
           <Link href="https://langfuse.com/changelog" target="_blank">
@@ -156,6 +150,15 @@ export const VersionLabel = ({ className }: { className?: string }) => {
           <Link href="https://langfuse.com/roadmap" target="_blank">
             <Map size={16} className="mr-2" />
             Roadmap
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link
+            href="https://github.com/langfuse/langfuse/releases"
+            target="_blank"
+          >
+            <Github size={16} className="mr-2" />
+            Releases
           </Link>
         </DropdownMenuItem>
         {!isLangfuseCloud && (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reorder version menu items in `VersionLabel.tsx`, moving 'Releases' below 'Roadmap' and adjusting separators.
> 
>   - **UI Changes**:
>     - Reorder version menu items in `VersionLabel.tsx`.
>     - Move 'Releases' menu item below 'Roadmap'.
>     - Add separator after 'Background Migrations' when not in Langfuse Cloud.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b5a44ee3a7b9e6346b2ff72ed30bc52f8c3714ea. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->