### PR TITLE
ci: remove pr title check from merge_queue

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -3,7 +3,6 @@ name: "Validate PR Title"
 
 on:
   workflow_dispatch:
-  merge_group:
   pull_request:
     branches:
       - "**"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `merge_group` trigger from PR title validation workflow.
> 
>   - **Workflow Trigger**:
>     - Removes `merge_group` trigger from `.github/workflows/validate-pr-title.yml`, leaving only `workflow_dispatch` and `pull_request` triggers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 29fcfd28f7e3a6b1ea5eb3bb33dc53fa22e3361c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->