### PR TITLE
feat(prompt-experiments): allow for structured output

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -160,6 +160,7 @@ export async function fetchLLMCompletion(
       _projectId: traceParams.projectId,
       _isLocalEventExportEnabled: true,
       environment: traceParams.environment,
+      metadata: traceParams.metadata,
     });
     finalCallbacks.push(handler);
 

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -282,6 +282,7 @@ export const ExperimentMetadataSchema = z
     provider: z.string(),
     model: z.string(),
     model_params: ZodModelConfig,
+    structured_output_schema: LLMJSONSchema.optional(),
     error: z.string().optional(),
   })
   .strict();

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -491,6 +491,7 @@ type PromptExperimentEnvironment = typeof PROMPT_EXPERIMENT_ENVIRONMENT;
 export type TraceParams = {
   traceName: string;
   traceId: string;
+  metadata?: Record<string, unknown>;
   projectId: string;
   environment: PromptExperimentEnvironment;
   tokenCountDelegate: TokenCountDelegate;

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -10,7 +10,7 @@ import { JSONObjectSchema } from "../../utils/zod";
 /* eslint-disable no-unused-vars */
 // disable lint as this is exported and used in web/worker
 
-export const LLMJSONSchema = z.record(z.string(), z.unknown());
+export const LLMJSONSchema = z.record(z.string(), z.any());
 export type LLMJSONSchema = z.infer<typeof LLMJSONSchema>;
 
 export const JSONSchemaFormSchema = z

--- a/web/src/features/experiments/server/router.ts
+++ b/web/src/features/experiments/server/router.ts
@@ -172,6 +172,7 @@ export const experimentsRouter = createTRPCRouter({
           model: z.string().min(1, "Please select a model"),
           modelParams: ZodModelConfig,
         }),
+        structuredOutputSchema: z.record(z.string(), z.unknown()).optional(),
       }),
     )
     .mutation(async ({ input, ctx }) => {
@@ -190,6 +191,9 @@ export const experimentsRouter = createTRPCRouter({
         provider: input.modelConfig.provider,
         model: input.modelConfig.model,
         model_params: input.modelConfig.modelParams,
+        ...(input.structuredOutputSchema && {
+          structured_output_schema: input.structuredOutputSchema,
+        }),
       };
       const name =
         input.name ?? `${input.promptId}-${new Date().toISOString()}`;

--- a/web/src/features/experiments/server/router.ts
+++ b/web/src/features/experiments/server/router.ts
@@ -172,7 +172,7 @@ export const experimentsRouter = createTRPCRouter({
           model: z.string().min(1, "Please select a model"),
           modelParams: ZodModelConfig,
         }),
-        structuredOutputSchema: z.record(z.string(), z.unknown()).optional(),
+        structuredOutputSchema: z.record(z.string(), z.any()).optional(),
       }),
     )
     .mutation(async ({ input, ctx }) => {
@@ -203,7 +203,7 @@ export const experimentsRouter = createTRPCRouter({
           name: name,
           description: input.description,
           datasetId: input.datasetId,
-          metadata: metadata,
+          metadata,
           projectId: input.projectId,
         },
       });

--- a/web/src/features/experiments/types.ts
+++ b/web/src/features/experiments/types.ts
@@ -15,6 +15,7 @@ export const CreateExperimentData = z.object({
     model: z.string().min(1, "Please select a model"),
     modelParams: ZodModelConfig,
   }),
+  structuredOutputSchema: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type CreateExperiment = z.infer<typeof CreateExperimentData>;

--- a/web/src/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
+++ b/web/src/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
@@ -95,7 +95,13 @@ export const CreateOrEditLLMSchemaDialog: React.FC<
     }
   }, [existingLlmSchema, form, props.defaultValues]);
 
-  async function onSubmit(values: FormValues) {
+  async function onSubmit(
+    values: FormValues,
+    event?: React.BaseSyntheticEvent,
+  ) {
+    event?.preventDefault();
+    event?.stopPropagation();
+
     let result;
     if (existingLlmSchema) {
       result = await updateLlmSchema.mutateAsync({
@@ -164,7 +170,10 @@ export const CreateOrEditLLMSchemaDialog: React.FC<
 
         <Form {...form}>
           <form
-            onSubmit={form.handleSubmit(onSubmit)}
+            onSubmit={(e) => {
+              e.stopPropagation();
+              form.handleSubmit(onSubmit)(e);
+            }}
             className="grid max-h-full min-h-0 overflow-hidden"
           >
             <DialogBody>

--- a/worker/src/features/experiments/experimentServiceClickhouse.ts
+++ b/worker/src/features/experiments/experimentServiceClickhouse.ts
@@ -171,6 +171,9 @@ async function processLLMCall(
     traceName: `dataset-run-item-${runItemId.slice(0, 5)}`,
     traceId,
     projectId: config.projectId,
+    metadata: {
+      output_schema: config.structuredOutputSchema,
+    },
     authCheck: {
       validKey: true as const,
       scope: {

--- a/worker/src/features/experiments/experimentServiceClickhouse.ts
+++ b/worker/src/features/experiments/experimentServiceClickhouse.ts
@@ -172,7 +172,7 @@ async function processLLMCall(
     traceId,
     projectId: config.projectId,
     metadata: {
-      output_schema: config.structuredOutputSchema,
+      structured_output_schema: config.structuredOutputSchema,
     },
     authCheck: {
       validKey: true as const,

--- a/worker/src/features/experiments/experimentServiceClickhouse.ts
+++ b/worker/src/features/experiments/experimentServiceClickhouse.ts
@@ -189,6 +189,7 @@ async function processLLMCall(
         config.provider,
         config.model,
         traceParams,
+        config.structuredOutputSchema,
       ),
     {
       numOfAttempts: 1, // Turn off retries as Langchain handles this

--- a/worker/src/features/experiments/utils.ts
+++ b/worker/src/features/experiments/utils.ts
@@ -257,24 +257,6 @@ export async function validateAndSetupExperiment(
 
   const allVariables = [...extractedVariables, ...placeholderNames];
 
-  // Extract and convert structured output schema if present
-  // The schema is stored as JSON, convert it to a Zod v3 schema
-  let structuredOutputSchema: zodV3.ZodSchema | undefined;
-  if (validatedRunMetadata.data.structured_output_schema) {
-    try {
-      // Convert JSON schema to Zod v3 schema
-      // We use passthrough to allow the schema structure as-is
-      structuredOutputSchema = zodV3
-        .object({})
-        .passthrough()
-        .describe(
-          JSON.stringify(validatedRunMetadata.data.structured_output_schema),
-        );
-    } catch (error) {
-      logger.warn("Failed to convert structured output schema", { error });
-    }
-  }
-
   return {
     datasetRun,
     prompt,
@@ -283,7 +265,7 @@ export async function validateAndSetupExperiment(
     provider,
     model,
     model_params,
-    structuredOutputSchema,
+    structuredOutputSchema: validatedRunMetadata.data.structured_output_schema,
     allVariables,
     placeholderNames,
     projectId,

--- a/worker/src/features/experiments/utils.ts
+++ b/worker/src/features/experiments/utils.ts
@@ -28,7 +28,6 @@ import {
 } from "@langfuse/shared/src/server";
 import { kyselyPrisma, prisma } from "@langfuse/shared/src/db";
 import z from "zod/v4";
-import { z as zodV3 } from "zod/v3";
 import { createHash } from "crypto";
 
 /**

--- a/worker/src/features/utils/utilities.ts
+++ b/worker/src/features/utils/utilities.ts
@@ -5,7 +5,12 @@ import {
   logger,
   type TraceParams,
 } from "@langfuse/shared/src/server";
-import { ApiError, LLMApiKeySchema, ZodModelConfig } from "@langfuse/shared";
+import {
+  ApiError,
+  LLMApiKeySchema,
+  LlmSchema,
+  ZodModelConfig,
+} from "@langfuse/shared";
 import { z } from "zod/v4";
 import { z as zodV3 } from "zod/v3";
 import { ZodSchema as ZodV3Schema } from "zod/v3";
@@ -82,7 +87,7 @@ export async function callLLM(
   provider: string,
   model: string,
   traceParams?: Omit<TraceParams, "tokenCountDelegate">,
-  structuredOutputSchema?: ZodV3Schema,
+  structuredOutputSchema?: LlmSchema,
 ): Promise<string> {
   return withLLMErrorHandling(async () => {
     const { completion, processTracedEvents } = await fetchLLMCompletion({

--- a/worker/src/features/utils/utilities.ts
+++ b/worker/src/features/utils/utilities.ts
@@ -85,8 +85,8 @@ export async function callLLM(
   modelParams: z.infer<typeof ZodModelConfig>,
   provider: string,
   model: string,
-  structuredOutputSchema?: LlmSchema,
   traceParams?: TraceParams,
+  structuredOutputSchema?: LlmSchema,
 ): Promise<string> {
   return withLLMErrorHandling(async () => {
     const { completion, processTracedEvents } = await fetchLLMCompletion({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds structured output support for prompt experiments, allowing JSON schema definitions and processing in both frontend and backend.
> 
>   - **Behavior**:
>     - Adds support for structured output in prompt experiments by allowing users to define JSON schemas (`PromptExperimentsForm.tsx`, `CreateOrEditLLMSchemaDialog.tsx`).
>     - Validates structured output schema selection in `PromptExperimentsForm.tsx`.
>     - Updates `fetchLLMCompletion` to handle structured output schemas (`fetchLLMCompletion.ts`).
>   - **Schema Handling**:
>     - Adds `structured_output_schema` to `ExperimentMetadataSchema` in `types.ts`.
>     - Updates `CreateExperimentData` and `createExperiment` mutation to include `structuredOutputSchema` (`types.ts`, `router.ts`).
>   - **LLM Call**:
>     - Modifies `callLLM` and `processLLMCall` to support structured output schemas (`utilities.ts`, `experimentServiceClickhouse.ts`).
>   - **Misc**:
>     - Changes `LLMJSONSchema` to use `z.any()` instead of `z.unknown()` in `types.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 950a4b04a8842893c2a4eadd0d3ede1550d19afe. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->