### PR TITLE
chore: filter browser extensions from sentry errors

### DIFF
--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -46,7 +46,21 @@ Sentry.init({
   // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
   // result in 25% of transactions being profiled (0.5*0.5=0.25)
   profilesSampleRate: 0.5,
-  // ...
+
+  // Filter out browser extension errors
+  // see: https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-allowurls-and-denyurls
+  denyUrls: [
+    // Chrome extensions
+    /chrome-extension:\/\//i,
+    // Firefox extensions
+    /moz-extension:\/\//i,
+    // Safari extensions
+    /safari-extension:\/\//i,
+    // Edge extensions
+    /ms-browser-extension:\/\//i,
+    // Generic browser extension patterns
+    /app:\/\/\/scripts\//i,
+  ],
 
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `denyUrls` to Sentry configuration in `web/instrumentation-client.ts` to filter out browser extension errors.
> 
>   - **Behavior**:
>     - Adds `denyUrls` to Sentry configuration in `web/instrumentation-client.ts` to filter out errors from browser extensions.
>     - Filters include Chrome, Firefox, Safari, Edge, and generic browser extension patterns.
>   - **Misc**:
>     - Comments added to explain the purpose of `denyUrls` and link to Sentry documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cd6660aff46e69d81351f7e0ceb31359e523f128. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->