### PR TITLE
style: Fix grammar of org invite email subject

### DIFF
--- a/packages/shared/src/server/services/email/organizationInvitation/sendMembershipInvitationEmail.ts
+++ b/packages/shared/src/server/services/email/organizationInvitation/sendMembershipInvitationEmail.ts
@@ -76,7 +76,7 @@ export const sendMembershipInvitationEmail = async ({
     await mailer.sendMail({
       to,
       from: `Langfuse <${env.EMAIL_FROM_ADDRESS}>`,
-      subject: `${inviterName} invited you to join "${orgName}" organization on Langfuse`,
+      subject: `${inviterName} invited you to join the "${orgName}" organization on Langfuse`,
       html: htmlTemplate,
     });
   } catch (error) {


### PR DESCRIPTION
## What does this PR do?

I noticed when I was invited to a Langfuse organisation that the email subject felt a bit weird.  This adds a "the" so that the subject has better English grammar.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes grammar in the email subject line of organization invitation emails by adding "the" before the organization name.
> 
>   - **Email Subject**:
>     - Fixes grammar in the email subject line in `sendMembershipInvitationEmail` function in `sendMembershipInvitationEmail.ts` by adding "the" before the organization name.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2a0e7edb8ecef6acbb3eeccadddb8047e20f5334. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->