### PR TITLE
chore(annotation-queues-ui): show Source ID as column on Annotation Queue Items Table

### DIFF
--- a/web/src/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
@@ -36,6 +36,7 @@ import {
 import { Checkbox } from "@/src/components/ui/checkbox";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { StatusBadge } from "@/src/components/layouts/status-badge";
+import TableIdOrName from "@/src/components/table/table-id";
 
 const QueueItemTableMultiSelectAction = ({
   selectedItemIds,
@@ -126,6 +127,7 @@ const QueueItemTableMultiSelectAction = ({
 
 export type QueueItemRowData = {
   id: string;
+  sourceId: string;
   status: AnnotationQueueStatus;
   completedAt: string;
   annotatorUser: {
@@ -287,6 +289,18 @@ export function AnnotationQueueItemsTable({
       },
     },
     {
+      accessorKey: "sourceId",
+      header: "Source ID",
+      id: "sourceId",
+      size: 50,
+      cell: ({ row }) => {
+        const sourceId: QueueItemRowData["sourceId"] = row.getValue("sourceId");
+        return <TableIdOrName value={sourceId} />;
+      },
+      enableHiding: true,
+      defaultHidden: true,
+    },
+    {
       accessorKey: "status",
       header: "Status",
       id: "status",
@@ -358,6 +372,7 @@ export function AnnotationQueueItemsTable({
         userName: item.annotatorUserName ?? undefined,
         image: item.annotatorUserImage ?? undefined,
       },
+      sourceId: item.objectId,
     };
 
     switch (item.objectType) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `Source ID` column to `AnnotationQueueItemsTable`, updating data handling to include `sourceId`.
> 
>   - **Behavior**:
>     - Adds `Source ID` column to `AnnotationQueueItemsTable` in `AnnotationQueueItemsTable.tsx`.
>     - Column is hidden by default and can be toggled.
>   - **Data Handling**:
>     - Updates `QueueItemRowData` type to include `sourceId`.
>     - Modifies `convertToTableRow()` to map `objectId` to `sourceId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d89097a19d76b5bee35f5e511964f14998bb0382. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->