### PR TITLE
fix(trace-detail): nested observations not expanded in timeline

### DIFF
--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -251,7 +251,10 @@ export function Trace(props: {
 
   const [expandedItems, setExpandedItems] = useSessionStorage<string[]>(
     `${props.trace.id}-expanded`,
-    [`trace-${props.trace.id}`],
+    [
+      `trace-${props.trace.id}`,
+      ...getNestedObservationKeys(props.observations),
+    ],
   );
 
   // Build UI data once


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes issue with nested observations not being expanded in the timeline view by default in the `Trace` component.
> 
>   - **Behavior**:
>     - Fixes issue where nested observations were not expanded in the timeline view by default.
>     - `expandedItems` in `Trace` component now initialized with nested observation keys using `getNestedObservationKeys()`.
>   - **Functions**:
>     - Adds `getNestedObservationKeys()` to extract keys for nested observations in `index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 686754f016b5fb7f7e6e92fa5a8807061f19820e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->