### PR TITLE
chore: handle environment filter on scores table correctly

### DIFF
--- a/packages/shared/src/server/repositories/environments.ts
+++ b/packages/shared/src/server/repositories/environments.ts
@@ -21,7 +21,12 @@ export const getEnvironmentsForProject = async (
       FROM observations
       WHERE project_id = {projectId: String}
       ${fromTimestamp ? "AND start_time >= {fromTimestamp: DateTime64(3)}" : ""}
-    )
+    ) UNION ALL (
+      SELECT distinct environment
+      FROM scores
+      WHERE project_id = {projectId: String}
+      ${fromTimestamp ? "AND timestamp >= {fromTimestamp: DateTime64(3)}" : ""}
+    )  
   `;
 
   const results = await queryClickhouse<{

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -207,8 +207,12 @@ export default function ScoresTable({
     orderBy: orderByState,
   };
 
-  const scores = api.scores.all.useQuery(getAllPayload);
-  const totalScoreCountQuery = api.scores.countAll.useQuery(getCountPayload);
+  const scores = api.scores.all.useQuery(getAllPayload, {
+    enabled: !environmentFilterOptions.isLoading,
+  });
+  const totalScoreCountQuery = api.scores.countAll.useQuery(getCountPayload, {
+    enabled: !environmentFilterOptions.isLoading,
+  });
   const totalCount = totalScoreCountQuery.data?.totalCount ?? null;
 
   const scoreDeleteMutation = api.scores.deleteMany.useMutation({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Handle environment filter on scores table by including `scores` table environments and enabling queries based on filter loading state.
> 
>   - **Behavior**:
>     - `getEnvironmentsForProject` in `environments.ts` now includes environments from `scores` table.
>     - `ScoresTable` in `scores.tsx` enables queries only when `environmentFilterOptions` is not loading.
>   - **Queries**:
>     - Added `UNION ALL` clause in `getEnvironmentsForProject` to include `scores` table environments.
>     - Updated `useQuery` calls in `ScoresTable` to include `enabled` condition based on `environmentFilterOptions.isLoading`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d286a11fa3b2209cf28f7c02c69f0acaf7f2d0da. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->