### PR TITLE
fix(billing): automatically cancel and invoice stripe subscriptions when an org is deleted

### DIFF
--- a/web/src/ee/features/billing/server/stripeBillingService.ts
+++ b/web/src/ee/features/billing/server/stripeBillingService.ts
@@ -1007,6 +1007,77 @@ class BillingService {
   }
 
   /**
+   * Cancel the active subscription immediately and generate a final invoice.
+   * - Releases any active/not-started schedules first
+   * - Invoices outstanding usage now
+   * - No proration is applied
+   *
+   * Designed for destructive flows (e.g., org deletion). If no active
+   * subscription exists, this method is a no-op and returns success.
+   */
+  async cancelImmediatelyAndInvoice(orgId: string, opId?: string) {
+    const client = this.stripe;
+
+    const { parsedOrg } = await this.getParsedOrg(orgId);
+
+    const subscriptionId = parsedOrg.cloudConfig?.stripe?.activeSubscriptionId;
+    if (!subscriptionId) {
+      logger.info(
+        "stripeBillingService.subscription.cancel.now:noop.noActiveSubscription",
+        {
+          orgId,
+        },
+      );
+      return { status: "noop" as const };
+    }
+
+    const subscription = await this.retrieveSubscriptionWithSchedule(
+      client,
+      subscriptionId,
+    );
+
+    // Release any pending schedule before immediate cancel
+    await this.releaseExistingSubscriptionScheduleIfAny(subscription, opId);
+
+    const cancelNowKey = makeIdempotencyKey({
+      kind: IdempotencyKind.enum["subscription.cancel.now"],
+      fields: { subscriptionId },
+      opId,
+    });
+
+    logger.info("stripeBillingService.subscription.cancel.now", {
+      subscriptionId,
+      customerId: subscription.customer,
+      orgId,
+      idempotencyKey: cancelNowKey,
+      opId,
+      userId: this.ctx.session.user?.id,
+      userEmail: this.ctx.session.user?.email,
+    });
+
+    await client.subscriptions.cancel(
+      subscriptionId,
+      {
+        invoice_now: true,
+        prorate: false,
+      } as any,
+      { idempotencyKey: cancelNowKey },
+    );
+
+    void auditLog({
+      session: this.ctx.session,
+      orgId: parsedOrg.id,
+      resourceType: "organization",
+      resourceId: parsedOrg.id,
+      action: "BillingService.cancelImmediatelyAndInvoice",
+      before: parsedOrg.cloudConfig,
+      after: "webhook",
+    });
+
+    return { status: "success" as const };
+  }
+
+  /**
    * Clear any active or not-started subscription schedule for the org's subscription.
    *
    * @param orgId Organization id

--- a/web/src/ee/features/billing/utils/stripeIdempotencyKey.ts
+++ b/web/src/ee/features/billing/utils/stripeIdempotencyKey.ts
@@ -26,6 +26,7 @@ export const IdempotencyKind = z.enum([
   "subscription.schedule.create.fromSub",
   "subscription.schedule.update",
   "subscription.cancelAtPeriodEnd",
+  "subscription.cancel.now",
   "subscription.reactivate",
   "subscription.migrate.flexible",
   "subscription.schedule.clear",

--- a/web/src/features/organizations/server/organizationRouter.ts
+++ b/web/src/features/organizations/server/organizationRouter.ts
@@ -12,8 +12,6 @@ import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
 import { redis } from "@langfuse/shared/src/server";
 import { createBillingServiceFromContext } from "@/src/ee/features/billing/server/stripeBillingService";
 
-import { parseDbOrg } from "@langfuse/shared";
-
 export const organizationsRouter = createTRPCRouter({
   create: authenticatedProcedure
     .input(organizationNameSchema)

--- a/web/src/features/organizations/server/organizationRouter.ts
+++ b/web/src/features/organizations/server/organizationRouter.ts
@@ -10,6 +10,9 @@ import { throwIfNoOrganizationAccess } from "@/src/features/rbac/utils/checkOrga
 import { TRPCError } from "@trpc/server";
 import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
 import { redis } from "@langfuse/shared/src/server";
+import { createBillingServiceFromContext } from "@/src/ee/features/billing/server/stripeBillingService";
+
+import { parseDbOrg } from "@langfuse/shared";
 
 export const organizationsRouter = createTRPCRouter({
   create: authenticatedProcedure
@@ -104,11 +107,26 @@ export const organizationsRouter = createTRPCRouter({
           orgId: input.orgId,
         },
       });
+
       if (countProjects > 0) {
         throw new TRPCError({
           code: "FORBIDDEN",
           message:
             "Please delete or transfer all projects before deleting the organization.",
+        });
+      }
+
+      // Attempt to cancel Stripe subscription immediately (Cloud only) before deleting org
+      try {
+        const stripeBillingService = createBillingServiceFromContext(ctx);
+        await stripeBillingService.cancelImmediatelyAndInvoice(input.orgId);
+      } catch (e) {
+        // If billing cancellation fails for reasons other than no subscription, abort deletion
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message:
+            "Failed to cancel Stripe subscription prior to organization deletion",
+          cause: e as Error,
         });
       }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `cancelImmediatelyAndInvoice()` to handle Stripe subscription cancellations and invoicing when an organization is deleted.
> 
>   - **Behavior**:
>     - Adds `cancelImmediatelyAndInvoice()` to `BillingService` in `stripeBillingService.ts` to cancel active Stripe subscriptions and generate final invoices when an organization is deleted.
>     - Updates `organizationRouter.ts` to call `cancelImmediatelyAndInvoice()` before deleting an organization.
>   - **Idempotency**:
>     - Adds `subscription.cancel.now` to `IdempotencyKind` in `stripeIdempotencyKey.ts` for idempotency in immediate cancellations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 63a467f8bf7978b9ca8c4d4c0ba7ac1e74b4f97c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->