### PR TITLE
fix(dataset-runs): during loading states render skeletons for charts

### DIFF
--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -59,9 +59,10 @@ import { useScoreColumns } from "@/src/features/scores/hooks/useScoreColumns";
 import {
   scoreFilters,
   addPrefixToScoreKeys,
-  getScoreDataTypeIcon,
   convertScoreColumnsToAnalyticsData,
 } from "@/src/features/scores/lib/scoreColumns";
+import { getScoreLabelFromKey } from "@/src/features/scores/lib/aggregateScores";
+import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 
 export type DatasetRunRowData = {
   id: string;
@@ -601,9 +602,7 @@ export function DatasetRunsTable(props: {
   );
 
   // Check if we have charts to display
-  const hasCharts =
-    Boolean(props.selectedMetrics.length) &&
-    Boolean(runAggregatedMetrics?.size);
+  const hasCharts = Boolean(props.selectedMetrics.length);
 
   return (
     <>
@@ -623,6 +622,24 @@ export function DatasetRunsTable(props: {
             <div className="h-full w-full overflow-x-auto overflow-y-auto p-3">
               <div className="flex h-full w-full gap-4">
                 {props.selectedMetrics.map((key) => {
+                  const title =
+                    RESOURCE_METRICS.find((metric) => metric.key === key)
+                      ?.label ?? getScoreLabelFromKey(key);
+
+                  if (!Boolean(runAggregatedMetrics?.size)) {
+                    return (
+                      <div
+                        key={key}
+                        className="flex h-full min-w-80 max-w-full flex-col gap-2"
+                      >
+                        <span className="shrink-0 text-sm font-medium">
+                          {title}
+                        </span>
+                        <NoDataOrLoading isLoading={true} />
+                      </div>
+                    );
+                  }
+
                   const adapter = new CompareViewAdapter(
                     runAggregatedMetrics,
                     key,
@@ -636,11 +653,7 @@ export function DatasetRunsTable(props: {
                         <TimeseriesChart
                           chartData={chartData}
                           chartLabels={chartLabels}
-                          title={
-                            RESOURCE_METRICS.find(
-                              (metric) => metric.key === key,
-                            )?.label ?? key
-                          }
+                          title={title}
                           type="numeric"
                           maxFractionDigits={
                             RESOURCE_METRICS.find(
@@ -656,7 +669,7 @@ export function DatasetRunsTable(props: {
                       <TimeseriesChart
                         chartData={chartData}
                         chartLabels={chartLabels}
-                        title={`${getScoreDataTypeIcon(scoreData.dataType)} ${scoreData.name} (${scoreData.source.toLowerCase()})`}
+                        title={title}
                         type={
                           isNumericDataType(scoreData.dataType)
                             ? "numeric"

--- a/web/src/features/scores/lib/aggregateScores.ts
+++ b/web/src/features/scores/lib/aggregateScores.ts
@@ -1,3 +1,4 @@
+import { getScoreDataTypeIcon } from "@/src/features/scores/lib/scoreColumns";
 import {
   type ScoreAggregate,
   type ScoreSimplified,
@@ -18,6 +19,26 @@ export const composeAggregateScoreKey = ({
 }): string => {
   const formattedName = name.replaceAll(/[-\.]/g, "_"); // "-" and "." reserved for splitting in namespace
   return `${formattedName}-${source}-${dataType}`;
+};
+
+export const decomposeAggregateScoreKey = (
+  key: string,
+): {
+  name: string;
+  source: ScoreSourceType;
+  dataType: ScoreDataType;
+} => {
+  const [name, source, dataType] = key.split("-");
+  return {
+    name,
+    source: source as ScoreSourceType,
+    dataType: dataType as ScoreDataType,
+  };
+};
+
+export const getScoreLabelFromKey = (key: string): string => {
+  const { name, source, dataType } = decomposeAggregateScoreKey(key);
+  return `${getScoreDataTypeIcon(dataType)} ${name} (${source.toLowerCase()})`;
 };
 
 type ScoreToAggregate = (APIScoreV2 | ScoreSimplified) & {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Render skeletons for charts in `DatasetRunsTable.tsx` when data is loading and add utility functions for score key handling in `aggregateScores.ts`.
> 
>   - **Behavior**:
>     - In `DatasetRunsTable.tsx`, render skeletons using `NoDataOrLoading` when `runAggregatedMetrics` is not available.
>     - Simplified `hasCharts` logic to only check `props.selectedMetrics.length`.
>   - **Utilities**:
>     - Added `getScoreLabelFromKey` in `aggregateScores.ts` to generate score labels from keys.
>     - Added `decomposeAggregateScoreKey` in `aggregateScores.ts` to split score keys into components.
>   - **Misc**:
>     - Removed `getScoreDataTypeIcon` import from `DatasetRunsTable.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for dd6e310fe0586253ac2cd6ee030aa686d0a5f3a1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->