### PR TITLE
feat(metrics): add uniqueUserIds, uniqueSessionIds to traceView

### DIFF
--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -93,6 +93,20 @@ export const traceView: ViewDeclarationType = {
       description: "Unique scores attached to the trace.",
       unit: "scores",
     },
+    uniqueUserIds: {
+      sql: "uniq(traces.user_id)",
+      alias: "uniqueUserIds",
+      type: "integer",
+      description: "Count of unique userIds.",
+      unit: "users",
+    },
+    uniqueSessionIds: {
+      sql: "uniq(traces.session_id)",
+      alias: "uniqueSessionIds",
+      type: "integer",
+      description: "Count of unique sessionIds.",
+      unit: "sessions",
+    },
     latency: {
       sql: "date_diff('millisecond', min(observations.start_time), max(observations.end_time))",
       alias: "latency",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `uniqueUserIds` and `uniqueSessionIds` measures to `traceView` in `dataModel.ts` for counting unique user and session IDs.
> 
>   - **Measures**:
>     - Add `uniqueUserIds` to `traceView` in `dataModel.ts` to count unique user IDs using `uniq(traces.user_id)`.
>     - Add `uniqueSessionIds` to `traceView` in `dataModel.ts` to count unique session IDs using `uniq(traces.session_id)`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4282b8cfd48157887def18f6b4f0a6638b2c6a60. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->