### PR TITLE
fix(billing): exclude orgs with plan override from usage notifications

### DIFF
--- a/worker/src/ee/usageThresholds/thresholdProcessing.ts
+++ b/worker/src/ee/usageThresholds/thresholdProcessing.ts
@@ -300,7 +300,8 @@ export async function processThresholds(
   cumulativeUsage: number,
 ): Promise<ThresholdProcessingResult> {
   // 1. Skip notifications if org is on a paid plan (check this first, regardless of enforcement flag)
-  if (org.cloudConfig?.stripe?.activeSubscriptionId) {
+  // This includes both Stripe subscriptions and manual plan overrides
+  if (org.cloudConfig?.stripe?.activeSubscriptionId || org.cloudConfig?.plan) {
     // Build update data
     const updateData: OrgUpdateData = {
       orgId: org.id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `processThresholds` now skips enforcement for orgs with manual plan overrides, treating them as paid plans, with updated tests to verify behavior.
> 
>   - **Behavior**:
>     - `processThresholds` in `thresholdProcessing.ts` now skips enforcement for orgs with manual plan overrides, treating them as paid plans.
>     - Updates `updateData` to clear blocking state and invalidate cache if org transitions to manual plan override.
>   - **Tests**:
>     - Adds tests in `thresholdProcessing.test.ts` to verify no enforcement or emails for orgs with manual plan overrides ("Hobby", "Team", "Enterprise").
>     - Tests clearing of blocking state when transitioning to manual plan override.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 75315f8b99dc3d8589fd2a3377461558f85cc89f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->