### PR TITLE
feat(billing): Add new billing logic and update stripe integration

### DIFF
--- a/packages/shared/src/interfaces/cloudConfigSchema.ts
+++ b/packages/shared/src/interfaces/cloudConfigSchema.ts
@@ -21,6 +21,15 @@ export const CloudConfigSchema = z.object({
           cancelReason: z.string().optional(),
         })
         .optional(),
+      planSwitchScheduleInfo: z
+        .object({
+          // if a subscription has a schedule, we want to indicate this in the ui
+          subscriptionScheduleId: z.string().optional(),
+          switchAt: z.number().int().optional(),
+          productId: z.string().optional(),
+          usageProductId: z.string().optional(),
+        })
+        .optional(),
     })
     .transform((data) => ({
       ...data,

--- a/web/src/components/LocalIsoDate.tsx
+++ b/web/src/components/LocalIsoDate.tsx
@@ -1,5 +1,38 @@
 type Accuracy = "day" | "hour" | "minute" | "second" | "millisecond";
 
+export const formatLocalIsoDate = (
+  date: Date,
+  useUTC = false,
+  pAccuracy: Accuracy,
+) => {
+  const pad = (num: number) => String(num).padStart(2, "0");
+
+  const year = useUTC ? date.getUTCFullYear() : date.getFullYear();
+  const month = useUTC ? date.getUTCMonth() + 1 : date.getMonth() + 1;
+  const day = useUTC ? date.getUTCDate() : date.getDate();
+  const hours = useUTC ? date.getUTCHours() : date.getHours();
+  const minutes = useUTC ? date.getUTCMinutes() : date.getMinutes();
+  const seconds = useUTC ? date.getUTCSeconds() : date.getSeconds();
+  const ms = useUTC ? date.getUTCMilliseconds() : date.getMilliseconds();
+
+  let formatted = `${year}-${pad(month)}-${pad(day)}`;
+
+  if (["hour", "minute", "second", "millisecond"].includes(pAccuracy)) {
+    formatted += ` ${pad(hours)}`;
+  }
+  if (["minute", "second", "millisecond"].includes(pAccuracy)) {
+    formatted += `:${pad(minutes)}`;
+  }
+  if (["second", "millisecond"].includes(pAccuracy)) {
+    formatted += `:${pad(seconds)}`;
+  }
+  if (pAccuracy === "millisecond") {
+    formatted += `.${String(ms).padStart(3, "0")}`;
+  }
+
+  return formatted;
+};
+
 export const LocalIsoDate = ({
   date,
   accuracy = "second",
@@ -13,37 +46,8 @@ export const LocalIsoDate = ({
     return null;
   }
 
-  const formatDate = (date: Date, useUTC = false, pAccuracy: Accuracy) => {
-    const pad = (num: number) => String(num).padStart(2, "0");
-
-    const year = useUTC ? date.getUTCFullYear() : date.getFullYear();
-    const month = useUTC ? date.getUTCMonth() + 1 : date.getMonth() + 1;
-    const day = useUTC ? date.getUTCDate() : date.getDate();
-    const hours = useUTC ? date.getUTCHours() : date.getHours();
-    const minutes = useUTC ? date.getUTCMinutes() : date.getMinutes();
-    const seconds = useUTC ? date.getUTCSeconds() : date.getSeconds();
-    const ms = useUTC ? date.getUTCMilliseconds() : date.getMilliseconds();
-
-    let formatted = `${year}-${pad(month)}-${pad(day)}`;
-
-    if (["hour", "minute", "second", "millisecond"].includes(pAccuracy)) {
-      formatted += ` ${pad(hours)}`;
-    }
-    if (["minute", "second", "millisecond"].includes(pAccuracy)) {
-      formatted += `:${pad(minutes)}`;
-    }
-    if (["second", "millisecond"].includes(pAccuracy)) {
-      formatted += `:${pad(seconds)}`;
-    }
-    if (pAccuracy === "millisecond") {
-      formatted += `.${String(ms).padStart(3, "0")}`;
-    }
-
-    return formatted;
-  };
-
-  const localDateString = formatDate(date, false, accuracy);
-  const utcDateString = formatDate(date, true, "millisecond");
+  const localDateString = formatLocalIsoDate(date, false, accuracy);
+  const utcDateString = formatLocalIsoDate(date, true, "millisecond");
 
   return (
     <span title={`UTC: ${utcDateString}`} className={className}>

--- a/web/src/ee/features/billing/components/BillingActionButtons.tsx
+++ b/web/src/ee/features/billing/components/BillingActionButtons.tsx
@@ -7,9 +7,10 @@ import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvi
 import { StripeCustomerPortalButton } from "./StripeCustomerPortalButton";
 import { BillingSwitchPlanDialog } from "./BillingSwitchPlanDialog";
 import { useBillingInformation } from "./useBillingInformation";
+import { StripeCancellationButton } from "./StripeCancellationButton";
 
 export const BillingActionButtons = () => {
-  const { organization, cancellation } = useBillingInformation();
+  const { organization } = useBillingInformation();
   const { setOpen } = useSupportDrawer();
 
   // Do not show checkout or customer portal if manual plan is set in cloud config
@@ -41,13 +42,8 @@ export const BillingActionButtons = () => {
             title="Update Billing Details"
             variant="default"
           />
-          <StripeCustomerPortalButton
+          <StripeCancellationButton
             orgId={organization.id}
-            title={
-              cancellation?.isCancelled
-                ? "Reactivate Subscription"
-                : "Cancel Subscription"
-            }
             variant="secondary"
           />
         </>

--- a/web/src/ee/features/billing/components/BillingActionButtons.tsx
+++ b/web/src/ee/features/billing/components/BillingActionButtons.tsx
@@ -40,7 +40,7 @@ export const BillingActionButtons = () => {
           <StripeCustomerPortalButton
             orgId={organization.id}
             title="Update Billing Details"
-            variant="default"
+            variant="secondary"
           />
           <StripeCancellationButton
             orgId={organization.id}

--- a/web/src/ee/features/billing/components/BillingCurrentPlanLabel.tsx
+++ b/web/src/ee/features/billing/components/BillingCurrentPlanLabel.tsx
@@ -1,65 +1,19 @@
 // Langfuse Cloud only
 
-import { useMemo } from "react";
-
-import { useQueryOrganization } from "@/src/features/organizations/hooks";
 import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 
-import { planLabels } from "@langfuse/shared";
+import { useBillingInformation } from "@/src/ee/features/billing/components/useBillingInformation";
 
 export const BillingCurrentPlanLabel = () => {
-  const organization = useQueryOrganization();
-
-  const planLabel = useMemo(() => {
-    // Note: We pick the plan off the organization object, which in turn
-    // gets it from the current session.
-    return planLabels[organization?.plan ?? "cloud:hobby"];
-  }, [organization]);
-
-  const scheduledForCancellationDate = useMemo(() => {
-    const cancellationInfo =
-      organization?.cloudConfig?.stripe?.cancellationInfo;
-
-    if (!cancellationInfo) {
-      return null;
-    }
-
-    if (!cancellationInfo.scheduledForCancellation) {
-      return null;
-    }
-
-    if (!cancellationInfo.cancelAt) {
-      return null;
-    }
-
-    try {
-      const cancelAt = cancellationInfo.cancelAt;
-      const cancelAtDate =
-        typeof cancelAt === "number" && !Number.isNaN(cancelAt)
-          ? new Date(cancelAt * 1000)
-          : undefined;
-
-      const inFuture = cancelAtDate
-        ? cancelAtDate.getTime() > Date.now()
-        : false;
-
-      if (inFuture) {
-        return cancelAtDate;
-      } else {
-        return null;
-      }
-    } catch (error) {
-      return null;
-    }
-  }, [organization]);
+  const { planLabel, cancellation } = useBillingInformation();
 
   return (
     <div>
       <>Current plan: {planLabel} </>
-      {scheduledForCancellationDate && (
+      {cancellation?.isCancelled && cancellation.date && (
         <>
           <span>(will end on </span>
-          <LocalIsoDate date={scheduledForCancellationDate} accuracy="day" />
+          <LocalIsoDate date={cancellation.date} accuracy="day" />
           <span>)</span>
         </>
       )}

--- a/web/src/ee/features/billing/components/BillingScheduleNotification.tsx
+++ b/web/src/ee/features/billing/components/BillingScheduleNotification.tsx
@@ -11,23 +11,23 @@ export const BillingScheduleNotification = () => {
     return null;
   }
 
-  if (scheduledPlanSwitch) {
-    return (
-      <div className="mb-4 mt-6 flex overflow-x-auto rounded-lg border border-blue-200 bg-blue-100 py-2 text-sm text-blue-900 contrast-more:border-current dark:border-blue-200/30 dark:bg-blue-900/30 dark:text-blue-200 contrast-more:dark:border-current ltr:pr-4 rtl:pl-4">
-        <div className="flex items-center gap-2 pl-3 leading-7">
-          <InfoIcon className="h-4 w-4" />
-          {`Your organization is scheduled to switch from ${planLabel} to ${scheduledPlanSwitch.newPlanLabel} by the end of the current billing period.`}
-        </div>
-      </div>
-    );
-  }
-
   if (cancellation) {
     return (
       <div className="mb-4 mt-6 flex overflow-x-auto rounded-lg border border-blue-200 bg-blue-100 py-2 text-sm text-blue-900 contrast-more:border-current dark:border-blue-200/30 dark:bg-blue-900/30 dark:text-blue-200 contrast-more:dark:border-current ltr:pr-4 rtl:pl-4">
         <div className="flex items-center gap-2 pl-3 leading-7">
           <InfoIcon className="h-4 w-4" />
           {`Your organization cancelled the subscription. Features of the ${planLabel} plan will be available until the end of the billing period.`}
+        </div>
+      </div>
+    );
+  }
+
+  if (scheduledPlanSwitch) {
+    return (
+      <div className="mb-4 mt-6 flex overflow-x-auto rounded-lg border border-blue-200 bg-blue-100 py-2 text-sm text-blue-900 contrast-more:border-current dark:border-blue-200/30 dark:bg-blue-900/30 dark:text-blue-200 contrast-more:dark:border-current ltr:pr-4 rtl:pl-4">
+        <div className="flex items-center gap-2 pl-3 leading-7">
+          <InfoIcon className="h-4 w-4" />
+          {`Your organization is scheduled to switch from ${planLabel} to ${scheduledPlanSwitch.newPlanLabel} by the end of the current billing period.`}
         </div>
       </div>
     );

--- a/web/src/ee/features/billing/components/BillingScheduleNotification.tsx
+++ b/web/src/ee/features/billing/components/BillingScheduleNotification.tsx
@@ -1,0 +1,37 @@
+// Langfuse Cloud only
+
+import { InfoIcon } from "lucide-react";
+import { useBillingInformation } from "./useBillingInformation";
+
+export const BillingScheduleNotification = () => {
+  const { planLabel, cancellation, scheduledPlanSwitch } =
+    useBillingInformation();
+
+  if (!scheduledPlanSwitch && !cancellation) {
+    return null;
+  }
+
+  if (scheduledPlanSwitch) {
+    return (
+      <div className="mb-4 mt-6 flex overflow-x-auto rounded-lg border border-blue-200 bg-blue-100 py-2 text-sm text-blue-900 contrast-more:border-current dark:border-blue-200/30 dark:bg-blue-900/30 dark:text-blue-200 contrast-more:dark:border-current ltr:pr-4 rtl:pl-4">
+        <div className="flex items-center gap-2 pl-3 leading-7">
+          <InfoIcon className="h-4 w-4" />
+          {`Your organization is scheduled to switch from ${planLabel} to ${scheduledPlanSwitch.newPlanLabel} by the end of the current billing period.`}
+        </div>
+      </div>
+    );
+  }
+
+  if (cancellation) {
+    return (
+      <div className="mb-4 mt-6 flex overflow-x-auto rounded-lg border border-blue-200 bg-blue-100 py-2 text-sm text-blue-900 contrast-more:border-current dark:border-blue-200/30 dark:bg-blue-900/30 dark:text-blue-200 contrast-more:dark:border-current ltr:pr-4 rtl:pl-4">
+        <div className="flex items-center gap-2 pl-3 leading-7">
+          <InfoIcon className="h-4 w-4" />
+          {`Your organization cancelled the subscription. Features of the ${planLabel} plan will be available until the end of the billing period.`}
+        </div>
+      </div>
+    );
+  }
+
+  return <div></div>;
+};

--- a/web/src/ee/features/billing/components/BillingSettings.tsx
+++ b/web/src/ee/features/billing/components/BillingSettings.tsx
@@ -9,6 +9,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 import { UsageAlerts } from "./UsageAlerts";
 import { BillingUsageChart } from "./BillingUsageChart";
 import { BillingActionButtons } from "./BillingActionButtons";
+import { BillingScheduleNotification } from "./BillingScheduleNotification";
 
 export const BillingSettings = () => {
   const router = useRouter();
@@ -35,6 +36,8 @@ export const BillingSettings = () => {
 
   return (
     <div>
+      <BillingScheduleNotification />
+
       <Header title="Usage & Billing" />
       <div className="space-y-6">
         <BillingUsageChart />

--- a/web/src/ee/features/billing/components/BillingSwitchPlanDialog.tsx
+++ b/web/src/ee/features/billing/components/BillingSwitchPlanDialog.tsx
@@ -51,21 +51,6 @@ export const BillingSwitchPlanDialog = () => {
       },
     });
 
-  const mutClearPlanSwitchSchedule =
-    api.cloudBilling.clearPlanSwitchSchedule.useMutation({
-      onSuccess: () => {
-        toast.success("Kept current plan");
-        setProcessingPlanId(null);
-        setTimeout(() => {
-          window.location.reload();
-        }, 500);
-      },
-      onError: () => {
-        setProcessingPlanId(null);
-        toast.error("Failed to keep current plan");
-      },
-    });
-
   return (
     <Dialog
       onOpenChange={(open) => {

--- a/web/src/ee/features/billing/components/BillingSwitchPlanDialog.tsx
+++ b/web/src/ee/features/billing/components/BillingSwitchPlanDialog.tsx
@@ -6,10 +6,7 @@ import { useRouter } from "next/router";
 import { Button } from "@/src/components/ui/button";
 import {
   Dialog,
-  DialogClose,
   DialogContent,
-  DialogFooter,
-  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -17,18 +14,29 @@ import {
 } from "@/src/components/ui/dialog";
 import { toast } from "sonner";
 
-import { planLabels } from "@langfuse/shared";
-import { stripeProducts } from "@/src/ee/features/billing/utils/stripeProducts";
+// planLabels used inside StripeSwitchPlanButton
+import {
+  stripeProducts,
+  isUpgrade,
+} from "@/src/ee/features/billing/utils/stripeProducts";
 import { ActionButton } from "@/src/components/ActionButton";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
-import { useQueryOrganization } from "@/src/features/organizations/hooks";
+import { useBillingInformation } from "@/src/ee/features/billing/components/useBillingInformation";
 import { api } from "@/src/utils/api";
+import { StripeCancellationButton } from "./StripeCancellationButton";
+import { StripeSwitchPlanButton } from "./StripeSwitchPlanButton";
+import { StripeKeepPlanButton } from "./StripeKeepPlanButton";
 
 export const BillingSwitchPlanDialog = () => {
   const [processingPlanId, setProcessingPlanId] = useState<string | null>(null);
 
   const router = useRouter();
-  const organization = useQueryOrganization();
+  const {
+    organization,
+    cancellation,
+    scheduledPlanSwitch,
+    isLegacySubscription,
+  } = useBillingInformation();
   const capture = usePostHogClientCapture();
 
   const mutCreateCheckoutSession =
@@ -39,21 +47,22 @@ export const BillingSwitchPlanDialog = () => {
       },
       onError: () => {
         setProcessingPlanId(null);
+        toast.error("Failed to start checkout session");
       },
     });
 
-  const mutChangePlan =
-    api.cloudBilling.changeStripeSubscriptionProduct.useMutation({
+  const mutClearPlanSwitchSchedule =
+    api.cloudBilling.clearPlanSwitchSchedule.useMutation({
       onSuccess: () => {
-        toast.success("Plan changed successfully");
+        toast.success("Kept current plan");
         setProcessingPlanId(null);
-        // wait 1 second before reloading
         setTimeout(() => {
           window.location.reload();
         }, 500);
       },
       onError: () => {
         setProcessingPlanId(null);
+        toast.error("Failed to keep current plan");
       },
     });
 
@@ -81,120 +90,179 @@ export const BillingSwitchPlanDialog = () => {
           <div className="mb-3 grid grid-cols-1 gap-3 md:grid-cols-3">
             {stripeProducts
               .filter((product) => Boolean(product.checkout))
-              .map((product) => (
-                <div
-                  key={product.stripeProductId}
-                  className="relative flex flex-col rounded-xl border bg-card p-4 shadow-sm transition-all hover:shadow-md"
-                >
-                  <div className="mb-4">
-                    <h3 className="text-2xl font-bold">
-                      {product.checkout?.title}
-                    </h3>
-                    <div className="mt-4 space-y-1">
-                      <div className="text-2xl font-bold text-primary">
-                        {product.checkout?.price}
+              .map((product) => {
+                const currentProductId =
+                  organization?.cloudConfig?.stripe?.activeProductId;
+                const isThisUpgrade = currentProductId
+                  ? isUpgrade(currentProductId, product.stripeProductId)
+                  : true;
+                const isCurrentPlan =
+                  currentProductId === product.stripeProductId;
+
+                return (
+                  <div
+                    key={product.stripeProductId}
+                    className="relative flex flex-col rounded-xl border bg-card p-4 shadow-sm transition-all hover:shadow-md"
+                  >
+                    <div className="mb-4">
+                      {/* Labels above plan title */}
+                      <div className="mb-1 h-5 text-xs font-medium text-blue-700">
+                        {isCurrentPlan && <span>Current Plan</span>}
+                        {scheduledPlanSwitch &&
+                          organization?.cloudConfig?.stripe
+                            ?.planSwitchScheduleInfo?.productId ===
+                            product.stripeProductId && (
+                            <span className="ml-1">Starts next period</span>
+                          )}
+                        {scheduledPlanSwitch &&
+                          organization?.cloudConfig?.stripe?.activeProductId ===
+                            product.stripeProductId && (
+                            <span className="ml-1">(Until next period)</span>
+                          )}
+                        {!scheduledPlanSwitch &&
+                          cancellation?.isCancelled &&
+                          organization?.cloudConfig?.stripe?.activeProductId ===
+                            product.stripeProductId && (
+                            <span className="ml-1">(Until next period)</span>
+                          )}
                       </div>
-                      <div className="text-sm text-muted-foreground">
-                        + {product.checkout?.usagePrice}
+                      <h3 className="text-2xl font-bold">
+                        {product.checkout?.title}
+                      </h3>
+                      <div className="mt-4 space-y-1">
+                        <div className="text-2xl font-bold text-primary">
+                          {product.checkout?.price}
+                        </div>
+                        <div className="text-sm text-muted-foreground">
+                          + {product.checkout?.usagePrice}
+                        </div>
                       </div>
                     </div>
-                  </div>
-                  <div className="mb-4 text-sm text-muted-foreground">
-                    {product.checkout?.description}
-                  </div>
-                  <div className="space-y-2">
-                    <div className="text-sm font-medium">Main features:</div>
-                    <ul className="list-inside list-disc space-y-1 text-sm text-muted-foreground">
-                      {product.checkout?.mainFeatures.map((feature, index) => (
-                        <li key={index}>{feature}</li>
-                      ))}
-                    </ul>
-                  </div>
-                  <Link
-                    href="https://langfuse.com/pricing"
-                    target="_blank"
-                    className="mt-auto block py-4 text-sm text-muted-foreground hover:text-foreground"
-                  >
-                    Learn more about plan →
-                  </Link>
-                  {organization?.cloudConfig?.stripe?.activeProductId ? (
-                    // Change plan
-                    <Dialog>
-                      <DialogTrigger asChild>
-                        <Button
-                          disabled={
-                            organization?.cloudConfig?.stripe
-                              ?.activeProductId === product.stripeProductId
-                          }
-                          className="w-full"
-                        >
-                          {organization?.cloudConfig?.stripe
-                            ?.activeProductId === product.stripeProductId
-                            ? "Current plan"
-                            : "Change plan"}
-                        </Button>
-                      </DialogTrigger>
-                      <DialogContent>
-                        <DialogHeader>
-                          <DialogTitle>
-                            Confirm Change:{" "}
-                            {planLabels[organization?.plan ?? "cloud:hobby"]} →{" "}
-                            {product.checkout?.title}
-                          </DialogTitle>
-                          <DialogDescription className="pt-2">
-                            This will immediately generate an invoice for any
-                            usage on your current plan. Your new plan and
-                            billing period will start today. Are you sure you
-                            want to continue?
-                          </DialogDescription>
-                        </DialogHeader>
-                        <DialogFooter>
-                          <DialogClose asChild>
-                            <Button variant="secondary">Cancel</Button>
-                          </DialogClose>
-                          <ActionButton
-                            onClick={() => {
-                              if (organization) {
-                                setProcessingPlanId(product.stripeProductId);
-                                mutChangePlan.mutate({
-                                  orgId: organization.id,
-                                  stripeProductId: product.stripeProductId,
-                                });
+                    <div className="mb-4 text-sm text-muted-foreground">
+                      {product.checkout?.description}
+                    </div>
+                    <div className="space-y-2">
+                      <div className="text-sm font-medium">Main features:</div>
+                      <ul className="list-inside list-disc space-y-1 text-sm text-muted-foreground">
+                        {product.checkout?.mainFeatures.map(
+                          (feature, index) => (
+                            <li key={index}>{feature}</li>
+                          ),
+                        )}
+                      </ul>
+                    </div>
+                    <Link
+                      href="https://langfuse.com/pricing"
+                      target="_blank"
+                      className="mt-auto block py-4 text-sm text-muted-foreground hover:text-foreground"
+                    >
+                      Learn more about plan →
+                    </Link>
+                    {/* The default behavior the user is on a paid plan.*/}
+                    {organization?.cloudConfig?.stripe?.activeProductId ? (
+                      // Change plan view
+                      <div className="mt-2 space-y-2">
+                        {isCurrentPlan && (
+                          <>
+                            {/* Reactivate button when cancellation is scheduled on current plan */}
+                            {cancellation?.isCancelled && (
+                              <StripeCancellationButton
+                                orgId={organization?.id}
+                                variant="default"
+                                className="w-full"
+                              />
+                            )}
+                            {!cancellation?.isCancelled &&
+                              scheduledPlanSwitch && (
+                                <StripeKeepPlanButton
+                                  orgId={organization?.id}
+                                  stripeProductId={product.stripeProductId}
+                                  onProcessing={setProcessingPlanId}
+                                  processing={
+                                    processingPlanId === product.stripeProductId
+                                  }
+                                />
+                              )}
+                            {!cancellation?.isCancelled &&
+                              !scheduledPlanSwitch && (
+                                <Button className="w-full" disabled>
+                                  Current plan
+                                </Button>
+                              )}
+                          </>
+                        )}
+                        {/* A downgrade is scheduled and this is the new plan */}
+                        {!isCurrentPlan &&
+                          scheduledPlanSwitch &&
+                          organization?.cloudConfig?.stripe
+                            ?.planSwitchScheduleInfo?.productId ===
+                            product.stripeProductId && (
+                            <Button className="w-full" disabled>
+                              Scheduled
+                            </Button>
+                          )}
+
+                        {/* A downgrade is scheduled and this is not the new plan and not the current plan*/}
+                        {!isCurrentPlan &&
+                          scheduledPlanSwitch &&
+                          organization?.cloudConfig?.stripe
+                            ?.planSwitchScheduleInfo?.productId !==
+                            product.stripeProductId && (
+                            <StripeSwitchPlanButton
+                              orgId={organization?.id}
+                              currentPlan={organization?.plan}
+                              newPlanTitle={product.checkout?.title}
+                              isLegacySubscription={isLegacySubscription}
+                              isUpgrade={isThisUpgrade}
+                              stripeProductId={product.stripeProductId}
+                              onProcessing={setProcessingPlanId}
+                              processing={
+                                processingPlanId === product.stripeProductId
                               }
-                            }}
-                            loading={
+                            />
+                          )}
+
+                        {/* The default behavior when it is not the current plan and no schedule exists*/}
+                        {!isCurrentPlan && !scheduledPlanSwitch && (
+                          <StripeSwitchPlanButton
+                            orgId={organization?.id}
+                            currentPlan={organization?.plan}
+                            newPlanTitle={product.checkout?.title}
+                            isLegacySubscription={isLegacySubscription}
+                            isUpgrade={isThisUpgrade}
+                            stripeProductId={product.stripeProductId}
+                            onProcessing={setProcessingPlanId}
+                            processing={
                               processingPlanId === product.stripeProductId
                             }
-                          >
-                            Confirm
-                          </ActionButton>
-                        </DialogFooter>
-                      </DialogContent>
-                    </Dialog>
-                  ) : (
-                    // Upgrade, no plan yet
-                    <ActionButton
-                      onClick={() => {
-                        if (organization) {
-                          setProcessingPlanId(product.stripeProductId);
-                          mutCreateCheckoutSession.mutate({
-                            orgId: organization.id,
-                            stripeProductId: product.stripeProductId,
-                          });
+                          />
+                        )}
+                      </div>
+                    ) : (
+                      // The default behavior when the user is not on a paid plan.
+                      <ActionButton
+                        onClick={() => {
+                          if (organization) {
+                            setProcessingPlanId(product.stripeProductId);
+                            mutCreateCheckoutSession.mutate({
+                              orgId: organization.id,
+                              stripeProductId: product.stripeProductId,
+                            });
+                          }
+                        }}
+                        disabled={
+                          organization?.cloudConfig?.stripe?.activeProductId ===
+                          product.stripeProductId
                         }
-                      }}
-                      disabled={
-                        organization?.cloudConfig?.stripe?.activeProductId ===
-                        product.stripeProductId
-                      }
-                      className="w-full"
-                      loading={processingPlanId === product.stripeProductId}
-                    >
-                      Select plan
-                    </ActionButton>
-                  )}
-                </div>
-              ))}
+                        className="w-full"
+                        loading={processingPlanId === product.stripeProductId}
+                      >
+                        Select plan
+                      </ActionButton>
+                    )}
+                  </div>
+                );
+              })}
           </div>
         </DialogBody>
       </DialogContent>

--- a/web/src/ee/features/billing/components/BillingUsageChart.tsx
+++ b/web/src/ee/features/billing/components/BillingUsageChart.tsx
@@ -11,6 +11,7 @@ import { BillingCurrentPlanLabel } from "./BillingCurrentPlanLabel";
 
 export const BillingUsageChart = () => {
   const organization = useQueryOrganization();
+
   const usage = api.cloudBilling.getUsage.useQuery(
     {
       orgId: organization?.id as string,
@@ -24,6 +25,7 @@ export const BillingUsageChart = () => {
       },
     },
   );
+
   const hobbyPlanLimit =
     organization?.cloudConfig?.monthlyObservationLimit ?? MAX_EVENTS_FREE_PLAN;
   const plan: Plan = organization?.plan ?? "cloud:hobby";
@@ -78,7 +80,7 @@ export const BillingUsageChart = () => {
         )}
         {usage.data?.upcomingInvoice && (
           <p>
-            {`Next invoice (current usage): ${usage.data.upcomingInvoice.usdAmount} USD`}
+            {`Next invoice (Current Usage + Plan x Tax): ${usage.data.upcomingInvoice.usdAmount} USD`}
           </p>
         )}
       </div>

--- a/web/src/ee/features/billing/components/StripeCancellationButton.tsx
+++ b/web/src/ee/features/billing/components/StripeCancellationButton.tsx
@@ -17,9 +17,11 @@ import { toast } from "sonner";
 export const StripeCancellationButton = ({
   orgId,
   variant,
+  className,
 }: {
   orgId: string | undefined;
   variant: "secondary" | "default";
+  className?: string;
 }) => {
   const { cancellation } = useBillingInformation();
   const [loading, setLoading] = useState(false);
@@ -30,7 +32,10 @@ export const StripeCancellationButton = ({
       setLoading(false);
       setTimeout(() => window.location.reload(), 500);
     },
-    onError: () => setLoading(false),
+    onError: () => {
+      setLoading(false);
+      toast.error("Failed to cancel subscription");
+    },
   });
 
   const reactivateMutation =
@@ -40,7 +45,10 @@ export const StripeCancellationButton = ({
         setLoading(false);
         setTimeout(() => window.location.reload(), 500);
       },
-      onError: () => setLoading(false),
+      onError: () => {
+        setLoading(false);
+        toast.error("Failed to reactivate subscription");
+      },
     });
 
   if (!orgId) return null;
@@ -72,22 +80,28 @@ export const StripeCancellationButton = ({
             variant={variant}
             disabled={loading}
             title="Reactivate Subscription"
+            className={className}
           >
             {loading ? "Working…" : "Reactivate Subscription"}
           </Button>
         </DialogTrigger>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Confirm Reactivation</DialogTitle>
+            <DialogTitle className="text-lg">
+              Confirm Reactivation: Keep Your Subscription
+            </DialogTitle>
           </DialogHeader>
-          <DialogBody>
-            This will remove the scheduled cancellation and your subscription
-            will continue beyond the current billing period. Are you sure you
-            want to reactivate?
+          <DialogBody className="text-sm">
+            <p>
+              Reactivating removes the scheduled cancellation. Your subscription
+              will continue beyond the current billing period and renew until
+              you cancel again.
+            </p>
+            <p>By confirming, you agree to future renewals and charges.</p>
           </DialogBody>
           <DialogFooter>
             <DialogClose asChild>
-              <Button variant="secondary">Keep Scheduled Cancellation</Button>
+              <Button variant="secondary">Cancel</Button>
             </DialogClose>
             <Button variant="default" onClick={onReactivate} disabled={loading}>
               {loading ? "Reactivating…" : "Confirm Reactivation"}
@@ -112,12 +126,17 @@ export const StripeCancellationButton = ({
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Confirm Cancellation</DialogTitle>
+          <DialogTitle className="text-lg">Confirm Cancellation</DialogTitle>
         </DialogHeader>
-        <DialogBody>
-          This will cancel your subscription at the end of the current billing
-          period. You will retain access until then. Are you sure you want to
-          continue?
+        <DialogBody className="text-sm">
+          <p>
+            Your subscription will not renew. You will retain access until the
+            end of the current billing period
+          </p>
+          <p>
+            By confirming, you schedule the cancellation for period end. You can
+            reactivate before that date if you change your mind.
+          </p>
         </DialogBody>
         <DialogFooter>
           <DialogClose asChild>

--- a/web/src/ee/features/billing/components/StripeCancellationButton.tsx
+++ b/web/src/ee/features/billing/components/StripeCancellationButton.tsx
@@ -1,0 +1,133 @@
+import { Button } from "@/src/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/src/components/ui/dialog";
+import { useBillingInformation } from "./useBillingInformation";
+import { api } from "@/src/utils/api";
+import { useState } from "react";
+import { toast } from "sonner";
+
+export const StripeCancellationButton = ({
+  orgId,
+  variant,
+}: {
+  orgId: string | undefined;
+  variant: "secondary" | "default";
+}) => {
+  const { cancellation } = useBillingInformation();
+  const [loading, setLoading] = useState(false);
+
+  const cancelMutation = api.cloudBilling.cancelStripeSubscription.useMutation({
+    onSuccess: () => {
+      toast.success("Subscription will be cancelled at period end");
+      setLoading(false);
+      setTimeout(() => window.location.reload(), 500);
+    },
+    onError: () => setLoading(false),
+  });
+
+  const reactivateMutation =
+    api.cloudBilling.reactivateStripeSubscription.useMutation({
+      onSuccess: () => {
+        toast.success("Subscription reactivated");
+        setLoading(false);
+        setTimeout(() => window.location.reload(), 500);
+      },
+      onError: () => setLoading(false),
+    });
+
+  if (!orgId) return null;
+
+  const onReactivate = async () => {
+    try {
+      setLoading(true);
+      await reactivateMutation.mutateAsync({ orgId });
+    } catch (e) {
+      toast.error("Failed to reactivate subscription");
+    }
+  };
+
+  const onCancel = async () => {
+    try {
+      setLoading(true);
+      await cancelMutation.mutateAsync({ orgId });
+    } catch (e) {
+      toast.error("Failed to cancel subscription");
+    }
+  };
+
+  // Reactivate with confirm dialog
+  if (cancellation?.isCancelled) {
+    return (
+      <Dialog>
+        <DialogTrigger asChild>
+          <Button
+            variant={variant}
+            disabled={loading}
+            title="Reactivate Subscription"
+          >
+            {loading ? "Working…" : "Reactivate Subscription"}
+          </Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm Reactivation</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            This will remove the scheduled cancellation and your subscription
+            will continue beyond the current billing period. Are you sure you
+            want to reactivate?
+          </DialogBody>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="secondary">Keep Scheduled Cancellation</Button>
+            </DialogClose>
+            <Button variant="default" onClick={onReactivate} disabled={loading}>
+              {loading ? "Reactivating…" : "Confirm Reactivation"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  // Cancel with confirm dialog
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          variant={variant}
+          disabled={loading}
+          title="Cancel Subscription"
+        >
+          Cancel Subscription
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Confirm Cancellation</DialogTitle>
+        </DialogHeader>
+        <DialogBody>
+          This will cancel your subscription at the end of the current billing
+          period. You will retain access until then. Are you sure you want to
+          continue?
+        </DialogBody>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="secondary">Keep Subscription</Button>
+          </DialogClose>
+          <Button variant="destructive" onClick={onCancel} disabled={loading}>
+            {loading ? "Cancelling…" : "Confirm Cancellation"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/web/src/ee/features/billing/components/StripeCustomerPortalButton.tsx
+++ b/web/src/ee/features/billing/components/StripeCustomerPortalButton.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/src/components/ui/button";
 import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 import { api } from "@/src/utils/api";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 export const StripeCustomerPortalButton = ({
@@ -19,6 +19,26 @@ export const StripeCustomerPortalButton = ({
   });
 
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    // Make sure loading is always false when the user enters the page, even when navigation back via browser back button
+    const reset = () => setLoading(false);
+    const onPageShow = () => setLoading(false); // fires on bfcache restore
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") setLoading(false);
+    };
+
+    window.addEventListener("focus", reset);
+    window.addEventListener("pageshow", onPageShow);
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      window.removeEventListener("focus", reset);
+      window.removeEventListener("pageshow", onPageShow);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+
   const portalQuery = api.cloudBilling.getStripeCustomerPortalUrl.useQuery(
     { orgId: orgId as string },
     {

--- a/web/src/ee/features/billing/components/StripeKeepPlanButton.tsx
+++ b/web/src/ee/features/billing/components/StripeKeepPlanButton.tsx
@@ -1,0 +1,82 @@
+import { Button } from "@/src/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/src/components/ui/dialog";
+import { api } from "@/src/utils/api";
+import { toast } from "sonner";
+
+export const StripeKeepPlanButton = ({
+  orgId,
+  stripeProductId,
+  onProcessing,
+  processing,
+}: {
+  orgId: string | undefined;
+  stripeProductId: string;
+  onProcessing: (id: string | null) => void;
+  processing: boolean;
+}) => {
+  const clearSchedule = api.cloudBilling.clearPlanSwitchSchedule.useMutation({
+    onSuccess: () => {
+      toast.success("Kept current plan");
+      onProcessing(null);
+      setTimeout(() => window.location.reload(), 500);
+    },
+    onError: () => {
+      onProcessing(null);
+      toast.error("Failed to keep current plan");
+    },
+  });
+
+  if (!orgId) return null;
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button className="w-full" variant="default">
+          Keep Plan
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="text-lg">
+            Confirm Keeping Current Plan
+          </DialogTitle>
+        </DialogHeader>
+        <DialogBody className="text-sm">
+          <p>
+            You have a scheduled plan change at the end of the current billing
+            period. Keeping your current plan will remove that schedule and you
+            will remain on your existing plan.
+          </p>
+          <p>
+            Do you want to keep your current plan and cancel the scheduled
+            change?
+          </p>
+        </DialogBody>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="secondary">Go Back</Button>
+          </DialogClose>
+          <Button
+            variant="default"
+            onClick={() => {
+              onProcessing(stripeProductId);
+              clearSchedule.mutate({ orgId });
+            }}
+            disabled={processing}
+          >
+            {processing ? "Keeping…" : "Confirm Keep Plan"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/web/src/ee/features/billing/components/StripeSwitchPlanButton.tsx
+++ b/web/src/ee/features/billing/components/StripeSwitchPlanButton.tsx
@@ -1,0 +1,121 @@
+import { Button } from "@/src/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/src/components/ui/dialog";
+import { ActionButton } from "@/src/components/ActionButton";
+import { planLabels } from "@langfuse/shared";
+import { api } from "@/src/utils/api";
+import { toast } from "sonner";
+
+export const StripeSwitchPlanButton = ({
+  className,
+  orgId,
+  currentPlan,
+  newPlanTitle,
+  isLegacySubscription,
+  isUpgrade,
+  stripeProductId,
+  onProcessing,
+  processing,
+}: {
+  orgId: string | undefined;
+  currentPlan: keyof typeof planLabels | undefined;
+  newPlanTitle: string | undefined;
+  isLegacySubscription: boolean;
+  isUpgrade: boolean;
+  stripeProductId: string;
+  onProcessing: (id: string | null) => void;
+  processing: boolean;
+  className?: string;
+}) => {
+  const mutChangePlan =
+    api.cloudBilling.changeStripeSubscriptionProduct.useMutation({
+      onSuccess: () => {
+        toast.success("Plan changed successfully");
+        onProcessing(null);
+        setTimeout(() => window.location.reload(), 500);
+      },
+      onError: () => {
+        onProcessing(null);
+        toast.error("Failed to change plan");
+      },
+    });
+
+  if (!orgId) return null;
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button className="w-full">Change plan</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="text-lg">
+            Confirm Your Change: {planLabels[currentPlan ?? "cloud:hobby"]} →{" "}
+            {newPlanTitle}
+          </DialogTitle>
+        </DialogHeader>
+        <DialogBody className="text-sm">
+          {isLegacySubscription ? (
+            <>
+              <p>
+                We will charge today for usage to date. Your new plan starts
+                immediately and your billing period resets today.
+              </p>
+              <p>
+                By confirming, you accept today’s charge and immediate
+                activation.
+              </p>
+            </>
+          ) : isUpgrade ? (
+            <>
+              <p>
+                You will be charged a prorated base fee today for the remainder
+                of this billing period. Features update immediately; usage-based
+                charges continue for the rest of the billing period.
+              </p>
+              <p>
+                By confirming, you accept the prorated charge and immediate plan
+                change.
+              </p>
+            </>
+          ) : (
+            <>
+              <p>
+                No charge is made today. You stay on your current plan until the
+                end of this billing period, then we switch you to the new plan.
+                You can switch back anytime.
+              </p>
+              <p>
+                By confirming, you schedule the change at period end and
+                understand features will adjust at that time.
+              </p>
+            </>
+          )}
+        </DialogBody>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="secondary">Cancel</Button>
+          </DialogClose>
+          <ActionButton
+            onClick={() => {
+              onProcessing(stripeProductId);
+              mutChangePlan.mutate({ orgId, stripeProductId });
+            }}
+            loading={processing}
+            className={className}
+          >
+            Confirm
+          </ActionButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/web/src/ee/features/billing/components/useBillingInformation.tsx
+++ b/web/src/ee/features/billing/components/useBillingInformation.tsx
@@ -1,0 +1,107 @@
+import { useMemo } from "react";
+
+import { useQueryOrganization } from "@/src/features/organizations/hooks";
+import { formatLocalIsoDate } from "@/src/components/LocalIsoDate";
+import { planLabels } from "@langfuse/shared";
+import { stripeProducts } from "@/src/ee/features/billing/utils/stripeProducts";
+
+export type BillingCancellationInfo = {
+  isCancelled: boolean;
+  date: Date | null;
+  formatted: string | null;
+};
+
+export type BillingScheduledSwitchInfo = {
+  isScheduled: boolean;
+  date: Date | null;
+  formatted: string | null;
+  newPlanLabel: string | null;
+  scheduleId: string | undefined;
+};
+
+export type UseBillingInformationResult = {
+  organization: ReturnType<typeof useQueryOrganization>;
+  planLabel: string;
+  cancellation: BillingCancellationInfo | null;
+  scheduledPlanSwitch: BillingScheduledSwitchInfo | null;
+};
+
+export const useBillingInformation = (): UseBillingInformationResult => {
+  const organization = useQueryOrganization();
+
+  const planLabel = useMemo(() => {
+    return planLabels[organization?.plan ?? "cloud:hobby"];
+  }, [organization]);
+
+  const cancellation = useMemo<BillingCancellationInfo | null>(() => {
+    const cancellationInfo =
+      organization?.cloudConfig?.stripe?.cancellationInfo;
+    if (
+      !cancellationInfo?.scheduledForCancellation ||
+      !cancellationInfo.cancelAt
+    )
+      return null;
+
+    try {
+      const cancelAt = cancellationInfo.cancelAt;
+      const date =
+        typeof cancelAt === "number" && !Number.isNaN(cancelAt)
+          ? new Date(cancelAt * 1000)
+          : null;
+
+      if (!date || date.getTime() <= Date.now()) {
+        return null;
+      }
+
+      const formatted = formatLocalIsoDate(date, false, "day");
+      return { isCancelled: true, date, formatted };
+    } catch {
+      return null;
+    }
+  }, [organization]);
+
+  const scheduledPlanSwitch = useMemo<BillingScheduledSwitchInfo | null>(() => {
+    const scheduleInfo =
+      organization?.cloudConfig?.stripe?.planSwitchScheduleInfo;
+    if (!scheduleInfo?.switchAt) {
+      return null;
+    }
+
+    try {
+      const switchAt = scheduleInfo.switchAt;
+      const date =
+        typeof switchAt === "number" && !Number.isNaN(switchAt)
+          ? new Date(switchAt * 1000)
+          : null;
+
+      if (!date || date.getTime() <= Date.now()) {
+        return null;
+      }
+
+      const formatted = formatLocalIsoDate(date, false, "day");
+
+      const newPlanId = scheduleInfo.productId;
+      const product = newPlanId
+        ? stripeProducts.find((p) => p.stripeProductId === newPlanId)
+        : undefined;
+      const newPlanLabel = product ? planLabels[product.mappedPlan] : null;
+
+      return {
+        isScheduled: true,
+        date,
+        formatted,
+        newPlanLabel,
+        scheduleId: scheduleInfo.subscriptionScheduleId,
+      };
+    } catch {
+      return null;
+    }
+  }, [organization]);
+
+  return {
+    organization,
+    planLabel,
+    cancellation,
+    scheduledPlanSwitch,
+  };
+};

--- a/web/src/ee/features/billing/components/useBillingInformation.tsx
+++ b/web/src/ee/features/billing/components/useBillingInformation.tsx
@@ -24,6 +24,7 @@ export type UseBillingInformationResult = {
   planLabel: string;
   cancellation: BillingCancellationInfo | null;
   scheduledPlanSwitch: BillingScheduledSwitchInfo | null;
+  isLegacySubscription: boolean;
 };
 
 export const useBillingInformation = (): UseBillingInformationResult => {
@@ -103,5 +104,7 @@ export const useBillingInformation = (): UseBillingInformationResult => {
     planLabel,
     cancellation,
     scheduledPlanSwitch,
+    isLegacySubscription:
+      Boolean(organization?.cloudConfig?.stripe?.isLegacySubscription) === true,
   };
 };

--- a/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
+++ b/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
@@ -371,10 +371,12 @@ async function handleSubscriptionChanged(
           stripe: {
             ...parsedOrg.cloudConfig?.stripe,
             ...CloudConfigSchema.shape.stripe.parse({
+              customerId: customerId,
               activeProductId: undefined,
               activeSubscriptionId: undefined,
               activeUsageProductId: undefined,
-              customerId: customerId,
+              planSwitchScheduleInfo: undefined,
+              cancellationInfo: undefined,
             }),
           },
         },

--- a/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
+++ b/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
@@ -485,12 +485,15 @@ async function handleSubscriptionScheduleUpdated(
       stripe: {
         ...parsedOrg.cloudConfig?.stripe,
         ...CloudConfigSchema.shape.stripe.parse({
-          planSwitchScheduleInfo: {
-            subscriptionScheduleId: schedule.id,
-            switchAt,
-            productId: newProductId,
-            usageProductId,
-          },
+          planSwitchScheduleInfo:
+            schedule.status === "active"
+              ? {
+                  subscriptionScheduleId: schedule.id,
+                  switchAt,
+                  productId: newProductId,
+                  usageProductId,
+                }
+              : undefined,
         }),
       },
     };
@@ -510,8 +513,6 @@ async function handleSubscriptionScheduleUpdated(
 async function handleSubscriptionScheduleReleased(
   schedule: Stripe.SubscriptionSchedule,
 ) {
-  console.log("handleSubscriptionScheduleReleased:schedule", schedule);
-
   try {
     const md = parsePlanSwitchMetadata(schedule);
     if (!md.success) {
@@ -538,9 +539,7 @@ async function handleSubscriptionScheduleReleased(
       ...parsedOrg.cloudConfig,
       stripe: {
         ...parsedOrg.cloudConfig?.stripe,
-        ...CloudConfigSchema.shape.stripe.parse({
-          planSwitchScheduleInfo: undefined,
-        }),
+        planSwitchScheduleInfo: undefined,
       },
     };
 

--- a/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
+++ b/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
@@ -17,6 +17,7 @@ import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
 import { sendBillingAlertEmail } from "@langfuse/shared/src/server";
 import { Role } from "@langfuse/shared";
 import { UsageAlertService } from "@/src/ee/features/billing/server/usageAlertService";
+import { z } from "zod/v4";
 
 /*
  * Sign-up endpoint (email/password users), creates user in database.
@@ -91,6 +92,30 @@ export async function stripeWebhookApiHandler(req: NextRequest) {
       });
       await handleSubscriptionChanged(deletedSubscription, "deleted");
       break;
+    case "subscription_schedule.created": {
+      const schedule = event.data.object as Stripe.SubscriptionSchedule;
+      logger.info("[Stripe Webhook] Start subscription_schedule.created", {
+        payload: schedule,
+      });
+      await handleSubscriptionScheduleCreated(schedule);
+      break;
+    }
+    case "subscription_schedule.updated": {
+      const schedule = event.data.object as Stripe.SubscriptionSchedule;
+      logger.info("[Stripe Webhook] Start subscription_schedule.updated", {
+        payload: schedule,
+      });
+      await handleSubscriptionScheduleUpdated(schedule);
+      break;
+    }
+    case "subscription_schedule.released": {
+      const schedule = event.data.object as Stripe.SubscriptionSchedule;
+      logger.info("[Stripe Webhook] Start subscription_schedule.released", {
+        payload: schedule,
+      });
+      await handleSubscriptionScheduleReleased(schedule);
+      break;
+    }
     case "invoice.created":
       const invoiceData = event.data.object;
       logger.info("[Stripe Webhook] Start invoice.created", {
@@ -358,6 +383,172 @@ async function handleSubscriptionChanged(
   await new ApiAuthService(prisma, redis).invalidateOrgApiKeys(parsedOrg.id);
 
   return;
+}
+
+const PlanSwitchScheduleMetadataSchema = z.object({
+  orgId: z.string(),
+  reasons: z.literal("planSwitch.Downgrade"),
+  newProductId: z.string(),
+  usageProductId: z.string(),
+  switchAt: z
+    .union([z.string(), z.number()])
+    .transform((v) => (typeof v === "string" ? Number(v) : v)),
+});
+
+function parsePlanSwitchMetadata(schedule: Stripe.SubscriptionSchedule) {
+  return PlanSwitchScheduleMetadataSchema.safeParse(schedule.metadata ?? {});
+}
+
+async function handleSubscriptionScheduleCreated(
+  schedule: Stripe.SubscriptionSchedule,
+) {
+  try {
+    const md = parsePlanSwitchMetadata(schedule);
+    if (!md.success) {
+      logger.info(
+        "[Stripe Webhook] subscription_schedule.created without required metadata, skipping",
+      );
+      return;
+    }
+    const { orgId, switchAt, newProductId, usageProductId } = md.data;
+
+    const organization = await prisma.organization.findUnique({
+      where: { id: orgId },
+    });
+
+    if (!organization) {
+      logger.warn(
+        "[Stripe Webhook] Organization not found for subscription schedule created",
+        { orgId },
+      );
+      return;
+    }
+
+    const parsedOrg = parseDbOrg(organization);
+    const updatedCloudConfig = {
+      ...parsedOrg.cloudConfig,
+      stripe: {
+        ...parsedOrg.cloudConfig?.stripe,
+        ...CloudConfigSchema.shape.stripe.parse({
+          planSwitchScheduleInfo: {
+            subscriptionScheduleId: schedule.id,
+            switchAt,
+            productId: newProductId,
+            usageProductId,
+          },
+        }),
+      },
+    };
+
+    await prisma.organization.update({
+      where: { id: parsedOrg.id },
+      data: { cloudConfig: updatedCloudConfig },
+    });
+  } catch (error) {
+    logger.error(
+      "[Stripe Webhook] Error handling subscription_schedule.created",
+      { error, scheduleId: schedule.id },
+    );
+  }
+}
+
+async function handleSubscriptionScheduleUpdated(
+  schedule: Stripe.SubscriptionSchedule,
+) {
+  try {
+    const md = parsePlanSwitchMetadata(schedule);
+    if (!md.success) {
+      logger.info(
+        "[Stripe Webhook] subscription_schedule.updated without required metadata, skipping",
+      );
+      return;
+    }
+    const { orgId, switchAt, newProductId, usageProductId } = md.data;
+    const organization = await prisma.organization.findUnique({
+      where: { id: orgId },
+    });
+
+    if (!organization) {
+      logger.warn(
+        "[Stripe Webhook] Organization not found for subscription schedule updated",
+        { orgId },
+      );
+      return;
+    }
+
+    const parsedOrg = parseDbOrg(organization);
+    const updatedCloudConfig = {
+      ...parsedOrg.cloudConfig,
+      stripe: {
+        ...parsedOrg.cloudConfig?.stripe,
+        ...CloudConfigSchema.shape.stripe.parse({
+          planSwitchScheduleInfo: {
+            subscriptionScheduleId: schedule.id,
+            switchAt,
+            productId: newProductId,
+            usageProductId,
+          },
+        }),
+      },
+    };
+
+    await prisma.organization.update({
+      where: { id: parsedOrg.id },
+      data: { cloudConfig: updatedCloudConfig },
+    });
+  } catch (error) {
+    logger.error(
+      "[Stripe Webhook] Error handling subscription_schedule.updated",
+      { error, scheduleId: schedule.id },
+    );
+  }
+}
+
+async function handleSubscriptionScheduleReleased(
+  schedule: Stripe.SubscriptionSchedule,
+) {
+  try {
+    const md = parsePlanSwitchMetadata(schedule);
+    if (!md.success) {
+      logger.info(
+        "[Stripe Webhook] subscription_schedule.released without required metadata, skipping",
+      );
+      return;
+    }
+    const { orgId } = md.data;
+    const organization = await prisma.organization.findUnique({
+      where: { id: orgId },
+    });
+
+    if (!organization) {
+      logger.warn(
+        "[Stripe Webhook] Organization not found for subscription schedule released",
+        { orgId },
+      );
+      return;
+    }
+
+    const parsedOrg = parseDbOrg(organization);
+    const updatedCloudConfig = {
+      ...parsedOrg.cloudConfig,
+      stripe: {
+        ...parsedOrg.cloudConfig?.stripe,
+        ...CloudConfigSchema.shape.stripe.parse({
+          planSwitchScheduleInfo: undefined,
+        }),
+      },
+    };
+
+    await prisma.organization.update({
+      where: { id: parsedOrg.id },
+      data: { cloudConfig: updatedCloudConfig },
+    });
+  } catch (error) {
+    logger.error(
+      "[Stripe Webhook] Error handling subscription_schedule.released",
+      { error, scheduleId: schedule.id },
+    );
+  }
 }
 
 async function handleBillingAlertTriggered(

--- a/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
+++ b/web/src/ee/features/billing/server/stripeWebhookApiHandler.ts
@@ -345,6 +345,9 @@ async function handleSubscriptionChanged(
           cancellationInfo: cancellationInfo.scheduledForCancellation
             ? cancellationInfo
             : undefined,
+          planSwitchScheduleInfo: subscription.schedule
+            ? parsedOrg.cloudConfig?.stripe?.planSwitchScheduleInfo
+            : undefined, //unset if the schedule has been released
         }),
       },
     };
@@ -507,6 +510,8 @@ async function handleSubscriptionScheduleUpdated(
 async function handleSubscriptionScheduleReleased(
   schedule: Stripe.SubscriptionSchedule,
 ) {
+  console.log("handleSubscriptionScheduleReleased:schedule", schedule);
+
   try {
     const md = parsePlanSwitchMetadata(schedule);
     if (!md.success) {

--- a/web/src/ee/features/billing/utils/stripeProducts.ts
+++ b/web/src/ee/features/billing/utils/stripeProducts.ts
@@ -23,7 +23,7 @@ type StripeProduct = {
 export const stripeProducts: StripeProduct[] = [
   {
     stripeProductId: isTestEnvironment
-      ? "prod_RoYirvRQ4Kc6po" // test
+      ? "prod_RoYirvRQ4Kc6po" // sandbox
       : "prod_RoYirvRQ4Kc6po", // live
     mappedPlan: "cloud:core",
     orderKey: 1000,
@@ -43,7 +43,7 @@ export const stripeProducts: StripeProduct[] = [
   },
   {
     stripeProductId: isTestEnvironment
-      ? "prod_QhK7UMhrkVeF6R" // test
+      ? "prod_QhK7UMhrkVeF6R" // sandbox
       : "prod_QhK7UMhrkVeF6R", // live
     mappedPlan: "cloud:pro",
     orderKey: 2000,
@@ -64,7 +64,7 @@ export const stripeProducts: StripeProduct[] = [
   },
   {
     stripeProductId: isTestEnvironment
-      ? "prod_QhK9qKGH25BTcS" // test
+      ? "prod_QhK9qKGH25BTcS" // sandbox
       : "prod_QhK9qKGH25BTcS", // live
     mappedPlan: "cloud:team",
     orderKey: 3000,
@@ -85,7 +85,7 @@ export const stripeProducts: StripeProduct[] = [
   },
   {
     stripeProductId: isTestEnvironment
-      ? "prod_STnXok7GSSDmyF" // test
+      ? "prod_STnXok7GSSDmyF" // sandbox
       : "prod_STnXok7GSSDmyF", // live
     mappedPlan: "cloud:enterprise",
     checkout: null,
@@ -93,7 +93,9 @@ export const stripeProducts: StripeProduct[] = [
 ];
 
 export const stripeUsageProduct = {
-  id: "prod_T1VvYnUEfoqswU",
+  id: isTestEnvironment
+    ? "prod_T2DaIcLiiR78rs" // sandbox
+    : "prod_T2DaIcLiiR78rs", // live (TODO: needs to be update for live environment)
 };
 
 export const mapStripeProductIdToPlan = (productId: string): Plan | null =>

--- a/web/src/ee/features/billing/utils/stripeProducts.ts
+++ b/web/src/ee/features/billing/utils/stripeProducts.ts
@@ -26,7 +26,7 @@ export const stripeProducts: StripeProduct[] = [
       ? "prod_RoYirvRQ4Kc6po" // sandbox
       : "prod_RoYirvRQ4Kc6po", // live
     mappedPlan: "cloud:core",
-    orderKey: 1000,
+    orderKey: 59,
     checkout: {
       title: "Core",
       description:
@@ -46,7 +46,7 @@ export const stripeProducts: StripeProduct[] = [
       ? "prod_QhK7UMhrkVeF6R" // sandbox
       : "prod_QhK7UMhrkVeF6R", // live
     mappedPlan: "cloud:pro",
-    orderKey: 2000,
+    orderKey: 199,
     checkout: {
       title: "Pro",
       description:
@@ -67,7 +67,7 @@ export const stripeProducts: StripeProduct[] = [
       ? "prod_QhK9qKGH25BTcS" // sandbox
       : "prod_QhK9qKGH25BTcS", // live
     mappedPlan: "cloud:team",
-    orderKey: 3000,
+    orderKey: 499,
     checkout: {
       title: "Pro + Teams Add-on",
       description: "Organizational and security controls for larger teams.",


### PR DESCRIPTION
## What does this PR do?

Introduce new billing logic where each subscription is composed of two products – the plan (core, pro, team) and Langfuse Cloud Usage (the usage based component).

**Important:** Before merging into staging / production the new prices need to be created in our stripe dashboard.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces new dual-product billing logic and updates Stripe integration with new UI components and server-side logic for subscription management.
> 
>   - **Behavior**:
>     - Introduces dual-product subscription model: plan and usage components.
>     - Updates Stripe integration to support new billing logic in `cloudBillingRouter.ts`.
>     - Adds `cancelStripeSubscription`, `reactivateStripeSubscription`, and `clearPlanSwitchSchedule` mutations.
>     - Handles subscription schedule events in `stripeWebhookApiHandler.ts`.
>   - **UI Components**:
>     - Adds `BillingActionButtons`, `BillingCurrentPlanLabel`, `BillingScheduleNotification`, `BillingSwitchPlanDialog`, `BillingUsageChart`, `StripeCancellationButton`, `StripeCustomerPortalButton`, `StripeKeepPlanButton`, and `StripeSwitchPlanButton`.
>     - Refactors date formatting in `LocalIsoDate.tsx`.
>   - **Models and Utilities**:
>     - Updates `CloudConfigSchema` to include `planSwitchScheduleInfo`.
>     - Adds `useBillingInformation` hook for billing data management.
>     - Updates `stripeProducts.ts` with new product details and utility functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2d380c620a1941e2d4c8b0ff323fcdbcfb71aa28. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->