### PR TITLE
chore: decouple upload file from url signing in storage service

### DIFF
--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -356,7 +356,7 @@ Configuration: ${type} storage
 This file can be safely deleted.`;
 
         // Upload the test file
-        const result = await storageService.uploadFile({
+        const result = await storageService.uploadWithSignedUrl({
           fileName: testFileName,
           fileType: "text/plain",
           data: testContent,

--- a/worker/src/__tests__/dataRetentionProcessing.test.ts
+++ b/worker/src/__tests__/dataRetentionProcessing.test.ts
@@ -41,12 +41,11 @@ describe("DataRetentionProcessingJob", () => {
     const fileName = `${baseId}.json`;
     const fileType = "application/json";
     const data = JSON.stringify({ hello: "world" });
-    const expiresInSeconds = 3600;
+
     await storageService.uploadFile({
       fileName,
       fileType,
       data,
-      expiresInSeconds,
     });
 
     await clickhouseClient().insert({
@@ -90,12 +89,11 @@ describe("DataRetentionProcessingJob", () => {
     const fileName = `${baseId}.json`;
     const fileType = "application/json";
     const data = JSON.stringify({ hello: "world" });
-    const expiresInSeconds = 3600;
+
     await storageService.uploadFile({
       fileName,
       fileType,
       data,
-      expiresInSeconds,
     });
 
     await clickhouseClient().insert({
@@ -138,12 +136,11 @@ describe("DataRetentionProcessingJob", () => {
     const fileName = `${randomUUID()}.txt`;
     const fileType = "text/plain";
     const data = "Hello, world!";
-    const expiresInSeconds = 3600;
+
     await storageService.uploadFile({
       fileName,
       fileType,
       data,
-      expiresInSeconds,
     });
 
     const mediaId = randomUUID();
@@ -196,12 +193,11 @@ describe("DataRetentionProcessingJob", () => {
     const fileName = `${randomUUID()}.txt`;
     const fileType = "text/plain";
     const data = "Hello, world!";
-    const expiresInSeconds = 3600;
+
     await storageService.uploadFile({
       fileName,
       fileType,
       data,
-      expiresInSeconds,
     });
 
     const mediaId = randomUUID();

--- a/worker/src/__tests__/projectDeletionProcessing.test.ts
+++ b/worker/src/__tests__/projectDeletionProcessing.test.ts
@@ -204,12 +204,11 @@ describe("ProjectDeletionProcessingJob", () => {
     const fileName = `${randomUUID()}.txt`;
     const fileType = "text/plain";
     const data = "Hello, world!";
-    const expiresInSeconds = 3600;
+
     await storageService.uploadFile({
       fileName,
       fileType,
       data,
-      expiresInSeconds,
     });
 
     const mediaId = randomUUID();

--- a/worker/src/__tests__/scoreDeletion.test.ts
+++ b/worker/src/__tests__/scoreDeletion.test.ts
@@ -53,13 +53,12 @@ describe("score deletion", () => {
 
     const fileType = "application/json";
     const data = JSON.stringify({ hello: "world" });
-    const expiresInSeconds = 3600;
+
     await Promise.all([
       eventStorageService.uploadFile({
         fileName: `${projectId}/score/${scoreId}-score.json`,
         fileType,
         data,
-        expiresInSeconds,
       }),
     ]);
 

--- a/worker/src/__tests__/storageservice.test.ts
+++ b/worker/src/__tests__/storageservice.test.ts
@@ -33,7 +33,7 @@ describe("StorageService", () => {
     });
   });
 
-  test("uploadFile should upload a file and return a signed URL", async () => {
+  test("uploadWithSignedUrl should upload a file and return a signed URL", async () => {
     // Setup
     const fileName = `${randomUUID()}.txt`;
     const fileType = "text/plain";
@@ -41,7 +41,7 @@ describe("StorageService", () => {
     const expiresInSeconds = 3600;
 
     // When
-    const result = await storageService.uploadFile({
+    const result = await storageService.uploadWithSignedUrl({
       fileName,
       fileType,
       data,
@@ -112,7 +112,6 @@ describe("StorageService", () => {
       fileName,
       fileType,
       data,
-      expiresInSeconds,
     });
 
     // When
@@ -138,7 +137,6 @@ describe("StorageService", () => {
       fileName,
       fileType,
       data,
-      expiresInSeconds,
     });
 
     // When
@@ -197,7 +195,7 @@ describe("StorageService", () => {
     expect(signedUrl).not.toContain(env.LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT);
   });
 
-  test("uploadFile should return signed URL with external endpoint when configured", async () => {
+  test("uploadWithSignedUrl should return signed URL with external endpoint when configured", async () => {
     // Setup
     const fileName = `${randomUUID()}.txt`;
     const fileType = "text/plain";
@@ -205,12 +203,14 @@ describe("StorageService", () => {
     const expiresInSeconds = 3600;
 
     // When
-    const result = await storageServiceWithExternalEndpoint.uploadFile({
-      fileName,
-      fileType,
-      data,
-      expiresInSeconds,
-    });
+    const result = await storageServiceWithExternalEndpoint.uploadWithSignedUrl(
+      {
+        fileName,
+        fileType,
+        data,
+        expiresInSeconds,
+      },
+    );
 
     // Then
     expect(result.signedUrl).toContain("external-endpoint.example.com");

--- a/worker/src/__tests__/traceDeletion.test.ts
+++ b/worker/src/__tests__/traceDeletion.test.ts
@@ -92,19 +92,17 @@ describe("trace deletion", () => {
 
     const fileType = "text/plain";
     const data = "Hello, world!";
-    const expiresInSeconds = 3600;
+
     await Promise.all([
       mediaStorageService.uploadFile({
         fileName: `${projectId}/trace-${traceId}.txt`,
         fileType,
         data,
-        expiresInSeconds,
       }),
       mediaStorageService.uploadFile({
         fileName: `${projectId}/observation-${observationId}.txt`,
         fileType,
         data,
-        expiresInSeconds,
       }),
     ]);
 
@@ -186,12 +184,11 @@ describe("trace deletion", () => {
 
     const fileType = "text/plain";
     const data = "Hello, world!";
-    const expiresInSeconds = 3600;
+
     await mediaStorageService.uploadFile({
       fileName: `${projectId}/trace-${traceId1}.txt`,
       fileType,
       data,
-      expiresInSeconds,
     });
 
     const traceMediaId = randomUUID();
@@ -275,25 +272,22 @@ describe("trace deletion", () => {
 
     const fileType = "application/json";
     const data = JSON.stringify({ hello: "world" });
-    const expiresInSeconds = 3600;
+
     await Promise.all([
       eventStorageService.uploadFile({
         fileName: `${projectId}/traces/${traceId}-trace.json`,
         fileType,
         data,
-        expiresInSeconds,
       }),
       eventStorageService.uploadFile({
         fileName: `${projectId}/observation/${traceId}-observation.json`,
         fileType,
         data,
-        expiresInSeconds,
       }),
       eventStorageService.uploadFile({
         fileName: `${projectId}/score/${traceId}-score.json`,
         fileType,
         data,
-        expiresInSeconds,
       }),
     ]);
 

--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -118,7 +118,7 @@ export const handleBatchExportJob = async (
     forcePathStyle: env.LANGFUSE_S3_BATCH_EXPORT_FORCE_PATH_STYLE === "true",
     awsSse: env.LANGFUSE_S3_BATCH_EXPORT_SSE,
     awsSseKmsKeyId: env.LANGFUSE_S3_BATCH_EXPORT_SSE_KMS_KEY_ID,
-  }).uploadFile({
+  }).uploadWithSignedUrl({
     fileName,
     fileType:
       exportOptions[jobDetails.format as BatchExportFileFormat].fileType,

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -157,7 +157,6 @@ const processBlobStorageExport = async (config: {
       fileName: filePath,
       fileType: blobStorageProps.contentType,
       data: fileStream,
-      expiresInSeconds: 3600, // 1 hour expiry for the signed URL - is ignored
     });
 
     logger.info(

--- a/worker/src/queues/coreDataS3ExportQueue.ts
+++ b/worker/src/queues/coreDataS3ExportQueue.ts
@@ -138,7 +138,6 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
         fileName: `${env.LANGFUSE_S3_CORE_DATA_UPLOAD_PREFIX}${key}.jsonl`,
         fileType: "application/x-ndjson",
         data: value.map((item) => JSON.stringify(item)).join("\n"),
-        expiresInSeconds: 1, // not used as we only upload
       }),
     ),
   );


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes issue: https://github.com/langfuse/langfuse/issues/8856

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

I'm decoupling the uploadFile method from url signing in StorageService for s3, azure and GCS

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Decouples `uploadFile` from URL signing in `StorageService`, introducing `uploadWithSignedUrl` for S3, Azure, and GCS.
> 
>   - **Behavior**:
>     - Decouples `uploadFile` from URL signing in `StorageService` for S3, Azure, and GCS.
>     - Introduces `uploadWithSignedUrl` method for handling URL signing separately.
>   - **Service Implementations**:
>     - Updates `uploadFile` to return `void` in `StorageService.ts`.
>     - Adds `uploadWithSignedUrl` to `AzureBlobStorageService`, `S3StorageService`, and `GoogleCloudStorageService`.
>   - **Tests**:
>     - Updates tests in `dataRetentionProcessing.test.ts`, `projectDeletionProcessing.test.ts`, `scoreDeletion.test.ts`, `storageservice.test.ts`, and `traceDeletion.test.ts` to use `uploadWithSignedUrl` where URL signing is needed.
>   - **Misc**:
>     - Updates `handleBatchExportJob.ts`, `handleBlobStorageIntegrationProjectJob.ts`, and `coreDataS3ExportQueue.ts` to use `uploadWithSignedUrl` for operations requiring signed URLs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 191ca108a72efcfa16cf20655a1d35e91ab4e277. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->