### PR TITLE
fix(database-read-stream): when downloading traces/observations as csv annotations scored as zero dropped

### DIFF
--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -7,6 +7,7 @@ import {
   evalDatasetFormFilterCols,
   OrderByState,
   TracingSearchType,
+  isPresent,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 import {
@@ -588,7 +589,7 @@ export function prepareScoresForOutput(
       const existingValues = acc[score.name];
       const newValue =
         score.dataType === "NUMERIC" ? score.value : score.stringValue;
-      if (!newValue) return acc;
+      if (!isPresent(newValue)) return acc;
 
       if (!existingValues) {
         // First value determines the type


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes bug in `prepareScoresForOutput` in `getDatabaseReadStream.ts` to prevent dropping zero-valued scores by using `isPresent`.
> 
>   - **Bug Fix**:
>     - In `getDatabaseReadStream.ts`, `prepareScoresForOutput` function now uses `isPresent` to check score values, ensuring zero values are not dropped.
>   - **Imports**:
>     - Added `isPresent` import from `@langfuse/shared`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3a5a3957a99eae83a79e7d5f1c1ed1eaa34ba4d5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->