### PR TITLE
fix(trace-log): show json / formatted switch

### DIFF
--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -314,9 +314,6 @@ export const TracePreview = ({
                     className="ml-auto mr-1 h-fit px-2 py-0.5"
                     value={currentView}
                     onValueChange={(value) => {
-                      capture("trace_detail:log_view_mode_switch", {
-                        view: value,
-                      });
                       setCurrentView(value as "pretty" | "json");
                     }}
                   >

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -117,11 +117,12 @@ export const TracePreview = ({
 
   // For performance reasons, we preemptively disable the log view if there are too many observations.
   const isLogViewDisabled = observations.length > 50;
+  const showLogViewTab = observations.length > 0;
   useEffect(() => {
-    if (isLogViewDisabled && selectedTab === "log") {
+    if ((isLogViewDisabled || !showLogViewTab) && selectedTab === "log") {
       setSelectedTab("preview");
     }
-  }, [isLogViewDisabled, selectedTab, setSelectedTab]);
+  }, [isLogViewDisabled, showLogViewTab, selectedTab, setSelectedTab]);
 
   return (
     <div className="ph-no-capture col-span-2 flex h-full flex-1 flex-col overflow-hidden md:col-span-3">
@@ -269,18 +270,20 @@ export const TracePreview = ({
             <TooltipProvider>
               <TabsBarList>
                 <TabsBarTrigger value="preview">Preview</TabsBarTrigger>
-                <TabsBarTrigger value="log" disabled={isLogViewDisabled}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span>Log View (Beta)</span>
-                    </TooltipTrigger>
-                    <TooltipContent className="text-xs">
-                      {isLogViewDisabled
-                        ? `Log View is disabled for traces with more than 50 observations (this trace has ${observations.length})`
-                        : "Shows all observations concatenated. Great for quickly scanning through them. Nullish values are omitted."}
-                    </TooltipContent>
-                  </Tooltip>
-                </TabsBarTrigger>
+                {showLogViewTab && (
+                  <TabsBarTrigger value="log" disabled={isLogViewDisabled}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span>Log View (Beta)</span>
+                      </TooltipTrigger>
+                      <TooltipContent className="text-xs">
+                        {isLogViewDisabled
+                          ? `Log View is disabled for traces with more than 50 observations (this trace has ${observations.length})`
+                          : "Shows all observations concatenated. Great for quickly scanning through them. Nullish values are omitted."}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TabsBarTrigger>
+                )}
                 {showScoresTab && (
                   <TabsBarTrigger value="scores">Scores</TabsBarTrigger>
                 )}
@@ -290,6 +293,30 @@ export const TracePreview = ({
                     value={currentView}
                     onValueChange={(value) => {
                       capture("trace_detail:io_mode_switch", { view: value });
+                      setCurrentView(value as "pretty" | "json");
+                    }}
+                  >
+                    <TabsList className="h-fit py-0.5">
+                      <TabsTrigger
+                        value="pretty"
+                        className="h-fit px-1 text-xs"
+                      >
+                        Formatted
+                      </TabsTrigger>
+                      <TabsTrigger value="json" className="h-fit px-1 text-xs">
+                        JSON
+                      </TabsTrigger>
+                    </TabsList>
+                  </Tabs>
+                )}
+                {selectedTab === "log" && (
+                  <Tabs
+                    className="ml-auto mr-1 h-fit px-2 py-0.5"
+                    value={currentView}
+                    onValueChange={(value) => {
+                      capture("trace_detail:log_view_mode_switch", {
+                        view: value,
+                      });
                       setCurrentView(value as "pretty" | "json");
                     }}
                   >

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -350,13 +350,18 @@ export function Trace(props: {
           onLayout={panelState.onLayout}
         >
           <ResizablePanel
-            defaultSize={isTreePanelCollapsed ? 3 : panelState.sizes[0]}
-            minSize={isTreePanelCollapsed ? 3 : panelState.minSize}
-            maxSize={isTreePanelCollapsed ? 3 : panelState.maxSize}
+            defaultSize={isTreePanelCollapsed ? 0 : panelState.sizes[0]}
+            minSize={isTreePanelCollapsed ? 0 : panelState.minSize}
+            maxSize={isTreePanelCollapsed ? 0 : panelState.maxSize}
             className="md:flex md:h-full md:flex-col md:overflow-hidden"
+            style={
+              isTreePanelCollapsed
+                ? { flex: "0 0 32px", minWidth: "32px", maxWidth: "32px" }
+                : undefined
+            }
           >
             {isTreePanelCollapsed ? (
-              <div className="flex h-full items-start justify-center border-r pt-2">
+              <div className="flex h-full w-8 items-start justify-center border-r pt-2">
                 <Button
                   variant="ghost"
                   size="icon"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances `TracePreview` with a JSON/formatted view switch for logs and adjusts tree panel size when collapsed.
> 
>   - **Behavior**:
>     - Adds a JSON/formatted view switch for the log view in `TracePreview.tsx`.
>     - Disables log view if observations exceed 50 or are empty.
>   - **UI Components**:
>     - Hides log view tab if no observations in `TracePreview.tsx`.
>     - Adjusts tree panel default size to 0 when collapsed in `index.tsx`.
>   - **Misc**:
>     - Updates `useEffect` dependencies in `TracePreview.tsx` to include `showLogViewTab`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cfe749ecde77fa30e5d27852a530e397fdf910a5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->