### PR TITLE
fix(dataset-router): correct datasetItemIds value assignment in dataset filtering logic

### DIFF
--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -1093,12 +1093,12 @@ export const datasetRouter = createTRPCRouter({
           value: [datasetRunId],
           type: "stringOptions" as const,
         },
-        ...(datasetItemIds
+        ...(datasetItemIds && datasetItemIds.length > 0
           ? [
               {
                 column: "datasetItemId",
                 operator: "any of",
-                value: [datasetItemIds],
+                value: datasetItemIds,
                 type: "stringOptions" as const,
               },
             ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `datasetItemIds` assignment in `runItemsByRunId` in `dataset-router.ts` to ensure correct array handling in filters.
> 
>   - **Bug Fix**:
>     - Corrects `datasetItemIds` assignment in `runItemsByRunId` in `dataset-router.ts`.
>     - Ensures `datasetItemIds` is assigned as an array, not a nested array, in filter conditions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 32f2dd41209370ed1bb51c67f92002692f0164c5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->