### PR TITLE
feat(otel): parse vercel ai SDK ai.usage.*

### DIFF
--- a/web/src/features/otel/server/OtelIngestionProcessor.ts
+++ b/web/src/features/otel/server/OtelIngestionProcessor.ts
@@ -1413,7 +1413,25 @@ export class OtelIngestionProcessor {
         };
 
         const providerMetadata = attributes["ai.response.providerMetadata"];
-        if (providerMetadata) {
+
+        // Try reading token details from ai.usage
+        if (
+          ["ai.usage.cachedInputTokens", "ai.usage.reasoningTokens"].some((k) =>
+            Object.keys(attributes).includes(k),
+          )
+        ) {
+          if ("ai.usage.cachedInputTokens" in attributes) {
+            usageDetails["input_cached_tokens"] = JSON.parse(
+              attributes["ai.usage.cachedInputTokens"] as string,
+            ).intValue;
+          }
+          if ("ai.usage.reasoningTokens" in attributes) {
+            usageDetails["output_reasoning_tokens"] = JSON.parse(
+              attributes["ai.usage.reasoningTokens"] as string,
+            ).intValue;
+          }
+        } else if (providerMetadata) {
+          // Fall back to providerMetadata
           const parsed = JSON.parse(providerMetadata as string);
 
           if ("openai" in parsed) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `OtelIngestionProcessor.ts` to parse `ai.usage.cachedInputTokens` and `ai.usage.reasoningTokens` for Vercel AI SDK telemetry.
> 
>   - **Behavior**:
>     - In `OtelIngestionProcessor.ts`, `extractUsageDetails()` now parses `ai.usage.cachedInputTokens` and `ai.usage.reasoningTokens` from `attributes`.
>     - If these keys are present, their values are extracted and added to `usageDetails`.
>     - Falls back to `providerMetadata` if these keys are absent.
>   - **Misc**:
>     - Adds comments to clarify the logic for parsing `ai.usage.*` attributes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 37f9063132c074f71567adf54449cfdd2bf1d4eb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->