### PR TITLE
fix: use set utility for seen traces to fix cluster slot detection

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -17,3 +17,8 @@
 ### Environment Variables
 
 - Environment variables should be imported from the `env.mjs/ts` file of the respective package and not from `process.env.*` to ensure validation and typing.
+
+## Redis Invocations
+
+- Highlight usage of `redis.call` invocations. Those may have suboptimal redis cluster routing and will raise errors. Instead, use the native call patterns.
+  Example: `await redis?.call("SET", key, "1", "NX", "EX", TTLSeconds);` should use `await redis?.set(key, "1", "EX", TTLSeconds, "NX");` instead.

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1670,14 +1670,7 @@ export class OtelIngestionProcessor {
         [...traceIds].map(async (traceId) => {
           const key = `langfuse:project:${this.projectId}:trace:${traceId}:seen`;
           const TTLSeconds = 600; // 10 minutes
-          const result = await redis?.call(
-            "SET",
-            key,
-            "1",
-            "NX",
-            "EX",
-            TTLSeconds,
-          );
+          const result = await redis?.set(key, "1", "EX", TTLSeconds, "NX");
 
           return {
             traceId: traceId,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replace `redis.call` with `redis.set` in `OtelIngestionProcessor.ts` to improve Redis cluster routing and update `REVIEW.md` with guidance on Redis call usage.
> 
>   - **Behavior**:
>     - Replace `redis.call` with `redis.set` in `getSeenTracesSet()` in `OtelIngestionProcessor.ts` to improve Redis cluster routing.
>   - **Documentation**:
>     - Update `REVIEW.md` to advise against using `redis.call` for better Redis cluster routing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 907696c9a3e31fe4abe862d00740b023e53472a8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->