### PR TITLE
chore: mention in docs that node 24 is required now

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ pnpm run nuke              # Remove all node_modules, build files, wipe database
 
 ## Environment Setup
 
-- **Node.js**: Version 20 (specified in `.nvmrc`)
+- **Node.js**: Version 24 (specified in `.nvmrc`)
 - **Package Manager**: pnpm v9.5.0
 - **Database Dependencies**: Docker for local PostgreSQL, ClickHouse, Redis, MinIO
 - **Environment**: Copy `.env.dev.example` to `.env`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ We built a monorepo using [pnpm](https://pnpm.io/motivation) and [turbo](https:/
 
 Requirements
 
-- Node.js 20 as specified in the [.nvmrc](.nvmrc)
+- Node.js 24 as specified in the [.nvmrc](.nvmrc)
 - Pnpm v.9.5.0
 - Docker to run the database locally
 
@@ -137,7 +137,7 @@ Requirements
     cp .env.dev.example .env
    ```
 
-4. Run the entire infrastructure in dev mode. **Note**: if you have an existing database, this command wipes it. Also, this will fail on the very first run. Please run it again.
+5. Run the entire infrastructure in dev mode. **Note**: if you have an existing database, this command wipes it. Also, this will fail on the very first run. Please run it again.
 
    ```bash
    pnpm run dx # first run only (resets db, docker containers, etc...)
@@ -146,13 +146,11 @@ Requirements
 
    You will be asked whether you want to reset Postgres and ClickHouse. Confirm both with 'Y' and press enter.
 
-5. Open the web app in your browser to start using Langfuse:
-
+6. Open the web app in your browser to start using Langfuse:
    - [Sign up page, http://localhost:3000](http://localhost:3000)
    - [Demo project, http://localhost:3000/project/7a88fb47-b4e2-43b8-a06c-a5ce950dc53a](http://localhost:3000/project/7a88fb47-b4e2-43b8-a06c-a5ce950dc53a)
 
-6. Log in as a test user:
-
+7. Log in as a test user:
    - Username: `demo@langfuse.com`
    - Password: `password`
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update documentation to require Node.js version 24 instead of 20.
> 
>   - **Documentation**:
>     - Update Node.js version requirement from 20 to 24 in `CLAUDE.md` and `CONTRIBUTING.md`.
>     - Adjust numbering in `CONTRIBUTING.md` to reflect changes in steps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e47da3fead1abe31cb59043c6bfe75daa462577b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->