### PR TITLE
fix(support): ensure correct assignment of tenant id

### DIFF
--- a/web/src/features/entitlements/constants/entitlements.ts
+++ b/web/src/features/entitlements/constants/entitlements.ts
@@ -15,14 +15,12 @@ const entitlements = [
   "scheduled-blob-exports",
   "prompt-protected-labels",
   "admin-api",
-  "in-app-support",
 ] as const;
 export type Entitlement = (typeof entitlements)[number];
 
 const cloudAllPlansEntitlements: Entitlement[] = [
   "cloud-billing",
   "trace-deletion",
-  "in-app-support",
 ];
 
 const selfHostedAllPlansEntitlements: Entitlement[] = [

--- a/web/src/features/support-chat/IntroSection.tsx
+++ b/web/src/features/support-chat/IntroSection.tsx
@@ -16,7 +16,8 @@ import { Separator } from "@/src/components/ui/separator";
 import { usePlan } from "@/src/features/entitlements/hooks";
 import { isCloudPlan } from "@langfuse/shared";
 import { useUiCustomization } from "@/src/ee/features/ui-customization/useUiCustomization";
-import { useHasEntitlement } from "@/src/features/entitlements/hooks";
+
+import { env } from "@/src/env.mjs";
 
 type SupportType = "in-app-support" | "custom" | "community";
 
@@ -27,7 +28,14 @@ export function IntroSection({
   displayDensity?: "default" | "compact";
 }) {
   const uiCustomization = useUiCustomization();
-  const hasInAppSupportEntitlement = useHasEntitlement("in-app-support");
+
+  // Note: We previously added an entitlement for in-app support, but removed it for now.
+  //       The issue was that on global routes e.g., https://langfuse.com/setup, the entitlement
+  //       hook would not have access to an org or project an therefore no plan, always returning
+  //       false if asked. However on these pages, the in-app-chat should be available.
+  //       Therefore we now check for whether wer are in a cloud deployment instead.
+  // const hasInAppSupportEntitlement = useHasEntitlement("in-app-support");
+  const hasInAppSupportEntitlement = !!env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
   const plan = usePlan();
 
   const supportType: SupportType = useMemo(() => {

--- a/web/src/features/support-chat/SupportFormSection.tsx
+++ b/web/src/features/support-chat/SupportFormSection.tsx
@@ -33,7 +33,7 @@ import {
   SelectValue,
 } from "@/src/components/ui/select";
 import { Textarea } from "@/src/components/ui/textarea";
-import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
+import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { useMemo, useState } from "react";
 
 import {
@@ -54,7 +54,7 @@ export function SupportFormSection({
   onCancel: () => void;
   onSuccess: () => void;
 }) {
-  const projectId = useProjectIdFromURL();
+  const { organization, project } = useQueryProjectOrOrganization();
 
   // Tracks whether we've already warned about a short message
   const [warnedShortOnce, setWarnedShortOnce] = useState(false);
@@ -189,7 +189,8 @@ export function SupportFormSection({
         integrationType: parsed.integrationType,
         message: parsed.message,
         url: window.location.href,
-        projectId,
+        organizationId: organization?.id,
+        projectId: project?.id,
         browserMetadata: {
           userAgent: navigator.userAgent,
           platform: navigator.platform,

--- a/web/src/features/support-chat/plain/plainClient.ts
+++ b/web/src/features/support-chat/plain/plainClient.ts
@@ -88,7 +88,7 @@ function unwrap<T>(label: string, res: { data?: T; error?: unknown }): T {
   return res.data;
 }
 
-function tenantExternalId(orgId: string, region: string) {
+export function generateTenantExternalId(orgId: string, region: string) {
   return `cloud_${region}_org_${orgId}`;
 }
 
@@ -163,7 +163,7 @@ export async function syncTenantsAndTiers(
 
   await Promise.all(
     user.organizations.map(async (org: Organization) => {
-      const extId = tenantExternalId(org.id, region);
+      const extId = generateTenantExternalId(org.id, region);
       const upsertTenantRes = await client.upsertTenant({
         identifier: { externalId: extId },
         name: `${region} - ${org.name}`,
@@ -257,7 +257,7 @@ export async function syncCustomerTenantMemberships(
     .filter((id) => id?.startsWith(regionPrefix));
 
   const targetTenantIds: string[] = user.organizations.map((org) =>
-    tenantExternalId(org.id, region),
+    generateTenantExternalId(org.id, region),
   );
 
   const toRemove = existingTenantIdsInRegion.filter(
@@ -379,6 +379,7 @@ export async function createSupportThread(
     url?: string;
     integrationType?: string;
     attachmentIds?: string[];
+    tenantExternalId?: string;
   },
 ): Promise<CreateSupportThreadResult> {
   const { client } = ctx;
@@ -402,6 +403,9 @@ export async function createSupportThread(
     customerIdentifier: { emailAddress: input.email },
     components,
     threadFields,
+    tenantIdentifier: input.tenantExternalId
+      ? { externalId: input.tenantExternalId }
+      : undefined,
     attachmentIds: attachmentIds.length ? attachmentIds : undefined,
   });
 
@@ -416,6 +420,9 @@ export async function createSupportThread(
       title: input.title,
       customerIdentifier: { emailAddress: input.email },
       components,
+      tenantIdentifier: input.tenantExternalId
+        ? { externalId: input.tenantExternalId }
+        : undefined,
       attachmentIds: attachmentIds.length ? attachmentIds : undefined,
     });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor support chat to use cloud region for entitlement checks and include organization ID in support threads.
> 
>   - **Behavior**:
>     - Removed `in-app-support` entitlement from `entitlements.ts` and `cloudAllPlansEntitlements`.
>     - Updated `IntroSection.tsx` to check `env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` instead of `in-app-support` entitlement.
>     - Updated `SupportFormSection.tsx` to include `organizationId` and `projectId` in support thread creation.
>   - **Functions**:
>     - Renamed `tenantExternalId()` to `generateTenantExternalId()` in `plainClient.ts`.
>     - Updated `createSupportThread()` in `plainClient.ts` to include `tenantExternalId`.
>   - **Router**:
>     - Updated `plainRouter.ts` to validate organization and project access before creating support threads.
>     - Added `generateTenantExternalId` usage in `plainRouter.ts` for tenant identification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 34f2ce805f4a7b85811fe44208df006903f90c5f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->