### PR TITLE
Fix/keyboard shortcuts modifier handling

### DIFF
--- a/web/src/features/navigate-detail-pages/DetailPageNav.tsx
+++ b/web/src/features/navigate-detail-pages/DetailPageNav.tsx
@@ -45,7 +45,7 @@ export const DetailPageNav = (props: {
         return;
       }
       // don't trigger shortcuts if modifier keys are pressed (e.g., Cmd+K for universal search)
-      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
+      if (event.metaKey || event.ctrlKey) {
         return;
       }
 

--- a/web/src/features/navigate-detail-pages/DetailPageNav.tsx
+++ b/web/src/features/navigate-detail-pages/DetailPageNav.tsx
@@ -44,6 +44,10 @@ export const DetailPageNav = (props: {
       ) {
         return;
       }
+      // don't trigger shortcuts if modifier keys are pressed (e.g., Cmd+K for universal search)
+      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
+        return;
+      }
 
       if (event.key === "k" && previousPageEntry) {
         void router.push(


### PR DESCRIPTION
## What does this PR do?

Fix: prevent list navigation when using Cmd/Ctrl+K

Added a guard to skip `j/k` navigation if Cmd or Ctrl is pressed. This ensures
that the universal search shortcut (Cmd+K / Ctrl+K) works as intended without
also triggering list movement. As a result, only plain `j` and `k` control list
navigation, avoiding conflicts with system/browser shortcuts like Cmd+J or Cmd+K.

Fixes # (issue)

issue link: [issue](https://github.com/langfuse/langfuse/issues/8823)
Loom Video: [loom video](https://www.loom.com/share/015107c6c6124d14b8abeed0203eb068?sid=aceb7889-398d-4d1b-ab5b-62c3a77f27b4)


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevents `j/k` list navigation in `DetailPageNav.tsx` when Cmd or Ctrl is pressed to avoid conflicts with universal search shortcuts.
> 
>   - **Behavior**:
>     - Prevents `j/k` list navigation in `DetailPageNav.tsx` when Cmd or Ctrl is pressed.
>     - Ensures Cmd+K/Ctrl+K for universal search does not trigger list movement.
>   - **Code Changes**:
>     - Adds a guard clause in `handleKeyDown` function to check for `event.metaKey` or `event.ctrlKey`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4b7e77a54a5f7c0b84fb412eb4b4be9edcaaad12. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->