### PR TITLE
fix(runs-compare): infinite re-renders on data table

### DIFF
--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -184,5 +184,5 @@ function TablePeekViewComponent<TData>(props: TablePeekViewProps<TData>) {
 }
 
 export const TablePeekView = memo(TablePeekViewComponent, (prev, next) => {
-  return prev.selectedRowId === next.selectedRowId;
+  return prev.selectedRowId === next.selectedRowId && !!prev.row && !!next.row;
 }) as typeof TablePeekViewComponent;

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -227,18 +227,22 @@ function DatasetCompareRunsTableInternal(props: {
   });
 
   // Handle success callbacks for all queries - replaces `onSuccess`
-  useEffect(() => {
-    runs.forEach(({ runId, items }) => {
-      if (items.isSuccess && items.data) {
-        handleQuerySuccess(runId, items.data);
-      }
-    });
-  }, [
-    runs
-      .map((r) => `${r.runId}-${r.items.isSuccess}-${r.items.dataUpdatedAt}`)
-      .join("|"),
-    handleQuerySuccess,
-  ]);
+  useEffect(
+    () => {
+      runs.forEach(({ runId, items }) => {
+        if (items.isSuccess && items.data) {
+          handleQuerySuccess(runId, items.data);
+        }
+      });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      runs
+        .map((r) => `${r.runId}-${r.items.isSuccess}-${r.items.dataUpdatedAt}`)
+        .join("|"),
+      handleQuerySuccess,
+    ],
+  );
 
   const combinedData = useMemo(() => {
     if (!baseDatasetItems.data) return null;

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -223,15 +223,22 @@ function DatasetCompareRunsTableInternal(props: {
       },
     );
 
-    // replaces `onSuccess`
-    useEffect(() => {
-      if (query.isSuccess && query.data) {
-        handleQuerySuccess(runId, query.data);
-      }
-    }, [query.isSuccess, query.data, runId, handleQuerySuccess]);
-
     return { runId, items: query };
   });
+
+  // Handle success callbacks for all queries - replaces `onSuccess`
+  useEffect(() => {
+    runs.forEach(({ runId, items }) => {
+      if (items.isSuccess && items.data) {
+        handleQuerySuccess(runId, items.data);
+      }
+    });
+  }, [
+    runs
+      .map((r) => `${r.runId}-${r.items.isSuccess}-${r.items.dataUpdatedAt}`)
+      .join("|"),
+    handleQuerySuccess,
+  ]);
 
   const combinedData = useMemo(() => {
     if (!baseDatasetItems.data) return null;

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -226,23 +226,24 @@ function DatasetCompareRunsTableInternal(props: {
     return { runId, items: query };
   });
 
-  // Handle success callbacks for all queries - replaces `onSuccess`
-  useEffect(
-    () => {
-      runs.forEach(({ runId, items }) => {
-        if (items.isSuccess && items.data) {
-          handleQuerySuccess(runId, items.data);
-        }
-      });
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
+  // Create stable dependency for useEffect
+  const runStatesKey = useMemo(
+    () =>
       runs
         .map((r) => `${r.runId}-${r.items.isSuccess}-${r.items.dataUpdatedAt}`)
         .join("|"),
-      handleQuerySuccess,
-    ],
+    [runs],
   );
+
+  // Handle success callbacks for all queries - replaces `onSuccess`
+  useEffect(() => {
+    runs.forEach(({ runId, items }) => {
+      if (items.isSuccess && items.data) {
+        handleQuerySuccess(runId, items.data);
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runStatesKey, handleQuerySuccess]);
 
   const combinedData = useMemo(() => {
     if (!baseDatasetItems.data) return null;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix infinite re-renders in `TablePeekView` and optimize state updates in `DatasetCompareRunsTableInternal` to improve performance.
> 
>   - **Behavior**:
>     - Fix infinite re-renders in `TablePeekView` by adding checks for `row` existence in `peek.tsx`.
>     - Optimize state updates in `DatasetCompareRunsTableInternal` by checking if `unchangedCounts` actually change before updating.
>   - **Performance**:
>     - Use `runStatesKey` in `DatasetCompareRunsTableInternal` to create stable dependencies for `useEffect`, reducing unnecessary re-renders.
>     - Replace `onSuccess` with `useEffect` for handling query success callbacks in `DatasetCompareRunsTableInternal`.
>   - **Misc**:
>     - Add comments to clarify logic in `DatasetCompareRunsTableInternal`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 810ffdb37e1aa9df06cd8db3bbfd618c48c74132. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->