### PR TITLE
fix(home): home screen dashboard text in darkmode barely visible

### DIFF
--- a/web/src/features/dashboard/components/TracesBarListChart.tsx
+++ b/web/src/features/dashboard/components/TracesBarListChart.tsx
@@ -121,7 +121,7 @@ export const TracesBarListChart = ({
               valueFormatter={(number: number) =>
                 Intl.NumberFormat("en-US").format(number).toString()
               }
-              className="mt-6"
+              className="mt-6 [&_*]:text-muted-foreground [&_p]:text-muted-foreground [&_span]:text-muted-foreground"
               showAnimation={true}
               color={"indigo"}
             />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix text visibility in dark mode for `TracesBarListChart` by updating CSS classes.
> 
>   - **UI Fix**:
>     - Update `className` in `TracesBarListChart.tsx` to improve text visibility in dark mode by adding `text-muted-foreground` to all child elements of `BarList`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c458bfb692d92ab731a922d89bfbc9c6c9a85ddc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->