### PR TITLE
feat(billing): distinguish between new subscriptions and legacy subscriptions

### DIFF
--- a/packages/shared/src/interfaces/cloudConfigSchema.ts
+++ b/packages/shared/src/interfaces/cloudConfigSchema.ts
@@ -13,6 +13,7 @@ export const CloudConfigSchema = z.object({
       customerId: z.string().optional(),
       activeSubscriptionId: z.string().optional(),
       activeProductId: z.string().optional(),
+      activeUsageProductId: z.string().optional(),
       cancellationInfo: z
         .object({
           scheduledForCancellation: z.boolean(),

--- a/packages/shared/src/interfaces/cloudConfigSchema.ts
+++ b/packages/shared/src/interfaces/cloudConfigSchema.ts
@@ -22,6 +22,11 @@ export const CloudConfigSchema = z.object({
         })
         .optional(),
     })
+    .transform((data) => ({
+      ...data,
+      isLegacySubscription:
+        !!data?.activeProductId && !data?.activeUsageProductId,
+    }))
     .optional(),
 
   // custom rate limits for an organization

--- a/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
+++ b/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
@@ -275,6 +275,14 @@ async function handleSubscriptionChanged(
         });
   const productId = planProductItem?.price.product;
 
+  const usageProductItem =
+    items.length == 1
+      ? null // legacy setup; Set to null, so we can distinguish from the new setup
+      : items.find((it) => {
+          return it.price && it.price.recurring?.usage_type === "metered";
+        });
+  const usageProductId = usageProductItem?.price.product;
+
   if (!productId || typeof productId !== "string") {
     logger.error("[Stripe Webhook] Product ID not found");
     traceException("[Stripe Webhook] Product ID not found");
@@ -306,6 +314,7 @@ async function handleSubscriptionChanged(
         ...parsedOrg.cloudConfig?.stripe,
         ...CloudConfigSchema.shape.stripe.parse({
           activeProductId: productId,
+          activeUsageProductId: usageProductId,
           activeSubscriptionId: subscriptionId,
           customerId: customerId,
           cancellationInfo: cancellationInfo.scheduledForCancellation
@@ -336,6 +345,7 @@ async function handleSubscriptionChanged(
             ...CloudConfigSchema.shape.stripe.parse({
               activeProductId: undefined,
               activeSubscriptionId: undefined,
+              activeUsageProductId: undefined,
               customerId: customerId,
             }),
           },

--- a/web/src/ee/features/billing/utils/stripeProducts.ts
+++ b/web/src/ee/features/billing/utils/stripeProducts.ts
@@ -7,6 +7,7 @@ const isTestEnvironment =
 
 type StripeProduct = {
   stripeProductId: string;
+  orderKey?: number | undefined; // to check whether a plan is upgraded or downgraded
   mappedPlan: Plan;
   // include checkout if product can be subscribed to by new users
   checkout: {
@@ -22,9 +23,10 @@ type StripeProduct = {
 export const stripeProducts: StripeProduct[] = [
   {
     stripeProductId: isTestEnvironment
-      ? "prod_RoBuRrXjIUBIJ8" // test
+      ? "prod_RoYirvRQ4Kc6po" // test
       : "prod_RoYirvRQ4Kc6po", // live
     mappedPlan: "cloud:core",
+    orderKey: 1000,
     checkout: {
       title: "Core",
       description:
@@ -41,9 +43,10 @@ export const stripeProducts: StripeProduct[] = [
   },
   {
     stripeProductId: isTestEnvironment
-      ? "prod_QgDNYKXcBfvUQ3" // test
+      ? "prod_QhK7UMhrkVeF6R" // test
       : "prod_QhK7UMhrkVeF6R", // live
     mappedPlan: "cloud:pro",
+    orderKey: 2000,
     checkout: {
       title: "Pro",
       description:
@@ -62,9 +65,10 @@ export const stripeProducts: StripeProduct[] = [
   },
   {
     stripeProductId: isTestEnvironment
-      ? "prod_QgDOxTD64U6KDv" // test
+      ? "prod_QhK9qKGH25BTcS" // test
       : "prod_QhK9qKGH25BTcS", // live
     mappedPlan: "cloud:team",
+    orderKey: 3000,
     checkout: {
       title: "Pro + Teams Add-on",
       description: "Organizational and security controls for larger teams.",
@@ -81,13 +85,30 @@ export const stripeProducts: StripeProduct[] = [
   },
   {
     stripeProductId: isTestEnvironment
-      ? "prod_SToP5nTZpC4yO8" // test
+      ? "prod_STnXok7GSSDmyF" // test
       : "prod_STnXok7GSSDmyF", // live
     mappedPlan: "cloud:enterprise",
     checkout: null,
   },
 ];
 
+export const stripeUsageProduct = {
+  id: "prod_T1VvYnUEfoqswU",
+};
+
 export const mapStripeProductIdToPlan = (productId: string): Plan | null =>
   stripeProducts.find((product) => product.stripeProductId === productId)
     ?.mappedPlan ?? null;
+
+export const isUpgrade = (
+  oldProductId: string,
+  newProductId: string,
+): boolean => {
+  const oldProduct = stripeProducts.find(
+    (product) => product.stripeProductId === oldProductId,
+  );
+  const newProduct = stripeProducts.find(
+    (product) => product.stripeProductId === newProductId,
+  );
+  return (oldProduct?.orderKey ?? 0) < (newProduct?.orderKey ?? 0);
+};


### PR DESCRIPTION
We will have two shapes of “active subscription” data but no reliable way to tell them apart at runtime, which makes it hard to choose the correct upgrade path.

- Legacy: single productId
- New: two products — a plan (activePlanId/plan) and a usage-based productId