### PR TITLE
feat(api): enable advanced filtering in public API observations endpoint

### DIFF
--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -49,6 +49,32 @@ service:
           version:
             type: optional<string>
             docs: Optional filter to only include observations with a certain version.
+          filter:
+            type: optional<string>
+            docs: |
+              JSON string containing an array of filter conditions. When provided, this takes precedence over legacy filter parameters (userId, name, sessionId, tags, version, release, environment, fromTimestamp, toTimestamp).
+              Each filter condition has the following structure:
+              ```json
+              [
+                {
+                  "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+                  "column": string,         // Required. Column to filter on
+                  "operator": string,       // Required. Operator based on type:
+                                            // - datetime: ">", "<", ">=", "<="
+                                            // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                            // - stringOptions: "any of", "none of"
+                                            // - categoryOptions: "any of", "none of"
+                                            // - arrayOptions: "any of", "none of", "all of"
+                                            // - number: "=", ">", "<", ">=", "<="
+                                            // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
+                                            // - numberObject: "=", ">", "<", ">=", "<="
+                                            // - boolean: "=", "<>"
+                                            // - null: "is null", "is not null"
+                  "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
+                  "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
+                }
+              ]
+              ```
       response: ObservationsViews
 
 types:

--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -23,5 +23,6 @@ export { clickhouseSearchCondition } from "./clickhouse-sql/search";
 export {
   convertApiProvidedFilterToClickhouseFilter,
   createPublicApiObservationsColumnMapping,
+  deriveFilters,
   type ApiColumnMapping,
 } from "./public-api-filter-builder";

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -14,12 +14,13 @@ import {
   FilterList,
   FullObservations,
   orderByToClickhouseSql,
-  convertApiProvidedFilterToClickhouseFilter,
   createPublicApiObservationsColumnMapping,
+  deriveFilters,
   type ApiColumnMapping,
   ObservationPriceFields,
 } from "../queries";
 import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
+import type { FilterState } from "../../types";
 import {
   eventsScoresAggregation,
   eventsTracesAggregation,
@@ -831,6 +832,7 @@ type PublicApiObservationsQuery = {
   toStartTime?: string;
   version?: string;
   environment?: string | string[];
+  advancedFilters?: FilterState;
 };
 
 /**
@@ -840,12 +842,14 @@ type PublicApiObservationsQuery = {
 const getObservationsFromEventsTableForPublicApiInternal = async <T>(
   opts: PublicApiObservationsQuery & { select: "rows" | "count" },
 ): Promise<Array<T>> => {
-  const { projectId, page, limit, ...filterParams } = opts;
+  const { projectId, page, limit, advancedFilters, ...filterParams } = opts;
 
-  // Convert public API filters to FilterList using column mapping
-  const observationsFilter = convertApiProvidedFilterToClickhouseFilter(
+  // Convert and merge simple and advanced filters
+  const observationsFilter = deriveFilters(
     { ...filterParams, projectId, page, limit },
     PUBLIC_API_EVENTS_COLUMN_MAPPING,
+    advancedFilters,
+    eventsTableUiColumnDefinitions,
   );
 
   // Determine if we need to join traces (for userId filter)

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -2389,6 +2389,43 @@ paths:
           schema:
             type: string
             nullable: true
+        - name: filter
+          in: query
+          description: >-
+            JSON string containing an array of filter conditions. When provided,
+            this takes precedence over legacy filter parameters (userId, name,
+            sessionId, tags, version, release, environment, fromTimestamp,
+            toTimestamp).
+
+            Each filter condition has the following structure:
+
+            ```json
+
+            [
+              {
+                "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+                "column": string,         // Required. Column to filter on
+                "operator": string,       // Required. Operator based on type:
+                                          // - datetime: ">", "<", ">=", "<="
+                                          // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                          // - stringOptions: "any of", "none of"
+                                          // - categoryOptions: "any of", "none of"
+                                          // - arrayOptions: "any of", "none of", "all of"
+                                          // - number: "=", ">", "<", ">=", "<="
+                                          // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
+                                          // - numberObject: "=", ">", "<", ">=", "<="
+                                          // - boolean: "=", "<>"
+                                          // - null: "is null", "is not null"
+                "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
+                "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
+              }
+            ]
+
+            ```
+          required: false
+          schema:
+            type: string
+            nullable: true
       responses:
         '200':
           description: ''

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -1753,7 +1753,7 @@
           "request": {
             "description": "Get a list of observations",
             "url": {
-              "raw": "{{baseUrl}}/api/public/observations?page=&limit=&name=&userId=&type=&traceId=&level=&parentObservationId=&environment=&fromStartTime=&toStartTime=&version=",
+              "raw": "{{baseUrl}}/api/public/observations?page=&limit=&name=&userId=&type=&traceId=&level=&parentObservationId=&environment=&fromStartTime=&toStartTime=&version=&filter=",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1822,6 +1822,11 @@
                   "key": "version",
                   "value": "",
                   "description": "Optional filter to only include observations with a certain version."
+                },
+                {
+                  "key": "filter",
+                  "value": "",
+                  "description": "JSON string containing an array of filter conditions. When provided, this takes precedence over legacy filter parameters (userId, name, sessionId, tags, version, release, environment, fromTimestamp, toTimestamp).\nEach filter condition has the following structure:\n```json\n[\n  {\n    \"type\": string,           // Required. One of: \"datetime\", \"string\", \"number\", \"stringOptions\", \"categoryOptions\", \"arrayOptions\", \"stringObject\", \"numberObject\", \"boolean\", \"null\"\n    \"column\": string,         // Required. Column to filter on\n    \"operator\": string,       // Required. Operator based on type:\n                              // - datetime: \">\", \"<\", \">=\", \"<=\"\n                              // - string: \"=\", \"contains\", \"does not contain\", \"starts with\", \"ends with\"\n                              // - stringOptions: \"any of\", \"none of\"\n                              // - categoryOptions: \"any of\", \"none of\"\n                              // - arrayOptions: \"any of\", \"none of\", \"all of\"\n                              // - number: \"=\", \">\", \"<\", \">=\", \"<=\"\n                              // - stringObject: \"=\", \"contains\", \"does not contain\", \"starts with\", \"ends with\"\n                              // - numberObject: \"=\", \">\", \"<\", \">=\", \"<=\"\n                              // - boolean: \"=\", \"<>\"\n                              // - null: \"is null\", \"is not null\"\n    \"value\": any,             // Required (except for null type). Value to compare against. Type depends on filter type\n    \"key\": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata\n  }\n]\n```"
                 }
               ],
               "variable": []

--- a/web/src/__tests__/async/observation-api.servertest.ts
+++ b/web/src/__tests__/async/observation-api.servertest.ts
@@ -112,13 +112,20 @@ describe("/api/public/observations API Endpoint", () => {
             "GET",
             `/api/public/observations/${observationId}?useEventsTable=${useEventsTable}`,
           );
+
+          const expectedModelId = useEventsTable
+            ? "model_id" in observation
+              ? observation.model_id
+              : undefined
+            : "internal_model_id" in observation
+              ? observation.internal_model_id
+              : undefined;
+
           expect(getEventRes.body).toMatchObject({
             id: observationId,
             traceId: traceId,
             type: observation.type,
-            modelId: useEventsTable
-              ? observation.model_id
-              : observation.internal_model_id,
+            modelId: expectedModelId,
             inputPrice: 0.000005,
             input: observation.input,
             output: observation.output,

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -1,4 +1,3 @@
-import { convertApiProvidedFilterToClickhouseFilter } from "@langfuse/shared/src/server";
 import {
   convertDateToClickhouseDateTime,
   queryClickhouse,
@@ -9,9 +8,8 @@ import {
   convertClickhouseToDomain,
   type TraceRecordReadType,
   measureAndReturn,
-  FilterList,
   tracesTableUiColumnDefinitions,
-  createFilterFromFilterState,
+  deriveFilters,
 } from "@langfuse/shared/src/server";
 import { type OrderByState } from "@langfuse/shared";
 import { snakeCase } from "lodash";
@@ -40,35 +38,6 @@ export type TraceQueryType = {
   fields?: TraceFieldGroup[];
 };
 
-function deriveFilters(
-  props: TraceQueryType,
-  advancedFilters?: FilterState,
-): FilterList {
-  const filterList = new FilterList(
-    createFilterFromFilterState(
-      advancedFilters ?? [],
-      tracesTableUiColumnDefinitions,
-    ),
-  );
-
-  let simpleFilters = convertApiProvidedFilterToClickhouseFilter(
-    props,
-    filterParams,
-  );
-
-  // Advanced filter takes precedence. Remove all simple filters that are also in advanced filter
-  const advancedFilterColumns = new Set();
-  filterList.forEach((f) => advancedFilterColumns.add(f.field));
-  simpleFilters
-    .filter((sf) => {
-      return !advancedFilterColumns.has(sf.field);
-    })
-    .forEach((f) => filterList.push(f));
-
-  // Return merged filters
-  return filterList;
-}
-
 export const generateTracesForPublicApi = async ({
   props,
   advancedFilters,
@@ -84,7 +53,12 @@ export const generateTracesForPublicApi = async ({
   const includeObservations = requestedFields.includes("observations");
   const includeMetrics = requestedFields.includes("metrics");
 
-  let filter = deriveFilters(props, advancedFilters);
+  let filter = deriveFilters(
+    props,
+    filterParams,
+    advancedFilters,
+    tracesTableUiColumnDefinitions,
+  );
   const appliedFilter = filter.apply();
 
   const timeFilter = filter.find(
@@ -269,7 +243,12 @@ export const getTracesCountForPublicApi = async ({
   props: TraceQueryType;
   advancedFilters?: FilterState;
 }) => {
-  let filter = deriveFilters(props, advancedFilters);
+  let filter = deriveFilters(
+    props,
+    filterParams,
+    advancedFilters,
+    tracesTableUiColumnDefinitions,
+  );
   const appliedFilter = filter.apply();
 
   const query = `

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -3,6 +3,8 @@ import {
   ObservationLevel,
   paginationMetaResponseZod,
   publicApiPaginationZod,
+  singleFilter,
+  InvalidRequestError,
 } from "@langfuse/shared";
 
 import {
@@ -179,6 +181,20 @@ export const GetObservationsV1Query = z.object({
   fromStartTime: stringDateTime,
   toStartTime: stringDateTime,
   useEventsTable: useEventsTableSchema,
+  filter: z
+    .string()
+    .optional()
+    .transform((str) => {
+      if (!str) return undefined;
+      try {
+        const parsed = JSON.parse(str);
+        return parsed;
+      } catch (e) {
+        if (e instanceof InvalidRequestError) throw e;
+        throw new InvalidRequestError("Invalid JSON in filter parameter");
+      }
+    })
+    .pipe(z.array(singleFilter).optional()),
 });
 export const GetObservationsV1Response = z
   .object({

--- a/web/src/pages/api/public/observations/index.ts
+++ b/web/src/pages/api/public/observations/index.ts
@@ -38,6 +38,7 @@ export default withMiddlewares({
         fromStartTime: query.fromStartTime ?? undefined,
         toStartTime: query.toStartTime ?? undefined,
         version: query.version ?? undefined,
+        advancedFilters: query.filter,
       };
 
       // Use events table if query parameter is explicitly set, otherwise use environment variable


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> This PR adds advanced filtering capabilities to the public API's observations endpoint, allowing JSON-based filter conditions and reinstating a Boolean conversion lost in a previous rebase.
> 
>   - **Behavior**:
>     - Adds advanced filtering to `observations.yml` for the public API, allowing JSON-based filter conditions.
>     - Advanced filters take precedence over legacy parameters.
>   - **Functions**:
>     - Adds `deriveFilters()` in `public-api-filter-builder.ts` to merge simple and advanced filters.
>     - Updates `generateObservationsForPublicApi()` and `getObservationsCountForPublicApi()` in `observations.ts` to use `deriveFilters()`.
>   - **Tests**:
>     - Adds tests for advanced filtering in `observations-api.servertest.ts` and `observation-api.servertest.ts`.
>     - Tests include metadata filtering, merging filters, and handling malformed JSON.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9f7e9665ede595343e4c9d7097a5287c320118c1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->