### PR TITLE
fix: skip JSON parsing for completion start time strings

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1569,11 +1569,9 @@ export class OtelIngestionProcessor {
     startTimeISO?: string,
   ): string | null {
     try {
-      return JSON.parse(
-        attributes[
-          LangfuseOtelSpanAttributes.OBSERVATION_COMPLETION_START_TIME
-        ] as string,
-      );
+      return attributes[
+        LangfuseOtelSpanAttributes.OBSERVATION_COMPLETION_START_TIME
+      ] as any;
     } catch {
       // Fallthrough
     }

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -1529,6 +1529,18 @@ describe("OTel Resource Span Mapping", () => {
         "should cast input_tokens from string to number",
         {
           entity: "observation",
+          otelAttributeKey: "langfuse.observation.completion_start_time",
+          otelAttributeValue: {
+            stringValue: "2025-09-17T22:16:28.152000+02:00",
+          },
+          entityAttributeKey: "completionStartTime",
+          entityAttributeValue: "2025-09-17T22:16:28.152000+02:00",
+        },
+      ],
+      [
+        "should cast input_tokens from string to number",
+        {
+          entity: "observation",
           otelAttributeKey: "gen_ai.usage.input_tokens",
           otelAttributeValue: { stringValue: "15" },
           entityAttributeKey: "usageDetails.input",


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/9341

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Skip JSON parsing for `completion_start_time` in `OtelIngestionProcessor.ts` and add a test to verify correct handling.
> 
>   - **Behavior**:
>     - Skip JSON parsing for `completion_start_time` in `extractCompletionStartTime()` in `OtelIngestionProcessor.ts`.
>   - **Tests**:
>     - Add test case in `otelMapping.servertest.ts` to verify `completion_start_time` is correctly cast from string.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2526bc72b53534795a36e524a12e3f7db34c7ca1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->