### PR TITLE
feat(dataset-run-items): pin dataset item id column in ui table

### DIFF
--- a/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
@@ -73,6 +73,7 @@ export function DatasetRunItemsByRunTable(props: {
       header: "Dataset Item",
       id: "datasetItemId",
       size: 110,
+      isPinnedLeft: true,
       cell: ({ row }) => {
         const datasetItemId: string = row.getValue("datasetItemId");
         return (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Pins `datasetItemId` column to the left in `DatasetRunItemsByRunTable` for better visibility during horizontal scrolling.
> 
>   - **UI Changes**:
>     - Pins `datasetItemId` column to the left in `DatasetRunItemsByRunTable` to keep it visible during horizontal scrolling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5fe2f257176f51d93c29fbb20a7118846295b4ca. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->