### PR TITLE
feat(billing): show plan end in billing settings

### DIFF
--- a/packages/shared/src/interfaces/cloudConfigSchema.ts
+++ b/packages/shared/src/interfaces/cloudConfigSchema.ts
@@ -13,6 +13,13 @@ export const CloudConfigSchema = z.object({
       customerId: z.string().optional(),
       activeSubscriptionId: z.string().optional(),
       activeProductId: z.string().optional(),
+      cancellationInfo: z
+        .object({
+          scheduledForCancellation: z.boolean(),
+          cancelAt: z.number().int().optional(),
+          cancelReason: z.string().optional(),
+        })
+        .optional(),
     })
     .optional(),
 

--- a/web/src/components/LocalIsoDate.tsx
+++ b/web/src/components/LocalIsoDate.tsx
@@ -1,4 +1,4 @@
-type Accuracy = "minute" | "second" | "millisecond";
+type Accuracy = "day" | "hour" | "minute" | "second" | "millisecond";
 
 export const LocalIsoDate = ({
   date,
@@ -24,8 +24,14 @@ export const LocalIsoDate = ({
     const seconds = useUTC ? date.getUTCSeconds() : date.getSeconds();
     const ms = useUTC ? date.getUTCMilliseconds() : date.getMilliseconds();
 
-    let formatted = `${year}-${pad(month)}-${pad(day)} ${pad(hours)}:${pad(minutes)}`;
+    let formatted = `${year}-${pad(month)}-${pad(day)}`;
 
+    if (["hour", "minute", "second", "millisecond"].includes(pAccuracy)) {
+      formatted += ` ${pad(hours)}`;
+    }
+    if (["minute", "second", "millisecond"].includes(pAccuracy)) {
+      formatted += `:${pad(minutes)}`;
+    }
     if (["second", "millisecond"].includes(pAccuracy)) {
       formatted += `:${pad(seconds)}`;
     }

--- a/web/src/ee/features/billing/components/BillingCurrentPlanLabel.tsx
+++ b/web/src/ee/features/billing/components/BillingCurrentPlanLabel.tsx
@@ -1,0 +1,68 @@
+// Langfuse Cloud only
+
+import { useMemo } from "react";
+
+import { useQueryOrganization } from "@/src/features/organizations/hooks";
+import { LocalIsoDate } from "@/src/components/LocalIsoDate";
+
+import { planLabels } from "@langfuse/shared";
+
+export const BillingCurrentPlanLabel = () => {
+  const organization = useQueryOrganization();
+
+  const planLabel = useMemo(() => {
+    // Note: We pick the plan off the organization object, which in turn
+    // gets it from the current session.
+    return planLabels[organization?.plan ?? "cloud:hobby"];
+  }, [organization]);
+
+  const scheduledForCancellationDate = useMemo(() => {
+    const cancellationInfo =
+      organization?.cloudConfig?.stripe?.cancellationInfo;
+
+    if (!cancellationInfo) {
+      return null;
+    }
+
+    if (!cancellationInfo.scheduledForCancellation) {
+      return null;
+    }
+
+    if (!cancellationInfo.cancelAt) {
+      return null;
+    }
+
+    try {
+      const cancelAt = cancellationInfo.cancelAt;
+      const cancelAtDate =
+        typeof cancelAt === "number" && !Number.isNaN(cancelAt)
+          ? new Date(cancelAt * 1000)
+          : undefined;
+
+      const inFuture = cancelAtDate
+        ? cancelAtDate.getTime() > Date.now()
+        : false;
+
+      if (inFuture) {
+        return cancelAtDate;
+      } else {
+        return null;
+      }
+    } catch (error) {
+      return null;
+    }
+  }, [organization]);
+
+  return (
+    <div>
+      <>Current plan: {planLabel} </>
+      {scheduledForCancellationDate && (
+        <>
+          <span>(Plan will end on </span>
+          <LocalIsoDate date={scheduledForCancellationDate} accuracy="day" />
+          <span>)</span>
+        </>
+      )}
+    </div>
+  );
+};

--- a/web/src/ee/features/billing/components/BillingCurrentPlanLabel.tsx
+++ b/web/src/ee/features/billing/components/BillingCurrentPlanLabel.tsx
@@ -58,7 +58,7 @@ export const BillingCurrentPlanLabel = () => {
       <>Current plan: {planLabel} </>
       {scheduledForCancellationDate && (
         <>
-          <span>(Plan will end on </span>
+          <span>(will end on </span>
           <LocalIsoDate date={scheduledForCancellationDate} accuracy="day" />
           <span>)</span>
         </>

--- a/web/src/ee/features/billing/components/BillingUsageChart.tsx
+++ b/web/src/ee/features/billing/components/BillingUsageChart.tsx
@@ -5,8 +5,9 @@ import { MarkerBar } from "@tremor/react";
 import { useQueryOrganization } from "@/src/features/organizations/hooks";
 import { Card } from "@/src/components/ui/card";
 import { numberFormatter, compactNumberFormatter } from "@/src/utils/numbers";
-import { type Plan, planLabels } from "@langfuse/shared";
+import { type Plan } from "@langfuse/shared";
 import { MAX_EVENTS_FREE_PLAN } from "@/src/ee/features/billing/constants";
+import { BillingCurrentPlanLabel } from "./BillingCurrentPlanLabel";
 
 export const BillingUsageChart = () => {
   const organization = useQueryOrganization();
@@ -26,7 +27,6 @@ export const BillingUsageChart = () => {
   const hobbyPlanLimit =
     organization?.cloudConfig?.monthlyObservationLimit ?? MAX_EVENTS_FREE_PLAN;
   const plan: Plan = organization?.plan ?? "cloud:hobby";
-  const planLabel = planLabels[plan];
   const usageType = usage.data?.usageType
     ? usage.data.usageType.charAt(0).toUpperCase() +
       usage.data.usageType.slice(1)
@@ -70,7 +70,7 @@ export const BillingUsageChart = () => {
         )}
       </Card>
       <div className="mt-2 flex flex-col gap-1 text-sm text-muted-foreground">
-        <p>Current plan: {planLabel}</p>
+        <BillingCurrentPlanLabel />
         {usage.data?.billingPeriod && (
           <p>
             {`Billing period: ${usage.data.billingPeriod.start.toLocaleDateString()} - ${usage.data.billingPeriod.end.toLocaleDateString()}`}

--- a/web/src/ee/features/billing/components/StripeCustomerPortalButton.tsx
+++ b/web/src/ee/features/billing/components/StripeCustomerPortalButton.tsx
@@ -53,7 +53,12 @@ export const StripeCustomerPortalButton = ({
   }
 
   return (
-    <Button variant={variant} onClick={onClick} disabled={!orgId || loading}>
+    <Button
+      variant={variant}
+      onClick={onClick}
+      disabled={!orgId || loading}
+      title={title}
+    >
       {loading ? "Opening…" : title}
     </Button>
   );

--- a/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
+++ b/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
@@ -163,6 +163,55 @@ async function getOrgBasedOnCheckoutSessionAttachedToSubscription(
   return organization;
 }
 
+interface CancellationInfo {
+  scheduledForCancellation: boolean;
+  cancelAt: number | null; // Unix timestamp in seconds
+  cancelReason: string | null;
+}
+
+/**
+ * Determines if a subscription is scheduled for cancellation
+ * Works with both classic and flexible billing modes
+ *
+ * @param subscription The subscription object from a webhook event
+ * @returns Object with cancellation details
+ */
+function getSubscriptionCancellationStatus(
+  subscription: any,
+): CancellationInfo {
+  // Classic billing mode: Check cancel_at_period_end flag
+  const isClassicCancellation = subscription.cancel_at_period_end === true;
+
+  // Flexible billing mode: Check cancel_at timestamp
+  const isFlexibleCancellation =
+    subscription.cancel_at !== null && subscription.cancel_at !== undefined;
+
+  const scheduledForCancellation =
+    isClassicCancellation || isFlexibleCancellation;
+
+  let cancelAt: number | null = null;
+
+  if (isFlexibleCancellation) {
+    // For flexible billing mode, use the explicit cancel_at timestamp
+    cancelAt = subscription.cancel_at;
+  } else if (isClassicCancellation) {
+    // For classic billing mode, cancellation happens at period end
+    cancelAt = subscription.current_period_end;
+  }
+
+  // Extract cancellation reason if available
+  let cancelReason: string | null = null;
+  if (subscription.cancellation_details?.reason) {
+    cancelReason = subscription.cancellation_details.reason;
+  }
+
+  return {
+    scheduledForCancellation,
+    cancelAt,
+    cancelReason,
+  };
+}
+
 async function handleSubscriptionChanged(
   subscription: Stripe.Subscription,
   action: "created" | "deleted" | "updated",

--- a/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
+++ b/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
@@ -293,7 +293,9 @@ async function handleSubscriptionChanged(
 
   // update the cloud config with the product ID
   if (action === "created" || action === "updated") {
-    let updatedCloudConfig = {
+    const cancellationInfo = getSubscriptionCancellationStatus(subscription);
+
+    const updatedCloudConfig = {
       ...parsedOrg.cloudConfig,
       stripe: {
         ...parsedOrg.cloudConfig?.stripe,
@@ -301,6 +303,9 @@ async function handleSubscriptionChanged(
           activeProductId: productId,
           activeSubscriptionId: subscriptionId,
           customerId: customerId,
+          cancellationInfo: cancellationInfo.scheduledForCancellation
+            ? cancellationInfo
+            : undefined,
         }),
       },
     };


### PR DESCRIPTION
# What's New?

- Updated Billing Settings to reflect when a user cancelled a subscription, but is still on the old plan for some days

<img width="1372" height="920" alt="CleanShot 2025-09-10 at 16 17 28" src="https://github.com/user-attachments/assets/4b109001-aa39-4b76-b986-a9b709b26860" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Display subscription plan end date in billing settings when cancellation is scheduled, with UI and webhook updates.
> 
>   - **Behavior**:
>     - Display plan end date in billing settings when a subscription is cancelled but still active for a few days.
>     - Update `BillingActionButtons` to show "Reactivate Subscription" if cancellation is scheduled.
>     - Add `BillingCurrentPlanLabel` to show current plan and end date if applicable.
>   - **Schema**:
>     - Add `cancellationInfo` to `CloudConfigSchema` in `cloudConfigSchema.ts`.
>   - **Components**:
>     - Update `LocalIsoDate` to support `day` accuracy.
>     - Add `BillingCurrentPlanLabel` component.
>     - Modify `BillingUsageChart` to use `BillingCurrentPlanLabel`.
>   - **Webhook Handling**:
>     - Add `getSubscriptionCancellationStatus()` in `stripeWebhookApiHandler.ts` to determine cancellation status.
>     - Update `handleSubscriptionChanged()` to store cancellation info in cloud config.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 609096b5dbe046f5b58d69389e818bba2ee17202. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->