### PR TITLE
Align http status codes for queue name conflicts

### DIFF
--- a/fern/apis/server/definition/annotation-queues.yml
+++ b/fern/apis/server/definition/annotation-queues.yml
@@ -28,6 +28,8 @@ service:
       path: /annotation-queues
       request: CreateAnnotationQueueRequest
       response: AnnotationQueue
+      errors:
+        - commons.ConflictError
 
     getQueue:
       docs: Get an annotation queue by ID

--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -541,3 +541,6 @@ errors:
   MethodNotAllowedError:
     status-code: 405
     type: unknown
+  ConflictError:
+    status-code: 409
+    type: unknown

--- a/web/src/__tests__/annotation-queues-api.servertest.ts
+++ b/web/src/__tests__/annotation-queues-api.servertest.ts
@@ -204,7 +204,7 @@ describe("Annotation Queues API Endpoints", () => {
       expect(response.body.scoreConfigIds).toEqual([scoreConfig.id]);
     });
 
-    it("should return 400 if the queue name already exists", async () => {
+    it("should return 409 if the queue name already exists", async () => {
       const response = await makeAPICall(
         "POST",
         "/api/public/annotation-queues",
@@ -216,7 +216,7 @@ describe("Annotation Queues API Endpoints", () => {
         auth,
       );
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(409);
     });
 
     it("should return 400 if no score config IDs are provided", async () => {

--- a/web/src/features/prompts/server/actions/createPrompt.ts
+++ b/web/src/features/prompts/server/actions/createPrompt.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 import {
   InvalidRequestError,
+  LangfuseConflictError,
   parsePromptDependencyTags,
   jsonSchema,
   type PromptDependency,
@@ -237,7 +238,7 @@ export const duplicatePrompt = async ({
   });
 
   if (promptNameExists) {
-    throw new InvalidRequestError(
+    throw new LangfuseConflictError(
       `Prompt name ${name} already exists in project ${projectId}`,
     );
   }

--- a/web/src/pages/api/public/annotation-queues/index.ts
+++ b/web/src/pages/api/public/annotation-queues/index.ts
@@ -7,7 +7,7 @@ import {
   GetAnnotationQueuesQuery,
   GetAnnotationQueuesResponse,
 } from "@/src/features/public-api/types/annotation-queues";
-import { InvalidRequestError, MethodNotAllowedError } from "@langfuse/shared";
+import { InvalidRequestError, LangfuseConflictError, MethodNotAllowedError } from "@langfuse/shared";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
@@ -85,7 +85,7 @@ export default withMiddlewares({
       });
 
       if (existingQueue) {
-        throw new InvalidRequestError("A queue with this name already exists.");
+        throw new LangfuseConflictError("A queue with this name already exists.");
       }
 
       // verify the score configs exist

--- a/web/src/server/api/routers/models.ts
+++ b/web/src/server/api/routers/models.ts
@@ -254,7 +254,7 @@ export const modelRouter = createTRPCRouter({
 
         if (existingModelName && modelId !== existingModelName.id) {
           throw new TRPCError({
-            code: "BAD_REQUEST",
+            code: "CONFLICT",
             message: `Model name '${modelName}' already exists in project`,
           });
         }


### PR DESCRIPTION
## What does this PR do?

This PR standardizes the HTTP status codes for resource conflicts across the Langfuse API, changing them from 400 (Bad Request) to 409 (Conflict). This aligns the API with standard REST conventions, making it more predictable and easier for SDK developers to use.

Specifically, this fixes inconsistencies in:
-   **Annotation Queues API**: Creating a queue with an existing name now returns 409.
-   **Prompts Duplicate Function**: Duplicating a prompt with an existing name now returns 409.
-   **Models Router**: Creating a model with an existing name now returns 409.
-   **API Documentation**: Updated Fern API definitions to include `ConflictError`.

Fixes #LFE-6484

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [x] I haven't commented my code, particularly in hard-to-understand areas
- [x] I haven't checked if my PR needs changes to the documentation
- [ ] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [x] I haven't added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-6484](https://linear.app/langfuse/issue/LFE-6484/some-http-status-codes-are-confusing)

<a href="https://cursor.com/background-agent?bcId=bc-85dbb521-413d-4938-8203-19e19bcef467">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-85dbb521-413d-4938-8203-19e19bcef467">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

