### PR TITLE
chore: revert turbo cache

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -43,14 +43,6 @@ jobs:
           node-version: 24
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
-      - name: Setup Turbo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-lint-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-lint-
-            ${{ runner.os }}-turbo-
       - name: install dependencies
         run: |
           pnpm i
@@ -184,25 +176,6 @@ jobs:
           echo "LANGFUSE_INGESTION_QUEUE_DELAY_MS=1" >> .env
           echo "LANGFUSE_CACHE_PROMPT_ENABLED=false" >> .env
           echo "LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS=1" >> .env
-      - name: Setup Turbo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-web-sync-${{ matrix.node-version }}-${{ matrix.postgres-version }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-web-sync-${{ matrix.node-version }}-${{ matrix.postgres-version }}-
-            ${{ runner.os }}-turbo-web-sync-${{ matrix.node-version }}-
-            ${{ runner.os }}-turbo-
-      - name: Cache Next.js builds
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.npm
-            ${{ github.workspace }}/web/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('web/**/*.js', 'web/**/*.jsx', 'web/**/*.ts', 'web/**/*.tsx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}-
-            ${{ runner.os }}-nextjs-${{ matrix.node-version }}-
       - name: Run dev containers
         run: |
           docker compose -f docker-compose.dev.yml up -d
@@ -282,25 +255,6 @@ jobs:
           echo "LANGFUSE_TRACE_DELETE_CONCURRENCY=100" >> .env
           echo "ADMIN_API_KEY=admin-api-key" >> .env
           echo "LANGFUSE_EE_LICENSE_KEY=langfuse_ee_test" >> .env
-      - name: Setup Turbo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-web-async-${{ matrix.node-version }}-${{ matrix.postgres-version }}-${{ matrix.deploy-mode }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-web-async-${{ matrix.node-version }}-${{ matrix.postgres-version }}-${{ matrix.deploy-mode }}-
-            ${{ runner.os }}-turbo-web-async-${{ matrix.node-version }}-${{ matrix.postgres-version }}-
-            ${{ runner.os }}-turbo-
-      - name: Cache Next.js builds
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.npm
-            ${{ github.workspace }}/web/.next/cache
-          key: ${{ runner.os }}-nextjs-async-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('web/**/*.js', 'web/**/*.jsx', 'web/**/*.ts', 'web/**/*.tsx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-async-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}-
-            ${{ runner.os }}-nextjs-async-${{ matrix.node-version }}-
       - name: Run dev containers
         run: |
           docker compose -f docker-compose.dev${{ matrix.deploy-mode }}.yml up -d
@@ -418,24 +372,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_READ }}
           password: ${{ secrets.DOCKERHUB_TOKEN_READ }}
-      - name: Setup Turbo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-e2e-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-e2e-
-            ${{ runner.os }}-turbo-
-      - name: Cache Next.js builds
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.npm
-            ${{ github.workspace }}/web/.next/cache
-          key: ${{ runner.os }}-nextjs-e2e-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('web/**/*.js', 'web/**/*.jsx', 'web/**/*.ts', 'web/**/*.tsx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-e2e-${{ hashFiles('**/pnpm-lock.yaml') }}-
-            ${{ runner.os }}-nextjs-e2e-
       - name: install dependencies
         run: |
           pnpm install
@@ -496,24 +432,6 @@ jobs:
           node-version: 24
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
-      - name: Setup Turbo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-e2e-server-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-e2e-server-
-            ${{ runner.os }}-turbo-
-      - name: Cache Next.js builds
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.npm
-            ${{ github.workspace }}/web/.next/cache
-          key: ${{ runner.os }}-nextjs-e2e-server-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('web/**/*.js', 'web/**/*.jsx', 'web/**/*.ts', 'web/**/*.tsx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-e2e-server-${{ hashFiles('**/pnpm-lock.yaml') }}-
-            ${{ runner.os }}-nextjs-e2e-server-
       - name: install dependencies
         run: |
           pnpm install


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reverts Turbo cache setup in `pipeline.yml`, affecting multiple CI/CD jobs.
> 
>   - **Workflow Changes**:
>     - Remove Turbo cache setup from `pipeline.yml`.
>     - Affects jobs: `lint`, `tests-web-sync`, `tests-web-async`, `e2e-tests`, `e2e-server-tests`, and `test-docker-build`.
>     - Removes `actions/cache@v4` usage for `.turbo` path and related cache keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5fe0b7aac23b7dff04211a59e2fde6585b369d56. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->