### PR TITLE
feat(billing): Allow past subscribers see their invoices

### DIFF
--- a/web/src/ee/features/billing/components/BillingDiscountView.tsx
+++ b/web/src/ee/features/billing/components/BillingDiscountView.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from "next/router";
 import { api } from "@/src/utils/api";
 import { Badge } from "@/src/components/ui/badge";
 import { useBillingInformation } from "@/src/ee/features/billing/components/useBillingInformation";

--- a/web/src/ee/features/billing/components/BillingSettings.tsx
+++ b/web/src/ee/features/billing/components/BillingSettings.tsx
@@ -11,7 +11,6 @@ import { BillingUsageChart } from "./BillingUsageChart";
 import { BillingActionButtons } from "./BillingActionButtons";
 import { BillingScheduleNotification } from "./BillingScheduleNotification";
 import { BillingInvoiceTable } from "./BillingInvoiceTable";
-import { useBillingInformation } from "./useBillingInformation";
 
 export const BillingSettings = () => {
   const router = useRouter();
@@ -23,7 +22,7 @@ export const BillingSettings = () => {
 
   const entitled = useHasEntitlement("cloud-billing");
   const isUsageAlertEntitled = useHasEntitlement("cloud-usage-alerts");
-  const billingInfo = useBillingInformation();
+
   if (!entitled) return null;
 
   if (!hasAccess)
@@ -46,9 +45,7 @@ export const BillingSettings = () => {
         <BillingUsageChart />
         <BillingActionButtons />
         {isUsageAlertEntitled && orgId && <UsageAlerts orgId={orgId} />}
-        {orgId && billingInfo.hasActiveSubscription && (
-          <BillingInvoiceTable orgId={orgId} />
-        )}
+        <BillingInvoiceTable />
       </div>
     </div>
   );

--- a/web/src/ee/features/billing/server/stripeBillingService.ts
+++ b/web/src/ee/features/billing/server/stripeBillingService.ts
@@ -134,16 +134,17 @@ class BillingService {
 
   private async retrieveInvoiceList(
     stripeCustomerId: string,
-    subscriptionId: string,
     limit: number,
     startingAfter?: string,
     endingBefore?: string,
   ) {
     const client = this.stripe;
 
+    // Note: We assume each stripe Customer has only one subscription
+    // if this changes, we need to update the code to not leak other subscriptions
+
     const result = await client.invoices.list({
       customer: stripeCustomerId,
-      subscription: subscriptionId, // one customer may have multiple subscriptions (one per org)
       limit: limit,
       starting_after: startingAfter,
       ending_before: endingBefore,
@@ -1067,27 +1068,28 @@ class BillingService {
     const stripeCustomerId = parsedOrg.cloudConfig?.stripe?.customerId;
     const stripeSubscriptionId =
       parsedOrg.cloudConfig?.stripe?.activeSubscriptionId;
-
-    if (!stripeCustomerId || !stripeSubscriptionId) {
+    if (!stripeCustomerId) {
       throw new TRPCError({
         code: "INTERNAL_SERVER_ERROR",
         message: "No stripe customer or subscription found",
       });
     }
 
+    // retrieve all invoices for the customer (also past subscriptions when cancelled)
     const list = await this.retrieveInvoiceList(
       stripeCustomerId,
-      stripeSubscriptionId,
       pagination.limit,
       pagination.startingAfter,
       pagination.endingBefore,
     );
 
-    const preview = await this.createInvoicePreview(
-      client,
-      stripeCustomerId,
-      stripeSubscriptionId,
-    );
+    const preview = stripeSubscriptionId
+      ? await this.createInvoicePreview(
+          client,
+          stripeCustomerId,
+          stripeSubscriptionId,
+        )
+      : null;
 
     const priceCache = new Map<string, Stripe.Price>();
 


### PR DESCRIPTION
## What's New

- The invoice table in the billing settings now shows up for users who had a subscription in the past and cancelled it

<img width="1532" height="1127" alt="CleanShot 2025-09-18 at 16 09 53" src="https://github.com/user-attachments/assets/1da87c18-f968-4e53-b466-9de05c5ed176" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Allow past subscribers to view their invoices by updating UI components and backend logic to handle users with a Stripe customer ID but no active subscription.
> 
>   - **Behavior**:
>     - `BillingInvoiceTable` and `BillingDiscountView` now render for past subscribers by checking `stripe.customerId` instead of `activeSubscriptionId`.
>     - `BillingInvoiceTable` in `BillingSettings.tsx` shows invoices for users with a `stripe.customerId`, even if the subscription is canceled.
>   - **Backend**:
>     - `retrieveInvoiceList` in `stripeBillingService.ts` no longer requires `subscriptionId`, allowing invoice retrieval for past subscriptions.
>     - `getInvoices` in `stripeBillingService.ts` fetches invoices for customers without active subscriptions.
>   - **Misc**:
>     - Removed unused imports and variables in `BillingDiscountView.tsx` and `BillingUsageChart.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 39e6f6ab62c3b9e4557421ccd155af83b591e348. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->