### PR TITLE
chore: reduce event propagation processing delay to 1s

### DIFF
--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -256,7 +256,7 @@ export const handleEventPropagationJob = async (
         await queue.add(
           QueueJobs.EventPropagationJob,
           { timestamp: new Date(), id: randomUUID() },
-          { delay: 10000 }, // 10 second delay
+          { delay: 1000 }, // 1 second delay
         );
         logger.info(
           `Scheduled next event propagation job with 10s delay. Remaining partitions: ${partitions.length - 1}`,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce delay for scheduling next event propagation job from 10s to 1s in `handleEventPropagationJob()`.
> 
>   - **Behavior**:
>     - Reduce delay for scheduling next event propagation job from 10s to 1s in `handleEventPropagationJob()` in `handleEventPropagationJob.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e7f9af33c066cb8b5be898f97b5a04a6e6ddd484. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->