### PR TITLE
chore(peek): navigation event to create browser history entry

### DIFF
--- a/web/src/components/table/peek/hooks/useDatasetComparePeekState.ts
+++ b/web/src/components/table/peek/hooks/useDatasetComparePeekState.ts
@@ -28,7 +28,7 @@ export const useDatasetComparePeekState = () => {
         return;
       }
 
-      router.replace(
+      router.push(
         {
           pathname,
           query: params.toString(),

--- a/web/src/components/table/peek/hooks/useObservationPeekState.ts
+++ b/web/src/components/table/peek/hooks/useObservationPeekState.ts
@@ -28,7 +28,7 @@ export const useObservationPeekState = () => {
         return;
       }
 
-      router.replace(
+      router.push(
         {
           pathname,
           query: params.toString(),

--- a/web/src/components/table/peek/hooks/usePeekState.ts
+++ b/web/src/components/table/peek/hooks/usePeekState.ts
@@ -22,7 +22,7 @@ export const usePeekState = () => {
         return;
       }
 
-      router.replace(
+      router.push(
         {
           pathname,
           query: params.toString(),

--- a/web/src/components/table/peek/hooks/useTracePeekState.ts
+++ b/web/src/components/table/peek/hooks/useTracePeekState.ts
@@ -28,7 +28,7 @@ export const useTracePeekState = () => {
         return;
       }
 
-      router.replace(
+      router.push(
         {
           pathname,
           query: params.toString(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `router.replace` with `router.push` in four hooks to create new browser history entries on navigation events.
> 
>   - **Behavior**:
>     - Change `router.replace` to `router.push` in `useDatasetComparePeekState`, `useObservationPeekState`, `usePeekState`, and `useTracePeekState` to create new browser history entries on navigation events.
>   - **Files Affected**:
>     - `useDatasetComparePeekState.ts`
>     - `useObservationPeekState.ts`
>     - `usePeekState.ts`
>     - `useTracePeekState.ts`
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 683047d71c3bc4c26c07b364e3df132f73cf3779. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->