### PR TITLE
feat: process livekit semantic attributes in otel parsing

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1027,6 +1027,14 @@ export class OtelIngestionProcessor {
       return { input, output };
     }
 
+    // LiveKit
+    input = attributes["lk.input_text"];
+    output =
+      attributes["lk.function_tool.output"] || attributes["lk.response.text"];
+    if (input || output) {
+      return { input, output };
+    }
+
     // Logfire uses single `events` array for GenAI events
     const eventsArray = attributes["events"];
     if (typeof eventsArray === "string" || Array.isArray(eventsArray)) {

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -2129,6 +2129,42 @@ describe("OTel Resource Span Mapping", () => {
           entityAttributeValue: '{"foo": "bar"}',
         },
       ],
+      [
+        "should map lk.input_text to input",
+        {
+          entity: "observation",
+          otelAttributeKey: "lk.input_text",
+          otelAttributeValue: {
+            stringValue: "What is the weather today?",
+          },
+          entityAttributeKey: "input",
+          entityAttributeValue: "What is the weather today?",
+        },
+      ],
+      [
+        "should map lk.response.text to output",
+        {
+          entity: "observation",
+          otelAttributeKey: "lk.response.text",
+          otelAttributeValue: {
+            stringValue: "The weather is sunny with a high of 75°F.",
+          },
+          entityAttributeKey: "output",
+          entityAttributeValue: "The weather is sunny with a high of 75°F.",
+        },
+      ],
+      [
+        "should map lk.function_tool.output to output",
+        {
+          entity: "observation",
+          otelAttributeKey: "lk.function_tool.output",
+          otelAttributeValue: {
+            stringValue: '{"temperature": 75, "condition": "sunny"}',
+          },
+          entityAttributeKey: "output",
+          entityAttributeValue: '{"temperature": 75, "condition": "sunny"}',
+        },
+      ],
     ])(
       "Attributes: %s",
       async (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `OtelIngestionProcessor` to process LiveKit semantic attributes for input and output mapping in OpenTelemetry parsing.
> 
>   - **Behavior**:
>     - `OtelIngestionProcessor` in `OtelIngestionProcessor.ts` now processes LiveKit attributes `lk.input_text`, `lk.function_tool.output`, and `lk.response.text` to map them to `input` and `output`.
>   - **Tests**:
>     - Added test cases in `otelMapping.servertest.ts` to verify mapping of `lk.input_text` to `input` and `lk.response.text`/`lk.function_tool.output` to `output`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b8e3e7417e8369c8ba6ca1bc3ebec4b418201459. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->