### PR TITLE
feat: add gcp vertex tool inputs and outputs on otel spans

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1080,6 +1080,13 @@ export class OtelIngestionProcessor {
       return { input, output };
     }
 
+    // GCP Vertex Agent Tool call input and output
+    input = attributes["gcp.vertex.agent.tool_call_args"];
+    output = attributes["gcp.vertex.agent.tool_response"];
+    if (input || output) {
+      return { input, output };
+    }
+
     // TraceLoop uses attributes property
     const inputAttributes = Object.keys(attributes).filter((key) =>
       key.startsWith("gen_ai.prompt"),

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -492,6 +492,7 @@ describe("OTel Resource Span Mapping", () => {
         environment: "production",
       });
     });
+
     it("should throw an error if langfuse scope spans have wrong project ID", async () => {
       const langfuseOtelSpans = [
         {
@@ -2012,6 +2013,30 @@ describe("OTel Resource Span Mapping", () => {
         {
           entity: "observation",
           otelAttributeKey: "gen_ai.output.messages",
+          otelAttributeValue: {
+            stringValue: '{"foo": "bar"}',
+          },
+          entityAttributeKey: "output",
+          entityAttributeValue: '{"foo": "bar"}',
+        },
+      ],
+      [
+        "should map gcp.vertex.agent.tool_call_args to input",
+        {
+          entity: "observation",
+          otelAttributeKey: "gcp.vertex.agent.tool_call_args",
+          otelAttributeValue: {
+            stringValue: '{"foo": "bar"}',
+          },
+          entityAttributeKey: "input",
+          entityAttributeValue: '{"foo": "bar"}',
+        },
+      ],
+      [
+        "should map gcp.vertex.agent.tool_response to output",
+        {
+          entity: "observation",
+          otelAttributeKey: "gcp.vertex.agent.tool_response",
           otelAttributeValue: {
             stringValue: '{"foo": "bar"}',
           },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for GCP Vertex AI tool call inputs and outputs in OpenTelemetry spans by updating `OtelIngestionProcessor` and adding test cases.
> 
>   - **Behavior**:
>     - `OtelIngestionProcessor` in `OtelIngestionProcessor.ts` now processes `gcp.vertex.agent.tool_call_args` and `gcp.vertex.agent.tool_response` attributes to map them as input and output respectively.
>   - **Tests**:
>     - Added test cases in `otelMapping.servertest.ts` to verify mapping of `gcp.vertex.agent.tool_call_args` to input and `gcp.vertex.agent.tool_response` to output.
>     - Ensures correct mapping and handling of these attributes in observation events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 51f43c38aca2a0237092dbcbae6c41030c1113bd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->