### PR TITLE
fix(trace-ui): panel min width

### DIFF
--- a/web/src/components/trace/hooks/usePanelState.ts
+++ b/web/src/components/trace/hooks/usePanelState.ts
@@ -9,7 +9,7 @@ export function usePanelState(
   panelGroupId: string,
   viewType: "timeline" | "tree",
 ) {
-  const MIN_WIDTH_PX = 355;
+  const MIN_WIDTH_PX = 255;
   const MAX_TREE_WIDTH_PX = 700;
 
   const [panelState, setPanelState] = useState<PanelState>({

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -142,6 +142,18 @@ export function Trace(props: {
   // Derive collapsed state from actual panel size (single source of truth = autoSaveId)
   // This avoids cross-tab sync issues from storing collapsed state separately
   const [isTreePanelCollapsed, setIsTreePanelCollapsed] = useState(false);
+
+  // Sync initial collapsed state from actual panel size on mount
+  useEffect(() => {
+    if (treePanelRef.current) {
+      const currentSize = treePanelRef.current.getSize();
+      const collapsed = currentSize <= 5;
+      if (collapsed !== isTreePanelCollapsed) {
+        setIsTreePanelCollapsed(collapsed);
+      }
+    }
+  }, []);
+
   const isAuthenticatedAndProjectMember = useIsAuthenticatedAndProjectMember(
     props.projectId,
   );
@@ -564,7 +576,6 @@ export function Trace(props: {
               collapsedSize={3}
               onResize={(size) => {
                 // Derive collapsed state from actual panel size
-                // This is the ONLY source of truth (autoSaveId handles persistence)
                 const collapsed = size <= 5;
                 if (collapsed !== isTreePanelCollapsed) {
                   setIsTreePanelCollapsed(collapsed);
@@ -578,7 +589,8 @@ export function Trace(props: {
                     variant="ghost"
                     size="icon"
                     onClick={() => {
-                      treePanelRef.current?.resize(TREE_DEFAULT_WIDTH);
+                      // Use minSize as the smallest legal value we can expand to
+                      treePanelRef.current?.resize(panelState.minSize);
                       capture("trace_detail:tree_panel_toggle", {
                         collapsed: false,
                       });
@@ -742,7 +754,7 @@ export function Trace(props: {
                           size="icon"
                           onClick={() => {
                             if (isTreePanelCollapsed) {
-                              treePanelRef.current?.resize(TREE_DEFAULT_WIDTH);
+                              treePanelRef.current?.resize(panelState.minSize);
                             } else {
                               treePanelRef.current?.collapse();
                             }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reduce panel minimum width to 255px and adjust resize logic in trace UI.
> 
>   - **Behavior**:
>     - Reduce `MIN_WIDTH_PX` from 355 to 255 in `usePanelState()` in `usePanelState.ts`.
>     - Adjust panel resize logic in `Trace` in `index.tsx` to use `panelState.minSize` for expansion.
>   - **State Management**:
>     - Sync initial collapsed state from panel size on mount in `Trace` in `index.tsx`.
>     - Update `onResize` logic in `Trace` in `index.tsx` to derive collapsed state from panel size.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c864d91ad236c877a302912c41824de1f173d5c2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->