### PR TITLE
fix(trace-ui): make row label sticky for long cells

### DIFF
--- a/web/src/components/table/ValueCell.tsx
+++ b/web/src/components/table/ValueCell.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/src/components/ui/button";
 import { Copy, Check } from "lucide-react";
 
 const MAX_STRING_LENGTH_FOR_LINK_DETECTION = 1500;
-const MAX_CELL_DISPLAY_CHARS = 2000;
+export const MAX_CELL_DISPLAY_CHARS = 2000;
 const SMALL_ARRAY_THRESHOLD = 5;
 const ARRAY_PREVIEW_ITEMS = 3;
 const OBJECT_PREVIEW_KEYS = 2;

--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -350,7 +350,7 @@ function JsonPrettyTable({
         const availableTextWidth = `calc(100% - ${indentationWidth + buttonWidth + CELL_PADDING_X + MARGIN_LEFT_1}px)`;
 
         const valueLength = getValueStringLength(row.original.value);
-        const isLongValue = valueLength > MAX_CELL_DISPLAY_CHARS;
+        const isLongValue = valueLength > MAX_CELL_DISPLAY_CHARS / 3; // already long if we don't truncate
 
         const content = (
           <div className="flex items-start break-words">
@@ -391,9 +391,7 @@ function JsonPrettyTable({
         );
 
         return isLongValue ? (
-          <div className="sticky top-0 z-10 bg-card/95 py-1 backdrop-blur-sm">
-            {content}
-          </div>
+          <div className="sticky top-0 py-1">{content}</div>
         ) : (
           content
         );

--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -349,7 +349,10 @@ function JsonPrettyTable({
         const buttonWidth = row.original.hasChildren ? BUTTON_WIDTH : 0;
         const availableTextWidth = `calc(100% - ${indentationWidth + buttonWidth + CELL_PADDING_X + MARGIN_LEFT_1}px)`;
 
-        return (
+        const valueLength = getValueStringLength(row.original.value);
+        const isLongValue = valueLength > MAX_CELL_DISPLAY_CHARS;
+
+        const content = (
           <div className="flex items-start break-words">
             <div
               className="flex flex-shrink-0 items-center justify-end"
@@ -385,6 +388,14 @@ function JsonPrettyTable({
               {row.original.key}
             </span>
           </div>
+        );
+
+        return isLongValue ? (
+          <div className="sticky top-0 z-10 bg-card/95 py-1 backdrop-blur-sm">
+            {content}
+          </div>
+        ) : (
+          content
         );
       },
     },
@@ -562,7 +573,7 @@ function JsonPrettyTable({
               {row.getVisibleCells().map((cell) => (
                 <TableCell
                   key={cell.id}
-                  className="whitespace-normal px-2 py-1"
+                  className="whitespace-normal px-2 py-1 align-top"
                   style={{ width: `${cell.column.columnDef.size}%` }}
                 >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Make row labels sticky for long cells in `JsonPrettyTable` by checking content length and applying sticky styling.
> 
>   - **Behavior**:
>     - In `PrettyJsonView.tsx`, `JsonPrettyTable` now makes row labels sticky if the cell content is long (length > `MAX_CELL_DISPLAY_CHARS / 3`).
>     - Sticky behavior is applied by wrapping content in a `div` with `className="sticky top-0 py-1"`.
>   - **Constants**:
>     - Export `MAX_CELL_DISPLAY_CHARS` from `ValueCell.tsx` for use in `PrettyJsonView.tsx`.
>   - **Styling**:
>     - Add `align-top` class to `TableCell` in `PrettyJsonTable` to improve alignment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5b72a8e730c45c1a2429e87b43294d94c34e627b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->