### PR TITLE
chore: run sdk-api-spec-bot on changes in fern dir only

### DIFF
--- a/.github/workflows/sdk-api-spec.yml
+++ b/.github/workflows/sdk-api-spec.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'fern/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update GitHub Actions workflow to trigger only on changes in the `fern` directory.
> 
>   - **Workflow Trigger**:
>     - Updates `.github/workflows/sdk-api-spec.yml` to trigger only on changes within the `fern` directory under the `main` branch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d5f83fda800f6cb47098c3f8131e4fb48daf09fa. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->