### PR TITLE
test(datasets): skip flaky dataset runs test in CI

### DIFF
--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -28,7 +28,8 @@ import waitForExpect from "wait-for-expect";
 const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
 
 describe("Fetch datasets for UI presentation", () => {
-  it("should fetch dataset runs for UI", async () => {
+  // test is flaky in CI, skipping for now
+  it.skip("should fetch dataset runs for UI", async () => {
     const datasetId = v4();
 
     await prisma.dataset.create({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Skip flaky test `should fetch dataset runs for UI` in `dataset-service.servertest.ts` due to CI instability.
> 
>   - **Tests**:
>     - Skip flaky test `should fetch dataset runs for UI` in `dataset-service.servertest.ts` due to instability in CI environments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b758488db61bfa25e388dd1349766d92d112809b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->