### PR TITLE
fix(otel): missing cached input and reasoning tokens (AI SDK)

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1441,7 +1441,7 @@ export class OtelIngestionProcessor {
           return {
             input: 0,
             output: 0,
-          }
+          };
         }
 
         const usageDetails: Record<string, number | undefined> = {
@@ -1482,14 +1482,20 @@ export class OtelIngestionProcessor {
           )
         ) {
           if ("ai.usage.cachedInputTokens" in attributes) {
-            const cachedTokenValue = attributes["ai.usage.cachedInputTokens"] as string;
+            const cachedTokenValue = attributes[
+              "ai.usage.cachedInputTokens"
+            ] as string;
             const parsedTokenValue = JSON.parse(cachedTokenValue);
-            usageDetails["input_cached_tokens"] = parsedTokenValue.intValue ?? parseInt(parsedTokenValue);
+            usageDetails["input_cached_tokens"] =
+              parsedTokenValue.intValue ?? parseInt(parsedTokenValue);
           }
           if ("ai.usage.reasoningTokens" in attributes) {
-            const reasoningTokenValue = attributes["ai.usage.reasoningTokens"] as string;
+            const reasoningTokenValue = attributes[
+              "ai.usage.reasoningTokens"
+            ] as string;
             const parsedTokenValue = JSON.parse(reasoningTokenValue);
-            usageDetails["output_reasoning_tokens"] = parsedTokenValue.intValue ?? parseInt(parsedTokenValue);
+            usageDetails["output_reasoning_tokens"] =
+              parsedTokenValue.intValue ?? parseInt(parsedTokenValue);
           }
         } else if (providerMetadata) {
           // Fall back to providerMetadata


### PR DESCRIPTION
## What does this PR do?

Fixes missing cached input and reasoning tokens. Before the usage/cost breakdowns didn't have these tokens. This was unique to the AI SDK.

The mappings for `ai.usage.cachedInputTokens` and `ai.usage.reasoningTokens` weren't quite right. Also, to prevent multiple observations from counting the same tokens, I'm returning `{ input: 0, output: 0 }` if there's no `gen_ai.usage.*` attributes.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #9482 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
<img width="1523" height="474" alt="image" src="https://github.com/user-attachments/assets/014e7c40-a670-4bec-b3ce-93980361c1a4" />


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't checked if my PR needs changes to the documentation
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes missing cached input and reasoning tokens in AI SDK by updating `OtelIngestionProcessor` to handle `gen_ai.usage.*` attributes correctly.
> 
>   - **Behavior**:
>     - Fixes missing cached input and reasoning tokens in AI SDK usage/cost breakdowns in `OtelIngestionProcessor`.
>     - Returns `{ input: 0, output: 0 }` if no `gen_ai.usage.*` attributes are present to prevent duplicate token counts.
>   - **Functions**:
>     - Updates `extractUsageDetails()` in `OtelIngestionProcessor.ts` to correctly parse `ai.usage.cachedInputTokens` and `ai.usage.reasoningTokens`.
>     - Adds check for `gen_ai.usage.*` attributes in `extractUsageDetails()` to determine token extraction behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 99f34ebc88fe513888587e1c47b5f3e902600322. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->