### PR TITLE
fix: make redis recently-processed cache cluster-safe

### DIFF
--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -226,6 +226,8 @@ export const ingestionQueueProcessorBuilder = (
       }
 
       // Set "seen" keys in Redis to avoid reprocessing for fast updates.
+      // We use Promise.all internally instead of a redis.pipeline since autoPipelining should handle it correctly
+      // while being redis cluster aware.
       if (env.LANGFUSE_ENABLE_REDIS_SEEN_EVENT_CACHE === "true" && redis) {
         try {
           await Promise.all(

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -227,17 +227,25 @@ export const ingestionQueueProcessorBuilder = (
 
       // Set "seen" keys in Redis to avoid reprocessing for fast updates.
       if (env.LANGFUSE_ENABLE_REDIS_SEEN_EVENT_CACHE === "true" && redis) {
-        const pipeline = redis.pipeline();
-        for (const event of eventFiles) {
-          const key = event.file.split("/").pop() ?? "";
-          pipeline.set(
-            `langfuse:ingestion:recently-processed:${job.data.payload.authCheck.scope.projectId}:${job.data.payload.data.type}:${job.data.payload.data.eventBodyId}:${key?.replace(".json", "")}`,
-            "1",
-            "EX",
-            60 * 5, // 5 minutes
+        try {
+          await Promise.all(
+            eventFiles
+              .map((e) => e.file.split("/").pop() ?? "")
+              .map((key) =>
+                redis!.set(
+                  `langfuse:ingestion:recently-processed:${job.data.payload.authCheck.scope.projectId}:${job.data.payload.data.type}:${job.data.payload.data.eventBodyId}:${key.replace(".json", "")}`,
+                  "1",
+                  "EX",
+                  60 * 5, // 5 minutes
+                ),
+              ),
+          );
+        } catch (e) {
+          logger.warn(
+            `Failed to set recently-processed cache. Continuing processing.`,
+            e,
           );
         }
-        await pipeline.exec();
       }
 
       // Perform merge of those events


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Make Redis recently-processed cache cluster-safe in `ingestionQueue.ts` by using `Promise.all()` instead of `redis.pipeline()`.
> 
>   - **Behavior**:
>     - Replaces `redis.pipeline()` with `Promise.all()` in `ingestionQueueProcessorBuilder` to make Redis cache cluster-safe.
>     - Logs a warning if setting the recently-processed cache fails, allowing processing to continue.
>   - **Misc**:
>     - Removes unused `pipeline.exec()` call.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ad60a0d482f14436ce88cc884fb7eac7ef48fbe3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->