### PR TITLE
fix(billing): Conditionally show spend alert UI

### DIFF
--- a/web/src/ee/features/billing/components/BillingSettings.tsx
+++ b/web/src/ee/features/billing/components/BillingSettings.tsx
@@ -15,6 +15,7 @@ import { BillingPlanPeriodView } from "@/src/ee/features/billing/components/Bill
 import { useIsCloudBillingAvailable } from "@/src/ee/features/billing/utils/isCloudBilling";
 import { SpendAlertsSection } from "./SpendAlerts/SpendAlertsSection";
 import { BillingTransitionInfoCard } from "./BillingTransitionInfoCard";
+import { useBillingInformation } from "./useBillingInformation";
 
 export const BillingSettings = () => {
   const router = useRouter();
@@ -27,6 +28,7 @@ export const BillingSettings = () => {
   const isCloudBillingAvailable = useIsCloudBillingAvailable();
   const isCloudBillingEntitled = useHasEntitlement("cloud-billing");
   const isSpendAlertEntitled = useHasEntitlement("cloud-spend-alerts");
+  const { hasActiveSubscription } = useBillingInformation();
 
   // Don't render billing settings if cloud billing is not available
   if (!isCloudBillingAvailable) {
@@ -62,7 +64,9 @@ export const BillingSettings = () => {
         <BillingActionButtons />
         <BillingTransitionInfoCard />
         <BillingInvoiceTable />
-        {isSpendAlertEntitled && orgId && <SpendAlertsSection orgId={orgId} />}
+        {isSpendAlertEntitled && orgId && hasActiveSubscription && (
+          <SpendAlertsSection orgId={orgId} />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## What does this PR do?

This PR addresses LFE-7257 by conditionally displaying the Spend Alerts UI in the billing settings. The Spend Alerts section will now only be visible to organizations that have an active Stripe subscription, preventing its display for manual/cloudconfig projects without billing integration.

Fixes #LFE-7257

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [ ] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my PR needs changes to the documentation
- [ ] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [x] I haven't added tests that prove my fix is effective or that my feature works
- [x] I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-7257](https://linear.app/langfuse/issue/LFE-7257/disable-spend-alert-settings-for-cloudconfig-manual-projects)

<a href="https://cursor.com/background-agent?bcId=bc-3c926e3a-5916-477a-987e-9fb79503a1b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c926e3a-5916-477a-987e-9fb79503a1b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Conditionally render `SpendAlertsSection` in `BillingSettings.tsx` based on active Stripe subscription.
> 
>   - **Behavior**:
>     - `SpendAlertsSection` in `BillingSettings.tsx` now only renders if `hasActiveSubscription` is true, in addition to existing conditions.
>     - Prevents display of Spend Alerts UI for manual/cloudconfig projects without billing integration.
>   - **Imports**:
>     - Adds `useBillingInformation` import to `BillingSettings.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 91ca3f92afced21be959b88ed76655e8ccb4c206. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->