### PR TITLE
Added Manta Graph button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
    <img alt="Docker Pulls" src="https://img.shields.io/docker/pulls/langfuse/langfuse?labelColor=%20%23FDB062&logo=Docker&labelColor=%20%23528bff"></a>
    <a href="https://pypi.python.org/pypi/langfuse"><img src="https://img.shields.io/pypi/dm/langfuse?logo=python&logoColor=white&label=pypi%20langfuse&color=blue" alt="langfuse Python package on PyPi"></a>
    <a href="https://www.npmjs.com/package/langfuse"><img src="https://img.shields.io/npm/dm/langfuse?logo=npm&logoColor=white&label=npm%20langfuse&color=blue" alt="langfuse npm package"></a>
+   <a href="https://getmanta.ai/langfuse"><img src="https://getmanta.ai/api/badges?text=Manta%20Graph&link=langfuse" alt="Langfuse graph on Manta"></a> 
    <br/>
    <a href="https://discord.com/invite/7NXusRtqYU" target="_blank">
    <img src="https://img.shields.io/discord/1111061815649124414?logo=discord&labelColor=%20%235462eb&logoColor=%20%23f5f5f5&color=%20%235462eb"


### PR DESCRIPTION
Manta Graph can be opened through a button in README, to see the solution in a form of interactive graph.

<img width="892" height="560" alt="image" src="https://github.com/user-attachments/assets/1df7330c-dac8-4346-aa56-5df859341d80" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added a Manta Graph button to `README.md` for accessing Langfuse graph on Manta.
> 
>   - **Documentation**:
>     - Added a Manta Graph button to `README.md` for accessing Langfuse graph on Manta.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3e9357bbfa9446511a43cb2df522ae84fd8bdb10. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->