### PR TITLE
fix: fix dataset items API limits

### DIFF
--- a/web/src/pages/api/public/dataset-items/index.ts
+++ b/web/src/pages/api/public/dataset-items/index.ts
@@ -17,6 +17,14 @@ import {
 import { logger } from "@langfuse/shared/src/server";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: "4.5mb",
+    },
+  },
+};
+
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
     name: "Create Dataset Item",

--- a/web/src/pages/api/public/dataset-run-items.ts
+++ b/web/src/pages/api/public/dataset-run-items.ts
@@ -23,6 +23,14 @@ import {
   getDatasetRunItemsCountForPublicApi,
 } from "@/src/features/public-api/server/dataset-run-items";
 
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: "4.5mb",
+    },
+  },
+};
+
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
     name: "Create Dataset Run Item",

--- a/web/src/pages/api/public/dataset-run-items.ts
+++ b/web/src/pages/api/public/dataset-run-items.ts
@@ -23,14 +23,6 @@ import {
   getDatasetRunItemsCountForPublicApi,
 } from "@/src/features/public-api/server/dataset-run-items";
 
-export const config = {
-  api: {
-    bodyParser: {
-      sizeLimit: "4.5mb",
-    },
-  },
-};
-
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
     name: "Create Dataset Run Item",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `bodyParser.sizeLimit` to `4.5mb` in `dataset-run-items.ts` to limit request body size for the API endpoint.
> 
>   - **Configuration**:
>     - Set `bodyParser.sizeLimit` to `4.5mb` in `dataset-run-items.ts` to limit request body size for the API endpoint.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c30511f4867c86bdd112a726614df5073d76095a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->