### PR TITLE
fix(playground): use text buttons

### DIFF
--- a/web/src/features/playground/page/components/MultiWindowPlayground.tsx
+++ b/web/src/features/playground/page/components/MultiWindowPlayground.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useCallback, useRef, useEffect } from "react";
 import { PlaygroundProvider } from "../context";
 import { SaveToPromptButton } from "./SaveToPromptButton";
 import { Button } from "@/src/components/ui/button";
-import { CopyPlus, X } from "lucide-react";
+import { Plus, X } from "lucide-react";
 import { MULTI_WINDOW_CONFIG, type MultiWindowState } from "../types";
 import { ModelParameters } from "@/src/components/ModelParameters";
 import { usePlaygroundContext } from "../context";
@@ -172,33 +172,45 @@ function PlaygroundWindowContent({
   }, [windowId, onCopy]);
 
   return (
-    <div className="playground-window flex h-full min-w-0 flex-col rounded-lg border bg-background shadow-sm">
+    <div className="playground-window flex h-full min-w-0 flex-col rounded-lg border bg-background shadow-sm @container">
       {/* Window Header */}
       <div className="relative flex-shrink-0 border-b bg-muted/50 px-3 py-1">
-        <div className="flex items-center pr-24">
+        <div className="flex items-center pr-32 @xl:pr-96">
           <div className="flex items-center gap-2">
             <ModelParameters {...playgroundContext} layout="compact" />
           </div>
 
           <div className="absolute right-3 top-1/2 flex -translate-y-1/2 items-center gap-2">
-            <TooltipProvider>
+            <TooltipProvider delayDuration={300}>
               <SaveToPromptButton />
 
               {/* Hide copy button on mobile */}
               {!isMobile && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      onClick={handleCopy}
-                      className="h-6 w-6 p-0 hover:bg-muted"
-                    >
-                      <CopyPlus size={14} />
-                      <span className="sr-only">Duplicate window</span>
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>Duplicate window</TooltipContent>
-                </Tooltip>
+                <>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        onClick={handleCopy}
+                        className="h-7 gap-1.5 px-2.5 text-xs @xl:hidden"
+                      >
+                        <Plus size={14} />
+                        <span className="sr-only">New split window</span>
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent className="text-xs">
+                      New split window
+                    </TooltipContent>
+                  </Tooltip>
+                  <Button
+                    variant="outline"
+                    onClick={handleCopy}
+                    className="hidden h-7 gap-1.5 px-2.5 text-xs @xl:flex"
+                  >
+                    <Plus size={14} />
+                    <span>New split window</span>
+                  </Button>
+                </>
               )}
               {canRemove && (
                 <Tooltip>
@@ -212,7 +224,9 @@ function PlaygroundWindowContent({
                       <span className="sr-only">Remove window</span>
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent>Remove window</TooltipContent>
+                  <TooltipContent className="text-xs">
+                    Remove window
+                  </TooltipContent>
                 </Tooltip>
               )}
             </TooltipProvider>

--- a/web/src/features/playground/page/components/SaveToPromptButton.tsx
+++ b/web/src/features/playground/page/components/SaveToPromptButton.tsx
@@ -91,22 +91,37 @@ export const SaveToPromptButton: React.FC<SaveToPromptButtonProps> = ({
   };
 
   return (
-    <TooltipProvider>
+    <TooltipProvider delayDuration={300}>
       <Popover>
         <Tooltip>
           <TooltipTrigger asChild>
             <PopoverTrigger asChild>
               <Button
-                variant="ghost"
-                className={cn("h-6 w-6 p-0 hover:bg-muted", className)}
+                variant="outline"
+                className={cn(
+                  "h-7 gap-1.5 px-2.5 text-xs @xl:hidden",
+                  className,
+                )}
               >
                 <Save size={14} />
                 <span className="sr-only">Save as prompt</span>
               </Button>
             </PopoverTrigger>
           </TooltipTrigger>
-          <TooltipContent>Save as prompt</TooltipContent>
+          <TooltipContent className="text-xs">Save as prompt</TooltipContent>
         </Tooltip>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            className={cn(
+              "hidden h-7 gap-1.5 px-2.5 text-xs @xl:flex",
+              className,
+            )}
+          >
+            <Save size={14} />
+            <span>Save as prompt</span>
+          </Button>
+        </PopoverTrigger>
         <PopoverContent>
           <Button className="mt-2 w-full" onClick={handleNewPrompt}>
             Save as new prompt


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switch button styles to outline variant and adjust tooltips and responsiveness in `MultiWindowPlayground.tsx` and `SaveToPromptButton.tsx`.
> 
>   - **Button Style Changes**:
>     - Change button variant from `ghost` to `outline` in `MultiWindowPlayground.tsx` and `SaveToPromptButton.tsx`.
>     - Adjust button size to `h-7` and add `gap-1.5 px-2.5 text-xs` for better alignment.
>     - Use `Plus` icon instead of `CopyPlus` for the copy button in `MultiWindowPlayground.tsx`.
>   - **Tooltip Adjustments**:
>     - Add `delayDuration={300}` to `TooltipProvider` in both `MultiWindowPlayground.tsx` and `SaveToPromptButton.tsx`.
>     - Update `TooltipContent` to use `text-xs` class for smaller text size.
>   - **Responsive Design**:
>     - Add `@xl:hidden` and `@xl:flex` classes to buttons for responsive visibility in both files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ae19c123ee07c2ac1cb87c102fff79146b9eae54. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->