### PR TITLE
fix(trace-ui): show chatml only if success and more than 0 messages

### DIFF
--- a/web/src/components/trace/IOPreview.tsx
+++ b/web/src/components/trace/IOPreview.tsx
@@ -76,10 +76,17 @@ export const IOPreview: React.FC<{
     const inResult = normalizeInput(input, ctx);
     const outResult = normalizeOutput(output, ctx);
     const outputClean = cleanLegacyOutput(output, output);
+    const messages = combineInputOutputMessages(
+      inResult,
+      outResult,
+      outputClean,
+    );
 
     return {
-      canDisplayAsChat: inResult.success || outResult.success,
-      allMessages: combineInputOutputMessages(inResult, outResult, outputClean),
+      // display as chat if normalization succeeded AND we have messages to show
+      canDisplayAsChat:
+        (inResult.success || outResult.success) && messages.length > 0,
+      allMessages: messages,
       additionalInput: extractAdditionalInput(input),
     };
   }, [input, output, metadata, props.observationName]);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `IOPreview.tsx` to display chat only if normalization succeeds and there are messages.
> 
>   - **Behavior**:
>     - Update `canDisplayAsChat` in `IOPreview.tsx` to require successful normalization and non-zero messages for chat display.
>     - Ensures chat is shown only if `inResult.success` or `outResult.success` and `messages.length > 0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3b0cc76b5b6c1d5f75baab321701bf99bbf284e5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->