### PR TITLE
fix(llm-completion): add transformations for providers requiring a user message

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -46,6 +46,21 @@ import { HttpsProxyAgent } from "https-proxy-agent";
 
 const isLangfuseCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 
+const PROVIDERS_WITH_REQUIRED_USER_MESSAGE = [
+  LLMAdapter.VertexAI,
+  LLMAdapter.Anthropic,
+];
+
+const transformSystemMessageToUserMessage = (
+  messages: ChatMessage[],
+): BaseMessage[] => {
+  const safeContent =
+    typeof messages[0].content === "string"
+      ? messages[0].content
+      : JSON.stringify(messages[0].content);
+  return [new HumanMessage(safeContent)];
+};
+
 type ProcessTracedEvents = () => Promise<void>;
 
 type LLMCompletionParams = {
@@ -174,13 +189,13 @@ export async function fetchLLMCompletion(
   };
 
   let finalMessages: BaseMessage[];
-  // VertexAI requires at least 1 user message
-  if (modelParams.adapter === LLMAdapter.VertexAI && messages.length === 1) {
-    const safeContent =
-      typeof messages[0].content === "string"
-        ? messages[0].content
-        : JSON.stringify(messages[0].content);
-    finalMessages = [new HumanMessage(safeContent)];
+  // Some providers require at least 1 user message
+  if (
+    messages.length === 1 &&
+    PROVIDERS_WITH_REQUIRED_USER_MESSAGE.includes(modelParams.adapter)
+  ) {
+    // Ensure provider schema compliance
+    finalMessages = transformSystemMessageToUserMessage(messages);
   } else {
     finalMessages = messages.map((message) => {
       // For arbitrary content types, convert to string safely


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds transformation in `fetchLLMCompletion.ts` to convert system messages to user messages for `VertexAI` and `Anthropic` when required.
> 
>   - **Behavior**:
>     - Adds `transformSystemMessageToUserMessage` function in `fetchLLMCompletion.ts` to convert system messages to user messages for providers requiring a user message.
>     - Updates `fetchLLMCompletion` to apply this transformation for `VertexAI` and `Anthropic` when only one message is present.
>   - **Constants**:
>     - Introduces `PROVIDERS_WITH_REQUIRED_USER_MESSAGE` array to list providers needing a user message.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for df75e20c88bf97b9974e92bde887ac8ccff8c07d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->