### PR TITLE
chore(cloud): limit org members to 2 on free plan to be in line with pricing/packaging

### DIFF
--- a/web/src/ee/features/billing/components/BillingDiscountView.tsx
+++ b/web/src/ee/features/billing/components/BillingDiscountView.tsx
@@ -5,13 +5,13 @@ import { BillingDiscountCodeButton } from "@/src/ee/features/billing/components/
 
 export const BillingDiscountView = () => {
   const { organization } = useBillingInformation();
-  
+
   // Hide promotion code view and button when user is on Hobby Plan
   // Hobby plan users don't have an active subscription ID
   if (!organization?.cloudConfig?.stripe?.activeSubscriptionId) {
     return null;
   }
-  
+
   const shouldRenderComponent = Boolean(
     organization?.cloudConfig?.stripe?.customerId,
   );

--- a/web/src/features/entitlements/constants/entitlements.ts
+++ b/web/src/features/entitlements/constants/entitlements.ts
@@ -54,7 +54,7 @@ export const entitlementAccess: Record<
   "cloud:hobby": {
     entitlements: [...cloudAllPlansEntitlements],
     entitlementLimits: {
-      "organization-member-count": 3, // 2 acc to billing page, 1 overage possible
+      "organization-member-count": 2,
       "data-access-days": 30,
       "annotation-queue-count": 1,
       "model-based-evaluations-count-evaluators": false,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce `organization-member-count` limit to 2 for `cloud:hobby` plan in `entitlements.ts`.
> 
>   - **Entitlements**:
>     - Reduce `organization-member-count` limit from 3 to 2 for `cloud:hobby` plan in `entitlements.ts`.
>   - **Misc**:
>     - Minor whitespace changes in `BillingDiscountView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f296533406167c21c0d165fbb06f41f4235f6fe7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->