### PR TITLE
fix: score filter UI issues

### DIFF
--- a/web/src/__tests__/filter-query-encoding-decoding.clienttest.ts
+++ b/web/src/__tests__/filter-query-encoding-decoding.clienttest.ts
@@ -14,6 +14,7 @@ const TEST_COLUMN_TO_QUERY_KEY = {
   length: "length",
   name: "name",
   ratings: "ratings",
+  scores: "scores",
 };
 
 const TEST_COLUMN_DEFS = [
@@ -25,6 +26,7 @@ const TEST_COLUMN_DEFS = [
   { id: "length", name: "length", type: "number" as const },
   { id: "name", name: "name", type: "string" as const },
   { id: "ratings", name: "ratings", type: "categoryOptions" as const },
+  { id: "scores", name: "scores", type: "numberObject" as const },
 ];
 
 type FilterQueryOptions = Record<
@@ -66,6 +68,7 @@ describe("Filter Query Encoding & Decoding", () => {
     length: [],
     name: [],
     ratings: [],
+    scores: [],
   };
 
   describe("Encoding", () => {
@@ -519,6 +522,28 @@ describe("Filter Query Encoding & Decoding", () => {
         "ratings.danger:high ratings.accuracy:excellent,good",
       );
     });
+
+    it("should encode numberObject and categoryOptions filters with spaces in keys by quoting", () => {
+      const filters: FilterState = [
+        {
+          column: "scores",
+          type: "numberObject",
+          operator: "<",
+          key: "Neural Validation",
+          value: 1,
+        },
+        {
+          column: "ratings",
+          type: "categoryOptions",
+          operator: "any of",
+          key: "Danger Level",
+          value: ["high"],
+        },
+      ];
+      expect(encodeFilters(filters, mockOptions)).toBe(
+        'scores."Neural Validation":<:1 ratings."Danger Level":high',
+      );
+    });
   });
 
   describe("Decoding", () => {
@@ -913,6 +938,28 @@ describe("Filter Query Encoding & Decoding", () => {
         },
       ]);
     });
+
+    it("should decode quoted keys with spaces in numberObject and categoryOptions filters", () => {
+      const query =
+        'scores."Neural Validation":<:1 ratings."Danger Level":high';
+      const decoded = decodeFilters(query, mockOptions);
+      expect(decoded).toEqual([
+        {
+          column: "scores",
+          type: "numberObject",
+          operator: "<",
+          key: "Neural Validation",
+          value: 1,
+        },
+        {
+          column: "ratings",
+          type: "categoryOptions",
+          operator: "any of",
+          key: "Danger Level",
+          value: ["high"],
+        },
+      ]);
+    });
   });
 
   describe("Round-trip consistency", () => {
@@ -1062,6 +1109,30 @@ describe("Filter Query Encoding & Decoding", () => {
       const deserialized = decodeFilters(serialized, mockOptions);
 
       expect(deserialized).toEqual(mixedFilters);
+    });
+
+    it("should maintain consistency for filters with quoted keys containing spaces", () => {
+      const filters: FilterState = [
+        {
+          column: "scores",
+          type: "numberObject",
+          operator: "<",
+          key: "Neural Validation",
+          value: 1,
+        },
+        {
+          column: "ratings",
+          type: "categoryOptions",
+          operator: "any of",
+          key: "Danger Level",
+          value: ["high"],
+        },
+      ];
+
+      const serialized = encodeFilters(filters, mockOptions);
+      const deserialized = decodeFilters(serialized, mockOptions);
+
+      expect(deserialized).toEqual(filters);
     });
   });
 });

--- a/web/src/components/table/key-value-filter-builder.tsx
+++ b/web/src/components/table/key-value-filter-builder.tsx
@@ -80,9 +80,14 @@ export function KeyValueFilterBuilder(props: KeyValueFilterBuilderProps) {
   // Track which popover is open (by index)
   const [openPopoverIndex, setOpenPopoverIndex] = useState<number | null>(null);
 
-  // Initialize from activeFilters (which only has complete filters)
+  // Sync with activeFilters, but preserve draft filters when user is editing
   useEffect(() => {
-    setLocalFilters(activeFilters.length > 0 ? activeFilters : []);
+    // Always sync when activeFilters has content (handles external updates like URL changes)
+    if (activeFilters.length > 0) {
+      setLocalFilters(activeFilters);
+    }
+    // When activeFilters is empty, keep existing localFilters to preserve drafts
+    // This allows users to temporarily clear values while editing without losing the filter row
   }, [activeFilters]);
 
   const handleFilterChange = (

--- a/web/src/features/filters/lib/filter-query-encoding.ts
+++ b/web/src/features/filters/lib/filter-query-encoding.ts
@@ -19,6 +19,7 @@ export const createShortKeyGetter =
 function splitQueryParts(query: string): string[] {
   const parts: string[] = [];
   let current = "";
+  let inQuotes = false;
   let i = 0;
 
   while (i < query.length) {
@@ -31,12 +32,16 @@ function splitQueryParts(query: string): string[] {
         i++;
         current += query[i];
       }
-    } else if (char === " " && current.trim()) {
-      // Unescaped space - end current part
+    } else if (char === '"') {
+      // Toggle quote state and include the quote
+      inQuotes = !inQuotes;
+      current += char;
+    } else if (char === " " && !inQuotes && current.trim()) {
+      // Unescaped space outside quotes - end current part
       parts.push(current);
       current = "";
-    } else if (char !== " ") {
-      // Regular character
+    } else if (char !== " " || inQuotes) {
+      // Regular character, or space inside quotes
       current += char;
     }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix score filter UI issues by enhancing filter query encoding/decoding to handle quoted keys with spaces and improving filter state management.
> 
>   - **Encoding/Decoding**:
>     - Add support for encoding and decoding `numberObject` and `categoryOptions` filters with spaces in keys by quoting in `filter-query-encoding-decoding.clienttest.ts` and `filter-query-encoding.ts`.
>     - Modify `splitQueryParts()` in `filter-query-encoding.ts` to handle spaces inside quotes.
>   - **UI Behavior**:
>     - Update `KeyValueFilterBuilder` in `key-value-filter-builder.tsx` to sync `localFilters` with `activeFilters` while preserving drafts when `activeFilters` is empty.
>   - **Tests**:
>     - Add tests for encoding/decoding filters with quoted keys and spaces in `filter-query-encoding-decoding.clienttest.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 247309fc98fcd0cb47fc31cb44ead0b6b469a3d2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->