### PR TITLE
chore: Check tracing configuration for data retention

### DIFF
--- a/web/src/features/setup/components/SetupPage.tsx
+++ b/web/src/features/setup/components/SetupPage.tsx
@@ -66,7 +66,9 @@ export function SetupPage() {
   const capture = usePostHogClientCapture();
   useEffect(() => {
     if (hasTracingConfigured !== undefined) {
-      capture("onboarding:tracing_check_active", { active: hasTracingConfigured });
+      capture("onboarding:tracing_check_active", {
+        active: hasTracingConfigured,
+      });
     }
   }, [hasTracingConfigured, capture]);
 

--- a/web/src/features/setup/components/SetupPage.tsx
+++ b/web/src/features/setup/components/SetupPage.tsx
@@ -50,7 +50,7 @@ export function SetupPage() {
         ? 3
         : 2;
 
-  const hasAnyTrace = api.traces.hasAny.useQuery(
+  const hasTracingConfigured = api.traces.hasTracingConfigured.useQuery(
     { projectId: queryProjectId as string },
     {
       enabled: queryProjectId !== undefined && stepInt === 4,
@@ -65,10 +65,10 @@ export function SetupPage() {
 
   const capture = usePostHogClientCapture();
   useEffect(() => {
-    if (hasAnyTrace !== undefined) {
-      capture("onboarding:tracing_check_active", { active: hasAnyTrace });
+    if (hasTracingConfigured !== undefined) {
+      capture("onboarding:tracing_check_active", { active: hasTracingConfigured });
     }
-  }, [hasAnyTrace, capture]);
+  }, [hasTracingConfigured, capture]);
 
   return (
     <ContainerPage
@@ -202,7 +202,7 @@ export function SetupPage() {
           stepInt === 4 && project && organization && (
             <TracingSetup
               projectId={project.id}
-              hasAnyTrace={hasAnyTrace ?? false}
+              hasTracingConfigured={hasTracingConfigured ?? false}
             />
           )
         }
@@ -223,9 +223,9 @@ export function SetupPage() {
           <Button
             className="mt-4 self-start"
             onClick={() => router.push(`/project/${project.id}`)}
-            variant={hasAnyTrace ? "default" : "secondary"}
+            variant={hasTracingConfigured ? "default" : "secondary"}
           >
-            {hasAnyTrace ? "Open Dashboard" : "Skip for now"}
+            {hasTracingConfigured ? "Open Dashboard" : "Skip for now"}
           </Button>
         )
       }
@@ -235,10 +235,10 @@ export function SetupPage() {
 
 const TracingSetup = ({
   projectId,
-  hasAnyTrace,
+  hasTracingConfigured,
 }: {
   projectId: string;
-  hasAnyTrace?: boolean;
+  hasTracingConfigured?: boolean;
 }) => {
   const [apiKeys, setApiKeys] = useState<
     RouterOutput["projectApiKeys"]["create"] | null
@@ -288,7 +288,7 @@ const TracingSetup = ({
       <div>
         <Header
           title="Setup Tracing"
-          status={hasAnyTrace ? "active" : "pending"}
+          status={hasTracingConfigured ? "active" : "pending"}
         />
         <p className="mb-4 text-sm text-muted-foreground">
           Tracing is used to track and analyze your LLM calls. You can always

--- a/web/src/features/setup/components/SetupTracingButton.tsx
+++ b/web/src/features/setup/components/SetupTracingButton.tsx
@@ -15,7 +15,7 @@ const SetupTracingButton = () => {
   const router = useRouter();
   const queryProjectId = router.query.projectId as string | undefined;
 
-  const { data: hasAnyTrace, isLoading } = api.traces.hasAny.useQuery(
+  const { data: hasTracingConfigured, isLoading } = api.traces.hasTracingConfigured.useQuery(
     { projectId: queryProjectId as string },
     {
       enabled: queryProjectId !== undefined,
@@ -31,18 +31,18 @@ const SetupTracingButton = () => {
   const capturedEventAlready = useRef<boolean | undefined>(undefined);
   const capture = usePostHogClientCapture();
   useEffect(() => {
-    if (hasAnyTrace !== undefined && !capturedEventAlready.current) {
-      capture("onboarding:tracing_check_active", { active: hasAnyTrace });
+    if (hasTracingConfigured !== undefined && !capturedEventAlready.current) {
+      capture("onboarding:tracing_check_active", { active: hasTracingConfigured });
       capturedEventAlready.current = true;
     }
-  }, [hasAnyTrace, capture]);
+  }, [hasTracingConfigured, capture]);
 
   const hasAccess = useHasProjectAccess({
     projectId: project?.id,
     scope: "apiKeys:CUD",
   });
 
-  if (isLoading || hasAnyTrace || !project) {
+  if (isLoading || hasTracingConfigured || !project) {
     return null;
   }
 

--- a/web/src/features/setup/components/SetupTracingButton.tsx
+++ b/web/src/features/setup/components/SetupTracingButton.tsx
@@ -15,24 +15,27 @@ const SetupTracingButton = () => {
   const router = useRouter();
   const queryProjectId = router.query.projectId as string | undefined;
 
-  const { data: hasTracingConfigured, isLoading } = api.traces.hasTracingConfigured.useQuery(
-    { projectId: queryProjectId as string },
-    {
-      enabled: queryProjectId !== undefined,
-      trpc: {
-        context: {
-          skipBatch: true,
+  const { data: hasTracingConfigured, isLoading } =
+    api.traces.hasTracingConfigured.useQuery(
+      { projectId: queryProjectId as string },
+      {
+        enabled: queryProjectId !== undefined,
+        trpc: {
+          context: {
+            skipBatch: true,
+          },
         },
       },
-    },
-  );
+    );
 
   // dedupe result via useRef, otherwise we'll capture the event multiple times on session refresh
   const capturedEventAlready = useRef<boolean | undefined>(undefined);
   const capture = usePostHogClientCapture();
   useEffect(() => {
     if (hasTracingConfigured !== undefined && !capturedEventAlready.current) {
-      capture("onboarding:tracing_check_active", { active: hasTracingConfigured });
+      capture("onboarding:tracing_check_active", {
+        active: hasTracingConfigured,
+      });
       capturedEventAlready.current = true;
     }
   }, [hasTracingConfigured, capture]);

--- a/web/src/pages/project/[projectId]/observations.tsx
+++ b/web/src/pages/project/[projectId]/observations.tsx
@@ -14,18 +14,19 @@ export default function Generations() {
   const projectId = router.query.projectId as string;
 
   // Check if the user has tracing configured
-  const { data: hasTracingConfigured, isLoading } = api.traces.hasTracingConfigured.useQuery(
-    { projectId },
-    {
-      enabled: !!projectId,
-      trpc: {
-        context: {
-          skipBatch: true,
+  const { data: hasTracingConfigured, isLoading } =
+    api.traces.hasTracingConfigured.useQuery(
+      { projectId },
+      {
+        enabled: !!projectId,
+        trpc: {
+          context: {
+            skipBatch: true,
+          },
         },
+        refetchInterval: 10_000,
       },
-      refetchInterval: 10_000,
-    },
-  );
+    );
 
   const showOnboarding = !isLoading && !hasTracingConfigured;
 

--- a/web/src/pages/project/[projectId]/observations.tsx
+++ b/web/src/pages/project/[projectId]/observations.tsx
@@ -13,8 +13,8 @@ export default function Generations() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
 
-  // Check if the user has any traces
-  const { data: hasAnyTrace, isLoading } = api.traces.hasAny.useQuery(
+  // Check if the user has tracing configured
+  const { data: hasTracingConfigured, isLoading } = api.traces.hasTracingConfigured.useQuery(
     { projectId },
     {
       enabled: !!projectId,
@@ -27,7 +27,7 @@ export default function Generations() {
     },
   );
 
-  const showOnboarding = !isLoading && !hasAnyTrace;
+  const showOnboarding = !isLoading && !hasTracingConfigured;
 
   return (
     <Page

--- a/web/src/pages/project/[projectId]/traces.tsx
+++ b/web/src/pages/project/[projectId]/traces.tsx
@@ -14,18 +14,19 @@ export default function Traces() {
   const projectId = router.query.projectId as string;
 
   // Check if the user has tracing configured
-  const { data: hasTracingConfigured, isLoading } = api.traces.hasTracingConfigured.useQuery(
-    { projectId },
-    {
-      enabled: !!projectId,
-      trpc: {
-        context: {
-          skipBatch: true,
+  const { data: hasTracingConfigured, isLoading } =
+    api.traces.hasTracingConfigured.useQuery(
+      { projectId },
+      {
+        enabled: !!projectId,
+        trpc: {
+          context: {
+            skipBatch: true,
+          },
         },
+        refetchInterval: 10_000,
       },
-      refetchInterval: 10_000,
-    },
-  );
+    );
 
   const showOnboarding = !isLoading && !hasTracingConfigured;
 

--- a/web/src/pages/project/[projectId]/traces.tsx
+++ b/web/src/pages/project/[projectId]/traces.tsx
@@ -13,8 +13,8 @@ export default function Traces() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
 
-  // Check if the user has any traces
-  const { data: hasAnyTrace, isLoading } = api.traces.hasAny.useQuery(
+  // Check if the user has tracing configured
+  const { data: hasTracingConfigured, isLoading } = api.traces.hasTracingConfigured.useQuery(
     { projectId },
     {
       enabled: !!projectId,
@@ -27,7 +27,7 @@ export default function Traces() {
     },
   );
 
-  const showOnboarding = !isLoading && !hasAnyTrace;
+  const showOnboarding = !isLoading && !hasTracingConfigured;
 
   return (
     <Page

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -81,11 +81,11 @@ export const traceRouter = createTRPCRouter({
     .query(async ({ input, ctx }) => {
       // Check if there are any traces in the database
       const hasTraces = await hasAnyTrace(input.projectId);
-      
+
       if (hasTraces) {
         return true;
       }
-      
+
       // If no traces, check if data retention is configured
       // This indicates the user has configured tracing even if data retention cleaned all traces
       const project = await ctx.prisma.project.findUnique({
@@ -96,7 +96,7 @@ export const traceRouter = createTRPCRouter({
           retentionDays: true,
         },
       });
-      
+
       return !!(project?.retentionDays && project.retentionDays > 0);
     }),
   all: protectedProjectProcedure

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -72,14 +72,32 @@ export type ObservationReturnType = Omit<
 >;
 
 export const traceRouter = createTRPCRouter({
-  hasAny: protectedProjectProcedure
+  hasTracingConfigured: protectedProjectProcedure
     .input(
       z.object({
         projectId: z.string(),
       }),
     )
-    .query(async ({ input }) => {
-      return hasAnyTrace(input.projectId);
+    .query(async ({ input, ctx }) => {
+      // Check if there are any traces in the database
+      const hasTraces = await hasAnyTrace(input.projectId);
+      
+      if (hasTraces) {
+        return true;
+      }
+      
+      // If no traces, check if data retention is configured
+      // This indicates the user has configured tracing even if data retention cleaned all traces
+      const project = await ctx.prisma.project.findUnique({
+        where: {
+          id: input.projectId,
+        },
+        select: {
+          retentionDays: true,
+        },
+      });
+      
+      return !!(project?.retentionDays && project.retentionDays > 0);
     }),
   all: protectedProjectProcedure
     .input(TraceFilterOptions)


### PR DESCRIPTION
## What does this PR do?

This PR resolves an issue where the tracing configuration UI would incorrectly appear for projects that have data retention configured, even after all traces were deleted by the retention policy.

The logic for determining if tracing is configured has been updated to consider two factors:
1. The existence of any traces in the project.
2. Whether the project has `retentionDays` configured (if `retentionDays > 0`, it implies tracing has been set up).

The tRPC route `traces.hasAny` has been renamed to `traces.hasTracingConfigured` to better reflect this expanded logic.

Fixes #LFE-6250

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-6250](https://linear.app/langfuse/issue/LFE-6250/tracing-config-ui-shows-up-when-data-retention-deletes-all-data-from)

<a href="https://cursor.com/background-agent?bcId=bc-9db68c68-5582-418f-a0fd-04832d3f9f0c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9db68c68-5582-418f-a0fd-04832d3f9f0c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update tracing configuration logic to consider `retentionDays` and rename `traces.hasAny` to `traces.hasTracingConfigured`.
> 
>   - **Behavior**:
>     - Update logic in `traces.ts` to determine tracing configuration by checking for traces and `retentionDays` > 0.
>     - Rename tRPC route `traces.hasAny` to `traces.hasTracingConfigured`.
>   - **UI Components**:
>     - Replace `hasAnyTrace` with `hasTracingConfigured` in `SetupPage.tsx`, `SetupTracingButton.tsx`, `observations.tsx`, and `traces.tsx`.
>     - Update button and onboarding logic to use `hasTracingConfigured`.
>   - **Misc**:
>     - Add `refetchInterval` to `useQuery` calls in `observations.tsx` and `traces.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0ef02a6b871b388706963d8dde97e5aa7651d13d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->