### PR TITLE
fix: change tRPC error code for ClickHouse errors

### DIFF
--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -143,7 +143,7 @@ const withErrorHandling = t.middleware(async ({ ctx, next }) => {
       // Surface ClickHouse errors using an advice message
       // which is supposed to provide a bit of guidance to the user.
       res.error = new TRPCError({
-        code: "TIMEOUT",
+        code: "SERVICE_UNAVAILABLE",
         message: ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
       });
     } else {

--- a/web/src/utils/trpcErrorToast.tsx
+++ b/web/src/utils/trpcErrorToast.tsx
@@ -22,6 +22,7 @@ const errorTitleMap = {
   TOO_MANY_REQUESTS: "Too Many Requests",
   CLIENT_CLOSED_REQUEST: "Client Closed Request",
   INTERNAL_SERVER_ERROR: "Internal Server Error",
+  SERVICE_UNAVAILABLE: "Backend Service Overloaded",
 } as const;
 
 const getErrorTitleAndHttpCode = (error: TRPCClientError<any>) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change ClickHouse error code from `TIMEOUT` to `SERVICE_UNAVAILABLE` and update error message mapping in `trpc.ts` and `trpcErrorToast.tsx`.
> 
>   - **Behavior**:
>     - Change ClickHouse error code from `TIMEOUT` to `SERVICE_UNAVAILABLE` in `withErrorHandling` middleware in `trpc.ts`.
>     - Update `errorTitleMap` in `trpcErrorToast.tsx` to include `SERVICE_UNAVAILABLE` with message "Backend Service Overloaded".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fba305fcc067630ea967e30f98058e891566c69d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->