### PR TITLE
style(dataset-table-ui): reposition columns for run items making IO more prominent; drop repetitive columns

### DIFF
--- a/packages/shared/scripts/seeder/seed-postgres.ts
+++ b/packages/shared/scripts/seeder/seed-postgres.ts
@@ -533,23 +533,13 @@ export async function createDatasets(
         const datasetItem = await prisma.datasetItem.upsert({
           where: {
             id_projectId: {
-              id: generateDatasetItemId(
-                datasetName,
-                index,
-                projectId,
-                SEED_DATASETS.indexOf(data) || 0,
-              ),
+              id: generateDatasetItemId(datasetName, index, projectId),
               projectId,
             },
           },
           create: {
             projectId,
-            id: generateDatasetItemId(
-              datasetName,
-              index,
-              projectId,
-              SEED_DATASETS.indexOf(data) || 0,
-            ),
+            id: generateDatasetItemId(datasetName, index, projectId),
             datasetId: dataset.id,
             sourceTraceId: sourceTraceId ?? null,
             sourceObservationId: null,

--- a/packages/shared/scripts/seeder/utils/data-generators.ts
+++ b/packages/shared/scripts/seeder/utils/data-generators.ts
@@ -106,7 +106,6 @@ export class DataGenerator {
         input.datasetName,
         input.itemIndex,
         projectId,
-        input.runNumber || 0,
       ),
       dataset_item_input: input.item.input,
       dataset_item_expected_output: input.item.expectedOutput,

--- a/packages/shared/scripts/seeder/utils/seed-helpers.ts
+++ b/packages/shared/scripts/seeder/utils/seed-helpers.ts
@@ -11,9 +11,8 @@ export const generateDatasetItemId = (
   datasetName: string,
   itemIndex: number,
   projectId: string,
-  runNumber: number,
 ) => {
-  return `dataset-item-${datasetName}-${itemIndex}-${projectId.slice(-8)}-${runNumber}`;
+  return `dataset-item-${datasetName}-${itemIndex}-${projectId.slice(-8)}-0`;
 };
 
 export const generateDatasetRunTraceId = (

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -81,8 +81,8 @@ const formatQueryKey = (queryKey?: QueryKeyType): QueryKeyType => {
 // Run items are added async for prompt experiment runs, so we must continue to refetch until all items are present
 // As evaluations are added async too, we must compare the scores for all run items to check if they're all complete
 const isDataComplete = (
-  prevData: RouterOutputs["datasets"]["runitemsByRunIdOrItemId"],
-  newData: RouterOutputs["datasets"]["runitemsByRunIdOrItemId"],
+  prevData: RouterOutputs["datasets"]["runItemsByRunId"],
+  newData: RouterOutputs["datasets"]["runItemsByRunId"],
 ) => {
   if (prevData.totalRunItems !== newData.totalRunItems) return false;
 
@@ -153,7 +153,7 @@ function DatasetCompareRunsTableInternal(props: {
     () =>
       (props.runIds ?? []).map((runId) => ({
         runId,
-        queryKey: getQueryKey(api.datasets.runitemsByRunIdOrItemId, {
+        queryKey: getQueryKey(api.datasets.runItemsByRunId, {
           projectId: props.projectId,
           datasetId: props.datasetId,
           datasetRunId: runId,
@@ -178,8 +178,8 @@ function DatasetCompareRunsTableInternal(props: {
         if (
           prevData &&
           isDataComplete(
-            prevData as RouterOutputs["datasets"]["runitemsByRunIdOrItemId"],
-            newData as RouterOutputs["datasets"]["runitemsByRunIdOrItemId"],
+            prevData as RouterOutputs["datasets"]["runItemsByRunId"],
+            newData as RouterOutputs["datasets"]["runItemsByRunId"],
           )
         ) {
           const newCount = prevCount + 1;
@@ -202,7 +202,7 @@ function DatasetCompareRunsTableInternal(props: {
 
   // 3. Use the queries with success callback
   const runs = runQueries.map(({ runId }) => {
-    const query = api.datasets.runitemsByRunIdOrItemId.useQuery(
+    const query = api.datasets.runItemsByRunId.useQuery(
       {
         projectId: props.projectId,
         datasetId: props.datasetId,

--- a/web/src/features/datasets/components/DatasetIOCells.tsx
+++ b/web/src/features/datasets/components/DatasetIOCells.tsx
@@ -92,7 +92,7 @@ export const TraceObservationIOCell = ({
   return (
     <MemoizedIOTableCell
       isLoading={
-        (!!!observationId ? trace.isLoading : observation.isLoading) || !data
+        (!!observationId ? observation.isLoading : trace.isLoading) || !data
       }
       data={io === "output" ? data?.output : data?.input}
       className={cn(io === "output" && "bg-accent-light-green")}

--- a/web/src/features/datasets/components/DatasetIOCells.tsx
+++ b/web/src/features/datasets/components/DatasetIOCells.tsx
@@ -1,0 +1,102 @@
+import { api } from "@/src/utils/api";
+import { cn } from "@/src/utils/tailwind";
+import { MemoizedIOTableCell } from "@/src/components/ui/IOTableCell";
+import { IOTableCell } from "@/src/components/ui/IOTableCell";
+
+export const DatasetItemIOCell = ({
+  projectId,
+  datasetId,
+  datasetItemId,
+  io,
+  singleLine = false,
+}: {
+  projectId: string;
+  datasetId: string;
+  datasetItemId: string;
+  io: "expectedOutput" | "input";
+  singleLine?: boolean;
+}) => {
+  const datasetItem = api.datasets.itemById.useQuery(
+    {
+      projectId: projectId,
+      datasetId: datasetId,
+      datasetItemId: datasetItemId,
+    },
+    {
+      trpc: {
+        context: {
+          skipBatch: true,
+        },
+      },
+      refetchOnMount: false, // prevents refetching loops
+    },
+  );
+
+  return (
+    <IOTableCell
+      isLoading={datasetItem.isLoading}
+      data={
+        io === "expectedOutput"
+          ? datasetItem.data?.expectedOutput
+          : datasetItem.data?.input
+      }
+      singleLine={singleLine}
+    />
+  );
+};
+
+export const TraceObservationIOCell = ({
+  traceId,
+  projectId,
+  observationId,
+  io,
+  fromTimestamp,
+  singleLine = false,
+}: {
+  traceId: string;
+  projectId: string;
+  observationId?: string;
+  io: "input" | "output";
+  fromTimestamp: Date;
+  singleLine?: boolean;
+}) => {
+  // Subtract 1 day from the fromTimestamp as a buffer in case the trace happened before the run
+  const fromTimestampModified = new Date(
+    fromTimestamp.getTime() - 24 * 60 * 60 * 1000,
+  );
+
+  // conditionally fetch the trace or observation depending on the presence of observationId
+  const trace = api.traces.byId.useQuery(
+    { traceId, projectId, fromTimestamp: fromTimestampModified },
+    {
+      enabled: observationId === undefined,
+      refetchOnMount: false, // prevents refetching loops
+      staleTime: 60 * 1000, // 1 minute
+    },
+  );
+  const observation = api.observations.byId.useQuery(
+    {
+      observationId: observationId as string, // disabled when observationId is undefined
+      projectId,
+      traceId,
+    },
+    {
+      enabled: observationId !== undefined,
+      refetchOnMount: false, // prevents refetching loops
+      staleTime: 60 * 1000, // 1 minute
+    },
+  );
+
+  const data = observationId === undefined ? trace.data : observation.data;
+
+  return (
+    <MemoizedIOTableCell
+      isLoading={
+        (!!!observationId ? trace.isLoading : observation.isLoading) || !data
+      }
+      data={io === "output" ? data?.output : data?.input}
+      className={cn(io === "output" && "bg-accent-light-green")}
+      singleLine={singleLine}
+    />
+  );
+};

--- a/web/src/features/datasets/components/DatasetRunItemsByItemTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsByItemTable.tsx
@@ -1,0 +1,279 @@
+import { DataTable } from "@/src/components/table/data-table";
+import TableLink from "@/src/components/table/table-link";
+import { type LangfuseColumnDef } from "@/src/components/table/types";
+import { api } from "@/src/utils/api";
+import { formatIntervalSeconds } from "@/src/utils/dates";
+import { useQueryParams, withDefault, NumberParam } from "use-query-params";
+import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
+import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
+import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
+import { useEffect, useMemo } from "react";
+import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
+import { ListTree } from "lucide-react";
+import { useScoreColumns } from "@/src/features/scores/hooks/useScoreColumns";
+import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
+import { LocalIsoDate } from "@/src/components/LocalIsoDate";
+import { Skeleton } from "@/src/components/ui/skeleton";
+import { scoreFilters } from "@/src/features/scores/lib/scoreColumns";
+import TableIdOrName from "@/src/components/table/table-id";
+import { convertRunItemToItemsByItemUiTableRow } from "@/src/features/datasets/lib/convertRunItemDataToUiTableRow";
+import {
+  DatasetItemIOCell,
+  TraceObservationIOCell,
+} from "@/src/features/datasets/components/DatasetIOCells";
+import { type DatasetRunItemByItemRowData } from "@/src/features/datasets/lib/types";
+
+export function DatasetRunItemsByItemTable(props: {
+  projectId: string;
+  datasetId: string;
+  datasetItemId: string;
+}) {
+  const { setDetailPageList } = useDetailPageLists();
+  const [paginationState, setPaginationState] = useQueryParams({
+    pageIndex: withDefault(NumberParam, 0),
+    pageSize: withDefault(NumberParam, 20),
+  });
+
+  const runItems = api.datasets.runItemsByItemId.useQuery({
+    ...props,
+    page: paginationState.pageIndex,
+    limit: paginationState.pageSize,
+  });
+
+  const [rowHeight, setRowHeight] = useRowHeightLocalStorage("traces", "m");
+
+  useEffect(() => {
+    if (runItems.isSuccess) {
+      setDetailPageList(
+        "traces",
+        runItems.data.runItems
+          .filter((i) => !!i.trace)
+          .map((i) => ({ id: i.trace!.id })),
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runItems.isSuccess, runItems.data]);
+
+  const { scoreColumns, isLoading: isColumnLoading } =
+    useScoreColumns<DatasetRunItemByItemRowData>({
+      projectId: props.projectId,
+      scoreColumnKey: "scores",
+      filter: scoreFilters.forDatasetItems({
+        datasetItemIds: [props.datasetItemId],
+        datasetId: props.datasetId,
+      }),
+    });
+
+  const columns: LangfuseColumnDef<DatasetRunItemByItemRowData>[] = [
+    {
+      accessorKey: "datasetRunName",
+      header: "Run Name",
+      id: "datasetRunName",
+      size: 150,
+      isPinnedLeft: true,
+      cell: ({ row }) => {
+        const datasetRunName: string | undefined =
+          row.getValue("datasetRunName");
+        return <TableIdOrName value={datasetRunName || "-"} />;
+      },
+    },
+    {
+      accessorKey: "runAt",
+      header: "Run At",
+      id: "runAt",
+      size: 150,
+      cell: ({ row }) => {
+        const value: DatasetRunItemByItemRowData["runAt"] =
+          row.getValue("runAt");
+        return <LocalIsoDate date={value} />;
+      },
+    },
+    {
+      accessorKey: "input",
+      header: "Trace Input",
+      id: "input",
+      size: 200,
+      enableHiding: true,
+      cell: ({ row }) => {
+        const trace: DatasetRunItemByItemRowData["trace"] =
+          row.getValue("trace");
+        const runAt: DatasetRunItemByItemRowData["runAt"] =
+          row.getValue("runAt");
+        return trace ? (
+          <TraceObservationIOCell
+            traceId={trace.traceId}
+            projectId={props.projectId}
+            observationId={trace.observationId}
+            io="input"
+            fromTimestamp={runAt}
+            singleLine={rowHeight === "s"}
+          />
+        ) : null;
+      },
+    },
+    {
+      accessorKey: "output",
+      header: "Trace Output",
+      id: "output",
+      size: 200,
+      enableHiding: true,
+      cell: ({ row }) => {
+        const trace: DatasetRunItemByItemRowData["trace"] =
+          row.getValue("trace");
+        const runAt: DatasetRunItemByItemRowData["runAt"] =
+          row.getValue("runAt");
+        return trace ? (
+          <TraceObservationIOCell
+            traceId={trace.traceId}
+            projectId={props.projectId}
+            observationId={trace.observationId}
+            io="output"
+            fromTimestamp={runAt}
+            singleLine={rowHeight === "s"}
+          />
+        ) : null;
+      },
+    },
+    {
+      accessorKey: "expectedOutput",
+      header: "Expected Output",
+      id: "expectedOutput",
+      size: 200,
+      enableHiding: true,
+      cell: ({ row }) => {
+        const datasetItemId: string = row.getValue("datasetItemId");
+        return datasetItemId ? (
+          <DatasetItemIOCell
+            projectId={props.projectId}
+            datasetId={props.datasetId}
+            datasetItemId={datasetItemId}
+            io="expectedOutput"
+            singleLine={rowHeight === "s"}
+          />
+        ) : null;
+      },
+    },
+    {
+      accessorKey: "trace",
+      header: "Trace",
+      id: "trace",
+      size: 60,
+      cell: ({ row }) => {
+        const trace: DatasetRunItemByItemRowData["trace"] =
+          row.getValue("trace");
+        if (!trace) return null;
+        return trace.observationId ? (
+          <TableLink
+            path={`/project/${props.projectId}/traces/${encodeURIComponent(trace.traceId)}?observation=${encodeURIComponent(trace.observationId)}`}
+            value={`Trace: ${trace.traceId}, Observation: ${trace.observationId}`}
+            icon={<ListTree className="h-4 w-4" />}
+          />
+        ) : (
+          <TableLink
+            path={`/project/${props.projectId}/traces/${encodeURIComponent(trace.traceId)}`}
+            value={`Trace: ${trace.traceId}`}
+            icon={<ListTree className="h-4 w-4" />}
+          />
+        );
+      },
+    },
+    {
+      accessorKey: "latency",
+      header: "Latency",
+      id: "latency",
+      size: 70,
+      enableHiding: true,
+      cell: ({ row }) => {
+        const latency: DatasetRunItemByItemRowData["latency"] =
+          row.getValue("latency");
+        return <>{!!latency ? formatIntervalSeconds(latency) : null}</>;
+      },
+    },
+    {
+      accessorKey: "totalCost",
+      header: "Cost",
+      id: "totalCost",
+      size: 60,
+      enableHiding: true,
+      cell: ({ row }) => {
+        const totalCost: DatasetRunItemByItemRowData["totalCost"] =
+          row.getValue("totalCost");
+        return <>{totalCost}</>;
+      },
+    },
+    {
+      accessorKey: "scores",
+      header: "Scores",
+      id: "scores",
+      enableHiding: true,
+      defaultHidden: true,
+      cell: () => {
+        return isColumnLoading ? <Skeleton className="h-3 w-1/2" /> : null;
+      },
+      columns: scoreColumns,
+    },
+  ];
+
+  const [columnVisibility, setColumnVisibility] =
+    useColumnVisibility<DatasetRunItemByItemRowData>(
+      `datasetRunsByItemColumnVisibility-${props.projectId}`,
+      columns,
+    );
+
+  const [columnOrder, setColumnOrder] =
+    useColumnOrder<DatasetRunItemByItemRowData>(
+      "datasetRunsByItemColumnOrder",
+      columns,
+    );
+
+  const rows = useMemo(() => {
+    return runItems.isSuccess
+      ? runItems.data.runItems.map((item) =>
+          convertRunItemToItemsByItemUiTableRow(item),
+        )
+      : [];
+  }, [runItems.isSuccess, runItems.data?.runItems]);
+
+  return (
+    <>
+      <DataTableToolbar
+        columns={columns}
+        columnVisibility={columnVisibility}
+        setColumnVisibility={setColumnVisibility}
+        columnOrder={columnOrder}
+        setColumnOrder={setColumnOrder}
+        rowHeight={rowHeight}
+        setRowHeight={setRowHeight}
+      />
+      <DataTable
+        tableName={"datasetRunItems"}
+        columns={columns}
+        data={
+          runItems.isLoading
+            ? { isLoading: true, isError: false }
+            : runItems.isError
+              ? {
+                  isLoading: false,
+                  isError: true,
+                  error: runItems.error.message,
+                }
+              : {
+                  isLoading: false,
+                  isError: false,
+                  data: rows,
+                }
+        }
+        pagination={{
+          totalCount: runItems.data?.totalRunItems ?? null,
+          onChange: setPaginationState,
+          state: paginationState,
+        }}
+        columnVisibility={columnVisibility}
+        onColumnVisibilityChange={setColumnVisibility}
+        columnOrder={columnOrder}
+        onColumnOrderChange={setColumnOrder}
+        rowHeight={rowHeight}
+      />
+    </>
+  );
+}

--- a/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/src/features/datasets/components/DatasetIOCells";
 import { convertRunItemToItemsByRunUiTableRow } from "@/src/features/datasets/lib/convertRunItemDataToUiTableRow";
 import { type DatasetRunItemByRunRowData } from "@/src/features/datasets/lib/types";
+import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 
 export function DatasetRunItemsByRunTable(props: {
   projectId: string;
@@ -80,6 +81,17 @@ export function DatasetRunItemsByRunTable(props: {
             value={datasetItemId}
           />
         );
+      },
+    },
+    {
+      accessorKey: "runAt",
+      header: "Run At",
+      id: "runAt",
+      size: 150,
+      cell: ({ row }) => {
+        const value: DatasetRunItemByRunRowData["runAt"] =
+          row.getValue("runAt");
+        return <LocalIsoDate date={value} />;
       },
     },
     {

--- a/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
@@ -4,64 +4,35 @@ import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { api } from "@/src/utils/api";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import { useQueryParams, withDefault, NumberParam } from "use-query-params";
-import { usdFormatter } from "../../../utils/numbers";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
 import { useEffect, useMemo } from "react";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
-import { cn } from "@/src/utils/tailwind";
-import { MemoizedIOTableCell } from "@/src/components/ui/IOTableCell";
-import { IOTableCell } from "@/src/components/ui/IOTableCell";
 import { ListTree } from "lucide-react";
-import { type ScoreAggregate } from "@langfuse/shared";
 import { useScoreColumns } from "@/src/features/scores/hooks/useScoreColumns";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
-import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { scoreFilters } from "@/src/features/scores/lib/scoreColumns";
-import TableIdOrName from "@/src/components/table/table-id";
+import {
+  DatasetItemIOCell,
+  TraceObservationIOCell,
+} from "@/src/features/datasets/components/DatasetIOCells";
+import { convertRunItemToItemsByRunUiTableRow } from "@/src/features/datasets/lib/convertRunItemDataToUiTableRow";
+import { type DatasetRunItemByRunRowData } from "@/src/features/datasets/lib/types";
 
-export type DatasetRunItemRowData = {
-  id: string;
-  runAt: Date;
-  datasetItemId: string;
-  datasetRunName?: string;
-  trace?: {
-    traceId: string;
-    observationId?: string;
-  };
-  // i/o not set explicitly, but fetched from the server from the cell
-  input?: unknown;
-  output?: unknown;
-  expectedOutput?: unknown;
-
-  // scores holds grouped column with individual scores
-  scores: ScoreAggregate;
-  latency?: number;
-  totalCost?: string;
-};
-
-export function DatasetRunItemsTable(
-  props:
-    | {
-        projectId: string;
-        datasetId: string;
-        datasetRunId: string; // View from run page
-      }
-    | {
-        projectId: string;
-        datasetId: string;
-        datasetItemId: string; // View from item page
-      },
-) {
+export function DatasetRunItemsByRunTable(props: {
+  projectId: string;
+  datasetId: string;
+  datasetRunId: string;
+}) {
   const { setDetailPageList } = useDetailPageLists();
   const [paginationState, setPaginationState] = useQueryParams({
     pageIndex: withDefault(NumberParam, 0),
     pageSize: withDefault(NumberParam, 20),
   });
 
-  const runItems = api.datasets.runitemsByRunIdOrItemId.useQuery({
+  const runItems = api.datasets.runItemsByRunId.useQuery({
     ...props,
     page: paginationState.pageIndex,
     limit: paginationState.pageSize,
@@ -77,54 +48,25 @@ export function DatasetRunItemsTable(
           .filter((i) => !!i.trace)
           .map((i) => ({ id: i.trace!.id })),
       );
-      // set the datasetItems list only when viewing this table from the run page
-      if ("datasetRunId" in props)
-        setDetailPageList(
-          "datasetItems",
-          runItems.data.runItems.map((i) => ({ id: i.datasetItemId })),
-        );
+      setDetailPageList(
+        "datasetItems",
+        runItems.data.runItems.map((i) => ({ id: i.datasetItemId })),
+      );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runItems.isSuccess, runItems.data]);
 
   const { scoreColumns, isLoading: isColumnLoading } =
-    useScoreColumns<DatasetRunItemRowData>({
+    useScoreColumns<DatasetRunItemByRunRowData>({
       projectId: props.projectId,
       scoreColumnKey: "scores",
-      filter:
-        "datasetRunId" in props
-          ? scoreFilters.forDatasetRunItems({
-              datasetRunIds: [props.datasetRunId],
-              datasetId: props.datasetId,
-            })
-          : scoreFilters.forDatasetItems({
-              datasetItemIds: [props.datasetItemId],
-              datasetId: props.datasetId,
-            }),
+      filter: scoreFilters.forDatasetRunItems({
+        datasetRunIds: [props.datasetRunId],
+        datasetId: props.datasetId,
+      }),
     });
 
-  const columns: LangfuseColumnDef<DatasetRunItemRowData>[] = [
-    {
-      accessorKey: "runAt",
-      header: "Run At",
-      id: "runAt",
-      size: 150,
-      cell: ({ row }) => {
-        const value: DatasetRunItemRowData["runAt"] = row.getValue("runAt");
-        return <LocalIsoDate date={value} />;
-      },
-    },
-    {
-      accessorKey: "datasetRunName",
-      header: "Run Name",
-      id: "datasetRunName",
-      size: 150,
-      cell: ({ row }) => {
-        const datasetRunName: string | undefined =
-          row.getValue("datasetRunName");
-        return <TableIdOrName value={datasetRunName || "-"} />;
-      },
-    },
+  const columns: LangfuseColumnDef<DatasetRunItemByRunRowData>[] = [
     {
       accessorKey: "datasetItemId",
       header: "Dataset Item",
@@ -146,7 +88,8 @@ export function DatasetRunItemsTable(
       id: "trace",
       size: 60,
       cell: ({ row }) => {
-        const trace: DatasetRunItemRowData["trace"] = row.getValue("trace");
+        const trace: DatasetRunItemByRunRowData["trace"] =
+          row.getValue("trace");
         if (!trace) return null;
         return trace.observationId ? (
           <TableLink
@@ -170,7 +113,7 @@ export function DatasetRunItemsTable(
       size: 70,
       enableHiding: true,
       cell: ({ row }) => {
-        const latency: DatasetRunItemRowData["latency"] =
+        const latency: DatasetRunItemByRunRowData["latency"] =
           row.getValue("latency");
         return <>{!!latency ? formatIntervalSeconds(latency) : null}</>;
       },
@@ -182,7 +125,7 @@ export function DatasetRunItemsTable(
       size: 60,
       enableHiding: true,
       cell: ({ row }) => {
-        const totalCost: DatasetRunItemRowData["totalCost"] =
+        const totalCost: DatasetRunItemByRunRowData["totalCost"] =
           row.getValue("totalCost");
         return <>{totalCost}</>;
       },
@@ -200,13 +143,15 @@ export function DatasetRunItemsTable(
     },
     {
       accessorKey: "input",
-      header: `${"datasetItemId" in props ? "Trace Input" : "Input"}`,
+      header: "Trace Input",
       id: "input",
       size: 200,
       enableHiding: true,
       cell: ({ row }) => {
-        const trace: DatasetRunItemRowData["trace"] = row.getValue("trace");
-        const runAt: DatasetRunItemRowData["runAt"] = row.getValue("runAt");
+        const trace: DatasetRunItemByRunRowData["trace"] =
+          row.getValue("trace");
+        const runAt: DatasetRunItemByRunRowData["runAt"] =
+          row.getValue("runAt");
         return trace ? (
           <TraceObservationIOCell
             traceId={trace.traceId}
@@ -221,13 +166,15 @@ export function DatasetRunItemsTable(
     },
     {
       accessorKey: "output",
-      header: `${"datasetItemId" in props ? "Trace Output" : "Output"}`,
+      header: "Output",
       id: "output",
       size: 200,
       enableHiding: true,
       cell: ({ row }) => {
-        const trace: DatasetRunItemRowData["trace"] = row.getValue("trace");
-        const runAt: DatasetRunItemRowData["runAt"] = row.getValue("runAt");
+        const trace: DatasetRunItemByRunRowData["trace"] =
+          row.getValue("trace");
+        const runAt: DatasetRunItemByRunRowData["runAt"] =
+          row.getValue("runAt");
         return trace ? (
           <TraceObservationIOCell
             traceId={trace.traceId}
@@ -262,40 +209,22 @@ export function DatasetRunItemsTable(
   ];
 
   const [columnVisibility, setColumnVisibility] =
-    useColumnVisibility<DatasetRunItemRowData>(
+    useColumnVisibility<DatasetRunItemByRunRowData>(
       `datasetRunsItemsColumnVisibility-${props.projectId}`,
       columns,
     );
 
-  const [columnOrder, setColumnOrder] = useColumnOrder<DatasetRunItemRowData>(
-    "datasetRunsItemsColumnOrder",
-    columns,
-  );
+  const [columnOrder, setColumnOrder] =
+    useColumnOrder<DatasetRunItemByRunRowData>(
+      "datasetRunsItemsColumnOrder",
+      columns,
+    );
 
   const rows = useMemo(() => {
     return runItems.isSuccess
-      ? runItems.data.runItems.map((item) => {
-          return {
-            id: item.id,
-            runAt: item.createdAt,
-            datasetItemId: item.datasetItemId,
-            datasetRunName: item.datasetRunName,
-            trace: !!item.trace?.id
-              ? {
-                  traceId: item.trace.id,
-                  observationId: item.observation?.id,
-                }
-              : undefined,
-            scores: item.scores,
-            totalCost: !!item.observation?.calculatedTotalCost
-              ? usdFormatter(item.observation.calculatedTotalCost.toNumber())
-              : !!item.trace?.totalCost
-                ? usdFormatter(item.trace.totalCost)
-                : undefined,
-            latency:
-              item.observation?.latency ?? item.trace?.duration ?? undefined,
-          };
-        })
+      ? runItems.data.runItems.map((item) =>
+          convertRunItemToItemsByRunUiTableRow(item),
+        )
       : [];
   }, [runItems.isSuccess, runItems.data?.runItems]);
 
@@ -342,101 +271,3 @@ export function DatasetRunItemsTable(
     </>
   );
 }
-
-const TraceObservationIOCell = ({
-  traceId,
-  projectId,
-  observationId,
-  io,
-  fromTimestamp,
-  singleLine = false,
-}: {
-  traceId: string;
-  projectId: string;
-  observationId?: string;
-  io: "input" | "output";
-  fromTimestamp: Date;
-  singleLine?: boolean;
-}) => {
-  // Subtract 1 day from the fromTimestamp as a buffer in case the trace happened before the run
-  const fromTimestampModified = new Date(
-    fromTimestamp.getTime() - 24 * 60 * 60 * 1000,
-  );
-
-  // conditionally fetch the trace or observation depending on the presence of observationId
-  const trace = api.traces.byId.useQuery(
-    { traceId, projectId, fromTimestamp: fromTimestampModified },
-    {
-      enabled: observationId === undefined,
-      refetchOnMount: false, // prevents refetching loops
-      staleTime: 60 * 1000, // 1 minute
-    },
-  );
-  const observation = api.observations.byId.useQuery(
-    {
-      observationId: observationId as string, // disabled when observationId is undefined
-      projectId,
-      traceId,
-    },
-    {
-      enabled: observationId !== undefined,
-      refetchOnMount: false, // prevents refetching loops
-      staleTime: 60 * 1000, // 1 minute
-    },
-  );
-
-  const data = observationId === undefined ? trace.data : observation.data;
-
-  return (
-    <MemoizedIOTableCell
-      isLoading={
-        (!!!observationId ? trace.isLoading : observation.isLoading) || !data
-      }
-      data={io === "output" ? data?.output : data?.input}
-      className={cn(io === "output" && "bg-accent-light-green")}
-      singleLine={singleLine}
-    />
-  );
-};
-
-const DatasetItemIOCell = ({
-  projectId,
-  datasetId,
-  datasetItemId,
-  io,
-  singleLine = false,
-}: {
-  projectId: string;
-  datasetId: string;
-  datasetItemId: string;
-  io: "expectedOutput" | "input";
-  singleLine?: boolean;
-}) => {
-  const datasetItem = api.datasets.itemById.useQuery(
-    {
-      projectId: projectId,
-      datasetId: datasetId,
-      datasetItemId: datasetItemId,
-    },
-    {
-      trpc: {
-        context: {
-          skipBatch: true,
-        },
-      },
-      refetchOnMount: false, // prevents refetching loops
-    },
-  );
-
-  return (
-    <IOTableCell
-      isLoading={datasetItem.isLoading}
-      data={
-        io === "expectedOutput"
-          ? datasetItem.data?.expectedOutput
-          : datasetItem.data?.input
-      }
-      singleLine={singleLine}
-    />
-  );
-};

--- a/web/src/features/datasets/lib/convertRunItemDataToUiTableRow.ts
+++ b/web/src/features/datasets/lib/convertRunItemDataToUiTableRow.ts
@@ -1,0 +1,52 @@
+import { usdFormatter } from "@/src/utils/numbers";
+import {
+  type DatasetRunItemByRunRowData,
+  type DatasetRunItemByItemRowData,
+  type EnrichedDatasetRunItem,
+} from "./types";
+
+export const convertRunItemToItemsByItemUiTableRow = (
+  item: EnrichedDatasetRunItem,
+): DatasetRunItemByItemRowData => {
+  return {
+    id: item.id,
+    runAt: item.createdAt,
+    datasetRunName: item.datasetRunName,
+    trace: !!item.trace?.id
+      ? {
+          traceId: item.trace.id,
+          observationId: item.observation?.id,
+        }
+      : undefined,
+    scores: item.scores,
+    totalCost: !!item.observation?.calculatedTotalCost
+      ? usdFormatter(item.observation.calculatedTotalCost.toNumber())
+      : !!item.trace?.totalCost
+        ? usdFormatter(item.trace.totalCost)
+        : undefined,
+    latency: item.observation?.latency ?? item.trace?.duration ?? undefined,
+  };
+};
+
+export const convertRunItemToItemsByRunUiTableRow = (
+  item: EnrichedDatasetRunItem,
+): DatasetRunItemByRunRowData => {
+  return {
+    id: item.id,
+    runAt: item.createdAt,
+    datasetItemId: item.datasetItemId,
+    trace: !!item.trace?.id
+      ? {
+          traceId: item.trace.id,
+          observationId: item.observation?.id,
+        }
+      : undefined,
+    scores: item.scores,
+    totalCost: !!item.observation?.calculatedTotalCost
+      ? usdFormatter(item.observation.calculatedTotalCost.toNumber())
+      : !!item.trace?.totalCost
+        ? usdFormatter(item.trace.totalCost)
+        : undefined,
+    latency: item.observation?.latency ?? item.trace?.duration ?? undefined,
+  };
+};

--- a/web/src/features/datasets/lib/types.ts
+++ b/web/src/features/datasets/lib/types.ts
@@ -1,0 +1,60 @@
+import type { ScoreAggregate } from "@langfuse/shared";
+import type Decimal from "decimal.js";
+
+export type EnrichedDatasetRunItem = {
+  datasetRunName: string;
+  id: string;
+  createdAt: Date;
+  datasetItemId: string;
+  observation:
+    | {
+        id: string;
+        latency: number;
+        calculatedTotalCost: Decimal;
+      }
+    | undefined;
+  trace: {
+    id: string;
+    duration: number;
+    totalCost: number;
+  };
+  scores: ScoreAggregate;
+};
+
+export type DatasetRunItemByItemRowData = {
+  id: string;
+  runAt: Date;
+  datasetRunName?: string;
+  trace?: {
+    traceId: string;
+    observationId?: string;
+  };
+  // i/o not set explicitly, but fetched from the server from the cell
+  input?: unknown;
+  output?: unknown;
+  expectedOutput?: unknown;
+
+  // scores holds grouped column with individual scores
+  scores: ScoreAggregate;
+  latency?: number;
+  totalCost?: string;
+};
+
+export type DatasetRunItemByRunRowData = {
+  id: string;
+  runAt: Date;
+  datasetItemId: string;
+  trace?: {
+    traceId: string;
+    observationId?: string;
+  };
+  // i/o not set explicitly, but fetched from the server from the cell
+  input?: unknown;
+  output?: unknown;
+  expectedOutput?: unknown;
+
+  // scores holds grouped column with individual scores
+  scores: ScoreAggregate;
+  latency?: number;
+  totalCost?: string;
+};

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -962,6 +962,210 @@ export const datasetRouter = createTRPCRouter({
 
       return;
     }),
+  runItemsByItemId: protectedProjectProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        datasetId: z.string(),
+        datasetItemId: z.string(),
+        ...optionalPaginationZod,
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      const { datasetItemId, datasetId } = input;
+
+      const filter = [
+        {
+          column: "datasetItemId",
+          operator: "any of",
+          value: [datasetItemId],
+          type: "stringOptions" as const,
+        },
+      ] as FilterState;
+
+      const datasetItem = await ctx.prisma.datasetItem.findFirst({
+        where: {
+          id: datasetItemId,
+          projectId: input.projectId,
+        },
+      });
+      if (!datasetItem) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Dataset item not found",
+        });
+      }
+
+      const [runItems, totalRunItems] = await Promise.all([
+        getDatasetRunItemsByDatasetIdCh({
+          projectId: input.projectId,
+          datasetId: datasetId,
+          filter,
+          // ensure consistent ordering with datasets.baseDatasetItemByDatasetId
+          // CH run items are created in reverse order as postgres execution path
+          // can be refactored once we switch to CH only implementation
+          orderBy: [
+            {
+              column: "createdAt",
+              order: "ASC",
+            },
+            { column: "datasetItemId", order: "DESC" },
+          ],
+          limit: input.limit ?? undefined,
+          offset:
+            input.page !== undefined && input.limit !== undefined
+              ? input.page * input.limit
+              : undefined,
+        }),
+        getDatasetRunItemsCountByDatasetIdCh({
+          projectId: input.projectId,
+          datasetId: datasetId,
+          filter,
+        }),
+      ]);
+
+      const runItemNameMap = runItems.reduce(
+        (map, item) => {
+          map[item.id] = item.datasetRunName;
+          return map;
+        },
+        {} as Record<string, string>,
+      );
+
+      const enrichedRunItems = (
+        await getRunItemsByRunIdOrItemId(
+          input.projectId,
+          runItems.map((runItem) => ({
+            id: runItem.id,
+            traceId: runItem.traceId,
+            observationId: runItem.observationId,
+            createdAt: runItem.createdAt,
+            updatedAt: runItem.updatedAt,
+            projectId: runItem.projectId,
+            datasetRunId: runItem.datasetRunId,
+            datasetItemId: runItem.datasetItemId,
+          })),
+        )
+      ).map((runItem) => ({
+        ...runItem,
+        datasetRunName: runItemNameMap[runItem.id],
+      }));
+
+      // Note: We early return in case of no run items, when adding parameters here, make sure to update the early return above
+      return {
+        totalRunItems,
+        runItems: enrichedRunItems,
+      };
+    }),
+
+  runItemsByRunId: protectedProjectProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        datasetId: z.string(),
+        datasetRunId: z.string(),
+        datasetItemIds: z.array(z.string()).optional(),
+        ...optionalPaginationZod,
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      const { datasetRunId, datasetItemIds, datasetId } = input;
+
+      const datasetRun = await ctx.prisma.datasetRuns.findFirst({
+        where: {
+          id: datasetRunId,
+          projectId: input.projectId,
+        },
+      });
+
+      if (!datasetRun) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Dataset run not found",
+        });
+      }
+
+      const filter = [
+        {
+          column: "datasetRunId",
+          operator: "any of",
+          value: [datasetRunId],
+          type: "stringOptions" as const,
+        },
+        ...(datasetItemIds
+          ? [
+              {
+                column: "datasetItemId",
+                operator: "any of",
+                value: [datasetItemIds],
+                type: "stringOptions" as const,
+              },
+            ]
+          : []),
+      ] as FilterState;
+
+      const [runItems, totalRunItems] = await Promise.all([
+        getDatasetRunItemsByDatasetIdCh({
+          projectId: input.projectId,
+          datasetId: datasetId,
+          filter,
+          // ensure consistent ordering with datasets.baseDatasetItemByDatasetId
+          // CH run items are created in reverse order as postgres execution path
+          // can be refactored once we switch to CH only implementation
+          orderBy: [
+            {
+              column: "createdAt",
+              order: "ASC",
+            },
+            { column: "datasetItemId", order: "DESC" },
+          ],
+          limit: input.limit ?? undefined,
+          offset:
+            input.page !== undefined && input.limit !== undefined
+              ? input.page * input.limit
+              : undefined,
+        }),
+        getDatasetRunItemsCountByDatasetIdCh({
+          projectId: input.projectId,
+          datasetId: datasetId,
+          filter,
+        }),
+      ]);
+
+      const runItemNameMap = runItems.reduce(
+        (map, item) => {
+          map[item.id] = item.datasetRunName;
+          return map;
+        },
+        {} as Record<string, string>,
+      );
+
+      const enrichedRunItems = (
+        await getRunItemsByRunIdOrItemId(
+          input.projectId,
+          runItems.map((runItem) => ({
+            id: runItem.id,
+            traceId: runItem.traceId,
+            observationId: runItem.observationId,
+            createdAt: runItem.createdAt,
+            updatedAt: runItem.updatedAt,
+            projectId: runItem.projectId,
+            datasetRunId: runItem.datasetRunId,
+            datasetItemId: runItem.datasetItemId,
+          })),
+        )
+      ).map((runItem) => ({
+        ...runItem,
+        datasetRunName: runItemNameMap[runItem.id],
+      }));
+
+      // Note: We early return in case of no run items, when adding parameters here, make sure to update the early return above
+      return {
+        totalRunItems,
+        runItems: enrichedRunItems,
+      };
+    }),
+
   // TODO: separate out into two procedures
   runitemsByRunIdOrItemId: protectedProjectProcedure
     .input(
@@ -1113,6 +1317,7 @@ export const datasetRouter = createTRPCRouter({
         runItems: enrichedRunItems,
       };
     }),
+
   datasetItemsBasedOnTraceOrObservation: protectedProjectProcedure
     .input(
       z.object({

--- a/web/src/features/scores/lib/types.ts
+++ b/web/src/features/scores/lib/types.ts
@@ -1,15 +1,19 @@
 import { type ObservationsTableRow } from "@/src/components/table/use-cases/observations";
 import { type SessionTableRow } from "@/src/components/table/use-cases/sessions";
 import { type TracesTableRow } from "@/src/components/table/use-cases/traces";
-import { type DatasetRunItemRowData } from "@/src/features/datasets/components/DatasetRunItemsTable";
 import { type DatasetRunRowData } from "@/src/features/datasets/components/DatasetRunsTable";
+import {
+  type DatasetRunItemByItemRowData,
+  type DatasetRunItemByRunRowData,
+} from "@/src/features/datasets/lib/types";
 import { type PromptVersionTableRow } from "@/src/pages/project/[projectId]/prompts/metrics";
 import { type ScoreDataType, type ScoreSourceType } from "@langfuse/shared";
 
 export type TableRowTypesWithIndividualScoreColumns =
   | ObservationsTableRow
   | TracesTableRow
-  | DatasetRunItemRowData
+  | DatasetRunItemByItemRowData
+  | DatasetRunItemByRunRowData
   | DatasetRunRowData
   | PromptVersionTableRow
   | SessionTableRow;

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId].tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId].tsx
@@ -6,7 +6,6 @@ import {
   ResizablePanel,
   ResizablePanelGroup,
 } from "@/src/components/ui/resizable";
-import { DatasetRunItemsTable } from "@/src/features/datasets/components/DatasetRunItemsTable";
 import { EditDatasetItem } from "@/src/features/datasets/components/EditDatasetItem";
 import { NewDatasetItemFromExistingObject } from "@/src/features/datasets/components/NewDatasetItemFromExistingObject";
 import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
@@ -29,6 +28,7 @@ import {
   PopoverTrigger,
 } from "@/src/components/ui/popover";
 import { useState } from "react";
+import { DatasetRunItemsByItemTable } from "@/src/features/datasets/components/DatasetRunItemsByItemTable";
 
 export default function Dataset() {
   const router = useRouter();
@@ -236,7 +236,7 @@ export default function Dataset() {
         <ResizableHandle withHandle className="bg-border" />
         <ResizablePanel minSize={10} className="flex flex-col space-y-4">
           <Header title="Runs" />
-          <DatasetRunItemsTable
+          <DatasetRunItemsByItemTable
             projectId={projectId}
             datasetItemId={itemId}
             datasetId={datasetId}

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/runs/[runId].tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/runs/[runId].tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/src/components/ui/button";
 import { JSONView } from "@/src/components/ui/CodeJsonViewer";
-import { DatasetRunItemsTable } from "@/src/features/datasets/components/DatasetRunItemsTable";
+import { DatasetRunItemsByRunTable } from "@/src/features/datasets/components/DatasetRunItemsByRunTable";
 import { DeleteDatasetRunButton } from "@/src/features/datasets/components/DeleteDatasetRunButton";
 import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 import { api } from "@/src/utils/api";
@@ -94,7 +94,7 @@ export default function Dataset() {
     >
       <div className="grid flex-1 grid-cols-[1fr,auto] overflow-hidden">
         <div className="flex h-full flex-col overflow-hidden">
-          <DatasetRunItemsTable
+          <DatasetRunItemsByRunTable
             projectId={projectId}
             datasetId={datasetId}
             datasetRunId={runId}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reorganized dataset table UI by introducing new components for better data display and interaction, and updated backend queries to support these changes.
> 
>   - **UI Enhancements**:
>     - Introduced `DatasetRunItemsByItemTable` and `DatasetRunItemsByRunTable` components for better data organization.
>     - Added `DatasetItemIOCell` and `TraceObservationIOCell` components in `DatasetIOCells.tsx` for handling input/output display.
>     - Updated `DatasetCompareRunsTable.tsx` to use `runItemsByRunId` query.
>   - **Backend Changes**:
>     - Added `runItemsByItemId` and `runItemsByRunId` queries in `dataset-router.ts` for fetching run items by item and run IDs.
>   - **Code Refactoring**:
>     - Renamed `DatasetRunItemsTable.tsx` to `DatasetRunItemsByRunTable.tsx`.
>     - Removed `runNumber` parameter from `generateDatasetItemId` in `seed-helpers.ts` and `data-generators.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a318be185a7da14119f025c349ea16d58e6db526. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->