### PR TITLE
chore(cloud): remove eval count limit from hobby/free plan

### DIFF
--- a/web/src/features/entitlements/constants/entitlements.ts
+++ b/web/src/features/entitlements/constants/entitlements.ts
@@ -57,7 +57,7 @@ export const entitlementAccess: Record<
       "organization-member-count": 3, // 2 acc to billing page, 1 overage possible
       "data-access-days": 30,
       "annotation-queue-count": 1,
-      "model-based-evaluations-count-evaluators": 1,
+      "model-based-evaluations-count-evaluators": false,
       "prompt-management-count-prompts": false,
     },
   },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove evaluation count limit for `model-based-evaluations-count-evaluators` in `cloud:hobby` plan.
> 
>   - **Behavior**:
>     - Removes evaluation count limit for `model-based-evaluations-count-evaluators` in `cloud:hobby` plan in `entitlements.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c37bf3d26e2c9e26d48a06e16884ac2bc5b431ea. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->