### PR TITLE
chore: skip not found jobs for exports

### DIFF
--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -77,6 +77,13 @@ export const handleBatchExportJob = async (
     );
   }
 
+  if (span) {
+    span.setAttribute(
+      "messaging.bullmq.job.input.query",
+      JSON.stringify(parsedQuery.data),
+    );
+  }
+
   // handle db read stream
   const dbReadStream = await getDatabaseReadStream({
     projectId,

--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -4,6 +4,7 @@ import {
   BatchExportQuerySchema,
   BatchExportStatus,
   exportOptions,
+  LangfuseNotFoundError,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 import {
@@ -48,7 +49,7 @@ export const handleBatchExportJob = async (
   });
 
   if (!jobDetails) {
-    throw new Error(
+    throw new LangfuseNotFoundError(
       `Job not found for project: ${projectId} and export ${batchExportId}`,
     );
   }

--- a/worker/src/queues/batchExportQueue.ts
+++ b/worker/src/queues/batchExportQueue.ts
@@ -24,7 +24,7 @@ export const batchExportQueueProcessor = async (
   } catch (e) {
     if (e instanceof LangfuseNotFoundError) {
       logger.warn(
-        `Batch export ${job.data.payload.batchExportId} not found. Job will be retried.`,
+        `Batch export ${job.data.payload.batchExportId} not found. Job will be skipped.`,
       );
       return true;
     }

--- a/worker/src/queues/batchExportQueue.ts
+++ b/worker/src/queues/batchExportQueue.ts
@@ -1,6 +1,10 @@
 import { Job } from "bullmq";
 
-import { BaseError, BatchExportStatus } from "@langfuse/shared";
+import {
+  BaseError,
+  BatchExportStatus,
+  LangfuseNotFoundError,
+} from "@langfuse/shared";
 import { kyselyPrisma } from "@langfuse/shared/src/db";
 
 import { traceException, logger } from "@langfuse/shared/src/server";
@@ -18,6 +22,12 @@ export const batchExportQueueProcessor = async (
 
     return true;
   } catch (e) {
+    if (e instanceof LangfuseNotFoundError) {
+      logger.warn(
+        `Batch export ${job.data.payload.batchExportId} not found. Job will be retried.`,
+      );
+      return true;
+    }
     const displayError =
       e instanceof BaseError ? e.message : "An internal error occurred";
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduce `LangfuseNotFoundError` to handle not found jobs in batch export, logging a warning and retrying the job.
> 
>   - **Error Handling**:
>     - Introduce `LangfuseNotFoundError` in `handleBatchExportJob.ts` and `batchExportQueue.ts` to handle not found jobs.
>     - Log a warning and retry the job if `LangfuseNotFoundError` is caught in `batchExportQueueProcessor`.
>   - **Tracing**:
>     - Add `messaging.bullmq.job.input.query` attribute to span in `handleBatchExportJob` for better tracing of job input queries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c51c078a46e738eef3f8dd334666ad7ae3a69d28. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->