### PR TITLE
fix(json-view): expand to up to 100 rows on root

### DIFF
--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -60,7 +60,11 @@ const MARGIN_LEFT_1 = 4;
 const CELL_PADDING_X = 8; // px-2
 
 // Constants for smart expansion logic
+// Used for nested objects to control smart expansion depth
 const DEFAULT_MAX_ROWS = 20;
+// Used for root-level objects where user has no parent to expand from. Therefore,
+// set higher to ensure objects like metadata with many keys are still displayed
+const DEFAULT_MAX_ROWS_IF_ROOT = 100;
 const DEEPEST_DEFAULT_EXPANSION_LEVEL = 10;
 
 const MAX_CELL_DISPLAY_CHARS = 2000;
@@ -670,7 +674,7 @@ export function PrettyJsonView(props: {
           const topLevelKeys = Object.keys(
             parsedJson as Record<string, unknown>,
           );
-          if (topLevelKeys.length > DEFAULT_MAX_ROWS) {
+          if (topLevelKeys.length > DEFAULT_MAX_ROWS_IF_ROOT) {
             // return empty array to skip expansion directly
             return [];
           }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase root-level JSON expansion limit to 100 rows in `PrettyJsonView`.
> 
>   - **Behavior**:
>     - Increase root-level JSON expansion limit from 20 to 100 rows in `PrettyJsonView`.
>     - Adjusts `DEFAULT_MAX_ROWS_IF_ROOT` constant to 100 in `PrettyJsonView.tsx`.
>   - **Logic**:
>     - Modify condition in `baseTableData` to use `DEFAULT_MAX_ROWS_IF_ROOT` for root-level objects.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 91cf816125c98df8c9043553e1a689a71a40c47e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->