### PR TITLE
feat(scores): support `queueId` when creating a score via ingestion API (#9349)

### DIFF
--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -258,7 +258,7 @@ types:
         docs: Reference a score config on a score. When set, config and score name must be equal and value must comply to optionally defined numerical range
       queueId:
         type: optional<string>
-        docs: Reference an annotation queue on a score. Populated if the score was initially created in an annotation queue.
+        docs: The annotation queue referenced by the score. Indicates if score was initially created while processing annotation queue.
       environment:
         type: optional<string>
         docs: The environment from which this score originated. Can be any lowercase alphanumeric string with hyphens and underscores that does not start with 'langfuse'.
@@ -319,7 +319,7 @@ types:
         docs: Reference a score config on a score. When set, config and score name must be equal and value must comply to optionally defined numerical range
       queueId:
         type: optional<string>
-        docs: Reference an annotation queue on a score. Populated if the score was initially created in an annotation queue.
+        docs: The annotation queue referenced by the score. Indicates if score was initially created while processing annotation queue.
       environment:
         type: optional<string>
         docs: The environment from which this score originated. Can be any lowercase alphanumeric string with hyphens and underscores that does not start with 'langfuse'.

--- a/fern/apis/server/definition/ingestion.yml
+++ b/fern/apis/server/definition/ingestion.yml
@@ -277,6 +277,9 @@ types:
       datasetRunId: optional<string>
       name: string
       environment: optional<string>
+      queueId:
+        type: optional<string>
+        docs: Reference an annotation queue on a score. Populated if the score was initially created in an annotation queue.
       value:
         type: commons.CreateScoreValue
         docs: The value of the score. Must be passed as string for categorical scores, and numeric for boolean and numeric scores. Boolean score values must equal either 1 or 0 (true or false)

--- a/fern/apis/server/definition/ingestion.yml
+++ b/fern/apis/server/definition/ingestion.yml
@@ -279,7 +279,7 @@ types:
       environment: optional<string>
       queueId:
         type: optional<string>
-        docs: Reference an annotation queue on a score. Populated if the score was initially created in an annotation queue.
+        docs: The annotation queue referenced by the score. Indicates if score was initially created while processing annotation queue.
       value:
         type: commons.CreateScoreValue
         docs: The value of the score. Must be passed as string for categorical scores, and numeric for boolean and numeric scores. Boolean score values must equal either 1 or 0 (true or false)

--- a/fern/apis/server/definition/score.yml
+++ b/fern/apis/server/definition/score.yml
@@ -37,6 +37,9 @@ types:
       environment:
         type: optional<string>
         docs: The environment of the score. Can be any lowercase alphanumeric string with hyphens and underscores that does not start with 'langfuse'.
+      queueId:
+        type: optional<string>
+        docs: Reference an annotation queue on a score. Populated if the score was initially created in an annotation queue.
       dataType:
         type: optional<commons.ScoreDataType>
         docs: The data type of the score. When passing a configId this field is inferred. Otherwise, this field must be passed or will default to numeric.

--- a/fern/apis/server/definition/score.yml
+++ b/fern/apis/server/definition/score.yml
@@ -39,7 +39,7 @@ types:
         docs: The environment of the score. Can be any lowercase alphanumeric string with hyphens and underscores that does not start with 'langfuse'.
       queueId:
         type: optional<string>
-        docs: Reference an annotation queue on a score. Populated if the score was initially created in an annotation queue.
+        docs: The annotation queue referenced by the score. Indicates if score was initially created while processing annotation queue.
       dataType:
         type: optional<commons.ScoreDataType>
         docs: The data type of the score. When passing a configId this field is inferred. Otherwise, this field must be passed or will default to numeric.

--- a/packages/shared/src/features/scores/interfaces/shared.ts
+++ b/packages/shared/src/features/scores/interfaces/shared.ts
@@ -17,4 +17,5 @@ export const PostScoreBodyFoundationSchema = z.object({
   comment: z.string().nullish(),
   metadata: jsonSchema.nullish(),
   environment: z.string().default("default"),
+  queueId: z.string().nullish(),
 });

--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -480,6 +480,7 @@ const createAllIngestionSchemas = ({
     source: z
       .enum(["API", "EVAL", "ANNOTATION"])
       .default("API" as ScoreSourceType),
+    queueId: z.string().nullish(),
   });
 
   const ScoreBody = applyScoreValidation(

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -5624,8 +5624,8 @@ components:
           type: string
           nullable: true
           description: >-
-            Reference an annotation queue on a score. Populated if the score was
-            initially created in an annotation queue.
+            The annotation queue referenced by the score. Indicates if score was
+            initially created while processing annotation queue.
         environment:
           type: string
           nullable: true
@@ -5779,8 +5779,8 @@ components:
           type: string
           nullable: true
           description: >-
-            Reference an annotation queue on a score. Populated if the score was
-            initially created in an annotation queue.
+            The annotation queue referenced by the score. Indicates if score was
+            initially created while processing annotation queue.
         environment:
           type: string
           nullable: true
@@ -6791,6 +6791,12 @@ components:
         environment:
           type: string
           nullable: true
+        queueId:
+          type: string
+          nullable: true
+          description: >-
+            The annotation queue referenced by the score. Indicates if score was
+            initially created while processing annotation queue.
         value:
           $ref: '#/components/schemas/CreateScoreValue'
           description: >-
@@ -8411,8 +8417,8 @@ components:
           type: string
           nullable: true
           description: >-
-            Reference an annotation queue on a score. Populated if the score
-            was initially created in an annotation queue.
+            The annotation queue referenced by the score. Indicates if score was
+            initially created while processing annotation queue.
         dataType:
           $ref: '#/components/schemas/ScoreDataType'
           nullable: true

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -8407,6 +8407,12 @@ components:
             The environment of the score. Can be any lowercase alphanumeric
             string with hyphens and underscores that does not start with
             'langfuse'.
+        queueId:
+          type: string
+          nullable: true
+          description: >-
+            Reference an annotation queue on a score. Populated if the score
+            was initially created in an annotation queue.
         dataType:
           $ref: '#/components/schemas/ScoreDataType'
           nullable: true

--- a/web/src/__tests__/async/scores-api-v1.servertest.ts
+++ b/web/src/__tests__/async/scores-api-v1.servertest.ts
@@ -248,10 +248,11 @@ describe("/api/public/scores API Endpoint", () => {
       });
     });
 
-    it("should post score with score config if in valid range", async () => {
+    it("should post score with score config and queue id if in valid range", async () => {
       const configId = v4();
       const traceId = v4();
       const scoreId = v4();
+      const queueId = v4();
 
       const { projectId: projectId, auth } = await createOrgProjectAndApiKey();
 
@@ -283,6 +284,7 @@ describe("/api/public/scores API Endpoint", () => {
         observation_id: null,
         environment: "production",
         config_id: config.id,
+        queue_id: queueId,
       });
       await createScoresCh([score]);
 
@@ -304,6 +306,7 @@ describe("/api/public/scores API Endpoint", () => {
       expect(fetchedScore.body?.source).toBe("API");
       expect(fetchedScore.body?.projectId).toBe(projectId);
       expect(fetchedScore.body?.environment).toBe("production");
+      expect(fetchedScore.body?.queueId).toBe(queueId);
       expect(fetchedScore.body?.metadata).toEqual({
         "test-key": "test-value",
       });

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -521,6 +521,7 @@ export class IngestionService {
                 ? convertJsonSchemaToRecord(scoreEvent.body.metadata)
                 : {},
               string_value: validatedScore.stringValue,
+              queue_id: validatedScore.queueId ?? null,
               created_at: Date.now(),
               updated_at: Date.now(),
               event_ts: new Date(scoreEvent.timestamp).getTime(),

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -1019,6 +1019,7 @@ describe("Ingestion end-to-end tests", () => {
       },
     });
 
+    const queueId = randomUUID();
     const scoreEventList: ScoreEventType[] = [
       {
         id: randomUUID(),
@@ -1033,6 +1034,7 @@ describe("Ingestion end-to-end tests", () => {
           source: ScoreSource.API,
           value: 100.5,
           observationId: generationId,
+          queueId,
           environment,
         },
       },

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -1114,6 +1114,7 @@ describe("Ingestion end-to-end tests", () => {
     expect(score.observation_id).toBe(generationId);
     expect(score.value).toBe(100.5);
     expect(score.config_id).toBe(scoreConfigId);
+    expect(score.queue_id).toBe(queueId);
   });
 
   it("should silently reject invalid scores while processing valid ones", async () => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `queueId` support for score creation via ingestion API, updating models, API definitions, and tests.
> 
>   - **Behavior**:
>     - Add `queueId` support in score creation via ingestion API in `ingestion.yml` and `score.yml`.
>     - Update `PostScoreBodyFoundationSchema` in `shared.ts` to include `queueId`.
>     - Modify `processScoreEventList()` in `IngestionService` to handle `queueId`.
>   - **Documentation**:
>     - Update `queueId` documentation in `commons.yml` and `openapi.yml` to clarify its role in score creation.
>   - **Tests**:
>     - Add test cases in `scores-api-v1.servertest.ts` and `IngestionService.integration.test.ts` to verify `queueId` handling in score creation and ingestion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c13beaa2487adc3efaf386c520c233249552e47d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->