### PR TITLE
chore: ingest otel events into new events table (dev)

### DIFF
--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -98,7 +98,7 @@ CREATE TABLE IF NOT EXISTS events
 
       level LowCardinality(String),
       status_message String, -- Threat '' and null the same for search
-      completion_start_time Nullable(DateTime64(3)),
+      completion_start_time Nullable(DateTime64(6)),
 
       -- Prompt
       prompt_id Nullable(String),

--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -152,8 +152,8 @@ CREATE TABLE IF NOT EXISTS events
       blob_storage_file_path String,
       event_raw String,
       event_bytes UInt64,
-      created_at DateTime64(3) DEFAULT now(),
-      updated_at DateTime64(3) DEFAULT now(),
+      created_at DateTime64(6) DEFAULT now(),
+      updated_at DateTime64(6) DEFAULT now(),
       event_ts DateTime64(6),
       is_deleted UInt8,
 

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -183,8 +183,7 @@ export class OtelIngestionProcessor {
           return [];
         }
 
-        // Process all events normally first
-        const allEvents = resourceSpans
+        return resourceSpans
           .filter((r) => Boolean(r))
           .flatMap((resourceSpan) => {
             const resourceAttributes =
@@ -345,8 +344,6 @@ export class OtelIngestionProcessor {
 
             return events;
           });
-
-        return allEvents;
       } catch (error) {
         logger.error("Error processing OTEL spans to events:", error);
         traceException(error, span);

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -305,7 +305,7 @@ export class OtelIngestionProcessor {
                     spanAttributes,
                     scopeSpan?.scope?.name ?? "",
                   ),
-                  model: this.extractModelName(spanAttributes),
+                  modelName: this.extractModelName(spanAttributes),
                   completionStartTime: this.extractCompletionStartTime(
                     spanAttributes,
                     startTimeISO,

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -192,7 +192,7 @@ export class OtelIngestionProcessor {
             const events: any[] = [];
 
             for (const scopeSpan of resourceSpan?.scopeSpans ?? []) {
-              // const scopeAttributes = this.extractScopeAttributes(scopeSpan);
+              const scopeAttributes = this.extractScopeAttributes(scopeSpan);
               for (const span of scopeSpan?.spans ?? []) {
                 const spanAttributes = this.extractSpanAttributes(span);
                 const traceId = this.parseId(span.traceId);
@@ -209,6 +209,25 @@ export class OtelIngestionProcessor {
                   OtelIngestionProcessor.convertNanoTimestampToISO(
                     span.endTimeUnixNano,
                   );
+
+                // Extract metadata from different sources
+                const spanMetadata = this.extractMetadata(
+                  spanAttributes,
+                  "observation",
+                );
+                const traceMetadata = this.extractMetadata(
+                  spanAttributes,
+                  "trace",
+                );
+
+                // Construct metadata object with the specified structure
+                const metadata = {
+                  attributes: spanAttributes,
+                  resourceAttributes: resourceAttributes,
+                  scopeAttributes: scopeAttributes,
+                  ...spanMetadata,
+                  ...traceMetadata,
+                };
 
                 events.push({
                   projectId: this.projectId,
@@ -286,6 +305,7 @@ export class OtelIngestionProcessor {
                   }),
 
                   // Metadata
+                  metadata,
 
                   // Source data
                   eventRaw: JSON.stringify(span),

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -222,7 +222,7 @@ export class OtelIngestionProcessor {
 
                 // Construct metadata object with the specified structure
                 const metadata = {
-                  attributes: spanAttributes,
+                  // attributes: spanAttributes,
                   resourceAttributes: resourceAttributes,
                   scopeAttributes: scopeAttributes,
                   ...spanMetadata,
@@ -309,8 +309,7 @@ export class OtelIngestionProcessor {
 
                   // Source data
                   eventRaw: JSON.stringify(span),
-                  // TODO: Review size estimates and check whether this is performant
-                  eventBytes: JSON.stringify(span).length,
+                  eventBytes: Buffer.byteLength(JSON.stringify(span), "utf8"),
                 });
               }
             }

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -229,6 +229,25 @@ export class OtelIngestionProcessor {
                   ...traceMetadata,
                 };
 
+                // Extract instrumentation metadata
+                const serviceName = resourceAttributes?.["service.name"] as
+                  | string
+                  | undefined;
+                const serviceVersion = resourceAttributes?.[
+                  "service.version"
+                ] as string | undefined;
+                const telemetrySdkLanguage = resourceAttributes?.[
+                  "telemetry.sdk.language"
+                ] as string | undefined;
+                const telemetrySdkName = resourceAttributes?.[
+                  "telemetry.sdk.name"
+                ] as string | undefined;
+                const telemetrySdkVersion = resourceAttributes?.[
+                  "telemetry.sdk.version"
+                ] as string | undefined;
+                const scopeName = scopeSpan?.scope?.name;
+                const scopeVersion = scopeSpan?.scope?.version;
+
                 events.push({
                   projectId: this.projectId,
                   traceId,
@@ -306,6 +325,16 @@ export class OtelIngestionProcessor {
 
                   // Metadata
                   metadata,
+
+                  // Instrumentation metadata
+                  source: "otel",
+                  serviceName,
+                  serviceVersion,
+                  scopeName,
+                  scopeVersion,
+                  telemetrySdkLanguage,
+                  telemetrySdkName,
+                  telemetrySdkVersion,
 
                   // Source data
                   eventRaw: JSON.stringify(span),

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -269,6 +269,10 @@ export class OtelIngestionProcessor {
                     scopeSpan?.scope?.name ?? "",
                   ),
                   model: this.extractModelName(spanAttributes),
+                  completionStartTime: this.extractCompletionStartTime(
+                    spanAttributes,
+                    startTimeISO,
+                  ),
 
                   // TODO: Usage details
 

--- a/packages/shared/src/server/repositories/definitions.ts
+++ b/packages/shared/src/server/repositories/definitions.ts
@@ -507,3 +507,94 @@ export const convertPostgresScoreToInsert = (
     is_deleted: 0,
   };
 };
+
+export const eventRecordBaseSchema = z.object({
+  // Identifiers
+  org_id: z.string().nullish(),
+  project_id: z.string(),
+  trace_id: z.string(),
+  span_id: z.string(),
+  // We mainly use the id for compatibility with old events that always had a `id` column.
+  id: z.string(), // same as span_id. Needs to be set manually.
+  parent_span_id: z.string().nullish(),
+
+  // Core properties
+  name: z.string(),
+  type: z.string(),
+  environment: z.string().default("default"),
+  version: z.string().nullish(),
+
+  user_id: z.string().nullish(),
+  session_id: z.string().nullish(),
+
+  level: z.string(),
+  status_message: z.string().nullish(),
+
+  // Prompt
+  prompt_id: z.string().nullish(),
+  prompt_name: z.string().nullish(),
+  prompt_version: z.string().nullish(),
+
+  // Model
+  model_id: z.string().nullish(),
+  provided_model_name: z.string().nullish(),
+  model_parameters: z.string().nullish(),
+
+  // Usage & Cost
+  provided_usage_details: UsageCostSchema,
+  usage_details: UsageCostSchema,
+  provided_cost_details: UsageCostSchema,
+  cost_details: UsageCostSchema,
+  total_cost: z.number().nullish(),
+
+  // I/O
+  input: z.string().nullish(),
+  output: z.string().nullish(),
+
+  // Metadata - multiple approaches supported
+  metadata: z.record(z.string(), z.string()),
+  metadata_names: z.array(z.string()).default([]),
+  metadata_values: z.array(z.any()).default([]),
+  metadata_string_names: z.array(z.string()).default([]),
+  metadata_string_values: z.array(z.string()).default([]),
+  metadata_number_names: z.array(z.string()).default([]),
+  metadata_number_values: z.array(z.number()).default([]),
+  metadata_bool_names: z.array(z.string()).default([]),
+  metadata_bool_values: z.array(z.number()).default([]),
+
+  // Source metadata (Instrumentation)
+  source: z.string(),
+  service_name: z.string().nullish(),
+  service_version: z.string().nullish(),
+  scope_name: z.string().nullish(),
+  scope_version: z.string().nullish(),
+  telemetry_sdk_language: z.string().nullish(),
+  telemetry_sdk_name: z.string().nullish(),
+  telemetry_sdk_version: z.string().nullish(),
+
+  // Generic props
+  blob_storage_file_path: z.string(),
+  event_raw: z.string(),
+  event_bytes: z.number(),
+  is_deleted: z.number(),
+});
+
+export const eventRecordReadSchema = eventRecordBaseSchema.extend({
+  start_time: clickhouseStringDateSchema,
+  end_time: clickhouseStringDateSchema.nullish(),
+  completion_start_time: clickhouseStringDateSchema.nullish(),
+  created_at: clickhouseStringDateSchema,
+  updated_at: clickhouseStringDateSchema,
+  event_ts: clickhouseStringDateSchema,
+});
+export type EventRecordReadType = z.infer<typeof eventRecordReadSchema>;
+
+export const eventRecordInsertSchema = eventRecordBaseSchema.extend({
+  start_time: z.number(),
+  end_time: z.number().nullish(),
+  completion_start_time: z.number().nullish(),
+  created_at: z.number(),
+  updated_at: z.number(),
+  event_ts: z.number(),
+});
+export type EventRecordInsertType = z.infer<typeof eventRecordInsertSchema>;

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -271,7 +271,11 @@ const EnvSchema = z.object({
     .positive()
     .default(120_000), // 2 minutes
 
+  // Deprecated. Do not use!
   LANGFUSE_EXPERIMENT_RETURN_NEW_RESULT: z
+    .enum(["true", "false"])
+    .default("false"),
+  LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE: z
     .enum(["true", "false"])
     .default("false"),
 

--- a/worker/src/queues/otelIngestionQueue.ts
+++ b/worker/src/queues/otelIngestionQueue.ts
@@ -143,8 +143,9 @@ export const otelIngestionQueueProcessor: Processor = async (
     if (env.LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE === "true") {
       try {
         const events = processor.processToEvent(parsedSpans);
-        console.log(events);
-        await Promise.all(events.map((e) => ingestionService.writeEvent(e)));
+        await Promise.all(
+          events.map((e) => ingestionService.writeEvent(e, fileKey)),
+        );
       } catch (e) {
         traceException(e); // Mark span as errored
         logger.warn(`Failed to process events for ${projectId}: ${e}`, e);

--- a/worker/src/queues/otelIngestionQueue.ts
+++ b/worker/src/queues/otelIngestionQueue.ts
@@ -70,8 +70,9 @@ export const otelIngestionQueueProcessor: Processor = async (
       projectId,
       publicKey,
     });
+    const parsedSpans = JSON.parse(resourceSpans);
     const events: IngestionEventType[] =
-      await processor.processToIngestionEvents(JSON.parse(resourceSpans));
+      await processor.processToIngestionEvents(parsedSpans);
     // Here, we split the events into observations and non-observations.
     // Observations go into the IngestionService directly whereas the non-observations make another run through the processEventBatch method.
     const traces = events.filter(
@@ -136,6 +137,20 @@ export const otelIngestionQueueProcessor: Processor = async (
         ),
       ].flat(),
     );
+
+    // If inserts into the events table are enabled, we run the dedicated processing for the otel
+    // spans and move them into the dedicated IngestionService processor.
+    if (env.LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE === "true") {
+      try {
+        const events = processor.processToEvent(parsedSpans);
+        console.log(events);
+        await Promise.all(events.map((e) => ingestionService.writeEvent(e)));
+      } catch (e) {
+        traceException(e); // Mark span as errored
+        logger.warn(`Failed to process events for ${projectId}: ${e}`, e);
+        // Fallthrough while setting is experimental
+      }
+    }
   } catch (e) {
     if (e instanceof ForbiddenError) {
       traceException(e);

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -11,6 +11,7 @@ import {
   TraceRecordInsertType,
   TraceNullRecordInsertType,
   DatasetRunItemRecordInsertType,
+  EventRecordInsertType,
 } from "@langfuse/shared/src/server";
 
 import { env } from "../../env";
@@ -44,6 +45,7 @@ export class ClickhouseWriter {
       [TableName.Observations]: [],
       [TableName.BlobStorageFileLog]: [],
       [TableName.DatasetRunItems]: [],
+      [TableName.Events]: [],
     };
 
     this.start();
@@ -111,6 +113,7 @@ export class ClickhouseWriter {
           this.flush(TableName.Observations, fullQueue),
           this.flush(TableName.BlobStorageFileLog, fullQueue),
           this.flush(TableName.DatasetRunItems, fullQueue),
+          this.flush(TableName.Events, fullQueue),
         ]).catch((err) => {
           logger.error("ClickhouseWriter.flushAll", err);
         });
@@ -495,6 +498,7 @@ export enum TableName {
   Observations = "observations", // eslint-disable-line no-unused-vars
   BlobStorageFileLog = "blob_storage_file_log", // eslint-disable-line no-unused-vars
   DatasetRunItems = "dataset_run_items_rmt", // eslint-disable-line no-unused-vars
+  Events = "events", // eslint-disable-line no-unused-vars
 }
 
 type RecordInsertType<T extends TableName> = T extends TableName.Scores
@@ -509,7 +513,9 @@ type RecordInsertType<T extends TableName> = T extends TableName.Scores
           ? BlobStorageFileLogInsertType
           : T extends TableName.DatasetRunItems
             ? DatasetRunItemRecordInsertType
-            : never;
+            : T extends TableName.Events
+              ? EventRecordInsertType
+              : never;
 
 type ClickhouseQueue = {
   [T in TableName]: ClickhouseWriterQueueItem<T>[];

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -98,8 +98,7 @@ export type EventInput = {
   promptVersion?: string;
 
   // Model
-  modelId?: string;
-  providedModelName?: string;
+  modelName?: string;
   modelParameters?: string;
 
   // Usage & Cost
@@ -317,7 +316,7 @@ export class IngestionService {
 
       // Model
       // model_id: eventData.modelId,
-      provided_model_name: eventData.model,
+      provided_model_name: eventData.modelName,
       model_parameters: eventData.modelParameters,
 
       // Usage & Cost

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -118,7 +118,7 @@ export type EventInput = {
   metadata: Record<string, unknown>;
 
   // Source/instrumentation metadata
-  source?: string;
+  source: string;
   serviceName?: string;
   serviceVersion?: string;
   scopeName?: string;
@@ -343,14 +343,14 @@ export class IngestionService {
       metadata_bool_values: metadataBoolValues,
 
       // Source/instrumentation metadata
-      // source: eventData.source ?? "otel",
-      // service_name: eventData.serviceName,
-      // service_version: eventData.serviceVersion,
-      // scope_name: eventData.scopeName,
-      // scope_version: eventData.scopeVersion,
-      // telemetry_sdk_language: eventData.telemetrySdkLanguage,
-      // telemetry_sdk_name: eventData.telemetrySdkName,
-      // telemetry_sdk_version: eventData.telemetrySdkVersion,
+      source: eventData.source,
+      service_name: eventData.serviceName,
+      service_version: eventData.serviceVersion,
+      scope_name: eventData.scopeName,
+      scope_version: eventData.scopeVersion,
+      telemetry_sdk_language: eventData.telemetrySdkLanguage,
+      telemetry_sdk_name: eventData.telemetrySdkName,
+      telemetry_sdk_version: eventData.telemetrySdkVersion,
 
       // Storage
       blob_storage_file_path: fileKey,

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -250,8 +250,12 @@ export class IngestionService {
    * events are immutable and written once.
    *
    * @param eventData - The event data to write
+   * @param fileKey - The file key where the raw event data is stored
    */
-  public async writeEvent(eventData: EventInput): Promise<void> {
+  public async writeEvent(
+    eventData: EventInput,
+    fileKey: string,
+  ): Promise<void> {
     logger.debug(
       `Writing event for project ${eventData.projectId} and span ${eventData.spanId}`,
     );
@@ -349,7 +353,7 @@ export class IngestionService {
       // telemetry_sdk_version: eventData.telemetrySdkVersion,
 
       // Storage
-      // blob_storage_file_path: eventData.blobStorageFilePath ?? "",
+      blob_storage_file_path: fileKey,
       event_raw: eventData.eventRaw ?? "",
       event_bytes: eventData.eventBytes ?? 0,
 

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -72,7 +72,7 @@ export type EventInput = {
   projectId: string;
   traceId: string;
   spanId: string;
-  startTime: number;
+  startTimeISO: string;
 
   // Optional identifiers
   orgId?: string;
@@ -83,8 +83,8 @@ export type EventInput = {
   type?: string;
   environment?: string;
   version?: string;
-  endTime?: number;
-  completionStartTime?: number;
+  endTimeISO: string;
+  completionStartTime?: string;
 
   // User/session
   userId?: string;
@@ -292,7 +292,9 @@ export class IngestionService {
       // Timestamps
       start_time: this.getNanosecondTimestamp(eventData.startTimeISO),
       end_time: this.getNanosecondTimestamp(eventData.endTimeISO),
-      // completion_start_time: eventData.completionStartTime,
+      completion_start_time: eventData.completionStartTime
+        ? this.getNanosecondTimestamp(eventData.completionStartTime)
+        : null,
 
       // Prompt
       // prompt_id: eventData.promptId,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Ingests OpenTelemetry events into a new ClickHouse `events` table with enhanced processing and schema support, controlled by an environment flag.
> 
>   - **Behavior**:
>     - Adds `processToEvent()` in `OtelIngestionProcessor.ts` to convert OTEL spans to event records.
>     - Updates `otelIngestionQueue.ts` to process OTEL spans and write events to ClickHouse if `LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE` is enabled.
>     - Modifies `dev-tables.sh` to create `events` table with `DateTime64(6)` precision for timestamps.
>   - **Models**:
>     - Adds `eventRecordBaseSchema`, `eventRecordReadSchema`, and `eventRecordInsertSchema` in `definitions.ts` for event records.
>     - Introduces `EventInput` type in `IngestionService/index.ts` for flexible event data handling.
>   - **Services**:
>     - Implements `writeEvent()` in `IngestionService/index.ts` to write events to ClickHouse.
>     - Updates `ClickhouseWriter/index.ts` to handle `events` table writes.
>   - **Environment**:
>     - Adds `LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE` flag in `env.ts` to toggle event table insertion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 308d8240143544d52d3f6211300cc5c6af6b7dd4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->