### PR TITLE
fix: fix keycloak in lf cloud

### DIFF
--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -440,13 +440,15 @@ const extendedPrismaAdapter: Adapter = {
     // (refresh_expires_in and not-before-policy in).
     // So, we need to remove this data from the payload before linking an account.
     // https://github.com/nextauthjs/next-auth/issues/7655
-    if (data.provider === "keycloak") {
+    if (data.provider.endsWith("keycloak")) {
+      // endsWith required as the multi-tenant cloud SSO providers are in the "domain.provider" format
       delete data["refresh_expires_in"];
       delete data["not-before-policy"];
     }
 
     // WorkOS returns profile data that doesn't match the schema
-    if (data.provider === "workos") {
+    if (data.provider.endsWith("workos")) {
+      // endsWith required as the multi-tenant cloud SSO providers are in the "domain.provider" format
       delete data["profile"];
     }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `auth.ts`, `linkAccount` now checks if provider names end with "keycloak" or "workos" to support multi-tenant SSO providers.
> 
>   - **Behavior**:
>     - In `auth.ts`, `linkAccount` function now checks if `data.provider` ends with "keycloak" or "workos" instead of exact match.
>     - Handles multi-tenant cloud SSO providers using "domain.provider" format.
>   - **Misc**:
>     - Comments added to explain the use of `endsWith` for multi-tenant SSO providers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ab42b3f2e0816bbfd411af61b811ab694b794755. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->