### PR TITLE
chore: add sdk-api-spec bot

### DIFF
--- a/.github/workflows/sdk-api-spec.yml
+++ b/.github/workflows/sdk-api-spec.yml
@@ -1,9 +1,9 @@
 name: SDK API Spec Generation
 
 on:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
 
 concurrency:
@@ -17,20 +17,27 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
-          cache: "npm"
+          node-version: "24"
+          cache: "pnpm"
 
       - name: Install dependencies
-        run: npm install
+        run: pnpm install
 
       - name: Install Fern CLI
-        run: npm install -g fern-api
+        run: pnpm add -g fern-api
 
       - name: Generate SDK specs
-        run: npx fern-api generate --api server
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        run: npx fern-api generate --api server --force --log-level debug
 
       - name: Update Python SDK
         env:
@@ -116,4 +123,3 @@ jobs:
 
           # Create PR
           gh pr create --title "Update TypeScript SDK API spec" --body ""
-

--- a/.github/workflows/sdk-api-spec.yml
+++ b/.github/workflows/sdk-api-spec.yml
@@ -1,0 +1,119 @@
+name: SDK API Spec Generation
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: sdk-api-spec-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate-sdk-specs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install Fern CLI
+        run: npm install -g fern-api
+
+      - name: Generate SDK specs
+        run: npx fern-api generate --api server
+
+      - name: Update Python SDK
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Clone langfuse-python repository
+          git clone https://github.com/langfuse/langfuse-python.git ../langfuse-python
+          cd ../langfuse-python
+
+          # Configure git
+          git config user.name "api-spec-bot"
+          git config user.email "api-spec-bot@langfuse.com"
+
+          # Delete existing API contents
+          rm -rf langfuse/api/*
+
+          # Copy generated Python SDK files
+          cp -r ../langfuse/generated/python/* langfuse/api/
+
+          # Install poetry and format
+          pip install poetry
+          cd langfuse/api
+          poetry run ruff format . || echo "Ruff format completed with warnings"
+          cd ../..
+
+          # Check for changes
+          if git diff --quiet; then
+            echo "No changes detected in Python SDK"
+            exit 0
+          fi
+
+          # Close existing api-spec-bot PRs
+          gh pr list --author api-spec-bot --state open --json number --jq '.[].number' | xargs -I {} gh pr close {}
+
+          # Create new branch and push changes
+          BRANCH_NAME="api-spec-bot-${{ github.sha }}"
+          git checkout -b "$BRANCH_NAME"
+          git add .
+          git commit -m "Update Python SDK API spec from ${{ github.sha }}"
+          git push origin "$BRANCH_NAME"
+
+          # Create PR
+          gh pr create --title "Update Python SDK API spec" --body ""
+
+      - name: Update TypeScript SDK
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Clone langfuse-js repository
+          git clone https://github.com/langfuse/langfuse-js.git ../langfuse-js
+          cd ../langfuse-js
+
+          # Configure git
+          git config user.name "api-spec-bot"
+          git config user.email "api-spec-bot@langfuse.com"
+
+          # Delete existing API contents
+          rm -rf packages/core/src/api/*
+
+          # Copy generated TypeScript SDK files
+          cp -r ../langfuse/generated/typescript/* packages/core/src/api/
+
+          # Install dependencies and format
+          npm install -g pnpm
+          pnpm install
+          pnpm format || echo "Format completed with warnings"
+
+          # Check for changes
+          if git diff --quiet; then
+            echo "No changes detected in TypeScript SDK"
+            exit 0
+          fi
+
+          # Close existing api-spec-bot PRs
+          gh pr list --author api-spec-bot --state open --json number --jq '.[].number' | xargs -I {} gh pr close {}
+
+          # Create new branch and push changes
+          BRANCH_NAME="api-spec-bot-${{ github.sha }}"
+          git checkout -b "$BRANCH_NAME"
+          git add .
+          git commit -m "Update TypeScript SDK API spec from ${{ github.sha }}"
+          git push origin "$BRANCH_NAME"
+
+          # Create PR
+          gh pr create --title "Update TypeScript SDK API spec" --body ""
+

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "INLINE_RUNTIME_CHUNK=false dotenv -e ../.env -- next build",
-    "dev": "dotenv -e ../.env -- next dev --turbo",
+    "dev": "dotenv -e ../.env -- next dev",
     "dev:http": "dotenv -e ../.env -- next dev --experimental-https --experimental-https-key ./localhost+1-key.pem --experimental-https-cert ./localhost+1.pem",
     "lint": "dotenv -e ../.env -- next lint --max-warnings 0",
     "lint:fix": "dotenv -e ../.env -- next lint --fix",

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "INLINE_RUNTIME_CHUNK=false dotenv -e ../.env -- next build",
-    "dev": "dotenv -e ../.env -- next dev",
+    "dev": "dotenv -e ../.env -- next dev --turbo",
     "dev:http": "dotenv -e ../.env -- next dev --experimental-https --experimental-https-key ./localhost+1-key.pem --experimental-https-cert ./localhost+1.pem",
     "lint": "dotenv -e ../.env -- next lint --max-warnings 0",
     "lint:fix": "dotenv -e ../.env -- next lint --fix",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds GitHub Actions workflow for SDK API spec generation and updates `dev` script in `web/package.json` to use `--turbo`.
> 
>   - **GitHub Actions Workflow**:
>     - Adds `sdk-api-spec.yml` to automate SDK API spec generation and updates for Python and TypeScript.
>     - Uses `fern-api` to generate SDK specs and updates respective repositories.
>     - Closes existing PRs by `api-spec-bot` before creating new ones.
>   - **Scripts**:
>     - Updates `dev` script in `web/package.json` to include `--turbo` flag for Next.js.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5b8b2abe17f765ed1d2bbb15379d5ee4305ff681. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->