### PR TITLE
chore: add new metric for event byte length

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -16,6 +16,7 @@ import {
   getS3EventStorageClient,
   QueueJobs,
   instrumentSync,
+  recordDistribution,
 } from "../";
 
 import { LangfuseOtelSpanAttributes } from "./attributes";
@@ -248,6 +249,16 @@ export class OtelIngestionProcessor {
                 const scopeVersion = scopeSpan?.scope?.version;
 
                 const stringifiedSpan = JSON.stringify(span);
+                const eventBytes = Buffer.byteLength(stringifiedSpan, "utf8");
+
+                recordDistribution(
+                  "langfuse.ingestion.otel.event.byte_length",
+                  eventBytes,
+                  {
+                    source: "otel",
+                    sdk_language: telemetrySdkLanguage || "",
+                  },
+                );
 
                 events.push({
                   projectId: this.projectId,
@@ -339,7 +350,7 @@ export class OtelIngestionProcessor {
 
                   // Source data
                   // eventRaw: stringifiedSpan,
-                  eventBytes: Buffer.byteLength(stringifiedSpan, "utf8"),
+                  eventBytes,
                 });
               }
             }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add metric to track event byte length in `OtelIngestionProcessor` by recording it in `processToEvent()` method.
> 
>   - **Metrics**:
>     - Add `recordDistribution` call in `OtelIngestionProcessor` to track `langfuse.ingestion.otel.event.byte_length`.
>     - Calculate `eventBytes` using `Buffer.byteLength` for each span in `processToEvent()`.
>   - **Refactoring**:
>     - Use `eventBytes` variable instead of recalculating byte length in `processToEvent()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1b7e9dd018ef9ba260f7f361d26d90ea45e43812. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->