### PR TITLE
chore: skip otel processing on empty batch

### DIFF
--- a/web/src/__tests__/async/otel-api.servertest.ts
+++ b/web/src/__tests__/async/otel-api.servertest.ts
@@ -210,4 +210,18 @@ describe("/api/public/otel/v1/traces API Endpoint", () => {
       expect(observation!.totalUsage).toBe(2037);
     }, 25_000);
   }, 30_000);
+
+  it("should skip processing for empty resourceSpans", async () => {
+    const payload = {
+      // resourceSpans: []
+    };
+
+    const response = await makeAPICall(
+      "POST",
+      "/api/public/otel/v1/traces",
+      payload,
+    );
+
+    expect(response.status).toBe(200);
+  });
 });

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -90,6 +90,10 @@ export default withMiddlewares({
         }
       }
 
+      if (!resourceSpans || resourceSpans.length === 0) {
+        // Skip processing if list is empty
+      }
+
       const processor = new OtelIngestionProcessor({
         projectId: auth.scope.projectId,
         publicKey: auth.scope.publicKey,

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -91,7 +91,7 @@ export default withMiddlewares({
       }
 
       if (!resourceSpans || resourceSpans.length === 0) {
-        // Skip processing if list is empty
+        return res.status(200).json({});
       }
 
       const processor = new OtelIngestionProcessor({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Skip processing in OpenTelemetry traces API when `resourceSpans` is empty, returning a 200 status.
> 
>   - **Behavior**:
>     - Skips processing in `index.ts` if `resourceSpans` is empty, returning a 200 status with an empty JSON response.
>   - **Tests**:
>     - Adds test in `otel-api.servertest.ts` to verify skipping behavior for empty `resourceSpans`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 232ee9ea6ec3b77c08a6b26f21b7baedb0f9a2ef. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->