### PR TITLE
chore(llm-connections): remove all atla keys

### DIFF
--- a/packages/shared/prisma/migrations/20251013134801_drop_atla_llm_keys/migration.sql
+++ b/packages/shared/prisma/migrations/20251013134801_drop_atla_llm_keys/migration.sql
@@ -1,0 +1,1 @@
+DELETE FROM "llm_api_keys" WHERE adapter = 'atla'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove 'atla' adapter keys from `llm_api_keys` via SQL migration.
> 
>   - **Database Migration**:
>     - Adds `migration.sql` to remove entries from `llm_api_keys` where `adapter` is 'atla'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b2d39de57c6238f2f7b0e40ed5aa4ae9d161538f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->