### PR TITLE
feat(model-prices): add gpt-5-pro

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -2076,5 +2076,43 @@
       "tokensPerMessage": 3
     },
     "tokenizer_id": "openai"
+  },
+  {
+    "id": "cmgg9zco3000004l258um9xk8",
+    "model_name": "gpt-5-pro",
+    "match_pattern": "(?i)^(gpt-5-pro)$",
+    "created_at": "2025-10-07T08:03:54.727Z",
+    "updated_at": "2025-10-07T08:03:54.727Z",
+    "prices": {
+      "input": 15e-6,
+      "output": 120e-6,
+      "output_reasoning_tokens": 120e-6,
+      "output_reasoning": 120e-6
+    },
+    "tokenizer_config": {
+      "tokensPerName": 1,
+      "tokenizerModel": "gpt-4",
+      "tokensPerMessage": 3
+    },
+    "tokenizer_id": "openai"
+  },
+  {
+    "id": "cmgga0vh9000104l22qe4fes4",
+    "model_name": "gpt-5-pro-2025-10-06",
+    "match_pattern": "(?i)^(gpt-5-pro-2025-10-06)$",
+    "created_at": "2025-10-07T08:03:54.727Z",
+    "updated_at": "2025-10-07T08:03:54.727Z",
+    "prices": {
+      "input": 15e-6,
+      "output": 120e-6,
+      "output_reasoning_tokens": 120e-6,
+      "output_reasoning": 120e-6
+    },
+    "tokenizer_config": {
+      "tokensPerName": 1,
+      "tokenizerModel": "gpt-4",
+      "tokensPerMessage": 3
+    },
+    "tokenizer_id": "openai"
   }
 ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `gpt-5-pro` and `gpt-5-pro-2025-10-06` models with pricing and tokenizer details to `default-model-prices.json`.
> 
>   - **Models**:
>     - Add `gpt-5-pro` and `gpt-5-pro-2025-10-06` to `default-model-prices.json`.
>   - **Pricing**:
>     - `gpt-5-pro` and `gpt-5-pro-2025-10-06` have input price of `15e-6` and output price of `120e-6`.
>     - Both models have `output_reasoning_tokens` and `output_reasoning` priced at `120e-6`.
>   - **Tokenizer**:
>     - Both models use `gpt-4` tokenizer with `tokensPerName` as `1` and `tokensPerMessage` as `3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7be881abd98eec9c33583c150b47f0b47fb6c8bf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->