### PR TITLE
feat(trace-table): decode unicode in truncated JSONs

### DIFF
--- a/web/src/components/ui/IOTableCell.tsx
+++ b/web/src/components/ui/IOTableCell.tsx
@@ -11,6 +11,7 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@/src/components/ui/hover-card";
+import { decodeUnicodeEscapesOnly } from "@/src/utils/unicode";
 
 const IOTableCellContent = ({
   data,
@@ -35,15 +36,18 @@ const IOTableCellContent = ({
         className,
       )}
     >
-      {stringifiedJson}
+      {stringifiedJson
+        ? decodeUnicodeEscapesOnly(stringifiedJson, true)
+        : stringifiedJson}
     </div>
   ) : shouldTruncate ? (
     <div className="ph-no-capture grid h-full grid-cols-1">
       <JSONView
-        json={
+        json={decodeUnicodeEscapesOnly(
           stringifiedJson.slice(0, IO_TABLE_CHAR_LIMIT) +
-          `...[truncated ${stringifiedJson.length - IO_TABLE_CHAR_LIMIT} characters]`
-        }
+            `...[truncated ${stringifiedJson.length - IO_TABLE_CHAR_LIMIT} characters]`,
+          true, // greedy mode for double-escaped Unicode (e.g., \\uXXXX)
+        )}
         className={cn("h-full w-full self-stretch rounded-sm", className)}
         codeClassName="py-1 px-2 min-h-0 h-full overflow-y-auto"
         collapseStringsAfterLength={null} // in table, show full strings as row height is fixed
@@ -54,7 +58,9 @@ const IOTableCellContent = ({
     </div>
   ) : (
     <JSONView
-      json={data}
+      json={
+        stringifiedJson ? decodeUnicodeEscapesOnly(stringifiedJson, true) : data
+      }
       className={cn(
         "ph-no-capture h-full w-full self-stretch rounded-sm",
         className,

--- a/web/src/utils/unicode.clienttest.ts
+++ b/web/src/utils/unicode.clienttest.ts
@@ -1,0 +1,73 @@
+import { decodeUnicodeEscapesOnly } from "@/src/utils/unicode";
+
+describe("decodeUnicodeEscapesOnly", () => {
+  it("should decode basic Unicode escapes (Chinese, Korean)", () => {
+    expect(decodeUnicodeEscapesOnly("\\u4f60\\u597d")).toBe("你好"); // Chinese "hello"
+    expect(decodeUnicodeEscapesOnly("\\uc548\\ub155")).toBe("안녕"); // Korean "hello"
+  });
+
+  it("should decode surrogate pairs, i.e. emoji", () => {
+    expect(decodeUnicodeEscapesOnly("\\ud83d\\ude00")).toBe("😀"); // grinning face
+    expect(decodeUnicodeEscapesOnly("Hello \\ud83d\\udc4b World")).toBe(
+      "Hello 👋 World",
+    ); // waving hand
+  });
+
+  it("should handle multi-backslash scenarios", () => {
+    // Even number of backslashes: literal backslash + uXXXX (not decoded)
+    expect(decodeUnicodeEscapesOnly("\\\\u4f60")).toBe("\\u4f60");
+
+    // Odd number (3): literal backslash + decoded unicode
+    expect(decodeUnicodeEscapesOnly("\\\\\\u4f60")).toBe("\\你");
+  });
+
+  it("should be robust to truncation", () => {
+    // Incomplete escape sequence at end
+    expect(decodeUnicodeEscapesOnly("text \\u4f")).toBe("text \\u4f");
+
+    // Incomplete surrogate pair (high surrogate only)
+    expect(decodeUnicodeEscapesOnly("text \\ud83d")).toBe("text \\ud83d");
+
+    // Invalid hex digits
+    expect(decodeUnicodeEscapesOnly("\\uZZZZ")).toBe("\\uZZZZ");
+  });
+
+  it("should preserve other escape sequences", () => {
+    expect(decodeUnicodeEscapesOnly('\\"hello\\"')).toBe('\\"hello\\"');
+    expect(decodeUnicodeEscapesOnly("\\n\\t\\r")).toBe("\\n\\t\\r");
+    expect(decodeUnicodeEscapesOnly("\\\\")).toBe("\\\\");
+  });
+
+  it("should handle mixed content", () => {
+    expect(
+      decodeUnicodeEscapesOnly(
+        '{"name": "\\u4f60\\u597d", "emoji": "\\ud83d\\ude00"}',
+      ),
+    ).toBe('{"name": "你好", "emoji": "😀"}');
+  });
+
+  it("should handle no escapes", () => {
+    expect(decodeUnicodeEscapesOnly("")).toBe("");
+    expect(decodeUnicodeEscapesOnly("hello world")).toBe("hello world");
+    expect(decodeUnicodeEscapesOnly("Hello 👋 World")).toBe("Hello 👋 World");
+  });
+
+  describe("greedy mode", () => {
+    it("should decode double-escaped Unicode in greedy mode", () => {
+      // \\uXXXX / \\\\uXXXX decodes to character
+      expect(decodeUnicodeEscapesOnly("\\\\u4f60\\\\u597d", true)).toBe("你好");
+    });
+
+    it("should decode double-escaped surrogate pairs in greedy mode", () => {
+      // Greedy mode with emoji
+      expect(decodeUnicodeEscapesOnly("\\\\ud83d\\\\ude00", true)).toBe("😀");
+    });
+
+    it("should handle mixed content in greedy mode", () => {
+      const input = '{"content": "\\\\uc885\\\\ubd80\\\\uc138"}';
+      expect(decodeUnicodeEscapesOnly(input, true)).toBe(
+        '{"content": "종부세"}',
+      );
+    });
+  });
+});

--- a/web/src/utils/unicode.ts
+++ b/web/src/utils/unicode.ts
@@ -11,7 +11,7 @@ const LOW_SURROGATE_END = 0xdfff;
  * Decodes ONLY \uXXXX unicode escapes. Does not touch other escapes like \" \\n \\t etc.
  * Handles surrogate pairs (\uD83D\uDE00 -> 😀). Robust to truncation/invalid hex.
  * Invalid/truncated \uXXXX are left literal. Collapses paired backslashes before 'u' based on parity.
- * greedy mode decodes all \uXXXX patterns regardless of backslash escaping (e.g., \\u1234 -> 你).
+ * greedy mode decodes all \uXXXX patterns regardless of backslash escaping (e.g., \\u4F60 -> 你).
  *
  * Used to make i.e. chinese characters render from truncated JSON strings where
  * JSON.parse would fail.

--- a/web/src/utils/unicode.ts
+++ b/web/src/utils/unicode.ts
@@ -1,0 +1,202 @@
+const BACKSLASH = 92;
+const U_CHAR = 117;
+// high surrogate is the first code of a surrogate pair (\uD83D\uDE00 -> 😀)
+const HIGH_SURROGATE_START = 0xd800;
+const HIGH_SURROGATE_END = 0xdbff;
+// low surrogate is the 2nd pair.
+const LOW_SURROGATE_START = 0xdc00;
+const LOW_SURROGATE_END = 0xdfff;
+
+/**
+ * Decodes ONLY \uXXXX unicode escapes. Does not touch other escapes like \" \\n \\t etc.
+ * Handles surrogate pairs (\uD83D\uDE00 -> 😀). Robust to truncation/invalid hex.
+ * Invalid/truncated \uXXXX are left literal. Collapses paired backslashes before 'u' based on parity.
+ * Greedy mode collapses all \ before 'u' for incorrect escapes, i.e. \\\\u1234 -> \u1234
+ *
+ * Used to make i.e. chinese characters render from truncated JSON strings where
+ * JSON.parse would fail.
+ *
+ * Custom (i.e. no regex) implementation for performance reasons. Only way to do single pass.
+ * Overoptimized? yes, probably..
+ * see also: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt
+ *
+ * @param input - The string to decode
+ * @param greedy - If true, decodes invalid escapes \\\\u1234 -> \u1234
+ */
+export function decodeUnicodeEscapesOnly(
+  input: string,
+  greedy: boolean = false,
+): string {
+  const n = input.length;
+  const out: string[] = [];
+  let i = 0;
+  let lastEmit = 0;
+
+  const hex = (cc: number): number => {
+    if (cc >= 48 && cc <= 57) return cc - 48; // 0-9
+    if (cc >= 65 && cc <= 70) return cc - 55; // A-F
+    if (cc >= 97 && cc <= 102) return cc - 87; // a-f
+    return -1;
+  };
+
+  // parse 4 hex digits (abcd) at given position, return unicode or -1 if invalid
+  const parseHex4 = (str: string, pos: number): number => {
+    const a = hex(str.charCodeAt(pos));
+    const b = hex(str.charCodeAt(pos + 1));
+    const c = hex(str.charCodeAt(pos + 2));
+    const d = hex(str.charCodeAt(pos + 3));
+    // bit shift instead of multiplication for performance, recreating the 16bit unicode
+    return (a | b | c | d) >= 0 ? (a << 12) | (b << 8) | (c << 4) | d : -1;
+  };
+
+  // Try decoding surrogate pair starting at position (after first \uXXXX)
+  // Returns decoded character + bytes consumed, or null if not valid
+  const tryDecodeSurrogatePair = (
+    str: string,
+    pos: number,
+    high: number,
+    maxLen: number,
+  ): { decoded: string; consumed: number } | null => {
+    if (high < HIGH_SURROGATE_START || high > HIGH_SURROGATE_END) return null;
+    if (pos + 6 > maxLen) return null;
+    if (str.charCodeAt(pos) !== BACKSLASH) return null;
+    if (str.charCodeAt(pos + 1) !== U_CHAR) return null;
+
+    const low = parseHex4(str, pos + 2);
+    if (low === -1) return null;
+    if (low < LOW_SURROGATE_START || low > LOW_SURROGATE_END) return null;
+
+    const cp =
+      ((high - HIGH_SURROGATE_START) << 10) +
+      (low - LOW_SURROGATE_START) +
+      0x10000;
+    return { decoded: String.fromCodePoint(cp), consumed: 6 };
+  };
+
+  while (i < n) {
+    // is not a '\'? continue
+    if (input.charCodeAt(i) !== BACKSLASH) {
+      i++;
+      continue;
+    }
+
+    // count backslashes in run
+    let j = i + 1;
+    while (j < n && input.charCodeAt(j) === BACKSLASH) j++;
+    const run = j - i;
+
+    // only consider backslash if directly followed by 'u'
+    if (j < n && input.charCodeAt(j) === U_CHAR) {
+      // Emit preceding literal and collapse paired backslashes
+      if (lastEmit < i) out.push(input.slice(lastEmit, i));
+      const pairs = run >> 1;
+      if (pairs) out.push("\\".repeat(pairs));
+
+      if ((run & 1) === 0) {
+        // Even run: the 'u' is not escaped -> leave it untouched
+        i = j;
+        lastEmit = i;
+        continue;
+      }
+
+      // Odd run: attempt to decode \uXXXX starting at j
+      if (j + 5 <= n) {
+        const codeUnit = parseHex4(input, j + 1);
+        if (codeUnit !== -1) {
+          // Try surrogate pair decoding
+          const pair = tryDecodeSurrogatePair(input, j + 5, codeUnit, n);
+          if (pair) {
+            out.push(pair.decoded);
+            i = j + 5 + pair.consumed;
+            lastEmit = i;
+            continue;
+          }
+
+          // Lone high surrogate -> leave literal \uXXXX
+          if (
+            codeUnit >= HIGH_SURROGATE_START &&
+            codeUnit <= HIGH_SURROGATE_END
+          ) {
+            out.push("\\u" + input.slice(j + 1, j + 5));
+            i = j + 5;
+            lastEmit = i;
+            continue;
+          }
+
+          // Low surrogate alone? leave literal (ill-formed)
+          if (
+            codeUnit >= LOW_SURROGATE_START &&
+            codeUnit <= LOW_SURROGATE_END
+          ) {
+            out.push("\\u" + input.slice(j + 1, j + 5));
+            i = j + 5;
+            lastEmit = i;
+            continue;
+          }
+
+          // normal unicode code unit of BMP (non emoji unicode char)
+          out.push(String.fromCharCode(codeUnit));
+          i = j + 5;
+          lastEmit = i;
+          continue;
+        }
+      }
+
+      // Odd run but invalid/truncated hex -> emit '\u' literally
+      out.push("\\u");
+      i = j + 1;
+      lastEmit = i;
+      continue;
+    }
+
+    // '\' not followed by 'u', don't do anything
+    i = j;
+  }
+
+  if (lastEmit < n) out.push(input.slice(lastEmit));
+  let result = out.join("");
+
+  // Greedy mode: decode any remaining \uXXXX patterns in single pass (e.g., from double-escaped data like \\uXXXX)
+  // 2nd pass over the result string
+  if (greedy) {
+    const out2: string[] = [];
+    const m = result.length;
+    let i = 0;
+    let lastEmit = 0;
+
+    while (i < m) {
+      // Look for \uXXXX pattern
+      if (
+        result.charCodeAt(i) === BACKSLASH &&
+        i + 5 <= m &&
+        result.charCodeAt(i + 1) === U_CHAR
+      ) {
+        const codeUnit = parseHex4(result, i + 2);
+        if (codeUnit !== -1) {
+          // Try surrogate pair decoding
+          const pair = tryDecodeSurrogatePair(result, i + 6, codeUnit, m);
+          if (pair) {
+            if (lastEmit < i) out2.push(result.slice(lastEmit, i));
+            out2.push(pair.decoded);
+            i = i + 6 + pair.consumed;
+            lastEmit = i;
+            continue;
+          }
+
+          // Regular BMP character (not part of surrogate pair)
+          if (lastEmit < i) out2.push(result.slice(lastEmit, i));
+          out2.push(String.fromCharCode(codeUnit));
+          i += 6;
+          lastEmit = i;
+          continue;
+        }
+      }
+      i++;
+    }
+
+    if (lastEmit < m) out2.push(result.slice(lastEmit));
+    result = out2.join("");
+  }
+
+  return result;
+}


### PR DESCRIPTION
fixes #9526 

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `decodeUnicodeEscapesOnly` to decode Unicode escapes in JSON strings, integrating it into `IOTableCell` and providing comprehensive tests.
> 
>   - **Functionality**:
>     - Adds `decodeUnicodeEscapesOnly` in `unicode.ts` to decode `\uXXXX` Unicode escapes, handling surrogate pairs and supporting a greedy mode for double-escaped sequences.
>     - Integrates `decodeUnicodeEscapesOnly` into `IOTableCellContent` in `IOTableCell.tsx` to decode Unicode in JSON strings, especially when truncated.
>   - **Testing**:
>     - Adds `unicode.clienttest.ts` with tests for `decodeUnicodeEscapesOnly`, covering basic Unicode, surrogate pairs, multi-backslash scenarios, truncation, and greedy mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5e2fa35c3a9518a917ee5dd5413a3df00a3b18b3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->