### PR TITLE
fix(playground): replace console warnings with toast notifications in usePersistedWindowIds hook

### DIFF
--- a/web/src/features/playground/page/hooks/usePersistedWindowIds.ts
+++ b/web/src/features/playground/page/hooks/usePersistedWindowIds.ts
@@ -8,6 +8,7 @@ import {
   removeWindowState,
   clearAllPlaygroundData,
 } from "../storage/windowStorage";
+import { toast } from "sonner";
 
 /**
  * Hook to persist window IDs across page refreshes.
@@ -42,7 +43,7 @@ export function usePersistedWindowIds() {
         return windowId;
       }
       if (windowIds.length >= MULTI_WINDOW_CONFIG.MAX_WINDOWS) {
-        console.warn(
+        toast.error(
           `Maximum window limit of ${MULTI_WINDOW_CONFIG.MAX_WINDOWS} reached`,
         );
         return null;
@@ -61,7 +62,7 @@ export function usePersistedWindowIds() {
   const addWindowWithCopy = useCallback(
     (sourceWindowId?: string) => {
       if (windowIds.length >= MULTI_WINDOW_CONFIG.MAX_WINDOWS) {
-        console.warn(
+        toast.error(
           `Maximum window limit of ${MULTI_WINDOW_CONFIG.MAX_WINDOWS} reached`,
         );
         return null;
@@ -87,7 +88,7 @@ export function usePersistedWindowIds() {
   const removeWindowId = useCallback(
     (windowId: string) => {
       if (windowIds.length <= 1) {
-        console.warn("Cannot remove the last remaining window");
+        toast.error("Cannot remove the last remaining window");
         return;
       }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces console warnings with toast notifications in `usePersistedWindowIds` for better user feedback.
> 
>   - **Behavior**:
>     - Replaces `console.warn` with `toast.error` in `usePersistedWindowIds` for user feedback.
>     - Handles cases: maximum window limit reached and attempting to remove the last window.
>   - **Imports**:
>     - Adds `toast` import from `sonner` in `usePersistedWindowIds.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f08bf8947add9e88489211d73d72bb59c16554a5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->