### PR TITLE
perf(dataset-runs-metrics): utilise trace_id bloom filter in filtered observations

### DIFF
--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -312,20 +312,28 @@ const getDatasetRunsTableInternal = async <T>(
         o.start_time,
         o.end_time,
         o.total_cost
-      FROM observations o FINAL
+      FROM observations o
       WHERE o.project_id = {projectId: String}
         AND o.start_time >= (
           SELECT min(dri.dataset_run_created_at) - INTERVAL 1 DAY 
           FROM dataset_run_items_rmt dri 
           WHERE dri.project_id = {projectId: String} 
-            AND dri.dataset_id = {datasetId: String}
+          AND dri.dataset_id = {datasetId: String}
         )
         AND o.start_time <= (
           SELECT max(dri.dataset_run_created_at) + INTERVAL 1 DAY 
           FROM dataset_run_items_rmt dri 
           WHERE dri.project_id = {projectId: String} 
-            AND dri.dataset_id = {datasetId: String}
+          AND dri.dataset_id = {datasetId: String}
         )
+        AND o.trace_id in  (
+          SELECT dri.trace_id
+          FROM dataset_run_items_rmt dri 
+          WHERE dri.project_id = {projectId: String} 
+          AND dri.dataset_id = {datasetId: String}
+        )
+      ORDER BY o.event_ts DESC
+      LIMIT 1 by id, project_id
     ),
   `;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimizes `getDatasetRunsTableInternal` in `dataset-run-items.ts` by filtering observations with a `trace_id` subquery and removing `FINAL` keyword for performance improvement.
> 
>   - **Performance Optimization**:
>     - In `getDatasetRunsTableInternal` in `dataset-run-items.ts`, added a filter on `trace_id` using a subquery to limit observations to those with matching `trace_id` in `dataset_run_items_rmt`.
>     - Removed `FINAL` keyword from `observations` table query to improve performance.
>     - Added `ORDER BY o.event_ts DESC LIMIT 1 by id, project_id` to ensure only the latest observation per `id` and `project_id` is processed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c849ec7f2684dc217ab41677bf344d0f4cb97e57. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->