### PR TITLE
Fix sentry build warning

### DIFF
--- a/web/src/instrumentation.ts
+++ b/web/src/instrumentation.ts
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/nextjs";
+
 // See: https://vercel.com/docs/observability/otel-overview
 export async function register() {
   // This variable is set in the .env file or environment variables
@@ -7,9 +9,35 @@ export async function register() {
       ? process.env.NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT === "true"
       : true;
 
-  if (process.env.NEXT_RUNTIME === "nodejs" && isInitLoadingEnabled) {
-    console.log("Running init scripts...");
-    await import("./observability.config");
-    await import("./initialize");
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    // Initialize Sentry for server-side
+    Sentry.init({
+      dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+      environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
+      release: process.env.NEXT_PUBLIC_BUILD_ID,
+
+      // Set tracesSampleRate to 1.0 to capture 100%
+      // of transactions for performance monitoring.
+      tracesSampleRate: process.env.NEXT_PUBLIC_LANGFUSE_TRACING_SAMPLE_RATE
+        ? Number(process.env.NEXT_PUBLIC_LANGFUSE_TRACING_SAMPLE_RATE)
+        : 0,
+
+      debug: false,
+
+      // Set profilesSampleRate to 1.0 to profile every transaction.
+      // Since profilesSampleRate is relative to tracesSampleRate,
+      // the final profiling rate can be computed as tracesSampleRate * profilesSampleRate
+      profilesSampleRate: 0.5,
+    });
+
+    if (isInitLoadingEnabled) {
+      console.log("Running init scripts...");
+      await import("./observability.config");
+      await import("./initialize");
+    }
   }
 }
+
+// Hook to capture errors from nested React Server Components
+// See: https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#errors-from-nested-react-server-components
+export const onRequestError = Sentry.captureRequestError;


### PR DESCRIPTION
## What does this PR do?

This PR resolves a Sentry build warning (`Could not find onRequestError hook in instrumentation file`) by correctly configuring Sentry's server-side instrumentation for Next.js. It initializes Sentry and exports the `onRequestError` hook within `web/src/instrumentation.ts` as recommended by Sentry's documentation for capturing errors from nested React Server Components.

Fixes # LFE-7182

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [ ] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my PR needs changes to the documentation
- [ ] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [x] I haven't added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-7182](https://linear.app/langfuse/issue/LFE-7182/fix-sentry-build-warning)

<a href="https://cursor.com/background-agent?bcId=bc-80a72bfb-bfe9-4956-887f-f33c873fe9b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-80a72bfb-bfe9-4956-887f-f33c873fe9b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Sentry build warning by configuring server-side instrumentation and exporting `onRequestError` in `web/src/instrumentation.ts`.
> 
>   - **Behavior**:
>     - Fixes Sentry build warning by configuring server-side instrumentation in `web/src/instrumentation.ts`.
>     - Initializes Sentry with `Sentry.init()` using environment variables for DSN, environment, release, and sampling rates.
>     - Exports `onRequestError` hook to capture errors from nested React Server Components.
>   - **Configuration**:
>     - Sets `tracesSampleRate` based on `NEXT_PUBLIC_LANGFUSE_TRACING_SAMPLE_RATE` or defaults to 0.
>     - Sets `profilesSampleRate` to 0.5.
>     - Conditional initialization of scripts based on `isInitLoadingEnabled`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for debf3b0ba58fdaac7cc4d4726550158406ee621d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->