### PR TITLE
chore(billing): read cycle usage from db instead of clickhouse for hobby plan users

### DIFF
--- a/web/src/ee/features/billing/components/BillingUsageChart.tsx
+++ b/web/src/ee/features/billing/components/BillingUsageChart.tsx
@@ -46,7 +46,7 @@ export const BillingUsageChart = () => {
           <>
             <p className="text-sm text-muted-foreground">
               {usage.data.billingPeriod
-                ? `${usageType} in current billing period`
+                ? `${usageType} in current billing period (updated about once every 60 minutes)`
                 : `${usageType} / last 30d`}
             </p>
             <div className="text-3xl font-bold">

--- a/web/src/ee/features/billing/server/stripeBillingService.ts
+++ b/web/src/ee/features/billing/server/stripeBillingService.ts
@@ -1556,7 +1556,6 @@ class BillingService {
           billingPeriod,
         };
       } catch (e) {
-        // Fail softly and fallback to Clickhouse
         logger.error(
           "Failed to get usage from Stripe, using usage from Clickhouse",
           { error: e },
@@ -1564,7 +1563,6 @@ class BillingService {
       }
     }
     // [A] End ----------------------------------------------------------------------------------------
-
     // [B] We have no active subscription -> get usage from cached Organization data (likely hobby plan or fallback)
     // ------------------------------------------------------------------------------------------------
 
@@ -1584,7 +1582,6 @@ class BillingService {
         end: billingCycleEnd,
       },
     };
-
     // [B] End ----------------------------------------------------------------------------------------
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Read cycle usage from the database for hobby plan users instead of Clickhouse, updating `BillingService` and `BillingUsageChart` accordingly.
> 
>   - **Behavior**:
>     - `BillingService.getSubscriptionInfo()` now calculates billing period from cached data for hobby plan users without active subscriptions.
>     - `BillingService.getUsage()` retrieves usage from cached organization data for hobby plan users, using a background job that updates every 60 minutes.
>   - **UI**:
>     - `BillingUsageChart.tsx` updated to display usage data update frequency ("updated about once every 60 minutes").
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 41b5d1e89aa4e88023fa82a6dd432c2095fb60ba. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->