### PR TITLE
chore(cloud): allow selection of HIPAA cloud region on sign-in/sign-up page

### DIFF
--- a/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
+++ b/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
@@ -116,7 +116,7 @@ export function CloudRegionSwitch({
             <p>
               The Business Associate Agreement (BAA) is only effective on the Cloud Pro and Teams plans.{" "}
               <a
-                href="https://langfuse.com/baa"
+                href="https://langfuse.com/security/hipaa"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-primary-accent underline hover:text-hover-primary-accent"

--- a/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
+++ b/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
@@ -16,6 +16,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/src/components/ui/dialog";
+import { useState } from "react";
 
 const regions =
   env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "STAGING"
@@ -34,26 +35,23 @@ const regions =
             flag: "🚧",
           },
         ]
-      : env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "HIPAA"
-        ? [
-            {
-              name: "HIPAA",
-              hostname: "hipaa.cloud.langfuse.com",
-              flag: "⚕️",
-            },
-          ]
-        : [
-            {
-              name: "US",
-              hostname: "us.cloud.langfuse.com",
-              flag: "🇺🇸",
-            },
-            {
-              name: "EU",
-              hostname: "cloud.langfuse.com",
-              flag: "🇪🇺",
-            },
-          ];
+      : [
+          {
+            name: "US",
+            hostname: "us.cloud.langfuse.com",
+            flag: "🇺🇸",
+          },
+          {
+            name: "EU",
+            hostname: "cloud.langfuse.com",
+            flag: "🇪🇺",
+          },
+          {
+            name: "HIPAA",
+            hostname: "hipaa.cloud.langfuse.com",
+            flag: "⚕️",
+          },
+        ];
 
 export function CloudRegionSwitch({
   isSignUpPage,
@@ -61,6 +59,9 @@ export function CloudRegionSwitch({
   isSignUpPage?: boolean;
 }) {
   const capture = usePostHogClientCapture();
+  const [selectedRegion, setSelectedRegion] = useState<string>(
+    env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION ?? "US"
+  );
 
   if (env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === undefined) return null;
 
@@ -85,6 +86,7 @@ export function CloudRegionSwitch({
         <Select
           value={currentRegion?.name}
           onValueChange={(value) => {
+            setSelectedRegion(value);
             const region = regions.find((region) => region.name === value);
             if (!region) return;
             capture(
@@ -113,6 +115,22 @@ export function CloudRegionSwitch({
             ))}
           </SelectContent>
         </Select>
+        
+        {(selectedRegion === "HIPAA" || env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "HIPAA") && (
+          <div className="mt-2 rounded-md bg-muted/50 p-3 text-xs text-muted-foreground">
+            <p>
+              The Business Associate Agreement (BAA) is only effective on the Cloud Pro and Teams plans.{" "}
+              <a
+                href="https://langfuse.com/baa"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary-accent underline hover:text-hover-primary-accent"
+              >
+                Learn more about HIPAA compliance →
+              </a>
+            </p>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -136,19 +154,19 @@ const DataRegionInfo = () => (
       </DialogHeader>
       <DialogBody>
         <DialogDescription className="flex flex-col gap-2">
-          <p>Langfuse Cloud is available in two data regions:</p>
+          <p>Langfuse Cloud is available in three data regions:</p>
           <ul className="list-disc pl-5">
             <li>US: Oregon (AWS us-west-2)</li>
             <li>EU: Ireland (AWS eu-west-1)</li>
+            <li>HIPAA: HIPAA-compliant region (available with Pro and Teams plans)</li>
           </ul>
           <p>
             Regions are strictly separated, and no data is shared across
             regions. Choosing a region close to you can help improve speed and
             comply with local data residency laws and privacy regulations.
-            Contact us to onboard into a HIPAA compliant region.
           </p>
           <p>
-            You can have accounts in both regions and data migrations are
+            You can have accounts in multiple regions and data migrations are
             available on Team plans.
           </p>
           <p>

--- a/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
+++ b/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
@@ -153,7 +153,7 @@ const DataRegionInfo = () => (
           <ul className="list-disc pl-5">
             <li>US: Oregon (AWS us-west-2)</li>
             <li>EU: Ireland (AWS eu-west-1)</li>
-            <li>HIPAA: HIPAA-compliant region (available with Pro and Teams plans)</li>
+            <li>HIPAA: Oregon (AWS us-west-2) - HIPAA-compliant region (available with Pro and Teams plans)</li>
           </ul>
           <p>
             Regions are strictly separated, and no data is shared across
@@ -161,18 +161,26 @@ const DataRegionInfo = () => (
             comply with local data residency laws and privacy regulations.
           </p>
           <p>
-            You can have accounts in multiple regions and data migrations are
-            available on Team plans.
+            You can have accounts in multiple regions. Each region requires a separate subscription.
           </p>
           <p>
-            For more information, visit{" "}
+            Learn more about{" "}
+            <a
+              href="https://langfuse.com/security/data-regions"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary-accent underline"
+            >
+              data regions
+            </a>
+            {" "}and{" "}
             <a
               href="https://langfuse.com/docs/data-security-privacy"
               target="_blank"
               rel="noopener noreferrer"
               className="text-primary-accent underline"
             >
-              langfuse.com/security
+              data security & privacy
             </a>
             .
           </p>

--- a/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
+++ b/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
@@ -110,11 +110,12 @@ export function CloudRegionSwitch({
             ))}
           </SelectContent>
         </Select>
-        
+
         {env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "HIPAA" && (
           <div className="mt-2 rounded-md bg-muted/50 p-3 text-xs text-muted-foreground">
             <p>
-              The Business Associate Agreement (BAA) is only effective on the Cloud Pro and Teams plans.{" "}
+              The Business Associate Agreement (BAA) is only effective on the
+              Cloud Pro and Teams plans.{" "}
               <a
                 href="https://langfuse.com/security/hipaa"
                 target="_blank"
@@ -153,7 +154,10 @@ const DataRegionInfo = () => (
           <ul className="list-disc pl-5">
             <li>US: Oregon (AWS us-west-2)</li>
             <li>EU: Ireland (AWS eu-west-1)</li>
-            <li>HIPAA: Oregon (AWS us-west-2) - HIPAA-compliant region (available with Pro and Teams plans)</li>
+            <li>
+              HIPAA: Oregon (AWS us-west-2) - HIPAA-compliant region (available
+              with Pro and Teams plans)
+            </li>
           </ul>
           <p>
             Regions are strictly separated, and no data is shared across
@@ -161,7 +165,8 @@ const DataRegionInfo = () => (
             comply with local data residency laws and privacy regulations.
           </p>
           <p>
-            You can have accounts in multiple regions. Each region requires a separate subscription.
+            You can have accounts in multiple regions. Each region requires a
+            separate subscription.
           </p>
           <p>
             Learn more about{" "}
@@ -172,8 +177,8 @@ const DataRegionInfo = () => (
               className="text-primary-accent underline"
             >
               data regions
-            </a>
-            {" "}and{" "}
+            </a>{" "}
+            and{" "}
             <a
               href="https://langfuse.com/docs/data-security-privacy"
               target="_blank"

--- a/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
+++ b/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
@@ -16,7 +16,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/src/components/ui/dialog";
-import { useState } from "react";
 
 const regions =
   env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "STAGING"
@@ -59,9 +58,6 @@ export function CloudRegionSwitch({
   isSignUpPage?: boolean;
 }) {
   const capture = usePostHogClientCapture();
-  const [selectedRegion, setSelectedRegion] = useState<string>(
-    env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION ?? "US"
-  );
 
   if (env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === undefined) return null;
 
@@ -86,7 +82,6 @@ export function CloudRegionSwitch({
         <Select
           value={currentRegion?.name}
           onValueChange={(value) => {
-            setSelectedRegion(value);
             const region = regions.find((region) => region.name === value);
             if (!region) return;
             capture(
@@ -116,7 +111,7 @@ export function CloudRegionSwitch({
           </SelectContent>
         </Select>
         
-        {(selectedRegion === "HIPAA" || env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "HIPAA") && (
+        {env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "HIPAA" && (
           <div className="mt-2 rounded-md bg-muted/50 p-3 text-xs text-muted-foreground">
             <p>
               The Business Associate Agreement (BAA) is only effective on the Cloud Pro and Teams plans.{" "}

--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -38,7 +38,6 @@ import { Code } from "lucide-react";
 import { useRouter } from "next/router";
 import { captureException } from "@sentry/nextjs";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
-import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
 
 const credentialAuthForm = z.object({
   email: z.string().email(),
@@ -405,7 +404,6 @@ export default function SignIn({
   runningOnHuggingFaceSpaces,
 }: PageProps) {
   const router = useRouter();
-  const { setOpen: setSupportDrawerOpen } = useSupportDrawer();
   useHuggingFaceRedirect(runningOnHuggingFaceSpaces);
 
   // handle NextAuth error codes: https://next-auth.js.org/configuration/pages#sign-in-page
@@ -576,12 +574,12 @@ export default function SignIn({
             If you are experiencing issues signing in, please force refresh this
             page (CMD + SHIFT + R) or clear your browser cache. We are working
             on a solution.{" "}
-            <span
+            <a
+              href="mailto:support@langfuse.com"
               className="cursor-pointer whitespace-nowrap text-xs font-medium text-primary-accent hover:text-hover-primary-accent"
-              onClick={() => setSupportDrawerOpen(true)}
             >
               (contact us)
-            </span>
+            </a>
           </div>
         )}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds HIPAA region selection to sign-in/sign-up and updates support contact method.
> 
>   - **Behavior**:
>     - Adds HIPAA region to `regions` array in `AuthCloudRegionSwitch.tsx` for selection during sign-in/sign-up.
>     - Displays HIPAA-specific information when HIPAA region is selected.
>     - Updates `DataRegionInfo` to include HIPAA region details.
>   - **Sign-In Page**:
>     - Removes `useSupportDrawer` import and usage in `sign-in.tsx`.
>     - Changes support contact method to mailto link in `sign-in.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for dd9b35f7c542a46f6fe35551b7434240a02b41dc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->