### PR TITLE
feat(api): GET /scores support for filtering by sessionId

### DIFF
--- a/fern/apis/server/definition/score-v2.yml
+++ b/fern/apis/server/definition/score-v2.yml
@@ -50,6 +50,9 @@ service:
           configId:
             type: optional<string>
             docs: Retrieve only scores with a specific configId.
+          sessionId:
+            type: optional<string>
+            docs: Retrieve only scores with a specific sessionId.
           queueId:
             type: optional<string>
             docs: Retrieve only scores with a specific annotation queueId.

--- a/packages/shared/src/features/scores/interfaces/api/v2/endpoints.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v2/endpoints.ts
@@ -8,7 +8,9 @@ export const GetScoreQueryV2 = GetScoreQuery;
 export const GetScoreResponseV2 = APIScoreSchemaV2;
 
 // GET /scores v2
-export const GetScoresQueryV2 = GetScoresQuery;
+export const GetScoresQueryV2 = GetScoresQuery.extend({
+  sessionId: z.string().nullish(),
+});
 export const GetScoreResponseDataV2 = z.intersection(
   APIScoreSchemaV2,
   z.object({

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -4017,6 +4017,13 @@ paths:
           schema:
             type: string
             nullable: true
+        - name: sessionId
+          in: query
+          description: Retrieve only scores with a specific sessionId.
+          required: false
+          schema:
+            type: string
+            nullable: true
         - name: queueId
           in: query
           description: Retrieve only scores with a specific annotation queueId.

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -2875,7 +2875,7 @@
           "request": {
             "description": "Get a list of scores (supports both trace and session scores)",
             "url": {
-              "raw": "{{baseUrl}}/api/public/v2/scores?page=&limit=&userId=&name=&fromTimestamp=&toTimestamp=&environment=&source=&operator=&value=&scoreIds=&configId=&queueId=&dataType=&traceTags=",
+              "raw": "{{baseUrl}}/api/public/v2/scores?page=&limit=&userId=&name=&fromTimestamp=&toTimestamp=&environment=&source=&operator=&value=&scoreIds=&configId=&sessionId=&queueId=&dataType=&traceTags=",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -2945,6 +2945,11 @@
                   "key": "configId",
                   "value": "",
                   "description": "Retrieve only scores with a specific configId."
+                },
+                {
+                  "key": "sessionId",
+                  "value": "",
+                  "description": "Retrieve only scores with a specific sessionId."
                 },
                 {
                   "key": "queueId",

--- a/web/src/__tests__/async/scores-api-v1.servertest.ts
+++ b/web/src/__tests__/async/scores-api-v1.servertest.ts
@@ -1031,6 +1031,25 @@ describe("/api/public/scores API Endpoint", () => {
           ]),
         );
       });
+
+      it("should reject session ID filtering", async () => {
+        try {
+          await makeZodVerifiedAPICall(
+            z.object({
+              message: z.string(),
+              error: z.array(z.object({})),
+            }),
+            "GET",
+            `/api/public/scores?sessionId=${sessionId}`,
+            undefined,
+            authentication,
+          );
+        } catch (error) {
+          expect((error as Error).message).toContain(
+            "API call did not return 200, returned status 400",
+          );
+        }
+      });
     });
   });
 });

--- a/web/src/__tests__/async/scores-api-v1.servertest.ts
+++ b/web/src/__tests__/async/scores-api-v1.servertest.ts
@@ -11,7 +11,10 @@ import {
   createTracesCh,
   createOrgProjectAndApiKey,
 } from "@langfuse/shared/src/server";
-import { makeZodVerifiedAPICall } from "@/src/__tests__/test-utils";
+import {
+  makeAPICall,
+  makeZodVerifiedAPICall,
+} from "@/src/__tests__/test-utils";
 import {
   DeleteScoreResponseV1,
   GetScoreResponseV1,
@@ -1034,11 +1037,7 @@ describe("/api/public/scores API Endpoint", () => {
 
       it("should reject session ID filtering", async () => {
         try {
-          await makeZodVerifiedAPICall(
-            z.object({
-              message: z.string(),
-              error: z.array(z.object({})),
-            }),
+          await makeAPICall(
             "GET",
             `/api/public/scores?sessionId=${sessionId}`,
             undefined,

--- a/web/src/__tests__/async/scores-api-v2.servertest.ts
+++ b/web/src/__tests__/async/scores-api-v2.servertest.ts
@@ -865,6 +865,39 @@ describe("/api/public/v2/scores API Endpoint", () => {
           ]),
         );
       });
+
+      it("should filter scores by session ID", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponseV2,
+          "GET",
+          `/api/public/v2/scores?sessionId=${sessionId}`,
+          undefined,
+          authentication,
+        );
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({
+          page: 1,
+          limit: 50,
+          totalItems: 2,
+          totalPages: 1,
+        });
+        expect(getScore.body.data).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: scoreId_6,
+              sessionId: sessionId,
+              name: scoreName,
+              value: 100.5,
+            }),
+            expect.objectContaining({
+              id: scoreId_7,
+              sessionId: sessionId,
+              name: "session-score-name",
+              value: 100.5,
+            }),
+          ]),
+        );
+      });
     });
   });
 });

--- a/web/src/features/public-api/server/scores.ts
+++ b/web/src/features/public-api/server/scores.ts
@@ -20,6 +20,7 @@ export type ScoreQueryType = {
   value?: number;
   scoreId?: string;
   configId?: string;
+  sessionId?: string;
   queueId?: string;
   traceTags?: string | string[];
   operator?: string;
@@ -319,6 +320,13 @@ const secureScoreFilterOptions = [
   {
     id: "configId",
     clickhouseSelect: "config_id",
+    clickhouseTable: "scores",
+    filterType: "StringFilter",
+    clickhousePrefix: "s",
+  },
+  {
+    id: "sessionId",
+    clickhouseSelect: "session_id",
     clickhouseTable: "scores",
     filterType: "StringFilter",
     clickhousePrefix: "s",

--- a/web/src/pages/api/public/v2/scores/index.ts
+++ b/web/src/pages/api/public/v2/scores/index.ts
@@ -20,6 +20,7 @@ export default withMiddlewares({
         userId: query.userId ?? undefined,
         name: query.name ?? undefined,
         configId: query.configId ?? undefined,
+        sessionId: query.sessionId ?? undefined,
         queueId: query.queueId ?? undefined,
         traceTags: query.traceTags ?? undefined,
         dataType: query.dataType ?? undefined,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for filtering scores by `sessionId` in the GET /scores API endpoint for version 2.
> 
>   - **Behavior**:
>     - Add `sessionId` as an optional query parameter for filtering in `GET /scores` in `score-v2.yml`, `endpoints.ts`, and `openapi.yml`.
>     - Update Postman collection in `collection.json` to include `sessionId` in the request URL.
>   - **Tests**:
>     - Add test case in `scores-api-v2.servertest.ts` to verify filtering by `sessionId` returns correct scores.
>     - Ensure `scores-api-v1.servertest.ts` rejects `sessionId` filtering for v1 API.
>   - **Server Logic**:
>     - Update `ScoreQueryType` in `scores.ts` to include `sessionId`.
>     - Add `sessionId` to `secureScoreFilterOptions` in `scores.ts` for Clickhouse query filtering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 634b8267d6ab39e07548fc7167f3f6044c0a1e13. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->