### PR TITLE
feat(tables-ui): pin columns in annotation and prompt metrics tables

### DIFF
--- a/web/src/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueueItemsTable.tsx
@@ -183,6 +183,7 @@ export function AnnotationQueueItemsTable({
       id: "select",
       accessorKey: "select",
       size: 30,
+      isPinnedLeft: true,
       isFixedPosition: true,
       header: ({ table }) => {
         return (

--- a/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueuesTable.tsx
@@ -66,6 +66,7 @@ export function AnnotationQueuesTable({ projectId }: { projectId: string }) {
       header: "Name",
       id: "key",
       size: 150,
+      isPinnedLeft: true,
       isFixedPosition: true,
       cell: ({ row }) => {
         const key: RowData["key"] = row.getValue("key");

--- a/web/src/pages/project/[projectId]/prompts/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/metrics.tsx
@@ -155,6 +155,7 @@ export default function PromptVersionTable({
       accessorKey: "version",
       id: "version",
       header: "Version",
+      isPinnedLeft: true,
       size: 80,
       cell: ({ row }) => {
         const version = row.getValue("version");
@@ -170,6 +171,7 @@ export default function PromptVersionTable({
       accessorKey: "labels",
       id: "labels",
       header: "Labels",
+      isPinnedLeft: true,
       size: 160,
       cell: ({ row }) => {
         const values: string[] = row.getValue("labels");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Pin columns to the left in `AnnotationQueueItemsTable`, `AnnotationQueuesTable`, and `PromptVersionTable` to enhance UI visibility during scrolling.
> 
>   - **Behavior**:
>     - Pin `select` column to the left in `AnnotationQueueItemsTable`.
>     - Pin `key` column to the left in `AnnotationQueuesTable`.
>     - Pin `version` and `labels` columns to the left in `PromptVersionTable`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1d72f741b83a383e8feffa1d3e14e44d158c9d38. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->