### PR TITLE
fix(experiments-ui): resolve composed prompts for prompt-experiment setup

### DIFF
--- a/web/src/features/experiments/server/router.ts
+++ b/web/src/features/experiments/server/router.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "crypto";
 import {
   type ExperimentMetadata,
   ExperimentCreateQueue,
+  PromptService,
   QueueJobs,
   QueueName,
   redis,
@@ -93,15 +94,19 @@ export const experimentsRouter = createTRPCRouter({
         };
       }
 
+      const promptService = new PromptService(ctx.prisma, redis);
+      const resolvedPrompt = await promptService.resolvePrompt(prompt);
+
       const extractedVariables = extractVariables(
-        prompt?.type === PromptType.Text
-          ? (prompt.prompt?.toString() ?? "")
-          : JSON.stringify(prompt.prompt),
+        resolvedPrompt?.type === PromptType.Text
+          ? (resolvedPrompt.prompt?.toString() ?? "")
+          : JSON.stringify(resolvedPrompt?.prompt),
       );
 
       const promptMessages =
-        prompt?.type === PromptType.Chat && Array.isArray(prompt.prompt)
-          ? prompt.prompt
+        resolvedPrompt?.type === PromptType.Chat &&
+        Array.isArray(resolvedPrompt?.prompt)
+          ? resolvedPrompt.prompt
           : [];
       const placeholderNames = extractPlaceholderNames(
         promptMessages as PromptMessage[],

--- a/web/src/features/experiments/server/router.ts
+++ b/web/src/features/experiments/server/router.ts
@@ -97,6 +97,13 @@ export const experimentsRouter = createTRPCRouter({
       const promptService = new PromptService(ctx.prisma, redis);
       const resolvedPrompt = await promptService.resolvePrompt(prompt);
 
+      if (!resolvedPrompt) {
+        return {
+          isValid: false,
+          message: "Selected prompt not found.",
+        };
+      }
+
       const extractedVariables = extractVariables(
         resolvedPrompt?.type === PromptType.Text
           ? (resolvedPrompt.prompt?.toString() ?? "")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Resolve composed prompts using `PromptService` in `experimentsRouter` to ensure correct prompt data is used for validation.
> 
>   - **Behavior**:
>     - Use `PromptService` to resolve prompts in `validateConfig` query in `router.ts`.
>     - Return error if resolved prompt is not found or has no variables/placeholders.
>   - **Validation**:
>     - Update variable extraction to use `resolvedPrompt` instead of `prompt`.
>     - Ensure dataset items contain variables before proceeding.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f9af2deefd7c6972b336f8e20d7e2baa201fcaa4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->