### PR TITLE
fix(billing): apply existing discounts to new subscription phase when updating via subscription schedule

### DIFF
--- a/web/src/ee/features/billing/server/stripeBillingService.ts
+++ b/web/src/ee/features/billing/server/stripeBillingService.ts
@@ -1199,17 +1199,17 @@ class BillingService {
       const shouldTruncate = invoices.length === pagination.limit;
 
       // remove the last item to account for the preview row
-      const modfiedRows = shouldTruncate
+      const modifiedInvoiceRows = shouldTruncate
         ? [previewRow, ...invoices.slice(0, Math.max(0, pagination.limit - 1))]
         : [previewRow, ...invoices];
 
       return {
-        invoices: modfiedRows,
+        invoices: modifiedInvoiceRows,
         hasMore: list.has_more || shouldTruncate, // if we truncated the list there is at least one more element to show
         cursors: {
           next:
-            modfiedRows.length > 1
-              ? modfiedRows[modfiedRows.length - 1]!.id
+            modifiedInvoiceRows.length > 1
+              ? modifiedInvoiceRows[modifiedInvoiceRows.length - 1]!.id
               : undefined, // last real invoice id
           prev: invoices.length ? invoices[0]!.id : undefined, // first real invoice id
         },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Apply existing discounts to new subscription phases in `BillingService` and update invoice preview and pagination logic in `stripeBillingService.ts`.
> 
>   - **Behavior**:
>     - Apply existing discounts to new subscription phases in `BillingService` when updating via subscription schedule.
>     - Modify `createInvoicePreview()` to return `null` if subscription status is not eligible.
>   - **Functions**:
>     - Update `getInvoices()` to include preview row logic and handle pagination correctly.
>     - Add logic to map existing discounts to new discounts in subscription schedule updates.
>   - **Misc**:
>     - Adjust cursor logic in `getInvoices()` to account for preview row inclusion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for aa8a8a97760951de9e2b24efea69fbb7ebffa76a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->