### PR TITLE
chore: filter out http errors from sentry

### DIFF
--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -24,6 +24,16 @@ Sentry.init({
       return null;
     }
 
+    // Filter HTTP client errors from tRPC endpoints
+    // These are captured at the network level by httpClientIntegration but are already
+    // handled by tRPC's error handling system
+    if (
+      event.exception?.values?.[0]?.mechanism?.type === "http.client" &&
+      event.request?.url?.includes("/api/trpc/")
+    ) {
+      return null;
+    }
+
     return event;
   },
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Filters out HTTP client errors from tRPC endpoints in Sentry to reduce noise in logs.
> 
>   - **Behavior**:
>     - Filters out HTTP client errors from tRPC endpoints in Sentry in `beforeSend` function in `web/instrumentation-client.ts`.
>     - Specifically filters events with mechanism type `http.client` and URLs containing `/api/trpc/`.
>   - **Purpose**:
>     - Reduces noise in Sentry logs by excluding errors already handled by tRPC's error handling system.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1ec3a242d4a893c0a5395636c4d313b6b0b7a4a0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->