### PR TITLE
chore: add debugging log for invalid start_time in batch exports

### DIFF
--- a/packages/shared/src/server/repositories/observations_converters.ts
+++ b/packages/shared/src/server/repositories/observations_converters.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_RENDERING_PROPS,
   applyInputOutputRendering,
 } from "../utils/rendering";
+import { logger } from "../logger";
 
 export const convertObservation = (
   record: ObservationRecordReadType,
@@ -18,6 +19,18 @@ export const convertObservation = (
 ): Observation => {
   const reducedCostDetails = reduceUsageOrCostDetails(record.cost_details);
   const reducedUsageDetails = reduceUsageOrCostDetails(record.usage_details);
+
+  if (!record.start_time) {
+    logger.error(
+      `Found invalid value start_time: ${record.start_time} for record ${record.id} in project ${record.project_id}. Processing will fail.`,
+      {
+        ...record,
+        input: null,
+        output: null,
+        metadata: null,
+      },
+    );
+  }
 
   return {
     id: record.id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds error logging for invalid `start_time` in `convertObservation` in `observations_converters.ts`.
> 
>   - **Behavior**:
>     - Adds error logging for invalid `start_time` in `convertObservation` in `observations_converters.ts`.
>     - Logs error with record details excluding `input`, `output`, and `metadata` fields.
>   - **Imports**:
>     - Imports `logger` from `../logger`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 242962d3750b6aa807c517c56912e170e6c890ad. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->