### PR TITLE
fix(comments): Fix text selection in trace comments

### DIFF
--- a/web/src/features/comments/CommentList.tsx
+++ b/web/src/features/comments/CommentList.tsx
@@ -227,7 +227,7 @@ export function CommentList({
                       : (comment.authorUserId ?? "U")}
                   </AvatarFallback>
                 </Avatar>
-                <div className="relative rounded-md" data-vaul-no-drag>
+                <div className="relative rounded-md">
                   <div className="flex h-6 flex-row items-center justify-between px-1 py-0 text-sm">
                     <div className="text-sm font-medium">
                       {comment.authorUserName ?? comment.authorUserId ?? "User"}

--- a/web/src/features/comments/CommentList.tsx
+++ b/web/src/features/comments/CommentList.tsx
@@ -227,7 +227,7 @@ export function CommentList({
                       : (comment.authorUserId ?? "U")}
                   </AvatarFallback>
                 </Avatar>
-                <div className="relative rounded-md">
+                <div className="relative rounded-md" data-vaul-no-drag>
                   <div className="flex h-6 flex-row items-center justify-between px-1 py-0 text-sm">
                     <div className="text-sm font-medium">
                       {comment.authorUserName ?? comment.authorUserId ?? "User"}

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -238,3 +238,17 @@
     }
   }
 }
+
+/* 
+ * Fix for Vaul drawer blocking text selection
+ * Vaul applies user-select: none to the entire drawer on desktop via CSS media query
+ * We override this for drawers that set blockTextSelection={false}
+ * See: node_modules/vaul/dist/index.js line 84
+ */
+[data-vaul-drawer][data-allow-text-selection="true"],
+[data-vaul-drawer][data-allow-text-selection="true"] * {
+  user-select: text !important;
+  -webkit-user-select: text !important;
+  -moz-user-select: text !important;
+  -ms-user-select: text !important;
+}


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where text in trace comments could not be selected. 


## Problem

Text selection was not working in drawer components due to Vaul applying `user-select: none` via CSS on desktop devices. (!) Applying  `data-vaul-no-drag` alone does not solve the issue.

## Root Cause

Vaul (the drawer library) injects this CSS globally (source: `node_modules/vaul/dist/index.js` line 84):

```css
@media (hover: hover) and (pointer: fine) {
  [data-vaul-drawer] {
    user-select: none; /* Blocks ALL text selection in drawer on desktop */
  }
}
```

This prevents text selection in the entire drawer on non-touch devices (desktops with mice/trackpads).

## Solution

### 1. Added `blockTextSelection` prop to Drawer component

**File:** `web/src/components/ui/drawer.tsx`

- Added optional `blockTextSelection` prop (defaults to `false`)
- Drawer passes a `data-allow-text-selection` attribute to the content
- Uses React Context to share the prop between Drawer and DrawerContent

### 2. CSS Override in globals.css

**File:** `web/src/styles/globals.css`

Added CSS to override Vaul's `user-select: none` for drawers that allow text selection:

```css
[data-vaul-drawer][data-allow-text-selection="true"],
[data-vaul-drawer][data-allow-text-selection="true"] * {
  user-select: text !important;
  -webkit-user-select: text !important;
  -moz-user-select: text !important;
  -ms-user-select: text !important;
}
```



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes text selection in trace comments by adding `blockTextSelection` prop to Drawer and overriding CSS in `globals.css`.
> 
>   - **Behavior**:
>     - Fixes text selection issue in trace comments within drawer components by allowing text selection on non-touch devices.
>   - **Components**:
>     - Adds `blockTextSelection` prop to `Drawer` in `drawer.tsx`, defaulting to `false`.
>     - Uses React Context to pass `blockTextSelection` from `Drawer` to `DrawerContent`.
>     - `DrawerContent` sets `data-allow-text-selection` attribute based on `blockTextSelection`.
>   - **Styles**:
>     - Overrides Vaul's `user-select: none` in `globals.css` for drawers with `data-allow-text-selection="true"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a2cd8dcf8d7201b35d18db8214ed7fb7649d951f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->