### PR TITLE
chore: update sdk-api-spec bot

### DIFF
--- a/.github/workflows/sdk-api-spec.yml
+++ b/.github/workflows/sdk-api-spec.yml
@@ -55,6 +55,10 @@ jobs:
           # Copy generated Python SDK files
           cp -r ../langfuse/generated/python/* langfuse/api/
 
+          # Remove unnecessary integration tests created by Fern
+          # (could not find the right option to prevent this in generation step)
+          rm -rf langfuse/api/tests
+
           # Install poetry and format
           pip install poetry
           poetry install --all-extras
@@ -73,11 +77,11 @@ jobs:
           BRANCH_NAME="api-spec-bot-${{ github.sha }}"
           git checkout -b "$BRANCH_NAME"
           git add .
-          git commit -m "feat(api): update API spec from langfuse/langfuse ${{ github.sha }}"
+          git commit -m "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::8}"
           git push origin "$BRANCH_NAME"
 
           # Create PR
-          gh pr create --title "feat(api): update API spec from langfuse/langfuse ${{ github.sha }}" --body ""
+          gh pr create --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::8}" --body ""
 
       - name: Update TypeScript SDK
         env:
@@ -117,8 +121,8 @@ jobs:
           BRANCH_NAME="api-spec-bot-${{ github.sha }}"
           git checkout -b "$BRANCH_NAME"
           git add .
-          git commit -m "feat(api): update API spec from langfuse/langfuse ${{ github.sha }}" --no-verify
+          git commit -m "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::8}" --no-verify
           git push origin "$BRANCH_NAME"
 
           # Create PR
-          gh pr create --title "feat(api): update API spec from langfuse/langfuse ${{ github.sha }}" --body ""
+          gh pr create --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::8}" --body ""

--- a/fern/apis/server/generators.yml
+++ b/fern/apis/server/generators.yml
@@ -31,7 +31,7 @@ groups:
       #     client-class-name: LangfuseClient
 
       - name: fernapi/fern-typescript-node-sdk
-        version: 2.6.1
+        version: 2.12.3
         output:
           location: local-file-system
           path: ../../../generated/typescript

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "langfuse",
-  "version": "0.56.0"
+  "version": "0.77.5"
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `sdk-api-spec.yml` to remove unnecessary tests and use shortened SHA, and update TypeScript SDK generator version.
> 
>   - **Workflow Changes**:
>     - In `.github/workflows/sdk-api-spec.yml`, remove `langfuse/api/tests` directory to eliminate unnecessary integration tests.
>     - Modify commit and PR creation commands to use `${GITHUB_SHA::8}` for shortened SHA.
>   - **Generator Version Update**:
>     - Update `fernapi/fern-typescript-node-sdk` version from `2.6.1` to `2.12.3` in `generators.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 06f5396a8b9609fc766924a930857311618d87ee. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->