### PR TITLE
style(io-table-cell): support content expand on hover

### DIFF
--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -235,13 +235,11 @@ export function TableViewPresetsDrawer({
   };
 
   const onSubmit = (id?: string) => (data: { name: string }) => {
-    console.log("submitting");
     if (id) {
       handleUpdateViewName({ id, name: data.name });
       setIsEditPopoverOpen(false);
       setDropdownId(null);
     } else {
-      console.log("Creating view");
       handleCreateView({ name: data.name });
     }
   };

--- a/web/src/components/ui/IOTableCell.tsx
+++ b/web/src/components/ui/IOTableCell.tsx
@@ -6,22 +6,21 @@ import {
 } from "@/src/components/ui/CodeJsonViewer";
 import { cn } from "@/src/utils/tailwind";
 import { memo } from "react";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/src/components/ui/hover-card";
 
-export const IOTableCell = ({
+const IOTableCellContent = ({
   data,
-  isLoading = false,
+  singleLine,
   className,
-  singleLine = false,
 }: {
   data: unknown;
-  isLoading?: boolean;
+  singleLine: boolean;
   className?: string;
-  singleLine?: boolean;
 }) => {
-  if (isLoading) {
-    return <JsonSkeleton className="h-full w-full overflow-hidden px-2 py-1" />;
-  }
-
   const stringifiedJson =
     data !== null && data !== undefined ? stringifyJsonNode(data) : undefined;
 
@@ -29,44 +28,94 @@ export const IOTableCell = ({
   const shouldTruncate =
     stringifiedJson && stringifiedJson.length > IO_TABLE_CHAR_LIMIT;
 
-  return (
-    <>
-      {singleLine ? (
-        <div
-          className={cn(
-            "ph-no-capture h-full w-full self-stretch overflow-hidden overflow-y-auto truncate rounded-sm border px-2 py-0.5",
-            className,
-          )}
-        >
-          {stringifiedJson}
-        </div>
-      ) : shouldTruncate ? (
-        <div className="ph-no-capture grid h-full grid-cols-1">
-          <JSONView
-            json={
-              stringifiedJson.slice(0, IO_TABLE_CHAR_LIMIT) +
-              `...[truncated ${stringifiedJson.length - IO_TABLE_CHAR_LIMIT} characters]`
-            }
-            className={cn("h-full w-full self-stretch rounded-sm", className)}
-            codeClassName="py-1 px-2 min-h-0 h-full overflow-y-auto"
-            collapseStringsAfterLength={null} // in table, show full strings as row height is fixed
-          />
-          <div className="text-xs text-muted-foreground">
-            Content was truncated.
-          </div>
-        </div>
-      ) : (
-        <JSONView
-          json={data}
-          className={cn(
-            "ph-no-capture h-full w-full self-stretch rounded-sm",
-            className,
-          )}
-          codeClassName="py-1 px-2 min-h-0 h-full overflow-y-auto"
-          collapseStringsAfterLength={null} // in table, show full strings as row height is fixed
-        />
+  return singleLine ? (
+    <div
+      className={cn(
+        "ph-no-capture h-full w-full self-stretch overflow-hidden overflow-y-auto truncate rounded-sm border px-2 py-0.5",
+        className,
       )}
-    </>
+    >
+      {stringifiedJson}
+    </div>
+  ) : shouldTruncate ? (
+    <div className="ph-no-capture grid h-full grid-cols-1">
+      <JSONView
+        json={
+          stringifiedJson.slice(0, IO_TABLE_CHAR_LIMIT) +
+          `...[truncated ${stringifiedJson.length - IO_TABLE_CHAR_LIMIT} characters]`
+        }
+        className={cn("h-full w-full self-stretch rounded-sm", className)}
+        codeClassName="py-1 px-2 min-h-0 h-full overflow-y-auto"
+        collapseStringsAfterLength={null} // in table, show full strings as row height is fixed
+      />
+      <div className="text-xs text-muted-foreground">
+        Content was truncated.
+      </div>
+    </div>
+  ) : (
+    <JSONView
+      json={data}
+      className={cn(
+        "ph-no-capture h-full w-full self-stretch rounded-sm",
+        className,
+      )}
+      codeClassName="py-1 px-2 min-h-0 h-full overflow-y-auto"
+      collapseStringsAfterLength={null} // in table, show full strings as row height is fixed
+    />
   );
 };
+
+export const IOTableCell = ({
+  data,
+  isLoading = false,
+  className,
+  singleLine = false,
+  enableExpandOnHover = false,
+}: {
+  data: unknown;
+  isLoading?: boolean;
+  className?: string;
+  singleLine?: boolean;
+  enableExpandOnHover?: boolean;
+}) => {
+  if (isLoading) {
+    return <JsonSkeleton className="h-full w-full overflow-hidden px-2 py-1" />;
+  }
+
+  if (!enableExpandOnHover) {
+    return (
+      <IOTableCellContent
+        data={data}
+        singleLine={singleLine}
+        className={className}
+      />
+    );
+  }
+
+  return (
+    <HoverCard openDelay={300} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <div className="group/io-cell relative h-full w-full">
+          <IOTableCellContent
+            data={data}
+            singleLine={singleLine}
+            className={className}
+          />
+        </div>
+      </HoverCardTrigger>
+      <HoverCardContent
+        className="max-h-[40vh] w-[400px] overflow-y-auto"
+        side="top"
+        align="start"
+      >
+        <JSONView
+          json={data}
+          className="w-full"
+          codeClassName="p-0 border-none"
+        />
+      </HoverCardContent>
+    </HoverCard>
+  );
+};
+
 export const MemoizedIOTableCell = memo(IOTableCell);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add hover-to-expand functionality in `IOTableCell` and remove console logs from `data-table-view-presets-drawer.tsx`.
> 
>   - **Behavior**:
>     - Add hover-to-expand functionality in `IOTableCell` using `HoverCard`, allowing content to expand on hover.
>     - Removed console logs from `onSubmit` in `data-table-view-presets-drawer.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3a34f264400effc2dca09e17c539bf18c723f421. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->