### PR TITLE
feat(dataset-run-metrics): add total cost column to dataset runs table

### DIFF
--- a/packages/shared/src/server/repositories/dataset-run-items-converters.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items-converters.ts
@@ -15,6 +15,7 @@ export const convertToDatasetRunMetrics = (row: any) => {
     metadata: row.datasetRunMetadata,
     countRunItems: row.count_run_items,
     avgTotalCost: undefined,
+    totalCost: undefined,
     avgLatency: undefined,
     scores: undefined,
     datasetId: row.dataset_id,

--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -279,6 +279,7 @@ describe("Fetch datasets for UI presentation", () => {
         // Use ClickHouse metrics if available, otherwise use defaults for runs without dataset_run_items_rmt
         countRunItems: run.countRunItems ?? 0,
         avgTotalCost: run.avgTotalCost ?? null,
+        totalCost: run.totalCost ?? null,
         avgLatency: run.avgLatency ?? null,
         scores: aggregateScores(
           traceScores.filter((s) => s.datasetRunId === run.id),
@@ -306,6 +307,7 @@ describe("Fetch datasets for UI presentation", () => {
 
     expect(firstRun.avgLatency).toBeGreaterThanOrEqual(10800);
     expect(firstRun.avgTotalCost?.toString()).toStrictEqual("275");
+    expect(firstRun.totalCost?.toString()).toStrictEqual("550");
 
     const expectedObject = {
       [`${scoreName.replaceAll("-", "_")}-API-NUMERIC`]: {
@@ -454,6 +456,7 @@ describe("Fetch datasets for UI presentation", () => {
         // Use ClickHouse metrics if available, otherwise use defaults for runs without dataset_run_items_rmt
         countRunItems: run.countRunItems ?? 0,
         avgTotalCost: run.avgTotalCost ?? null,
+        totalCost: run.totalCost ?? null,
         avgLatency: run.avgLatency ?? null,
         scores: aggregateScores(
           traceScores.filter((s) => s.datasetRunId === run.id),

--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -70,6 +70,7 @@ export type DatasetRunRowData = {
   countRunItems: string;
   avgLatency: number | undefined;
   avgTotalCost: string | undefined;
+  totalCost: string | undefined;
   // scores holds grouped column with individual scores
   runItemScores?: ScoreAggregate | undefined;
   runScores?: ScoreAggregate | undefined;
@@ -464,6 +465,20 @@ export function DatasetRunsTable(props: {
       },
     },
     {
+      accessorKey: "totalCost",
+      header: "Total Cost (sum)",
+      id: "totalCost",
+      size: 130,
+      enableHiding: true,
+      cell: ({ row }) => {
+        const totalCost: DatasetRunRowData["totalCost"] =
+          row.getValue("totalCost");
+        if (!totalCost || runsMetrics.isPending)
+          return <Skeleton className="h-3 w-1/2" />;
+        return <>{totalCost}</>;
+      },
+    },
+    {
       accessorKey: "runScores",
       header: "Run-Level Scores",
       id: "runScores",
@@ -553,6 +568,9 @@ export function DatasetRunsTable(props: {
       avgLatency: item.avgLatency ?? 0,
       avgTotalCost: item.avgTotalCost
         ? usdFormatter(item.avgTotalCost.toNumber())
+        : usdFormatter(0),
+      totalCost: item.totalCost
+        ? usdFormatter(item.totalCost.toNumber())
         : usdFormatter(0),
       runItemScores: item.scores,
       runScores: item.runScores

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -382,6 +382,7 @@ export const datasetRouter = createTRPCRouter({
           // Use ClickHouse metrics if available, otherwise use defaults for runs without dataset_run_items_rmt
           countRunItems: run.countRunItems ?? 0,
           avgTotalCost: run.avgTotalCost ?? null,
+          totalCost: run.totalCost ?? null,
           avgLatency: run.avgLatency ?? null,
           scores: aggregateScores(
             traceScores.filter((s) => s.datasetRunId === run.id),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `totalCost` column to dataset runs table, updating models, queries, and UI components to handle the new metric.
> 
>   - **Behavior**:
>     - Add `totalCost` column to dataset runs table in `DatasetRunsTable.tsx`.
>     - Update `convertToDatasetRunMetrics` in `dataset-run-items-converters.ts` to include `totalCost`.
>     - Modify `getDatasetRunsTableInternal` in `dataset-run-items.ts` to calculate `totalCost`.
>   - **Models**:
>     - Add `totalCost` to `DatasetRunsMetrics` and `DatasetRunsMetricsRecordType` in `dataset-run-items.ts`.
>   - **Tests**:
>     - Update tests in `dataset-service.servertest.ts` to check for `totalCost`.
>   - **API**:
>     - Update `runsByDatasetIdMetrics` in `dataset-router.ts` to include `totalCost`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d3cd8eb19ac4361be0317e6d7d60e2f585650765. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->