### PR TITLE
Bug fix: Self-hosted hitting `cloudBilling.getUsage`

### DIFF
--- a/web/src/ee/features/billing/utils/isCloudBilling.ts
+++ b/web/src/ee/features/billing/utils/isCloudBilling.ts
@@ -23,6 +23,6 @@ export function isCloudBillingEnabled(): boolean {
  * @returns true if cloud billing features should be shown/enabled
  */
 export function useIsCloudBillingAvailable(): boolean {
-  const cloudRegion = useLangfuseCloudRegion();
-  return Boolean(cloudRegion);
+  const { region } = useLangfuseCloudRegion();
+  return Boolean(region);
 }


### PR DESCRIPTION
## What does this PR do?

The `useLangfuseCloudRegion` hook returns an object, but `useIsCloudBillingAvailable` does not reference the region field. This PR fixes this reference to ensure the client doesn't hit `cloudBilling.getUsage`

```ts
export const useLangfuseCloudRegion = (): {
  isLangfuseCloud: boolean;
  region: string | undefined;
} => {
  return {
    isLangfuseCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
    region: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
  };
};
```


```ts
export function useIsCloudBillingAvailable(): boolean {
  const cloudRegion = useLangfuseCloudRegion();
  return Boolean(cloudRegion); // <-- returns an object, we need to check region.
}
```

Fixes # (issue)

<img width="360" height="137" alt="image" src="https://github.com/user-attachments/assets/ca506c89-d8df-4fd1-a814-14df5b351366" />


```
2025-10-07T12:18:52Z service/web/38c3eda5e8404b2b9e51772e01b97a18 2025-10-07T12:18:52.912Z error 	middleware intercepted error with code INTERNAL_SERVER_ERROR Stripe client not initialized
2025-10-07T12:18:52Z service/web/38c3eda5e8404b2b9e51772e01b97a18 TRPCError: Stripe client not initialized
2025-10-07T12:18:52Z service/web/38c3eda5e8404b2b9e51772e01b97a18     at r (/app/web/.next/server/pages/api/trpc/[trpc].js:293:39225)
2025-10-07T12:18:52Z service/web/38c3eda5e8404b2b9e51772e01b97a18     at /app/web/.next/server/pages/api/trpc/[trpc].js:271:41068
2025-10-07T12:18:52Z service/web/38c3eda5e8404b2b9e51772e01b97a18     at resolveMiddleware (file:///app/node_modules/.pnpm/@trpc+server@11.4.4_typescript@5.9.2/node_modules/@trpc/server/dist/initTRPC-XuvQcOiC.mjs:221:23)
2025-10-07T12:18:52Z service/web/38c3eda5e8404b2b9e51772e01b97a18     at callRecursive (file:///app/node_modules/.pnpm/@trpc+server@11.4.4_typescript@5.9.2/node_modules/@trpc/server/dist/initTRPC-XuvQcOiC.mjs:256:24)
2025-10-07T12:18:52Z service/web/38c3eda5e8404b2b9e51772e01b97a18     at Object.next (file:///app/node_modules/.pnpm/@trpc+server@11.4.4_typescript@5.9.2/node_modules/@trpc/server/dist/initTRPC-XuvQcOiC.mjs:262:12)
2025-10-07T12:18:52Z service/web/38c3eda5e8404b2b9e51772e01b97a18     at inputValidatorMiddleware (file:///app/node_modules/.pnpm/@trpc+server@11.4.4_typescript@5.9.2/node_modules/@trpc/server/dist/initTRPC-XuvQcOiC.mjs:50:15)
2025-10-07T12:18:52Z service/web/38c3eda5e8404b2b9e51772e01b97a18     at async callRecursive (file:///app/node_modules/.pnpm/@trpc+server@11.4.4_typescript@5.9.2/node_modules/@trpc/server/dist/initTRPC-XuvQcOiC.mjs:256:18)
2025-10-07T12:18:52Z service/web/38c3eda5e8404b2b9e51772e01b97a18     at async callRecursive (file:///app/node_modules/.pnpm/@trpc+server@11.4.4_typescript@5.9.2/node_modules/@trpc/server/dist/initTRPC-XuvQcOiC.mjs:256:18)
2025-10-07T12:18:52Z service/web/38c3eda5e8404b2b9e51772e01b97a18     at async /app/web/.next/server/chunks/467.js:1:10930
2025-10-07T12:18:52Z service/web/38c3eda5e8404b2b9e51772e01b97a18     at async callRecursive (file:///app/node_modules/.pnpm/@trpc+server@11.4.4_typescript@5.9.2/node_modules/@trpc/server/dist/initTRPC-XuvQcOiC.mjs:256:18)
```

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
