### PR TITLE
fix(datasets): update score filters to handle empty run lists in DatasetRunsTable and DatasetCompare components

### DIFF
--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -277,10 +277,12 @@ export function DatasetRunsTable(props: {
     useScoreColumns<DatasetRunRowData>({
       scoreColumnKey: "runItemScores",
       projectId: props.projectId,
-      filter: scoreFilters.forDatasetRunItems({
-        datasetRunIds: runs.data?.runs.map((r) => r.id) ?? [],
-        datasetId: props.datasetId,
-      }),
+      filter: runs.data?.runs?.length
+        ? scoreFilters.forDatasetRunItems({
+            datasetRunIds: runs.data.runs.map((r) => r.id),
+            datasetId: props.datasetId,
+          })
+        : [],
       isFilterDataPending: runs.isPending,
     });
 
@@ -288,9 +290,11 @@ export function DatasetRunsTable(props: {
     useScoreColumns<DatasetRunRowData>({
       scoreColumnKey: "runScores",
       projectId: props.projectId,
-      filter: scoreFilters.forDatasetRuns({
-        datasetRunIds: runs.data?.runs.map((r) => r.id) ?? [],
-      }),
+      filter: runs.data?.runs?.length
+        ? scoreFilters.forDatasetRuns({
+            datasetRunIds: runs.data?.runs.map((r) => r.id),
+          })
+        : [],
       prefix: "Run-level",
       isFilterDataPending: runs.isPending,
     });
@@ -298,10 +302,12 @@ export function DatasetRunsTable(props: {
   const scoreKeysAndProps = api.scores.getScoreColumns.useQuery(
     {
       projectId: props.projectId,
-      filter: scoreFilters.forDatasetRunItems({
-        datasetRunIds: runs.data?.runs.map((r) => r.id) ?? [],
-        datasetId: props.datasetId,
-      }),
+      filter: runs.data?.runs?.length
+        ? scoreFilters.forDatasetRunItems({
+            datasetRunIds: runs.data?.runs.map((r) => r.id),
+            datasetId: props.datasetId,
+          })
+        : [],
     },
     {
       enabled: runs.isSuccess,

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/compare.tsx
@@ -96,10 +96,13 @@ export default function DatasetCompare() {
   const scoreKeysAndProps = api.scores.getScoreColumns.useQuery(
     {
       projectId: projectId,
-      filter: scoreFilters.forDatasetRunItems({
-        datasetRunIds: runIds ?? [],
-        datasetId,
-      }),
+      filter:
+        runIds && runIds.length > 0
+          ? scoreFilters.forDatasetRunItems({
+              datasetRunIds: runIds,
+              datasetId,
+            })
+          : [],
     },
     {
       enabled: runIds && runIds.length > 1,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `DatasetRunsTable` and `DatasetCompare` components to handle empty run lists by conditionally applying score filters.
> 
>   - **Behavior**:
>     - Update `DatasetRunsTable` to apply score filters conditionally based on the presence of runs. If no runs are present, an empty filter is used.
>     - Update `DatasetCompare` to apply score filters conditionally based on the presence of `runIds`. If `runIds` is empty, an empty filter is used.
>   - **Components**:
>     - In `DatasetRunsTable.tsx`, modify `useScoreColumns` and `api.scores.getScoreColumns.useQuery` to handle empty run lists.
>     - In `compare.tsx`, modify `api.scores.getScoreColumns.useQuery` to handle empty `runIds`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8f51efcc128a1a8b8d2ee3baedc89ce2f384c80d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->