### PR TITLE
feat(billing): enforce blocking of ingestion on isIngestionSuspended flag

### DIFF
--- a/packages/shared/src/server/auth/invalidateApiKeys.ts
+++ b/packages/shared/src/server/auth/invalidateApiKeys.ts
@@ -1,0 +1,110 @@
+import { prisma } from "../../db";
+import { redis, safeMultiDel } from "..";
+import { logger } from "../logger";
+
+import { type ApiKey } from "../../db";
+
+/**
+ * Invalidate specific API keys from Redis cache
+ *
+ * Utility used by higher-level helpers to remove individual API keys from the cache,
+ * e.g. after key rotation, revocation, or entitlement/plan changes.
+ *
+ * Behavior:
+ * - Skips keys without a `fastHashedSecretKey`
+ * - No-ops when Redis is not configured
+ *
+ * @param apiKeys - List of API key records to invalidate
+ * @param identifier - Context string for logging (e.g., org or project identifier)
+ */
+export async function invalidate(apiKeys: ApiKey[], identifier: string) {
+  const hashKeys = apiKeys.map((key) => key.fastHashedSecretKey);
+
+  const filteredHashKeys = hashKeys.filter((hash): hash is string =>
+    Boolean(hash),
+  );
+  if (filteredHashKeys.length === 0) {
+    logger.info("No valid keys to invalidate");
+    return;
+  }
+
+  if (redis) {
+    logger.info(`Invalidating API keys in redis for ${identifier}`);
+    const keysToDelete = filteredHashKeys.map((hash) => `api-key:${hash}`);
+    await safeMultiDel(redis, keysToDelete);
+  }
+}
+
+/**
+ * Invalidate all API keys for an organization from Redis cache
+ *
+ * This function is used when organization-level changes occur that affect API key validity,
+ * such as:
+ * - Plan changes (subscription created/updated/deleted)
+ * - Usage threshold state changes (blocking/unblocking)
+ * - Billing cycle changes
+ *
+ * @param orgId - The organization ID whose API keys should be invalidated
+ */
+export async function invalidateOrgApiKeys(orgId: string): Promise<void> {
+  const apiKeys = await prisma.apiKey.findMany({
+    where: {
+      OR: [
+        {
+          project: {
+            orgId,
+          },
+        },
+        { orgId },
+      ],
+    },
+  });
+
+  const hashKeys = apiKeys
+    .map((key) => key.fastHashedSecretKey)
+    .filter((hash): hash is string => Boolean(hash));
+
+  if (hashKeys.length === 0) {
+    logger.info(`No valid API keys to invalidate for org ${orgId}`);
+    return;
+  }
+
+  if (redis) {
+    logger.info(`Invalidating API keys in redis for org ${orgId}`);
+    const keysToDelete = hashKeys.map((hash) => `api-key:${hash}`);
+    await safeMultiDel(redis, keysToDelete);
+  }
+}
+
+/**
+ * Invalidate all API keys for a project from Redis cache
+ *
+ * This function is used when project-level changes occur that affect API key validity.
+ *
+ * @param projectId - The project ID whose API keys should be invalidated
+ */
+export async function invalidateProjectApiKeys(
+  projectId: string,
+): Promise<void> {
+  const apiKeys = await prisma.apiKey.findMany({
+    where: {
+      projectId: projectId,
+      scope: "PROJECT",
+    },
+  });
+
+  const hashKeys = apiKeys
+    .map((key) => key.fastHashedSecretKey)
+    .filter((hash): hash is string => Boolean(hash));
+
+  if (hashKeys.length === 0) {
+    logger.info(`No valid API keys to invalidate for project ${projectId}`);
+    return;
+  }
+
+  if (redis) {
+    logger.info(`Invalidating API keys in redis for project ${projectId}`);
+    const keysToDelete = hashKeys.map((hash) => `api-key:${hash}`);
+    await safeMultiDel(redis, keysToDelete);
+  }
+}

--- a/packages/shared/src/server/auth/types.ts
+++ b/packages/shared/src/server/auth/types.ts
@@ -16,6 +16,7 @@ const ApiKeyBaseSchema = z.object({
   orgId: z.string(),
   plan: z.enum(plans as unknown as [string, ...string[]]),
   rateLimitOverrides: CloudConfigRateLimit.nullish(),
+  isIngestionSuspended: z.boolean(),
 });
 
 export const OrgEnrichedApiKey = z.discriminatedUnion("scope", [
@@ -64,6 +65,7 @@ type ApiAccessScopeMetadata = {
   rateLimitOverrides: z.infer<typeof CloudConfigRateLimit>;
   apiKeyId: string;
   publicKey: string;
+  isIngestionSuspended: boolean;
 };
 
 export type ApiAccessScopeIngestion = BaseApiAccessScope &

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -11,6 +11,7 @@ export * from "./services/traces-ui-table-service";
 export * from "./services/InMemoryFilterService";
 export * from "./evalJobConfigCache";
 export * from "./auth/apiKeys";
+export * from "./auth/invalidateApiKeys";
 export * from "./auth/customSsoProvider";
 export * from "./auth/gitHubEnterpriseProvider";
 export * from "./llm/fetchLLMCompletion";

--- a/web/src/__tests__/api-auth.servertest.ts
+++ b/web/src/__tests__/api-auth.servertest.ts
@@ -317,6 +317,7 @@ describe("Authenticate API calls", () => {
           },
         ],
         createdAt: apiKey?.createdAt.toISOString(),
+        isIngestionSuspended: expect.any(Boolean),
       });
 
       await prisma.organization.update({
@@ -435,6 +436,7 @@ describe("Authenticate API calls", () => {
           },
         ],
         createdAt: apiKey?.createdAt.toISOString(),
+        isIngestionSuspended: expect.any(Boolean),
       });
 
       await prisma.organization.update({
@@ -547,6 +549,7 @@ describe("Authenticate API calls", () => {
         createdAt: expect.any(String),
         lastUsedAt: null,
         expiresAt: null,
+        isIngestionSuspended: expect.any(Boolean),
         projectId: expect.any(String),
         orgId: "seed-org-id",
         plan: "cloud:hobby",
@@ -643,6 +646,7 @@ describe("Authenticate API calls", () => {
         plan: "cloud:hobby",
         createdAt: apiKey?.createdAt.toISOString(),
         scope: "PROJECT",
+        isIngestionSuspended: expect.any(Boolean),
       });
 
       await new ApiAuthService(prisma, redis).deleteApiKey(

--- a/web/src/features/public-api/server/apiAuth.ts
+++ b/web/src/features/public-api/server/apiAuth.ts
@@ -9,7 +9,6 @@ import {
   logger,
   instrumentAsync,
   addUserToSpan,
-  safeMultiDel,
   invalidate as invalidateShared,
   invalidateOrgApiKeys as invalidateOrgApiKeysShared,
   invalidateProjectApiKeys as invalidateProjectApiKeysShared,

--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -15,6 +15,7 @@ import {
   MethodNotAllowedError,
   BaseError,
   UnauthorizedError,
+  ForbiddenError,
 } from "@langfuse/shared";
 import { processEventBatch } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
@@ -83,6 +84,11 @@ export default async function handler(
     if (!authCheck.scope.projectId) {
       throw new UnauthorizedError(
         "Missing projectId in scope. Are you using an organization key?",
+      );
+    }
+    if (authCheck.scope.isIngestionSuspended) {
+      throw new ForbiddenError(
+        "Ingestion suspended: Usage threshold exceeded. Please upgrade your plan.",
       );
     }
 

--- a/web/src/pages/api/public/media/index.ts
+++ b/web/src/pages/api/public/media/index.ts
@@ -26,6 +26,13 @@ export default withMiddlewares({
     successStatusCode: 201,
     rateLimitResource: "ingestion",
     fn: async ({ body, auth }) => {
+      // Check if ingestion is suspended due to usage threshold
+      if (auth.scope.isIngestionSuspended) {
+        throw new ForbiddenError(
+          "Ingestion suspended: Usage threshold exceeded. Please upgrade your plan.",
+        );
+      }
+
       if (auth.scope.accessLevel !== "project") throw new ForbiddenError();
 
       const { projectId } = auth.scope;

--- a/worker/src/__tests__/usageThresholdCacheInvalidation.test.ts
+++ b/worker/src/__tests__/usageThresholdCacheInvalidation.test.ts
@@ -1,12 +1,4 @@
-import {
-  describe,
-  it,
-  expect,
-  beforeEach,
-  afterEach,
-  afterAll,
-  vi,
-} from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { prisma } from "@langfuse/shared/src/db";
 import { type ParsedOrganization } from "@langfuse/shared";
 import {
@@ -101,12 +93,6 @@ describe("Usage Threshold Cache Invalidation", () => {
       if (keys.length > 0) {
         await redis.del(keys);
       }
-    }
-  });
-
-  afterAll(async () => {
-    if (redis) {
-      await redis.quit();
     }
   });
 

--- a/worker/src/__tests__/usageThresholdCacheInvalidation.test.ts
+++ b/worker/src/__tests__/usageThresholdCacheInvalidation.test.ts
@@ -1,0 +1,464 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  afterAll,
+  vi,
+} from "vitest";
+import { prisma } from "@langfuse/shared/src/db";
+import { type ParsedOrganization } from "@langfuse/shared";
+import {
+  redis,
+  hashSecretKey,
+  getDisplaySecretKey,
+  createShaHash,
+} from "@langfuse/shared/src/server";
+import { processThresholds } from "../ee/usageThresholds/thresholdProcessing";
+
+// Enable enforcement feature flag for tests
+vi.hoisted(() => {
+  process.env.LANGFUSE_USAGE_THRESHOLD_ENFORCEMENT_ENABLED = "true";
+});
+
+// SALT is defined in web env, not worker env
+const SALT = process.env.SALT || "test-salt-for-hashing";
+
+describe("Usage Threshold Cache Invalidation", () => {
+  const testOrgId = "test-org-cache-invalidation";
+  const testProjectId = "test-project-cache-invalidation";
+  const testApiKeyId = "test-api-key-cache-invalidation";
+  const testApiKeyPublic = "pk-lf-test-cache-inv";
+  const testApiKeySecret = "sk-lf-test-cache-inv";
+
+  beforeEach(async () => {
+    // Clean up any existing test data
+    await prisma.apiKey.deleteMany({
+      where: { id: testApiKeyId },
+    });
+    await prisma.project.deleteMany({
+      where: { id: testProjectId },
+    });
+    await prisma.organization.deleteMany({
+      where: { id: testOrgId },
+    });
+
+    // Create test organization
+    await prisma.organization.create({
+      data: {
+        id: testOrgId,
+        name: "Test Org Cache Invalidation",
+        billingCycleAnchor: new Date("2024-01-15T00:00:00Z"),
+      },
+    });
+
+    // Create test project
+    await prisma.project.create({
+      data: {
+        id: testProjectId,
+        name: "Test Project Cache Invalidation",
+        orgId: testOrgId,
+      },
+    });
+
+    // Create test API key
+    await prisma.apiKey.create({
+      data: {
+        id: testApiKeyId,
+        publicKey: testApiKeyPublic,
+        hashedSecretKey: await hashSecretKey(testApiKeySecret),
+        displaySecretKey: getDisplaySecretKey(testApiKeySecret),
+        projectId: testProjectId,
+        note: "Test key for cache invalidation",
+      },
+    });
+
+    // Clear Redis cache
+    if (redis) {
+      const keys = await redis.keys("api-key:*");
+      if (keys.length > 0) {
+        await redis.del(keys);
+      }
+    }
+  });
+
+  afterEach(async () => {
+    // Clean up test data
+    await prisma.apiKey.deleteMany({
+      where: { id: testApiKeyId },
+    });
+    await prisma.project.deleteMany({
+      where: { id: testProjectId },
+    });
+    await prisma.organization.deleteMany({
+      where: { id: testOrgId },
+    });
+
+    // Clear Redis cache
+    if (redis) {
+      const keys = await redis.keys("api-key:*");
+      if (keys.length > 0) {
+        await redis.del(keys);
+      }
+    }
+  });
+
+  afterAll(async () => {
+    if (redis) {
+      await redis.quit();
+    }
+  });
+
+  it("should invalidate API key cache when org blocking state changes to BLOCKED", async () => {
+    if (!redis) {
+      console.log("Redis not available, skipping test");
+      return;
+    }
+
+    // Step 1: Add API key to cache
+    const fastHashedKey = createShaHash(testApiKeySecret, SALT);
+
+    await prisma.apiKey.update({
+      where: { id: testApiKeyId },
+      data: { fastHashedSecretKey: fastHashedKey },
+    });
+
+    // Simulate cached API key in Redis
+    const cachedApiKey = {
+      id: testApiKeyId,
+      publicKey: testApiKeyPublic,
+      hashedSecretKey: await hashSecretKey(testApiKeySecret),
+      fastHashedSecretKey: fastHashedKey,
+      displaySecretKey: getDisplaySecretKey(testApiKeySecret),
+      note: "Test key",
+      createdAt: new Date().toISOString(),
+      lastUsedAt: null,
+      expiresAt: null,
+      projectId: testProjectId,
+      orgId: testOrgId,
+      plan: "cloud:hobby",
+      scope: "PROJECT",
+      rateLimitOverrides: null,
+      isIngestionSuspended: false,
+    };
+
+    await redis.set(
+      `api-key:${fastHashedKey}`,
+      JSON.stringify(cachedApiKey),
+      "EX",
+      3600,
+    );
+
+    // Verify key is in cache
+    const cachedBefore = await redis.get(`api-key:${fastHashedKey}`);
+    expect(cachedBefore).not.toBeNull();
+
+    // Step 2: Trigger threshold processing that blocks the org (200k threshold)
+    const org: ParsedOrganization = {
+      id: testOrgId,
+      name: "Test Org",
+      cloudConfig: null,
+      metadata: null,
+      billingCycleAnchor: new Date("2024-01-15T00:00:00Z"),
+      billingCycleLastUpdatedAt: null,
+      billingCycleLastUsage: 150_000, // Below blocking threshold
+      billingCycleUsageState: null, // Not blocked yet
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+      updatedAt: new Date("2024-01-01T00:00:00Z"),
+    };
+
+    await processThresholds(org, 200_000); // Cross blocking threshold
+
+    // Step 3: Verify cache was invalidated
+    const cachedAfter = await redis.get(`api-key:${fastHashedKey}`);
+    expect(cachedAfter).toBeNull();
+
+    // Step 4: Verify org state was updated
+    const updatedOrg = await prisma.organization.findUnique({
+      where: { id: testOrgId },
+    });
+    expect(updatedOrg?.billingCycleUsageState).toBe("BLOCKED");
+  });
+
+  it("should invalidate API key cache when org blocking state changes from BLOCKED to null", async () => {
+    if (!redis) {
+      console.log("Redis not available, skipping test");
+      return;
+    }
+
+    // Step 1: Set org to BLOCKED state
+    await prisma.organization.update({
+      where: { id: testOrgId },
+      data: {
+        billingCycleUsageState: "BLOCKED",
+        billingCycleLastUsage: 250_000,
+      },
+    });
+
+    // Step 2: Add API key to cache with isIngestionSuspended = true
+    const fastHashedKey = createShaHash(testApiKeySecret, SALT);
+
+    await prisma.apiKey.update({
+      where: { id: testApiKeyId },
+      data: { fastHashedSecretKey: fastHashedKey },
+    });
+
+    const cachedApiKey = {
+      id: testApiKeyId,
+      publicKey: testApiKeyPublic,
+      hashedSecretKey: await hashSecretKey(testApiKeySecret),
+      fastHashedSecretKey: fastHashedKey,
+      displaySecretKey: getDisplaySecretKey(testApiKeySecret),
+      note: "Test key",
+      createdAt: new Date().toISOString(),
+      lastUsedAt: null,
+      expiresAt: null,
+      projectId: testProjectId,
+      orgId: testOrgId,
+      plan: "cloud:hobby",
+      scope: "PROJECT",
+      rateLimitOverrides: null,
+      isIngestionSuspended: true, // Blocked
+    };
+
+    await redis.set(
+      `api-key:${fastHashedKey}`,
+      JSON.stringify(cachedApiKey),
+      "EX",
+      3600,
+    );
+
+    // Verify key is in cache
+    const cachedBefore = await redis.get(`api-key:${fastHashedKey}`);
+    expect(cachedBefore).not.toBeNull();
+
+    // Step 3: Simulate org moving to paid plan (usage still high but now allowed)
+    await prisma.organization.update({
+      where: { id: testOrgId },
+      data: {
+        cloudConfig: {
+          stripe: {
+            customerId: "cus_test",
+            activeSubscriptionId: "sub_test",
+            activeProductId: "prod_test",
+          },
+        },
+      },
+    });
+
+    // Trigger threshold processing (paid plan = no blocking)
+    const org: ParsedOrganization = {
+      id: testOrgId,
+      name: "Test Org",
+      cloudConfig: {
+        stripe: {
+          customerId: "cus_test",
+          activeSubscriptionId: "sub_test",
+          activeProductId: "prod_test",
+          isLegacySubscription: false,
+        },
+      },
+      metadata: null,
+      billingCycleAnchor: new Date("2024-01-15T00:00:00Z"),
+      billingCycleLastUpdatedAt: new Date(),
+      billingCycleLastUsage: 250_000,
+      billingCycleUsageState: "BLOCKED", // Previously blocked
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+      updatedAt: new Date("2024-01-01T00:00:00Z"),
+    };
+
+    await processThresholds(org, 300_000); // Still high usage but paid plan
+
+    // Step 4: Verify cache was invalidated
+    const cachedAfter = await redis.get(`api-key:${fastHashedKey}`);
+    expect(cachedAfter).toBeNull();
+
+    // Step 5: Verify org state was updated to unblocked
+    const updatedOrg = await prisma.organization.findUnique({
+      where: { id: testOrgId },
+    });
+    expect(updatedOrg?.billingCycleUsageState).toBeNull();
+  });
+
+  it("should NOT invalidate cache when state does not change", async () => {
+    if (!redis) {
+      console.log("Redis not available, skipping test");
+      return;
+    }
+
+    // Step 1: Add API key to cache
+    const fastHashedKey = createShaHash(testApiKeySecret, SALT);
+
+    await prisma.apiKey.update({
+      where: { id: testApiKeyId },
+      data: { fastHashedSecretKey: fastHashedKey },
+    });
+
+    const cachedApiKey = {
+      id: testApiKeyId,
+      publicKey: testApiKeyPublic,
+      hashedSecretKey: await hashSecretKey(testApiKeySecret),
+      fastHashedSecretKey: fastHashedKey,
+      displaySecretKey: getDisplaySecretKey(testApiKeySecret),
+      note: "Test key",
+      createdAt: new Date().toISOString(),
+      lastUsedAt: null,
+      expiresAt: null,
+      projectId: testProjectId,
+      orgId: testOrgId,
+      plan: "cloud:hobby",
+      scope: "PROJECT",
+      rateLimitOverrides: null,
+      isIngestionSuspended: false,
+    };
+
+    await redis.set(
+      `api-key:${fastHashedKey}`,
+      JSON.stringify(cachedApiKey),
+      "EX",
+      3600,
+    );
+
+    // Verify key is in cache
+    const cachedBefore = await redis.get(`api-key:${fastHashedKey}`);
+    expect(cachedBefore).not.toBeNull();
+
+    // Step 2: Trigger threshold processing with usage that doesn't cross thresholds
+    const org: ParsedOrganization = {
+      id: testOrgId,
+      name: "Test Org",
+      cloudConfig: null,
+      metadata: null,
+      billingCycleAnchor: new Date("2024-01-15T00:00:00Z"),
+      billingCycleLastUpdatedAt: null,
+      billingCycleLastUsage: 30_000,
+      billingCycleUsageState: null,
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+      updatedAt: new Date("2024-01-01T00:00:00Z"),
+    };
+
+    await processThresholds(org, 40_000); // Still below thresholds
+
+    // Step 3: Verify cache was NOT invalidated (state didn't change)
+    const cachedAfter = await redis.get(`api-key:${fastHashedKey}`);
+    expect(cachedAfter).not.toBeNull();
+    expect(cachedAfter).toBe(cachedBefore);
+  });
+
+  it("should handle multiple API keys for same org", async () => {
+    if (!redis) {
+      console.log("Redis not available, skipping test");
+      return;
+    }
+
+    // Create second API key
+    const testApiKeyId2 = "test-api-key-cache-inv-2";
+    const testApiKeyPublic2 = "pk-lf-test-cache-inv-2";
+    const testApiKeySecret2 = "sk-lf-test-cache-inv-2";
+
+    await prisma.apiKey.create({
+      data: {
+        id: testApiKeyId2,
+        publicKey: testApiKeyPublic2,
+        hashedSecretKey: await hashSecretKey(testApiKeySecret2),
+        displaySecretKey: getDisplaySecretKey(testApiKeySecret2),
+        projectId: testProjectId,
+        note: "Test key 2",
+      },
+    });
+
+    // Add both keys to cache
+    const fastHashedKey1 = createShaHash(testApiKeySecret, SALT);
+    const fastHashedKey2 = createShaHash(testApiKeySecret2, SALT);
+
+    await prisma.apiKey.update({
+      where: { id: testApiKeyId },
+      data: { fastHashedSecretKey: fastHashedKey1 },
+    });
+
+    await prisma.apiKey.update({
+      where: { id: testApiKeyId2 },
+      data: { fastHashedSecretKey: fastHashedKey2 },
+    });
+
+    const cachedApiKey1 = {
+      id: testApiKeyId,
+      publicKey: testApiKeyPublic,
+      hashedSecretKey: await hashSecretKey(testApiKeySecret),
+      fastHashedSecretKey: fastHashedKey1,
+      displaySecretKey: getDisplaySecretKey(testApiKeySecret),
+      note: "Test key 1",
+      createdAt: new Date().toISOString(),
+      lastUsedAt: null,
+      expiresAt: null,
+      projectId: testProjectId,
+      orgId: testOrgId,
+      plan: "cloud:hobby",
+      scope: "PROJECT",
+      rateLimitOverrides: null,
+      isIngestionSuspended: false,
+    };
+
+    const cachedApiKey2 = {
+      id: testApiKeyId2,
+      publicKey: testApiKeyPublic2,
+      hashedSecretKey: await hashSecretKey(testApiKeySecret2),
+      fastHashedSecretKey: fastHashedKey2,
+      displaySecretKey: getDisplaySecretKey(testApiKeySecret2),
+      note: "Test key 2",
+      createdAt: new Date().toISOString(),
+      lastUsedAt: null,
+      expiresAt: null,
+      projectId: testProjectId,
+      orgId: testOrgId,
+      plan: "cloud:hobby",
+      scope: "PROJECT",
+      rateLimitOverrides: null,
+      isIngestionSuspended: false,
+    };
+
+    await redis.set(
+      `api-key:${fastHashedKey1}`,
+      JSON.stringify(cachedApiKey1),
+      "EX",
+      3600,
+    );
+
+    await redis.set(
+      `api-key:${fastHashedKey2}`,
+      JSON.stringify(cachedApiKey2),
+      "EX",
+      3600,
+    );
+
+    // Verify both keys are in cache
+    expect(await redis.get(`api-key:${fastHashedKey1}`)).not.toBeNull();
+    expect(await redis.get(`api-key:${fastHashedKey2}`)).not.toBeNull();
+
+    // Trigger blocking
+    const org: ParsedOrganization = {
+      id: testOrgId,
+      name: "Test Org",
+      cloudConfig: null,
+      metadata: null,
+      billingCycleAnchor: new Date("2024-01-15T00:00:00Z"),
+      billingCycleLastUpdatedAt: null,
+      billingCycleLastUsage: 150_000,
+      billingCycleUsageState: null,
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+      updatedAt: new Date("2024-01-01T00:00:00Z"),
+    };
+
+    await processThresholds(org, 200_000);
+
+    // Verify both keys were invalidated
+    expect(await redis.get(`api-key:${fastHashedKey1}`)).toBeNull();
+    expect(await redis.get(`api-key:${fastHashedKey2}`)).toBeNull();
+
+    // Clean up second key
+    await prisma.apiKey.delete({
+      where: { id: testApiKeyId2 },
+    });
+  });
+});


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enforces ingestion blocking based on `isIngestionSuspended` flag, adds API key invalidation logic, and updates tests and billing logic accordingly.
> 
>   - **Behavior**:
>     - Enforces ingestion blocking based on `isIngestionSuspended` flag in `apiAuth.ts`, `ingestion.ts`, `media/index.ts`, and `otel/v1/traces/index.ts`.
>     - Adds `isIngestionSuspended` boolean to `ApiKeyBaseSchema` in `types.ts`.
>     - Updates `processThresholds()` in `thresholdProcessing.ts` to handle cache invalidation when blocking state changes.
>   - **API Key Invalidation**:
>     - New `invalidateApiKeys.ts` file with functions `invalidate()`, `invalidateOrgApiKeys()`, and `invalidateProjectApiKeys()` for Redis cache.
>     - Refactors `ApiAuthService` in `apiAuth.ts` to use shared invalidation functions.
>   - **Tests**:
>     - Adds tests in `api-auth.servertest.ts`, `thresholdProcessing.test.ts`, and `usageThresholdCacheInvalidation.test.ts` to verify ingestion blocking and cache invalidation behavior.
>   - **Misc**:
>     - Updates `stripeWebhookHandler.ts` to invalidate API keys on subscription changes.
>     - Exports new functions in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6312dcae1dba47bf4ef1bb3d0fa16ddac607a175. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->