### PR TITLE
fix(home): dashboard dark mode score analysis graph

### DIFF
--- a/web/src/features/dashboard/components/score-analytics/NumericScoreHistogram.tsx
+++ b/web/src/features/dashboard/components/score-analytics/NumericScoreHistogram.tsx
@@ -7,11 +7,12 @@ import {
 } from "@langfuse/shared";
 import { createTracesTimeFilter } from "@/src/features/dashboard/lib/dashboard-utils";
 import React from "react";
-import { BarChart } from "@tremor/react";
+import { BarChart, type CustomTooltipProps } from "@tremor/react";
 import { Card } from "@/src/components/ui/card";
 import { getColorsForCategories } from "@/src/features/dashboard/utils/getColorsForCategories";
 import { padChartData } from "@/src/features/dashboard/lib/score-analytics-utils";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
+import { Tooltip } from "@/src/features/dashboard/components/Tooltip";
 
 export function NumericScoreHistogram(props: {
   projectId: string;
@@ -64,12 +65,19 @@ export function NumericScoreHistogram(props: {
   const colors = getColorsForCategories(chartLabels);
   const paddedChartData = padChartData(chartData);
 
+  const TooltipComponent = (tooltipProps: CustomTooltipProps) => (
+    <Tooltip
+      {...tooltipProps}
+      formatter={(value) => Intl.NumberFormat("en-US").format(value).toString()}
+    />
+  );
+
   return histogram.isLoading || !Boolean(chartData.length) ? (
     <NoDataOrLoading isLoading={histogram.isLoading} />
   ) : (
     <Card className="min-h-[9rem] w-full flex-1 rounded-tremor-default border">
       <BarChart
-        className="mt-4"
+        className="mt-4 [&_text]:fill-muted-foreground [&_tspan]:fill-muted-foreground"
         data={paddedChartData}
         index="binLabel"
         categories={chartLabels}
@@ -79,6 +87,7 @@ export function NumericScoreHistogram(props: {
         }
         yAxisWidth={48}
         barCategoryGap={"0%"}
+        customTooltip={TooltipComponent}
       />
     </Card>
   );

--- a/web/src/features/dashboard/components/score-analytics/ScoreAnalytics.tsx
+++ b/web/src/features/dashboard/components/score-analytics/ScoreAnalytics.tsx
@@ -98,7 +98,7 @@ export function ScoreAnalytics(props: {
     >
       {Boolean(scoreKeysAndProps.data?.scoreColumns.length) &&
       Boolean(scoreAnalyticsValues.length) ? (
-        <div className="grid grid-flow-row gap-4">
+        <div className="grid grid-flow-row gap-4 [&_text]:fill-muted-foreground [&_tspan]:fill-muted-foreground">
           {scoreAnalyticsValues.map(({ key: scoreKey }, index) => {
             const scoreData = scoreKeyToData.get(scoreKey);
             if (!scoreData) return null;

--- a/web/src/features/scores/components/ScoreChart.tsx
+++ b/web/src/features/scores/components/ScoreChart.tsx
@@ -1,11 +1,12 @@
 import { compactNumberFormatter } from "@/src/utils/numbers";
 import { getColorsForCategories } from "@/src/features/dashboard/utils/getColorsForCategories";
 import { isEmptyChart } from "@/src/features/dashboard/lib/score-analytics-utils";
-import { BarChart, LineChart } from "@tremor/react";
+import { BarChart, LineChart, type CustomTooltipProps } from "@tremor/react";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 import { Card } from "@/src/components/ui/card";
 import { type ChartBin } from "@/src/features/scores/types";
 import { cn } from "@/src/utils/tailwind";
+import { Tooltip } from "@/src/features/dashboard/components/Tooltip";
 
 export function CategoricalChart(props: {
   chartData: ChartBin[];
@@ -23,6 +24,13 @@ export function CategoricalChart(props: {
     else return "40%";
   };
   const colors = getColorsForCategories(props.chartLabels);
+
+  const TooltipComponent = (tooltipProps: CustomTooltipProps) => (
+    <Tooltip
+      {...tooltipProps}
+      formatter={(value) => Intl.NumberFormat("en-US").format(value).toString()}
+    />
+  );
 
   return isEmptyChart({ data: props.chartData }) ? (
     <NoDataOrLoading
@@ -52,6 +60,7 @@ export function CategoricalChart(props: {
         barCategoryGap={barCategoryGap(props.chartData.length)}
         stack={props.stack ?? true}
         showXAxis={props.showXAxis ?? true}
+        customTooltip={TooltipComponent}
       />
     </Card>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes dark mode text visibility and adds custom tooltips with number formatting to score analysis graphs.
> 
>   - **Dark Mode Fixes**:
>     - Updated text color in `NumericScoreHistogram` and `ScoreAnalytics` to `fill-muted-foreground` for better visibility in dark mode.
>     - Applied text color changes to `CategoricalChart` in `ScoreChart.tsx`.
>   - **Tooltips**:
>     - Added `TooltipComponent` with number formatting to `NumericScoreHistogram` and `CategoricalChart`.
>     - Utilizes `Intl.NumberFormat` for consistent number formatting in tooltips.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for eef61c93afd3006718b4425ec2f7e355bc10876b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->