### PR TITLE
chore: pick any unlocked partition in event prop job

### DIFF
--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -371,7 +371,7 @@ export const handleEventPropagationJob = async (
         operation_name: "dropPartition",
       },
       clickhouseConfigs: {
-        request_timeout: 120000, // 2 minutes timeout
+        request_timeout: 180000, // 3 minutes timeout
       },
     });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `handleEventPropagationJob` to process specified partition first, fallback to oldest unlocked if locked, and increase `dropPartition` timeout.
> 
>   - **Behavior**:
>     - In `handleEventPropagationJob`, attempt to process specified partition first; if locked, fall back to oldest unlocked partition.
>     - Increase `request_timeout` for `dropPartition` operation from 2 to 3 minutes.
>   - **Logging**:
>     - Update logging messages to reflect new partition processing logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 20bbf30d8c4921a111ab4709cf4161e0c1434a1c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->