### PR TITLE
fix: clamp start_time for event propagation to avoid unix timestamp errors

### DIFF
--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -154,7 +154,8 @@ export const handleEventPropagationJob = async (
           -- this way we threat the case as the "wrapper" for spans backfilled this way.
           coalesce(obs.parent_observation_id, obs.trace_id) AS parent_span_id,
           -- Convert timestamps from DateTime64(3) to DateTime64(6) via implicit conversion
-          obs.start_time,
+          -- Clamp start_time to 1970-01-01 or later (Unix epoch minimum) to avoid toUnixTimestamp() errors
+          greatest(obs.start_time, toDateTime64('1970-01-01', 3)) AS start_time,
           obs.end_time,
           obs.name,
           obs.type,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Clamps `start_time` in `handleEventPropagationJob` to prevent Unix timestamp errors.
> 
>   - **Behavior**:
>     - Clamps `start_time` to 1970-01-01 or later in `handleEventPropagationJob` to prevent `toUnixTimestamp()` errors.
>   - **SQL Query**:
>     - Uses `greatest(obs.start_time, toDateTime64('1970-01-01', 3))` to ensure valid Unix timestamps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 006bf1e48023d9906d777c974ed710b3f13af3cb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->