### PR TITLE
chore(cloud): switch to in-app support for sso setup to replace email

### DIFF
--- a/web/src/ee/features/sso-settings/components/SSOSettings.tsx
+++ b/web/src/ee/features/sso-settings/components/SSOSettings.tsx
@@ -2,9 +2,12 @@ import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 import { AlertCircle } from "lucide-react";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import Header from "@/src/components/layouts/header";
+import { Button } from "@/src/components/ui/button";
+import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
 
 export const SSOSettings = () => {
   const hasEntitlement = useHasEntitlement("cloud-multi-tenant-sso");
+  const { setOpen: setSupportDrawerOpen } = useSupportDrawer();
 
   const commonContent = (
     <>
@@ -40,15 +43,17 @@ export const SSOSettings = () => {
       <Alert>
         <AlertCircle className="h-4 w-4" />
         <AlertTitle>Contact Langfuse Support</AlertTitle>
-        <AlertDescription>
-          To set up or change your SSO configuration, please reach out to{" "}
-          <a
-            href="mailto:support@langfuse.com"
-            className="font-medium underline underline-offset-4"
+        <AlertDescription className="flex flex-col gap-3">
+          <p>
+            To set up or change your SSO configuration, please reach out to our
+            support engineering team.
+          </p>
+          <Button
+            onClick={() => setSupportDrawerOpen(true)}
+            className="self-start"
           >
-            support@langfuse.com
-          </a>
-          .
+            Contact Support
+          </Button>
         </AlertDescription>
       </Alert>
     </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces email support with in-app support button in `SSOSettings.tsx`, opening support drawer via `useSupportDrawer`.
> 
>   - **Behavior**:
>     - Replaces email link with in-app support button in `SSOSettings.tsx`.
>     - Button opens support drawer using `setSupportDrawerOpen` from `useSupportDrawer`.
>   - **UI Components**:
>     - Adds `Button` component to `AlertDescription` in `SSOSettings.tsx`.
>     - Removes email link to `support@langfuse.com`.
>   - **Imports**:
>     - Adds `Button` and `useSupportDrawer` imports in `SSOSettings.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a7fbcbca77730b471fd742ecac68465129f8380e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->