### PR TITLE
fix(design-system): hover card layering

### DIFF
--- a/web/src/components/grouped-score-badge.tsx
+++ b/web/src/components/grouped-score-badge.tsx
@@ -70,7 +70,7 @@ const ScoreGroupBadge = <T extends APIScoreV2 | LastUserScore>({
                 <HoverCardTrigger className="inline-block">
                   <MessageCircleMoreIcon className="mb-[0.0625rem] !size-3" />
                 </HoverCardTrigger>
-                <HoverCardContent className="max-h-[50dvh] overflow-y-auto whitespace-normal break-normal">
+                <HoverCardContent className="max-h-[50dvh] overflow-y-auto whitespace-normal break-normal text-xs">
                   <p className="whitespace-pre-wrap">{s.comment}</p>
                 </HoverCardContent>
               </HoverCard>
@@ -80,7 +80,7 @@ const ScoreGroupBadge = <T extends APIScoreV2 | LastUserScore>({
                 <HoverCardTrigger className="inline-block">
                   <BracesIcon className="mb-[0.0625rem] !size-3" />
                 </HoverCardTrigger>
-                <HoverCardContent className="max-h-[50dvh] overflow-y-auto whitespace-normal break-normal rounded-md border-none p-0">
+                <HoverCardContent className="max-h-[50dvh] overflow-y-auto whitespace-normal break-normal rounded-md border-none p-0 text-xs">
                   <JSONView codeClassName="!rounded-md" json={s.metadata} />
                 </HoverCardContent>
               </HoverCard>

--- a/web/src/components/scores-table-cell.tsx
+++ b/web/src/components/scores-table-cell.tsx
@@ -70,7 +70,7 @@ export const ScoresTableCell = ({
             <HoverCardTrigger className="inline-block cursor-pointer">
               <MessageCircleMore size={12} />
             </HoverCardTrigger>
-            <HoverCardContent className="overflow-hidden whitespace-normal break-normal">
+            <HoverCardContent className="overflow-hidden whitespace-normal break-normal text-xs">
               <p className="whitespace-pre-wrap">{aggregate.comment}</p>
             </HoverCardContent>
           </HoverCard>
@@ -111,7 +111,7 @@ export const ScoresTableCell = ({
               />
             </div>
           </HoverCardTrigger>
-          <HoverCardContent className="z-20 flex max-h-[40vh] max-w-64 flex-col overflow-y-auto whitespace-normal break-normal">
+          <HoverCardContent className="z-20 flex max-h-[40vh] max-w-64 flex-col overflow-y-auto whitespace-normal break-normal text-xs">
             <ScoreValueCounts valueCounts={aggregate.valueCounts} wrap={wrap} />
           </HoverCardContent>
         </HoverCard>
@@ -159,7 +159,7 @@ function AggregateScoreMetadataPeek({
       <HoverCardTrigger className="inline-block cursor-pointer">
         <BracesIcon size={12} />
       </HoverCardTrigger>
-      <HoverCardContent className="overflow-hidden whitespace-normal break-normal rounded-md border-none p-0">
+      <HoverCardContent className="overflow-hidden whitespace-normal break-normal rounded-md border-none p-0 text-xs">
         {metadataLoaded ? (
           <JSONView codeClassName="!rounded-md" json={metadata} />
         ) : (

--- a/web/src/components/ui/hover-card.tsx
+++ b/web/src/components/ui/hover-card.tsx
@@ -13,16 +13,18 @@ const HoverCardContent = React.forwardRef<
   React.ElementRef<typeof HoverCardPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
 >(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <HoverCardPrimitive.Content
-    ref={ref}
-    align={align}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 w-64 rounded-md border bg-popover p-3 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className,
-    )}
-    {...props}
-  />
+  <HoverCardPrimitive.Portal>
+    <HoverCardPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-[9999] w-64 rounded-md border bg-popover p-3 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </HoverCardPrimitive.Portal>
 ));
 HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix hover card layering by adding `HoverCardPrimitive.Portal` and standardizing text size to `text-xs`.
> 
>   - **Behavior**:
>     - Add `HoverCardPrimitive.Portal` to `HoverCardContent` in `hover-card.tsx` to ensure hover cards are rendered on top of other elements.
>     - Set `z-index` to `9999` in `HoverCardContent` for higher layering.
>   - **Styling**:
>     - Add `text-xs` class to `HoverCardContent` in `grouped-score-badge.tsx` and `scores-table-cell.tsx` for consistent text size.
>   - **Misc**:
>     - Minor refactoring in `hover-card.tsx` to improve hover card layering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 518fc06bc34d14971e90c28683b81e8d74cbf7bf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->