### PR TITLE
feat(table-ui): pin all select columns for y-/x-overflow

### DIFF
--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -71,8 +71,6 @@ interface DataTableProps<TData, TValue> {
   shouldRenderGroupHeaders?: boolean;
   onRowClick?: (row: TData) => void;
   peekView?: PeekViewProps<TData>;
-  // LFE-6580: drop pinFirstColumn to use columnPinning interface instead
-  pinFirstColumn?: boolean;
   hidePagination?: boolean;
   tableName: string;
   getRowClassName?: (row: TData) => string;
@@ -159,7 +157,6 @@ export function DataTable<TData extends object, TValue>({
   shouldRenderGroupHeaders = false,
   onRowClick,
   peekView,
-  pinFirstColumn = false,
   hidePagination = false,
   tableName,
   getRowClassName,
@@ -324,9 +321,6 @@ export function DataTable<TData extends object, TValue>({
                         className={cn(
                           "group p-1 first:pl-2",
                           sortingEnabled && "cursor-pointer",
-                          pinFirstColumn &&
-                            header.index === 0 &&
-                            "sticky left-0 z-20 border-r bg-background",
                           getPinningClasses(header.column),
                         )}
                         style={{
@@ -420,7 +414,6 @@ export function DataTable<TData extends object, TValue>({
                 data={data}
                 help={help}
                 onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
-                pinFirstColumn={pinFirstColumn}
                 tableSnapshot={{
                   tableDataUpdatedAt: peekView?.tableDataUpdatedAt,
                   columnVisibility,
@@ -436,7 +429,6 @@ export function DataTable<TData extends object, TValue>({
                 data={data}
                 help={help}
                 onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
-                pinFirstColumn={pinFirstColumn}
                 getRowClassName={getRowClassName}
               />
             )}
@@ -486,7 +478,6 @@ interface TableBodyComponentProps<TData> {
   data: AsyncTableData<TData[]>;
   help?: { description: string; href: string };
   onRowClick?: (row: TData) => void;
-  pinFirstColumn?: boolean;
   getRowClassName?: (row: TData) => string;
   tableSnapshot?: {
     tableDataUpdatedAt?: number;
@@ -537,7 +528,6 @@ function TableBodyComponent<TData>({
   data,
   help,
   onRowClick,
-  pinFirstColumn = false,
   getRowClassName,
 }: TableBodyComponentProps<TData>) {
   return (
@@ -565,9 +555,6 @@ function TableBodyComponent<TData>({
                 className={cn(
                   "overflow-hidden border-b p-1 text-xs first:pl-2",
                   rowheighttw === "s" && "whitespace-nowrap",
-                  pinFirstColumn &&
-                    cell.column.getIndex() === 0 &&
-                    "sticky left-0 border-r bg-background",
                   getPinningClasses(cell.column),
                 )}
                 style={{

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -127,7 +127,6 @@ export type TracesTableProps = {
   projectId: string;
   userId?: string;
   omittedFilter?: string[];
-  pinFirstColumn?: boolean;
   hideControls?: boolean;
   externalFilterState?: FilterState;
   externalDateRange?: TableDateRange;
@@ -1214,7 +1213,6 @@ export default function TracesTable({
         columnOrder={columnOrder}
         onColumnOrderChange={setColumnOrder}
         rowHeight={rowHeight}
-        pinFirstColumn={!hideControls}
         peekView={peekConfig}
         tableName={"traces"}
       />

--- a/web/src/features/table/components/TableSelectionManager.tsx
+++ b/web/src/features/table/components/TableSelectionManager.tsx
@@ -25,6 +25,7 @@ export function TableSelectionManager<TData>({
       accessorKey: "select",
       size: 35,
       isFixedPosition: true,
+      isPinnedLeft: true,
       header: ({ table }: { table: Table<TData> }) => (
         <div className="flex h-full items-center">
           <Checkbox


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance table UI by pinning all select columns for overflow, removing `pinFirstColumn` prop, and updating pinning logic in `DataTable` and `TableSelectionManager`.
> 
>   - **Behavior**:
>     - Remove `pinFirstColumn` prop from `DataTable` and `TracesTable`.
>     - Pin all select columns to the left for overflow handling in `TableSelectionManager`.
>   - **Components**:
>     - Update `DataTable` to use `columnPinning` state for pinning logic.
>     - Modify `TableSelectionManager` to set `isPinnedLeft: true` for selection column.
>   - **Misc**:
>     - Remove `pinFirstColumn` references in `data-table.tsx` and `traces.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8cd2f0a0bd4509925c2679a98c6a8c1dc5e95e8c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->