### PR TITLE
chore: limit trace filter options

### DIFF
--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -215,13 +215,13 @@ export const traceRouter = createTRPCRouter({
           input.projectId,
           timestampFilter ? [timestampFilter] : [],
           undefined,
-          1000,
+          100,
         ),
         getTracesGroupedBySessionId(
           input.projectId,
           timestampFilter ? [timestampFilter] : [],
           undefined,
-          1000,
+          100,
         ),
       ]);
 

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -214,10 +214,14 @@ export const traceRouter = createTRPCRouter({
         getTracesGroupedByUsers(
           input.projectId,
           timestampFilter ? [timestampFilter] : [],
+          undefined,
+          1000,
         ),
         getTracesGroupedBySessionId(
           input.projectId,
           timestampFilter ? [timestampFilter] : [],
+          undefined,
+          1000,
         ),
       ]);
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Limit trace filter options to 100 results for user and session ID groupings in `traces.ts`.
> 
>   - **Behavior**:
>     - Limits trace filter options by adding a maximum of 100 results for `getTracesGroupedByUsers` and `getTracesGroupedBySessionId` in `traces.ts`.
>   - **Functions**:
>     - Modifies `filterOptions` query in `traceRouter` to include a limit of 100 for user and session ID groupings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5d316fedb315267574ca687cf678a3285a946eca. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->