### PR TITLE
fix: avoid read after end errors in otel ingest

### DIFF
--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -103,8 +103,7 @@ export default withMiddlewares({
 
       // At this point, we have the raw OpenTelemetry Span body. We upload the full batch to S3
       // and the OtelIngestionProcessor logic will handle processing in the worker container.
-      await processor.publishToOtelIngestionQueue(resourceSpans);
-      return {};
+      return processor.publishToOtelIngestionQueue(resourceSpans);
     },
   }),
 });

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -36,7 +36,8 @@ export default withMiddlewares({
         });
       } catch (e) {
         logger.error(`Failed to read request body`, e);
-        return res.status(400).json({ error: "Failed to read request body" });
+        res.status(400);
+        return { error: "Failed to read request body" };
       }
 
       if (req.headers["content-encoding"]?.includes("gzip")) {
@@ -48,9 +49,8 @@ export default withMiddlewares({
           });
         } catch (e) {
           logger.error(`Failed to decompress request body`, e);
-          return res
-            .status(400)
-            .json({ error: "Failed to decompress request body" });
+          res.status(400);
+          return { error: "Failed to decompress request body" };
         }
       }
 
@@ -62,7 +62,9 @@ export default withMiddlewares({
         (!contentType.includes("application/json") &&
           !contentType.includes("application/x-protobuf"))
       ) {
-        return res.status(400).json({ error: "Invalid content type" });
+        logger.error(`Invalid content type: ${contentType}`);
+        res.status(400);
+        return { error: "Invalid content type" };
       }
       if (contentType.includes("application/x-protobuf")) {
         try {
@@ -76,9 +78,8 @@ export default withMiddlewares({
             ).resourceSpans;
         } catch (e) {
           logger.error(`Failed to parse OTel Protobuf`, e);
-          return res
-            .status(400)
-            .json({ error: "Failed to parse OTel Protobuf Trace" });
+          res.status(400);
+          return { error: "Failed to parse OTel Protobuf Trace" };
         }
       }
       if (contentType.includes("application/json")) {
@@ -86,14 +87,13 @@ export default withMiddlewares({
           resourceSpans = JSON.parse(body.toString()).resourceSpans;
         } catch (e) {
           logger.error(`Failed to parse OTel JSON`, e);
-          return res
-            .status(400)
-            .json({ error: "Failed to parse OTel JSON Trace" });
+          res.status(400);
+          return { error: "Failed to parse OTel JSON Trace" };
         }
       }
 
       if (!resourceSpans || resourceSpans.length === 0) {
-        return res.status(200).json({});
+        return {};
       }
 
       const processor = new OtelIngestionProcessor({
@@ -103,7 +103,8 @@ export default withMiddlewares({
 
       // At this point, we have the raw OpenTelemetry Span body. We upload the full batch to S3
       // and the OtelIngestionProcessor logic will handle processing in the worker container.
-      return processor.publishToOtelIngestionQueue(resourceSpans);
+      await processor.publishToOtelIngestionQueue(resourceSpans);
+      return {};
     },
   }),
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify response handling in `index.ts` to prevent read after end errors by separating status setting and return statements.
> 
>   - **Behavior**:
>     - Modify response handling in `index.ts` to prevent read after end errors by separating `res.status()` and return statements.
>     - Ensure `res.status(400)` is called before returning error objects for body read, decompression, content type, and parsing errors.
>     - Change `return res.status(200).json({})` to `return {}` when `resourceSpans` is empty.
>     - Use `await` with `processor.publishToOtelIngestionQueue(resourceSpans)` to ensure asynchronous operation completion before returning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ea7349fb79ebfc5e643e381a4c0402ef03a852d6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->