### PR TITLE
Add sso param for direct idp signin

### DIFF
--- a/web/src/__e2e__/auth.spec.ts
+++ b/web/src/__e2e__/auth.spec.ts
@@ -138,3 +138,31 @@ test("Unauthenticated user should be redirected to relative URL after login", as
   // Expect to be redirected to the relative URL
   await expect(page).toHaveURL(relativeUrl);
 });
+
+test("SSO URL parameter should trigger NextAuth signIn", async ({ page }) => {
+  // Test with a standard provider (google)
+  await page.goto("/auth/sign-in?sso=google");
+  
+  // Wait for redirect to NextAuth's OAuth flow
+  // Since we don't have actual OAuth providers configured in tests,
+  // we expect to be redirected to an error page or OAuth provider URL
+  await page.waitForTimeout(2000);
+  
+  // The page should have attempted to redirect to OAuth provider
+  // Since we're testing the functionality and not the actual OAuth flow,
+  // we just verify that the page URL has changed from the sign-in page
+  const currentUrl = page.url();
+  expect(currentUrl).not.toBe("/auth/sign-in?sso=google");
+});
+
+test("SSO URL parameter should work with multi-tenant provider format", async ({ page }) => {
+  // Test with multi-tenant provider format (domain.provider)
+  await page.goto("/auth/sign-in?sso=khanacademy.com.okta");
+  
+  // Wait for redirect to NextAuth's OAuth flow
+  await page.waitForTimeout(2000);
+  
+  // The page should have attempted to redirect to OAuth provider
+  const currentUrl = page.url();
+  expect(currentUrl).not.toBe("/auth/sign-in?sso=khanacademy.com.okta");
+});


### PR DESCRIPTION
## What does this PR do?

This PR introduces an optional `sso` URL parameter to the `/auth/sign-in` page. When present, this parameter automatically triggers an IdP-initiated sign-in flow using the specified authentication provider (e.g., `google`, `khanacademy.com.okta`). Upon successful authentication, the user is redirected to `/`. This feature supports multi-tenant SSO and direct social login links, enhancing the flexibility of the authentication process. It includes error handling and PostHog analytics tracking.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- [x] I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

---
<a href="https://cursor.com/background-agent?bcId=bc-fb3087e5-d5a5-43bf-9b6e-b961f45b614e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fb3087e5-d5a5-43bf-9b6e-b961f45b614e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

