### PR TITLE
fix(otel): Make sure we do not process empty otel events

### DIFF
--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -115,6 +115,9 @@ export const processEventBatch = async (
     error?: string;
   }[];
 }> => {
+  if (input.length === 0) {
+    return { successes: [], errors: [] };
+  }
   const { delay = null, source = "api", isLangfuseInternal = false } = options;
 
   // add context of api call to the span

--- a/worker/src/__tests__/processEventBatch.empty.test.ts
+++ b/worker/src/__tests__/processEventBatch.empty.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, assert } from "vitest";
+import { processEventBatch } from "@langfuse/shared/src/server";
+
+describe("processEventBatch - empty batch", () => {
+  it("returns early on empty input", async () => {
+    // Auth check with missing projectId will cause an exeption unless
+    // there is an early return in processEventBatch
+    const authCheck = {
+      validKey: true as const,
+      scope: {
+        projectId: null,
+        accessLevel: "project" as const,
+      },
+    };
+
+    assert.doesNotThrow(
+      async () => await processEventBatch([], authCheck, {}),
+      "UnauthorizedError",
+    );
+
+    const res = await processEventBatch([], authCheck, {});
+    expect(res.successes).toEqual([]);
+    expect(res.errors).toEqual([]);
+  });
+});

--- a/worker/src/__tests__/processEventBatch.empty.test.ts
+++ b/worker/src/__tests__/processEventBatch.empty.test.ts
@@ -3,7 +3,7 @@ import { processEventBatch } from "@langfuse/shared/src/server";
 
 describe("processEventBatch - empty batch", () => {
   it("returns early on empty input", async () => {
-    // Auth check with missing projectId will cause an exeption unless
+    // Auth check with missing projectId will cause an exception unless
     // there is an early return in processEventBatch
     const authCheck = {
       validKey: true as const,

--- a/worker/src/__tests__/processEventBatch.test.ts
+++ b/worker/src/__tests__/processEventBatch.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, assert } from "vitest";
 import { processEventBatch } from "@langfuse/shared/src/server";
 
-describe("processEventBatch - empty batch", () => {
+describe("processEventBatch", () => {
   it("returns early on empty input", async () => {
     // Auth check with missing projectId will cause an exception unless
     // there is an early return in processEventBatch


### PR DESCRIPTION
On some codepaths `processEventBatch` can be called on an empty `input`. e.g.  when `otelIngestionQueueProcessor` processes spans without any trace metadata. This behavior is generally benign because `processEventBatch` will just call a bunch of flat-maps and reduce functions on an empty array. Yet it is somewhat confusing from the o11y perspective: calls to `processEventBatch` with `batch_size = 0` is nothing but noise. This PR adds an early exit which should get rid of the noise and spare a couple of cycles along the way :) 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds early exit in `processEventBatch` for empty inputs to reduce noise and adds a test for this behavior.
> 
>   - **Behavior**:
>     - Adds early exit in `processEventBatch` in `processEventBatch.ts` for empty `input` arrays, returning empty `successes` and `errors`.
>   - **Tests**:
>     - Adds test in `processEventBatch.test.ts` to verify early exit behavior for empty `input` arrays, ensuring no `UnauthorizedError` is thrown and results are empty.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2db7b3d6e93f18cbbfbd8bdd76d1a7708e9b522c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->