### PR TITLE
feat(onboarding): add onboarding for dataset item creation management

### DIFF
--- a/web/src/components/onboarding/DatasetItemsOnboarding.tsx
+++ b/web/src/components/onboarding/DatasetItemsOnboarding.tsx
@@ -1,0 +1,188 @@
+import { useState } from "react";
+import { type CsvPreviewResult } from "@/src/features/datasets/lib/csvHelpers";
+import { SplashScreen } from "@/src/components/ui/splash-screen";
+import { Braces, Code, ListTree, Upload } from "lucide-react";
+import DocPopup from "@/src/components/layouts/doc-popup";
+import Link from "next/link";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/src/components/ui/dialog";
+import { UploadDatasetCsv } from "@/src/features/datasets/components/UploadDatasetCsv";
+import { PreviewCsvImport } from "@/src/features/datasets/components/PreviewCsvImport";
+import { NewDatasetItemForm } from "@/src/features/datasets/components/NewDatasetItemForm";
+import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { cn } from "@/src/utils/tailwind";
+
+interface DatasetItemEntryPointRowProps {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  onClick?: () => void;
+  hasAccess?: boolean;
+  comingSoon?: boolean;
+  docPopup?: {
+    description: string;
+    href: string;
+  };
+}
+
+const DatasetItemEntryPointRow = ({
+  icon,
+  title,
+  description,
+  onClick,
+  hasAccess = true,
+  comingSoon = false,
+  docPopup,
+}: DatasetItemEntryPointRowProps) => {
+  const disabled = !hasAccess || comingSoon;
+  return (
+    <div
+      className={cn(
+        "flex h-20 items-center gap-4 rounded-lg border border-border p-4 transition-colors",
+        disabled
+          ? "bg-muted text-muted-foreground opacity-60"
+          : "cursor-pointer bg-card hover:bg-accent/50",
+      )}
+      onClick={!disabled ? onClick : undefined}
+      title={
+        !hasAccess
+          ? "You don't have access to this feature, please contact your administrator"
+          : undefined
+      }
+    >
+      <div className="flex items-center">{icon}</div>
+      <div className="flex flex-1 flex-col gap-1">
+        <h3 className="font-semibold">{title}</h3>
+        <div className="flex items-center gap-1">
+          <p className="text-sm text-muted-foreground">{description}</p>
+          {docPopup && (
+            <DocPopup description={docPopup.description} href={docPopup.href} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const DatasetItemsOnboarding = ({
+  projectId,
+  datasetId,
+}: {
+  projectId: string;
+  datasetId: string;
+}) => {
+  const capture = usePostHogClientCapture();
+  const [preview, setPreview] = useState<CsvPreviewResult | null>(null);
+  const [csvFile, setCsvFile] = useState<File | null>(null);
+  const [isUploadDialogOpen, setIsUploadDialogOpen] = useState(false);
+  const [isNewItemDialogOpen, setIsNewItemDialogOpen] = useState(false);
+
+  const hasProjectAccess = useHasProjectAccess({
+    projectId,
+    scope: "datasets:CUD",
+  });
+
+  return (
+    <SplashScreen
+      title="Add items to your dataset"
+      description="Datasets are collections of specific edge cases and underrepresented patterns used to evaluate your application."
+    >
+      <div className="flex flex-col gap-4">
+        <Dialog
+          open={hasProjectAccess && isUploadDialogOpen}
+          onOpenChange={setIsUploadDialogOpen}
+        >
+          <DialogTrigger asChild disabled={!hasProjectAccess}>
+            <DatasetItemEntryPointRow
+              icon={<Upload className="h-5 w-5" />}
+              title="Upload CSV"
+              description="Import dataset items from a CSV file"
+              onClick={() => {
+                if (hasProjectAccess) {
+                  capture("dataset_item:upload_csv_button_click");
+                }
+              }}
+              hasAccess={hasProjectAccess}
+            />
+          </DialogTrigger>
+          <DialogContent size="lg">
+            {preview ? (
+              <PreviewCsvImport
+                preview={preview}
+                csvFile={csvFile}
+                projectId={projectId}
+                datasetId={datasetId}
+                setCsvFile={setCsvFile}
+                setPreview={setPreview}
+              />
+            ) : (
+              <UploadDatasetCsv
+                setPreview={setPreview}
+                setCsvFile={setCsvFile}
+              />
+            )}
+          </DialogContent>
+        </Dialog>
+
+        <Dialog
+          open={hasProjectAccess && isNewItemDialogOpen}
+          onOpenChange={setIsNewItemDialogOpen}
+        >
+          <DialogTrigger asChild disabled={!hasProjectAccess}>
+            <DatasetItemEntryPointRow
+              icon={<Braces className="h-5 w-5" />}
+              title="Add Manually"
+              description="Manually input a single item"
+              onClick={() => {
+                if (hasProjectAccess) {
+                  capture("dataset_item:new_form_open");
+                }
+              }}
+              hasAccess={hasProjectAccess}
+            />
+          </DialogTrigger>
+          <DialogContent size="lg">
+            <DialogHeader>
+              <DialogTitle>Create dataset item</DialogTitle>
+            </DialogHeader>
+            <NewDatasetItemForm
+              projectId={projectId}
+              datasetId={datasetId}
+              onFormSuccess={() => setIsNewItemDialogOpen(false)}
+              className="h-full overflow-y-auto"
+            />
+          </DialogContent>
+        </Dialog>
+
+        <Link
+          href="https://langfuse.com/docs/evaluation/experiments/datasets#create-items-from-production-data"
+          target="_blank"
+        >
+          <DatasetItemEntryPointRow
+            icon={<Code className="h-5 w-5" />}
+            title="Add via Code"
+            description="Use our Python/TS/JS SDKs or custom API"
+          />
+        </Link>
+
+        <DatasetItemEntryPointRow
+          icon={<ListTree className="h-5 w-5" />}
+          title="Select Traces"
+          description="Coming soon!"
+          comingSoon
+          docPopup={{
+            description:
+              "Creating items from production data is supported on single trace level. Click to view docs for more details.",
+            href: "https://langfuse.com/docs/evaluation/experiments/datasets#create-items-from-production-data",
+          }}
+        />
+      </div>
+    </SplashScreen>
+  );
+};

--- a/web/src/components/onboarding/DatasetItemsOnboarding.tsx
+++ b/web/src/components/onboarding/DatasetItemsOnboarding.tsx
@@ -43,6 +43,8 @@ const DatasetItemEntryPointRow = ({
   const disabled = !hasAccess || comingSoon;
   return (
     <div
+      role="button"
+      tabIndex={0}
       className={cn(
         "flex h-20 items-center gap-4 rounded-lg border border-border p-4 transition-colors",
         disabled

--- a/web/src/components/ui/splash-screen.tsx
+++ b/web/src/components/ui/splash-screen.tsx
@@ -32,6 +32,7 @@ export interface SplashScreenProps {
   primaryAction?: ActionConfig;
   secondaryAction?: ActionConfig;
   gettingStarted?: string | React.ReactNode;
+  children?: React.ReactNode;
   className?: string;
 }
 
@@ -77,6 +78,7 @@ export function SplashScreen({
   primaryAction,
   secondaryAction,
   gettingStarted,
+  children,
 }: SplashScreenProps) {
   return (
     <div className={cn("mx-auto flex max-w-4xl flex-col items-center p-8")}>
@@ -131,6 +133,8 @@ export function SplashScreen({
           />
         </div>
       )}
+
+      {children && <div className="my-6 w-full max-w-3xl">{children}</div>}
 
       {valuePropositions.length > 0 && (
         <div className="my-6 grid w-full max-w-3xl grid-cols-1 gap-4 md:grid-cols-2">

--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -22,7 +22,7 @@ import {
 } from "@langfuse/shared";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
@@ -31,9 +31,6 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 import { StatusBadge } from "@/src/components/layouts/status-badge";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
-import { type CsvPreviewResult } from "@/src/features/datasets/lib/csvHelpers";
-import { PreviewCsvImport } from "@/src/features/datasets/components/PreviewCsvImport";
-import { UploadDatasetCsv } from "@/src/features/datasets/components/UploadDatasetCsv";
 import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 import { BatchExportTableButton } from "@/src/components/BatchExportTableButton";
 import { BatchExportTableName } from "@langfuse/shared";
@@ -67,8 +64,6 @@ export function DatasetItemsTable({
   const { setDetailPageList } = useDetailPageLists();
   const utils = api.useUtils();
   const capture = usePostHogClientCapture();
-  const [preview, setPreview] = useState<CsvPreviewResult | null>(null);
-  const [csvFile, setCsvFile] = useState<File | null>(null);
   const [paginationState, setPaginationState] = useQueryParams({
     pageIndex: withDefault(NumberParam, 0),
     pageSize: withDefault(NumberParam, 50),
@@ -98,11 +93,6 @@ export function DatasetItemsTable({
     limit: paginationState.pageSize,
     searchQuery: searchQuery ?? undefined,
     searchType: searchType,
-  });
-
-  const totalDatasetItemCount = api.datasets.countItemsByDatasetId.useQuery({
-    projectId,
-    datasetId,
   });
 
   useEffect(() => {
@@ -368,52 +358,6 @@ export function DatasetItemsTable({
 
   const setFilterStateWithDebounce = useDebounce(setFilterState);
   const setSearchQueryWithDebounce = useDebounce(setSearchQuery, 300);
-
-  if (totalDatasetItemCount.data === 0 && hasAccess) {
-    return (
-      <>
-        <DataTableToolbar
-          columns={columns}
-          filterColumnDefinition={datasetItemFilterColumns}
-          filterState={filterState}
-          setFilterState={setFilterStateWithDebounce}
-          columnVisibility={columnVisibility}
-          setColumnVisibility={setColumnVisibility}
-          columnOrder={columnOrder}
-          setColumnOrder={setColumnOrder}
-          rowHeight={rowHeight}
-          setRowHeight={setRowHeight}
-          actionButtons={[menuItems, batchExportButton].filter(Boolean)}
-          searchConfig={{
-            metadataSearchFields: ["ID"],
-            updateQuery: setSearchQueryWithDebounce,
-            currentQuery: searchQuery ?? undefined,
-            // Disable full text search as we don't have any dataset items added to the dataset yet.
-            tableAllowsFullTextSearch: false,
-            setSearchType,
-            searchType,
-            customDropdownLabels: {
-              metadata: "IDs",
-              fullText: "Full Text",
-            },
-            hidePerformanceWarning: true,
-          }}
-        />
-        {preview ? (
-          <PreviewCsvImport
-            preview={preview}
-            csvFile={csvFile}
-            projectId={projectId}
-            datasetId={datasetId}
-            setCsvFile={setCsvFile}
-            setPreview={setPreview}
-          />
-        ) : (
-          <UploadDatasetCsv setPreview={setPreview} setCsvFile={setCsvFile} />
-        )}
-      </>
-    );
-  }
 
   return (
     <>

--- a/web/src/features/datasets/components/UploadDatasetCsvButton.tsx
+++ b/web/src/features/datasets/components/UploadDatasetCsvButton.tsx
@@ -13,7 +13,6 @@ import { ActionButton } from "@/src/components/ActionButton";
 import { type CsvPreviewResult } from "@/src/features/datasets/lib/csvHelpers";
 import { PreviewCsvImport } from "@/src/features/datasets/components/PreviewCsvImport";
 import { UploadDatasetCsv } from "@/src/features/datasets/components/UploadDatasetCsv";
-import { api } from "@/src/utils/api";
 
 export const UploadDatasetCsvButton = (props: {
   projectId: string;
@@ -28,15 +27,6 @@ export const UploadDatasetCsvButton = (props: {
     scope: "datasets:CUD",
   });
   const capture = usePostHogClientCapture();
-
-  const itemCount = api.datasets.countItemsByDatasetId.useQuery({
-    projectId: props.projectId,
-    datasetId: props.datasetId,
-  });
-
-  if (hasAccess && itemCount.data === 0) {
-    return null;
-  }
 
   return (
     <Dialog open={hasAccess && open} onOpenChange={setOpen}>

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/items.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/items.tsx
@@ -37,7 +37,8 @@ export default function DatasetItems() {
     datasetId,
   });
 
-  const showOnboarding = !totalDatasetItemCount.data;
+  const showOnboarding =
+    totalDatasetItemCount.isSuccess && totalDatasetItemCount.data === 0;
 
   return (
     <Page

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/items.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/items.tsx
@@ -20,6 +20,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from "@/src/components/ui/dropdown-menu";
+import { DatasetItemsOnboarding } from "@/src/components/onboarding/DatasetItemsOnboarding";
 
 export default function DatasetItems() {
   const router = useRouter();
@@ -30,6 +31,13 @@ export default function DatasetItems() {
     datasetId,
     projectId,
   });
+
+  const totalDatasetItemCount = api.datasets.countItemsByDatasetId.useQuery({
+    projectId,
+    datasetId,
+  });
+
+  const showOnboarding = !totalDatasetItemCount.data;
 
   return (
     <Page
@@ -50,11 +58,18 @@ export default function DatasetItems() {
         },
         actionButtonsRight: (
           <>
-            <NewDatasetItemButton projectId={projectId} datasetId={datasetId} />
-            <UploadDatasetCsvButton
-              projectId={projectId}
-              datasetId={datasetId}
-            />
+            {!showOnboarding && (
+              <>
+                <NewDatasetItemButton
+                  projectId={projectId}
+                  datasetId={datasetId}
+                />
+                <UploadDatasetCsvButton
+                  projectId={projectId}
+                  datasetId={datasetId}
+                />
+              </>
+            )}
             <DetailPageNav
               currentId={datasetId}
               path={(entry) =>
@@ -105,7 +120,11 @@ export default function DatasetItems() {
         ),
       }}
     >
-      <DatasetItemsTable projectId={projectId} datasetId={datasetId} />
+      {showOnboarding ? (
+        <DatasetItemsOnboarding projectId={projectId} datasetId={datasetId} />
+      ) : (
+        <DatasetItemsTable projectId={projectId} datasetId={datasetId} />
+      )}
     </Page>
   );
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds onboarding for dataset item creation with CSV upload and manual entry options, displayed when no items exist.
> 
>   - **Onboarding Feature**:
>     - Adds `DatasetItemsOnboarding` component in `DatasetItemsOnboarding.tsx` for onboarding users to dataset item creation.
>     - Displays onboarding when `totalDatasetItemCount` is zero in `items.tsx`.
>     - Includes options for CSV upload, manual entry, and future features.
>   - **UI Changes**:
>     - Updates `SplashScreen` in `splash-screen.tsx` to accept `children` prop for custom content.
>     - Removes CSV upload logic from `DatasetItemsTable.tsx` and `UploadDatasetCsvButton.tsx` when onboarding is shown.
>   - **Behavior**:
>     - Onboarding replaces `DatasetItemsTable` in `items.tsx` when no items exist.
>     - CSV upload and manual entry buttons are hidden during onboarding in `items.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 43a6164ebfe0513fcefe41b97e82807d5fe4f8a9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->