### PR TITLE
feat(support): Send acknowledgement email to user on thread create

### DIFF
--- a/web/src/features/support-chat/SupportFormSection.tsx
+++ b/web/src/features/support-chat/SupportFormSection.tsx
@@ -210,7 +210,7 @@ export function SupportFormSection({
   };
 
   const messageIsShortAfterWarning =
-    warnedShortOnce && (form.getValues("message") ?? "").trim().length < 20;
+    warnedShortOnce && (form.getValues("message") ?? "").trim().length < 50;
 
   // --- Compact attachment row helpers
   const totalMB = (totalUploadBytes / (1024 * 1024)).toFixed(2);

--- a/web/src/features/support-chat/SupportFormSection.tsx
+++ b/web/src/features/support-chat/SupportFormSection.tsx
@@ -127,7 +127,7 @@ export function SupportFormSection({
     const parsed: SupportFormValues = SupportFormSchema.parse(values);
     const msgLen = (parsed.message ?? "").trim().length;
 
-    if (msgLen < 20 && !warnedShortOnce) {
+    if (msgLen < 50 && !warnedShortOnce) {
       setWarnedShortOnce(true);
       return;
     }
@@ -385,37 +385,6 @@ export function SupportFormSection({
                           : "Please explain as fully as possible what you're aiming to do, and what you'd like help with."
                       }
                     />
-                    <div className="absolute inset-x-2 bottom-2 pr-1">
-                      <Dropzone
-                        className="border-none p-0 text-left"
-                        maxFiles={5}
-                        maxSize={1024 * 1024 * 10}
-                        onDrop={(accepted) => setFiles(accepted)}
-                        onError={console.error}
-                        src={files}
-                      >
-                        {/* Small, single-line trigger */}
-                        <DropzoneEmptyState>
-                          <div className="flex w-full cursor-pointer items-center justify-start gap-2 p-2 text-xs">
-                            <Paperclip className="h-4 w-4" />
-                            <span className="truncate">
-                              {hasFiles
-                                ? `${files!.length} file${files!.length > 1 ? "s" : ""} • ${totalMB} MB`
-                                : "Attach files"}
-                            </span>
-                          </div>
-                        </DropzoneEmptyState>
-                        {/* Keep content area minimal; we still allow preview slot if needed */}
-                        <DropzoneContent>
-                          <div className="flex w-full cursor-pointer items-center justify-start gap-2 p-2 text-xs">
-                            <Paperclip className="h-4 w-4" />
-                            <span className="truncate">
-                              {hasFiles ? "Add more" : "Attach files"}
-                            </span>
-                          </div>
-                        </DropzoneContent>
-                      </Dropzone>
-                    </div>
                   </div>
                 </FormControl>
 
@@ -432,37 +401,65 @@ export function SupportFormSection({
                 )}
 
                 <FormMessage />
+
+                <Dropzone
+                  className="mt-1 border-none p-0 text-left"
+                  maxFiles={5}
+                  maxSize={1024 * 1024 * 10}
+                  onDrop={(accepted) => setFiles(accepted)}
+                  onError={console.error}
+                  src={files}
+                >
+                  {/* Small, single-line trigger */}
+                  <DropzoneEmptyState>
+                    <div className="flex w-full cursor-pointer items-center justify-start gap-2 p-2 text-xs">
+                      <Paperclip className="h-4 w-4" />
+                      <span className="truncate">
+                        {hasFiles
+                          ? `${files!.length} file${files!.length > 1 ? "s" : ""} • ${totalMB} MB`
+                          : "Attach files"}
+                      </span>
+                    </div>
+                  </DropzoneEmptyState>
+                  {/* Keep content area minimal; we still allow preview slot if needed */}
+                  <DropzoneContent>
+                    <div className="flex w-full cursor-pointer items-center justify-start gap-2 p-2 text-xs">
+                      <Paperclip className="h-4 w-4" />
+                      <span className="truncate">Attach files</span>
+                    </div>
+                  </DropzoneContent>
+                </Dropzone>
+
+                {files && files.length > 0 && (
+                  <div className="p-0 text-left text-sm font-medium">
+                    <div className="mb-2 text-xs font-medium text-muted-foreground">
+                      Attached files
+                    </div>
+                    {files?.map((file) => (
+                      <div
+                        key={file.name}
+                        className="flex flex-row items-center justify-start gap-2 text-xs"
+                      >
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-xs"
+                          onClick={() =>
+                            setFiles(files.filter((f) => f.name !== file.name))
+                          }
+                          className="p-0"
+                        >
+                          <span className="sr-only">Remove file</span>
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                        {file.name}
+                      </div>
+                    ))}
+                  </div>
+                )}
               </FormItem>
             )}
           />
-
-          {files && files.length > 0 && (
-            <div className="p-0 text-left text-sm font-medium">
-              <div className="mb-2 text-xs font-medium text-muted-foreground">
-                Attached files
-              </div>
-              {files?.map((file) => (
-                <div
-                  key={file.name}
-                  className="flex flex-row items-center justify-start gap-2 text-xs"
-                >
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-xs"
-                    onClick={() =>
-                      setFiles(files.filter((f) => f.name !== file.name))
-                    }
-                    className="p-0"
-                  >
-                    <span className="sr-only">Remove file</span>
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </Button>
-                  {file.name}
-                </div>
-              ))}
-            </div>
-          )}
 
           {/* Actions */}
           <div className="flex flex-row gap-2">
@@ -496,6 +493,13 @@ export function SupportFormSection({
               )}
             </Button>
           </div>
+
+          {isSubmittingLocal && (
+            <div className="text-xs text-muted-foreground">
+              This can take a few seconds — hang tight while we submit your
+              request.
+            </div>
+          )}
         </form>
       </Form>
     </div>

--- a/web/src/features/support-chat/plain/plainClient.ts
+++ b/web/src/features/support-chat/plain/plainClient.ts
@@ -478,7 +478,7 @@ export async function createThreadEvent(
 }
 
 // ===== Notifications (best-effort / non-throwing) =====
-export async function postUserMessage(
+export async function replyToThread(
   ctx: PlainCtx,
   input: {
     threadId: string;
@@ -498,20 +498,22 @@ export async function postUserMessage(
         ? input.attachmentIds
         : undefined,
     impersonation:
-      input.impersonate === false
-        ? undefined
-        : {
+      input.impersonate === true
+        ? {
             asCustomer: {
               customerIdentifier: {
                 emailAddress: input.userEmail,
               },
             },
-          },
+          }
+        : undefined,
   });
 
   if (res.error) {
     logger.error("replyToThread failed", describeSdkError(res.error));
   }
+
+  return res;
 }
 
 // ===== Threads (no initial message) =====

--- a/web/src/features/support-chat/plain/plainClient.ts
+++ b/web/src/features/support-chat/plain/plainClient.ts
@@ -601,3 +601,24 @@ export async function createThread(
     createdWithThreadFields: true,
   };
 }
+
+// ===== Auto acknowledgement (best-effort / non-throwing) =====
+export async function postAutoAcknowledgement(
+  ctx: PlainCtx,
+  input: {
+    threadId: string;
+  },
+) {
+  const { client } = ctx;
+  const text =
+    "Thank you for your message. We will get back to you as soon as possible. If you want to add any additional context to your request, just answer t this email.";
+  const res = await client.replyToThread({
+    threadId: input.threadId,
+    textContent: text,
+    markdownContent: text,
+  });
+
+  if (res.error) {
+    logger.error("postAutoAcknowledgement failed", describeSdkError(res.error));
+  }
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds acknowledgment email feature for support thread creation and updates support form message length and attachment handling.
> 
>   - **Behavior**:
>     - Sends acknowledgment email to user on support thread creation using `sendAcknowledgementEmail()` in `plainClient.ts`.
>     - Increases minimum message length from 20 to 50 characters in `SupportFormSection.tsx`.
>   - **Functions**:
>     - Adds `sendAcknowledgementEmail()` to send acknowledgment emails.
>     - Adds `createThread()` to create threads without an initial message.
>     - Modifies `replyToThread()` to handle impersonation and attachments.
>   - **UI Changes**:
>     - Moves `Dropzone` for file attachments in `SupportFormSection.tsx`.
>     - Displays a message when submitting in `SupportFormSection.tsx`.
>   - **Misc**:
>     - Changes `attachmentType` to `AttachmentType.Email` in `createAttachmentUploadUrls()` in `plainClient.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 120af5512027f8ebcd88aaa81579b20601ad263e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->