### PR TITLE
fix(otel): add root span metadata to trace

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -512,6 +512,7 @@ export class OtelIngestionProcessor {
         metadata: {
           ...resourceAttributeMetadata,
           ...this.extractMetadata(attributes, "trace"),
+          ...this.extractMetadata(attributes, "observation"),
           ...(isLangfuseSDKSpans
             ? {}
             : { attributes: spanAttributesInMetadata }),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds extraction of 'observation' metadata in `OtelIngestionProcessor` to enhance span metadata handling.
> 
>   - **Behavior**:
>     - Adds extraction of 'observation' metadata in `OtelIngestionProcessor` class.
>     - Affects metadata handling for spans, specifically in `createTraceEvent()` and `processSpan()` methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cf09492362e3ca69191587a107182599e1d86abc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->