### PR TITLE
fix(home): home screen dashboard text in darkmode barely visible 2

### DIFF
--- a/web/src/features/dashboard/components/UserChart.tsx
+++ b/web/src/features/dashboard/components/UserChart.tsx
@@ -178,7 +178,7 @@ export const UserChart = ({
                     <BarList
                       data={item.data}
                       valueFormatter={item.formatter}
-                      className="mt-2"
+                      className="mt-2 [&_*]:text-muted-foreground [&_p]:text-muted-foreground [&_span]:text-muted-foreground"
                       showAnimation={true}
                       color={"indigo"}
                     />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve text visibility in dark mode for `UserChart` component by updating CSS classes.
> 
>   - **CSS Update**:
>     - Modify `className` in `UserChart` component to improve text visibility in dark mode by adding `text-muted-foreground` to all child elements of `BarList`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d68bf8b8b1dee0729e2814f9ab6ab3432fff1df4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->