### PR TITLE
fix(dataset-run-items): pagination for single dataset run detail view

### DIFF
--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -531,14 +531,24 @@ const getDatasetRunItemsTableInternal = async <T>(
     datasetRunItemsTableUiColumnDefinitions,
   );
 
-  const query = `
+  const query =
+    opts.select === "rows"
+      ? `
+    SELECT *
+    FROM (
+      SELECT
+        ${selectString}
+      FROM dataset_run_items_rmt dri 
+      WHERE ${appliedFilter.query}
+      ${orderByClause}
+      LIMIT 1 BY dri.project_id, dri.dataset_id, dri.dataset_run_id, dri.dataset_item_id
+    ) AS deduplicated
+    ${limit !== undefined && offset !== undefined ? `LIMIT ${limit} OFFSET ${offset}` : ""};`
+      : `
     SELECT
       ${selectString}
     FROM dataset_run_items_rmt dri 
-    WHERE ${appliedFilter.query}
-    ${orderByClause}
-    ${opts.select === "rows" ? "LIMIT 1 BY dri.project_id, dri.dataset_id, dri.dataset_run_id, dri.dataset_item_id" : ""}
-    ${limit !== undefined && offset !== undefined ? `LIMIT ${limit} OFFSET ${offset}` : ""};`;
+    WHERE ${appliedFilter.query};`;
 
   const res = await queryClickhouse<T>({
     query,

--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -554,6 +554,7 @@ const getDatasetRunItemsTableInternal = async <T>(
     query,
     params: {
       ...appliedFilter.params,
+      ...(limit !== undefined && offset !== undefined ? { limit, offset } : {}),
     },
     tags: {
       ...(opts.tags ?? {}),

--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -1442,6 +1442,28 @@ describe("Fetch datasets for UI presentation", () => {
     expect(secondRunItem.datasetItemId).toEqual(datasetItemId2);
     expect(secondRunItem.trace?.id).toEqual(traceId2);
     expect(secondRunItem.observation?.id).toEqual(observationId);
+
+    // Test pagination
+    const page1 = await getDatasetRunItemsByDatasetIdCh({
+      projectId: projectId,
+      datasetId: datasetId,
+      filter: [],
+      limit: 1,
+      offset: 0,
+    });
+    expect(page1).toHaveLength(1);
+
+    const page2 = await getDatasetRunItemsByDatasetIdCh({
+      projectId: projectId,
+      datasetId: datasetId,
+      filter: [],
+      limit: 1,
+      offset: 1,
+    });
+    expect(page2).toHaveLength(1);
+
+    // Verify no overlap
+    expect(page1[0].id).not.toEqual(page2[0].id);
   });
 
   it("should fetch dataset items correctly", async () => {

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -1069,7 +1069,9 @@ export const datasetRouter = createTRPCRouter({
           ],
           limit: input.limit ?? undefined,
           offset:
-            input.page && input.limit ? input.page * input.limit : undefined,
+            input.page !== undefined && input.limit !== undefined
+              ? input.page * input.limit
+              : undefined,
         }),
         getDatasetRunItemsCountByDatasetIdCh({
           projectId: input.projectId,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add pagination support for dataset run items in single dataset run detail view, with updated query logic and test cases.
> 
>   - **Behavior**:
>     - Adds pagination support to `getDatasetRunItemsTableInternal` in `dataset-run-items.ts` for single dataset run detail view.
>     - Updates query logic to handle `LIMIT` and `OFFSET` for `rows` selection.
>   - **Tests**:
>     - Adds pagination test cases in `dataset-service.servertest.ts` to verify no overlap between pages.
>   - **Misc**:
>     - Adjusts `offset` calculation in `dataset-router.ts` to ensure correct pagination behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 890d3ece097af15bdbabb6db05c9c0e96a4f030d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->