### PR TITLE
fix: include session scores in posthog export

### DIFF
--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1475,7 +1475,7 @@ export const getScoresForPostHog = async function* (
       OR s.dataset_run_id IS NOT NULL
     )
     AND (
-      t.project_id IS NULL 
+      t.project_id = '' -- use the default value for the string type to filter for absence
       OR (
         t.project_id = {projectId: String}
         AND t.timestamp >= {minTimestamp: DateTime64(3)} - INTERVAL 7 DAY


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes filtering in `getScoresForPostHog` to include session scores by setting `t.project_id = ''` for absence filtering.
> 
>   - **Behavior**:
>     - Fixes filtering in `getScoresForPostHog` in `scores.ts` to include session scores by setting `t.project_id = ''` for absence filtering.
>   - **Misc**:
>     - Adjusts SQL query to ensure correct filtering of scores with null `project_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for da4184fb00c173a153355566f864c93580e524c6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->