### PR TITLE
fix(trace-ui): make tracetree scrollable again

### DIFF
--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -666,7 +666,7 @@ export function Trace(props: {
                     )}
                   </div>
                 ) : (
-                  <div className="h-full w-full flex-1 flex-col overflow-hidden">
+                  <div className="flex h-full w-full flex-col overflow-hidden">
                     {isGraphViewAvailable && showGraph ? (
                       <ResizablePanelGroup
                         direction="vertical"
@@ -677,9 +677,11 @@ export function Trace(props: {
                           defaultSize={treeGraphSizes[0]}
                           minSize={5}
                           maxSize={95}
-                          className="overflow-y-auto overflow-x-hidden px-2"
+                          className="flex flex-col overflow-hidden px-2"
                         >
-                          <div className="pb-2">{treeOrSearchContent}</div>
+                          <div className="min-h-0 flex-1 overflow-y-auto pb-2">
+                            {treeOrSearchContent}
+                          </div>
                         </ResizablePanel>
 
                         <ResizableHandle className="relative h-px bg-border transition-colors duration-200 after:absolute after:inset-x-0 after:top-0 after:h-1 after:-translate-y-px after:bg-blue-200 after:opacity-0 after:transition-opacity after:duration-200 hover:after:opacity-100 data-[resize-handle-state='drag']:after:opacity-100" />
@@ -697,8 +699,10 @@ export function Trace(props: {
                         </ResizablePanel>
                       </ResizablePanelGroup>
                     ) : (
-                      <div className="h-full w-full overflow-auto px-2">
-                        <div className="pb-2">{treeOrSearchContent}</div>
+                      <div className="flex h-full w-full flex-col overflow-hidden px-2">
+                        <div className="min-h-0 flex-1 overflow-y-auto pb-2">
+                          {treeOrSearchContent}
+                        </div>
                       </div>
                     )}
                   </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes scrollability of trace tree in `Trace` component by adjusting CSS classes for layout and overflow properties.
> 
>   - **Behavior**:
>     - Fixes scrollability of trace tree in `Trace` component in `index.tsx` by adjusting CSS classes.
>     - Ensures `treeOrSearchContent` is wrapped in a scrollable container with `overflow-y-auto`.
>   - **Layout**:
>     - Changes `div` class from `overflow-hidden` to `flex flex-col overflow-hidden` for better layout control.
>     - Wraps `treeOrSearchContent` in `div` with `min-h-0 flex-1 overflow-y-auto pb-2` for scrollability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for eba2d9fc1ef24968f8d0eca636bee584a9760572. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->