### PR TITLE
fix(otel): parse AI SDK cached input tokens if provided as string

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1677,14 +1677,18 @@ export class OtelIngestionProcessor {
           )
         ) {
           if ("ai.usage.cachedInputTokens" in attributes) {
-            usageDetails["input_cached_tokens"] = JSON.parse(
-              attributes["ai.usage.cachedInputTokens"] as string,
-            ).intValue;
+            const value = attributes["ai.usage.cachedInputTokens"] as string;
+            const parsed = JSON.parse(value);
+
+            usageDetails["input_cached_tokens"] =
+              typeof parsed === "number" ? parsed : JSON.parse(value).intValue;
           }
           if ("ai.usage.reasoningTokens" in attributes) {
-            usageDetails["output_reasoning_tokens"] = JSON.parse(
-              attributes["ai.usage.reasoningTokens"] as string,
-            ).intValue;
+            const value = attributes["ai.usage.reasoningTokens"] as string;
+            const parsed = JSON.parse(value);
+
+            usageDetails["output_reasoning_tokens"] =
+              typeof parsed === "number" ? parsed : JSON.parse(value).intValue;
           }
         } else if (providerMetadata) {
           // Fall back to providerMetadata


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix parsing of AI SDK cached input tokens in `OtelIngestionProcessor.ts` to handle string inputs correctly.
> 
>   - **Behavior**:
>     - In `OtelIngestionProcessor.ts`, `extractUsageDetails` method now parses `ai.usage.cachedInputTokens` and `ai.usage.reasoningTokens` as strings and checks if parsed value is a number.
>     - If parsed value is not a number, it extracts `intValue` from the parsed object.
>   - **Misc**:
>     - No changes to other files or methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9da84ff172ac50feaabe43c272b871f4182ec79f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->