### PR TITLE
fix(billing): Avoid 500s through uninitialized stripe client in dev environment

### DIFF
--- a/web/src/ee/features/billing/components/BillingUsageChart.tsx
+++ b/web/src/ee/features/billing/components/BillingUsageChart.tsx
@@ -33,6 +33,12 @@ export const BillingUsageChart = () => {
       usage.data.usageType.slice(1)
     : "Events";
 
+  if (usage.data === null) {
+    // Might happen in dev mode if STRIPE_SECRET_KEY is not set
+    // This avoids errors for all developers not working on or testing the billing features
+    return null;
+  }
+
   return (
     <div>
       <Card className="p-3">

--- a/web/src/ee/features/billing/server/cloudBillingRouter.ts
+++ b/web/src/ee/features/billing/server/cloudBillingRouter.ts
@@ -12,6 +12,7 @@ import { throwIfNoOrganizationAccess } from "@/src/features/rbac/utils/checkOrga
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { logger } from "@langfuse/shared/src/server";
 import { createBillingServiceFromContext } from "./stripeBillingService";
+import { env } from "@/src/env.mjs";
 
 export const cloudBillingRouter = createTRPCRouter({
   getSubscriptionInfo: protectedOrganizationProcedure
@@ -272,6 +273,14 @@ export const cloudBillingRouter = createTRPCRouter({
         scope: "langfuseCloudBilling:CRUD",
         session: ctx.session,
       });
+
+      if (
+        env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION == "DEV" &&
+        !env.STRIPE_SECRET_KEY
+      ) {
+        logger.warn("STRIPE_SECRET_KEY not set, returning 0 usage");
+        return null;
+      }
 
       const stripeBillingService = createBillingServiceFromContext(ctx);
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix 500 errors in dev by returning null when Stripe client is uninitialized in `BillingUsageChart.tsx` and `cloudBillingRouter.ts`.
> 
>   - **Behavior**:
>     - In `BillingUsageChart.tsx`, return `null` if `usage.data` is `null` to avoid errors when `STRIPE_SECRET_KEY` is not set in dev mode.
>     - In `cloudBillingRouter.ts`, log a warning and return `null` in `getUsage` if `STRIPE_SECRET_KEY` is not set and `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` is "DEV".
>   - **Logging**:
>     - Add warning log in `cloudBillingRouter.ts` when `STRIPE_SECRET_KEY` is not set in dev environment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9d09f4eb8aa06c9a052bd09a1d46db51d45f5ff5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->