### PR TITLE
fix(models): drop preview from gemini-2.5-flash-lite

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1876,7 +1876,7 @@
     "model_name": "gemini-2.5-flash-lite",
     "match_pattern": "(?i)^(gemini-2.5-flash-lite)$",
     "created_at": "2025-07-03T13:44:06.964Z",
-    "updated_at": "2025-07-03T13:44:06.964Z",
+    "updated_at": "2025-09-22T20:04:00.000Z",
     "prices": {
       "input": 0.1e-6,
       "prompt_token_count": 0.1e-6,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `updated_at` timestamp for `gemini-2.5-flash-lite` model in `default-model-prices.json`.
> 
>   - **Update**:
>     - Change `updated_at` timestamp for `gemini-2.5-flash-lite` model in `default-model-prices.json` from `2025-07-03T13:44:06.964Z` to `2025-09-22T20:04:00.000Z`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f7d171b28cf694cff1a5f1d24ee7cde87e623ceb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->