### PR TITLE
fix(home): chart axis in dark mode

### DIFF
--- a/web/src/features/dashboard/components/ChartScores.tsx
+++ b/web/src/features/dashboard/components/ChartScores.tsx
@@ -91,6 +91,7 @@ export function ChartScores(props: {
     >
       {!isEmptyTimeSeries({ data: extractedScores }) ? (
         <BaseTimeSeriesChart
+          className="[&_text]:fill-muted-foreground [&_tspan]:fill-muted-foreground"
           agg={props.agg}
           data={extractedScores}
           connectNulls

--- a/web/src/features/dashboard/components/LatencyChart.tsx
+++ b/web/src/features/dashboard/components/LatencyChart.tsx
@@ -173,6 +173,7 @@ export const GenerationLatencyChart = ({
               <>
                 {!isEmptyTimeSeries({ data: item.data }) ? (
                   <BaseTimeSeriesChart
+                    className="[&_text]:fill-muted-foreground [&_tspan]:fill-muted-foreground"
                     agg={agg}
                     data={item.data}
                     connectNulls={true}

--- a/web/src/features/dashboard/components/ModelUsageChart.tsx
+++ b/web/src/features/dashboard/components/ModelUsageChart.tsx
@@ -354,6 +354,7 @@ export const ModelUsageChart = ({
                   />
                 ) : (
                   <BaseTimeSeriesChart
+                    className="[&_text]:fill-muted-foreground [&_tspan]:fill-muted-foreground"
                     agg={agg}
                     data={item.data}
                     showLegend={true}

--- a/web/src/features/dashboard/components/Tooltip.tsx
+++ b/web/src/features/dashboard/components/Tooltip.tsx
@@ -1,7 +1,3 @@
-import {
-  ChartTooltipFrame,
-  ChartTooltipRow,
-} from "@tremor/react/dist/components/chart-elements/common/ChartTooltip";
 import { cn } from "@/src/utils/tailwind";
 import { type CustomTooltipProps } from "@tremor/react";
 import { getRandomColor } from "@/src/features/dashboard/utils/getColorsForCategories";
@@ -24,39 +20,29 @@ export const Tooltip = ({
   );
 
   return (
-    <ChartTooltipFrame>
-      <div
-        className={cn(
-          // light
-          "border-b border-tremor-border px-4 py-2",
-          // dark
-          "dark:border-dark-tremor-border",
-        )}
-      >
-        <p
-          className={cn(
-            // common
-            "font-medium",
-            // light
-            "text-tremor-content-emphasis",
-            // dark
-            "dark:text-dark-tremor-content-emphasis",
-          )}
-        >
+    <div className="rounded-md border border-border bg-background opacity-100 shadow-lg">
+      <div className={cn("border-b border-border px-4 py-2")}>
+        <p className={cn("text-sm font-medium text-muted-foreground")}>
           {label}
         </p>
       </div>
 
       <div className={cn("space-y-1 px-4 py-2")}>
         {sortedPayload.map(({ name, value, color }, index) => (
-          <ChartTooltipRow
-            key={`${index}`}
-            value={formatter(Number(value))}
-            name={name?.toString() ?? ""}
-            color={color ?? getRandomColor()}
-          />
+          <div key={`${index}`} className="flex items-center gap-2">
+            <div
+              className="h-3 w-3 flex-shrink-0 rounded-sm"
+              style={{ backgroundColor: color ?? getRandomColor() }}
+            />
+            <span className="flex-1 text-sm text-muted-foreground">
+              {name?.toString() ?? ""}
+            </span>
+            <span className="text-sm font-medium text-muted-foreground">
+              {formatter(Number(value))}
+            </span>
+          </div>
         ))}
       </div>
-    </ChartTooltipFrame>
+    </div>
   );
 };

--- a/web/src/features/dashboard/components/Tooltip.tsx
+++ b/web/src/features/dashboard/components/Tooltip.tsx
@@ -21,13 +21,13 @@ export const Tooltip = ({
 
   return (
     <div className="rounded-md border border-border bg-background opacity-100 shadow-lg">
-      <div className={cn("border-b border-border px-4 py-2")}>
+      <div className={cn("border-b border-border px-3 py-1.5")}>
         <p className={cn("text-sm font-medium text-muted-foreground")}>
           {label}
         </p>
       </div>
 
-      <div className={cn("space-y-1 px-4 py-2")}>
+      <div className={cn("space-y-1 px-3 py-1.5")}>
         {sortedPayload.map(({ name, value, color }, index) => (
           <div key={`${index}`} className="flex items-center gap-2">
             <div

--- a/web/src/features/dashboard/components/TracesTimeSeriesChart.tsx
+++ b/web/src/features/dashboard/components/TracesTimeSeriesChart.tsx
@@ -177,7 +177,7 @@ export const TracesAndObservationsTimeSeriesChart = ({
                 />
                 {!isEmptyTimeSeries({ data: item.data }) ? (
                   <BaseTimeSeriesChart
-                    className="h-full min-h-80 self-stretch"
+                    className="h-full min-h-80 self-stretch [&_text]:fill-muted-foreground [&_tspan]:fill-muted-foreground"
                     agg={agg}
                     data={item.data}
                     connectNulls={true}

--- a/web/src/features/dashboard/components/score-analytics/NumericScoreTimeSeriesChart.tsx
+++ b/web/src/features/dashboard/components/score-analytics/NumericScoreTimeSeriesChart.tsx
@@ -108,6 +108,7 @@ export function NumericScoreTimeSeriesChart(props: {
   }) ? (
     <Card className="min-h-[9rem] w-full flex-1 rounded-tremor-default border">
       <BaseTimeSeriesChart
+        className="[&_text]:fill-muted-foreground [&_tspan]:fill-muted-foreground"
         agg={props.agg}
         data={extractedScores}
         connectNulls

--- a/web/src/features/scores/components/ScoreChart.tsx
+++ b/web/src/features/scores/components/ScoreChart.tsx
@@ -38,7 +38,7 @@ export function CategoricalChart(props: {
     >
       <BarChart
         className={cn(
-          "max-h-full min-h-0 min-w-0 max-w-full",
+          "max-h-full min-h-0 min-w-0 max-w-full [&_text]:fill-muted-foreground [&_tspan]:fill-muted-foreground",
           props.chartClass,
         )}
         data={props.chartData}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes chart text color in dark mode by adding CSS class to chart components and refactors `Tooltip` component.
> 
>   - **Behavior**:
>     - Adds CSS class `[&_text]:fill-muted-foreground [&_tspan]:fill-muted-foreground` to `BaseTimeSeriesChart` in `ChartScores.tsx`, `LatencyChart.tsx`, `ModelUsageChart.tsx`, `TracesTimeSeriesChart.tsx`, `NumericScoreTimeSeriesChart.tsx`, and `ScoreChart.tsx` to fix text color in dark mode.
>   - **Components**:
>     - Refactors `Tooltip` in `Tooltip.tsx` to remove unused imports and simplify structure.
>     - Removes `ChartTooltipFrame` and `ChartTooltipRow` from `Tooltip.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a0ed3b7cbbe3c2bec909e481a8236d7724ee8226. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->