### PR TITLE
style(dataset-item): detail view to show item IO and past runs in two tabs

### DIFF
--- a/web/src/features/datasets/components/DatasetItemDetailPage.tsx
+++ b/web/src/features/datasets/components/DatasetItemDetailPage.tsx
@@ -1,12 +1,5 @@
-import Header from "@/src/components/layouts/header";
 import Page from "@/src/components/layouts/page";
 import { Button } from "@/src/components/ui/button";
-import {
-  ResizableHandle,
-  ResizablePanel,
-  ResizablePanelGroup,
-} from "@/src/components/ui/resizable";
-import { EditDatasetItem } from "@/src/features/datasets/components/EditDatasetItem";
 import { NewDatasetItemFromExistingObject } from "@/src/features/datasets/components/NewDatasetItemFromExistingObject";
 import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 import { api } from "@/src/utils/api";
@@ -28,9 +21,20 @@ import {
   PopoverTrigger,
 } from "@/src/components/ui/popover";
 import { useState } from "react";
-import { DatasetRunItemsByItemTable } from "@/src/features/datasets/components/DatasetRunItemsByItemTable";
+import { getDatasetItemTabs } from "@/src/features/navigation/utils/dataset-item-tabs";
+import { type DatasetItemTab } from "@/src/features/navigation/utils/dataset-item-tabs";
+import { type ReactNode } from "react";
+import { Skeleton } from "@/src/components/ui/skeleton";
 
-export default function Dataset() {
+export const DatasetItemDetailPage = ({
+  activeTab,
+  withPadding = true,
+  children,
+}: {
+  activeTab: DatasetItemTab;
+  withPadding?: boolean;
+  children: ReactNode;
+}) => {
   const router = useRouter();
   const projectId = router.query.projectId as string;
   const datasetId = router.query.datasetId as string;
@@ -106,7 +110,7 @@ export default function Dataset() {
 
   return (
     <Page
-      withPadding
+      withPadding={withPadding}
       headerProps={{
         title: itemId,
         itemType: "DATASET_ITEM",
@@ -121,6 +125,10 @@ export default function Dataset() {
             href: `/project/${projectId}/datasets/${datasetId}/items`,
           },
         ],
+        tabsProps: {
+          tabs: getDatasetItemTabs({ projectId, datasetId, itemId }),
+          activeTab,
+        },
         actionButtonsLeft: (
           <>
             {item.data?.status && (
@@ -188,7 +196,7 @@ export default function Dataset() {
               }
               listKey="datasetItems"
             />
-            {item.data && (
+            {item.data ? (
               <NewDatasetItemFromExistingObject
                 projectId={projectId}
                 fromDatasetId={item.data.datasetId}
@@ -199,6 +207,10 @@ export default function Dataset() {
                 metadata={JSON.stringify(item.data.metadata)}
                 isCopyItem
               />
+            ) : (
+              <Button variant="outline" size="icon" disabled>
+                <Skeleton className="h-5 w-5" />
+              </Button>
             )}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -221,28 +233,7 @@ export default function Dataset() {
         ),
       }}
     >
-      <ResizablePanelGroup direction="vertical">
-        <ResizablePanel
-          minSize={10}
-          defaultSize={50}
-          className="!overflow-y-auto"
-        >
-          <EditDatasetItem
-            key={item.data?.id}
-            projectId={projectId}
-            datasetItem={item.data ?? null}
-          />
-        </ResizablePanel>
-        <ResizableHandle withHandle className="bg-border" />
-        <ResizablePanel minSize={10} className="flex flex-col space-y-4">
-          <Header title="Runs" />
-          <DatasetRunItemsByItemTable
-            projectId={projectId}
-            datasetItemId={itemId}
-            datasetId={datasetId}
-          />
-        </ResizablePanel>
-      </ResizablePanelGroup>
+      {children}
     </Page>
   );
-}
+};

--- a/web/src/features/navigation/utils/dataset-item-tabs.ts
+++ b/web/src/features/navigation/utils/dataset-item-tabs.ts
@@ -1,0 +1,28 @@
+export const DATASET_ITEM_TABS = {
+  ITEM: "item",
+  RUNS: "runs",
+} as const;
+
+export type DatasetItemTab =
+  (typeof DATASET_ITEM_TABS)[keyof typeof DATASET_ITEM_TABS];
+
+export const getDatasetItemTabs = ({
+  projectId,
+  datasetId,
+  itemId,
+}: {
+  projectId: string;
+  datasetId: string;
+  itemId: string;
+}) => [
+  {
+    value: DATASET_ITEM_TABS.ITEM,
+    label: "Item",
+    href: `/project/${projectId}/datasets/${datasetId}/items/${itemId}`,
+  },
+  {
+    value: DATASET_ITEM_TABS.RUNS,
+    label: "Runs",
+    href: `/project/${projectId}/datasets/${datasetId}/items/${itemId}/runs`,
+  },
+];

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId]/index.tsx
@@ -1,0 +1,33 @@
+import { useRouter } from "next/router";
+import { DATASET_ITEM_TABS } from "@/src/features/navigation/utils/dataset-item-tabs";
+import { DatasetItemDetailPage } from "@/src/features/datasets/components/DatasetItemDetailPage";
+import { EditDatasetItem } from "@/src/features/datasets/components/EditDatasetItem";
+import { api } from "@/src/utils/api";
+
+export default function Dataset() {
+  const router = useRouter();
+  const projectId = router.query.projectId as string;
+  const datasetId = router.query.datasetId as string;
+  const itemId = router.query.itemId as string;
+
+  const item = api.datasets.itemById.useQuery(
+    {
+      datasetId,
+      projectId,
+      datasetItemId: itemId,
+    },
+    {
+      refetchOnWindowFocus: false, // breaks dirty form state
+    },
+  );
+
+  return (
+    <DatasetItemDetailPage activeTab={DATASET_ITEM_TABS.ITEM}>
+      <EditDatasetItem
+        key={itemId}
+        projectId={projectId}
+        datasetItem={item.data ?? null}
+      />
+    </DatasetItemDetailPage>
+  );
+}

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId]/runs.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/items/[itemId]/runs.tsx
@@ -1,0 +1,24 @@
+import { useRouter } from "next/router";
+import { DatasetRunItemsByItemTable } from "@/src/features/datasets/components/DatasetRunItemsByItemTable";
+import { DATASET_ITEM_TABS } from "@/src/features/navigation/utils/dataset-item-tabs";
+import { DatasetItemDetailPage } from "@/src/features/datasets/components/DatasetItemDetailPage";
+
+export default function Dataset() {
+  const router = useRouter();
+  const projectId = router.query.projectId as string;
+  const datasetId = router.query.datasetId as string;
+  const itemId = router.query.itemId as string;
+
+  return (
+    <DatasetItemDetailPage
+      withPadding={false}
+      activeTab={DATASET_ITEM_TABS.RUNS}
+    >
+      <DatasetRunItemsByItemTable
+        projectId={projectId}
+        datasetItemId={itemId}
+        datasetId={datasetId}
+      />
+    </DatasetItemDetailPage>
+  );
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor dataset item detail view to use tabs for item details and past runs, with new pages for each tab.
> 
>   - **Behavior**:
>     - Refactor `DatasetItemDetailPage` to use tabs for item details and past runs.
>     - Introduces `getDatasetItemTabs` in `dataset-item-tabs.ts` to manage tab navigation.
>   - **Components**:
>     - `DatasetItemDetailPage` now accepts `activeTab` and `children` props to render content based on the active tab.
>     - Removes `ResizablePanelGroup` and related components from `DatasetItemDetailPage.tsx`.
>   - **Pages**:
>     - Adds `index.tsx` for item details and `runs.tsx` for past runs under `items/[itemId]`.
>     - Each page uses `DatasetItemDetailPage` with appropriate `activeTab`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cd6ca60a189a8e145a2c522048093a29db2691c3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->