### PR TITLE
fix(log-view): increase limit to 150 obs

### DIFF
--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -116,7 +116,7 @@ export const TracePreview = ({
   );
 
   // For performance reasons, we preemptively disable the log view if there are too many observations.
-  const isLogViewDisabled = observations.length > 50;
+  const isLogViewDisabled = observations.length > 150;
   const showLogViewTab = observations.length > 0;
   useEffect(() => {
     if ((isLogViewDisabled || !showLogViewTab) && selectedTab === "log") {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase log view disable limit from 50 to 150 observations in `TracePreview.tsx`.
> 
>   - **Behavior**:
>     - Increase log view disable limit from 50 to 150 observations in `TracePreview.tsx`.
>     - Update tooltip message to reflect new limit in `TracePreview.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 570343e77a506926e0331ad55d26eaf9e021ccd1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->