### PR TITLE
fix(otel-mapper): null model props shouldn't cause map to generation

### DIFF
--- a/packages/shared/src/server/otel/ObservationTypeMapper.ts
+++ b/packages/shared/src/server/otel/ObservationTypeMapper.ts
@@ -33,7 +33,8 @@ class SimpleAttributeMapper implements ObservationTypeMapper {
     _scopeData?: Record<string, unknown>,
   ): boolean {
     return (
-      this.attributeKey in attributes && attributes[this.attributeKey] != null
+      this.attributeKey in attributes &&
+      hasMeaningfulValue(attributes[this.attributeKey])
     );
   }
 
@@ -100,6 +101,20 @@ class CustomAttributeMapper implements ObservationTypeMapper {
 
     return null;
   }
+}
+
+// value is not null, undefined, empty string, or empty object/array
+function hasMeaningfulValue(value: unknown): boolean {
+  if (value === null || value === undefined || value === "") {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (typeof value === "object" && value !== null) {
+    return Object.keys(value).length > 0;
+  }
+  return true;
 }
 
 /**
@@ -240,7 +255,7 @@ export class ObservationTypeMapperRegistry {
           "llm.model_name",
           "model",
         ];
-        return modelKeys.some((key) => attributes[key] != null);
+        return modelKeys.some((key) => hasMeaningfulValue(attributes[key]));
       },
       () => "GENERATION",
     ),

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -1453,7 +1453,6 @@ describe("OTel Resource Span Mapping", () => {
                 ...defaultSpanProps,
                 name: "tool-call",
                 attributes: [
-                  // All these empty/null model-related attributes trigger the ModelBased mapper
                   { key: "model", value: { stringValue: "" } },
                   { key: "provided_model_name", value: { stringValue: "" } },
                   { key: "internal_model_id", value: { stringValue: "" } },
@@ -1490,7 +1489,7 @@ describe("OTel Resource Span Mapping", () => {
         (event) => event.type !== "trace-create",
       );
 
-      // BUG: will register as generation-create but should be span-create
+      // Tool-call spans with empty model-related attributes should remain as span-create
       expect(observationEvent?.type).toBe("span-create");
     });
 

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -1444,7 +1444,7 @@ describe("OTel Resource Span Mapping", () => {
       expect(retrieverEvent?.body.usageDetails.input).toBe(50);
     });
 
-    it("should incorrectly map tool-call spans to generation-create when empty model-related attributes exist", async () => {
+    it("should map tool-call spans with empty model-related attributes to span-create (not generation-create)", async () => {
       const resourceSpan = {
         scopeSpans: [
           {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces `hasMeaningfulValue` function to improve observation type mapping by handling null or empty model properties, ensuring correct span classification.
> 
>   - **Behavior**:
>     - Introduces `hasMeaningfulValue` function in `ObservationTypeMapper.ts` to check for non-null, non-empty values.
>     - Updates `SimpleAttributeMapper.canMap()` and `CustomAttributeMapper` to use `hasMeaningfulValue`.
>     - Ensures spans with empty model-related attributes map to `span-create` instead of `generation-create`.
>   - **Tests**:
>     - Adds test in `otelMapping.servertest.ts` to verify mapping of tool-call spans with empty attributes to `span-create`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d79ef760ab7da35492d64df0c43a02bc13381226. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->