### PR TITLE
chore(dataset-remote-run): validate remote run URL

### DIFF
--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -40,6 +40,7 @@ import {
   getCategoricalScoresGroupedByName,
   getDatasetRunsTableRowsCh,
   getDatasetRunsTableCountCh,
+  validateWebhookURL,
 } from "@langfuse/shared/src/server";
 import { createId as createCuid } from "@paralleldrive/cuid2";
 import {
@@ -1372,7 +1373,16 @@ export const datasetRouter = createTRPCRouter({
       if (!dataset.remoteExperimentUrl) {
         throw new TRPCError({
           code: "BAD_REQUEST",
-          message: "No remoteExperiment URL configured for this dataset",
+          message: "No remote run URL configured for this dataset",
+        });
+      }
+
+      try {
+        await validateWebhookURL(dataset.remoteExperimentUrl);
+      } catch (error) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Invalid remote run URL: ${error instanceof Error ? error.message : "Unknown error"}`,
         });
       }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds URL validation for remote run URLs in `dataset-router.ts` to ensure valid URLs before triggering remote experiments.
> 
>   - **Behavior**:
>     - Adds URL validation for `remoteExperimentUrl` in `triggerRemoteExperiment` in `dataset-router.ts` using `validateWebhookURL`.
>     - Throws `TRPCError` with `BAD_REQUEST` if URL is invalid, specifying the error message.
>   - **Misc**:
>     - Updates error message for missing `remoteExperimentUrl` in `triggerRemoteExperiment` to "No remote run URL configured for this dataset".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0e99c14bd79efa86214c525eb7c7b304aa3fffb4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->