### PR TITLE
chore: use simpler to install CH client + doc update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,12 +111,16 @@ Requirements
 - Node.js 24 as specified in the [.nvmrc](.nvmrc)
 - Pnpm v.9.5.0
 - Docker to run the database locally
+- Clickhouse client
 
 **Note:** You can also simply run Langfuse in a **GitHub Codespace** via the provided devcontainer. To do this, click on the green "Code" button in the top right corner of the repository and select "Open with Codespaces".
 
 **Steps**
 
-1. Install [golang-migrate](https://github.com/golang-migrate/migrate/tree/master/cmd/migrate#migrate-cli) as CLI
+1. Install development dependencies:
+	- [golang-migrate](https://github.com/golang-migrate/migrate/tree/master/cmd/migrate#migrate-cli) as CLI
+	- [clickhouse binary](https://clickhouse.com/docs/install) on macOS with brew: `brew install --cask clickhouse`
+
 2. Fork the repository and clone it locally
 
    ```bash

--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -54,9 +54,9 @@ else
     exit 1
 fi
 
-if ! command -v clickhouse-client &> /dev/null
+if ! command -v clickhouse &> /dev/null
 then
-	echo "Error: clickhouse-client could not be found. Please install ClickHouse client tools."
+	echo "Error: clickhouse binary could not be found. Please install ClickHouse client tools."
 	exit 1
 fi
 
@@ -65,7 +65,7 @@ echo "Creating development tables in ClickHouse..."
 # Execute the CREATE TABLE statements
 # Add your development tables here using CREATE TABLE IF NOT EXISTS
 
-clickhouse-client \
+clickhouse client \
   --host="${CLICKHOUSE_HOST}" \
   --port="${CLICKHOUSE_PORT}" \
   --user="${CLICKHOUSE_USER}" \
@@ -183,7 +183,7 @@ EOF
 
 echo "Populating development tables with sample data..."
 
-clickhouse-client \
+clickhouse client \
   --host="${CLICKHOUSE_HOST}" \
   --port="${CLICKHOUSE_PORT}" \
   --user="${CLICKHOUSE_USER}" \


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switch from `clickhouse-client` to `clickhouse` binary for ClickHouse operations and update documentation and scripts accordingly.
> 
>   - **Development Setup**:
>     - Updated `CONTRIBUTING.md` to recommend installing `clickhouse` binary instead of `clickhouse-client`.
>     - Added installation instructions for `clickhouse` binary using Homebrew on macOS.
>   - **Scripts**:
>     - Modified `dev-tables.sh` to use `clickhouse` binary instead of `clickhouse-client` for executing ClickHouse commands.
>     - Updated error messages in `dev-tables.sh` to reflect the change to `clickhouse` binary.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7a49d259cca9c6a85a9d52979aaf5c293546d53e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->