### PR TITLE
fix(llm-tools-and-schemas): allow periods in names

### DIFF
--- a/web/src/features/llm-schemas/validation.ts
+++ b/web/src/features/llm-schemas/validation.ts
@@ -4,8 +4,8 @@ import { LLMJSONSchema } from "@langfuse/shared";
 export const LLMSchemaNameSchema = z
   .string()
   .regex(
-    /^[a-zA-Z0-9_-]+$/,
-    "Name must contain only alphanumeric letters, hyphens and underscores",
+    /^[a-zA-Z0-9\._-]+$/,
+    "Name must contain only alphanumeric letters, hyphens, periods and underscores",
   )
   .min(1, "Name is required");
 

--- a/web/src/features/llm-tools/validation.ts
+++ b/web/src/features/llm-tools/validation.ts
@@ -4,8 +4,8 @@ import { LLMJSONSchema } from "@langfuse/shared";
 export const LLMToolNameSchema = z
   .string()
   .regex(
-    /^[a-zA-Z0-9_-]+$/,
-    "Name must contain only alphanumeric letters, hyphens and underscores",
+    /^[a-zA-Z0-9\._-]+$/,
+    "Name must contain only alphanumeric letters, hyphens, periods and underscores",
   )
   .min(1, "Name is required");
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Allow periods in schema and tool names by updating regex in `validation.ts`.
> 
>   - **Validation**:
>     - Updated regex in `LLMSchemaNameSchema` in `validation.ts` to allow periods in names.
>     - Updated regex in `LLMToolNameSchema` in `validation.ts` to allow periods in names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 522b54034a4f57eb2b9fbff04b34920f9f4ebb05. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->