### PR TITLE
feat(ui): add cloudregion to project/org information in settings

### DIFF
--- a/web/src/pages/organization/[organizationId]/settings/index.tsx
+++ b/web/src/pages/organization/[organizationId]/settings/index.tsx
@@ -69,10 +69,10 @@ export const getOrganizationSettingsPages = ({
             json={{
               name: organization.name,
               id: organization.id,
+              ...organization.metadata,
               ...(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION && {
                 cloudRegion: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
               }),
-              ...organization.metadata,
             }}
           />
         </div>

--- a/web/src/pages/organization/[organizationId]/settings/index.tsx
+++ b/web/src/pages/organization/[organizationId]/settings/index.tsx
@@ -17,6 +17,7 @@ import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { ApiKeyList } from "@/src/features/public-api/components/ApiKeyList";
 import AIFeatureSwitch from "@/src/features/organizations/components/AIFeatureSwitch";
 import { useIsCloudBillingAvailable } from "@/src/ee/features/billing/utils/isCloudBilling";
+import { env } from "@/src/env.mjs";
 
 type OrganizationSettingsPage = {
   title: string;
@@ -68,6 +69,9 @@ export const getOrganizationSettingsPages = ({
             json={{
               name: organization.name,
               id: organization.id,
+              ...(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION && {
+                cloudRegion: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
+              }),
               ...organization.metadata,
             }}
           />

--- a/web/src/pages/project/[projectId]/settings/index.tsx
+++ b/web/src/pages/project/[projectId]/settings/index.tsx
@@ -27,6 +27,7 @@ import ContainerPage from "@/src/components/layouts/container-page";
 import ProtectedLabelsSettings from "@/src/features/prompts/components/ProtectedLabelsSettings";
 import { Slack } from "lucide-react";
 import { ScoreConfigSettings } from "@/src/features/score-configs/components/ScoreConfigSettings";
+import { env } from "@/src/env.mjs";
 
 type ProjectSettingsPage = {
   title: string;
@@ -97,6 +98,9 @@ export const getProjectSettingsPages = ({
                 id: organization.id,
                 ...organization.metadata,
               },
+              ...(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION && {
+                cloudRegion: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
+              }),
             }}
           />
         </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `cloudRegion` to organization and project settings pages if `env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` is set.
> 
>   - **Behavior**:
>     - Add `cloudRegion` to organization and project settings pages in `index.tsx` if `env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` is set.
>   - **Files**:
>     - `organization/[organizationId]/settings/index.tsx`: Adds `cloudRegion` to organization metadata.
>     - `project/[projectId]/settings/index.tsx`: Adds `cloudRegion` to project metadata.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bb49b5e2b915cf6f148b5030962cb1e49e337543. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->