### PR TITLE
fix(otel): preferential parsing of environment key from span attributes

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1131,11 +1131,11 @@ export class OtelIngestionProcessor {
     ];
 
     for (const key of environmentAttributeKeys) {
-      if (resourceAttributes[key]) {
-        return resourceAttributes[key] as string;
-      }
       if (attributes[key]) {
         return attributes[key] as string;
+      }
+      if (resourceAttributes[key]) {
+        return resourceAttributes[key] as string;
       }
     }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `OtelIngestionProcessor.ts`, `extractEnvironment()` now prioritizes parsing environment keys from `attributes` over `resourceAttributes`.
> 
>   - **Behavior**:
>     - In `OtelIngestionProcessor.ts`, `extractEnvironment()` now prefers `attributes` over `resourceAttributes` when parsing environment keys.
>     - The order of checks in the loop is changed to prioritize `attributes` first, then `resourceAttributes`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 353384d6bf27bddf0a994a72087957c391e9dba4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->