### PR TITLE
fix(trace-timeline): cannot select items other than the first 2

### DIFF
--- a/web/src/components/trace/TraceTimelineView.tsx
+++ b/web/src/components/trace/TraceTimelineView.tsx
@@ -324,6 +324,7 @@ function TraceTreeItem({
       key={`observation-${observation.id}`}
       itemId={`observation-${observation.id}`}
       onClick={(e) => {
+        e.stopPropagation();
         const isIconClick = (e.target as HTMLElement).closest(
           "svg.MuiSvgIcon-root",
         );
@@ -642,6 +643,7 @@ export function TraceTimelineView({
                       "absolute left-3 top-1/2 z-10 -translate-y-1/2",
                   }}
                   onClick={(e) => {
+                    e.stopPropagation();
                     const isIconClick = (e.target as HTMLElement).closest(
                       "svg.MuiSvgIcon-root",
                     );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes selection issue in `TraceTreeItem` and `TraceTimelineView` by stopping event propagation on item click.
> 
>   - **Behavior**:
>     - Fixes issue in `TraceTreeItem` and `TraceTimelineView` where only the first two items could be selected by adding `e.stopPropagation()` to the `onClick` event handlers.
>   - **Misc**:
>     - No changes to logic or data handling, only event handling adjustment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e1e306012b0677ed3425d6cce60cef07035d565a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->