### PR TITLE
fix(tables): cmd+click opens traces and observations in a new tab

### DIFF
--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -1143,6 +1143,34 @@ export default function ObservationsTable({
         columnVisibility={columnVisibility}
         onColumnVisibilityChange={setColumnVisibilityState}
         rowHeight={rowHeight}
+        onRowClick={(row, event) => {
+          // Handle Command/Ctrl+click to open observation in new tab
+          if (event && (event.metaKey || event.ctrlKey)) {
+            // Prevent the default peek behavior
+            event.preventDefault();
+
+            // Construct the observation URL directly to avoid race conditions
+            const observationId = row.id;
+            const traceId = row.traceId;
+            const timestamp = row.timestamp;
+
+            if (traceId) {
+              let observationUrl = `/project/${projectId}/traces/${encodeURIComponent(traceId)}`;
+
+              const params = new URLSearchParams();
+              params.set("observation", observationId);
+              if (timestamp) {
+                params.set("timestamp", timestamp.toISOString());
+              }
+
+              observationUrl += `?${params.toString()}`;
+
+              const fullUrl = `${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}${observationUrl}`;
+              window.open(fullUrl, "_blank");
+            }
+          }
+          // For normal clicks, let the data-table handle opening the peek view
+        }}
       />
     </>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance data table row click behavior to open traces and observations in new tabs with Command/Ctrl+click, updating `onRowClick` logic in `data-table.tsx`, `observations.tsx`, and `traces.tsx`.
> 
>   - **Behavior**:
>     - `onRowClick` function signature in `data-table.tsx` updated to include `event` parameter for handling modifier keys.
>     - Command/Ctrl+click on rows in `observations.tsx` and `traces.tsx` opens the respective trace or observation in a new tab.
>     - Prevents default peek behavior if Command/Ctrl+click is detected.
>   - **Implementation**:
>     - Constructs URLs for new tabs using `traceId`, `observationId`, and `timestamp`.
>     - Uses `window.open()` to open the constructed URL in a new tab.
>   - **Files Affected**:
>     - `data-table.tsx`: Updated `onRowClick` logic.
>     - `observations.tsx`: Added Command/Ctrl+click handling for observations.
>     - `traces.tsx`: Added Command/Ctrl+click handling for traces.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 27371f708054be9f9bde31853b4dfa84faad7b50. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->