### PR TITLE
fix(traces): tag assignment opening trace detail

### DIFF
--- a/web/src/features/tag/components/TagManager.tsx
+++ b/web/src/features/tag/components/TagManager.tsx
@@ -106,6 +106,11 @@ const TagManager = ({
             e.stopPropagation();
           }
         }}
+        onKeyDown={(e) => {
+          if (isTableCell) {
+            e.stopPropagation();
+          }
+        }}
       >
         <Label className="text-base capitalize">{itemName} Tags</Label>
         <Command


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `onKeyDown` event handler to `PopoverContent` in `TagManager.tsx` to stop event propagation when `isTableCell` is true.
> 
>   - **Behavior**:
>     - Adds `onKeyDown` event handler to `PopoverContent` in `TagManager.tsx` to stop event propagation when `isTableCell` is true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b795fbabcc1d147877d343fe969ff0a3980d1e89. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->