### PR TITLE
fix: restore missing sessions view filters

### DIFF
--- a/packages/shared/src/server/repositories/trace-sessions.ts
+++ b/packages/shared/src/server/repositories/trace-sessions.ts
@@ -9,7 +9,9 @@ export const getPublicSessionsFilter = async (
   // Theoretically we should also filter the sessions by environment here. As this would return a huge list that's probably not feasible.
   // I.e. we only perform the environment check on the ClickHouse queries.
 
-  const sessionsBookmarkedFilter = filter?.find((f) => f.column === "⭐️");
+  const sessionsBookmarkedFilter = filter?.find(
+    (f) => f.column === "⭐️" || f.column === "bookmarked",
+  );
 
   let additionalBookmarkFilter: z.infer<typeof singleFilter>[] = [];
   if (sessionsBookmarkedFilter) {
@@ -65,7 +67,12 @@ export const getPublicSessionsFilter = async (
   }
 
   return filter
-    ? [...filter.filter((f) => f.column !== "⭐️"), ...additionalBookmarkFilter]
+    ? [
+        ...filter.filter(
+          (f) => f.column !== "⭐️" && f.column !== "bookmarked",
+        ),
+        ...additionalBookmarkFilter,
+      ]
     : [...additionalBookmarkFilter];
 };
 

--- a/packages/shared/src/tableDefinitions/sessionsView.ts
+++ b/packages/shared/src/tableDefinitions/sessionsView.ts
@@ -83,7 +83,7 @@ export const sessionsViewCols: ColumnDefinition[] = [
   },
   {
     name: "Trace Tags",
-    id: "tags",
+    id: "traceTags",
     type: "arrayOptions",
     internal: 't."tags"',
     options: [], // to be filled in at runtime
@@ -106,7 +106,7 @@ export const sessionsViewCols: ColumnDefinition[] = [
 
 export type SessionOptions = {
   userIds: Array<SingleValueOption>;
-  tags: Array<SingleValueOption>;
+  traceTags: Array<SingleValueOption>;
   scores_avg?: Array<string>;
   score_categories?: Array<MultiValueOption>;
 };
@@ -118,8 +118,8 @@ export function sessionsTableColsWithOptions(
     if (col.id === "userIds") {
       return formatColumnOptions(col, options?.userIds ?? []);
     }
-    if (col.id === "tags") {
-      return formatColumnOptions(col, options?.tags ?? []);
+    if (col.id === "traceTags") {
+      return formatColumnOptions(col, options?.traceTags ?? []);
     }
     if (col.id === "scores_avg") {
       return formatColumnOptions(col, options?.scores_avg ?? []);

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -202,7 +202,7 @@ export default function SessionsTable({
       bookmarked: ["Bookmarked", "Not bookmarked"],
       id: [],
       userIds: filterOptions.data?.userIds?.map((u) => u.value) || [],
-      tags: filterOptions.data?.tags?.map((t) => t.value) || [],
+      traceTags: filterOptions.data?.traceTags?.map((t) => t.value) || [],
       environment:
         environmentFilterOptions.data?.map((value) => value.environment) || [],
       sessionDuration: [],

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -200,6 +200,8 @@ export default function SessionsTable({
   const newFilterOptions = useMemo(
     () => ({
       bookmarked: ["Bookmarked", "Not bookmarked"],
+      id: [],
+      userIds: filterOptions.data?.userIds?.map((u) => u.value) || [],
       tags: filterOptions.data?.tags?.map((t) => t.value) || [],
       environment:
         environmentFilterOptions.data?.map((value) => value.environment) || [],

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -197,8 +197,19 @@ export default function SessionsTable({
     },
   );
 
-  const newFilterOptions = useMemo(
-    () => ({
+  const newFilterOptions = useMemo(() => {
+    const scoreCategories =
+      filterOptions.data?.score_categories?.reduce(
+        (acc, score) => {
+          acc[score.label] = score.values;
+          return acc;
+        },
+        {} as Record<string, string[]>,
+      ) || {};
+
+    const scoresNumeric = filterOptions.data?.scores_avg || [];
+
+    return {
       bookmarked: ["Bookmarked", "Not bookmarked"],
       id: [],
       userIds: filterOptions.data?.userIds?.map((u) => u.value) || [],
@@ -210,12 +221,14 @@ export default function SessionsTable({
       inputTokens: [],
       outputTokens: [],
       totalTokens: [],
+      usage: [],
       inputCost: [],
       outputCost: [],
       totalCost: [],
-    }),
-    [environmentFilterOptions.data, filterOptions.data],
-  );
+      "Scores (categorical)": scoreCategories,
+      "Scores (numeric)": scoresNumeric,
+    };
+  }, [environmentFilterOptions.data, filterOptions.data]);
 
   const queryFilter = useSidebarFilterState(
     sessionFilterConfig,

--- a/web/src/features/filters/config/sessions-config.ts
+++ b/web/src/features/filters/config/sessions-config.ts
@@ -14,7 +14,7 @@ const SESSION_COLUMN_TO_QUERY_KEY: ColumnToQueryKeyMap = {
   inputTokens: "inputTokens",
   outputTokens: "outputTokens",
   totalTokens: "totalTokens",
-  tags: "tags",
+  traceTags: "tags",
   environment: "env",
 };
 
@@ -45,7 +45,7 @@ export const sessionFilterConfig: FilterConfig = {
     },
     {
       type: "categorical" as const,
-      column: "tags",
+      column: "traceTags",
       label: "Trace Tags",
     },
     {

--- a/web/src/features/filters/config/sessions-config.ts
+++ b/web/src/features/filters/config/sessions-config.ts
@@ -14,8 +14,11 @@ const SESSION_COLUMN_TO_QUERY_KEY: ColumnToQueryKeyMap = {
   inputTokens: "inputTokens",
   outputTokens: "outputTokens",
   totalTokens: "totalTokens",
+  usage: "usage",
   traceTags: "tags",
   environment: "env",
+  "Scores (categorical)": "scoreCategories",
+  "Scores (numeric)": "scoresNumeric",
 };
 
 export const sessionFilterConfig: FilterConfig = {
@@ -114,6 +117,23 @@ export const sessionFilterConfig: FilterConfig = {
       min: 0,
       max: 100,
       unit: "$",
+    },
+    {
+      type: "numeric" as const,
+      column: "usage",
+      label: "Usage",
+      min: 0,
+      max: 1000000,
+    },
+    {
+      type: "keyValue" as const,
+      column: "Scores (categorical)",
+      label: "Categorical Scores",
+    },
+    {
+      type: "numericKeyValue" as const,
+      column: "Scores (numeric)",
+      label: "Numeric Scores",
     },
   ],
 };

--- a/web/src/features/filters/config/sessions-config.ts
+++ b/web/src/features/filters/config/sessions-config.ts
@@ -12,6 +12,8 @@ const SESSION_COLUMN_TO_QUERY_KEY: ColumnToQueryKeyMap = {
   inputTokens: "inputTokens",
   outputTokens: "outputTokens",
   totalTokens: "totalTokens",
+  tags: "tags",
+  environment: "env",
 };
 
 export const sessionFilterConfig: FilterConfig = {
@@ -24,6 +26,16 @@ export const sessionFilterConfig: FilterConfig = {
   defaultExpanded: ["bookmarked"],
 
   facets: [
+    {
+      type: "categorical" as const,
+      column: "environment",
+      label: "Environment",
+    },
+    {
+      type: "categorical" as const,
+      column: "tags",
+      label: "Trace Tags",
+    },
     {
       type: "boolean" as const,
       column: "bookmarked",

--- a/web/src/features/filters/config/sessions-config.ts
+++ b/web/src/features/filters/config/sessions-config.ts
@@ -4,6 +4,8 @@ import type { ColumnToQueryKeyMap } from "@/src/features/filters/lib/filter-quer
 
 const SESSION_COLUMN_TO_QUERY_KEY: ColumnToQueryKeyMap = {
   bookmarked: "bookmarked",
+  id: "id",
+  userIds: "userIds",
   sessionDuration: "duration",
   countTraces: "traces",
   inputCost: "inputCost",
@@ -30,6 +32,16 @@ export const sessionFilterConfig: FilterConfig = {
       type: "categorical" as const,
       column: "environment",
       label: "Environment",
+    },
+    {
+      type: "string" as const,
+      column: "id",
+      label: "ID",
+    },
+    {
+      type: "categorical" as const,
+      column: "userIds",
+      label: "User IDs",
     },
     {
       type: "categorical" as const,

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -367,7 +367,7 @@ export const sessionRouter = createTRPCRouter({
           userIds: userIds.map((row) => ({
             value: row.user,
           })),
-          tags: tags.map((row) => ({
+          traceTags: tags.map((row) => ({
             value: row.value,
           })),
           scores_avg: numericScoreNames.map((s) => s.name),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Restores missing session view filters, adds new filter options, and renames fields for consistency.
> 
>   - **Behavior**:
>     - Restores session view filters by updating `getPublicSessionsFilter` in `trace-sessions.ts` to handle both `"⭐️"` and `"bookmarked"` columns.
>     - Adds new filter options for `id`, `userIds`, `traceTags`, `environment`, `usage`, and scores in `sessions-config.ts`.
>   - **Renames**:
>     - Renames `tags` to `traceTags` in `sessionsView.ts` and `sessions.ts`.
>   - **Misc**:
>     - Removes unused environment filter logic in `sessions.tsx`.
>     - Updates `sessionFilterConfig` in `sessions-config.ts` to include new facets for filtering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for beed472b773a10988b279db2b14975bd55920bc3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->