### PR TITLE
chore: terminate tokenizer workers before freeing them from memory

### DIFF
--- a/worker/src/utils/shutdown.ts
+++ b/worker/src/utils/shutdown.ts
@@ -37,9 +37,6 @@ export const onShutdown: NodeJS.SignalsListener = async (signal) => {
   // Shutdown clickhouse connections
   await ClickHouseClientManager.getInstance().closeAllConnections();
 
-  freeAllTokenizers();
-  logger.info("All tokenizers are cleaned up from memory.");
-
   // Shutdown tokenization worker threads
   try {
     await getTokenCountWorkerManager().terminate();
@@ -47,6 +44,9 @@ export const onShutdown: NodeJS.SignalsListener = async (signal) => {
   } catch (error) {
     logger.error("Error terminating token count worker threads", error);
   }
+
+  freeAllTokenizers();
+  logger.info("All tokenizers are cleaned up from memory.");
 
   logger.info("Shutdown complete, exiting process...");
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reorder `freeAllTokenizers()` call in `onShutdown` to occur after terminating tokenization worker threads in `shutdown.ts`.
> 
>   - **Behavior**:
>     - Move `freeAllTokenizers()` call in `onShutdown` in `shutdown.ts` to occur after terminating tokenization worker threads.
>     - Ensures tokenizers are freed from memory only after worker threads are terminated.
>   - **Logging**:
>     - Adjust log message order to reflect new shutdown sequence in `shutdown.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c08bbfcfd5ea5f4854b344f9a009e67024438cce. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->