### PR TITLE
fix(sentry): don't report user errors

### DIFF
--- a/web/src/pages/api/trpc/[trpc].ts
+++ b/web/src/pages/api/trpc/[trpc].ts
@@ -13,7 +13,16 @@ export default createNextApiHandler({
   router: appRouter,
   createContext: createTRPCContext,
   onError: ({ path, error }) => {
-    if (error.code === "NOT_FOUND" || error.code === "UNAUTHORIZED") {
+    // User errors that should not be reported to Sentry
+    const userErrorCodes = [
+      "NOT_FOUND",
+      "UNAUTHORIZED",
+      "FORBIDDEN",
+      "BAD_REQUEST",
+      "PRECONDITION_FAILED",
+    ];
+
+    if (userErrorCodes.includes(error.code)) {
       logger.info(
         `tRPC route failed on ${path ?? "<no-path>"}: ${error.message}`,
         error,
@@ -23,8 +32,9 @@ export default createNextApiHandler({
         `tRPC route failed on ${path ?? "<no-path>"}: ${error.message}`,
         error,
       );
+      // Only report system errors to Sentry, not user errors
+      traceException(error);
     }
-    traceException(error);
     return error;
   },
   responseMeta() {


### PR DESCRIPTION
## What does this PR do?

This PR prevents user-induced `TRPCClientError`s, such as those caused by incorrect LLM API keys, from being reported to Sentry. These errors are now logged at an info level and only displayed to the user via an error toast, reducing Sentry noise for expected user-facing issues.

Fixes #LFE-6775

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have checked if my changes generate no new warnings (`npm run lint`)

---
Linear Issue: [LFE-6775](https://linear.app/langfuse/issue/LFE-6775/dont-throw-if-users-create-an-llm-config-with-incorrect-api-key)

<a href="https://cursor.com/background-agent?bcId=bc-3aaeeb86-4cc8-404f-91d1-284ea95afe17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3aaeeb86-4cc8-404f-91d1-284ea95afe17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevents user-induced `TRPCClientError`s from being reported to Sentry, logging them at info level in `[trpc].ts`.
> 
>   - **Behavior**:
>     - Prevents user-induced `TRPCClientError`s from being reported to Sentry in `[trpc].ts`.
>     - Logs user errors (`NOT_FOUND`, `UNAUTHORIZED`, `FORBIDDEN`, `BAD_REQUEST`, `PRECONDITION_FAILED`) at info level.
>     - Displays user errors to users via error toast.
>   - **Error Handling**:
>     - Only system errors are reported to Sentry.
>     - Uses `logger.info` for user errors and `logger.error` for system errors in `onError` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4c40e002dd60a51b4cdb47b10479307a69287666. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->