### PR TITLE
feat(datasets): support DEL API endpoint

### DIFF
--- a/fern/apis/server/definition/datasets.yml
+++ b/fern/apis/server/definition/datasets.yml
@@ -33,6 +33,13 @@ service:
       path: /v2/datasets
       request: CreateDatasetRequest
       response: commons.Dataset
+    delete:
+      method: DELETE
+      docs: Delete a dataset
+      path: /v2/datasets/{datasetName}
+      path-parameters:
+        datasetName: string
+      response: DeleteDatasetResponse
     getRun:
       method: GET
       docs: Get a dataset run and its items
@@ -81,5 +88,8 @@ types:
       data: list<commons.DatasetRun>
       meta: pagination.MetaResponse
   DeleteDatasetRunResponse:
+    properties:
+      message: string
+  DeleteDatasetResponse:
     properties:
       message: string

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -1347,6 +1347,51 @@ paths:
               schema: {}
       security:
         - BasicAuth: []
+    delete:
+      description: Delete a dataset
+      operationId: datasets_delete
+      tags:
+        - Datasets
+      parameters:
+        - name: datasetName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteDatasetResponse'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
   /api/public/datasets/{datasetName}/runs/{runName}:
     get:
       description: Get a dataset run and its items
@@ -6342,6 +6387,14 @@ components:
         - meta
     DeleteDatasetRunResponse:
       title: DeleteDatasetRunResponse
+      type: object
+      properties:
+        message:
+          type: string
+      required:
+        - message
+    DeleteDatasetResponse:
+      title: DeleteDatasetResponse
       type: object
       properties:
         message:

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -1017,6 +1017,39 @@
         },
         {
           "_type": "endpoint",
+          "name": "Delete",
+          "request": {
+            "description": "Delete a dataset",
+            "url": {
+              "raw": "{{baseUrl}}/api/public/v2/datasets/:datasetName",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "public",
+                "v2",
+                "datasets",
+                ":datasetName"
+              ],
+              "query": [],
+              "variable": [
+                {
+                  "key": "datasetName",
+                  "value": "",
+                  "description": null
+                }
+              ]
+            },
+            "header": [],
+            "method": "DELETE",
+            "auth": null,
+            "body": null
+          },
+          "response": []
+        },
+        {
+          "_type": "endpoint",
           "name": "Get Run",
           "request": {
             "description": "Get a dataset run and its items",

--- a/web/src/__tests__/async/datasets-api.servertest.ts
+++ b/web/src/__tests__/async/datasets-api.servertest.ts
@@ -550,7 +550,7 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
       });
 
       expect(dbRunItems).toHaveLength(0);
-    }, 30000);
+    }, 50000);
   }, 90000);
 
   it("should create and get a dataset items (via datasets (v1), individually, and as a list)", async () => {

--- a/web/src/__tests__/async/datasets-api.servertest.ts
+++ b/web/src/__tests__/async/datasets-api.servertest.ts
@@ -3,6 +3,7 @@ import { prisma } from "@langfuse/shared/src/db";
 import {
   makeAPICall,
   makeZodVerifiedAPICall,
+  waitForQueueToBeEmpty,
 } from "@/src/__tests__/test-utils";
 import { v4 } from "uuid";
 import {
@@ -33,6 +34,7 @@ import {
   getDatasetRunItemsByDatasetIdCh,
   createDatasetRunItemsCh,
   createDatasetRunItem,
+  QueueName,
 } from "@langfuse/shared/src/server";
 import waitForExpect from "wait-for-expect";
 
@@ -76,6 +78,9 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
   });
 
   it("should delete a dataset and its runs and run items", async () => {
+    // Ensure queue is empty before starting test to avoid interference from previous tests
+    await waitForQueueToBeEmpty(QueueName.DatasetDelete);
+
     const datasetName = `dataset-${uuidv4()}`;
     const runName = `run-${uuidv4()}`;
     const nonExistentDatasetName = `non-existent-${uuidv4()}`;
@@ -190,7 +195,7 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
       });
 
       expect(dbRunItems).toHaveLength(0);
-    }, 50000);
+    }, 60000);
   }, 90000);
 
   it("should create and get a dataset (v1), include special characters", async () => {
@@ -1506,6 +1511,9 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
   }, 90000);
 
   it("should delete a dataset run and its run items", async () => {
+    // Ensure queue is empty before starting test to avoid interference from previous tests
+    await waitForQueueToBeEmpty(QueueName.DatasetDelete);
+
     const datasetName = `dataset-${uuidv4()}`;
     const runName = `run-${uuidv4()}`;
     const nonExistentRunName = `non-existent-${uuidv4()}`;

--- a/web/src/__tests__/async/datasets-api.servertest.ts
+++ b/web/src/__tests__/async/datasets-api.servertest.ts
@@ -1259,7 +1259,16 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
       const dbRunItems = await getDatasetRunItemsByDatasetIdCh({
         projectId: dataset.body.projectId,
         datasetId: dataset.body.id,
-        filter: [],
+        filter: dbRunBeforeDelete?.id
+          ? [
+              {
+                column: "datasetRunId",
+                operator: "any of",
+                value: [dbRunBeforeDelete.id],
+                type: "stringOptions" as const,
+              },
+            ]
+          : [],
         orderBy: {
           column: "createdAt",
           order: "DESC",

--- a/web/src/__tests__/async/datasets-api.servertest.ts
+++ b/web/src/__tests__/async/datasets-api.servertest.ts
@@ -75,6 +75,124 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     await createObservationsCh([observation]);
   });
 
+  it("should delete a dataset and its runs and run items", async () => {
+    const datasetName = `dataset-${uuidv4()}`;
+    const runName = `run-${uuidv4()}`;
+    const nonExistentDatasetName = `non-existent-${uuidv4()}`;
+
+    // Create a dataset
+    const dataset = await makeZodVerifiedAPICall(
+      PostDatasetsV2Response,
+      "POST",
+      "/api/public/v2/datasets",
+      {
+        name: datasetName,
+      },
+      auth,
+    );
+    expect(dataset.status).toBe(200);
+
+    // Create a dataset item
+    const datasetItem = await makeZodVerifiedAPICall(
+      PostDatasetItemsV1Response,
+      "POST",
+      "/api/public/dataset-items",
+      {
+        datasetName,
+        id: uuidv4(),
+        input: { key: "value" },
+      },
+      auth,
+    );
+    expect(datasetItem.status).toBe(200);
+
+    // Create a dataset run with run items
+    const runItem = await makeZodVerifiedAPICall(
+      PostDatasetRunItemsV1Response,
+      "POST",
+      "/api/public/dataset-run-items",
+      {
+        datasetItemId: datasetItem.body.id,
+        traceId: traceId,
+        runName: runName,
+        metadata: { key: "value" },
+      },
+      auth,
+    );
+    expect(runItem.status).toBe(200);
+
+    // Attempt to delete non-existent dataset should fail
+    const deleteNonExistent = await makeAPICall(
+      "DELETE",
+      `/api/public/v2/datasets/${encodeURIComponent(nonExistentDatasetName)}`,
+      undefined,
+      auth,
+    );
+    expect(deleteNonExistent.status).toBe(404);
+
+    // Verify run exists in database before deletion
+    const dbRunBeforeDelete = await prisma.datasetRuns.findFirst({
+      where: {
+        name: runName,
+        projectId: dataset.body.projectId,
+        dataset: {
+          name: datasetName,
+        },
+      },
+    });
+    expect(dbRunBeforeDelete).not.toBeNull();
+
+    // Delete the dataset and verify response matches DeleteDatasetResponse
+    const deleteResponse = await makeZodVerifiedAPICall(
+      DeleteDatasetV2Response,
+      "DELETE",
+      `/api/public/v2/datasets/${encodeURIComponent(datasetName)}`,
+      undefined,
+      auth,
+    );
+    expect(deleteResponse.status).toBe(200);
+    expect(deleteResponse.body).toEqual({
+      message: "Dataset successfully deleted",
+    });
+
+    // Verify dataset no longer exists in database
+    const dbDatasetAfterDelete = await prisma.dataset.findFirst({
+      where: {
+        name: datasetName,
+        projectId: dataset.body.projectId,
+      },
+    });
+    expect(dbDatasetAfterDelete).toBeNull();
+
+    // Verify run no longer exists in database
+    const dbRunAfterDelete = await prisma.datasetRuns.findFirst({
+      where: {
+        name: runName,
+        projectId: dataset.body.projectId,
+        dataset: {
+          name: datasetName,
+        },
+      },
+    });
+    expect(dbRunAfterDelete).toBeNull();
+
+    // Verify run items are also deleted
+    await waitForExpect(async () => {
+      const dbRunItems = await getDatasetRunItemsByDatasetIdCh({
+        projectId: dataset.body.projectId,
+        datasetId: dataset.body.id,
+        filter: [],
+        orderBy: {
+          column: "createdAt",
+          order: "DESC",
+        },
+        limit: 10,
+      });
+
+      expect(dbRunItems).toHaveLength(0);
+    }, 50000);
+  }, 90000);
+
   it("should create and get a dataset (v1), include special characters", async () => {
     const createRes = await makeZodVerifiedAPICall(
       PostDatasetsV1Response,
@@ -434,124 +552,6 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
       }),
     });
   });
-
-  it("should delete a dataset and its runs and run items", async () => {
-    const datasetName = `dataset-${uuidv4()}`;
-    const runName = `run-${uuidv4()}`;
-    const nonExistentDatasetName = `non-existent-${uuidv4()}`;
-
-    // Create a dataset
-    const dataset = await makeZodVerifiedAPICall(
-      PostDatasetsV2Response,
-      "POST",
-      "/api/public/v2/datasets",
-      {
-        name: datasetName,
-      },
-      auth,
-    );
-    expect(dataset.status).toBe(200);
-
-    // Create a dataset item
-    const datasetItem = await makeZodVerifiedAPICall(
-      PostDatasetItemsV1Response,
-      "POST",
-      "/api/public/dataset-items",
-      {
-        datasetName,
-        id: uuidv4(),
-        input: { key: "value" },
-      },
-      auth,
-    );
-    expect(datasetItem.status).toBe(200);
-
-    // Create a dataset run with run items
-    const runItem = await makeZodVerifiedAPICall(
-      PostDatasetRunItemsV1Response,
-      "POST",
-      "/api/public/dataset-run-items",
-      {
-        datasetItemId: datasetItem.body.id,
-        traceId: traceId,
-        runName: runName,
-        metadata: { key: "value" },
-      },
-      auth,
-    );
-    expect(runItem.status).toBe(200);
-
-    // Attempt to delete non-existent dataset should fail
-    const deleteNonExistent = await makeAPICall(
-      "DELETE",
-      `/api/public/v2/datasets/${encodeURIComponent(nonExistentDatasetName)}`,
-      undefined,
-      auth,
-    );
-    expect(deleteNonExistent.status).toBe(404);
-
-    // Verify run exists in database before deletion
-    const dbRunBeforeDelete = await prisma.datasetRuns.findFirst({
-      where: {
-        name: runName,
-        projectId: dataset.body.projectId,
-        dataset: {
-          name: datasetName,
-        },
-      },
-    });
-    expect(dbRunBeforeDelete).not.toBeNull();
-
-    // Delete the dataset and verify response matches DeleteDatasetResponse
-    const deleteResponse = await makeZodVerifiedAPICall(
-      DeleteDatasetV2Response,
-      "DELETE",
-      `/api/public/v2/datasets/${encodeURIComponent(datasetName)}`,
-      undefined,
-      auth,
-    );
-    expect(deleteResponse.status).toBe(200);
-    expect(deleteResponse.body).toEqual({
-      message: "Dataset successfully deleted",
-    });
-
-    // Verify dataset no longer exists in database
-    const dbDatasetAfterDelete = await prisma.dataset.findFirst({
-      where: {
-        name: datasetName,
-        projectId: dataset.body.projectId,
-      },
-    });
-    expect(dbDatasetAfterDelete).toBeNull();
-
-    // Verify run no longer exists in database
-    const dbRunAfterDelete = await prisma.datasetRuns.findFirst({
-      where: {
-        name: runName,
-        projectId: dataset.body.projectId,
-        dataset: {
-          name: datasetName,
-        },
-      },
-    });
-    expect(dbRunAfterDelete).toBeNull();
-
-    // Verify run items are also deleted
-    await waitForExpect(async () => {
-      const dbRunItems = await getDatasetRunItemsByDatasetIdCh({
-        projectId: dataset.body.projectId,
-        datasetId: dataset.body.id,
-        filter: [],
-        orderBy: {
-          column: "createdAt",
-          order: "DESC",
-        },
-        limit: 10,
-      });
-
-      expect(dbRunItems).toHaveLength(0);
-    }, 50000);
-  }, 90000);
 
   it("should create and get a dataset items (via datasets (v1), individually, and as a list)", async () => {
     await makeZodVerifiedAPICall(
@@ -1150,135 +1150,6 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     });
   });
 
-  it("should delete a dataset run and its run items", async () => {
-    const datasetName = `dataset-${uuidv4()}`;
-    const runName = `run-${uuidv4()}`;
-    const nonExistentRunName = `non-existent-${uuidv4()}`;
-
-    // Create a dataset
-    const dataset = await makeZodVerifiedAPICall(
-      PostDatasetsV1Response,
-      "POST",
-      "/api/public/datasets",
-      {
-        name: datasetName,
-      },
-      auth,
-    );
-    expect(dataset.status).toBe(200);
-
-    // Create a dataset item
-    const datasetItem = await makeZodVerifiedAPICall(
-      PostDatasetItemsV1Response,
-      "POST",
-      "/api/public/dataset-items",
-      {
-        datasetName,
-        id: uuidv4(),
-        input: { key: "value" },
-      },
-      auth,
-    );
-    expect(datasetItem.status).toBe(200);
-
-    // Create a dataset run with run items
-    const runItem = await makeZodVerifiedAPICall(
-      PostDatasetRunItemsV1Response,
-      "POST",
-      "/api/public/dataset-run-items",
-      {
-        datasetItemId: datasetItem.body.id,
-        traceId: traceId,
-        runName: runName,
-        metadata: { key: "value" },
-      },
-      auth,
-    );
-    expect(runItem.status).toBe(200);
-
-    // Create another project and auth to test cross-project access
-    const { auth: otherAuth } = await createOrgProjectAndApiKey();
-
-    // Attempt to delete run with different project's auth should fail
-    const deleteWithWrongAuth = await makeAPICall(
-      "DELETE",
-      `/api/public/datasets/${encodeURIComponent(datasetName)}/runs/${encodeURIComponent(runName)}`,
-      undefined,
-      otherAuth,
-    );
-    expect(deleteWithWrongAuth.status).toBe(404);
-
-    // Attempt to delete non-existent run should fail
-    const deleteNonExistent = await makeAPICall(
-      "DELETE",
-      `/api/public/datasets/${encodeURIComponent(datasetName)}/runs/${encodeURIComponent(nonExistentRunName)}`,
-      undefined,
-      auth,
-    );
-    expect(deleteNonExistent.status).toBe(404);
-
-    // Verify run exists in database before deletion
-    const dbRunBeforeDelete = await prisma.datasetRuns.findFirst({
-      where: {
-        name: runName,
-        projectId: dataset.body.projectId,
-        dataset: {
-          name: datasetName,
-        },
-      },
-    });
-    expect(dbRunBeforeDelete).not.toBeNull();
-
-    // Delete the run and verify response matches DeleteDatasetRunV1Response
-    const deleteResponse = await makeZodVerifiedAPICall(
-      DeleteDatasetRunV1Response,
-      "DELETE",
-      `/api/public/datasets/${encodeURIComponent(datasetName)}/runs/${encodeURIComponent(runName)}`,
-      undefined,
-      auth,
-    );
-    expect(deleteResponse.status).toBe(200);
-    expect(deleteResponse.body).toEqual({
-      message: "Dataset run successfully deleted",
-    });
-
-    // Verify run no longer exists in database
-    const dbRunAfterDelete = await prisma.datasetRuns.findFirst({
-      where: {
-        name: runName,
-        projectId: dataset.body.projectId,
-        dataset: {
-          name: datasetName,
-        },
-      },
-    });
-    expect(dbRunAfterDelete).toBeNull();
-
-    // Verify run items are also deleted
-    await waitForExpect(async () => {
-      const dbRunItems = await getDatasetRunItemsByDatasetIdCh({
-        projectId: dataset.body.projectId,
-        datasetId: dataset.body.id,
-        filter: dbRunBeforeDelete?.id
-          ? [
-              {
-                column: "datasetRunId",
-                operator: "any of",
-                value: [dbRunBeforeDelete.id],
-                type: "stringOptions" as const,
-              },
-            ]
-          : [],
-        orderBy: {
-          column: "createdAt",
-          order: "DESC",
-        },
-        limit: 10,
-      });
-      expect(dbRunItems).toHaveLength(0);
-    }, 60000);
-  }, 90000);
-
   it("dataset-run-items should fail when neither trace nor observation provided", async () => {
     const response = await makeAPICall(
       "POST",
@@ -1632,5 +1503,134 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     );
 
     expect(nonExistent.status).toBe(404);
+  }, 90000);
+
+  it("should delete a dataset run and its run items", async () => {
+    const datasetName = `dataset-${uuidv4()}`;
+    const runName = `run-${uuidv4()}`;
+    const nonExistentRunName = `non-existent-${uuidv4()}`;
+
+    // Create a dataset
+    const dataset = await makeZodVerifiedAPICall(
+      PostDatasetsV1Response,
+      "POST",
+      "/api/public/datasets",
+      {
+        name: datasetName,
+      },
+      auth,
+    );
+    expect(dataset.status).toBe(200);
+
+    // Create a dataset item
+    const datasetItem = await makeZodVerifiedAPICall(
+      PostDatasetItemsV1Response,
+      "POST",
+      "/api/public/dataset-items",
+      {
+        datasetName,
+        id: uuidv4(),
+        input: { key: "value" },
+      },
+      auth,
+    );
+    expect(datasetItem.status).toBe(200);
+
+    // Create a dataset run with run items
+    const runItem = await makeZodVerifiedAPICall(
+      PostDatasetRunItemsV1Response,
+      "POST",
+      "/api/public/dataset-run-items",
+      {
+        datasetItemId: datasetItem.body.id,
+        traceId: traceId,
+        runName: runName,
+        metadata: { key: "value" },
+      },
+      auth,
+    );
+    expect(runItem.status).toBe(200);
+
+    // Create another project and auth to test cross-project access
+    const { auth: otherAuth } = await createOrgProjectAndApiKey();
+
+    // Attempt to delete run with different project's auth should fail
+    const deleteWithWrongAuth = await makeAPICall(
+      "DELETE",
+      `/api/public/datasets/${encodeURIComponent(datasetName)}/runs/${encodeURIComponent(runName)}`,
+      undefined,
+      otherAuth,
+    );
+    expect(deleteWithWrongAuth.status).toBe(404);
+
+    // Attempt to delete non-existent run should fail
+    const deleteNonExistent = await makeAPICall(
+      "DELETE",
+      `/api/public/datasets/${encodeURIComponent(datasetName)}/runs/${encodeURIComponent(nonExistentRunName)}`,
+      undefined,
+      auth,
+    );
+    expect(deleteNonExistent.status).toBe(404);
+
+    // Verify run exists in database before deletion
+    const dbRunBeforeDelete = await prisma.datasetRuns.findFirst({
+      where: {
+        name: runName,
+        projectId: dataset.body.projectId,
+        dataset: {
+          name: datasetName,
+        },
+      },
+    });
+    expect(dbRunBeforeDelete).not.toBeNull();
+
+    // Delete the run and verify response matches DeleteDatasetRunV1Response
+    const deleteResponse = await makeZodVerifiedAPICall(
+      DeleteDatasetRunV1Response,
+      "DELETE",
+      `/api/public/datasets/${encodeURIComponent(datasetName)}/runs/${encodeURIComponent(runName)}`,
+      undefined,
+      auth,
+    );
+    expect(deleteResponse.status).toBe(200);
+    expect(deleteResponse.body).toEqual({
+      message: "Dataset run successfully deleted",
+    });
+
+    // Verify run no longer exists in database
+    const dbRunAfterDelete = await prisma.datasetRuns.findFirst({
+      where: {
+        name: runName,
+        projectId: dataset.body.projectId,
+        dataset: {
+          name: datasetName,
+        },
+      },
+    });
+    expect(dbRunAfterDelete).toBeNull();
+
+    // Verify run items are also deleted
+    await waitForExpect(async () => {
+      const dbRunItems = await getDatasetRunItemsByDatasetIdCh({
+        projectId: dataset.body.projectId,
+        datasetId: dataset.body.id,
+        filter: dbRunBeforeDelete?.id
+          ? [
+              {
+                column: "datasetRunId",
+                operator: "any of",
+                value: [dbRunBeforeDelete.id],
+                type: "stringOptions" as const,
+              },
+            ]
+          : [],
+        orderBy: {
+          column: "createdAt",
+          order: "DESC",
+        },
+        limit: 10,
+      });
+      expect(dbRunItems).toHaveLength(0);
+    }, 60000);
   }, 90000);
 });

--- a/web/src/__tests__/async/datasets-api.servertest.ts
+++ b/web/src/__tests__/async/datasets-api.servertest.ts
@@ -1267,7 +1267,7 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
         limit: 10,
       });
       expect(dbRunItems).toHaveLength(0);
-    }, 30000);
+    }, 60000);
   }, 90000);
 
   it("dataset-run-items should fail when neither trace nor observation provided", async () => {

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -673,18 +673,18 @@ export const datasetRouter = createTRPCRouter({
         },
       });
 
-      await addToDeleteDatasetQueue({
-        deletionType: "dataset",
-        projectId: input.projectId,
-        datasetId: deletedDataset.id,
-      });
-
       await auditLog({
         session: ctx.session,
         resourceType: "dataset",
         resourceId: deletedDataset.id,
         action: "delete",
         before: deletedDataset,
+      });
+
+      await addToDeleteDatasetQueue({
+        deletionType: "dataset",
+        projectId: input.projectId,
+        datasetId: deletedDataset.id,
       });
 
       return deletedDataset;

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -135,6 +135,16 @@ export const GetDatasetV2Query = z.object({
 });
 export const GetDatasetV2Response = APIDataset.strict();
 
+// DELETE /v2/datasets/{datasetName}
+export const DeleteDatasetV2Query = z.object({
+  datasetName: queryStringZod,
+});
+export const DeleteDatasetV2Response = z
+  .object({
+    message: z.literal("Dataset successfully deleted"),
+  })
+  .strict();
+
 // GET /datasets/{name}/runs
 export const GetDatasetRunsV1Query = z.object({
   name: queryStringZod, // dataset name from URL, name as it is v1

--- a/web/src/pages/api/public/v2/datasets/[datasetName]/index.ts
+++ b/web/src/pages/api/public/v2/datasets/[datasetName]/index.ts
@@ -1,5 +1,7 @@
 import { prisma } from "@langfuse/shared/src/db";
 import {
+  DeleteDatasetV2Query,
+  DeleteDatasetV2Response,
   GetDatasetV2Query,
   GetDatasetV2Response,
   transformDbDatasetToAPIDataset,
@@ -7,6 +9,8 @@ import {
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import { LangfuseNotFoundError } from "@langfuse/shared";
+import { addToDeleteDatasetQueue } from "@langfuse/shared/src/server";
+import { auditLog } from "@/src/features/audit-logs/auditLog";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
@@ -28,6 +32,55 @@ export default withMiddlewares({
         throw new LangfuseNotFoundError("Dataset not found");
       }
       return transformDbDatasetToAPIDataset(dataset);
+    },
+  }),
+  DELETE: createAuthedProjectAPIRoute({
+    name: "delete-dataset",
+    querySchema: DeleteDatasetV2Query,
+    responseSchema: DeleteDatasetV2Response,
+    rateLimitResource: "datasets",
+    fn: async ({ query, auth }) => {
+      const { datasetName } = query;
+
+      const dataset = await prisma.dataset.findFirst({
+        where: {
+          name: datasetName,
+          projectId: auth.scope.projectId,
+        },
+      });
+
+      if (!dataset) {
+        throw new LangfuseNotFoundError("Dataset not found");
+      }
+
+      await prisma.dataset.delete({
+        where: {
+          projectId_name: {
+            projectId: auth.scope.projectId,
+            name: datasetName,
+          },
+        },
+      });
+
+      await auditLog({
+        action: "delete",
+        resourceType: "dataset",
+        resourceId: dataset.id,
+        projectId: auth.scope.projectId,
+        orgId: auth.scope.orgId,
+        apiKeyId: auth.scope.apiKeyId,
+        before: dataset,
+      });
+
+      await addToDeleteDatasetQueue({
+        deletionType: "dataset",
+        projectId: auth.scope.projectId,
+        datasetId: dataset.id,
+      });
+
+      return {
+        message: "Dataset successfully deleted" as const,
+      };
     },
   }),
 });

--- a/web/src/pages/api/public/v2/datasets/index.ts
+++ b/web/src/pages/api/public/v2/datasets/index.ts
@@ -1,5 +1,7 @@
 import { prisma } from "@langfuse/shared/src/db";
 import {
+  DeleteDatasetsV2Body,
+  DeleteDatasetsV2Response,
   GetDatasetsV2Query,
   GetDatasetsV2Response,
   PostDatasetsV2Body,
@@ -9,6 +11,7 @@ import {
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { addToDeleteDatasetQueue } from "@langfuse/shared/src/server";
 
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
@@ -91,6 +94,44 @@ export default withMiddlewares({
           totalItems,
           totalPages: Math.ceil(totalItems / query.limit),
         },
+      };
+    },
+  }),
+  DELETE: createAuthedProjectAPIRoute({
+    name: "Delete Dataset",
+    bodySchema: DeleteDatasetsV2Body,
+    responseSchema: DeleteDatasetsV2Response,
+    rateLimitResource: "datasets",
+    fn: async ({ body, auth }) => {
+      const { name } = body;
+
+      const dataset = await prisma.dataset.delete({
+        where: {
+          projectId_name: {
+            projectId: auth.scope.projectId,
+            name,
+          },
+        },
+      });
+
+      await addToDeleteDatasetQueue({
+        deletionType: "dataset",
+        projectId: auth.scope.projectId,
+        datasetId: dataset.id,
+      });
+
+      await auditLog({
+        action: "delete",
+        resourceType: "dataset",
+        resourceId: dataset.id,
+        projectId: auth.scope.projectId,
+        orgId: auth.scope.orgId,
+        apiKeyId: auth.scope.apiKeyId,
+        before: dataset,
+      });
+
+      return {
+        message: "Dataset successfully deleted" as const,
       };
     },
   }),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add DELETE endpoint for datasets, update models and tests, and ensure proper queue handling for deletions.
> 
>   - **API Changes**:
>     - Add `DELETE /v2/datasets/{datasetName}` endpoint in `datasets.yml` and `openapi.yml`.
>     - Update Postman collection to include `Delete` endpoint for datasets.
>   - **Backend Logic**:
>     - Implement `delete-dataset` route in `dataset-router.ts` and `index.ts`.
>     - Add `DeleteDatasetResponse` model in `datasets.ts`.
>     - Ensure `addToDeleteDatasetQueue` is called after dataset deletion in `dataset-router.ts` and `index.ts`.
>   - **Testing**:
>     - Add test for dataset deletion in `datasets-api.servertest.ts`.
>     - Ensure queue is empty before tests using `waitForQueueToBeEmpty` in `test-utils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for abb2f1f290e67780cf370f709cd9c582e75ae3c8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->