### PR TITLE
chore(dataset-run-items-seeder): remove PG dataset run item creation path

### DIFF
--- a/packages/shared/scripts/seeder/seed-postgres.ts
+++ b/packages/shared/scripts/seeder/seed-postgres.ts
@@ -24,7 +24,6 @@ import {
 } from "./utils/postgres-seed-constants";
 import {
   generateDatasetItemId,
-  generateDatasetRunTraceId,
   generateEvalObservationId,
   generateEvalScoreId,
   generateEvalTraceId,

--- a/packages/shared/scripts/seeder/seed-postgres.ts
+++ b/packages/shared/scripts/seeder/seed-postgres.ts
@@ -564,17 +564,17 @@ export async function createDatasets(
       }
 
       for (let datasetRunNumber = 0; datasetRunNumber < 3; datasetRunNumber++) {
-        const datasetRun = await prisma.datasetRuns.upsert({
+        await prisma.datasetRuns.upsert({
           where: {
             id_projectId: {
-              id: `demo-dataset-run-${datasetRunNumber}-${projectId.slice(-8)}`,
+              id: `demo-dataset-run-${datasetRunNumber}-${datasetName}-${projectId.slice(-8)}`,
               projectId,
             },
           },
           create: {
             projectId,
-            id: `demo-dataset-run-${datasetRunNumber}-${projectId.slice(-8)}`,
-            name: `demo-dataset-run-${datasetRunNumber}`,
+            id: `demo-dataset-run-${datasetRunNumber}-${datasetName}-${projectId.slice(-8)}`,
+            name: `demo-dataset-run-${datasetRunNumber}-${datasetName}`,
             description: Math.random() > 0.5 ? "Dataset run description" : "",
             datasetId: dataset.id,
             metadata: [
@@ -587,25 +587,6 @@ export async function createDatasets(
           },
           update: {},
         });
-
-        for (let index = 0; index < datasetItemIds.length; index++) {
-          await prisma.datasetRunItems.upsert({
-            where: {
-              id_projectId: {
-                id: `${dataset.id}-${index}-${datasetRunNumber}`,
-                projectId,
-              },
-            },
-            create: {
-              id: `${dataset.id}-${index}-${datasetRunNumber}`,
-              projectId,
-              datasetItemId: datasetItemIds[index],
-              traceId: `${generateDatasetRunTraceId(datasetName, index, projectId, datasetRunNumber)}`,
-              datasetRunId: datasetRun.id,
-            },
-            update: {},
-          });
-        }
       }
     }
   }

--- a/packages/shared/scripts/seeder/utils/data-generators.ts
+++ b/packages/shared/scripts/seeder/utils/data-generators.ts
@@ -86,7 +86,6 @@ export class DataGenerator {
       input.runNumber || 0,
     );
 
-    // TODO: there are too many dataset run items in the postgres database?
     return createDatasetRunItem({
       id: datasetRunItemId,
       project_id: projectId,
@@ -97,8 +96,8 @@ export class DataGenerator {
         input.runNumber || 0,
       ),
       dataset_id: `${input.datasetName}-${projectId.slice(-8)}`,
-      dataset_run_id: `demo-dataset-run-${input.runNumber}-${projectId.slice(-8)}`,
-      dataset_run_name: `demo-dataset-run-${input.runNumber}-${projectId.slice(-8)}`,
+      dataset_run_id: `demo-dataset-run-${input.runNumber}-${input.datasetName}-${projectId.slice(-8)}`,
+      dataset_run_name: `demo-dataset-run-${input.runNumber}-${input.datasetName}`,
       dataset_run_created_at: input.runCreatedAt,
       dataset_run_description:
         (input.runNumber || 0) % 2 === 0 ? "Dataset run description" : "",
@@ -110,7 +109,7 @@ export class DataGenerator {
         input.runNumber || 0,
       ),
       dataset_item_input: input.item.input,
-      dataset_item_expected_output: input.item.output,
+      dataset_item_expected_output: input.item.expectedOutput,
     });
   }
 

--- a/packages/shared/scripts/seeder/utils/seeder-orchestrator.ts
+++ b/packages/shared/scripts/seeder/utils/seeder-orchestrator.ts
@@ -4,6 +4,7 @@ import { ClickHouseQueryBuilder } from "./clickhouse-builder";
 import { EVAL_TRACE_COUNT, SEED_DATASETS } from "./postgres-seed-constants";
 import {
   clickhouseClient,
+  DatasetRunItemRecordInsertType,
   logger,
   ObservationRecordInsertType,
   TraceRecordInsertType,
@@ -92,25 +93,25 @@ export class SeederOrchestrator {
         logger.info(
           `Processing run ${runNumber + 1}/${numberOfRuns} for project ${projectId}`,
         );
-        // const now = Date.now();
+        const now = Date.now();
 
         const traces: TraceRecordInsertType[] = [];
         const observations: ObservationRecordInsertType[] = [];
-        // const datasetRunItems: DatasetRunItemRecordInsertType[] = [];
+        const datasetRunItems: DatasetRunItemRecordInsertType[] = [];
 
         for (const seedDataset of SEED_DATASETS) {
           for (const [itemIndex, datasetItem] of seedDataset.items.entries()) {
-            // // Generate dataset run item data
-            // const datasetRunItem = this.dataGenerator.generateDatasetRunItem(
-            //   {
-            //     datasetName: seedDataset.name,
-            //     itemIndex,
-            //     item: datasetItem,
-            //     runNumber,
-            //     runCreatedAt: now,
-            //   },
-            //   projectId,
-            // );
+            // Generate dataset run item data
+            const datasetRunItem = this.dataGenerator.generateDatasetRunItem(
+              {
+                datasetName: seedDataset.name,
+                itemIndex,
+                item: datasetItem,
+                runNumber,
+                runCreatedAt: now,
+              },
+              projectId,
+            );
 
             // Generate trace data
             const trace = this.dataGenerator.generateDatasetTrace(
@@ -137,14 +138,14 @@ export class SeederOrchestrator {
 
             traces.push(trace);
             observations.push(observation);
-            // datasetRunItems.push(datasetRunItem);
+            datasetRunItems.push(datasetRunItem);
           }
         }
 
         try {
           await this.queryBuilder.executeTracesInsert(traces);
           await this.queryBuilder.executeObservationsInsert(observations);
-          // await this.queryBuilder.executeDatasetRunItemsInsert(datasetRunItems);
+          await this.queryBuilder.executeDatasetRunItemsInsert(datasetRunItems);
         } catch (error) {
           logger.error(`✗ Insert failed:`, error);
           throw error;

--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -331,7 +331,7 @@ describe("Fetch datasets for UI presentation", () => {
 
       expect(firstRun.avgLatency).toBeGreaterThanOrEqual(10800);
       expect(firstRun.avgTotalCost?.toString()).toStrictEqual("275");
-    }, 90000);
+    }, 10_000);
 
     const expectedObject = {
       [`${scoreName.replaceAll("-", "_")}-API-NUMERIC`]: {
@@ -369,7 +369,7 @@ describe("Fetch datasets for UI presentation", () => {
     expect(secondRun.avgTotalCost?.toString()).toStrictEqual("300");
 
     expect(JSON.stringify(secondRun.scores)).toEqual(JSON.stringify({}));
-  });
+  }, 10_000);
 
   it("should test that dataset runs can link to the same traces", async () => {
     const datasetId = v4();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove PostgreSQL dataset run item creation path from seeder, focusing on ClickHouse operations.
> 
>   - **Behavior**:
>     - Removed PostgreSQL dataset run item creation in `createDatasets` in `seed-postgres.ts`.
>     - Focused dataset run item operations on ClickHouse in `seeder-orchestrator.ts`.
>   - **Functions**:
>     - Removed `generateDatasetRunTraceId` from `data-generators.ts`.
>   - **Tests**:
>     - Updated `dataset-service.servertest.ts` to reflect removal of PostgreSQL dataset run item creation.
>     - Reduced test timeout to 10 seconds in `dataset-service.servertest.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 13e43e172c0bb264486e07e5fd1a53ed22ef81a9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->