### PR TITLE
feat(prompts): add PromptType to list prompt API

### DIFF
--- a/fern/apis/server/definition/prompts.yml
+++ b/fern/apis/server/definition/prompts.yml
@@ -66,6 +66,9 @@ types:
   PromptMeta:
     properties:
       name: string
+      type:
+        type: PromptType
+        docs: Indicates whether the prompt is a text or chat prompt.
       versions: list<integer>
       labels: list<string>
       tags: list<string>
@@ -113,6 +116,11 @@ types:
     union:
       chat: ChatPrompt
       text: TextPrompt
+
+  PromptType:
+    enum:
+      - chat
+      - text
 
   BasePrompt:
     properties:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -7648,6 +7648,9 @@ components:
       properties:
         name:
           type: string
+        type:
+          $ref: '#/components/schemas/PromptType'
+          description: Indicates whether the prompt is a text or chat prompt.
         versions:
           type: array
           items:
@@ -7669,6 +7672,7 @@ components:
             filters (if any are provided)
       required:
         - name
+        - type
         - versions
         - labels
         - tags
@@ -7784,6 +7788,12 @@ components:
             - $ref: '#/components/schemas/TextPrompt'
           required:
             - type
+    PromptType:
+      title: PromptType
+      type: string
+      enum:
+        - chat
+        - text
     BasePrompt:
       title: BasePrompt
       type: object

--- a/web/src/__tests__/async/prompts.v2.servertest.ts
+++ b/web/src/__tests__/async/prompts.v2.servertest.ts
@@ -1269,6 +1269,7 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       expect(promptMeta1.versions).toEqual([1, 2, 4]);
       expect(promptMeta1.labels).toEqual(["production", "version2"]);
       expect(promptMeta1.tags).toEqual([]);
+      expect(promptMeta1.type).toBe(PromptType.Text);
       expect(promptMeta1.lastUpdatedAt).toBeDefined();
 
       // Validate prompt-2 meta
@@ -1276,6 +1277,7 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       expect(promptMeta2.versions).toEqual([1, 2, 3]);
       expect(promptMeta2.labels).toEqual(["dev", "production", "staging"]);
       expect(promptMeta2.tags).toEqual([]);
+      expect(promptMeta2.type).toBe(PromptType.Text);
       expect(promptMeta2.lastUpdatedAt).toBeDefined();
 
       // Validate prompt-3 meta
@@ -1283,6 +1285,7 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       expect(promptMeta3.versions).toEqual([1]);
       expect(promptMeta3.labels).toEqual(["production"]);
       expect(promptMeta3.tags).toEqual(["tag-1"]);
+      expect(promptMeta3.type).toBe(PromptType.Chat);
       expect(promptMeta3.lastUpdatedAt).toBeDefined();
 
       // Validate pagination
@@ -1314,6 +1317,7 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       expect(body.data[0].versions).toEqual([1, 2, 4]);
       expect(body.data[0].labels).toEqual(["production", "version2"]);
       expect(body.data[0].tags).toEqual([]);
+      expect(body.data[0].type).toBe(PromptType.Text);
 
       // Validate pagination
       expect(body.meta.page).toBe(1);
@@ -1336,6 +1340,7 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       expect(body2.data[0].versions).toEqual([1, 2, 3]);
       expect(body2.data[0].labels).toEqual(["dev", "production", "staging"]);
       expect(body2.data[0].tags).toEqual([]);
+      expect(body2.data[0].type).toBe(PromptType.Text);
 
       // Validate pagination
       expect(body2.meta.page).toBe(1);
@@ -1370,6 +1375,7 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       expect(body.data[0].versions).toEqual([1]);
       expect(body.data[0].labels).toEqual(["production"]);
       expect(body.data[0].tags).toEqual(["tag-1"]);
+      expect(body.data[0].type).toBe(PromptType.Chat);
 
       // Validate pagination
       expect(body.meta.page).toBe(1);
@@ -1409,6 +1415,14 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       expect(
         body.data.some((promptMeta) => promptMeta.name === "prompt-3"),
       ).toBe(true);
+      const expectedTypesByName: Record<string, PromptType> = {
+        "prompt-1": PromptType.Text,
+        "prompt-2": PromptType.Text,
+        "prompt-3": PromptType.Chat,
+      };
+      body.data.forEach((promptMeta) =>
+        expect(promptMeta.type).toBe(expectedTypesByName[promptMeta.name]),
+      );
 
       // Validate pagination
       expect(body.meta.page).toBe(1);
@@ -1431,6 +1445,7 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       expect(body2.data[0].versions).toEqual([3]); // Only version 3 should be present as it is the only one with dev label
       expect(body2.data[0].labels).toEqual(["dev"]); // Only dev label should be present
       expect(body2.data[0].tags).toEqual([]);
+      expect(body2.data[0].type).toBe(PromptType.Text);
 
       // Validate pagination
       expect(body2.meta.page).toBe(1);
@@ -1502,12 +1517,14 @@ describe("/api/public/v2/prompts API Endpoint", () => {
     );
     expect(prompt1).toBeDefined();
     expect(prompt1?.lastConfig).toEqual({ version: 4 });
+    expect(prompt1?.type).toBe(PromptType.Text);
 
     const prompt2 = body.data.find(
       (promptMeta) => promptMeta.name === "prompt-2",
     );
     expect(prompt2).toBeDefined();
     expect(prompt2?.lastConfig).toEqual({});
+    expect(prompt2?.type).toBe(PromptType.Text);
 
     // validate with label filter
     const response2 = await makeAPICall(
@@ -1522,6 +1539,7 @@ describe("/api/public/v2/prompts API Endpoint", () => {
     expect(body2.data).toHaveLength(1);
     expect(body2.data[0].name).toBe("prompt-1");
     expect(body2.data[0].lastConfig).toEqual({ version: 2 });
+    expect(body2.data[0].type).toBe(PromptType.Text);
 
     // validate with version filter
     const response3 = await makeAPICall(
@@ -1538,6 +1556,7 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       (promptMeta) => promptMeta.name === "prompt-1",
     );
     expect(prompt1v1?.lastConfig).toEqual({ version: 1 });
+    expect(prompt1v1?.type).toBe(PromptType.Text);
   });
 
   it("should respect the fromUpdatedAt and toUpdatedAt filters on GET /prompts", async () => {
@@ -3140,6 +3159,7 @@ const getMockPrompts = (projectId: string, otherProjectId: string) => [
     projectId,
     config: {},
     tags: ["tag-1"],
+    type: PromptType.Chat,
     version: 1,
     updatedAt: new Date("2000-01-01T00:00:00.000Z"),
   },

--- a/web/src/features/prompts/server/actions/getPromptsMeta.ts
+++ b/web/src/features/prompts/server/actions/getPromptsMeta.ts
@@ -2,6 +2,7 @@ import {
   type GetPromptsMetaType,
   type FilterState,
   promptsTableCols,
+  type PromptType,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 import { tableColumnsToSqlFilterAndPrefix } from "@langfuse/shared/src/server";
@@ -14,10 +15,11 @@ export const getPromptsMeta = async (
   const { projectId, page, limit } = params;
 
   const promptsMeta = (await prisma.$queryRaw`
-    WITH latest_version_config AS (
+    WITH latest_version_details AS (
       SELECT
           p.name,
-          p.config
+          p.config,
+          p.type
       FROM
           prompts p
       WHERE
@@ -59,10 +61,11 @@ export const getPromptsMeta = async (
 
     SELECT
       v.*,
+      l.type AS type,
       l.config AS "lastConfig"
     FROM
       versions v
-    LEFT JOIN latest_version_config l ON v.name = l.name
+    LEFT JOIN latest_version_details l ON v.name = l.name
   `) as PromptsMeta[];
 
   const [{ count: totalItemsCount }] = (await prisma.$queryRaw`
@@ -91,6 +94,7 @@ type PromptsMeta = {
   labels: string[];
   tags: string[];
   lastUpdatedAt: Date;
+  type: PromptType;
   lastConfig: unknown; // json object
 };
 


### PR DESCRIPTION
## What does this PR do?



<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue) https://github.com/orgs/langfuse/discussions/9037

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `PromptType` to prompt metadata in the API, distinguishing between text and chat prompts, with updates to models, API schema, and tests.
> 
>   - **Behavior**:
>     - Adds `PromptType` to `PromptMeta` in `prompts.yml` and `openapi.yml`, indicating if a prompt is text or chat.
>     - Updates `getPromptsMeta()` in `getPromptsMeta.ts` to include `PromptType` in the response.
>   - **Tests**:
>     - Updates tests in `prompts.v2.servertest.ts` to validate `PromptType` for prompts, ensuring correct type assignment and retrieval.
>     - Adds checks for `PromptType` in various test scenarios, including fetching and creating prompts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7994468eee353865a072e01c7f8164191ebfc8a0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->