### PR TITLE
fix(ci): specify types tightly to not block merge queue

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -2,10 +2,14 @@
 name: "Validate PR Title"
 
 on:
-  workflow_dispatch:
   pull_request:
     branches:
       - "**"
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
 
 jobs:
   validate-pr-title:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Specify PR event types in `validate-pr-title.yml` to optimize CI workflow triggers.
> 
>   - **CI Workflow**:
>     - Updates `.github/workflows/validate-pr-title.yml` to specify PR event types: `opened`, `edited`, `synchronize`, `reopened`.
>     - Removes `workflow_dispatch` trigger from the workflow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 750f0b43dacc44c5290dc29ad0b34644fd145a7a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->