### PR TITLE
chore: increase default throughput on create eval queue

### DIFF
--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -113,9 +113,9 @@ if (env.QUEUE_CONSUMER_CREATE_EVAL_QUEUE_IS_ENABLED === "true") {
     {
       concurrency: env.LANGFUSE_EVAL_CREATOR_WORKER_CONCURRENCY,
       limiter: {
-        // Process at most `max` jobs per 2 seconds globally
+        // Process at most `max` jobs per `duration` milliseconds globally
         max: env.LANGFUSE_EVAL_CREATOR_WORKER_CONCURRENCY,
-        duration: 2_000,
+        duration: env.LANGFUSE_EVAL_CREATOR_LIMITER_DURATION,
       },
     },
   );

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -91,6 +91,10 @@ const EnvSchema = z.object({
   CLICKHOUSE_DB: z.string().default("default"),
   CLICKHOUSE_PASSWORD: z.string(),
   CLICKHOUSE_CLUSTER_ENABLED: z.enum(["true", "false"]).default("true"),
+  LANGFUSE_EVAL_CREATOR_LIMITER_DURATION: z.coerce
+    .number()
+    .positive()
+    .default(500),
   LANGFUSE_EVAL_CREATOR_WORKER_CONCURRENCY: z.coerce
     .number()
     .positive()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase job processing rate for `CreateEvalQueue` using new `LANGFUSE_EVAL_CREATOR_LIMITER_DURATION` environment variable.
> 
>   - **Behavior**:
>     - In `app.ts`, update job processing rate for `CreateEvalQueue` using `LANGFUSE_EVAL_CREATOR_LIMITER_DURATION`.
>   - **Environment**:
>     - Add `LANGFUSE_EVAL_CREATOR_LIMITER_DURATION` to `env.ts` with a default of 500 milliseconds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b2495350ca97a9ba8e287527a24f715dfada261f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->