### PR TITLE
chore: use consistent slot hashing for trace seen cache

### DIFF
--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -165,6 +165,9 @@ export const env = createEnv({
     OTEL_SERVICE_NAME: z.string().default("web"),
     OTEL_TRACE_SAMPLING_RATIO: z.coerce.number().gt(0).lte(1).default(1),
 
+    // Redis
+    REDIS_CLUSTER_ENABLED: z.enum(["true", "false"]).default("false"),
+
     // clickhouse
     CLICKHOUSE_URL: z.string().url(),
     CLICKHOUSE_CLUSTER_NAME: z.string().default("default"),
@@ -480,6 +483,8 @@ export const env = createEnv({
     CLICKHOUSE_USER: process.env.CLICKHOUSE_USER,
     CLICKHOUSE_PASSWORD: process.env.CLICKHOUSE_PASSWORD,
     CLICKHOUSE_CLUSTER_ENABLED: process.env.CLICKHOUSE_CLUSTER_ENABLED,
+    // Redis
+    REDIS_CLUSTER_ENABLED: process.env.REDIS_CLUSTER_ENABLED,
     // EE ui customization
     LANGFUSE_UI_API_HOST: process.env.LANGFUSE_UI_API_HOST,
     LANGFUSE_UI_DOCUMENTATION_HREF: process.env.LANGFUSE_UI_DOCUMENTATION_HREF,

--- a/web/src/features/otel/server/OtelIngestionProcessor.ts
+++ b/web/src/features/otel/server/OtelIngestionProcessor.ts
@@ -17,6 +17,7 @@ import {
 
 import { LangfuseOtelSpanAttributes } from "./attributes";
 import { ObservationTypeMapperRegistry } from "./ObservationTypeMapper";
+import { env } from "@/src/env.mjs";
 
 // Type definitions for internal processor state
 interface TraceState {
@@ -1622,7 +1623,10 @@ export class OtelIngestionProcessor {
     try {
       const results = await Promise.all(
         [...traceIds].map(async (traceId) => {
-          const key = `langfuse:project:${this.projectId}:trace:${traceId}:seen`;
+          const key =
+            env.REDIS_CLUSTER_ENABLED === "true"
+              ? `langfuse:project:{${this.projectId}}:trace:${traceId}:seen`
+              : `langfuse:project:${this.projectId}:trace:${traceId}:seen`;
           const TTLSeconds = 600; // 10 minutes
           const result = await redis?.call(
             "SET",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `OtelIngestionProcessor` to use consistent Redis key hashing based on `REDIS_CLUSTER_ENABLED` environment variable.
> 
>   - **Behavior**:
>     - In `OtelIngestionProcessor.ts`, `getSeenTracesSet()` now uses `env.REDIS_CLUSTER_ENABLED` to determine Redis key format for trace IDs.
>     - If `REDIS_CLUSTER_ENABLED` is "true", keys are formatted as `langfuse:project:{projectId}:trace:{traceId}:seen`.
>     - If "false", keys are formatted as `langfuse:project:projectId:trace:traceId:seen`.
>   - **Environment Variables**:
>     - Added `REDIS_CLUSTER_ENABLED` to `env.mjs` with default "false".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 112c414e97f9d867be30fcb8afdae9097aeefdef. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->