### PR TITLE
fix(support): remove support-drawer resize cookie

### DIFF
--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -340,7 +340,7 @@ export default function Layout(props: PropsWithChildren) {
         <SidebarProvider>
           <div className="flex h-dvh w-full flex-col">
             <PaymentBanner />
-            <div className="flex min-h-0 flex-1 pt-banner-offset">
+            <div className="pt-banner-offset flex min-h-0 flex-1">
               <AppSidebar
                 navItems={mainNavigation}
                 secondaryNavItems={secondaryNavigation}
@@ -373,49 +373,6 @@ export function ResizableContent({ children }: PropsWithChildren) {
   const { open, setOpen } = useSupportDrawer();
   const isDesktop = useMediaQuery({ query: "(min-width: 768px)" });
 
-  // Keep cookie-based layout only for desktop
-  const COOKIE_KEY = "react-resizable-panels:layout:supportDrawer";
-  const [mounted, setMounted] = useState(false);
-  const [defaultLayout, setDefaultLayout] = useState<number[] | undefined>(
-    undefined,
-  );
-
-  useEffect(() => {
-    setMounted(true);
-    if (!isDesktop /* || !open */) return; // no layout restore needed on mobile (and you can also gate on open if you want)
-    try {
-      if (typeof document !== "undefined") {
-        const match = document.cookie.match(
-          new RegExp(
-            "(?:^|; )" +
-              COOKIE_KEY.replace(/([.$?*|{}()\[\]\\\/\+^])/g, "\\$1") +
-              "=([^;]*)",
-          ),
-        );
-        if (match?.[1]) {
-          const parsed = JSON.parse(decodeURIComponent(match[1]));
-          if (Array.isArray(parsed) && parsed.length === 2) {
-            setDefaultLayout(parsed as number[]);
-          }
-        }
-      }
-    } catch {
-      // ignore cookie parse errors
-    }
-  }, [isDesktop /*, open */]);
-
-  const onLayout = (sizes: number[]) => {
-    if (!isDesktop) return;
-    try {
-      document.cookie = `${COOKIE_KEY}=${encodeURIComponent(
-        JSON.stringify(sizes),
-      )}; path=/; max-age=${60 * 60 * 24 * 365}`;
-    } catch {
-      // ignore cookie write errors
-    }
-  };
-
-  // MOBILE: main + overlay drawer
   if (!isDesktop) {
     return (
       <>
@@ -424,7 +381,7 @@ export function ResizableContent({ children }: PropsWithChildren) {
         <Drawer open={open} onOpenChange={setOpen} forceDirection="bottom">
           <DrawerContent
             id="support-drawer"
-            className="inset-x-0 bottom-0 top-[calc(var(--banner-offset)+10px)] min-h-screen-with-banner"
+            className="min-h-screen-with-banner inset-x-0 bottom-0 top-[calc(var(--banner-offset)+10px)]"
             size="full"
           >
             <DrawerHeader className="absolute inset-x-0 top-0 p-0 text-left">
@@ -451,19 +408,11 @@ export function ResizableContent({ children }: PropsWithChildren) {
     return <main className="h-full flex-1">{children}</main>;
   }
 
-  if (!mounted) {
-    return <main className="h-full flex-1">{children}</main>;
-  }
-
-  const mainDefault = defaultLayout?.[0] ?? 70;
-  const drawerDefault = defaultLayout?.[1] ?? 30;
+  const mainDefault = 70;
+  const drawerDefault = 30;
 
   return (
-    <ResizablePanelGroup
-      direction="horizontal"
-      className="flex h-full w-full"
-      onLayout={onLayout}
-    >
+    <ResizablePanelGroup direction="horizontal" className="flex h-full w-full">
       <ResizablePanel defaultSize={mainDefault} minSize={30}>
         <main className="relative h-full w-full overflow-scroll">
           {children}

--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -340,7 +340,7 @@ export default function Layout(props: PropsWithChildren) {
         <SidebarProvider>
           <div className="flex h-dvh w-full flex-col">
             <PaymentBanner />
-            <div className="pt-banner-offset flex min-h-0 flex-1">
+            <div className="flex min-h-0 flex-1 pt-banner-offset">
               <AppSidebar
                 navItems={mainNavigation}
                 secondaryNavItems={secondaryNavigation}
@@ -381,7 +381,7 @@ export function ResizableContent({ children }: PropsWithChildren) {
         <Drawer open={open} onOpenChange={setOpen} forceDirection="bottom">
           <DrawerContent
             id="support-drawer"
-            className="min-h-screen-with-banner inset-x-0 bottom-0 top-[calc(var(--banner-offset)+10px)]"
+            className="inset-x-0 bottom-0 top-[calc(var(--banner-offset)+10px)] min-h-screen-with-banner"
             size="full"
           >
             <DrawerHeader className="absolute inset-x-0 top-0 p-0 text-left">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Removes cookie-based layout persistence for support drawer in `layout.tsx`, using hardcoded default sizes instead.
> 
>   - **Behavior**:
>     - Removes cookie-based layout persistence for support drawer in `ResizableContent` in `layout.tsx`.
>     - Default sizes for `mainDefault` and `drawerDefault` are now hardcoded to 70 and 30, respectively.
>   - **Code Removal**:
>     - Deletes `useEffect` for reading and setting cookie `react-resizable-panels:layout:supportDrawer`.
>     - Removes `onLayout` function for writing layout sizes to cookies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b8ba5a852b598367d5d6811b98093e916f2854fd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->