### PR TITLE
chore: renaming a helper function to match time units

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -259,7 +259,7 @@ export class IngestionService {
       `Writing event for project ${eventData.projectId} and span ${eventData.spanId}`,
     );
 
-    const now = this.getNanosecondTimestamp();
+    const now = this.getMicrosecondTimestamp();
 
     // Store the full metadata JSON
     const metadata = eventData.metadata;
@@ -303,10 +303,10 @@ export class IngestionService {
       status_message: eventData.statusMessage,
 
       // Timestamps
-      start_time: this.getNanosecondTimestamp(eventData.startTimeISO),
-      end_time: this.getNanosecondTimestamp(eventData.endTimeISO),
+      start_time: this.getMicrosecondTimestamp(eventData.startTimeISO),
+      end_time: this.getMicrosecondTimestamp(eventData.endTimeISO),
       completion_start_time: eventData.completionStartTime
-        ? this.getNanosecondTimestamp(eventData.completionStartTime)
+        ? this.getMicrosecondTimestamp(eventData.completionStartTime)
         : null,
 
       // Prompt
@@ -1532,7 +1532,7 @@ export class IngestionService {
     return typeof obj === "string" ? obj : JSON.stringify(obj);
   }
 
-  private getNanosecondTimestamp(timestamp?: string | null): number {
+  private getMicrosecondTimestamp(timestamp?: string | null): number {
     return timestamp ? new Date(timestamp).getTime() * 1000 : Date.now() * 1000;
   }
 


### PR DESCRIPTION
Pretty sure it microseconds in this instance.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renames `getNanosecondTimestamp()` to `getMicrosecondTimestamp()` in `IngestionService` and updates its usage to reflect microsecond precision.
> 
>   - **Function Renaming**:
>     - Renames `getNanosecondTimestamp()` to `getMicrosecondTimestamp()` in `IngestionService`.
>   - **Function Usage**:
>     - Updates calls to `getNanosecondTimestamp()` to `getMicrosecondTimestamp()` in `writeEvent()` and other methods in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 112a49dbf74839a80f4dc6996afca09382fd0f81. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->