### PR TITLE
chore(dataset-run-items): clean up deprecated code

### DIFF
--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -317,20 +317,17 @@ const getDatasetRunsTableInternal = async <T>(
         AND o.start_time >= (
           SELECT min(dri.dataset_run_created_at) - INTERVAL 1 DAY 
           FROM dataset_run_items_rmt dri 
-          WHERE dri.project_id = {projectId: String} 
-          AND dri.dataset_id = {datasetId: String}
+          WHERE ${baseFilter.query}
         )
         AND o.start_time <= (
           SELECT max(dri.dataset_run_created_at) + INTERVAL 1 DAY 
           FROM dataset_run_items_rmt dri 
-          WHERE dri.project_id = {projectId: String} 
-          AND dri.dataset_id = {datasetId: String}
+          WHERE ${baseFilter.query}
         )
         AND o.trace_id in  (
           SELECT dri.trace_id
           FROM dataset_run_items_rmt dri 
-          WHERE dri.project_id = {projectId: String} 
-          AND dri.dataset_id = {datasetId: String}
+          WHERE ${baseFilter.query}
         )
       ORDER BY o.event_ts DESC
       LIMIT 1 by id, project_id
@@ -410,6 +407,7 @@ const getDatasetRunsTableInternal = async <T>(
       ...appliedScoresFilter.params,
       ...baseFilter.params,
       ...appliedFilter.params,
+      ...(limit !== undefined && offset !== undefined ? { limit, offset } : {}),
     },
     tags: {
       ...(opts.tags ?? {}),

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -155,13 +155,14 @@ function DatasetCompareRunsTableInternal(props: {
         runId,
         queryKey: getQueryKey(api.datasets.runitemsByRunIdOrItemId, {
           projectId: props.projectId,
+          datasetId: props.datasetId,
           datasetRunId: runId,
           datasetItemIds: baseDatasetItems.data?.datasetItems.map(
             (item) => item.id,
           ),
         }),
       })),
-    [props.runIds, props.projectId, baseDatasetItems.data],
+    [props.runIds, props.projectId, props.datasetId, baseDatasetItems.data],
   );
 
   // 2. Track changes using onSuccess callback in the queries instead of useEffect
@@ -204,6 +205,7 @@ function DatasetCompareRunsTableInternal(props: {
     const query = api.datasets.runitemsByRunIdOrItemId.useQuery(
       {
         projectId: props.projectId,
+        datasetId: props.datasetId,
         datasetRunId: runId,
         datasetItemIds: baseDatasetItems.data?.datasetItems.map(
           (item) => item.id,

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -968,7 +968,7 @@ export const datasetRouter = createTRPCRouter({
       z
         .object({
           projectId: z.string(),
-          datasetId: z.string().optional(), // require for new procedures
+          datasetId: z.string().optional(),
           datasetRunId: z.string().optional(),
           datasetItemId: z.string().optional(),
           datasetItemIds: z.array(z.string()).optional(),
@@ -1200,50 +1200,6 @@ export const datasetRouter = createTRPCRouter({
       );
 
       return datasetRuns;
-    }),
-  getRunLevelScoreKeysAndProps: protectedProjectProcedure
-    .input(
-      z.object({
-        projectId: z.string(),
-        datasetId: z.string(),
-      }),
-    )
-    .query(async ({ input, ctx }) => {
-      const dataset = await ctx.prisma.dataset.findUnique({
-        where: {
-          id_projectId: {
-            id: input.datasetId,
-            projectId: input.projectId,
-          },
-        },
-        select: {
-          id: true,
-          createdAt: true,
-        },
-      });
-
-      if (!dataset) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Dataset not found",
-        });
-      }
-
-      const datasetRuns = await ctx.prisma.datasetRuns.findMany({
-        where: {
-          datasetId: input.datasetId,
-          projectId: input.projectId,
-        },
-        select: {
-          id: true,
-        },
-      });
-
-      if (datasetRuns.length === 0) {
-        return [];
-      }
-
-      return [];
     }),
   upsertRemoteExperiment: protectedProjectProcedure
     .input(

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -968,7 +968,7 @@ export const datasetRouter = createTRPCRouter({
       z
         .object({
           projectId: z.string(),
-          datasetId: z.string().optional(),
+          datasetId: z.string().optional(), // require for new procedures
           datasetRunId: z.string().optional(),
           datasetItemId: z.string().optional(),
           datasetItemIds: z.array(z.string()).optional(),

--- a/web/src/features/datasets/server/service.ts
+++ b/web/src/features/datasets/server/service.ts
@@ -24,21 +24,15 @@ import Decimal from "decimal.js";
 export const datasetRunsTableSchema = z.object({
   projectId: z.string(),
   datasetId: z.string(),
-  // LFE-6397: deprecated, remove runIds
-  runIds: z.array(z.string()).optional(),
-  // LFE-6397: remove optional
-  filter: z.array(singleFilter).optional(),
+  filter: z.array(singleFilter),
   ...optionalPaginationZod,
 });
 
 export const datasetRunTableMetricsSchema = z.object({
   projectId: z.string(),
   datasetId: z.string(),
-  // LFE-6397: remove optional
-  runIds: z.array(z.string()).optional(),
+  runIds: z.array(z.string()),
   filter: z.array(singleFilter),
-  // LFE-6397: deprecated, remove optional pagination
-  ...optionalPaginationZod,
 });
 
 export type DatasetRunsTableInput = z.infer<typeof datasetRunsTableSchema>;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Clean up deprecated code related to dataset run items by removing unused queries, updating schemas, and refining query logic.
> 
>   - **Behavior**:
>     - Removed deprecated `getRunLevelScoreKeysAndProps` query from `dataset-router.ts`.
>     - Updated `getDatasetRunsTableInternal` in `dataset-run-items.ts` to use `baseFilter.query` instead of hardcoded project and dataset IDs.
>     - Added `limit` and `offset` parameters to query parameters in `getDatasetRunsTableInternal`.
>   - **Schemas**:
>     - Removed optional `runIds` and `filter` from `datasetRunsTableSchema` and `datasetRunTableMetricsSchema` in `service.ts`.
>   - **Components**:
>     - Added `datasetId` to `queryKey` in `DatasetCompareRunsTableInternal` in `DatasetCompareRunsTable.tsx`.
>     - Updated dependencies for `useMemo` in `DatasetCompareRunsTableInternal` to include `datasetId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cd5c39a1f1d28681da37390ba42f8a73c9bd3662. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->