### PR TITLE
chore: move reads to read replica

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -38,6 +38,7 @@ const EnvSchema = z.object({
   LANGFUSE_CACHE_PROMPT_ENABLED: z.enum(["true", "false"]).default("true"),
   LANGFUSE_CACHE_PROMPT_TTL_SECONDS: z.coerce.number().default(300), // 5 minutes
   CLICKHOUSE_URL: z.string().url(),
+  CLICKHOUSE_READ_ONLY_URL: z.string().url().optional(),
   CLICKHOUSE_CLUSTER_NAME: z.string().default("default"),
   CLICKHOUSE_DB: z.string().default("default"),
   CLICKHOUSE_USER: z.string(),

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -68,7 +68,7 @@ export class ClickHouseClientManager {
   ) => {
     return preferredClickhouseService === "ReadWrite"
       ? env.CLICKHOUSE_URL
-      : (env.CLICKHOUSE_READ_ONLY_URL ?? env.CLICKHOUSE_URL);
+      : env.CLICKHOUSE_READ_ONLY_URL || env.CLICKHOUSE_URL;
   };
 
   /**

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -6,6 +6,8 @@ import { propagation, context } from "@opentelemetry/api";
 
 export type ClickhouseClientType = ReturnType<typeof createClient>;
 
+export type PreferredClickhouseService = "ReadWrite" | "ReadOnly";
+
 /**
  * ClickHouseClientManager provides a singleton pattern for managing ClickHouse clients.
  * It creates and reuses clients based on their configuration to avoid creating
@@ -35,21 +37,39 @@ export class ClickHouseClientManager {
    * @param opts Client parameters
    * @returns String hash key
    */
-  private generateClientSettingsKey(
+  private generateClientSettings(
     opts: NodeClickHouseClientConfigOptions,
-  ): string {
+    preferredClickhouseService: PreferredClickhouseService = "ReadWrite",
+  ): NodeClickHouseClientConfigOptions {
     const keyParams = {
-      url: env.CLICKHOUSE_URL,
+      url: this.getClickhouseUrl(preferredClickhouseService),
       username: env.CLICKHOUSE_USER,
       password: env.CLICKHOUSE_PASSWORD,
       database: env.CLICKHOUSE_DB,
-      http_headers: opts?.http_headers,
+      http_headers: opts?.http_headers ?? {},
       settings: opts?.clickhouse_settings,
-      request_timeout: opts?.request_timeout ?? 30000,
+      ...(opts.request_timeout
+        ? { request_timeout: opts.request_timeout }
+        : {}),
+
       // Include any other relevant config options
     };
-    return JSON.stringify(keyParams);
+    return keyParams;
   }
+
+  private generateClientSettingsKey(
+    settings: NodeClickHouseClientConfigOptions,
+  ): string {
+    return JSON.stringify(settings);
+  }
+
+  private getClickhouseUrl = (
+    preferredClickhouseService: PreferredClickhouseService,
+  ) => {
+    return preferredClickhouseService === "ReadWrite"
+      ? env.CLICKHOUSE_URL
+      : (env.CLICKHOUSE_READ_ONLY_URL ?? env.CLICKHOUSE_URL);
+  };
 
   /**
    * Get or create a client based on the provided parameters
@@ -58,13 +78,17 @@ export class ClickHouseClientManager {
    */
   public getClient(
     opts: NodeClickHouseClientConfigOptions,
+    preferredClickhouseService: PreferredClickhouseService = "ReadWrite",
   ): ClickhouseClientType {
-    const key = this.generateClientSettingsKey(opts);
+    const settings = this.generateClientSettings(
+      opts,
+      preferredClickhouseService,
+    );
+    const key = this.generateClientSettingsKey(settings);
     if (!this.clientMap.has(key)) {
-      const headers = opts?.http_headers ?? {};
       const activeSpan = getCurrentSpan();
       if (activeSpan) {
-        propagation.inject(context.active(), headers);
+        propagation.inject(context.active(), settings.http_headers);
       }
 
       const cloudOptions: Record<string, unknown> = {};
@@ -78,11 +102,7 @@ export class ClickHouseClientManager {
 
       const client = createClient({
         ...opts,
-        url: env.CLICKHOUSE_URL,
-        username: env.CLICKHOUSE_USER,
-        password: env.CLICKHOUSE_PASSWORD,
-        database: env.CLICKHOUSE_DB,
-        http_headers: headers,
+        ...settings,
         keep_alive: {
           idle_socket_ttl: env.CLICKHOUSE_KEEP_ALIVE_IDLE_SOCKET_TTL,
         },
@@ -99,9 +119,6 @@ export class ClickHouseClientManager {
               }
             : {}),
         },
-        ...(opts.request_timeout
-          ? { request_timeout: opts.request_timeout }
-          : {}),
       });
 
       this.clientMap.set(key, client);
@@ -122,8 +139,14 @@ export class ClickHouseClientManager {
   }
 }
 
-export const clickhouseClient = (opts?: NodeClickHouseClientConfigOptions) => {
-  return ClickHouseClientManager.getInstance().getClient(opts ?? {});
+export const clickhouseClient = (
+  opts?: NodeClickHouseClientConfigOptions,
+  preferredClickhouseService: PreferredClickhouseService = "ReadWrite",
+) => {
+  return ClickHouseClientManager.getInstance().getClient(
+    opts ?? {},
+    preferredClickhouseService,
+  );
 };
 
 /**

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -25,7 +25,10 @@ import {
 import { OrderByState } from "../../interfaces/orderBy";
 import { getTimeframesTracesAMT, getTracesByIds } from "./traces";
 import { measureAndReturn } from "../clickhouse/measureAndReturn";
-import { convertDateToClickhouseDateTime } from "../clickhouse/client";
+import {
+  convertDateToClickhouseDateTime,
+  PreferredClickhouseService,
+} from "../clickhouse/client";
 import { convertObservation } from "./observations_converters";
 import { clickhouseSearchCondition } from "../queries/clickhouse-sql/search";
 import {
@@ -120,12 +123,19 @@ export type GetObservationsForTraceOpts<IncludeIO extends boolean> = {
   projectId: string;
   timestamp?: Date;
   includeIO?: IncludeIO;
+  preferredClickhouseService?: PreferredClickhouseService;
 };
 
 export const getObservationsForTrace = async <IncludeIO extends boolean>(
   opts: GetObservationsForTraceOpts<IncludeIO>,
 ) => {
-  const { traceId, projectId, timestamp, includeIO = false } = opts;
+  const {
+    traceId,
+    projectId,
+    timestamp,
+    includeIO = false,
+    preferredClickhouseService,
+  } = opts;
 
   const query = `
   SELECT
@@ -178,6 +188,7 @@ export const getObservationsForTrace = async <IncludeIO extends boolean>(
       kind: "list",
       projectId,
     },
+    preferredClickhouseService,
   });
 
   // Large number of observations in trace with large input / output / metadata will lead to

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -24,7 +24,10 @@ import {
   ScoreAggregation,
 } from "./scores_converters";
 import { SCORE_TO_TRACE_OBSERVATIONS_INTERVAL } from "./constants";
-import { convertDateToClickhouseDateTime } from "../clickhouse/client";
+import {
+  convertDateToClickhouseDateTime,
+  PreferredClickhouseService,
+} from "../clickhouse/client";
 import { ScoreRecordReadType } from "./definitions";
 import { env } from "../../env";
 import { _handleGetScoreById, _handleGetScoresByIds } from "./scores-utils";
@@ -152,6 +155,7 @@ export type GetScoresForTracesProps<
   clickhouseConfigs?: ClickHouseClientConfigOptions;
   excludeMetadata?: ExcludeMetadata;
   includeHasMetadata?: IncludeHasMetadata;
+  preferredClickhouseService?: PreferredClickhouseService;
 };
 
 type GetScoresForSessionsProps<
@@ -375,6 +379,7 @@ export const getScoresForTraces = async <
     clickhouseConfigs,
     excludeMetadata = false,
     includeHasMetadata = false,
+    preferredClickhouseService,
   } = props;
 
   const select = formatMetadataSelect(excludeMetadata, includeHasMetadata);
@@ -417,6 +422,7 @@ export const getScoresForTraces = async <
       projectId,
     },
     clickhouseConfigs,
+    preferredClickhouseService,
   });
 
   return rows.map((row) => {

--- a/web/src/features/public-api/server/observations.ts
+++ b/web/src/features/public-api/server/observations.ts
@@ -102,6 +102,7 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
         query: query.replace("__TRACE_TABLE__", "traces"),
         params: input.params,
         tags: { ...input.tags, experiment_amt: "original" },
+        preferredClickhouseService: "ReadOnly",
       });
       return result.map((r) => convertObservation(r));
     },
@@ -110,6 +111,7 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
         query: query.replace("__TRACE_TABLE__", "traces_all_amt"),
         params: input.params,
         tags: { ...input.tags, experiment_amt: "new" },
+        preferredClickhouseService: "ReadOnly",
       });
       return result.map((r) => convertObservation(r));
     },
@@ -147,6 +149,7 @@ export const getObservationsCountForPublicApi = async (props: QueryType) => {
         query: query.replace("__TRACE_TABLE__", "traces"),
         params: input.params,
         tags: { ...input.tags, experiment_amt: "original" },
+        preferredClickhouseService: "ReadOnly",
       });
       return records.map((record) => Number(record.count)).shift();
     },
@@ -155,6 +158,7 @@ export const getObservationsCountForPublicApi = async (props: QueryType) => {
         query: query.replace("__TRACE_TABLE__", "traces_all_amt"),
         params: input.params,
         tags: { ...input.tags, experiment_amt: "new" },
+        preferredClickhouseService: "ReadOnly",
       });
       return records.map((record) => Number(record.count)).shift();
     },

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -146,6 +146,7 @@ export const generateTracesForPublicApi = async ({
         operation_name: "getTracesForPublicApi",
       },
       fromTimestamp: timeFilter?.value ?? undefined,
+      preferredClickhouseService: "ReadOnly",
     },
     existingExecution: (input) => {
       // If user provides an order we prefer it or fallback to timestamp as the default.
@@ -208,6 +209,7 @@ export const generateTracesForPublicApi = async ({
         query,
         params: input.params,
         tags: { ...input.tags, experiment_amt: "original" },
+        preferredClickhouseService: "ReadOnly",
       });
     },
     newExecution: (input) => {
@@ -268,6 +270,7 @@ export const generateTracesForPublicApi = async ({
         query,
         params: input.params,
         tags: { ...input.tags, experiment_amt: "new" },
+        preferredClickhouseService: "ReadOnly",
       });
     },
   });
@@ -331,6 +334,7 @@ export const getTracesCountForPublicApi = async ({
         query: query.replace("__TRACE_TABLE__", "traces"),
         params: input.params,
         tags: { ...input.tags, experiment_amt: "original" },
+        preferredClickhouseService: "ReadOnly",
       });
       return records.map((record) => Number(record.count)).shift();
     },
@@ -340,6 +344,7 @@ export const getTracesCountForPublicApi = async ({
         query: query.replace("__TRACE_TABLE__", traceAmt),
         params: input.params,
         tags: { ...input.tags, experiment_amt: "new" },
+        preferredClickhouseService: "ReadOnly",
       });
       return records.map((record) => Number(record.count)).shift();
     },

--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -47,11 +47,13 @@ export default withMiddlewares({
           projectId: auth.scope.projectId,
           timestamp: trace?.timestamp,
           includeIO: true,
+          preferredClickhouseService: "ReadOnly",
         }),
         getScoresForTraces({
           projectId: auth.scope.projectId,
           traceIds: [traceId],
           timestamp: trace?.timestamp,
+          preferredClickhouseService: "ReadOnly",
         }),
       ]);
 

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -81,7 +81,9 @@ export default withMiddlewares({
           props: filterProps,
           orderBy: query.orderBy ?? null,
         }),
-        getTracesCountForPublicApi({ props: filterProps }),
+        getTracesCountForPublicApi({
+          props: filterProps,
+        }),
       ]);
 
       const finalCount = count || 0;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduce `CLICKHOUSE_READ_ONLY_URL` for directing read operations to a ClickHouse read replica, enhancing performance and load distribution.
> 
>   - **Environment**:
>     - Add `CLICKHOUSE_READ_ONLY_URL` to `env.ts` for optional read-only ClickHouse connections.
>   - **Client Management**:
>     - Update `ClickHouseClientManager` in `client.ts` to use `CLICKHOUSE_READ_ONLY_URL` for read operations.
>     - Add `PreferredClickhouseService` type to specify service preference ("ReadWrite" or "ReadOnly").
>   - **Repositories**:
>     - Update `queryClickhouseStream` and `queryClickhouse` in `clickhouse.ts` to accept `preferredClickhouseService` parameter.
>     - Modify `getObservationsForTrace` in `observations.ts` to use read-only service for public API.
>     - Adjust `getScoresForTraces` in `scores.ts` to utilize read-only service for trace score retrieval.
>   - **Public API**:
>     - Set `preferredClickhouseService` to "ReadOnly" for `generateObservationsForPublicApi` and `getObservationsCountForPublicApi` in `observations.ts`.
>     - Apply read-only service for `generateTracesForPublicApi` and `getTracesCountForPublicApi` in `traces.ts`.
>     - Ensure read operations in `traces/[traceId].ts` and `traces/index.ts` use read-only service.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6e66109ea9d9bed88d3cfc52ba9970958d0225e1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->