### PR TITLE
fix(datasets): graphs not readable in dark mode

### DIFF
--- a/web/src/features/scores/components/ScoreChart.tsx
+++ b/web/src/features/scores/components/ScoreChart.tsx
@@ -74,12 +74,23 @@ export function NumericChart(props: {
 }) {
   const colors = getColorsForCategories(props.chartLabels);
 
+  const TooltipComponent = (tooltipProps: CustomTooltipProps) => (
+    <div className="max-w-56">
+      <Tooltip
+        {...tooltipProps}
+        formatter={(value) =>
+          compactNumberFormatter(value, props.maxFractionDigits)
+        }
+      />
+    </div>
+  );
+
   return isEmptyChart({ data: props.chartData }) ? (
     <NoDataOrLoading isLoading={false} />
   ) : (
     <Card className="max-h-full min-h-0 min-w-0 max-w-full flex-1 rounded-tremor-default border">
       <LineChart
-        className="max-h-full min-h-0 min-w-0 max-w-full"
+        className="max-h-full min-h-0 min-w-0 max-w-full [&_text]:fill-muted-foreground [&_tspan]:fill-muted-foreground"
         data={props.chartData}
         index={props.index}
         categories={props.chartLabels}
@@ -92,6 +103,7 @@ export function NumericChart(props: {
         onValueChange={() => {}}
         enableLegendSlider={true}
         showXAxis={false}
+        customTooltip={TooltipComponent}
       />
     </Card>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves graph readability in dark mode by adjusting text color and tooltip components in `ScoreChart.tsx`.
> 
>   - **Behavior**:
>     - Adjusts text color in `LineChart` and `BarChart` components in `ScoreChart.tsx` for better readability in dark mode using `fill-muted-foreground`.
>     - Adds `TooltipComponent` to `NumericChart` and `CategoricalChart` to format tooltips with `compactNumberFormatter` and `Intl.NumberFormat` respectively.
>   - **Misc**:
>     - Adds a wrapper `div` with `max-w-56` to `TooltipComponent` in `NumericChart` for layout consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4e06b0f963acaa9f21bfee972f25b179b9dcf3b9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->