### PR TITLE
fix: empty trace names breaking filter options

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -830,6 +830,7 @@ export const getTracesGroupedByName = async (
         from traces t FINAL
         WHERE t.project_id = {projectId: String}
         AND t.name IS NOT NULL
+        AND t.name != ''
         ${timestampFilterRes?.query ? `AND ${timestampFilterRes.query}` : ""}
         GROUP BY name
         ORDER BY count(*) desc
@@ -860,6 +861,7 @@ export const getTracesGroupedByName = async (
         from ${traceAmt} t
         WHERE t.project_id = {projectId: String}
         AND t.name IS NOT NULL
+        AND t.name != ''
         GROUP BY name
         ORDER BY count(*) desc
         LIMIT 1000;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add condition to filter out empty trace names in `getTracesGroupedByName()` queries in `traces.ts`.
> 
>   - **Behavior**:
>     - Add condition `AND t.name != ''` to filter out empty trace names in `getTracesGroupedByName()` and `getTracesGroupedByName` new execution query in `traces.ts`.
>   - **Misc**:
>     - No changes to function signatures or additional logic, just SQL query modification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 12ac0b8bf578ff620125af7a64ec02c1cbf14a03. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->