### PR TITLE
feat(single-trace): add copy button on value cell of json view

### DIFF
--- a/web/src/components/table/ValueCell.tsx
+++ b/web/src/components/table/ValueCell.tsx
@@ -1,7 +1,10 @@
-import { memo } from "react";
+import { memo, useState } from "react";
 import { type Row } from "@tanstack/react-table";
 import { urlRegex } from "@langfuse/shared";
 import { type JsonTableRow } from "@/src/components/table/utils/jsonExpansionUtils";
+import { copyTextToClipboard } from "@/src/utils/clipboard";
+import { Button } from "@/src/components/ui/button";
+import { Copy, Check } from "lucide-react";
 
 const MAX_STRING_LENGTH_FOR_LINK_DETECTION = 1500;
 const MAX_CELL_DISPLAY_CHARS = 2000;
@@ -137,6 +140,20 @@ function getTruncatedValue(value: string, maxChars: number): string {
   return truncated + "...";
 }
 
+function getCopyValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value; // Return string without quotes
+  }
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
 export const ValueCell = memo(
   ({
     row,
@@ -150,6 +167,20 @@ export const ValueCell = memo(
     const { value, type } = row.original;
     const cellId = `${row.id}-value`;
     const isCellExpanded = expandedCells.has(cellId);
+    const [showCopySuccess, setShowCopySuccess] = useState(false);
+
+    const handleCopy = async (e: React.MouseEvent) => {
+      e.stopPropagation();
+      const copyValue = getCopyValue(value);
+
+      try {
+        await copyTextToClipboard(copyValue);
+        setShowCopySuccess(true);
+        setTimeout(() => setShowCopySuccess(false), 1500);
+      } catch (error) {
+        // Copy failed silently
+      }
+    };
 
     const getDisplayValue = () => {
       switch (type) {
@@ -245,7 +276,7 @@ export const ValueCell = memo(
     const { content, needsTruncation } = getDisplayValue();
 
     return (
-      <div className={`${MONO_TEXT_CLASSES} max-w-full`}>
+      <div className={`${MONO_TEXT_CLASSES} group relative max-w-full`}>
         {content}
         {needsTruncation && !row.original.hasChildren && (
           <div
@@ -260,6 +291,22 @@ export const ValueCell = memo(
               : `\n...expand (${getValueStringLength(value) - MAX_CELL_DISPLAY_CHARS} more characters)`}
           </div>
         )}
+
+        {/* Copy button - appears on hover */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="absolute right-0 top-1/2 h-5 w-5 -translate-y-1/2 border bg-background/80 p-0.5 opacity-0 shadow-sm transition-opacity duration-200 hover:bg-background group-hover:opacity-100"
+          onClick={handleCopy}
+          title="Copy value"
+          aria-label="Copy cell value"
+        >
+          {showCopySuccess ? (
+            <Check className="h-2.5 w-2.5 text-green-600" />
+          ) : (
+            <Copy className="h-2.5 w-2.5" />
+          )}
+        </Button>
       </div>
     );
   },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add a copy button to `ValueCell` in `ValueCell.tsx` for copying cell values to clipboard with hover and success feedback.
> 
>   - **Feature**:
>     - Add copy button to `ValueCell` in `ValueCell.tsx` for copying cell values to clipboard.
>     - Button appears on hover and shows success icon briefly after copying.
>   - **Functions**:
>     - Add `getCopyValue()` to format value for copying.
>     - Add `handleCopy()` to manage copy operation and success state.
>   - **UI**:
>     - Use `Button` component for copy action with hover and success state styles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 297800422b551d764cc1c149705f71180f33e7d9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->