### PR TITLE
fix(trpc-error-toasts): improve error handling to expose safe messages for 5xx errors

### DIFF
--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -157,7 +157,9 @@ const withErrorHandling = t.middleware(async ({ ctx, next }) => {
       res.error = new TRPCError({
         code: res.error.code,
         cause: null, // do not expose stack traces
-        message: isSafeToExpose ? res.error.message : "Internal error",
+        message: isSafeToExpose
+          ? res.error.message
+          : "Internal error. We have been notified and are working on it.",
       });
     }
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves error handling in `trpc.ts` by exposing original messages for 4xx errors and using a generic message for 5xx errors.
> 
>   - **Error Handling**:
>     - In `trpc.ts`, modify `withErrorHandling` middleware to check HTTP status codes using `getHTTPStatusCodeFromError`.
>     - Expose original error message for 4xx errors; use generic message for 5xx errors: "Internal error. We have been notified and are working on it."
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7849ada0f32a179f1c9fc03167c1e9ef6017f112. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->