### PR TITLE
fix(trace): jumptoplayground can cause infinite loop

### DIFF
--- a/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -116,13 +116,17 @@ export const JumpToPlaygroundButton: React.FC<JumpToPlaygroundButtonProps> = (
     return modelProviderMap;
   }, [apiKeys.data]);
 
+  const promptData = props.source === "prompt" ? props.prompt : null;
+  const generationData =
+    props.source === "generation" ? props.generation : null;
+
   useEffect(() => {
-    if (props.source === "prompt") {
-      setCapturedState(parsePrompt(props.prompt));
-    } else if (props.source === "generation") {
-      setCapturedState(parseGeneration(props.generation, modelToProviderMap));
+    if (promptData) {
+      setCapturedState(parsePrompt(promptData));
+    } else if (generationData) {
+      setCapturedState(parseGeneration(generationData, modelToProviderMap));
     }
-  }, [props, modelToProviderMap]);
+  }, [promptData, generationData, modelToProviderMap]);
 
   useEffect(() => {
     if (capturedState) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes infinite loop in `JumpToPlaygroundButton.tsx` by refactoring `useEffect` dependencies.
> 
>   - **Behavior**:
>     - Fixes infinite loop in `JumpToPlaygroundButton.tsx` by refactoring `useEffect` dependencies.
>     - Extracts `promptData` and `generationData` from `props` to avoid unnecessary re-renders.
>   - **Code Quality**:
>     - Refactors `useEffect` to depend on `promptData` and `generationData` instead of `props`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6be3960f4d03142d47acb4f0b7ba0e9a639c0ab6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->