### PR TITLE
fix(table-column-visibilty): show fixed position columns as unmoveable in visibility drawer 

### DIFF
--- a/web/src/components/table/data-table-column-visibility-filter.tsx
+++ b/web/src/components/table/data-table-column-visibility-filter.tsx
@@ -96,10 +96,11 @@ function ColumnVisibilityListItem<TData, TValue>({
   columnVisibility: VisibilityState;
   isOrderable?: boolean;
 }) {
+  const isFixedPosition = column.isFixedPosition;
   const { attributes, isDragging, listeners, setNodeRef, transform } =
     useSortable({
       id: column.accessorKey,
-      disabled: !isOrderable,
+      disabled: !isOrderable || isFixedPosition,
     });
 
   const isChecked = columnVisibility[column.accessorKey] && column.enableHiding;
@@ -123,20 +124,25 @@ function ColumnVisibilityListItem<TData, TValue>({
       <div className="flex items-center gap-2">
         <Checkbox
           id={`col-${column.accessorKey}`}
-          checked={isChecked || !column.enableHiding}
+          checked={isChecked || !column.enableHiding || isFixedPosition}
           onCheckedChange={() => {
-            if (column.enableHiding) toggleColumn(column.accessorKey);
+            if (column.enableHiding && !isFixedPosition)
+              toggleColumn(column.accessorKey);
           }}
-          disabled={!column.enableHiding}
+          disabled={!column.enableHiding || isFixedPosition}
           className="h-4 w-4"
         />
         <span
           className={cn(
             "text-sm capitalize",
-            !column.enableHiding && "opacity-50",
+            (!column.enableHiding || isFixedPosition) && "opacity-50",
           )}
           title={
-            !column.enableHiding ? "This column may not be hidden" : undefined
+            !column.enableHiding
+              ? "This column may not be hidden"
+              : isFixedPosition
+                ? "This column is fixed in position and cannot be hidden"
+                : undefined
           }
         >
           {column.header && typeof column.header === "string"
@@ -151,7 +157,7 @@ function ColumnVisibilityListItem<TData, TValue>({
         )}
       </div>
 
-      {isOrderable && (
+      {isOrderable && !isFixedPosition && (
         <Button
           {...attributes}
           {...listeners}
@@ -362,10 +368,14 @@ export function DataTableColumnVisibilityFilter<TData, TValue>({
     const { active, over } = event;
 
     if (active && over && active.id !== over.id) {
+      const activeColumn = columns.find((col) => col.accessorKey === active.id);
       const overColumn = columns.find((col) => col.accessorKey === over.id);
-      if (overColumn?.isFixedPosition) {
+
+      // Prevent reordering if either active or over column is fixed position
+      if (activeColumn?.isFixedPosition || overColumn?.isFixedPosition) {
         return;
       }
+
       if (isString(active.id) && isString(over.id)) {
         setColumnOrder!((columnOrder) => {
           const oldIndex = columnOrder.indexOf(active.id as string);

--- a/web/src/components/table/data-table-column-visibility-filter.tsx
+++ b/web/src/components/table/data-table-column-visibility-filter.tsx
@@ -363,7 +363,7 @@ export function DataTableColumnVisibilityFilter<TData, TValue>({
 
     if (active && over && active.id !== over.id) {
       const overColumn = columns.find((col) => col.accessorKey === over.id);
-      if (overColumn?.isPinned) {
+      if (overColumn?.isFixedPosition) {
         return;
       }
       if (isString(active.id) && isString(over.id)) {
@@ -450,7 +450,7 @@ export function DataTableColumnVisibilityFilter<TData, TValue>({
                     const column = columns.find(
                       (col) => col.accessorKey === columnId,
                     );
-                    if (!column || column.isPinned) return null;
+                    if (!column) return null;
 
                     if (!!column.columns && column.columns.length > 0) {
                       // Column groups

--- a/web/src/components/table/types.ts
+++ b/web/src/components/table/types.ts
@@ -16,7 +16,7 @@ type ExtendedColumnDef<TData extends RowData, TValue = unknown> = ColumnDef<
     description: string;
     href?: string;
   };
-  isPinned?: boolean; // if true, column cannot be reordered
+  isFixedPosition?: boolean; // if true, column cannot be reordered
 };
 
 // limits types of defined tanstack ColumnDef properties to specific subset of tanstack type union

--- a/web/src/components/table/use-cases/score-configs.tsx
+++ b/web/src/components/table/use-cases/score-configs.tsx
@@ -171,7 +171,7 @@ export function ScoreConfigsTable({ projectId }: { projectId: string }) {
       accessorKey: "action",
       header: "Action",
       size: 70,
-      isPinned: true,
+      isFixedPosition: true,
       enableHiding: true,
       cell: ({ row }) => {
         const { id: configId, isArchived, name } = row.original;

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -297,7 +297,7 @@ export default function SessionsTable({
     {
       accessorKey: "bookmarked",
       id: "bookmarked",
-      isPinned: true,
+      isFixedPosition: true,
       header: undefined,
       size: 50,
       cell: ({ row }) => {
@@ -323,7 +323,7 @@ export default function SessionsTable({
       id: "id",
       header: "ID",
       size: 200,
-      isPinned: true,
+      isFixedPosition: true,
       cell: ({ row }) => {
         const value: SessionTableRow["id"] = row.getValue("id");
         return value && typeof value === "string" ? (

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -459,7 +459,7 @@ export default function TracesTable({
             header: undefined,
             id: "bookmarked",
             size: 30,
-            isPinned: true,
+            isFixedPosition: true,
             cell: ({ row }: { row: Row<TracesTableRow> }) => {
               const bookmarked: TracesTableRow["bookmarked"] =
                 row.getValue("bookmarked");
@@ -973,7 +973,7 @@ export default function TracesTable({
             accessorKey: "action",
             header: "Action",
             size: 70,
-            isPinned: true,
+            isFixedPosition: true,
             cell: ({ row }: { row: Row<TracesTableRow> }) => {
               const traceId: TracesTableRow["id"] = row.getValue("id");
               return (

--- a/web/src/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
@@ -183,7 +183,7 @@ export function AnnotationQueueItemsTable({
       id: "select",
       accessorKey: "select",
       size: 30,
-      isPinned: true,
+      isFixedPosition: true,
       header: ({ table }) => {
         return (
           <div className="flex h-full items-center">
@@ -223,7 +223,7 @@ export function AnnotationQueueItemsTable({
       header: "Id",
       id: "id",
       size: 70,
-      isPinned: true,
+      isFixedPosition: true,
       cell: ({ row }) => {
         const id: QueueItemRowData["id"] = row.getValue("id");
         return (

--- a/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
@@ -66,7 +66,7 @@ export function AnnotationQueuesTable({ projectId }: { projectId: string }) {
       header: "Name",
       id: "key",
       size: 150,
-      isPinned: true,
+      isFixedPosition: true,
       cell: ({ row }) => {
         const key: RowData["key"] = row.getValue("key");
         return key && "id" in key && typeof key.id === "string" ? (
@@ -149,7 +149,7 @@ export function AnnotationQueuesTable({ projectId }: { projectId: string }) {
       accessorKey: "processAction",
       header: "Process",
       id: "processAction",
-      isPinned: true,
+      isFixedPosition: true,
       cell: ({ row }) => {
         const key: RowData["key"] = row.getValue("key");
         return !hasAccess ? (
@@ -174,7 +174,7 @@ export function AnnotationQueuesTable({ projectId }: { projectId: string }) {
       header: "Actions",
       id: "actions",
       size: 70,
-      isPinned: true,
+      isFixedPosition: true,
       cell: ({ row }) => {
         const key: RowData["key"] = row.getValue("key");
         return (

--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -130,7 +130,7 @@ export function DatasetItemsTable({
       header: "Item id",
       id: "id",
       size: 90,
-      isPinned: true,
+      isFixedPosition: true,
       cell: ({ row }) => {
         const id: string = row.getValue("id");
         return (

--- a/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
+++ b/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
@@ -70,7 +70,7 @@ export const getDatasetRunAggregateColumnProps = (isLoading: boolean) => ({
   accessorKey: "runs",
   header: "Runs",
   id: "runs",
-  isPinned: true,
+  isFixedPosition: true,
   cell: () => {
     return isLoading ? <Skeleton className="h-3 w-1/2" /> : null;
   },

--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -336,7 +336,7 @@ export function DatasetRunsTable(props: {
       id: "select",
       accessorKey: "select",
       size: 30,
-      isPinned: true,
+      isFixedPosition: true,
       header: ({ table }) => {
         return (
           <div className="flex h-full items-center">
@@ -372,6 +372,23 @@ export function DatasetRunsTable(props: {
       },
     },
     {
+      accessorKey: "name",
+      header: "Name",
+      id: "name",
+      size: 150,
+      isFixedPosition: true,
+      cell: ({ row }) => {
+        const name: DatasetRunRowData["name"] = row.getValue("name");
+        const id: DatasetRunRowData["id"] = row.getValue("id");
+        return (
+          <TableLink
+            path={`/project/${props.projectId}/datasets/${props.datasetId}/runs/${id}`}
+            value={name}
+          />
+        );
+      },
+    },
+    {
       accessorKey: "id",
       header: "Id",
       id: "id",
@@ -384,23 +401,6 @@ export function DatasetRunsTable(props: {
           <TableLink
             path={`/project/${props.projectId}/datasets/${props.datasetId}/runs/${id}`}
             value={id}
-          />
-        );
-      },
-    },
-    {
-      accessorKey: "name",
-      header: "Name",
-      id: "name",
-      size: 150,
-      isPinned: true,
-      cell: ({ row }) => {
-        const name: DatasetRunRowData["name"] = row.getValue("name");
-        const id: DatasetRunRowData["id"] = row.getValue("id");
-        return (
-          <TableLink
-            path={`/project/${props.projectId}/datasets/${props.datasetId}/runs/${id}`}
-            value={name}
           />
         );
       },

--- a/web/src/features/datasets/components/DatasetsTable.tsx
+++ b/web/src/features/datasets/components/DatasetsTable.tsx
@@ -91,7 +91,7 @@ export function DatasetsTable(props: { projectId: string }) {
       header: "Name",
       id: "key",
       size: 150,
-      isPinned: true,
+      isFixedPosition: true,
       cell: ({ row }) => {
         const key: RowData["key"] = row.getValue("key");
         return (

--- a/web/src/features/table/components/TableSelectionManager.tsx
+++ b/web/src/features/table/components/TableSelectionManager.tsx
@@ -24,7 +24,7 @@ export function TableSelectionManager<TData>({
       id: "select",
       accessorKey: "select",
       size: 35,
-      isPinned: true,
+      isFixedPosition: true,
       header: ({ table }: { table: Table<TData> }) => (
         <div className="flex h-full items-center">
           <Checkbox


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> This PR introduces `isFixedPosition` to mark columns as unmovable, updating column definitions and behavior across multiple components.
> 
>   - **Behavior**:
>     - Introduces `isFixedPosition` property in `types.ts` to mark columns as unmovable.
>     - Updates `ColumnVisibilityListItem` in `data-table-column-visibility-filter.tsx` to disable reordering and hiding for fixed columns.
>     - Prevents reordering of fixed columns in `DataTableColumnVisibilityFilter`.
>   - **Column Definitions**:
>     - Replaces `isPinned` with `isFixedPosition` in `score-configs.tsx`, `sessions.tsx`, `traces.tsx`, `AnnotationQueueItemsTable.tsx`, `AnnotationQueuesTable.tsx`, `DatasetItemsTable.tsx`, `DatasetRunAggregateColumnHelpers.tsx`, `DatasetRunsTable.tsx`, `DatasetsTable.tsx`.
>   - **Misc**:
>     - Updates `TableSelectionManager.tsx` to include `isFixedPosition` in selection column.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c1029fdfb0bbc33149c0ef5a8e8c625c7e503ca3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->