### PR TITLE
chore: do not upgrade to postgres 18

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -131,7 +131,7 @@ services:
       retries: 10
 
   postgres:
-    image: docker.io/postgres:${POSTGRES_VERSION:17}
+    image: docker.io/postgres:${POSTGRES_VERSION:-17}
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -131,7 +131,7 @@ services:
       retries: 10
 
   postgres:
-    image: docker.io/postgres:${POSTGRES_VERSION:-latest}
+    image: docker.io/postgres:${POSTGRES_VERSION:17}
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]

--- a/docker-compose.dev-azure.yml
+++ b/docker-compose.dev-azure.yml
@@ -32,7 +32,7 @@ services:
       - 6379:6379
 
   postgres:
-    image: docker.io/postgres:${POSTGRES_VERSION:17}
+    image: docker.io/postgres:${POSTGRES_VERSION:-17}
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]

--- a/docker-compose.dev-azure.yml
+++ b/docker-compose.dev-azure.yml
@@ -32,7 +32,7 @@ services:
       - 6379:6379
 
   postgres:
-    image: docker.io/postgres:${POSTGRES_VERSION:-latest}
+    image: docker.io/postgres:${POSTGRES_VERSION:17}
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]

--- a/docker-compose.dev-redis-cluster.yml
+++ b/docker-compose.dev-redis-cluster.yml
@@ -36,7 +36,7 @@ services:
       start_period: 1s
 
   postgres:
-    image: docker.io/postgres:${POSTGRES_VERSION:-latest}
+    image: docker.io/postgres:${POSTGRES_VERSION:17}
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]

--- a/docker-compose.dev-redis-cluster.yml
+++ b/docker-compose.dev-redis-cluster.yml
@@ -36,7 +36,7 @@ services:
       start_period: 1s
 
   postgres:
-    image: docker.io/postgres:${POSTGRES_VERSION:17}
+    image: docker.io/postgres:${POSTGRES_VERSION:-17}
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -44,7 +44,7 @@ services:
       - 127.0.0.1:6379:6379
 
   postgres:
-    image: docker.io/postgres:${POSTGRES_VERSION:-latest}
+    image: docker.io/postgres:${POSTGRES_VERSION:17}
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -44,7 +44,7 @@ services:
       - 127.0.0.1:6379:6379
 
   postgres:
-    image: docker.io/postgres:${POSTGRES_VERSION:17}
+    image: docker.io/postgres:${POSTGRES_VERSION:-17}
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,7 +142,7 @@ services:
       retries: 10
 
   postgres:
-    image: docker.io/postgres:${POSTGRES_VERSION:17}
+    image: docker.io/postgres:${POSTGRES_VERSION:-17}
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,7 +142,7 @@ services:
       retries: 10
 
   postgres:
-    image: docker.io/postgres:${POSTGRES_VERSION:-latest}
+    image: docker.io/postgres:${POSTGRES_VERSION:-15}
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,7 +142,7 @@ services:
       retries: 10
 
   postgres:
-    image: docker.io/postgres:${POSTGRES_VERSION:-15}
+    image: docker.io/postgres:${POSTGRES_VERSION:17}
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Set Postgres image version to 17 in multiple Docker Compose files to avoid upgrading to Postgres 18.
> 
>   - **Docker Compose Changes**:
>     - Set Postgres image version to `17` in `docker-compose.build.yml`, `docker-compose.dev-azure.yml`, `docker-compose.dev-redis-cluster.yml`, `docker-compose.dev.yml`, and `docker-compose.yml` to avoid upgrading to Postgres 18.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 23531dcd5c3f62d70b7001fbd67a93100c2428b6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->