### PR TITLE
fix(table): tags wrapping and being cropped

### DIFF
--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -678,7 +678,11 @@ export default function TracesTable({
             projectId={projectId}
             traceId={traceId}
             tracesFilter={tracesAllQueryFilter}
-            className={cn(rowHeight !== "s" && "flex-wrap")}
+            className={cn(
+              rowHeight === "s"
+                ? "overflow-x-auto"
+                : "max-h-full flex-wrap overflow-y-auto",
+            )}
             hideControls={hideControls}
           />
         );

--- a/web/src/features/tag/components/TagButton.tsx
+++ b/web/src/features/tag/components/TagButton.tsx
@@ -14,16 +14,16 @@ export const TagButton: React.FC<{
     variant="tertiary"
     size="icon-sm"
     disabled={viewOnly}
-    className={cn(viewOnly && "cursor-default")}
+    className={cn(viewOnly && "cursor-default", "w-fit min-w-16 max-w-40")}
     loading={loading}
   >
     <TagIcon className="mr-1 h-3.5 w-3.5 flex-shrink-0" />
     <span
       className={cn(
-        "w-full whitespace-nowrap",
-        !isTableCell &&
-          "min-w-6 whitespace-normal break-all text-xs sm:min-w-0 sm:break-normal sm:break-words",
+        "overflow-hidden text-ellipsis whitespace-nowrap",
+        !isTableCell && "text-xs",
       )}
+      title={tag}
     >
       {tag}
     </span>

--- a/web/src/features/tag/components/TagManager.tsx
+++ b/web/src/features/tag/components/TagManager.tsx
@@ -63,7 +63,13 @@ const TagManager = ({
 
   if (!hasAccess) {
     return (
-      <div className="flex gap-x-1 gap-y-1">
+      <div
+        className={cn(
+          "flex gap-x-1 gap-y-1",
+          !isTableCell && "flex-wrap",
+          className,
+        )}
+      >
         <TagList
           selectedTags={selectedTags}
           isLoading={isLoading}
@@ -88,8 +94,8 @@ const TagManager = ({
         <div
           className={cn(
             "flex gap-x-1 gap-y-1",
-            className,
             !isTableCell && "flex-wrap",
+            className,
           )}
         >
           <TagList


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix tag wrapping and cropping issues in tables by adjusting class names in `traces.tsx`, `TagButton.tsx`, and `TagManager.tsx`.
> 
>   - **Behavior**:
>     - Fix tag wrapping and cropping in `traces.tsx` by adjusting class names for `TagTracePopover` to handle different `rowHeight` values and overflow scenarios.
>     - Update `TagButton.tsx` to ensure proper tag display within buttons by modifying class names to include `w-fit`, `min-w-16`, and `max-w-40`.
>     - Adjust `TagManager.tsx` to handle tag display when access is restricted by modifying class names to include `flex-wrap` conditionally based on `isTableCell`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ecca795ccf25e24146cc50e6841166b3df286710. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->