### PR TITLE
chore: switch docker compose cluster to bitnami legacy

### DIFF
--- a/docker-compose.dev-redis-cluster.yml
+++ b/docker-compose.dev-redis-cluster.yml
@@ -55,7 +55,7 @@ services:
 
   # Redis Cluster. Requires a Unix host to work for network_mode: host. I.e. tests will fail on windows and mac with this setup.
   redis-node-0:
-    image: docker.io/bitnami-legacy/redis-cluster:8.0
+    image: docker.io/bitnamilegacy/redis-cluster:8.0
     network_mode: host
     volumes:
       - redis-cluster_data-0:/bitnami/redis/data
@@ -65,7 +65,7 @@ services:
       REDIS_NODES: 127.0.0.1:6370 127.0.0.1:6371 127.0.0.1:6372 127.0.0.1:6373 127.0.0.1:6374 127.0.0.1:6375
 
   redis-node-1:
-    image: docker.io/bitnami-legacy/redis-cluster:8.0
+    image: docker.io/bitnamilegacy/redis-cluster:8.0
     network_mode: host
     volumes:
       - redis-cluster_data-1:/bitnami/redis/data
@@ -75,7 +75,7 @@ services:
       REDIS_NODES: 127.0.0.1:6370 127.0.0.1:6371 127.0.0.1:6372 127.0.0.1:6373 127.0.0.1:6374 127.0.0.1:6375
 
   redis-node-2:
-    image: docker.io/bitnami-legacy/redis-cluster:8.0
+    image: docker.io/bitnamilegacy/redis-cluster:8.0
     network_mode: host
     volumes:
       - redis-cluster_data-2:/bitnami/redis/data
@@ -85,7 +85,7 @@ services:
       REDIS_NODES: 127.0.0.1:6370 127.0.0.1:6371 127.0.0.1:6372 127.0.0.1:6373 127.0.0.1:6374 127.0.0.1:6375
 
   redis-node-3:
-    image: docker.io/bitnami-legacy/redis-cluster:8.0
+    image: docker.io/bitnamilegacy/redis-cluster:8.0
     network_mode: host
     volumes:
       - redis-cluster_data-3:/bitnami/redis/data
@@ -95,7 +95,7 @@ services:
       REDIS_NODES: 127.0.0.1:6370 127.0.0.1:6371 127.0.0.1:6372 127.0.0.1:6373 127.0.0.1:6374 127.0.0.1:6375
 
   redis-node-4:
-    image: docker.io/bitnami-legacy/redis-cluster:8.0
+    image: docker.io/bitnamilegacy/redis-cluster:8.0
     network_mode: host
     volumes:
       - redis-cluster_data-4:/bitnami/redis/data
@@ -105,7 +105,7 @@ services:
       REDIS_NODES: 127.0.0.1:6370 127.0.0.1:6371 127.0.0.1:6372 127.0.0.1:6373 127.0.0.1:6374 127.0.0.1:6375
 
   redis-node-5:
-    image: docker.io/bitnami-legacy/redis-cluster:8.0
+    image: docker.io/bitnamilegacy/redis-cluster:8.0
     network_mode: host
     volumes:
       - redis-cluster_data-5:/bitnami/redis/data

--- a/docker-compose.dev-redis-cluster.yml
+++ b/docker-compose.dev-redis-cluster.yml
@@ -55,7 +55,7 @@ services:
 
   # Redis Cluster. Requires a Unix host to work for network_mode: host. I.e. tests will fail on windows and mac with this setup.
   redis-node-0:
-    image: docker.io/bitnami/redis-cluster:8.0
+    image: docker.io/bitnami-legacy/redis-cluster:8.0
     network_mode: host
     volumes:
       - redis-cluster_data-0:/bitnami/redis/data
@@ -65,7 +65,7 @@ services:
       REDIS_NODES: 127.0.0.1:6370 127.0.0.1:6371 127.0.0.1:6372 127.0.0.1:6373 127.0.0.1:6374 127.0.0.1:6375
 
   redis-node-1:
-    image: docker.io/bitnami/redis-cluster:8.0
+    image: docker.io/bitnami-legacy/redis-cluster:8.0
     network_mode: host
     volumes:
       - redis-cluster_data-1:/bitnami/redis/data
@@ -75,7 +75,7 @@ services:
       REDIS_NODES: 127.0.0.1:6370 127.0.0.1:6371 127.0.0.1:6372 127.0.0.1:6373 127.0.0.1:6374 127.0.0.1:6375
 
   redis-node-2:
-    image: docker.io/bitnami/redis-cluster:8.0
+    image: docker.io/bitnami-legacy/redis-cluster:8.0
     network_mode: host
     volumes:
       - redis-cluster_data-2:/bitnami/redis/data
@@ -85,7 +85,7 @@ services:
       REDIS_NODES: 127.0.0.1:6370 127.0.0.1:6371 127.0.0.1:6372 127.0.0.1:6373 127.0.0.1:6374 127.0.0.1:6375
 
   redis-node-3:
-    image: docker.io/bitnami/redis-cluster:8.0
+    image: docker.io/bitnami-legacy/redis-cluster:8.0
     network_mode: host
     volumes:
       - redis-cluster_data-3:/bitnami/redis/data
@@ -95,7 +95,7 @@ services:
       REDIS_NODES: 127.0.0.1:6370 127.0.0.1:6371 127.0.0.1:6372 127.0.0.1:6373 127.0.0.1:6374 127.0.0.1:6375
 
   redis-node-4:
-    image: docker.io/bitnami/redis-cluster:8.0
+    image: docker.io/bitnami-legacy/redis-cluster:8.0
     network_mode: host
     volumes:
       - redis-cluster_data-4:/bitnami/redis/data
@@ -105,7 +105,7 @@ services:
       REDIS_NODES: 127.0.0.1:6370 127.0.0.1:6371 127.0.0.1:6372 127.0.0.1:6373 127.0.0.1:6374 127.0.0.1:6375
 
   redis-node-5:
-    image: docker.io/bitnami/redis-cluster:8.0
+    image: docker.io/bitnami-legacy/redis-cluster:8.0
     network_mode: host
     volumes:
       - redis-cluster_data-5:/bitnami/redis/data


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Switches Redis cluster image to `bitnamilegacy` in `docker-compose.dev-redis-cluster.yml`.
> 
>   - **Docker Compose**:
>     - Switches Redis cluster image from `docker.io/bitnami/redis-cluster:8.0` to `docker.io/bitnamilegacy/redis-cluster:8.0` in `docker-compose.dev-redis-cluster.yml` for `redis-node-0` to `redis-node-5`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b3fad1b989a54a3fb161a6e9319cfedcf0ea08eb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->