### PR TITLE
feat(billing): write org.billingAnchor on organization create and subscription create and delete

### DIFF
--- a/web/src/__tests__/billingCycleHelpers.servertest.ts
+++ b/web/src/__tests__/billingCycleHelpers.servertest.ts
@@ -1,0 +1,174 @@
+/** @jest-environment node */
+import {
+  getBillingCycleAnchor,
+  getBillingCycleStart,
+} from "@/src/ee/features/usage-thresholds/utils/billingCycleHelpers";
+import { type Organization } from "@langfuse/shared";
+
+describe("getBillingCycleAnchor", () => {
+  it("returns billingCycleAnchor when set", () => {
+    const org = {
+      id: "org-1",
+      billingCycleAnchor: new Date("2024-01-15T10:30:00Z"),
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+    } as Organization;
+
+    const result = getBillingCycleAnchor(org);
+
+    expect(result).toEqual(new Date("2024-01-15T00:00:00Z")); // start of day
+  });
+
+  it("falls back to createdAt when billingCycleAnchor is null", () => {
+    const org = {
+      id: "org-1",
+      billingCycleAnchor: null,
+      createdAt: new Date("2024-01-01T10:30:00Z"),
+    } as Organization;
+
+    const result = getBillingCycleAnchor(org);
+
+    expect(result).toEqual(new Date("2024-01-01T00:00:00Z")); // start of day
+  });
+});
+
+describe("getBillingCycleStart", () => {
+  it("handles anchor on 15th consistently across months", () => {
+    const org = {
+      id: "org-1",
+      billingCycleAnchor: new Date("2024-01-15T00:00:00Z"),
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+    } as Organization;
+
+    // March 15th reference → cycle starts March 15
+    expect(getBillingCycleStart(org, new Date("2024-03-20T10:00:00Z"))).toEqual(
+      new Date("2024-03-15T00:00:00Z"),
+    );
+
+    // February 10th reference → cycle starts January 15 (previous month)
+    expect(getBillingCycleStart(org, new Date("2024-02-10T10:00:00Z"))).toEqual(
+      new Date("2024-01-15T00:00:00Z"),
+    );
+  });
+
+  it("handles anchor on 31st → adjusts to last day of month", () => {
+    const org = {
+      id: "org-1",
+      billingCycleAnchor: new Date("2024-01-31T00:00:00Z"),
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+    } as Organization;
+
+    // February (29 days in 2024, leap year) - reference after cycle day → Feb 29
+    expect(getBillingCycleStart(org, new Date("2024-03-05T10:00:00Z"))).toEqual(
+      new Date("2024-02-29T00:00:00Z"),
+    );
+
+    // April (30 days) - reference after cycle day → April 30
+    expect(getBillingCycleStart(org, new Date("2024-05-05T10:00:00Z"))).toEqual(
+      new Date("2024-04-30T00:00:00Z"),
+    );
+
+    // March (31 days) - reference after cycle day → March 31
+    expect(getBillingCycleStart(org, new Date("2024-04-05T10:00:00Z"))).toEqual(
+      new Date("2024-03-31T00:00:00Z"),
+    );
+  });
+
+  it("handles leap year February correctly", () => {
+    const org = {
+      id: "org-1",
+      billingCycleAnchor: new Date("2024-01-31T00:00:00Z"),
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+    } as Organization;
+
+    // 2024 is leap year - reference after Feb 29 → Feb 29
+    expect(getBillingCycleStart(org, new Date("2024-03-01T10:00:00Z"))).toEqual(
+      new Date("2024-02-29T00:00:00Z"),
+    );
+
+    // 2025 is not leap year - reference after Feb 28 → Feb 28
+    const org2025 = {
+      ...org,
+      billingCycleAnchor: new Date("2025-01-31T00:00:00Z"),
+    } as Organization;
+
+    expect(
+      getBillingCycleStart(org2025, new Date("2025-03-01T10:00:00Z")),
+    ).toEqual(new Date("2025-02-28T00:00:00Z"));
+  });
+
+  it("handles reference date before cycle start in current month", () => {
+    const org = {
+      id: "org-1",
+      billingCycleAnchor: new Date("2024-01-15T00:00:00Z"),
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+    } as Organization;
+
+    // Feb 10 (before Feb 15) → goes back to Jan 15
+    expect(getBillingCycleStart(org, new Date("2024-02-10T10:00:00Z"))).toEqual(
+      new Date("2024-01-15T00:00:00Z"),
+    );
+
+    // Feb 15 exactly → stays at Feb 15
+    expect(getBillingCycleStart(org, new Date("2024-02-15T00:00:00Z"))).toEqual(
+      new Date("2024-02-15T00:00:00Z"),
+    );
+
+    // Feb 20 (after Feb 15) → stays at Feb 15
+    expect(getBillingCycleStart(org, new Date("2024-02-20T10:00:00Z"))).toEqual(
+      new Date("2024-02-15T00:00:00Z"),
+    );
+  });
+
+  it("handles month boundaries with 31st anchor across year transition", () => {
+    const org = {
+      id: "org-1",
+      billingCycleAnchor: new Date("2023-12-31T00:00:00Z"),
+      createdAt: new Date("2023-12-01T00:00:00Z"),
+    } as Organization;
+
+    // Jan 2024 - reference after Jan 31 → Jan 31
+    expect(getBillingCycleStart(org, new Date("2024-02-05T10:00:00Z"))).toEqual(
+      new Date("2024-01-31T00:00:00Z"),
+    );
+
+    // Feb 2024 (leap year) - reference after Feb 29 → Feb 29
+    expect(getBillingCycleStart(org, new Date("2024-03-01T10:00:00Z"))).toEqual(
+      new Date("2024-02-29T00:00:00Z"),
+    );
+  });
+
+  it("handles year crossover with December anchor", () => {
+    const org = {
+      id: "org-1",
+      billingCycleAnchor: new Date("2023-12-15T00:00:00Z"),
+      createdAt: new Date("2023-12-01T00:00:00Z"),
+    } as Organization;
+
+    // Jan 10 (before Jan 15) → goes back to Dec 15 previous year
+    expect(getBillingCycleStart(org, new Date("2024-01-10T10:00:00Z"))).toEqual(
+      new Date("2023-12-15T00:00:00Z"),
+    );
+
+    // Jan 15 exactly → Jan 15 current year
+    expect(getBillingCycleStart(org, new Date("2024-01-15T00:00:00Z"))).toEqual(
+      new Date("2024-01-15T00:00:00Z"),
+    );
+
+    // Jan 20 (after Jan 15) → Jan 15 current year
+    expect(getBillingCycleStart(org, new Date("2024-01-20T10:00:00Z"))).toEqual(
+      new Date("2024-01-15T00:00:00Z"),
+    );
+  });
+
+  it("uses createdAt as fallback when billingCycleAnchor is null", () => {
+    const org = {
+      id: "org-1",
+      billingCycleAnchor: null,
+      createdAt: new Date("2024-01-15T10:30:00Z"),
+    } as Organization;
+
+    expect(getBillingCycleStart(org, new Date("2024-02-20T10:00:00Z"))).toEqual(
+      new Date("2024-02-15T00:00:00Z"),
+    );
+  });
+});

--- a/web/src/ee/features/admin-api/server/organizations/index.ts
+++ b/web/src/ee/features/admin-api/server/organizations/index.ts
@@ -3,6 +3,7 @@ import { logger } from "@langfuse/shared/src/server";
 import { organizationNameSchema } from "@/src/features/organizations/utils/organizationNameSchema";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { type NextApiRequest, type NextApiResponse } from "next";
+import { getOrgCreateDataWithAnchor } from "@/src/ee/features/usage-thresholds/services/setBillingCycleAnchor";
 
 export async function handleGetOrganizations(
   req: NextApiRequest,
@@ -54,10 +55,10 @@ export async function handleCreateOrganization(
 
   // Create the organization in the database
   const organization = await prisma.organization.create({
-    data: {
+    data: getOrgCreateDataWithAnchor({
       name,
       metadata,
-    },
+    }),
   });
 
   // Log the organization creation

--- a/web/src/ee/features/usage-thresholds/services/setBillingCycleAnchor.ts
+++ b/web/src/ee/features/usage-thresholds/services/setBillingCycleAnchor.ts
@@ -1,14 +1,5 @@
 import { prisma } from "@langfuse/shared/src/db";
-
-/**
- * Converts a date to UTC start of day (00:00:00.000)
- */
-function startOfDayUTC(date: Date): Date {
-  const d = new Date(date);
-  return new Date(
-    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
-  );
-}
+import { startOfDayUTC } from "@/src/ee/features/usage-thresholds/utils/billingCycleHelpers";
 
 /**
  * Get organization create data with billing cycle anchor set to start of day UTC

--- a/web/src/ee/features/usage-thresholds/services/setBillingCycleAnchor.ts
+++ b/web/src/ee/features/usage-thresholds/services/setBillingCycleAnchor.ts
@@ -1,0 +1,38 @@
+import { prisma } from "@langfuse/shared/src/db";
+
+/**
+ * Converts a date to UTC start of day (00:00:00.000)
+ */
+function startOfDayUTC(date: Date): Date {
+  const d = new Date(date);
+  return new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+  );
+}
+
+/**
+ * Get organization create data with billing cycle anchor set to start of day UTC
+ */
+export function getOrgCreateDataWithAnchor<T extends Record<string, unknown>>(
+  baseData: T,
+): T & { billingCycleAnchor: Date } {
+  return {
+    ...baseData,
+    billingCycleAnchor: startOfDayUTC(new Date()),
+  };
+}
+
+/**
+ * Update organization billing cycle anchor to start of day UTC
+ */
+export async function updateOrgBillingCycleAnchor(
+  orgId: string,
+  anchor?: Date,
+) {
+  return await prisma.organization.update({
+    where: { id: orgId },
+    data: {
+      billingCycleAnchor: startOfDayUTC(anchor ?? new Date()),
+    },
+  });
+}

--- a/web/src/ee/features/usage-thresholds/utils/billingCycleHelpers.ts
+++ b/web/src/ee/features/usage-thresholds/utils/billingCycleHelpers.ts
@@ -1,0 +1,73 @@
+import { getDaysInMonth, subMonths } from "date-fns";
+import { type Organization } from "@langfuse/shared";
+
+/**
+ * Start of day in UTC (00:00:00.000Z)
+ */
+function startOfDayUTC(date: Date): Date {
+  const d = new Date(date);
+  return new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+  );
+}
+
+/**
+ * Get billing cycle anchor with fallback to createdAt
+ * Always returns start of day in UTC
+ */
+export function getBillingCycleAnchor(org: Organization): Date {
+  return org.billingCycleAnchor
+    ? startOfDayUTC(org.billingCycleAnchor)
+    : startOfDayUTC(org.createdAt);
+}
+
+/**
+ * Calculate the billing cycle start date for the billing cycle containing the reference date
+ * Handles month boundaries correctly (e.g., 31st → 28/29/30 for shorter months)
+ *
+ * Returns the most recent occurrence of the billing cycle day that is on or before the reference date
+ *
+ * Example: If anchor is Jan 31 and reference is Feb 15:
+ * - Feb cycle day would be Feb 29 (adjusted from 31 due to leap year)
+ * - Since Feb 15 < Feb 29, we're still in Jan's cycle → return Jan 31
+ *
+ * Example: If anchor is Jan 15 and reference is Feb 20:
+ * - Feb cycle day is Feb 15
+ * - Since Feb 20 >= Feb 15, we're in Feb's cycle → return Feb 15
+ */
+export function getBillingCycleStart(
+  org: Organization,
+  referenceDate: Date,
+): Date {
+  const anchor = getBillingCycleAnchor(org);
+  const dayOfMonth = anchor.getUTCDate(); // e.g. 31
+
+  // Get reference month/year in UTC
+  const refYear = referenceDate.getUTCFullYear();
+  const refMonth = referenceDate.getUTCMonth();
+
+  // Calculate adjusted day for current month (handles 31 → 28/29/30)
+  const daysInRefMonth = getDaysInMonth(
+    new Date(Date.UTC(refYear, refMonth, 1)),
+  );
+  const adjustedDay = Math.min(dayOfMonth, daysInRefMonth);
+
+  const currentMonthCycleStart = new Date(
+    Date.UTC(refYear, refMonth, adjustedDay),
+  );
+
+  // If current month's cycle start is after reference date, use previous month
+  if (currentMonthCycleStart > referenceDate) {
+    const prevDate = subMonths(new Date(Date.UTC(refYear, refMonth, 1)), 1);
+    const daysInPrevMonth = getDaysInMonth(prevDate);
+    return new Date(
+      Date.UTC(
+        prevDate.getUTCFullYear(),
+        prevDate.getUTCMonth(),
+        Math.min(dayOfMonth, daysInPrevMonth),
+      ),
+    );
+  }
+
+  return currentMonthCycleStart;
+}

--- a/web/src/ee/features/usage-thresholds/utils/billingCycleHelpers.ts
+++ b/web/src/ee/features/usage-thresholds/utils/billingCycleHelpers.ts
@@ -4,7 +4,7 @@ import { type Organization } from "@langfuse/shared";
 /**
  * Start of day in UTC (00:00:00.000Z)
  */
-function startOfDayUTC(date: Date): Date {
+export function startOfDayUTC(date: Date): Date {
   const d = new Date(date);
   return new Date(
     Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),

--- a/web/src/features/organizations/server/organizationRouter.ts
+++ b/web/src/features/organizations/server/organizationRouter.ts
@@ -11,6 +11,7 @@ import { TRPCError } from "@trpc/server";
 import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
 import { redis } from "@langfuse/shared/src/server";
 import { createBillingServiceFromContext } from "@/src/ee/features/billing/server/stripeBillingService";
+import { getOrgCreateDataWithAnchor } from "@/src/ee/features/usage-thresholds/services/setBillingCycleAnchor";
 
 export const organizationsRouter = createTRPCRouter({
   create: authenticatedProcedure
@@ -23,7 +24,7 @@ export const organizationsRouter = createTRPCRouter({
         });
 
       const organization = await ctx.prisma.organization.create({
-        data: {
+        data: getOrgCreateDataWithAnchor({
           name: input.name,
           organizationMemberships: {
             create: {
@@ -31,7 +32,7 @@ export const organizationsRouter = createTRPCRouter({
               role: "OWNER",
             },
           },
-        },
+        }),
       });
       await auditLog({
         resourceType: "organization",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> This PR sets and updates `billingCycleAnchor` for organizations on creation and subscription events, with tests for billing cycle calculations.
> 
>   - **Behavior**:
>     - Set `billingCycleAnchor` on organization creation using `getOrgCreateDataWithAnchor()` in `organizationRouter.ts` and `index.ts`.
>     - Update `billingCycleAnchor` on subscription creation and deletion in `stripeWebhookHandler.ts` using `updateOrgBillingCycleAnchor()`.
>   - **Utilities**:
>     - Add `getBillingCycleAnchor()` and `getBillingCycleStart()` in `billingCycleHelpers.ts` to calculate billing cycle dates.
>     - Add `startOfDayUTC()` to normalize dates to start of day in UTC.
>   - **Tests**:
>     - Add tests in `billingCycleHelpers.servertest.ts` to verify billing cycle calculations, including edge cases like leap years and month boundaries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0acd316882b8b1068ad1af72e609e0edf13ef94d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->