### PR TITLE
fix: update prompt example to new TS SDK

### DIFF
--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -92,14 +92,14 @@ const getJsCode = (
 const langfuse = new Langfuse();
 
 // Get production prompt
-const prompt = await langfuse.getPrompt("${name}");
+const prompt = await langfuse.prompt.get("${name}");
 
 // Get by label
 // You can use as many labels as you'd like to identify different deployment targets
-${labels.length > 0 ? labels.map((label) => `const prompt = await langfuse.getPrompt("${name}", undefined, { label: "${label}" })`).join("\n") : ""}
+${labels.length > 0 ? labels.map((label) => `const prompt = await langfuse.prompt.get("${name}", undefined, { label: "${label}" })`).join("\n") : ""}
 
 // Get by version number, usually not recommended as it requires code changes to deploy new prompt versions
-langfuse.getPrompt("${name}", ${version})
+langfuse.prompt.get("${name}", ${version})
 `;
 
 export const PromptDetail = ({

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -99,7 +99,7 @@ const prompt = await langfuse.prompt.get("${name}");
 ${labels.length > 0 ? labels.map((label) => `const prompt = await langfuse.prompt.get("${name}", undefined, { label: "${label}" })`).join("\n") : ""}
 
 // Get by version number, usually not recommended as it requires code changes to deploy new prompt versions
-langfuse.prompt.get("${name}", ${version})
+await langfuse.prompt.get("${name}", ${version})
 `;
 
 export const PromptDetail = ({


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Update the JS/TS code examples under "Use Prompt" tab (`/prompts/langfuse-expert?tab=use-prompt`) to match new v4 SDK.  

<img width="1112" height="810" alt="image" src="https://github.com/user-attachments/assets/c7ad479d-a376-438e-9e76-736cb6e62d45" />

-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `getJsCode` in `prompt-detail.tsx` to use `langfuse.prompt.get` for v4 SDK compatibility.
> 
>   - **Behavior**:
>     - Update `getJsCode` function in `prompt-detail.tsx` to use `langfuse.prompt.get` instead of `langfuse.getPrompt` for fetching prompts by name, label, and version.
>   - **Misc**:
>     - Aligns JS/TS code examples with new v4 SDK in `prompt-detail.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 86dfdfb1c0161647dd4cece4ff11313a12c99a0c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->