### PR TITLE
feat: add Amazon Nova models and prices

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -2057,5 +2057,100 @@
       "tokensPerMessage": 3
     },
     "tokenizer_id": "openai"
+  },
+  {
+    "id": "cx13ryb4ozl0zxmrx1a77j58k5",
+    "model_name": "amazon-nova-micro",
+    "match_pattern": "(?i)^(amazon[\\s_-]?nova[\\s_-]?micro|nova-micro|amazon-nova-micro)$",
+    "created_at": "2025-09-15T05:28:00.000Z",
+    "updated_at": "2025-09-15T05:28:00.000Z",
+    "prices": {
+      "input": 3.5e-8,
+      "input_tokens": 3.5e-8,
+      "output": 1.4e-7,
+      "output_tokens": 1.4e-7,
+      "cache_creation_input_tokens": 4.375e-8,
+      "input_cache_creation": 4.375e-8,
+      "cache_read_input_tokens": 8.75e-9,
+      "input_cache_read": 8.75e-9,
+      "input_tokens_batch": 1.75e-8,
+      "input_batch": 1.75e-8,
+      "output_tokens_batch": 7e-8,
+      "output_batch": 7e-8
+    },
+    "tokenizer_config": null,
+    "tokenizer_id": null
+  },
+
+  {
+    "id": "cbxgj6302vo56hufsoypie58r8",
+    "model_name": "amazon-nova-lite",
+    "match_pattern": "(?i)^(amazon[\\s_-]?nova[\\s_-]?lite|nova-lite|amazon-nova-lite)$",
+    "created_at": "2025-09-15T05:28:00.000Z",
+    "updated_at": "2025-09-15T05:28:00.000Z",
+    "prices": {
+      "input": 6e-8,
+      "input_tokens": 6e-8,
+      "output": 2.4e-7,
+      "output_tokens": 2.4e-7,
+      "cache_creation_input_tokens": 7.5e-8,
+      "input_cache_creation": 7.5e-8,
+      "cache_read_input_tokens": 1.5e-8,
+      "input_cache_read": 1.5e-8,
+      "input_tokens_batch": 3e-8,
+      "input_batch": 3e-8,
+      "output_tokens_batch": 1.2e-7,
+      "output_batch": 1.2e-7
+    },
+    "tokenizer_config": null,
+    "tokenizer_id": null
+  },
+
+  {
+    "id": "cpyyzzeagxm4p8vv8m87ry76ed",
+    "model_name": "amazon-nova-pro",
+    "match_pattern": "(?i)^(amazon[\\s_-]?nova[\\s_-]?pro|nova-pro|amazon-nova-pro)$",
+    "created_at": "2025-09-15T05:28:00.000Z",
+    "updated_at": "2025-09-15T05:28:00.000Z",
+    "prices": {
+      "input": 8e-7,
+      "input_tokens": 8e-7,
+      "output": 3.2e-6,
+      "output_tokens": 3.2e-6,
+      "cache_creation_input_tokens": 1e-6,
+      "input_cache_creation": 1e-6,
+      "cache_read_input_tokens": 2e-7,
+      "input_cache_read": 2e-7,
+      "input_tokens_batch": 4e-7,
+      "input_batch": 4e-7,
+      "output_tokens_batch": 1.6e-6,
+      "output_batch": 1.6e-6
+    },
+    "tokenizer_config": null,
+    "tokenizer_id": null
+  },
+
+  {
+    "id": "cgursg4vdd47gepw14v8ca5wfc",
+    "model_name": "amazon-nova-premier",
+    "match_pattern": "(?i)^(amazon[\\s_-]?nova[\\s_-]?premier|nova-premier|amazon-nova-premier)$",
+    "created_at": "2025-09-15T05:28:00.000Z",
+    "updated_at": "2025-09-15T05:28:00.000Z",
+    "prices": {
+      "input": 2.5e-6,
+      "input_tokens": 2.5e-6,
+      "output": 1.25e-5,
+      "output_tokens": 1.25e-5,
+      "cache_creation_input_tokens": 3.125e-6,
+      "input_cache_creation": 3.125e-6,
+      "cache_read_input_tokens": 6.25e-7,
+      "input_cache_read": 6.25e-7,
+      "input_tokens_batch": 1.25e-6,
+      "input_batch": 1.25e-6,
+      "output_tokens_batch": 6.25e-6,
+      "output_batch": 6.25e-6
+    },
+    "tokenizer_config": null,
+    "tokenizer_id": null
   }
 ]


### PR DESCRIPTION
## What does this PR do?

Add the Amazon Nova family (micro, lite, pro, premier) to the models/prices registry.

- Appends four entries to `worker/src/constants/default-model-prices.json` with [official Bedrock pricing](https://aws.amazon.com/bedrock/pricing/) converted to USD-per-token.

Fixes: #9127 

## Type of change

- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] I have self-reviewed the code and verified the JSON structure and placement of the new entries.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md).
- [x] I ran code formatting (`pnpm run format`) where applicable.
- [x] I checked for obvious lint warnings (`pnpm run lint`).
- [x] I updated `updated_at` timestamps as required by CONTRIBUTING.md.
- [ ] I added tests (not applicable for this data-only change).
- [ ] I ran unit tests locally (note: many tests in this repo require infrastructure; see CONTRIBUTING.md).

## Files changed

- `worker/src/constants/default-model-prices.json` — append Amazon Nova model entries (micro/lite/pro/premier)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Amazon Nova models and their pricing to `default-model-prices.json`.
> 
>   - **Behavior**:
>     - Adds Amazon Nova models (micro, lite, pro, premier) to `default-model-prices.json`.
>     - Prices are based on official Bedrock pricing, converted to USD-per-token.
>   - **Data**:
>     - Appends four entries to `default-model-prices.json` for Amazon Nova models with detailed pricing structures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1395fa77c711743d5c86e09a031879c3e33845b7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->