### PR TITLE
fix: add current datetime to ai filter prompt

### DIFF
--- a/web/src/features/natural-language-filters/server/router.ts
+++ b/web/src/features/natural-language-filters/server/router.ts
@@ -100,21 +100,12 @@ export const naturalLanguageFilterRouter = createTRPCRouter({
 
         // Get current datetime in ISO format with day of week for AI context
         const now = new Date();
-        const daysOfWeek = [
-          "Sunday",
-          "Monday",
-          "Tuesday",
-          "Wednesday",
-          "Thursday",
-          "Friday",
-          "Saturday",
-        ];
-        const dayOfWeek = daysOfWeek[now.getDay()];
-        const currentDatetime = `${now.toISOString()} (${dayOfWeek})`;
+        const dayOfWeek = now.toLocaleDateString("en-US", { weekday: "long" });
+        const currentDatetime = `${dayOfWeek}, ${now.toISOString()}`;
 
         const messages = promptResponse.compile({
           userPrompt: input.prompt,
-          current_datetime: currentDatetime,
+          currentDatetime,
         });
         const modelParams = getDefaultModelParams();
 

--- a/web/src/features/natural-language-filters/server/router.ts
+++ b/web/src/features/natural-language-filters/server/router.ts
@@ -98,7 +98,24 @@ export const naturalLanguageFilterRouter = createTRPCRouter({
           { type: "chat" },
         );
 
-        const messages = promptResponse.compile({ userPrompt: input.prompt });
+        // Get current datetime in ISO format with day of week for AI context
+        const now = new Date();
+        const daysOfWeek = [
+          "Sunday",
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday",
+        ];
+        const dayOfWeek = daysOfWeek[now.getDay()];
+        const currentDatetime = `${now.toISOString()} (${dayOfWeek})`;
+
+        const messages = promptResponse.compile({
+          userPrompt: input.prompt,
+          current_datetime: currentDatetime,
+        });
         const modelParams = getDefaultModelParams();
 
         const llmCompletion = await fetchLLMCompletion({


### PR DESCRIPTION
## What does this PR do?

This PR adds the current datetime (ISO format + day of week) as a `current_datetime` parameter to the AI filter prompt compilation. This provides the AI with the necessary temporal context to correctly interpret queries like "all traces of last week", preventing it from returning irrelevant dates.

**Note:** The `get-filter-conditions-from-query` prompt in Langfuse will need to be updated separately to utilize this new `current_datetime` variable.

Fixes # LFE-6973

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-6973](https://linear.app/langfuse/issue/LFE-6973/add-curent-datetime-iso-datetime-day-of-week-as-param-to-ai-filter)

<a href="https://cursor.com/background-agent?bcId=bc-d6007348-2e28-469a-9b53-e35b1112556b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d6007348-2e28-469a-9b53-e35b1112556b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `currentDatetime` parameter to AI filter prompt in `router.ts` for better temporal context in queries.
> 
>   - **Behavior**:
>     - Adds `currentDatetime` parameter to AI filter prompt in `router.ts` to include current datetime in ISO format with day of week.
>     - Enhances AI's ability to interpret time-based queries like "all traces of last week".
>   - **Notes**:
>     - `get-filter-conditions-from-query` prompt in Langfuse needs separate update to use `currentDatetime`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5cfcb7dd40214117a465cd78a4ba3763af7e9ddf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->