### PR TITLE
feat(billing): add self-service enterprise plan

### DIFF
--- a/web/src/ee/features/billing/components/BillingSwitchPlanDialog.tsx
+++ b/web/src/ee/features/billing/components/BillingSwitchPlanDialog.tsx
@@ -81,7 +81,7 @@ export const BillingSwitchPlanDialog = ({
           </Button>
         </DialogHeader>
         <DialogBody>
-          <div className="mb-3 grid grid-cols-1 gap-3 md:grid-cols-3">
+          <div className="mb-3 grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
             {stripeProducts
               .filter((product) => Boolean(product.checkout))
               .map((product) => {

--- a/web/src/ee/features/billing/utils/stripeCatalogue.ts
+++ b/web/src/ee/features/billing/utils/stripeCatalogue.ts
@@ -85,13 +85,14 @@ export const stripeProducts: StripeProduct[] = [
   },
   {
     stripeProductId: isTestEnvironment
-      ? "price_1SDhpLAtiRUeGUNNctFWjEQf" // sandbox
+      ? "prod_STnXok7GSSDmyF" // sandbox
       : "prod_STnXok7GSSDmyF", // live
     mappedPlan: "cloud:enterprise",
     orderKey: 2499,
     checkout: {
       title: "Enterprise",
-      description: "For large scale teams. Enterprise-grade support and security.",
+      description:
+        "For large scale teams. Enterprise-grade support and security.",
       price: "$2499 / month",
       usagePrice: "$8-6/100k units (100k included, graduated pricing)",
       mainFeatures: [

--- a/web/src/ee/features/billing/utils/stripeCatalogue.ts
+++ b/web/src/ee/features/billing/utils/stripeCatalogue.ts
@@ -85,10 +85,25 @@ export const stripeProducts: StripeProduct[] = [
   },
   {
     stripeProductId: isTestEnvironment
-      ? "prod_STnXok7GSSDmyF" // sandbox
+      ? "price_1SDhpLAtiRUeGUNNctFWjEQf" // sandbox
       : "prod_STnXok7GSSDmyF", // live
     mappedPlan: "cloud:enterprise",
-    checkout: null,
+    orderKey: 2499,
+    checkout: {
+      title: "Enterprise",
+      description: "For large scale teams. Enterprise-grade support and security.",
+      price: "$2499 / month",
+      usagePrice: "$8-6/100k units (100k included, graduated pricing)",
+      mainFeatures: [
+        "Everything in Pro + Teams",
+        "Audit Logs",
+        "SCIM API",
+        "Custom rate limits",
+        "Uptime SLA",
+        "Support SLA",
+        "Dedicated support engineer",
+      ],
+    },
   },
 ];
 


### PR DESCRIPTION
# What's New?

- added new enterprise plan to self-checkout
- tested billing page

-> Note: Updated Enterprise Plan Product in Stripe Dashbaord with matching new default price.

<img width="1807" height="1280" alt="CleanShot 2025-10-02 at 11 56 46" src="https://github.com/user-attachments/assets/aaa6006b-55f4-4d83-b463-c30408b19258" />


## What does this PR do?

This PR implements the self-serveable Enterprise plan in Stripe, making it available for in-product checkout. It addresses Linear issue GTM-1435 by:

*   Adding the `checkout` configuration to the `cloud:enterprise` plan in `stripeCatalogue.ts`, including the specified test product ID (`price_1SDhpLAtiRUeGUNNctFWjEQf`), `orderKey: 2499`, and detailed checkout information.
*   Updating the `BillingSwitchPlanDialog.tsx` to use a responsive grid layout (`md:grid-cols-2 lg:grid-cols-4`) to properly display all four pricing plans (Core, Pro, Team, Enterprise).

This change ensures that the Enterprise plan is correctly integrated with existing billing workflows, including upgrade/downgrade logic, and is visible and selectable in the UI.

Fixes #GTM-1435

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [x] I haven't commented my code, particularly in hard-to-understand areas
- [x] I haven't checked if my PR needs changes to the documentation
- [ ] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [x] I haven't added tests that prove my fix is effective or that my feature works
- [x] I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [GTM-1435](https://linear.app/langfuse/issue/GTM-1435/adopt-enterprise-contract-in-stripe-and-make-it-self-serveable)

<a href="https://cursor.com/background-agent?bcId=bc-b8a08a38-dcdf-48bc-9fe8-151cd3ee5155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b8a08a38-dcdf-48bc-9fe8-151cd3ee5155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds self-service Enterprise plan to billing system, updating UI and Stripe configuration for in-product checkout.
> 
>   - **Behavior**:
>     - Adds self-service Enterprise plan to `stripeCatalogue.ts` with `orderKey: 2499` and detailed checkout info.
>     - Updates `BillingSwitchPlanDialog.tsx` to display four pricing plans using a responsive grid layout.
>   - **UI**:
>     - `BillingSwitchPlanDialog.tsx` now supports displaying the Enterprise plan alongside Core, Pro, and Team plans.
>   - **Stripe Integration**:
>     - Enterprise plan integrated into existing billing workflows, including upgrade/downgrade logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9978ee5d14640b88d8f0a80e4799466f797850bb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->