### PR TITLE
fix(ui): peek view should not have tr border radius

### DIFF
--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -108,7 +108,7 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
         side="right"
         className="flex max-h-full min-h-0 min-w-[60vw] flex-col gap-0 overflow-hidden rounded-l-xl p-0"
       >
-        <SheetHeader className="flex min-h-12 flex-row flex-nowrap items-center justify-between rounded-t-xl bg-header px-2">
+        <SheetHeader className="flex min-h-12 flex-row flex-nowrap items-center justify-between rounded-tl-xl bg-header px-2">
           <SheetTitle className="!mt-0 ml-2 flex min-w-0 flex-row items-center gap-2">
             <ItemBadge type={peekView.itemType} showLabel />
             <span


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjusts border radius in `SheetHeader` of `TablePeekViewComponent` to fix UI issue in `peek.tsx`.
> 
>   - **UI Fix**:
>     - Adjusts border radius in `SheetHeader` within `TablePeekViewComponent` in `peek.tsx` by changing `rounded-t-xl` to `rounded-tl-xl`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 39ae838dd932fd085ce2e58b3234c568c3d4e922. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->