### PR TITLE
fix: make chain coloring unique

### DIFF
--- a/web/src/components/ItemBadge.tsx
+++ b/web/src/components/ItemBadge.tsx
@@ -70,7 +70,7 @@ const iconVariants = cva(cn("h-4 w-4"), {
       SPAN: "text-muted-blue",
       AGENT: "text-purple-600",
       TOOL: "text-orange-600",
-      CHAIN: "text-indigo-600",
+      CHAIN: "text-violet-600",
       RETRIEVER: "text-teal-600",
       EMBEDDING: "text-amber-600",
       GUARDRAIL: "text-red-600",
@@ -82,7 +82,7 @@ const iconVariants = cva(cn("h-4 w-4"), {
       DATASET_ITEM: "text-primary-accent",
       ANNOTATION_QUEUE: "text-primary-accent",
       PROMPT: "text-primary-accent",
-      EVALUATOR: "text-primary-accent",
+      EVALUATOR: "text-primary-accent", // usually text-indigo-600
       RUNNING_EVALUATOR: "text-primary-accent",
     },
   },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `CHAIN` color to `text-violet-600` in `ItemBadge.tsx` for unique chain coloring.
> 
>   - **Behavior**:
>     - Change `CHAIN` color from `text-indigo-600` to `text-violet-600` in `iconVariants` in `ItemBadge.tsx`.
>     - Note: `EVALUATOR` color remains `text-primary-accent`, with a comment indicating it is usually `text-indigo-600`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bc82b6d4ecdfdbb0cde137291843df7742558f79. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->