### PR TITLE
chore: add evals admin api

### DIFF
--- a/web/src/pages/api/admin/evals.ts
+++ b/web/src/pages/api/admin/evals.ts
@@ -1,0 +1,87 @@
+import { type NextApiRequest, type NextApiResponse } from "next";
+import { z } from "zod/v4";
+import {
+  logger,
+  QueueName,
+  getQueue,
+  QueueJobs,
+} from "@langfuse/shared/src/server";
+import { AdminApiAuthService } from "@/src/ee/features/admin-api/server/adminApiAuth";
+import { prisma } from "@langfuse/shared/src/db";
+
+const ManageEvalBody = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("retry"),
+    createdAtCutoff: z.date(),
+    status: z.enum(["ERROR"]).nullable(),
+  }),
+]);
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  try {
+    // allow only POST and GET requests
+    if (req.method !== "POST" && req.method !== "GET") {
+      res.status(405).json({ error: "Method Not Allowed" });
+      return;
+    }
+
+    if (!AdminApiAuthService.handleAdminAuth(req, res, false)) {
+      return;
+    }
+
+    const body = ManageEvalBody.safeParse(req.body);
+
+    if (!body.success) {
+      res.status(400).json({ error: body.error });
+      return;
+    }
+
+    if (req.method === "POST" && body.data.action === "retry") {
+      logger.info(
+        `Retrying eval jobs for createdAtCutoff ${body.data.createdAtCutoff}`,
+      );
+
+      const queue = getQueue(QueueName.EvaluationExecution);
+      if (!queue) {
+        throw new Error("Failed to get queue");
+      }
+
+      const jobs = await prisma.jobExecution.findMany({
+        where: {
+          createdAt: {
+            gte: body.data.createdAtCutoff,
+          },
+          status: body.data.status ?? undefined,
+        },
+      });
+
+      if (jobs && jobs.length > 0) {
+        const chunkSize = 1000;
+        for (let i = 0; i < jobs.length; i += chunkSize) {
+          const chunk = jobs.slice(i, i + chunkSize);
+          await queue.addBulk(
+            chunk.map((job) => ({
+              name: QueueJobs.EvaluationExecution,
+              data: {
+                jobExecutionId: job.id,
+                projectId: job.projectId,
+                delay: 0,
+              },
+            })),
+          );
+        }
+      }
+
+      return res.status(200).json({ message: "Removed all jobs" });
+    }
+
+    // return not implemented error
+    res.status(404).json({ error: "Action does not exist" });
+  } catch (e) {
+    logger.error("failed to manage bullmq jobs", e);
+    res.status(500).json({ error: e });
+  }
+}

--- a/web/src/pages/api/admin/evals.ts
+++ b/web/src/pages/api/admin/evals.ts
@@ -75,7 +75,7 @@ export default async function handler(
         }
       }
 
-      return res.status(200).json({ message: "Removed all jobs" });
+      return res.status(200).json({ message: "Retried all jobs" });
     }
 
     // return not implemented error

--- a/web/src/pages/api/admin/evals.ts
+++ b/web/src/pages/api/admin/evals.ts
@@ -82,6 +82,6 @@ export default async function handler(
     res.status(404).json({ error: "Action does not exist" });
   } catch (e) {
     logger.error("failed to manage bullmq jobs", e);
-    res.status(500).json({ error: e });
+    res.status(500).json({ error: e.message });
   }
 }

--- a/web/src/pages/api/admin/evals.ts
+++ b/web/src/pages/api/admin/evals.ts
@@ -1,5 +1,5 @@
 import { type NextApiRequest, type NextApiResponse } from "next";
-import { z } from "zod/v4";
+import { uuidv4, z } from "zod/v4";
 import {
   logger,
   QueueName,
@@ -66,9 +66,13 @@ export default async function handler(
             chunk.map((job) => ({
               name: QueueJobs.EvaluationExecution,
               data: {
-                jobExecutionId: job.id,
-                projectId: job.projectId,
-                delay: 0,
+                timestamp: new Date(),
+                id: uuidv4(),
+                payload: {
+                  jobExecutionId: job.id,
+                  projectId: job.projectId,
+                  delay: 0,
+                },
               },
             })),
           );
@@ -82,6 +86,8 @@ export default async function handler(
     res.status(404).json({ error: "Action does not exist" });
   } catch (e) {
     logger.error("failed to manage bullmq jobs", e);
-    res.status(500).json({ error: e.message });
+    res
+      .status(500)
+      .json({ error: e instanceof Error ? e.message : "Unknown error" });
   }
 }

--- a/web/src/pages/api/admin/evals.ts
+++ b/web/src/pages/api/admin/evals.ts
@@ -1,5 +1,6 @@
 import { type NextApiRequest, type NextApiResponse } from "next";
-import { uuidv4, z } from "zod/v4";
+import { z } from "zod/v4";
+import { v4 as uuidv4 } from "uuid";
 import {
   logger,
   QueueName,

--- a/web/src/pages/api/admin/evals.ts
+++ b/web/src/pages/api/admin/evals.ts
@@ -12,7 +12,7 @@ import { prisma } from "@langfuse/shared/src/db";
 const ManageEvalBody = z.discriminatedUnion("action", [
   z.object({
     action: z.literal("retry"),
-    createdAtCutoff: z.date(),
+    createdAtCutoff: z.coerce.date(),
     status: z.enum(["ERROR"]).nullable(),
   }),
 ]);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds an admin API endpoint in `evals.ts` to retry evaluation jobs based on creation date and status, with authentication and error handling.
> 
>   - **New API Endpoint**:
>     - Adds `evals.ts` to handle admin API requests for evaluation jobs.
>     - Supports `POST` and `GET` methods; others return 405.
>   - **Authentication & Validation**:
>     - Uses `AdminApiAuthService.handleAdminAuth` for authentication.
>     - Validates request body with `ManageEvalBody` schema.
>   - **Job Management**:
>     - On `POST` with `retry` action, retries jobs created after `createdAtCutoff` with optional `status` filter.
>     - Retrieves jobs from `prisma.jobExecution` and adds them to the queue in chunks of 1000.
>   - **Error Handling**:
>     - Logs errors and returns appropriate HTTP status codes for method not allowed, bad request, and server errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f7d121ec70032f5cc1212f4bbe2e3f8142227f1a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->