### PR TITLE
perf: add output score index to job_executions table

### DIFF
--- a/packages/shared/prisma/migrations/20250930125453_job_executions_add_output_score_index/migration.sql
+++ b/packages/shared/prisma/migrations/20250930125453_job_executions_add_output_score_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "job_executions_project_id_job_output_score_id_idx" ON "job_executions"("project_id", "job_output_score_id");

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -929,6 +929,7 @@ model JobExecution {
   @@index([projectId, jobConfigurationId, jobInputTraceId])
   @@index([projectId, status])
   @@index([projectId, id])
+  @@index([projectId, jobOutputScoreId])
   @@map("job_executions")
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add index to `job_executions` table for `projectId` and `jobOutputScoreId` to improve query performance.
> 
>   - **Database Migration**:
>     - Adds `job_executions_project_id_job_output_score_id_idx` index to `job_executions` table in `migration.sql`.
>   - **Prisma Schema**:
>     - Updates `schema.prisma` to include the new index on `JobExecution` model for `projectId` and `jobOutputScoreId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fe3d0892841f966add42f29fc7408e44518916ac. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->