### PR TITLE
chore: remove hosting of ..-in-the-middle packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,3 @@
 public-hoist-pattern[]=*prisma*
 # for turbopack, ongoing issue see: https://github.com/vercel/next.js/issues/68805
 public-hoist-pattern[]=@aws-sdk/client-s3
-public-hoist-pattern[]=*import-in-the-middle*
-public-hoist-pattern[]=*require-in-the-middle*


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes `import-in-the-middle` and `require-in-the-middle` hoist patterns from `.npmrc`.
> 
>   - **Configuration**:
>     - Removes `public-hoist-pattern[]=*import-in-the-middle*` and `public-hoist-pattern[]=*require-in-the-middle*` from `.npmrc`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d3e1389e1dc02ccbdda24c0ad0274f1340e98602. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->