### PR TITLE
feat(datasets): support DnD for CSV file uploads

### DIFF
--- a/web/src/features/datasets/components/UploadDatasetCsv.tsx
+++ b/web/src/features/datasets/components/UploadDatasetCsv.tsx
@@ -5,9 +5,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/src/components/ui/card";
-import { Input } from "@/src/components/ui/input";
-import { UploadIcon } from "lucide-react";
-import { useRef } from "react";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { z } from "zod/v4";
 import {
@@ -15,6 +12,10 @@ import {
   parseCsvClient,
 } from "@/src/features/datasets/lib/csvHelpers";
 import { DialogBody } from "@/src/components/ui/dialog";
+import {
+  Dropzone,
+  DropzoneEmptyState,
+} from "@/src/components/ui/shadcn-io/dropzone";
 
 export const MAX_FILE_SIZE_BYTES = 1024 * 1024 * 1 * 10; // 10MB
 const ACCEPTED_FILE_TYPES = ["text/csv"] as const;
@@ -31,24 +32,18 @@ export const UploadDatasetCsv = ({
   setPreview: (preview: CsvPreviewResult | null) => void;
   setCsvFile: (file: File | null) => void;
 }) => {
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const handleFileSelect = async (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => {
-    const file = event.target.files?.[0];
+  const handleFiles = async (files: File[]) => {
+    const file = files[0];
     if (!file) return;
 
     const result = FileSchema.safeParse(file);
     if (!result.success) {
       showErrorToast("Invalid file type", "Please select a valid CSV file");
-      event.target.value = "";
       return;
     }
 
     if (file.size > MAX_FILE_SIZE_BYTES) {
       showErrorToast("File too large", "Maximum file size is 10MB");
-      event.target.value = "";
       return;
     }
 
@@ -61,7 +56,6 @@ export const UploadDatasetCsv = ({
 
       if (!Boolean(preview.columns.length)) {
         showErrorToast("Invalid CSV", "CSV must have at least 1 column");
-        event.target.value = "";
         return;
       }
 
@@ -71,8 +65,6 @@ export const UploadDatasetCsv = ({
         "Failed to parse CSV",
         error instanceof Error ? error.message : "Unknown error",
       );
-    } finally {
-      event.target.value = "";
     }
   };
 
@@ -87,25 +79,15 @@ export const UploadDatasetCsv = ({
           </CardDescription>
         </CardHeader>
         <CardContent>
-          {/* Hidden file input */}
-          <Input
-            type="file"
-            ref={fileInputRef}
-            className="hidden"
-            accept=".csv"
-            onChange={handleFileSelect}
-          />
-
-          {/* Clickable upload area */}
-          <div
-            className="flex max-h-full min-h-0 w-full cursor-pointer flex-col items-center justify-center gap-2 overflow-y-auto rounded-lg border border-dashed bg-secondary/50 p-4"
-            onClick={() => fileInputRef.current?.click()}
+          <Dropzone
+            onDrop={handleFiles}
+            accept={{ "text/csv": [".csv"] }}
+            maxFiles={1}
+            maxSize={MAX_FILE_SIZE_BYTES}
+            className="border-dashed bg-secondary/50"
           >
-            <UploadIcon className="h-6 w-6 text-secondary-foreground" />
-            <div className="text-sm text-secondary-foreground">
-              Click to select a CSV file
-            </div>
-          </div>
+            <DropzoneEmptyState />
+          </Dropzone>
         </CardContent>
       </Card>
     </DialogBody>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds drag-and-drop support for CSV uploads in `UploadDatasetCsv.tsx` using `Dropzone`, replacing the file input method.
> 
>   - **Behavior**:
>     - Replaces file input with `Dropzone` for CSV uploads in `UploadDatasetCsv.tsx`.
>     - Supports drag-and-drop and click-to-upload for CSV files.
>     - Validates file type and size, showing error toasts for invalid files.
>   - **Imports**:
>     - Removes unused imports: `Input`, `UploadIcon`, `useRef`.
>     - Adds `Dropzone` and `DropzoneEmptyState` imports.
>   - **Refactoring**:
>     - Removes `fileInputRef` and `handleFileSelect` in favor of `handleFiles` function for handling file uploads.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1588e26f38f8effc6ee99b97b3c4980904a66369. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->