### PR TITLE
Implement scroll preservation hook for langtab

### DIFF
--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -5,6 +5,7 @@ import DocPopup from "@/src/components/layouts/doc-popup";
 import { SidebarTrigger } from "@/src/components/ui/sidebar";
 import { cn } from "@/src/utils/tailwind";
 import Link from "next/link";
+import { usePreserveScrollOnTabSwitch } from "@/src/hooks/usePreserveScrollOnTabSwitch";
 
 type TabDefinition = {
   value: string;
@@ -42,6 +43,16 @@ const PageHeader = ({
   tabsProps,
   container = false,
 }: PageHeaderProps) => {
+  // Use the scroll preservation hook for tab navigation
+  const [compensateScrollRef, startPreserveScroll] =
+    usePreserveScrollOnTabSwitch<HTMLDivElement>(
+      tabsProps?.activeTab ?? "",
+      {
+        enabled: !!tabsProps,
+        storageKey: "page-header-tabs-scroll",
+      },
+    );
+
   return (
     <div className="sticky top-0 z-30 w-full border-b bg-background shadow-sm">
       <div className="flex flex-col justify-center">
@@ -115,6 +126,7 @@ const PageHeader = ({
           {tabsProps && (
             <div className={cn("ml-2", tabsProps.className)}>
               <div
+                ref={compensateScrollRef}
                 className={cn(
                   "inline-flex h-8 items-center justify-start",
                   tabsProps.listClassName,
@@ -124,6 +136,10 @@ const PageHeader = ({
                   <Link
                     key={tab.value}
                     href={tab.href}
+                    onClick={() => {
+                      // Preserve scroll position before navigation
+                      startPreserveScroll(tab.href);
+                    }}
                     className={cn(
                       "inline-flex h-full items-center justify-center whitespace-nowrap rounded-none border-b-4 border-transparent px-2 py-0.5 text-sm font-medium transition-all hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                       tab.value === tabsProps.activeTab

--- a/web/src/hooks/usePreserveScrollOnTabSwitch.ts
+++ b/web/src/hooks/usePreserveScrollOnTabSwitch.ts
@@ -1,0 +1,181 @@
+import { useCallback, useLayoutEffect, useRef } from "react";
+import { useRouter } from "next/router";
+
+type ScrollTarget = Window | Element;
+
+function isWindow(target: ScrollTarget): target is Window {
+  return (
+    (target as Window).scrollBy !== undefined &&
+    (target as Window).document !== undefined
+  );
+}
+
+function getComputedOverflowY(node: Element): string {
+  const style = window.getComputedStyle(node);
+  return style.overflowY;
+}
+
+function isScrollable(node: Element): boolean {
+  const overflowY = getComputedOverflowY(node);
+  if (overflowY !== "auto" && overflowY !== "scroll") return false;
+  return node.scrollHeight > node.clientHeight;
+}
+
+function findNearestScrollContainer(start: Element): ScrollTarget {
+  let node: Element | null = start;
+  while (node && node !== document.body) {
+    if (isScrollable(node)) return node;
+    node = node.parentElement;
+  }
+  return window;
+}
+
+export interface UsePreserveScrollOnTabSwitchOptions {
+  getScrollTarget?: (clickedElement: Element) => ScrollTarget;
+  enabled?: boolean;
+  storageKey?: string;
+}
+
+/**
+ * Preserves scroll position when switching between tabs that involve page navigation.
+ * This hook stores the scroll position before navigation and restores it after the new page loads.
+ *
+ * @param activeTab - The current active tab value
+ * @param options - Optional configuration for scroll target detection and enabling the behavior
+ */
+export function usePreserveScrollOnTabSwitch<T extends Element = Element>(
+  activeTab: string,
+  options?: UsePreserveScrollOnTabSwitchOptions,
+): [React.RefObject<T | null>, (targetHref: string) => void] {
+  const enabled = options?.enabled ?? true;
+  const storageKey = options?.storageKey ?? "tab-scroll-position";
+  const router = useRouter();
+  const elementRef = useRef<T | null>(null);
+  const isRestoringRef = useRef<boolean>(false);
+
+  // Store scroll position before tab switch
+  const startPreserveScroll = useCallback(
+    (targetHref: string) => {
+      if (!enabled) return;
+      const element = elementRef.current;
+      if (!element || !element.getBoundingClientRect) return;
+
+      const rect = element.getBoundingClientRect();
+      const scrollTarget =
+        options?.getScrollTarget?.(element) ??
+        findNearestScrollContainer(element);
+
+      let scrollTop = 0;
+      if (isWindow(scrollTarget)) {
+        scrollTop = window.scrollY;
+      } else {
+        scrollTop = (scrollTarget as Element).scrollTop;
+      }
+
+      // Store the scroll position and element position for this tab
+      const scrollData = {
+        elementTop: rect.top,
+        scrollTop,
+        timestamp: Date.now(),
+        targetHref,
+      };
+
+      try {
+        sessionStorage.setItem(
+          `${storageKey}-${router.asPath}`,
+          JSON.stringify(scrollData),
+        );
+      } catch (error) {
+        // Handle cases where sessionStorage is not available
+        console.warn("Failed to store scroll position:", error);
+      }
+    },
+    [enabled, options, router.asPath, storageKey],
+  );
+
+  // Restore scroll position after tab switch
+  const restoreScrollPosition = useCallback(() => {
+    if (!enabled || isRestoringRef.current) return;
+
+    try {
+      const storedData = sessionStorage.getItem(
+        `${storageKey}-${router.asPath}`,
+      );
+      if (!storedData) return;
+
+      const scrollData = JSON.parse(storedData);
+      
+      // Only restore if the data is recent (within 5 seconds)
+      if (Date.now() - scrollData.timestamp > 5000) {
+        sessionStorage.removeItem(`${storageKey}-${router.asPath}`);
+        return;
+      }
+
+      const element = elementRef.current;
+      if (!element) return;
+
+      const rect = element.getBoundingClientRect();
+      const scrollTarget =
+        options?.getScrollTarget?.(element) ??
+        findNearestScrollContainer(element);
+
+      // Calculate the difference between stored and current element position
+      const elementTopDelta = rect.top - scrollData.elementTop;
+      const targetScrollTop = scrollData.scrollTop + elementTopDelta;
+
+      isRestoringRef.current = true;
+
+      if (isWindow(scrollTarget)) {
+        window.scrollTo({ top: targetScrollTop, left: 0 });
+      } else {
+        (scrollTarget as Element).scrollTop = targetScrollTop;
+      }
+
+      // Clean up the stored data after restoration
+      sessionStorage.removeItem(`${storageKey}-${router.asPath}`);
+      
+      // Reset flag after a short delay
+      setTimeout(() => {
+        isRestoringRef.current = false;
+      }, 100);
+    } catch (error) {
+      console.warn("Failed to restore scroll position:", error);
+      isRestoringRef.current = false;
+    }
+  }, [enabled, router.asPath, storageKey, options]);
+
+  // Restore scroll position when the active tab changes (page loads)
+  useLayoutEffect(() => {
+    // Small delay to ensure the page content is fully rendered
+    const timeoutId = setTimeout(restoreScrollPosition, 50);
+    return () => clearTimeout(timeoutId);
+  }, [activeTab, restoreScrollPosition]);
+
+  // Clean up old stored data on unmount
+  useLayoutEffect(() => {
+    return () => {
+      // Clean up any stored scroll data older than 1 minute
+      try {
+        const keys = Object.keys(sessionStorage);
+        keys.forEach((key) => {
+          if (key.startsWith(storageKey)) {
+            try {
+              const data = JSON.parse(sessionStorage.getItem(key) || "{}");
+              if (Date.now() - (data.timestamp || 0) > 60000) {
+                sessionStorage.removeItem(key);
+              }
+            } catch {
+              sessionStorage.removeItem(key);
+            }
+          }
+        });
+      } catch (error) {
+        // Ignore errors during cleanup
+      }
+    };
+  }, [storageKey]);
+
+  return [elementRef, startPreserveScroll];
+}
+
+export default usePreserveScrollOnTabSwitch;


### PR DESCRIPTION
## What does this PR do?

This PR resolves scroll instability when switching tabs in the `PageHeader` component on langfuse.com. Previously, navigating between tabs (which are `Link` components leading to different pages) would reset the scroll position, leading to a jarring user experience.

It introduces a new hook, `usePreserveScrollOnTabSwitch`, which stores the scroll position and the relative position of the tab container in `sessionStorage` before navigation. Upon loading the new page, it restores the scroll position, compensating for any layout shifts, thereby maintaining scroll stability. This hook is integrated into the `PageHeader` component.

Fixes #LFE-6703

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [ ] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my PR needs changes to the documentation
- [ ] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [ ] I haven't added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-6703](https://linear.app/langfuse/issue/LFE-6703/scroll-stability-when-switching-tabs-langtab-on-langfusecom)

<a href="https://cursor.com/background-agent?bcId=bc-c69560d7-8bed-4f73-9c27-d473ac22bb7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c69560d7-8bed-4f73-9c27-d473ac22bb7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

