### PR TITLE
fix(tables): peek view sometimes not opening

### DIFF
--- a/web/src/components/table/peek/hooks/useTracePeekState.ts
+++ b/web/src/components/table/peek/hooks/useTracePeekState.ts
@@ -12,14 +12,19 @@ export const useTracePeekState = () => {
       const params = new URLSearchParams(url.search);
       const pathname = getPathnameWithoutBasePath();
 
+      const currentPeek = params.get("peek");
+
       if (!open || !id) {
+        if (!currentPeek) {
+          return;
+        }
+
         // close peek view
         params.delete("peek");
         params.delete("timestamp");
         params.delete("observation");
         params.delete("display");
-      } else if (open && id !== peek) {
-        // open peek view or update peek view
+      } else if (open && id !== currentPeek) {
         params.set("peek", id);
         const relevantTimestamp = time ?? (timestamp as string);
         if (relevantTimestamp) params.set("timestamp", relevantTimestamp);
@@ -37,7 +42,7 @@ export const useTracePeekState = () => {
         { shallow: true },
       );
     },
-    [router, peek, timestamp],
+    [router, timestamp],
   );
 
   return {


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimizes peek view state management and URL handling in `usePeekView.ts` and `useTracePeekState.ts`.
> 
>   - **Behavior**:
>     - Replaces `useState` and `useEffect` with `useMemo` and `useCallback` in `usePeekView.ts` to optimize peek view state management.
>     - Refines URL handling in `useTracePeekState.ts` to ensure peek view opens/closes correctly based on current state.
>   - **Functions**:
>     - Removes `getInitialRow()` function from `usePeekView.ts`.
>     - Updates `handleOnRowClickPeek` in `usePeekView.ts` to handle row clicks more efficiently.
>     - Modifies `setPeekView` in `useTracePeekState.ts` to handle URL query parameters more accurately.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ffe865f1c776582d02118923e993f17a0a87c658. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->
Fixes LFE-6243