### PR TITLE
chore(sdk-api-spec-bot): auto add reviewer

### DIFF
--- a/.github/workflows/sdk-api-spec.yml
+++ b/.github/workflows/sdk-api-spec.yml
@@ -73,6 +73,11 @@ jobs:
           # Close existing api-spec-bot PRs
           gh pr list --author langfuse-bot --state open --json number --jq '.[].number' | xargs -I {} gh pr close {}
 
+          # Get the GitHub username of the original commit author
+          cd ../langfuse
+          ORIGINAL_AUTHOR=$(gh api repos/langfuse/langfuse/commits/${GITHUB_SHA} --jq '.author.login')
+          cd ../langfuse-python
+
           # Create new branch and push changes
           BRANCH_NAME="api-spec-bot-${GITHUB_SHA::7}"
           git checkout -b "$BRANCH_NAME"
@@ -80,8 +85,8 @@ jobs:
           git commit -m "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}"
           git push origin "$BRANCH_NAME"
 
-          # Create PR
-          gh pr create --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" --body ""
+          # Create PR with original author as reviewer
+          gh pr create --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" --body "" --reviewer "$ORIGINAL_AUTHOR"
 
       - name: Update TypeScript SDK
         env:
@@ -126,6 +131,11 @@ jobs:
           # Close existing api-spec-bot PRs
           gh pr list --author langfuse-bot --state open --json number --jq '.[].number' | xargs -I {} gh pr close {}
 
+          # Get the GitHub username of the original commit author
+          cd ../langfuse
+          ORIGINAL_AUTHOR=$(gh api repos/langfuse/langfuse/commits/${GITHUB_SHA} --jq '.author.login')
+          cd ../langfuse-js
+
           # Create new branch and push changes
           BRANCH_NAME="api-spec-bot-${GITHUB_SHA::7}"
           git checkout -b "$BRANCH_NAME"
@@ -133,5 +143,5 @@ jobs:
           git commit -m "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" --no-verify
           git push origin "$BRANCH_NAME"
 
-          # Create PR
-          gh pr create --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" --body ""
+          # Create PR with original author as reviewer
+          gh pr create --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" --body "" --reviewer "$ORIGINAL_AUTHOR"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Automatically add original commit author as reviewer in PRs created by SDK API spec bot.
> 
>   - **Behavior**:
>     - Automatically adds the original commit author as a reviewer when creating a PR in `sdk-api-spec.yml`.
>     - Fetches the original commit author's GitHub username using `gh api`.
>   - **Workflow**:
>     - Modifies `gh pr create` command to include `--reviewer` flag with the original author's username in both Python and TypeScript SDK update steps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2f057b327f9ccc7fc37f87db2d26d0ccfe9c7e6b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->