### PR TITLE
fix(billing): Hide promotion code for hobby plan users

### DIFF
--- a/web/src/ee/features/billing/components/BillingDiscountView.tsx
+++ b/web/src/ee/features/billing/components/BillingDiscountView.tsx
@@ -5,6 +5,13 @@ import { BillingDiscountCodeButton } from "@/src/ee/features/billing/components/
 
 export const BillingDiscountView = () => {
   const { organization } = useBillingInformation();
+  
+  // Hide promotion code view and button when user is on Hobby Plan
+  // Hobby plan users don't have an active subscription ID
+  if (!organization?.cloudConfig?.stripe?.activeSubscriptionId) {
+    return null;
+  }
+  
   const shouldRenderComponent = Boolean(
     organization?.cloudConfig?.stripe?.customerId,
   );


### PR DESCRIPTION
## What does this PR do?

This PR hides the promotion code view and button (`BillingDiscountView` component) for users on the Hobby plan. This ensures that discount-related UI elements are only displayed to users with an active paid subscription, aligning the UI with the new billing setup. The component now returns `null` if `organization?.cloudConfig?.stripe?.activeSubscriptionId` is not set.

Fixes # GTM-1441

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [ ] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my PR needs changes to the documentation
- [ ] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [ ] I haven't added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [GTM-1441](https://linear.app/langfuse/issue/GTM-1441/billing-hide-promotion-code-view-and-button-when-user-is-on-hobby-plan)

<a href="https://cursor.com/background-agent?bcId=bc-2c548ef5-44e8-485c-a027-4d13a5dc37a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c548ef5-44e8-485c-a027-4d13a5dc37a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Hide promotion code view and button in `BillingDiscountView` for Hobby plan users by checking active subscription ID.
> 
>   - **Behavior**:
>     - `BillingDiscountView` component now returns `null` if `organization?.cloudConfig?.stripe?.activeSubscriptionId` is not set, hiding promotion code view and button for Hobby plan users.
>   - **Logic**:
>     - Checks `organization?.cloudConfig?.stripe?.activeSubscriptionId` to determine if the user is on a paid plan.
>   - **UI**:
>     - Promotion code view and button are only displayed for users with an active paid subscription.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e720089bba436db3aedb93b21f2b038eed46a916. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->