### PR TITLE
fix(otel): google adk i/o empty if tool calls are set

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1301,6 +1301,15 @@ export class OtelIngestionProcessor {
     // Google Vertex AI Agent-Developer-Kit (ADK)
     input = attributes["gcp.vertex.agent.llm_request"];
     output = attributes["gcp.vertex.agent.llm_response"];
+    // GCP Vertex Agent Tool call input and output
+    // see: https://github.com/google/adk-python/blob/9dce06f9b00259ec42241df4f6638955e783a9d1/src/google/adk/telemetry/tracing.py#L142
+    // Google sets llm_request and llm_response to {} when setting tool_call_args and tool_response
+    if (!input) {
+      input = attributes["gcp.vertex.agent.tool_call_args"];
+    }
+    if (!output) {
+      output = attributes["gcp.vertex.agent.tool_response"];
+    }
     if (input || output) {
       return { input, output, filteredAttributes };
     }
@@ -1372,13 +1381,6 @@ export class OtelIngestionProcessor {
     // Pydantic and Pipecat uses input and output
     input = attributes["input"];
     output = attributes["output"];
-    if (input || output) {
-      return { input, output, filteredAttributes };
-    }
-
-    // GCP Vertex Agent Tool call input and output
-    input = attributes["gcp.vertex.agent.tool_call_args"];
-    output = attributes["gcp.vertex.agent.tool_response"];
     if (input || output) {
       return { input, output, filteredAttributes };
     }

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1304,10 +1304,10 @@ export class OtelIngestionProcessor {
     // GCP Vertex Agent Tool call input and output
     // see: https://github.com/google/adk-python/blob/9dce06f9b00259ec42241df4f6638955e783a9d1/src/google/adk/telemetry/tracing.py#L142
     // Google sets llm_request and llm_response to {} when setting tool_call_args and tool_response
-    if (!input) {
+    if (input === "{}" || !input) {
       input = attributes["gcp.vertex.agent.tool_call_args"];
     }
-    if (!output) {
+    if (output === "{}" || !output) {
       output = attributes["gcp.vertex.agent.tool_response"];
     }
     if (input || output) {

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -4543,7 +4543,7 @@ describe("OTel Resource Span Mapping", () => {
     });
 
     it("should extract Google ADK tool call I/O from tool_call_args/tool_response when llm_request/llm_response are empty", async () => {
-      const traceId = "some-trace-id";
+      const traceId = "abcdef1234567890abcdef1234567890";
 
       const googleADKToolSpan = {
         resource: {

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -4644,7 +4644,7 @@ describe("OTel Resource Span Mapping", () => {
                   {
                     key: "gcp.vertex.agent.tool_response",
                     value: {
-                      stringValue: '{"result": "particularily juicy cake"}',
+                      stringValue: '{"result": "particularly juicy cake"}',
                     },
                   },
                   // These are empty for tool calls in Google ADK - bug trigger
@@ -4726,7 +4726,7 @@ describe("OTel Resource Span Mapping", () => {
 
       // Verify output is correctly extracted from tool_response
       expect(toolObservation?.body.output).toBe(
-        '{"result": "particularily juicy cake"}',
+        '{"result": "particularly juicy cake"}',
       );
 
       // Verify Google ADK attributes are NOT in metadata.attributes

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -4542,6 +4542,219 @@ describe("OTel Resource Span Mapping", () => {
       ).toBe("custom_value");
     });
 
+    it("should extract Google ADK tool call I/O from tool_call_args/tool_response when llm_request/llm_response are empty", async () => {
+      const traceId = "some-trace-id";
+
+      const googleADKToolSpan = {
+        resource: {
+          attributes: [
+            {
+              key: "telemetry.sdk.language",
+              value: { stringValue: "python" },
+            },
+            {
+              key: "telemetry.sdk.name",
+              value: { stringValue: "opentelemetry" },
+            },
+            {
+              key: "telemetry.sdk.version",
+              value: { stringValue: "1.33.1" },
+            },
+            {
+              key: "langfuse.environment",
+              value: { stringValue: "production" },
+            },
+            {
+              key: "service.name",
+              value: { stringValue: "unknown_service" },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: {
+              name: "openinference.instrumentation.google_adk",
+              version: "0.1.6",
+            },
+            spans: [
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from("89a16f45ba5e6d36", "hex"),
+                parentSpanId: Buffer.from("f55a0bb51dc69634", "hex"),
+                name: "execute_tool_bake_cake",
+                kind: 1,
+                startTimeUnixNano: {
+                  low: 310920000,
+                  high: 406677085,
+                  unsigned: true,
+                },
+                endTimeUnixNano: {
+                  low: 858579000,
+                  high: 406677085,
+                  unsigned: true,
+                },
+                attributes: [
+                  {
+                    key: "session.id",
+                    value: {
+                      stringValue: "test-session-333bff8e",
+                    },
+                  },
+                  {
+                    key: "user.id",
+                    value: { stringValue: "test-user" },
+                  },
+                  {
+                    key: "gen_ai.system",
+                    value: { stringValue: "gcp.vertex.agent" },
+                  },
+                  {
+                    key: "gen_ai.operation.name",
+                    value: { stringValue: "execute_tool" },
+                  },
+                  {
+                    key: "gen_ai.tool.name",
+                    value: { stringValue: "bake_cake" },
+                  },
+                  {
+                    key: "gen_ai.tool.description",
+                    value: {
+                      stringValue:
+                        "a tool that bakes a cake for you, with a lot of chocolate if you ask nicely",
+                    },
+                  },
+                  {
+                    key: "gen_ai.tool.call.id",
+                    value: {
+                      stringValue: "adk-chocolate-caked",
+                    },
+                  },
+                  {
+                    key: "gcp.vertex.agent.tool_call_args",
+                    value: {
+                      stringValue: '{"query": "much duplo"}',
+                    },
+                  },
+                  {
+                    key: "gcp.vertex.agent.event_id",
+                    value: {
+                      stringValue: "some-id",
+                    },
+                  },
+                  {
+                    key: "gcp.vertex.agent.tool_response",
+                    value: {
+                      stringValue: '{"result": "particularily juicy cake"}',
+                    },
+                  },
+                  // These are empty for tool calls in Google ADK - bug trigger
+                  {
+                    key: "gcp.vertex.agent.llm_request",
+                    value: { stringValue: "{}" },
+                  },
+                  {
+                    key: "gcp.vertex.agent.llm_response",
+                    value: { stringValue: "{}" },
+                  },
+                  {
+                    key: "tool.name",
+                    value: { stringValue: "bake_cake" },
+                  },
+                  {
+                    key: "tool.description",
+                    value: {
+                      stringValue:
+                        "a tool that bakes a cake for you, with a lot of chocolate if you ask nicely",
+                    },
+                  },
+                  {
+                    key: "tool.parameters",
+                    value: {
+                      stringValue: '{"query": "cake type"}',
+                    },
+                  },
+                  {
+                    key: "input.value",
+                    value: {
+                      stringValue: '{"query": "juicy chocolate"}',
+                    },
+                  },
+                  {
+                    key: "input.mime_type",
+                    value: { stringValue: "application/json" },
+                  },
+                  {
+                    key: "output.value",
+                    value: {
+                      stringValue:
+                        '{"id":"adk-chocolate-caked","name":"bake_cake","response":{"result":"duplo cake"}}',
+                    },
+                  },
+                  {
+                    key: "output.mime_type",
+                    value: { stringValue: "application/json" },
+                  },
+                  {
+                    key: "openinference.span.kind",
+                    value: { stringValue: "TOOL" },
+                  },
+                ],
+                events: [],
+                status: { code: 1 },
+              },
+            ],
+          },
+        ],
+      };
+
+      const googleADKEvents = await convertOtelSpanToIngestionEvent(
+        googleADKToolSpan,
+        new Set([traceId]),
+      );
+
+      const toolObservation = googleADKEvents.find(
+        (e) => e.type === "tool-create",
+      );
+
+      // Bug: input/output should NOT be "{}" from empty llm_request/llm_response
+      // Instead, they should come from tool_call_args and tool_response
+      expect(toolObservation?.body.input).not.toBe("{}");
+      expect(toolObservation?.body.output).not.toBe("{}");
+
+      // Verify input is correctly extracted from tool_call_args
+      expect(toolObservation?.body.input).toBe('{"query": "much duplo"}');
+
+      // Verify output is correctly extracted from tool_response
+      expect(toolObservation?.body.output).toBe(
+        '{"result": "particularily juicy cake"}',
+      );
+
+      // Verify Google ADK attributes are NOT in metadata.attributes
+      expect(
+        toolObservation?.body.metadata?.attributes?.[
+          "gcp.vertex.agent.tool_call_args"
+        ],
+      ).toBeUndefined();
+      expect(
+        toolObservation?.body.metadata?.attributes?.[
+          "gcp.vertex.agent.tool_response"
+        ],
+      ).toBeUndefined();
+      expect(
+        toolObservation?.body.metadata?.attributes?.[
+          "gcp.vertex.agent.llm_request"
+        ],
+      ).toBeUndefined();
+      expect(
+        toolObservation?.body.metadata?.attributes?.[
+          "gcp.vertex.agent.llm_response"
+        ],
+      ).toBeUndefined();
+
+      // Verify trace-level attributes
+      expect(toolObservation?.body.traceId).toBe(traceId);
+    });
+
     it("should stringify non-string attributes in observation metadata", async () => {
       const traceId = "abcdef1234567890abcdef1234567890";
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes input/output extraction for Google ADK spans in `OtelIngestionProcessor.ts` when `llm_request` and `llm_response` are empty, with tests added.
> 
>   - **Behavior**:
>     - In `OtelIngestionProcessor.ts`, updated logic to extract input/output from `tool_call_args` and `tool_response` when `llm_request` and `llm_response` are empty for Google ADK spans.
>   - **Tests**:
>     - Added test in `otelMapping.servertest.ts` to verify extraction of input/output from `tool_call_args` and `tool_response` when `llm_request` and `llm_response` are empty.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3f953eaa9aaa4bfdae66b4cf1e2cd7723c2f6143. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->