### PR TITLE
fix(dataset-run-items): depend on stable trpc properties

### DIFF
--- a/web/src/features/datasets/components/DatasetRunItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsTable.tsx
@@ -297,7 +297,7 @@ export function DatasetRunItemsTable(
           };
         })
       : [];
-  }, [runItems]);
+  }, [runItems.isSuccess, runItems.data?.runItems]);
 
   return (
     <>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `useMemo` dependency in `DatasetRunItemsTable.tsx` to use stable properties for memoization.
> 
>   - **Behavior**:
>     - Update dependency array in `useMemo` in `DatasetRunItemsTable.tsx` to use `runItems.isSuccess` and `runItems.data?.runItems` instead of just `runItems`.
>   - **Purpose**:
>     - Ensures stable properties are used for memoization, preventing unnecessary re-renders when unrelated properties change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7b767b0f924ed70da09700185c136539aefa4b90. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->