### PR TITLE
fix(prompts): variables broken when copying prompt content

### DIFF
--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -196,6 +196,7 @@ export function JSONView(props: {
 
 export function CodeView(props: {
   content: string | React.ReactNode[] | undefined | null;
+  originalContent?: string;
   className?: string;
   defaultCollapsed?: boolean;
   title?: string;
@@ -208,9 +209,10 @@ export function CodeView(props: {
     event.preventDefault();
     setIsCopied(true);
     const content =
-      typeof props.content === "string"
+      props.originalContent ??
+      (typeof props.content === "string"
         ? props.content
-        : (props.content?.join("\n") ?? "");
+        : (props.content?.join("\n") ?? ""));
     void copyTextToClipboard(content);
     setTimeout(() => setIsCopied(false), 1000);
 
@@ -326,7 +328,7 @@ export function stringifyJsonNode(node: unknown) {
   try {
     return JSON.stringify(
       node,
-      (key, value) => {
+      (_key, value) => {
         switch (typeof value) {
           case "bigint":
             return String(value) + "n";

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -537,6 +537,7 @@ export const PromptDetail = ({
                         projectId as string,
                         prompt.prompt,
                       )}
+                      originalContent={prompt.prompt}
                       title="Text Prompt"
                     />
                   )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes prompt content copying issue in `CodeView` by adding `originalContent` prop and updates `PromptDetail` to use it.
> 
>   - **Behavior**:
>     - Fixes issue in `CodeView` in `CodeJsonViewer.tsx` where incorrect content was copied by adding `originalContent` prop.
>     - Updates `PromptDetail` in `prompt-detail.tsx` to use `originalContent` prop for `CodeView`.
>   - **Functions**:
>     - Refactors `stringifyJsonNode` in `CodeJsonViewer.tsx` to ignore `key` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d677632b9cc659a4ca3215065653503aeb5c85eb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->