### PR TITLE
fix: set postgres timezone to UTC across docker compose (dev and prod)

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -142,6 +142,8 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
+      TZ: UTC
+      PGTZ: UTC
     ports:
       - 5432:5432
     volumes:

--- a/docker-compose.dev-azure.yml
+++ b/docker-compose.dev-azure.yml
@@ -44,6 +44,8 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=postgres
+      - TZ=UTC
+      - PGTZ=UTC
     ports:
       - 5432:5432
     volumes:

--- a/docker-compose.dev-redis-cluster.yml
+++ b/docker-compose.dev-redis-cluster.yml
@@ -48,6 +48,8 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=postgres
+      - TZ=UTC
+      - PGTZ=UTC
     ports:
       - 127.0.0.1:5432:5432
     volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -56,6 +56,8 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=postgres
+      - TZ=UTC
+      - PGTZ=UTC
     ports:
       - 127.0.0.1:5432:5432
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,6 +153,8 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres # CHANGEME
       POSTGRES_DB: postgres
+      TZ: UTC
+      PGTZ: UTC
     ports:
       - 127.0.0.1:5432:5432
     volumes:


### PR DESCRIPTION
context, we had an issue where local devserver was not UTC which led to tz issues, wanted to fix it for local dev setup and then also added these changes for docker compose deployments, does this make sense?