### PR TITLE
fix: require admin api key for background migration retries in OSS

### DIFF
--- a/web/src/features/background-migrations/components/background-migrations.tsx
+++ b/web/src/features/background-migrations/components/background-migrations.tsx
@@ -1,4 +1,3 @@
-import Header from "@/src/components/layouts/header";
 import { DataTable } from "@/src/components/table/data-table";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import { type LangfuseColumnDef } from "@/src/components/table/types";

--- a/web/src/features/background-migrations/components/background-migrations.tsx
+++ b/web/src/features/background-migrations/components/background-migrations.tsx
@@ -76,7 +76,7 @@ export default function BackgroundMigrationsTable() {
         return (
           <RetryBackgroundMigration
             backgroundMigrationName={name}
-            isRetryable={true}
+            isRetryable={isRetryable}
           />
         );
       },

--- a/web/src/features/background-migrations/components/background-migrations.tsx
+++ b/web/src/features/background-migrations/components/background-migrations.tsx
@@ -76,7 +76,7 @@ export default function BackgroundMigrationsTable() {
         return (
           <RetryBackgroundMigration
             backgroundMigrationName={name}
-            isRetryable={isRetryable}
+            isRetryable={true}
           />
         );
       },

--- a/web/src/features/background-migrations/components/background-migrations.tsx
+++ b/web/src/features/background-migrations/components/background-migrations.tsx
@@ -6,6 +6,7 @@ import { api } from "@/src/utils/api";
 import { type BackgroundMigration } from "@langfuse/shared";
 import { RetryBackgroundMigration } from "@/src/features/background-migrations/components/retry-background-migration";
 import { StatusBadge } from "@/src/components/layouts/status-badge";
+import Page from "@/src/components/layouts/page";
 
 export default function BackgroundMigrationsTable() {
   const backgroundMigrations = api.backgroundMigrations.all.useQuery();
@@ -75,7 +76,7 @@ export default function BackgroundMigrationsTable() {
         return (
           <RetryBackgroundMigration
             backgroundMigrationName={name}
-            isRetryable={isRetryable}
+            isRetryable={true}
           />
         );
       },
@@ -83,8 +84,11 @@ export default function BackgroundMigrationsTable() {
   ] as LangfuseColumnDef<BackgroundMigration>[];
 
   return (
-    <>
-      <Header title="Background Migrations" />
+    <Page
+      headerProps={{
+        title: "Background Migrations",
+      }}
+    >
       <DataTableToolbar columns={columns} />
       <DataTable
         tableName={"backgroundMigrations"}
@@ -105,6 +109,6 @@ export default function BackgroundMigrationsTable() {
                 }
         }
       />
-    </>
+    </Page>
   );
 }

--- a/web/src/features/background-migrations/components/retry-background-migration.tsx
+++ b/web/src/features/background-migrations/components/retry-background-migration.tsx
@@ -83,10 +83,22 @@ export function RetryBackgroundMigration({
             onChange={(e) => setAdminApiKey(e.target.value)}
             className="mt-1"
             disabled={isLoading}
+            autoComplete="off"
+            inputMode="text"
+            name="admin-api-key"
           />
           <p className="mt-1 text-xs text-muted-foreground">
             Required for security. This key must match your ADMIN_API_KEY
-            environment variable.
+            environment variable{" ("}
+            <a
+              href="https://langfuse.com/self-hosting/administration/organization-management-api#authentication"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-muted-foreground underline hover:text-primary"
+            >
+              Docs
+            </a>
+            {")."}
           </p>
         </div>
 

--- a/web/src/features/background-migrations/components/retry-background-migration.tsx
+++ b/web/src/features/background-migrations/components/retry-background-migration.tsx
@@ -6,7 +6,10 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/src/components/ui/popover";
+import { Input } from "@/src/components/ui/input";
+import { Label } from "@/src/components/ui/label";
 import { RotateCcw } from "lucide-react";
+import { toast } from "sonner";
 
 export function RetryBackgroundMigration({
   backgroundMigrationName,
@@ -17,13 +20,48 @@ export function RetryBackgroundMigration({
 }) {
   const utils = api.useUtils();
   const [isOpen, setIsOpen] = useState(false);
+  const [adminApiKey, setAdminApiKey] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
 
-  const mutRetryBackgroundMigration =
-    api.backgroundMigrations.retry.useMutation({
-      onSuccess: () => {
-        void utils.backgroundMigrations.invalidate();
-      },
-    });
+  const handleRetry = async () => {
+    if (!adminApiKey.trim()) {
+      toast.error("Admin API key is required");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const response = await fetch("/api/trpc/backgroundMigrations.retry", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${adminApiKey.trim()}`,
+        },
+        body: JSON.stringify({
+          json: { name: backgroundMigrationName },
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData?.error?.message || "Failed to retry background migration");
+      }
+
+      toast.success("Background migration scheduled for retry");
+      void utils.backgroundMigrations.invalidate();
+      setIsOpen(false);
+      setAdminApiKey("");
+    } catch (error) {
+      console.error("Error retrying background migration:", error);
+      toast.error(
+        error instanceof Error 
+          ? error.message 
+          : "Failed to retry background migration"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   return (
     <Popover open={isOpen} onOpenChange={() => setIsOpen(!isOpen)}>
@@ -32,25 +70,51 @@ export function RetryBackgroundMigration({
           <RotateCcw className="h-4 w-4" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent>
-        <h2 className="text-md mb-3 font-semibold">Please confirm</h2>
-        <p className="mb-3 text-sm">
+      <PopoverContent className="w-96">
+        <h2 className="text-md mb-3 font-semibold">Retry Background Migration</h2>
+        <p className="mb-4 text-sm">
           This action schedules the migration for retry. Restart the worker
           containers to re-initiate the migration.
         </p>
-        <div className="flex justify-end space-x-4">
+        
+        <div className="mb-4">
+          <Label htmlFor="admin-api-key" className="text-sm font-medium">
+            Admin API Key
+          </Label>
+          <Input
+            id="admin-api-key"
+            type="password"
+            placeholder="Enter admin API key"
+            value={adminApiKey}
+            onChange={(e) => setAdminApiKey(e.target.value)}
+            className="mt-1"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            Required for security. This key must match your ADMIN_API_KEY environment variable.
+          </p>
+        </div>
+        
+        <div className="flex justify-end space-x-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              setIsOpen(false);
+              setAdminApiKey("");
+            }}
+            disabled={isLoading}
+          >
+            Cancel
+          </Button>
           <Button
             type="button"
             variant="default"
-            loading={mutRetryBackgroundMigration.isPending}
-            onClick={() => {
-              void mutRetryBackgroundMigration.mutateAsync({
-                name: backgroundMigrationName,
-              });
-              setIsOpen(false);
-            }}
+            size="sm"
+            loading={isLoading}
+            onClick={handleRetry}
           >
-            Retry Background Migration
+            Retry Migration
           </Button>
         </div>
       </PopoverContent>

--- a/web/src/features/background-migrations/server/background-migrations-router.ts
+++ b/web/src/features/background-migrations/server/background-migrations-router.ts
@@ -1,5 +1,5 @@
 import { z } from "zod/v4";
-import { createTRPCRouter, protectedProcedure } from "@/src/server/api/trpc";
+import { createTRPCRouter, protectedProcedure, adminProcedure } from "@/src/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 
 export const backgroundMigrationsRouter = createTRPCRouter({
@@ -33,7 +33,7 @@ export const backgroundMigrationsRouter = createTRPCRouter({
 
     return { status: "FINISHED" };
   }),
-  retry: protectedProcedure
+  retry: adminProcedure
     .input(z.object({ name: z.string() }))
     .mutation(async ({ input, ctx }) => {
       const backgroundMigration =

--- a/web/src/features/background-migrations/server/background-migrations-router.ts
+++ b/web/src/features/background-migrations/server/background-migrations-router.ts
@@ -1,5 +1,9 @@
 import { z } from "zod/v4";
-import { createTRPCRouter, protectedProcedure, adminProcedure } from "@/src/server/api/trpc";
+import {
+  createTRPCRouter,
+  protectedProcedure,
+  adminProcedure,
+} from "@/src/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 
 export const backgroundMigrationsRouter = createTRPCRouter({
@@ -34,7 +38,7 @@ export const backgroundMigrationsRouter = createTRPCRouter({
     return { status: "FINISHED" };
   }),
   retry: adminProcedure
-    .input(z.object({ name: z.string() }))
+    .input(z.object({ name: z.string(), adminApiKey: z.string() }))
     .mutation(async ({ input, ctx }) => {
       const backgroundMigration =
         await ctx.prisma.backgroundMigration.findUnique({

--- a/web/src/features/background-migrations/server/background-migrations-router.ts
+++ b/web/src/features/background-migrations/server/background-migrations-router.ts
@@ -1,8 +1,8 @@
 import { z } from "zod/v4";
 import {
   createTRPCRouter,
-  protectedProcedure,
   adminProcedure,
+  authenticatedProcedure,
 } from "@/src/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { env } from "@/src/env.mjs";

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -88,7 +88,7 @@ import {
   addUserToSpan,
   contextWithLangfuseProps,
 } from "@langfuse/shared/src/server";
-import { env } from "@/src/env.mjs";
+
 import { AdminApiAuthService } from "@/src/ee/features/admin-api/server/adminApiAuth";
 
 setUpSuperjson();

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -554,7 +554,6 @@ const enforceAdminAuth = t.middleware(async (opts) => {
     });
   }
 
-  logger.info(`Verifying admin API key: ${result.data.adminApiKey}`);
   const adminAuthResult = AdminApiAuthService.verifyAdminAuthFromAuthString(
     result.data.adminApiKey,
     false,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Require admin API key for retrying background migrations, updating authentication logic and UI components.
> 
>   - **Authentication**:
>     - `AdminApiAuthService` in `adminApiAuth.ts` refactored to separate `verifyAdminAuthFromAuthString` and `verifyAdminAuthFromHeader`.
>     - New `adminProcedure` in `trpc.ts` for admin API key authentication.
>   - **Background Migrations**:
>     - `retry` mutation in `background-migrations-router.ts` now requires `adminApiKey`.
>     - `RetryBackgroundMigration` component updated to include admin API key input and validation.
>   - **UI Changes**:
>     - `BackgroundMigrationsTable` wrapped in `Page` component for consistent layout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4467e8f628c4e2de887ba3e6126d7ca0e23b50e1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->