### PR TITLE
perf: move more endpoints to read only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       service:
-        description: 'Service to be deployed'
+        description: "Service to be deployed"
         type: choice
         options:
           - all
@@ -15,7 +15,7 @@ on:
           - worker
         required: true
       environment:
-        description: 'Environment to deploy to'
+        description: "Environment to deploy to"
         type: choice
         options:
           - staging

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -318,6 +318,7 @@ export const getObservationById = async ({
   type,
   traceId,
   renderingProps = DEFAULT_RENDERING_PROPS,
+  preferredClickhouseService,
 }: {
   id: string;
   projectId: string;
@@ -326,6 +327,7 @@ export const getObservationById = async ({
   type?: ObservationType;
   traceId?: string;
   renderingProps?: RenderingProps;
+  preferredClickhouseService?: PreferredClickhouseService;
 }) => {
   const records = await getObservationByIdInternal({
     id,
@@ -335,6 +337,7 @@ export const getObservationById = async ({
     type,
     traceId,
     renderingProps,
+    preferredClickhouseService,
   });
   const mapped = records.map((record) =>
     convertObservation(record, renderingProps),
@@ -419,6 +422,7 @@ const getObservationByIdInternal = async ({
   type,
   traceId,
   renderingProps = DEFAULT_RENDERING_PROPS,
+  preferredClickhouseService,
 }: {
   id: string;
   projectId: string;
@@ -427,6 +431,7 @@ const getObservationByIdInternal = async ({
   type?: ObservationType;
   traceId?: string;
   renderingProps?: RenderingProps;
+  preferredClickhouseService?: PreferredClickhouseService;
 }) => {
   const query = `
   SELECT
@@ -483,6 +488,7 @@ const getObservationByIdInternal = async ({
       kind: "byId",
       projectId,
     },
+    preferredClickhouseService,
   });
 };
 

--- a/packages/shared/src/server/repositories/scores-utils.ts
+++ b/packages/shared/src/server/repositories/scores-utils.ts
@@ -1,4 +1,5 @@
 import { ScoreSourceType } from "../../domain";
+import { PreferredClickhouseService } from "../clickhouse/client";
 import { queryClickhouse } from "./clickhouse";
 import { ScoreRecordReadType } from "./definitions";
 import { convertToScore } from "./scores_converters";
@@ -13,11 +14,13 @@ export const _handleGetScoreById = async ({
   scoreId,
   source,
   scoreScope,
+  preferredClickhouseService,
 }: {
   projectId: string;
   scoreId: string;
   source?: ScoreSourceType;
   scoreScope: "traces_only" | "all";
+  preferredClickhouseService?: PreferredClickhouseService;
 }) => {
   const query = `
   SELECT *
@@ -44,6 +47,7 @@ export const _handleGetScoreById = async ({
       kind: "byId",
       projectId,
     },
+    preferredClickhouseService,
   });
   return rows.map(convertToScore).shift();
 };

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -21,6 +21,7 @@ import { UiColumnMappings } from "../../tableDefinitions";
 import {
   clickhouseClient,
   convertDateToClickhouseDateTime,
+  PreferredClickhouseService,
 } from "../clickhouse/client";
 import { convertClickhouseToDomain } from "./traces_converters";
 import { clickhouseSearchCondition } from "../queries/clickhouse-sql/search";
@@ -694,6 +695,7 @@ export const getTraceById = async ({
   fromTimestamp,
   renderingProps = DEFAULT_RENDERING_PROPS,
   clickhouseFeatureTag = "tracing",
+  preferredClickhouseService,
 }: {
   traceId: string;
   projectId: string;
@@ -701,6 +703,7 @@ export const getTraceById = async ({
   fromTimestamp?: Date;
   renderingProps?: RenderingProps;
   clickhouseFeatureTag?: string;
+  preferredClickhouseService?: PreferredClickhouseService;
 }) => {
   const records = await measureAndReturn({
     operationName: "getTraceById",
@@ -759,6 +762,7 @@ export const getTraceById = async ({
         query,
         params: input.params,
         tags: { ...input.tags, experiment_amt: "original" },
+        preferredClickhouseService,
       });
     },
     newExecution: (input) => {
@@ -794,6 +798,7 @@ export const getTraceById = async ({
         query,
         params: input.params,
         tags: { ...input.tags, experiment_amt: "new" },
+        preferredClickhouseService,
       });
     },
   });

--- a/web/src/features/public-api/server/scores-api-service.ts
+++ b/web/src/features/public-api/server/scores-api-service.ts
@@ -26,6 +26,7 @@ export class ScoresApiService {
       scoreId,
       source,
       scoreScope: this.apiVersion === "v1" ? "traces_only" : "all",
+      preferredClickhouseService: "ReadOnly",
     });
   }
 

--- a/web/src/features/public-api/server/scores.ts
+++ b/web/src/features/public-api/server/scores.ts
@@ -134,6 +134,7 @@ export const _handleGenerateScoresForPublicApi = async ({
         query: query.replace("__TRACE_TABLE__", "traces"),
         params: input.params,
         tags: { ...input.tags, experiment_amt: "original" },
+        preferredClickhouseService: "ReadOnly",
       });
 
       return records.map((record) => ({
@@ -159,6 +160,7 @@ export const _handleGenerateScoresForPublicApi = async ({
         query: query.replace("__TRACE_TABLE__", "traces_all_amt"),
         params: input.params,
         tags: { ...input.tags, experiment_amt: "new" },
+        preferredClickhouseService: "ReadOnly",
       });
 
       return records.map((record) => ({
@@ -246,6 +248,7 @@ export const _handleGetScoresCountForPublicApi = async ({
         query: query.replace("__TRACE_TABLE__", "traces"),
         params: input.params,
         tags: { ...input.tags, experiment_amt: "original" },
+        preferredClickhouseService: "ReadOnly",
       });
       return records.map((record) => Number(record.count)).shift();
     },
@@ -254,6 +257,7 @@ export const _handleGetScoresCountForPublicApi = async ({
         query: query.replace("__TRACE_TABLE__", "traces_all_amt"),
         params: input.params,
         tags: { ...input.tags, experiment_amt: "new" },
+        preferredClickhouseService: "ReadOnly",
       });
       return records.map((record) => Number(record.count)).shift();
     },

--- a/web/src/pages/api/public/observations/[observationId].ts
+++ b/web/src/pages/api/public/observations/[observationId].ts
@@ -19,6 +19,7 @@ export default withMiddlewares({
         id: query.observationId,
         projectId: auth.scope.projectId,
         fetchWithInputOutput: true,
+        preferredClickhouseService: "ReadOnly",
       });
       if (!clickhouseObservation) {
         throw new LangfuseNotFoundError(

--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -33,6 +33,7 @@ export default withMiddlewares({
         traceId,
         projectId: auth.scope.projectId,
         clickhouseFeatureTag: "tracing-public-api",
+        preferredClickhouseService: "ReadOnly",
       });
 
       if (!trace) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `preferredClickhouseService` to 'ReadOnly' for read operations in observations, traces, and scores modules to optimize database performance.
> 
>   - **Behavior**:
>     - Set `preferredClickhouseService: "ReadOnly"` for read operations in `getObservationById`, `getTraceById`, and `_handleGetScoreById`.
>     - Applied to public API routes in `observations/[observationId].ts` and `traces/[traceId].ts`.
>   - **Functions**:
>     - Updated `getObservationById` in `observations.ts` to include `preferredClickhouseService` parameter.
>     - Updated `getTraceById` in `traces.ts` to include `preferredClickhouseService` parameter.
>     - Updated `_handleGetScoreById` in `scores-utils.ts` to include `preferredClickhouseService` parameter.
>   - **Misc**:
>     - Minor string formatting changes in `.github/workflows/deploy.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 17fbf1aae50e1b86e191d7be9971cafa75021576. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->