### PR TITLE
fix(datasets): do not rely on pagination in compare view

### DIFF
--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -5,6 +5,7 @@ import {
   createScoresCh,
   createTracesCh,
   getDatasetRunItemsByDatasetIdCh,
+  getDatasetRunItemsCountByDatasetIdCh,
   getDatasetRunsTableMetricsCh,
   getScoresForDatasetRuns,
   getTraceScoresForDatasetRuns,
@@ -2662,92 +2663,129 @@ describe("Fetch datasets for UI presentation", () => {
 
     // Test 1: Pass first 10 dataset item IDs (indices 0-9) - should get count 2 but empty run items array
     const firstTenItems = datasetItemIds.slice(0, 10);
-    const result1 = await getDatasetRunItemsByDatasetIdCh({
-      projectId: projectId,
-      datasetId: datasetId,
-      filter: [
-        {
-          type: "stringOptions" as const,
-          column: "datasetItemId",
-          operator: "any of" as const,
-          value: firstTenItems,
-        },
-      ],
-      orderBy: [
-        {
-          column: "createdAt",
-          order: "ASC",
-        },
-      ],
-      limit: 50,
-      offset: 0,
-    });
+    const [runItems1, totalRunItems1] = await Promise.all([
+      getDatasetRunItemsByDatasetIdCh({
+        projectId: projectId,
+        datasetId: datasetId,
+        filter: [
+          {
+            type: "stringOptions" as const,
+            column: "datasetItemId",
+            operator: "any of" as const,
+            value: firstTenItems,
+          },
+        ],
+        orderBy: [
+          {
+            column: "createdAt",
+            order: "ASC",
+          },
+          { column: "datasetItemId", order: "DESC" },
+        ],
+      }),
+      getDatasetRunItemsCountByDatasetIdCh({
+        projectId: projectId,
+        datasetId: datasetId,
+        filter: [
+          {
+            type: "stringOptions" as const,
+            column: "datasetItemId",
+            operator: "any of" as const,
+            value: firstTenItems,
+          },
+        ],
+      }),
+    ]);
 
-    expect(result1.totalCount).toEqual(2); // Still shows total count of all run items in dataset
-    expect(result1.runItems).toHaveLength(0); // But no actual run items returned for these dataset items
+    expect(totalRunItems1).toEqual(0);
+    expect(runItems1).toHaveLength(0); // But no actual run items returned for these dataset items
 
     // Test 2: Pass second 10 dataset item IDs (indices 10-19) - should get count 2 and 2 run items
     const secondTenItems = datasetItemIds.slice(10, 20);
-    const result2 = await getDatasetRunItemsByDatasetIdCh({
-      projectId: projectId,
-      datasetId: datasetId,
-      filter: [
-        {
-          type: "stringOptions" as const,
-          column: "datasetItemId",
-          operator: "any of" as const,
-          value: secondTenItems,
-        },
-      ],
-      orderBy: [
-        {
-          column: "createdAt",
-          order: "ASC",
-        },
-      ],
-      limit: 50,
-      offset: 0,
-    });
+    const [runItems2, totalRunItems2] = await Promise.all([
+      getDatasetRunItemsByDatasetIdCh({
+        projectId: projectId,
+        datasetId: datasetId,
+        filter: [
+          {
+            type: "stringOptions" as const,
+            column: "datasetItemId",
+            operator: "any of" as const,
+            value: secondTenItems,
+          },
+        ],
+        orderBy: [
+          {
+            column: "createdAt",
+            order: "ASC",
+          },
+          { column: "datasetItemId", order: "DESC" },
+        ],
+      }),
+      getDatasetRunItemsCountByDatasetIdCh({
+        projectId: projectId,
+        datasetId: datasetId,
+        filter: [
+          {
+            type: "stringOptions" as const,
+            column: "datasetItemId",
+            operator: "any of" as const,
+            value: secondTenItems,
+          },
+        ],
+      }),
+    ]);
 
-    expect(result2.totalCount).toEqual(2); // Total count of all run items in dataset
-    expect(result2.runItems).toHaveLength(2); // Both run items returned since they match the filter
+    expect(totalRunItems2).toEqual(2); // Total count of all run items in dataset
+    expect(runItems2).toHaveLength(2); // Both run items returned since they match the filter
 
     // Verify the run items are the correct ones
-    const returnedRunItemIds = result2.runItems.map((item) => item.id);
+    const returnedRunItemIds = runItems2.map((item) => item.id);
     expect(returnedRunItemIds).toContain(runItem1Id);
     expect(returnedRunItemIds).toContain(runItem2Id);
 
     // Verify they have the correct dataset item IDs
-    const returnedDatasetItemIds = result2.runItems.map(
-      (item) => item.datasetItemId,
-    );
+    const returnedDatasetItemIds = runItems2.map((item) => item.datasetItemId);
     expect(returnedDatasetItemIds).toContain(datasetItemIds[10]);
     expect(returnedDatasetItemIds).toContain(datasetItemIds[11]);
 
     // Test 3: Pass third 10 dataset item IDs (indices 20-29) - should get count 2 but empty run items array
     const thirdTenItems = datasetItemIds.slice(20, 30);
-    const result3 = await getDatasetRunItemsByDatasetIdCh({
-      projectId: projectId,
-      datasetId: datasetId,
-      filter: [
-        {
-          type: "stringOptions" as const,
-          column: "datasetItemId",
-          operator: "any of" as const,
-          value: thirdTenItems,
-        },
-      ],
-      orderBy: [
-        {
-          column: "createdAt",
-          order: "ASC",
-        },
-      ],
-      limit: 50,
-      offset: 0,
-    });
+    const [runItems3, totalRunItems3] = await Promise.all([
+      getDatasetRunItemsByDatasetIdCh({
+        projectId: projectId,
+        datasetId: datasetId,
+        filter: [
+          {
+            type: "stringOptions" as const,
+            column: "datasetItemId",
+            operator: "any of" as const,
+            value: thirdTenItems,
+          },
+        ],
+        orderBy: [
+          {
+            column: "createdAt",
+            order: "ASC",
+          },
+          { column: "datasetItemId", order: "DESC" },
+        ],
+      }),
+      getDatasetRunItemsCountByDatasetIdCh({
+        projectId: projectId,
+        datasetId: datasetId,
+        filter: [
+          {
+            type: "stringOptions" as const,
+            column: "datasetItemId",
+            operator: "any of" as const,
+            value: thirdTenItems,
+          },
+        ],
+      }),
+    ]);
 
-    expect(result3.totalCount).toEqual(2); // Still shows total count of all run items in dataset
-    expect(result3.runItems).toHaveLength(0); // But no actual run items returned for these dataset items
+    expect(totalRunItems3).toEqual(0);
+    expect(runItems3).toHaveLength(0); // But no actual run items returned for these dataset items
   });
 });

--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -2610,10 +2610,11 @@ describe("Fetch datasets for UI presentation", () => {
     });
 
     const datasetRunId = v4();
+    const datasetRunName = v4();
     await prisma.datasetRuns.create({
       data: {
         id: datasetRunId,
-        name: v4(),
+        name: datasetRunName,
         datasetId,
         metadata: {},
         projectId,
@@ -2648,6 +2649,7 @@ describe("Fetch datasets for UI presentation", () => {
       project_id: projectId,
       dataset_item_id: datasetItemIds[10], // 11th item (index 10)
       dataset_id: datasetId,
+      dataset_run_name: datasetRunName,
     });
 
     const runItem2 = createDatasetRunItem({
@@ -2657,6 +2659,7 @@ describe("Fetch datasets for UI presentation", () => {
       project_id: projectId,
       dataset_item_id: datasetItemIds[11], // 12th item (index 11)
       dataset_id: datasetId,
+      dataset_run_name: datasetRunName,
     });
 
     await createDatasetRunItemsCh([runItem1, runItem2]);

--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -2664,7 +2664,7 @@ describe("Fetch datasets for UI presentation", () => {
 
     await createDatasetRunItemsCh([runItem1, runItem2]);
 
-    // Test 1: Pass first 10 dataset item IDs (indices 0-9) - should get count 2 but empty run items array
+    // Test 1: Pass first 10 dataset item IDs (indices 0-9) - should get empty run items array
     const firstTenItems = datasetItemIds.slice(0, 10);
     const [runItems1, totalRunItems1] = await Promise.all([
       getDatasetRunItemsByDatasetIdCh({
@@ -2752,7 +2752,7 @@ describe("Fetch datasets for UI presentation", () => {
     expect(returnedDatasetItemIds).toContain(datasetItemIds[10]);
     expect(returnedDatasetItemIds).toContain(datasetItemIds[11]);
 
-    // Test 3: Pass third 10 dataset item IDs (indices 20-29) - should get count 2 but empty run items array
+    // Test 3: Pass third 10 dataset item IDs (indices 20-29) - should get empty run items array
     const thirdTenItems = datasetItemIds.slice(20, 30);
     const [runItems3, totalRunItems3] = await Promise.all([
       getDatasetRunItemsByDatasetIdCh({

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -153,16 +153,12 @@ function DatasetCompareRunsTableInternal(props: {
         queryKey: getQueryKey(api.datasets.runitemsByRunIdOrItemId, {
           projectId: props.projectId,
           datasetRunId: runId,
-          page: paginationState.pageIndex,
-          limit: paginationState.pageSize,
+          datasetItemIds: baseDatasetItems.data?.datasetItems.map(
+            (item) => item.id,
+          ),
         }),
       })),
-    [
-      props.runIds,
-      props.projectId,
-      paginationState.pageIndex,
-      paginationState.pageSize,
-    ],
+    [props.runIds, props.projectId, baseDatasetItems.data],
   );
 
   // 2. Track changes using onSuccess callback in the queries instead of useEffect
@@ -206,8 +202,9 @@ function DatasetCompareRunsTableInternal(props: {
       {
         projectId: props.projectId,
         datasetRunId: runId,
-        page: paginationState.pageIndex,
-        limit: paginationState.pageSize,
+        datasetItemIds: baseDatasetItems.data?.datasetItems.map(
+          (item) => item.id,
+        ),
       },
       {
         refetchOnWindowFocus: false,

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -18,6 +18,7 @@ import {
   TracingSearchType,
   timeFilter,
   isClickhouseFilterColumn,
+  optionalPaginationZod,
 } from "@langfuse/shared";
 import { TRPCError } from "@trpc/server";
 import {
@@ -973,7 +974,8 @@ export const datasetRouter = createTRPCRouter({
           datasetId: z.string().optional(), // require for new procedures
           datasetRunId: z.string().optional(),
           datasetItemId: z.string().optional(),
-          ...paginationZod,
+          datasetItemIds: z.array(z.string()).optional(),
+          ...optionalPaginationZod,
         })
         .refine(
           (input) => input.datasetRunId || input.datasetItemId,
@@ -981,7 +983,7 @@ export const datasetRouter = createTRPCRouter({
         ),
     )
     .query(async ({ input, ctx }) => {
-      const { datasetRunId, datasetItemId, datasetId } = input;
+      const { datasetRunId, datasetItemId, datasetItemIds, datasetId } = input;
 
       const filter = [
         ...(datasetRunId
@@ -994,12 +996,15 @@ export const datasetRouter = createTRPCRouter({
               },
             ]
           : []),
-        ...(datasetItemId
+        ...(datasetItemId || datasetItemIds
           ? [
               {
                 column: "datasetItemId",
                 operator: "any of",
-                value: [datasetItemId],
+                value: [
+                  ...(datasetItemId ? [datasetItemId] : []),
+                  ...(datasetItemIds ?? []),
+                ],
                 type: "stringOptions" as const,
               },
             ]
@@ -1065,8 +1070,9 @@ export const datasetRouter = createTRPCRouter({
             },
             { column: "datasetItemId", order: "DESC" },
           ],
-          limit: input.limit,
-          offset: input.page * input.limit,
+          limit: input.limit ?? undefined,
+          offset:
+            input.page && input.limit ? input.page * input.limit : undefined,
         }),
         getDatasetRunItemsCountByDatasetIdCh({
           projectId: input.projectId,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove pagination reliance in dataset comparison view by using dataset item IDs for filtering, with updates to `DatasetCompareRunsTable` and `dataset-router`, and added test coverage.
> 
>   - **Behavior**:
>     - `DatasetCompareRunsTable.tsx`: Removed pagination parameters (`page`, `limit`) from `getQueryKey` and `useQuery` calls, replaced with `datasetItemIds` for filtering.
>     - `dataset-router.ts`: Updated `runitemsByRunIdOrItemId` to accept `datasetItemIds` and use `optionalPaginationZod`.
>   - **Tests**:
>     - Added test in `dataset-service.servertest.ts` to verify dataset run items filtering by `datasetItemIds` with varying item counts.
>   - **Misc**:
>     - Added `getDatasetRunItemsCountByDatasetIdCh` to imports in `dataset-service.servertest.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1ee52495e54227b8224268172ac3bd4107958daa. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->