### PR TITLE
perf: add a global concurrency limit to the createEvalQueue

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -90,6 +90,8 @@ export const getTimeframesTracesAMT = (
  * @param {string} traceId - ID of the trace to check
  * @param {Date} timestamp - Timestamp for time-based filtering, uses event payload or job timestamp
  * @param {FilterState} filter - Filter for the trace
+ * @param {Date} maxTimeStamp - Upper bound on timestamp
+ * @param {Date} exactTimestamp - Exact match for the trace
  * @returns {Promise<boolean>} - True if trace exists
  *
  * Notes:

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -112,6 +112,11 @@ if (env.QUEUE_CONSUMER_CREATE_EVAL_QUEUE_IS_ENABLED === "true") {
     evalJobCreatorQueueProcessor,
     {
       concurrency: env.LANGFUSE_EVAL_CREATOR_WORKER_CONCURRENCY,
+      limiter: {
+        // Process at most `max` jobs per 2 seconds globally
+        max: env.LANGFUSE_EVAL_CREATOR_WORKER_CONCURRENCY,
+        duration: 2_000,
+      },
     },
   );
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add global concurrency limiter to `createEvalQueue` to control job processing rate in `app.ts`.
> 
>   - **Performance**:
>     - Add global concurrency limiter to `createEvalQueue` in `app.ts`.
>     - Limits `evalJobCreatorQueueProcessor` to process at most `max` jobs per 2 seconds globally.
>   - **Misc**:
>     - Add `maxTimeStamp` and `exactTimestamp` parameters to `checkTraceExistsAndGetTimestamp` in `traces.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cdf714f8ba71d378d6c730be601b0b9fd100b67d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->