### PR TITLE
fix(ioredis): Add slotsRefreshTimeout to support AWS ElasticCache cluster

### DIFF
--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -73,21 +73,21 @@ const createRedisClusterInstance = (
       : {};
 
   const clusterOptions: ClusterOptions = {
-  // Return incoming addresses as-is - required for AWS ElastiCache Certificate resolution
-  dnsLookup: (address, callback) => {
-    callback(null, address);
-  },
-  slotsRefreshTimeout: 5000,
-  redisOptions: {
-    username: env.REDIS_USERNAME || undefined,
-    password: env.REDIS_AUTH || undefined,
-    ...defaultRedisOptions,
-    ...additionalOptions,
-    ...tlsOptions,
-  },
-  // Retry configuration for cluster
-  retryDelayOnFailover: 100,
-};
+    // Return incoming addresses as-is - required for AWS ElastiCache Certificate resolution
+    dnsLookup: (address, callback) => {
+      callback(null, address);
+    },
+    slotsRefreshTimeout: 5000,
+    redisOptions: {
+      username: env.REDIS_USERNAME || undefined,
+      password: env.REDIS_AUTH || undefined,
+      ...defaultRedisOptions,
+      ...additionalOptions,
+      ...tlsOptions,
+    },
+    // Retry configuration for cluster
+    retryDelayOnFailover: 100,
+  };
 
   const cluster = new Cluster(nodes, clusterOptions);
 

--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -4,6 +4,7 @@ import { env } from "../../env";
 import { logger } from "../logger";
 
 const defaultRedisOptions: Partial<RedisOptions> = {
+  enableReadyCheck: true,
   maxRetriesPerRequest: null,
   enableAutoPipelining: env.REDIS_ENABLE_AUTO_PIPELINING === "true",
   keyPrefix: env.REDIS_KEY_PREFIX ?? undefined,
@@ -72,20 +73,21 @@ const createRedisClusterInstance = (
       : {};
 
   const clusterOptions: ClusterOptions = {
-    // Return incoming addresses as-is - required for AWS ElastiCache Certificate resolution
-    dnsLookup: (address, callback) => {
-      callback(null, address);
-    },
-    redisOptions: {
-      username: env.REDIS_USERNAME || undefined,
-      password: env.REDIS_AUTH || undefined,
-      ...defaultRedisOptions,
-      ...additionalOptions,
-      ...tlsOptions,
-    },
-    // Retry configuration for cluster
-    retryDelayOnFailover: 100,
-  };
+  // Return incoming addresses as-is - required for AWS ElastiCache Certificate resolution
+  dnsLookup: (address, callback) => {
+    callback(null, address);
+  },
+  slotsRefreshTimeout: 5000,
+  redisOptions: {
+    username: env.REDIS_USERNAME || undefined,
+    password: env.REDIS_AUTH || undefined,
+    ...defaultRedisOptions,
+    ...additionalOptions,
+    ...tlsOptions,
+  },
+  // Retry configuration for cluster
+  retryDelayOnFailover: 100,
+};
 
   const cluster = new Cluster(nodes, clusterOptions);
 


### PR DESCRIPTION
## What does this PR do?

This PR addresses a Redis connection issue encountered when using AWS ElastiCache in cluster mode with TLS. Specifically, it resolves the following recurring error observed in production:
`Redis cluster error: Failed to refresh slots cache.
ClusterAllFailedError: Failed to refresh slots cache.`

<img width="1180" height="574" alt="image" src="https://github.com/user-attachments/assets/e2727d92-b6a0-49ea-93ac-6ef0c0afada2" />


The root cause was that AWS ElastiCache can take longer than the default timeout (1000ms) to respond during cluster topology changes or network latency. To handle this gracefully, we’ve increased the `slotsRefreshTimeout` to `5000ms` in the Redis Cluster configuration.

This change ensures that `ioredis` waits longer while refreshing the cluster slot cache, reducing the likelihood of `ClusterAllFailedError` during transient AWS network or failover events.

### Changes:
- Updated `ClusterOptions` in `redis.ts` to include:
  - `slotsRefreshTimeout: 5000`
  - Preserved AWS-compatible `dnsLookup` and TLS settings
- Ensures better compatibility and resilience with AWS ElastiCache Redis clusters

Fixes # (Internal ticket or issue ID, if available)

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

---

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

---

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`npm run lint`)
- [x] I have added tests (if applicable) or manually verified the fix
- [x] I have checked that new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase `slotsRefreshTimeout` to `5000ms` in `redis.ts` to improve AWS ElastiCache cluster compatibility.
> 
>   - **Behavior**:
>     - Increase `slotsRefreshTimeout` to `5000ms` in `createRedisClusterInstance()` in `redis.ts` to handle AWS ElastiCache latency.
>     - Ensures `ioredis` waits longer during cluster slot cache refresh, reducing `ClusterAllFailedError`.
>   - **Configuration**:
>     - Update `ClusterOptions` in `redis.ts` to include `slotsRefreshTimeout` and preserve AWS-compatible settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5ba30beba32ee58bbdba7b4e5fe3debd1b488537. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->