### PR TITLE
Investigate frontend race condition for observation errors

### DIFF
--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -84,16 +84,20 @@ export const ObservationPreview = ({
     (o) => o.id === currentObservationId,
   );
 
+  // Use the traceId from the current observation data instead of the URL parameter
+  // to avoid issues when the URL traceId becomes stale during navigation
+  const actualTraceId = currentObservation?.traceId ?? traceId;
+
   const observationWithInputAndOutput = api.observations.byId.useQuery({
     observationId: currentObservationId,
     startTime: currentObservation?.startTime,
-    traceId: traceId,
+    traceId: actualTraceId,
     projectId: projectId,
   });
 
   const observationMedia = api.media.getByTraceOrObservationId.useQuery(
     {
-      traceId: traceId,
+      traceId: actualTraceId,
       observationId: currentObservationId,
       projectId: projectId,
     },
@@ -165,7 +169,7 @@ export const ObservationPreview = ({
                     projectId={projectId}
                     scoreTarget={{
                       type: "trace",
-                      traceId: traceId,
+                      traceId: actualTraceId,
                       observationId: preloadedObservation.id,
                     }}
                     scores={scores}
@@ -464,7 +468,7 @@ export const ObservationPreview = ({
               <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden">
                 <ScoresTable
                   projectId={projectId}
-                  traceId={traceId}
+                  traceId={actualTraceId}
                   omittedFilter={["Observation ID"]}
                   observationId={preloadedObservation.id}
                   hiddenColumns={[


### PR DESCRIPTION
## What does this PR do?

This PR resolves the "observation not found" error (404) that occurred intermittently in the trace detail view of a session. The issue stemmed from a race condition where the `traceId` URL parameter became stale when navigating between observations in the peek view. The fix ensures that the `traceId` used for fetching observation details, media, scores, and annotations is always derived directly from the currently selected observation's data, rather than relying on the potentially outdated URL parameter.

Fixes #LFE-6969

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [ ] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my PR needs changes to the documentation
- [ ] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [x] I haven't added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-6969](https://linear.app/langfuse/issue/LFE-6969/unexpected-observation-not-found-in-trace-detail-view-of-a-session)

<a href="https://cursor.com/background-agent?bcId=bc-8e3f69d1-9507-448d-8d8a-693071da416c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8e3f69d1-9507-448d-8d8a-693071da416c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

