### PR TITLE
fix(experiment-form-ui): prevent event bubbling from embedded form submission handlers

### DIFF
--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -1131,7 +1131,10 @@ export const InnerEvaluatorForm = (props: {
     <Form {...form}>
       <form
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        onSubmit={form.handleSubmit(onSubmit)}
+        onSubmit={(e) => {
+          e.stopPropagation(); // Prevent event bubbling to parent forms
+          form.handleSubmit(onSubmit)(e);
+        }}
         onKeyDown={(e) => {
           if (e.key === "Enter" && e.target instanceof HTMLInputElement) {
             e.preventDefault();

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -475,7 +475,10 @@ export function CreateLLMApiKeyForm({
     <Form {...form}>
       <form
         className={cn("flex flex-col gap-4 overflow-auto")}
-        onSubmit={form.handleSubmit(onSubmit)}
+        onSubmit={(e) => {
+          e.stopPropagation(); // Prevent event bubbling to parent forms
+          form.handleSubmit(onSubmit)(e);
+        }}
       >
         <DialogBody>
           {/* LLM adapter */}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevents event bubbling in form submission handlers for `InnerEvaluatorForm` and `CreateLLMApiKeyForm`.
> 
>   - **Behavior**:
>     - Prevents event bubbling in `onSubmit` handlers in `InnerEvaluatorForm` and `CreateLLMApiKeyForm`.
>     - Specifically, adds `e.stopPropagation()` before `form.handleSubmit(onSubmit)(e)` in both components.
>   - **Files Affected**:
>     - `inner-evaluator-form.tsx`
>     - `CreateLLMApiKeyForm.tsx`
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 312345785f57bc1b7d2684043810250cfe57e751. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->