### PR TITLE
fix(sentry): don't throw trpcclienterror in sentry

### DIFF
--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -10,6 +10,23 @@ Sentry.init({
   environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
   release: process.env.NEXT_PUBLIC_BUILD_ID,
 
+  beforeSend(event, hint) {
+    const error = hint.originalException;
+
+    // Filter out TRPCClientErrors, we track them in DataDog.
+    // The users see those via toast notifications -> see handleTrpcError in web/src/utils/api.ts
+    if (
+      error &&
+      typeof error === "object" &&
+      "name" in error &&
+      error.name === "TRPCClientError"
+    ) {
+      return null;
+    }
+
+    return event;
+  },
+
   // Replay may only be enabled for the client-side
   integrations: [
     Sentry.replayIntegration({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `beforeSend` function to filter out `TRPCClientError` from Sentry in `web/instrumentation-client.ts`.
> 
>   - **Behavior**:
>     - Adds `beforeSend` function in `web/instrumentation-client.ts` to filter out `TRPCClientError` from being sent to Sentry.
>     - `TRPCClientError` is tracked in DataDog and shown to users via toast notifications.
>   - **Misc**:
>     - No changes to other error handling or Sentry configurations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 31265b7edca098c5bc3eb349beaf884441867de2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->