### PR TITLE
chore(cloud): show label that demo is not available only on HIPAA data region

### DIFF
--- a/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
+++ b/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
@@ -76,9 +76,9 @@ export function CloudRegionSwitch({
             Data Region
             <DataRegionInfo />
           </span>
-          {isSignUpPage && env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "US" ? (
+          {isSignUpPage && env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "HIPAA" ? (
             <p className="text-xs text-muted-foreground">
-              Demo project is only available in the EU region.
+              Demo project is not available in the HIPAA data region.
             </p>
           ) : null}
         </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modify `AuthCloudRegionSwitch.tsx` to show demo project unavailability message only for HIPAA data region.
> 
>   - **Behavior**:
>     - In `AuthCloudRegionSwitch.tsx`, change condition to show demo project availability message only when `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` is `HIPAA`.
>     - Message updated to "Demo project is not available in the HIPAA data region."
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e1840da8f89640085c4f537e400e16b2b5f4fa3e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->