### PR TITLE
docs(evals): add note to hisotric data eval execution tooltip

### DIFF
--- a/web/src/features/evals/components/eval-form-descriptions.tsx
+++ b/web/src/features/evals/components/eval-form-descriptions.tsx
@@ -32,7 +32,8 @@ export function TimeScopeDescription(props: {
           ? "all future"
           : "all existing"}{" "}
       {props.target === "trace" ? "traces" : "dataset run items"} that match
-      these filters.{" "}
+      these filters. Please note that it might take a while for your data to be
+      evaluated.
     </div>
   );
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a note in `TimeScopeDescription` to inform users about potential delays in data evaluation.
> 
>   - **Documentation Update**:
>     - Adds a note in `TimeScopeDescription` in `eval-form-descriptions.tsx` to inform users that data evaluation might take a while.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ed9a0c53a5dc4063a85d52881e18cc4ff97b1dd7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->