### PR TITLE
fix(billing): Update schema validation for existing redis api keys

### DIFF
--- a/packages/shared/src/server/auth/types.ts
+++ b/packages/shared/src/server/auth/types.ts
@@ -16,7 +16,7 @@ const ApiKeyBaseSchema = z.object({
   orgId: z.string(),
   plan: z.enum(plans as unknown as [string, ...string[]]),
   rateLimitOverrides: CloudConfigRateLimit.nullish(),
-  isIngestionSuspended: z.boolean(),
+  isIngestionSuspended: z.boolean().nullish(),
 });
 
 export const OrgEnrichedApiKey = z.discriminatedUnion("scope", [
@@ -65,7 +65,7 @@ type ApiAccessScopeMetadata = {
   rateLimitOverrides: z.infer<typeof CloudConfigRateLimit>;
   apiKeyId: string;
   publicKey: string;
-  isIngestionSuspended: boolean;
+  isIngestionSuspended: boolean | null | undefined;
 };
 
 export type ApiAccessScopeIngestion = BaseApiAccessScope &

--- a/web/src/__tests__/api-auth.servertest.ts
+++ b/web/src/__tests__/api-auth.servertest.ts
@@ -317,7 +317,7 @@ describe("Authenticate API calls", () => {
           },
         ],
         createdAt: apiKey?.createdAt.toISOString(),
-        isIngestionSuspended: expect.any(Boolean),
+        isIngestionSuspended: expect.anything(),
       });
 
       await prisma.organization.update({
@@ -436,7 +436,7 @@ describe("Authenticate API calls", () => {
           },
         ],
         createdAt: apiKey?.createdAt.toISOString(),
-        isIngestionSuspended: expect.any(Boolean),
+        isIngestionSuspended: expect.anything(),
       });
 
       await prisma.organization.update({
@@ -549,7 +549,7 @@ describe("Authenticate API calls", () => {
         createdAt: expect.any(String),
         lastUsedAt: null,
         expiresAt: null,
-        isIngestionSuspended: expect.any(Boolean),
+        isIngestionSuspended: expect.anything(),
         projectId: expect.any(String),
         orgId: "seed-org-id",
         plan: "cloud:hobby",
@@ -646,7 +646,7 @@ describe("Authenticate API calls", () => {
         plan: "cloud:hobby",
         createdAt: apiKey?.createdAt.toISOString(),
         scope: "PROJECT",
-        isIngestionSuspended: expect.any(Boolean),
+        isIngestionSuspended: expect.anything(),
       });
 
       await new ApiAuthService(prisma, redis).deleteApiKey(


### PR DESCRIPTION
Fix parsing error for `isIngestionSuspended` by allowing `null` or `undefined` values in its schema.

The `isIngestionSuspended` field, when retrieved from the database or cache, can be `null` or `undefined`. The previous strict `z.boolean()` schema caused parsing failures. This change updates the schema to `z.boolean().nullish()` and its corresponding TypeScript type, allowing these values to be correctly handled and interpreted as `false` (not suspended) by the existing business logic.

---
Linear Issue: [GTM-1527](https://linear.app/langfuse/issue/GTM-1527/free-tier-usage-thresholds-fix-parsing-error)

<a href="https://cursor.com/background-agent?bcId=bc-7bc2ca37-3a8f-4fa7-9967-a3b582f3d49b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7bc2ca37-3a8f-4fa7-9967-a3b582f3d49b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix parsing error for `isIngestionSuspended` by allowing `null` or `undefined` values in schema and TypeScript type.
> 
>   - **Schema Update**:
>     - Change `isIngestionSuspended` schema from `z.boolean()` to `z.boolean().nullish()` in `types.ts`.
>     - Update TypeScript type for `isIngestionSuspended` to `boolean | null | undefined` in `types.ts`.
>   - **Test Updates**:
>     - Modify `api-auth.servertest.ts` to expect `isIngestionSuspended` as `expect.anything()` instead of `expect.any(Boolean)` in 5 places.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0c950141067f5e96c60e93f15a75e3c610a5d23f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->