### PR TITLE
fix(playground): show user-friendly toast notification for JSON prettification; do not report to sentry

### DIFF
--- a/web/src/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
+++ b/web/src/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
@@ -31,6 +31,7 @@ import { api } from "@/src/utils/api";
 
 import { JSONSchemaFormSchema, type LlmSchema } from "@langfuse/shared";
 import { CodeMirrorEditor } from "@/src/components/editor";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 
 const formSchema = z.object({
   name: LLMSchemaNameSchema,
@@ -140,7 +141,11 @@ export const CreateOrEditLLMSchemaDialog: React.FC<
       const prettified = JSON.stringify(parsedJson, null, 2);
       form.setValue("schema", prettified);
     } catch (error) {
-      console.error("Failed to prettify JSON:", error);
+      showErrorToast(
+        "Failed to prettify JSON",
+        "Please verify your input is valid JSON",
+        "WARNING",
+      );
     }
   };
 

--- a/web/src/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
+++ b/web/src/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
@@ -31,6 +31,7 @@ import { api } from "@/src/utils/api";
 
 import { CodeMirrorEditor } from "@/src/components/editor";
 import { JSONSchemaFormSchema, type LlmTool } from "@langfuse/shared";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 
 const formSchema = z.object({
   name: LLMToolNameSchema,
@@ -140,7 +141,11 @@ export const CreateOrEditLLMToolDialog: React.FC<CreateOrEditLLMToolDialog> = (
       const prettified = JSON.stringify(parsedJson, null, 2);
       form.setValue("parameters", prettified);
     } catch (error) {
-      console.error("Failed to prettify JSON:", error);
+      showErrorToast(
+        "Failed to prettify JSON",
+        "Please verify your input is valid JSON",
+        "WARNING",
+      );
     }
   };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace console error logs with user-friendly toast notifications for JSON prettification errors in `CreateOrEditLLMSchemaDialog` and `CreateOrEditLLMToolDialog`.
> 
>   - **Behavior**:
>     - Replace `console.error` with `showErrorToast` for JSON prettification errors in `CreateOrEditLLMSchemaDialog` and `CreateOrEditLLMToolDialog`.
>     - Error message: "Failed to prettify JSON", with suggestion to verify input validity.
>   - **Misc**:
>     - Import `showErrorToast` in `CreateOrEditLLMSchemaDialog.tsx` and `CreateOrEditLLMToolDialog.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0e968978813ac6827da5c2f5974fb8ed01fdd578. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->