### PR TITLE
chore: update fern python generator

### DIFF
--- a/fern/apis/server/generators.yml
+++ b/fern/apis/server/generators.yml
@@ -10,7 +10,7 @@ groups:
           path: ../../../web/public/generated/api
 
       - name: fernapi/fern-python-sdk
-        version: 2.16.0
+        version: 4.28.5
         output:
           location: local-file-system
           path: ../../../generated/python

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "langfuse",
-  "version": "0.56.0"
+  "version": "0.77.5"
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `fern-python-sdk` version from `2.16.0` to `4.28.5` in `generators.yml`.
> 
>   - **Version Update**:
>     - Update `fern-python-sdk` version from `2.16.0` to `4.28.5` in `generators.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ea52a97df350e58a3dff1839ccc3360ff7629096. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->