### PR TITLE
feat(billing): add email templates for notifications 

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -3,6 +3,8 @@ export * from "./services/email/organizationInvitation/sendMembershipInvitationE
 export * from "./services/email/batchExportSuccess/sendBatchExportSuccessEmail";
 export * from "./services/email/passwordReset/sendResetPasswordVerificationRequest";
 export * from "./services/email/billingAlert/sendBillingAlertEmail";
+export * from "./services/email/usageThresholdWarning/sendUsageThresholdWarningEmail";
+export * from "./services/email/usageThresholdSuspension/sendUsageThresholdSuspensionEmail";
 export * from "./services/PromptService";
 export * from "./services/PromptService/types";
 export * from "./services/traces-ui-table-service";

--- a/packages/shared/src/server/services/email/usageThresholdSuspension/UsageThresholdSuspensionEmailTemplate.tsx
+++ b/packages/shared/src/server/services/email/usageThresholdSuspension/UsageThresholdSuspensionEmailTemplate.tsx
@@ -1,0 +1,139 @@
+import React from "react";
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Img,
+  Section,
+  Text,
+  Tailwind,
+  Preview,
+} from "@react-email/components";
+
+interface UsageThresholdSuspensionEmailProps {
+  organizationName: string;
+  currentUsage: number;
+  limit: number;
+  billingUrl: string;
+  receiverEmail: string;
+}
+
+export const UsageThresholdSuspensionEmailTemplate = ({
+  organizationName,
+  currentUsage,
+  limit,
+  billingUrl,
+  receiverEmail,
+}: UsageThresholdSuspensionEmailProps) => {
+  return (
+    <Html>
+      <Head />
+      <Preview>
+        🚨 URGENT: Ingestion suspended for &quot;{organizationName}&quot; -
+        limit exceeded
+      </Preview>
+      <Tailwind>
+        <Body className="bg-background my-auto mx-auto font-sans">
+          <Container className="mx-auto my-10 w-[465px] rounded border border-solid border-[#eaeaea] p-5">
+            <Section className="mt-8">
+              <Img
+                src="https://static.langfuse.com/langfuse_logo_transactional_email.png"
+                width="40"
+                height="40"
+                alt="Langfuse"
+                className="mx-auto my-0"
+              />
+            </Section>
+
+            <Section>
+              <Heading className="mx-0 my-[30px] p-0 text-center text-2xl font-normal text-black">
+                ⚠️ Ingestion Suspended
+              </Heading>
+              <Text className="text-gray-700 text-sm leading-6">
+                Your organization &quot;{organizationName}&quot; has exceeded
+                the <strong>{limit.toLocaleString()} event limit</strong> for
+                the free tier. Data ingestion has been suspended.
+              </Text>
+            </Section>
+
+            <Section className="mt-8">
+              <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-center">
+                <Text className="text-red-600 text-sm font-medium m-0 mb-1">
+                  Current Usage
+                </Text>
+                <Text className="text-3xl font-bold text-red-700 m-0">
+                  {currentUsage.toLocaleString()}
+                </Text>
+                <Text className="text-red-600 text-xs m-0 mt-1">
+                  Free tier limit: {limit.toLocaleString()} events
+                </Text>
+              </div>
+            </Section>
+
+            <Section className="mt-8 text-center">
+              <Button
+                className="rounded bg-red-600 px-5 py-3 text-center text-xs font-semibold text-white no-underline"
+                href={billingUrl}
+              >
+                Upgrade Now to Resume Ingestion
+              </Button>
+            </Section>
+
+            <Section className="mt-8">
+              <Heading className="text-black text-[18px] font-semibold">
+                What&apos;s affected?
+              </Heading>
+              <Text className="text-gray-700 text-sm leading-6">
+                •{" "}
+                <strong>
+                  New traces, observations, and scores cannot be ingested
+                </strong>
+                <br />
+                • Existing data remains accessible
+                <br />
+                • Dashboard and analytics continue to work
+                <br />• API calls to ingestion endpoints return 403 errors
+              </Text>
+            </Section>
+
+            <Section className="mt-8">
+              <Heading className="text-black text-[18px] font-semibold">
+                How to resolve:
+              </Heading>
+              <Text className="text-gray-700 text-sm leading-6">
+                • <strong>Upgrade plan</strong> for unlimited events and premium
+                features
+                <br />• Or contact support for custom plans and enterprise
+                options
+              </Text>
+            </Section>
+
+            <Hr className="border border-solid border-[#eaeaea] my-[26px] mx-0 w-full" />
+
+            <Section>
+              <Text className="text-[#666666] text-[12px] leading-[24px]">
+                This urgent notification was sent to {receiverEmail} regarding
+                ingestion suspension for &quot;{organizationName}&quot;.
+              </Text>
+              <Text className="text-[#666666] text-[12px] leading-[24px]">
+                Need immediate help? Contact us at{" "}
+                <a
+                  href="mailto:support@langfuse.com"
+                  className="text-blue-600 no-underline"
+                >
+                  support@langfuse.com
+                </a>
+              </Text>
+            </Section>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+export default UsageThresholdSuspensionEmailTemplate;

--- a/packages/shared/src/server/services/email/usageThresholdSuspension/sendUsageThresholdSuspensionEmail.ts
+++ b/packages/shared/src/server/services/email/usageThresholdSuspension/sendUsageThresholdSuspensionEmail.ts
@@ -1,0 +1,62 @@
+import { createTransport } from "nodemailer";
+import { parseConnectionUrl } from "nodemailer/lib/shared/index.js";
+import { render } from "@react-email/render";
+import { UsageThresholdSuspensionEmailTemplate } from "./UsageThresholdSuspensionEmailTemplate";
+import { logger } from "../../../logger";
+
+export interface UsageThresholdSuspensionEmailProps {
+  env: Partial<
+    Record<
+      "EMAIL_FROM_ADDRESS" | "SMTP_CONNECTION_URL" | "NEXTAUTH_URL",
+      string | undefined
+    >
+  >;
+  organizationName: string;
+  currentUsage: number;
+  limit: number;
+  billingUrl: string;
+  receiverEmail: string;
+}
+
+export const sendUsageThresholdSuspensionEmail = async ({
+  env,
+  organizationName,
+  currentUsage,
+  limit,
+  billingUrl,
+  receiverEmail,
+}: UsageThresholdSuspensionEmailProps) => {
+  if (!env.EMAIL_FROM_ADDRESS || !env.SMTP_CONNECTION_URL) {
+    logger.error(
+      "Missing environment variables for sending ingestion suspended email.",
+    );
+    return;
+  }
+
+  try {
+    const mailer = createTransport(parseConnectionUrl(env.SMTP_CONNECTION_URL));
+
+    const emailSubject = `🚨 URGENT: Langfuse ingestion suspended for ${organizationName}`;
+    const emailHtml = await render(
+      UsageThresholdSuspensionEmailTemplate({
+        organizationName,
+        currentUsage,
+        limit,
+        billingUrl,
+        receiverEmail,
+      }),
+    );
+
+    await mailer.sendMail({
+      to: receiverEmail,
+      from: {
+        address: env.EMAIL_FROM_ADDRESS,
+        name: "Langfuse",
+      },
+      subject: emailSubject,
+      html: emailHtml,
+    });
+  } catch (error) {
+    logger.error(`Failed to send ingestion suspended email`, error);
+  }
+};

--- a/packages/shared/src/server/services/email/usageThresholdWarning/UsageThresholdWarningEmailTemplate.tsx
+++ b/packages/shared/src/server/services/email/usageThresholdWarning/UsageThresholdWarningEmailTemplate.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Img,
+  Section,
+  Text,
+  Tailwind,
+  Row,
+  Column,
+  Preview,
+} from "@react-email/components";
+
+interface UsageThresholdWarningEmailProps {
+  organizationName: string;
+  currentUsage: number;
+  limit: number;
+  billingUrl: string;
+  receiverEmail: string;
+}
+
+export const UsageThresholdWarningEmailTemplate = ({
+  organizationName,
+  currentUsage,
+  limit,
+  billingUrl,
+  receiverEmail,
+}: UsageThresholdWarningEmailProps) => {
+  return (
+    <Html>
+      <Head />
+      <Preview>
+        Your Langfuse organization &quot;{organizationName}&quot; has reached{" "}
+        {currentUsage.toLocaleString()} events
+      </Preview>
+      <Tailwind>
+        <Body className="bg-background my-auto mx-auto font-sans">
+          <Container className="mx-auto my-10 w-[465px] rounded border border-solid border-[#eaeaea] p-5">
+            <Section className="mt-8">
+              <Img
+                src="https://static.langfuse.com/langfuse_logo_transactional_email.png"
+                width="40"
+                height="40"
+                alt="Langfuse"
+                className="mx-auto my-0"
+              />
+            </Section>
+
+            <Section>
+              <Heading className="mx-0 my-[30px] p-0 text-center text-2xl font-normal text-black">
+                Usage Threshold Reached
+              </Heading>
+              <Text className="text-gray-700 text-sm leading-6">
+                Your organization &quot;{organizationName}&quot; has reached{" "}
+                <strong>{currentUsage.toLocaleString()}</strong> events out of
+                your <strong>{limit.toLocaleString()}</strong> event limit for
+                the free tier.
+              </Text>
+            </Section>
+
+            <Section className="mt-8">
+              <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+                <Row>
+                  <Column className="text-center">
+                    <Text className="text-gray-600 text-sm font-medium m-0 mb-1">
+                      Current Usage
+                    </Text>
+                    <Text className="text-2xl font-bold text-gray-900 m-0">
+                      {currentUsage.toLocaleString()}
+                    </Text>
+                  </Column>
+                  <Column className="text-center">
+                    <Text className="text-gray-600 text-sm font-medium m-0 mb-1">
+                      Threshold
+                    </Text>
+                    <Text className="text-2xl font-bold text-gray-900 m-0">
+                      {limit.toLocaleString()}
+                    </Text>
+                  </Column>
+                </Row>
+              </div>
+            </Section>
+
+            <Section className="mt-8 text-center">
+              <Button
+                className="rounded bg-black px-5 py-3 text-center text-xs font-semibold text-white no-underline"
+                href={billingUrl}
+              >
+                Upgrade Your Plan
+              </Button>
+            </Section>
+
+            <Section className="mt-8">
+              <Heading className="text-black text-[18px] font-semibold">
+                What happens next?
+              </Heading>
+              <Text className="text-gray-700 text-sm leading-6">
+                • Your usage continues to be tracked for a grace period
+                <br />
+                • Ingestion will soon be suspended and incoming observations,
+                traces, and scores will be dropped unless you upgrade
+                <br />• Upgrade now for unlimited events and premium features
+              </Text>
+            </Section>
+
+            <Hr className="border border-solid border-[#eaeaea] my-[26px] mx-0 w-full" />
+
+            <Section>
+              <Text className="text-[#666666] text-[12px] leading-[24px]">
+                This email was sent to {receiverEmail} regarding usage alerts
+                for &quot;{organizationName}&quot;.
+              </Text>
+              <Text className="text-[#666666] text-[12px] leading-[24px]">
+                Questions? Contact us at{" "}
+                <a
+                  href="mailto:support@langfuse.com"
+                  className="text-blue-600 no-underline"
+                >
+                  support@langfuse.com
+                </a>
+              </Text>
+            </Section>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+export default UsageThresholdWarningEmailTemplate;

--- a/packages/shared/src/server/services/email/usageThresholdWarning/sendUsageThresholdWarningEmail.ts
+++ b/packages/shared/src/server/services/email/usageThresholdWarning/sendUsageThresholdWarningEmail.ts
@@ -1,0 +1,62 @@
+import { createTransport } from "nodemailer";
+import { parseConnectionUrl } from "nodemailer/lib/shared/index.js";
+import { render } from "@react-email/render";
+import { UsageThresholdWarningEmailTemplate } from "./UsageThresholdWarningEmailTemplate";
+import { logger } from "../../../logger";
+
+export interface UsageThresholdWarningEmailProps {
+  env: Partial<
+    Record<
+      "EMAIL_FROM_ADDRESS" | "SMTP_CONNECTION_URL" | "NEXTAUTH_URL",
+      string | undefined
+    >
+  >;
+  organizationName: string;
+  currentUsage: number;
+  limit: number;
+  billingUrl: string;
+  receiverEmail: string;
+}
+
+export const sendUsageThresholdWarningEmail = async ({
+  env,
+  organizationName,
+  currentUsage,
+  limit,
+  billingUrl,
+  receiverEmail,
+}: UsageThresholdWarningEmailProps) => {
+  if (!env.EMAIL_FROM_ADDRESS || !env.SMTP_CONNECTION_URL) {
+    logger.error(
+      "Missing environment variables for sending usage notification email.",
+    );
+    return;
+  }
+
+  try {
+    const mailer = createTransport(parseConnectionUrl(env.SMTP_CONNECTION_URL));
+
+    const emailSubject = `Langfuse Free Tier: ${organizationName} usage reached ${limit.toLocaleString()} events`;
+    const emailHtml = await render(
+      UsageThresholdWarningEmailTemplate({
+        organizationName,
+        currentUsage,
+        limit,
+        billingUrl,
+        receiverEmail,
+      }),
+    );
+
+    await mailer.sendMail({
+      to: receiverEmail,
+      from: {
+        address: env.EMAIL_FROM_ADDRESS,
+        name: "Langfuse",
+      },
+      subject: emailSubject,
+      html: emailHtml,
+    });
+  } catch (error) {
+    logger.error(`Failed to send usage notification email`, error);
+  }
+};

--- a/worker/src/ee/usageThresholds/thresholdProcessing.ts
+++ b/worker/src/ee/usageThresholds/thresholdProcessing.ts
@@ -192,7 +192,7 @@ export async function processThresholds(
   org: ParsedOrganization,
   cumulativeUsage: number,
 ): Promise<void> {
-  // 0. Skip notificaitons if org in on a paid plan
+  // 0. Skip notifications if org in on a paid plan
   if (org.cloudConfig?.stripe?.activeSubscriptionId) {
     await prisma.organization.update({
       where: { id: org.id },

--- a/worker/src/ee/usageThresholds/usageAggregation.ts
+++ b/worker/src/ee/usageThresholds/usageAggregation.ts
@@ -1,4 +1,3 @@
-import type { Organization } from "@prisma/client";
 import { prisma } from "@langfuse/shared/src/db";
 import {
   getTraceCountsByProjectAndDay,
@@ -36,7 +35,7 @@ interface UsageByOrg {
 /**
  * Organization with calculated billing cycle start date
  */
-interface OrgWithBillingStart extends Organization {
+interface OrgWithBillingStart extends ParsedOrganization {
   billingCycleStartForReference: Date;
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add email templates and logic for usage threshold notifications and suspensions, with tests for threshold processing.
> 
>   - **Email Templates**:
>     - Add `UsageThresholdSuspensionEmailTemplate` and `UsageThresholdWarningEmailTemplate` for email notifications.
>   - **Email Sending**:
>     - Implement `sendUsageThresholdSuspensionEmail` and `sendUsageThresholdWarningEmail` to send emails using `nodemailer`.
>   - **Threshold Processing**:
>     - Update `processThresholds` in `thresholdProcessing.ts` to send emails when usage crosses thresholds.
>     - Add `getOrgAdminEmails` to fetch admin emails for notifications.
>   - **Tests**:
>     - Add tests in `thresholdProcessing.test.ts` to verify threshold detection and email sending logic.
>     - Ensure tests cover boundary cases and multiple threshold crossings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4066ed38524da8787f3bc62f6b237161cae7805e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->