### PR TITLE
chore(billing): require credit card only on non-zero checkout sessions

### DIFF
--- a/web/src/ee/features/billing/server/stripeBillingService.ts
+++ b/web/src/ee/features/billing/server/stripeBillingService.ts
@@ -523,6 +523,7 @@ class BillingService {
       line_items: lineItems,
       client_reference_id: clientReferenceId,
       allow_promotion_codes: true,
+      payment_method_collection: "if_required",
       tax_id_collection: {
         enabled: true,
       },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `payment_method_collection: "if_required"` to `createCheckoutSession` in `stripeBillingService.ts` for non-zero checkout sessions.
> 
>   - **Behavior**:
>     - In `stripeBillingService.ts`, `createCheckoutSession` method now includes `payment_method_collection: "if_required"` to only require a credit card for non-zero checkout sessions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9ea435bb2763f084ac3123af995b1f32985519a3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->