### PR TITLE
chore: propagate byteSize in backfill

### DIFF
--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -202,7 +202,7 @@ export const handleEventPropagationJob = async (
           NULL AS telemetry_sdk_version,
           '' AS blob_storage_file_path,
           '' AS event_raw,
-          0 AS event_bytes,
+          byteSize(*) AS event_bytes,
           obs.created_at,
           obs.updated_at,
           obs.event_ts,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `event_bytes` calculation in `handleEventPropagationJob` to use `byteSize(*)` for accurate event data size.
> 
>   - **Behavior**:
>     - Update `event_bytes` calculation in `handleEventPropagationJob` in `handleEventPropagationJob.ts` to use `byteSize(*)` instead of `0`.
>     - This change ensures `event_bytes` reflects the actual byte size of the event data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d98ebf6201b30abaad886ab5782a94c8c1d41f1f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->