### PR TITLE
feat(cloud): export onboarding survey responses to s3

### DIFF
--- a/worker/src/queues/coreDataS3ExportQueue.ts
+++ b/worker/src/queues/coreDataS3ExportQueue.ts
@@ -49,6 +49,7 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
     projectMemberships,
     prompts,
     billingMeterBackup,
+    surveys,
   ] = await Promise.all([
     prisma.project.findMany({
       select: {
@@ -108,6 +109,17 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
       },
     }),
     prisma.billingMeterBackup.findMany(),
+    prisma.survey.findMany({
+      select: {
+        id: true,
+        surveyName: true,
+        response: true,
+        userId: true,
+        userEmail: true,
+        orgId: true,
+        createdAt: true,
+      },
+    }),
   ]);
 
   // Iterate through the tables and upload them to S3 as JSONLs
@@ -120,6 +132,7 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
       projectMemberships,
       prompts,
       billingMeterBackup,
+      surveys,
     }).map(async ([key, value]) =>
       s3Client.uploadFile({
         fileName: `${env.LANGFUSE_S3_CORE_DATA_UPLOAD_PREFIX}${key}.jsonl`,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add survey data export to S3 in `coreDataS3ExportQueue.ts`.
> 
>   - **Behavior**:
>     - Adds survey data export to S3 in `coreDataS3ExportQueue.ts`.
>     - Fetches survey data using `prisma.survey.findMany()` with fields: `id`, `surveyName`, `response`, `userId`, `userEmail`, `orgId`, `createdAt`.
>     - Uploads survey data to S3 as JSONL files using `s3Client.uploadFile()`.
>   - **Misc**:
>     - Updates `coreDataS3ExportProcessor` to include `surveys` in the data export process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cedd0860332caae47e5dc07fbdd6d6215b214a21. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->