### PR TITLE
fix(sentry): filter out invalid href errors in event reporting

### DIFF
--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -13,7 +13,6 @@ Sentry.init({
   beforeSend(event, hint) {
     const error = hint.originalException;
     const errorValue = event.exception?.values?.[0]?.value || "";
-    const errorMessage = event.message || "";
 
     // Filter out TRPCClientErrors, we track them in DataDog.
     // The users see those via toast notifications -> see handleTrpcError in web/src/utils/api.ts

--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -12,6 +12,8 @@ Sentry.init({
 
   beforeSend(event, hint) {
     const error = hint.originalException;
+    const errorValue = event.exception?.values?.[0]?.value || "";
+    const errorMessage = event.message || "";
 
     // Filter out TRPCClientErrors, we track them in DataDog.
     // The users see those via toast notifications -> see handleTrpcError in web/src/utils/api.ts
@@ -30,6 +32,15 @@ Sentry.init({
     if (
       event.exception?.values?.[0]?.mechanism?.type === "http.client" &&
       event.request?.url?.includes("/api/trpc/")
+    ) {
+      return null;
+    }
+
+    // Filter invalid href errors - these are from user-inputted data containing malformed URLs
+    // The Next.js router correctly rejects them, no need to log as errors
+    if (
+      errorValue.includes("Invalid href") &&
+      errorValue.includes("passed to next/router")
     ) {
       return null;
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a filter in `instrumentation-client.ts` to ignore invalid href errors in Sentry reporting.
> 
>   - **Behavior**:
>     - Adds a filter in `beforeSend` in `instrumentation-client.ts` to ignore errors with "Invalid href" and "passed to next/router" in the error message.
>     - This prevents logging errors from malformed URLs in user input, as they are correctly rejected by Next.js router.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b2a542156af3292af3940b08c143363a0bdf0699. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->