### PR TITLE
fix(dataset-run-item): enhance metadata conversion to handle various data types

### DIFF
--- a/worker/src/features/experiments/experimentServiceClickhouse.ts
+++ b/worker/src/features/experiments/experimentServiceClickhouse.ts
@@ -78,8 +78,6 @@ async function processItem(
       traceId: newTraceId,
       observationId: null,
       error: null,
-      input: datasetItem.input,
-      expectedOutput: datasetItem.expectedOutput,
       createdAt: timestamp,
       datasetId: datasetItem.datasetId,
       runId: config.runId,

--- a/worker/src/services/IngestionService/utils.ts
+++ b/worker/src/services/IngestionService/utils.ts
@@ -26,21 +26,31 @@ export const convertJsonSchemaToRecord = (
 export const convertPostgresJsonToMetadataRecord = (
   metadata: Prisma.JsonValue,
 ): Record<string, string> => {
-  return typeof metadata === "string"
-    ? { metadata: metadata }
-    : Array.isArray(metadata)
-      ? { metadata: JSON.stringify(metadata) }
-      : (metadata as Record<string, string>);
+  if (
+    typeof metadata === "string" ||
+    typeof metadata === "number" ||
+    typeof metadata === "boolean"
+  ) {
+    return { metadata: String(metadata) };
+  }
+  if (Array.isArray(metadata)) {
+    return { metadata: JSON.stringify(metadata) };
+  }
+  if (metadata && typeof metadata === "object") {
+    return convertRecordValuesToString(metadata as Record<string, unknown>);
+  }
+  return {};
 };
 
 export const convertRecordValuesToString = (
   record: Record<string, unknown>,
 ): Record<string, string> => {
+  const result: Record<string, string> = {};
   for (const key in record) {
     const value = record[key];
-    record[key] = typeof value === "string" ? value : JSON.stringify(value);
+    result[key] = typeof value === "string" ? value : JSON.stringify(value);
   }
-  return record as Record<string, string>;
+  return result;
 };
 
 export function overwriteObject(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance metadata conversion in `utils.ts` to handle various data types and streamline event processing in `experimentServiceClickhouse.ts`.
> 
>   - **Metadata Conversion**:
>     - `convertPostgresJsonToMetadataRecord` in `utils.ts` now handles `number` and `boolean` types, converting them to strings.
>     - `convertRecordValuesToString` in `utils.ts` now returns a new result object instead of modifying the input record.
>   - **Event Processing**:
>     - Removed `input` and `expectedOutput` from the event body in `processItem` in `experimentServiceClickhouse.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 23db3ce27b946ed0b3f01a64815f7246f523e705. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->