### PR TITLE
fix(trpc): show toast on trpc error to user

### DIFF
--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -15,6 +15,7 @@ import {
   TRPCClientError,
   type TRPCLink,
 } from "@trpc/client";
+import { QueryCache } from "@tanstack/react-query";
 import { createTRPCNext } from "@trpc/next";
 import { type inferRouterInputs, type inferRouterOutputs } from "@trpc/server";
 import { observable } from "@trpc/server/observable";
@@ -153,7 +154,6 @@ export const api = createTRPCNext<AppRouter>({
       queryClientConfig: {
         defaultOptions: {
           queries: {
-            onError: (error: unknown) => handleTrpcError(error),
             // react query defaults to `online`, but we want to disable it as it caused issues for some users
             networkMode: "always",
           },
@@ -163,6 +163,11 @@ export const api = createTRPCNext<AppRouter>({
             networkMode: "always",
           },
         },
+        queryCache: new QueryCache({
+          onError: (error) => {
+            handleTrpcError(error);
+          },
+        }),
       },
     };
   },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Moved `onError` handler to `queryCache` in `api.ts` to display toast on tRPC errors.
> 
>   - **Error Handling**:
>     - Moved `onError` handler from `queries` to `queryCache` in `api.ts` to show toast on tRPC errors.
>     - `handleTrpcError` function is used to process errors and display a toast notification.
>   - **Misc**:
>     - Removed redundant `onError` handler from `queries` in `api.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e9f2f0faf43d1a4ef969121c1af2dbcf9ae61443. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->