### PR TITLE
Add quick start buttons to scores screen

### DIFF
--- a/web/src/components/onboarding/ScoresOnboarding.tsx
+++ b/web/src/components/onboarding/ScoresOnboarding.tsx
@@ -5,7 +5,6 @@ import {
 } from "@/src/components/ui/splash-screen";
 import { ThumbsUp, Star, LineChart, Code } from "lucide-react";
 import { ActionButton } from "@/src/components/ActionButton";
-import { CreateOrEditAnnotationQueueButton } from "@/src/features/annotation-queues/components/CreateOrEditAnnotationQueueButton";
 
 export function ScoresOnboarding({ projectId }: { projectId: string }) {
   const valuePropositions: ValueProposition[] = [
@@ -46,16 +45,18 @@ export function ScoresOnboarding({ projectId }: { projectId: string }) {
           <>
             <ActionButton
               size="lg"
-              href={`/project/${projectId}/evals/new`}
+              href={`/project/${projectId}/evals`}
               variant="default"
             >
               Set up LLM-as-a-judge
             </ActionButton>
-            <CreateOrEditAnnotationQueueButton
-              variant="default"
-              projectId={projectId}
+            <ActionButton
               size="lg"
-            />
+              href={`/project/${projectId}/annotation-queues`}
+              variant="default"
+            >
+              Create Annotation Queue
+            </ActionButton>
           </>
         ),
       }}

--- a/web/src/components/onboarding/ScoresOnboarding.tsx
+++ b/web/src/components/onboarding/ScoresOnboarding.tsx
@@ -4,8 +4,10 @@ import {
   type ValueProposition,
 } from "@/src/components/ui/splash-screen";
 import { ThumbsUp, Star, LineChart, Code } from "lucide-react";
+import { ActionButton } from "@/src/components/ActionButton";
+import { CreateOrEditAnnotationQueueButton } from "@/src/features/annotation-queues/components/CreateOrEditAnnotationQueueButton";
 
-export function ScoresOnboarding() {
+export function ScoresOnboarding({ projectId }: { projectId: string }) {
   const valuePropositions: ValueProposition[] = [
     {
       title: "Collect user feedback",
@@ -38,6 +40,25 @@ export function ScoresOnboarding() {
       title="Get Started with Scores"
       description="Scores allow you to evaluate the quality/safety of your LLM application through user feedback, model-based evaluations, or manual review. Scores can be used programmatically via the API and SDKs to track custom metrics."
       valuePropositions={valuePropositions}
+      primaryAction={{
+        label: "Set up LLM-as-a-judge",
+        component: (
+          <>
+            <ActionButton
+              size="lg"
+              href={`/project/${projectId}/evals/new`}
+              variant="default"
+            >
+              Set up LLM-as-a-judge
+            </ActionButton>
+            <CreateOrEditAnnotationQueueButton
+              variant="default"
+              projectId={projectId}
+              size="lg"
+            />
+          </>
+        ),
+      }}
       secondaryAction={{
         label: "Learn More",
         href: "https://langfuse.com/docs/evaluation/evaluation-methods/custom-scores",

--- a/web/src/pages/project/[projectId]/scores.tsx
+++ b/web/src/pages/project/[projectId]/scores.tsx
@@ -38,7 +38,7 @@ export default function ScoresPage() {
     >
       {/* Show onboarding screen if user has no scores */}
       {showOnboarding ? (
-        <ScoresOnboarding />
+        <ScoresOnboarding projectId={projectId} />
       ) : (
         <ScoresTable projectId={projectId} />
       )}


### PR DESCRIPTION
## What does this PR do?

This PR addresses LFE-7091 by adding two prominent call-to-action buttons to the initial Scores onboarding screen. This improves user experience by providing direct links to "Set up LLM-as-a-judge" and "Create Annotation Queue", making it easier for new users to get started with evaluation features, similar to the existing human annotation queue CTA.

Fixes #LFE-7091

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [x] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my PR needs changes to the documentation
- [x] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [x] I haven't added tests that prove my fix is effective or that my feature works
- [x] I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-7091](https://linear.app/langfuse/issue/LFE-7091/evals-add-add-score-button-in-initial-scores-screen-to-get-started)

<a href="https://cursor.com/background-agent?bcId=bc-f3037638-933e-4317-978d-2116daa9ad37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f3037638-933e-4317-978d-2116daa9ad37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

