### PR TITLE
fix(peek): safe parse runs url parameter in compare data hook

### DIFF
--- a/web/src/components/table/peek/hooks/usePeekRunsCompareData.ts
+++ b/web/src/components/table/peek/hooks/usePeekRunsCompareData.ts
@@ -6,7 +6,15 @@ type UsePeekRunsCompareDataProps = {
   datasetItemId?: string;
   traceId?: string;
   timestamp?: Date;
-  runs?: string[];
+  runs?: string[] | string;
+};
+
+// Ensure runs is always an array - handle case where URL param comes as string
+const safeParseUrlParamToArray = (
+  runs?: string[] | string,
+): string[] | undefined => {
+  if (!runs) return undefined;
+  return Array.isArray(runs) ? runs : [runs];
 };
 
 export const usePeekRunsCompareData = ({
@@ -17,6 +25,8 @@ export const usePeekRunsCompareData = ({
   datasetItemId,
   runs,
 }: UsePeekRunsCompareDataProps) => {
+  const parsedRuns = safeParseUrlParamToArray(runs);
+
   const trace = api.traces.byIdWithObservationsAndScores.useQuery(
     {
       traceId: traceId as string,
@@ -49,10 +59,11 @@ export const usePeekRunsCompareData = ({
       projectId,
       datasetId: datasetId as string,
       datasetItemId: datasetItemId as string,
-      datasetRunIds: runs as string[] | undefined,
+      datasetRunIds: parsedRuns,
     },
     {
-      enabled: !!datasetId && !!datasetItemId && !!runs && runs.length > 0,
+      enabled:
+        !!datasetId && !!datasetItemId && !!parsedRuns && parsedRuns.length > 0,
     },
   );
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces `safeParseUrlParamToArray` in `usePeekRunsCompareData.ts` to ensure `runs` parameter is always an array, handling string inputs.
> 
>   - **Behavior**:
>     - Introduces `safeParseUrlParamToArray` function in `usePeekRunsCompareData.ts` to ensure `runs` is always an array.
>     - Handles cases where `runs` URL parameter is a string by converting it to an array.
>   - **Hook**:
>     - Updates `usePeekRunsCompareData` to use `safeParseUrlParamToArray` for `runs` parameter.
>     - Ensures `datasetRunIds` in `runItems` query is correctly formatted as an array.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 205ab742863addb9946dffdc58e71949f876cfcf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->