### PR TITLE
feat(billing): Add clickhouse queries to retrieve usage

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1635,3 +1635,62 @@ export const getGenerationsForPostHog = async function* (
     };
   }
 };
+
+/**
+ * Get observation counts grouped by project and day within a date range.
+ *
+ * Returns one row per project per day with the count of observations started on that day.
+ * Uses half-open interval [startDate, endDate) for filtering based on start_time.
+ *
+ * @param startDate - Start of date range (inclusive)
+ * @param endDate - End of date range (exclusive)
+ * @returns Array of { count, projectId, date } objects
+ *
+ * @example
+ * // Get observation counts for March 1-2, 2024
+ * const counts = await getObservationCountsByProjectAndDay({
+ *   startDate: new Date('2024-03-01T00:00:00Z'),
+ *   endDate: new Date('2024-03-03T00:00:00Z')
+ * });
+ */
+export const getObservationCountsByProjectAndDay = async ({
+  startDate,
+  endDate,
+}: {
+  startDate: Date;
+  endDate: Date;
+}) => {
+  const query = `
+    SELECT
+      count(*) as count,
+      project_id,
+      toDate(start_time) as date
+    FROM observations
+    WHERE start_time >= {startDate: DateTime64(3)}
+    AND start_time < {endDate: DateTime64(3)}
+    GROUP BY project_id, toDate(start_time)
+  `;
+
+  const rows = await queryClickhouse<{
+    count: string;
+    project_id: string;
+    date: string;
+  }>({
+    query,
+    params: {
+      startDate: convertDateToClickhouseDateTime(startDate),
+      endDate: convertDateToClickhouseDateTime(endDate),
+    },
+    tags: {
+      feature: "tracing",
+      type: "observation",
+      kind: "analytic",
+    },
+  });
+
+  return rows.map((row) => ({
+    count: Number(row.count),
+    projectId: row.project_id,
+    date: row.date,
+  }));
+};

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1584,7 +1584,7 @@ export const getScoreMetadataById = async (
   id: string,
   source?: ScoreSourceType,
 ) => {
-  const query = `    SELECT 
+  const query = `    SELECT
       metadata
     FROM scores s
     WHERE s.project_id = {projectId: String}
@@ -1615,4 +1615,63 @@ export const getScoreMetadataById = async (
       parseMetadataCHRecordToDomain(row.metadata as Record<string, string>),
     )
     .shift();
+};
+
+/**
+ * Get score counts grouped by project and day within a date range.
+ *
+ * Returns one row per project per day with the count of scores created on that day.
+ * Uses half-open interval [startDate, endDate) for filtering based on timestamp.
+ *
+ * @param startDate - Start of date range (inclusive)
+ * @param endDate - End of date range (exclusive)
+ * @returns Array of { count, projectId, date } objects
+ *
+ * @example
+ * // Get score counts for March 1-2, 2024
+ * const counts = await getScoreCountsByProjectAndDay({
+ *   startDate: new Date('2024-03-01T00:00:00Z'),
+ *   endDate: new Date('2024-03-03T00:00:00Z')
+ * });
+ */
+export const getScoreCountsByProjectAndDay = async ({
+  startDate,
+  endDate,
+}: {
+  startDate: Date;
+  endDate: Date;
+}) => {
+  const query = `
+    SELECT
+      count(*) as count,
+      project_id,
+      toDate(timestamp) as date
+    FROM scores
+    WHERE timestamp >= {startDate: DateTime64(3)}
+    AND timestamp < {endDate: DateTime64(3)}
+    GROUP BY project_id, toDate(timestamp)
+  `;
+
+  const rows = await queryClickhouse<{
+    count: string;
+    project_id: string;
+    date: string;
+  }>({
+    query,
+    params: {
+      startDate: convertDateToClickhouseDateTime(startDate),
+      endDate: convertDateToClickhouseDateTime(endDate),
+    },
+    tags: {
+      feature: "tracing",
+      type: "score",
+      kind: "analytic",
+    },
+  });
+
+  return rows.map((row) => ({
+    count: Number(row.count),
+    projectId: row.project_id,
+    date: row.date,
+  }));
 };

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -1996,3 +1996,68 @@ export async function getAgentGraphData(params: {
     },
   });
 }
+
+/**
+ * Get trace counts grouped by project and day within a date range.
+ *
+ * Returns one row per project per day with the count of traces created on that day.
+ * Uses half-open interval [startDate, endDate) for filtering.
+ *
+ * @param startDate - Start of date range (inclusive)
+ * @param endDate - End of date range (exclusive)
+ * @returns Array of { count, projectId, date } objects
+ *
+ * @example
+ * // Get trace counts for March 1-2, 2024
+ * const counts = await getTraceCountsByProjectAndDay({
+ *   startDate: new Date('2024-03-01T00:00:00Z'),
+ *   endDate: new Date('2024-03-03T00:00:00Z')
+ * });
+ * // Returns: [
+ * //   { count: 1500, projectId: 'proj-123', date: '2024-03-01' },
+ * //   { count: 1200, projectId: 'proj-123', date: '2024-03-02' },
+ * //   { count: 2300, projectId: 'proj-456', date: '2024-03-01' },
+ * //   ...
+ * // ]
+ */
+export const getTraceCountsByProjectAndDay = async ({
+  startDate,
+  endDate,
+}: {
+  startDate: Date;
+  endDate: Date;
+}) => {
+  const query = `
+    SELECT
+      count(*) as count,
+      project_id,
+      toDate(timestamp) as date
+    FROM traces
+    WHERE timestamp >= {startDate: DateTime64(3)}
+    AND timestamp < {endDate: DateTime64(3)}
+    GROUP BY project_id, toDate(timestamp)
+  `;
+
+  const rows = await queryClickhouse<{
+    count: string;
+    project_id: string;
+    date: string;
+  }>({
+    query,
+    params: {
+      startDate: convertDateToClickhouseDateTime(startDate),
+      endDate: convertDateToClickhouseDateTime(endDate),
+    },
+    tags: {
+      feature: "tracing",
+      type: "trace",
+      kind: "analytic",
+    },
+  });
+
+  return rows.map((row) => ({
+    count: Number(row.count),
+    projectId: row.project_id,
+    date: row.date,
+  }));
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add functions to retrieve observation, score, and trace counts grouped by project and day from Clickhouse.
> 
>   - **New Functions**:
>     - `getObservationCountsByProjectAndDay` in `observations.ts` to get observation counts grouped by project and day.
>     - `getScoreCountsByProjectAndDay` in `scores.ts` to get score counts grouped by project and day.
>     - `getTraceCountsByProjectAndDay` in `traces.ts` to get trace counts grouped by project and day.
>   - **Behavior**:
>     - Each function uses a half-open interval [startDate, endDate) for filtering.
>     - Returns an array of objects with `count`, `projectId`, and `date` fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 62ce037eac53da9f41527dd724869ff07db8a3a6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->