### PR TITLE
fix(natural-language-filters): show only on traces table

### DIFF
--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -103,6 +103,7 @@ interface DataTableToolbarProps<TData, TValue> {
   };
   orderByState?: OrderByState;
   viewConfig?: TableViewConfig;
+  filterWithAI?: boolean;
   className?: string;
 }
 
@@ -127,6 +128,7 @@ export function DataTableToolbar<TData, TValue>({
   className,
   orderByState,
   viewConfig,
+  filterWithAI = false,
 }: DataTableToolbarProps<TData, TValue>) {
   const [searchString, setSearchString] = useState(
     searchConfig?.currentQuery ?? "",
@@ -278,6 +280,7 @@ export function DataTableToolbar<TData, TValue>({
             filterState={filterState}
             onChange={setFilterState}
             columnsWithCustomSelect={columnsWithCustomSelect}
+            filterWithAI={filterWithAI}
           />
         )}
 

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -1136,6 +1136,7 @@ export default function TracesTable({
       {!hideControls && (
         <DataTableToolbar
           columns={columns}
+          filterWithAI
           viewConfig={{
             tableName: TableViewPresetTableName.Traces,
             projectId,

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -64,6 +64,7 @@ export function PopoverFilterBuilder({
   onChange,
   columnsWithCustomSelect = [],
   variant = "default",
+  filterWithAI = false,
 }: {
   columns: ColumnDefinition[];
   filterState: FilterState;
@@ -72,6 +73,7 @@ export function PopoverFilterBuilder({
     | ((newState: FilterState) => void);
   columnsWithCustomSelect?: string[];
   variant?: "default" | "icon";
+  filterWithAI?: boolean;
 }) {
   const capture = usePostHogClientCapture();
   const [wipFilterState, _setWipFilterState] =
@@ -173,6 +175,7 @@ export function PopoverFilterBuilder({
             filterState={wipFilterState}
             onChange={setWipFilterState}
             columnsWithCustomSelect={columnsWithCustomSelect}
+            filterWithAI={filterWithAI}
           />
         </PopoverContent>
       </Popover>
@@ -234,6 +237,7 @@ export function InlineFilterBuilder({
   onChange,
   disabled,
   columnsWithCustomSelect,
+  filterWithAI = false,
 }: {
   columns: ColumnDefinition[];
   filterState: FilterState;
@@ -242,6 +246,7 @@ export function InlineFilterBuilder({
     | ((newState: FilterState) => void);
   disabled?: boolean;
   columnsWithCustomSelect?: string[];
+  filterWithAI?: boolean;
 }) {
   const [wipFilterState, _setWipFilterState] =
     useState<WipFilterState>(filterState);
@@ -267,6 +272,7 @@ export function InlineFilterBuilder({
         onChange={setWipFilterState}
         disabled={disabled}
         columnsWithCustomSelect={columnsWithCustomSelect}
+        filterWithAI={filterWithAI}
       />
     </div>
   );
@@ -286,12 +292,14 @@ function FilterBuilderForm({
   onChange,
   disabled,
   columnsWithCustomSelect = [],
+  filterWithAI = false,
 }: {
   columns: ColumnDefinition[];
   filterState: WipFilterState;
   onChange: Dispatch<SetStateAction<WipFilterState>>;
   disabled?: boolean;
   columnsWithCustomSelect?: string[];
+  filterWithAI?: boolean;
 }) {
   const { isLangfuseCloud } = useLangfuseCloudRegion();
   const [showAiFilter, setShowAiFilter] = useState(false);
@@ -366,7 +374,7 @@ function FilterBuilderForm({
   return (
     <>
       {/* AI Filter Section at the top */}
-      {!disabled && isLangfuseCloud && (
+      {!disabled && isLangfuseCloud && filterWithAI && (
         <div className="flex flex-col gap-2">
           <Button
             onClick={() => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds AI-based filtering to the traces table with a `filterWithAI` prop to conditionally render AI filter options.
> 
>   - **Behavior**:
>     - Adds `filterWithAI` boolean prop to `DataTableToolbar`, `PopoverFilterBuilder`, and `InlineFilterBuilder` to enable AI-based filtering.
>     - AI filter is shown only on the traces table when `filterWithAI` is true and `isLangfuseCloud` is true.
>   - **Components**:
>     - Updates `DataTableToolbar` in `data-table-toolbar.tsx` to pass `filterWithAI` to `PopoverFilterBuilder`.
>     - Updates `TracesTable` in `traces.tsx` to set `filterWithAI` to true.
>     - Updates `PopoverFilterBuilder` and `InlineFilterBuilder` in `filter-builder.tsx` to accept `filterWithAI` prop and conditionally render AI filter options.
>   - **Misc**:
>     - Adds AI filter button and logic to `FilterBuilderForm` in `filter-builder.tsx` to handle AI filter creation and errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2d1e6459d9ee6f25f08f76685dbe705e3b8716a2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->