### PR TITLE
docs: add opentelemetry api definition

### DIFF
--- a/fern/apis/server/definition/ingestion.yml
+++ b/fern/apis/server/definition/ingestion.yml
@@ -7,10 +7,13 @@ service:
   base-path: /api/public
   endpoints:
     batch:
+      availability:
+        status: deprecated
+        message: "Use the OpenTelemetry endpoint at /api/public/otel/v1/traces instead. Learn more: https://langfuse.com/integrations/native/opentelemetry"
       docs: |
         **Legacy endpoint for batch ingestion for Langfuse Observability.**
 
-        -> Please use the OpenTelemetry endpoint (`/api/public/otel`). Learn more: https://langfuse.com/integrations/native/opentelemetry
+        -> Please use the OpenTelemetry endpoint (`/api/public/otel/v1/traces`). Learn more: https://langfuse.com/integrations/native/opentelemetry
 
         Within each batch, there can be multiple events.
         Each event has a type, an id, a timestamp, metadata and a body.

--- a/fern/apis/server/definition/opentelemetry.yml
+++ b/fern/apis/server/definition/opentelemetry.yml
@@ -1,0 +1,167 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
+service:
+  auth: true
+  base-path: /api/public
+  endpoints:
+    exportTraces:
+      docs: |
+        **OpenTelemetry Traces Ingestion Endpoint**
+
+        This endpoint implements the OTLP/HTTP specification for trace ingestion, providing native OpenTelemetry integration for Langfuse Observability.
+
+        **Supported Formats:**
+        - Binary Protobuf: `Content-Type: application/x-protobuf`
+        - JSON Protobuf: `Content-Type: application/json`
+        - Supports gzip compression via `Content-Encoding: gzip` header
+
+        **Specification Compliance:**
+        - Conforms to [OTLP/HTTP Trace Export](https://opentelemetry.io/docs/specs/otlp/#otlphttp)
+        - Implements `ExportTraceServiceRequest` message format
+
+        **Documentation:**
+        - Integration guide: https://langfuse.com/integrations/native/opentelemetry
+        - Data model: https://langfuse.com/docs/observability/data-model
+      method: POST
+      path: /otel/v1/traces
+      request:
+        name: OtelTraceRequest
+        body:
+          properties:
+            resourceSpans:
+              type: list<OtelResourceSpan>
+              docs: Array of resource spans containing trace data as defined in the OTLP specification
+        content-type: application/json
+      response: OtelTraceResponse
+      examples:
+        - name: BasicTraceExport
+          docs: Example JSON payload for exporting a simple trace with one span
+          request:
+            resourceSpans:
+              - resource:
+                  attributes:
+                    - key: service.name
+                      value:
+                        stringValue: "my-service"
+                    - key: service.version
+                      value:
+                        stringValue: "1.0.0"
+                scopeSpans:
+                  - scope:
+                      name: "langfuse-sdk"
+                      version: "2.60.3"
+                    spans:
+                      - traceId: "0123456789abcdef0123456789abcdef"
+                        spanId: "0123456789abcdef"
+                        name: "my-operation"
+                        kind: 1
+                        startTimeUnixNano: "1747872000000000000"
+                        endTimeUnixNano: "1747872001000000000"
+                        attributes:
+                          - key: "langfuse.observation.type"
+                            value:
+                              stringValue: "generation"
+                        status: {}
+          response:
+            body: {}
+
+types:
+  OtelResourceSpan:
+    docs: Represents a collection of spans from a single resource as per OTLP specification
+    properties:
+      resource:
+        type: optional<OtelResource>
+        docs: Resource information
+      scopeSpans:
+        type: optional<list<OtelScopeSpan>>
+        docs: Array of scope spans
+
+  OtelResource:
+    docs: Resource attributes identifying the source of telemetry
+    properties:
+      attributes:
+        type: optional<list<OtelAttribute>>
+        docs: Resource attributes like service.name, service.version, etc.
+
+  OtelScopeSpan:
+    docs: Collection of spans from a single instrumentation scope
+    properties:
+      scope:
+        type: optional<OtelScope>
+        docs: Instrumentation scope information
+      spans:
+        type: optional<list<OtelSpan>>
+        docs: Array of spans
+
+  OtelScope:
+    docs: Instrumentation scope information
+    properties:
+      name:
+        type: optional<string>
+        docs: Instrumentation scope name
+      version:
+        type: optional<string>
+        docs: Instrumentation scope version
+      attributes:
+        type: optional<list<OtelAttribute>>
+        docs: Additional scope attributes
+
+  OtelSpan:
+    docs: Individual span representing a unit of work or operation
+    properties:
+      traceId:
+        type: optional<unknown>
+        docs: Trace ID (16 bytes, hex-encoded string in JSON or Buffer in binary)
+      spanId:
+        type: optional<unknown>
+        docs: Span ID (8 bytes, hex-encoded string in JSON or Buffer in binary)
+      parentSpanId:
+        type: optional<unknown>
+        docs: Parent span ID if this is a child span
+      name:
+        type: optional<string>
+        docs: Span name describing the operation
+      kind:
+        type: optional<integer>
+        docs: Span kind (1=INTERNAL, 2=SERVER, 3=CLIENT, 4=PRODUCER, 5=CONSUMER)
+      startTimeUnixNano:
+        type: optional<unknown>
+        docs: Start time in nanoseconds since Unix epoch
+      endTimeUnixNano:
+        type: optional<unknown>
+        docs: End time in nanoseconds since Unix epoch
+      attributes:
+        type: optional<list<OtelAttribute>>
+        docs: Span attributes including Langfuse-specific attributes (langfuse.observation.*)
+      status:
+        type: optional<unknown>
+        docs: Span status object
+
+  OtelAttribute:
+    docs: Key-value attribute pair for resources, scopes, or spans
+    properties:
+      key:
+        type: optional<string>
+        docs: Attribute key (e.g., "service.name", "langfuse.observation.type")
+      value:
+        type: optional<OtelAttributeValue>
+        docs: Attribute value
+
+  OtelAttributeValue:
+    docs: Attribute value wrapper supporting different value types
+    properties:
+      stringValue:
+        type: optional<string>
+        docs: String value
+      intValue:
+        type: optional<integer>
+        docs: Integer value
+      doubleValue:
+        type: optional<double>
+        docs: Double value
+      boolValue:
+        type: optional<boolean>
+        docs: Boolean value
+
+  OtelTraceResponse:
+    docs: Response from trace export request. Empty object indicates success.
+    properties: {}

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -1555,8 +1555,8 @@ paths:
         **Legacy endpoint for batch ingestion for Langfuse Observability.**
 
 
-        -> Please use the OpenTelemetry endpoint (`/api/public/otel`). Learn
-        more: https://langfuse.com/integrations/native/opentelemetry
+        -> Please use the OpenTelemetry endpoint (`/api/public/otel/v1/traces`).
+        Learn more: https://langfuse.com/integrations/native/opentelemetry
 
 
         Within each batch, there can be multiple events.
@@ -2423,6 +2423,125 @@ paths:
               schema: {}
       security:
         - BasicAuth: []
+  /api/public/otel/v1/traces:
+    post:
+      description: >-
+        **OpenTelemetry Traces Ingestion Endpoint**
+
+
+        This endpoint implements the OTLP/HTTP specification for trace
+        ingestion, providing native OpenTelemetry integration for Langfuse
+        Observability.
+
+
+        **Supported Formats:**
+
+        - Binary Protobuf: `Content-Type: application/x-protobuf`
+
+        - JSON Protobuf: `Content-Type: application/json`
+
+        - Supports gzip compression via `Content-Encoding: gzip` header
+
+
+        **Specification Compliance:**
+
+        - Conforms to [OTLP/HTTP Trace
+        Export](https://opentelemetry.io/docs/specs/otlp/#otlphttp)
+
+        - Implements `ExportTraceServiceRequest` message format
+
+
+        **Documentation:**
+
+        - Integration guide:
+        https://langfuse.com/integrations/native/opentelemetry
+
+        - Data model: https://langfuse.com/docs/observability/data-model
+      operationId: opentelemetry_exportTraces
+      tags:
+        - Opentelemetry
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OtelTraceResponse'
+              examples:
+                BasicTraceExport:
+                  value: {}
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                resourceSpans:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/OtelResourceSpan'
+                  description: >-
+                    Array of resource spans containing trace data as defined in
+                    the OTLP specification
+              required:
+                - resourceSpans
+            examples:
+              BasicTraceExport:
+                value:
+                  resourceSpans:
+                    - resource:
+                        attributes:
+                          - key: service.name
+                            value:
+                              stringValue: my-service
+                          - key: service.version
+                            value:
+                              stringValue: 1.0.0
+                      scopeSpans:
+                        - scope:
+                            name: langfuse-sdk
+                            version: 2.60.3
+                          spans:
+                            - traceId: 0123456789abcdef0123456789abcdef
+                              spanId: 0123456789abcdef
+                              name: my-operation
+                              kind: 1
+                              startTimeUnixNano: '1747872000000000000'
+                              endTimeUnixNano: '1747872001000000000'
+                              attributes:
+                                - key: langfuse.observation.type
+                                  value:
+                                    stringValue: generation
+                              status: {}
   /api/public/organizations/memberships:
     get:
       description: >-
@@ -7413,6 +7532,147 @@ components:
       required:
         - data
         - meta
+    OtelResourceSpan:
+      title: OtelResourceSpan
+      type: object
+      description: >-
+        Represents a collection of spans from a single resource as per OTLP
+        specification
+      properties:
+        resource:
+          $ref: '#/components/schemas/OtelResource'
+          nullable: true
+          description: Resource information
+        scopeSpans:
+          type: array
+          items:
+            $ref: '#/components/schemas/OtelScopeSpan'
+          nullable: true
+          description: Array of scope spans
+    OtelResource:
+      title: OtelResource
+      type: object
+      description: Resource attributes identifying the source of telemetry
+      properties:
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/OtelAttribute'
+          nullable: true
+          description: Resource attributes like service.name, service.version, etc.
+    OtelScopeSpan:
+      title: OtelScopeSpan
+      type: object
+      description: Collection of spans from a single instrumentation scope
+      properties:
+        scope:
+          $ref: '#/components/schemas/OtelScope'
+          nullable: true
+          description: Instrumentation scope information
+        spans:
+          type: array
+          items:
+            $ref: '#/components/schemas/OtelSpan'
+          nullable: true
+          description: Array of spans
+    OtelScope:
+      title: OtelScope
+      type: object
+      description: Instrumentation scope information
+      properties:
+        name:
+          type: string
+          nullable: true
+          description: Instrumentation scope name
+        version:
+          type: string
+          nullable: true
+          description: Instrumentation scope version
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/OtelAttribute'
+          nullable: true
+          description: Additional scope attributes
+    OtelSpan:
+      title: OtelSpan
+      type: object
+      description: Individual span representing a unit of work or operation
+      properties:
+        traceId:
+          nullable: true
+          description: Trace ID (16 bytes, hex-encoded string in JSON or Buffer in binary)
+        spanId:
+          nullable: true
+          description: Span ID (8 bytes, hex-encoded string in JSON or Buffer in binary)
+        parentSpanId:
+          nullable: true
+          description: Parent span ID if this is a child span
+        name:
+          type: string
+          nullable: true
+          description: Span name describing the operation
+        kind:
+          type: integer
+          nullable: true
+          description: Span kind (1=INTERNAL, 2=SERVER, 3=CLIENT, 4=PRODUCER, 5=CONSUMER)
+        startTimeUnixNano:
+          nullable: true
+          description: Start time in nanoseconds since Unix epoch
+        endTimeUnixNano:
+          nullable: true
+          description: End time in nanoseconds since Unix epoch
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/OtelAttribute'
+          nullable: true
+          description: >-
+            Span attributes including Langfuse-specific attributes
+            (langfuse.observation.*)
+        status:
+          nullable: true
+          description: Span status object
+    OtelAttribute:
+      title: OtelAttribute
+      type: object
+      description: Key-value attribute pair for resources, scopes, or spans
+      properties:
+        key:
+          type: string
+          nullable: true
+          description: Attribute key (e.g., "service.name", "langfuse.observation.type")
+        value:
+          $ref: '#/components/schemas/OtelAttributeValue'
+          nullable: true
+          description: Attribute value
+    OtelAttributeValue:
+      title: OtelAttributeValue
+      type: object
+      description: Attribute value wrapper supporting different value types
+      properties:
+        stringValue:
+          type: string
+          nullable: true
+          description: String value
+        intValue:
+          type: integer
+          nullable: true
+          description: Integer value
+        doubleValue:
+          type: number
+          format: double
+          nullable: true
+          description: Double value
+        boolValue:
+          type: boolean
+          nullable: true
+          description: Boolean value
+    OtelTraceResponse:
+      title: OtelTraceResponse
+      type: object
+      description: Response from trace export request. Empty object indicates success.
+      properties: {}
     MembershipRole:
       title: MembershipRole
       type: string

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -1180,7 +1180,7 @@
           "_type": "endpoint",
           "name": "Batch",
           "request": {
-            "description": "**Legacy endpoint for batch ingestion for Langfuse Observability.**\n\n-> Please use the OpenTelemetry endpoint (`/api/public/otel`). Learn more: https://langfuse.com/integrations/native/opentelemetry\n\nWithin each batch, there can be multiple events.\nEach event has a type, an id, a timestamp, metadata and a body.\nInternally, we refer to this as the \"event envelope\" as it tells us something about the event but not the trace.\nWe use the event id within this envelope to deduplicate messages to avoid processing the same event twice, i.e. the event id should be unique per request.\nThe event.body.id is the ID of the actual trace and will be used for updates and will be visible within the Langfuse App.\nI.e. if you want to update a trace, you'd use the same body id, but separate event IDs.\n\nNotes:\n- Introduction to data model: https://langfuse.com/docs/observability/data-model\n- Batch sizes are limited to 3.5 MB in total. You need to adjust the number of events per batch accordingly.\n- The API does not return a 4xx status code for input errors. Instead, it responds with a 207 status code, which includes a list of the encountered errors.",
+            "description": "**Legacy endpoint for batch ingestion for Langfuse Observability.**\n\n-> Please use the OpenTelemetry endpoint (`/api/public/otel/v1/traces`). Learn more: https://langfuse.com/integrations/native/opentelemetry\n\nWithin each batch, there can be multiple events.\nEach event has a type, an id, a timestamp, metadata and a body.\nInternally, we refer to this as the \"event envelope\" as it tells us something about the event but not the trace.\nWe use the event id within this envelope to deduplicate messages to avoid processing the same event twice, i.e. the event id should be unique per request.\nThe event.body.id is the ID of the actual trace and will be used for updates and will be visible within the Langfuse App.\nI.e. if you want to update a trace, you'd use the same body id, but separate event IDs.\n\nNotes:\n- Introduction to data model: https://langfuse.com/docs/observability/data-model\n- Batch sizes are limited to 3.5 MB in total. You need to adjust the number of events per batch accordingly.\n- The API does not return a 4xx status code for input errors. Instead, it responds with a 207 status code, which includes a list of the encountered errors.",
             "url": {
               "raw": "{{baseUrl}}/api/public/ingestion",
               "host": [
@@ -1219,7 +1219,7 @@
               "status": "OK",
               "code": 200,
               "originalRequest": {
-                "description": "**Legacy endpoint for batch ingestion for Langfuse Observability.**\n\n-> Please use the OpenTelemetry endpoint (`/api/public/otel`). Learn more: https://langfuse.com/integrations/native/opentelemetry\n\nWithin each batch, there can be multiple events.\nEach event has a type, an id, a timestamp, metadata and a body.\nInternally, we refer to this as the \"event envelope\" as it tells us something about the event but not the trace.\nWe use the event id within this envelope to deduplicate messages to avoid processing the same event twice, i.e. the event id should be unique per request.\nThe event.body.id is the ID of the actual trace and will be used for updates and will be visible within the Langfuse App.\nI.e. if you want to update a trace, you'd use the same body id, but separate event IDs.\n\nNotes:\n- Introduction to data model: https://langfuse.com/docs/observability/data-model\n- Batch sizes are limited to 3.5 MB in total. You need to adjust the number of events per batch accordingly.\n- The API does not return a 4xx status code for input errors. Instead, it responds with a 207 status code, which includes a list of the encountered errors.",
+                "description": "**Legacy endpoint for batch ingestion for Langfuse Observability.**\n\n-> Please use the OpenTelemetry endpoint (`/api/public/otel/v1/traces`). Learn more: https://langfuse.com/integrations/native/opentelemetry\n\nWithin each batch, there can be multiple events.\nEach event has a type, an id, a timestamp, metadata and a body.\nInternally, we refer to this as the \"event envelope\" as it tells us something about the event but not the trace.\nWe use the event id within this envelope to deduplicate messages to avoid processing the same event twice, i.e. the event id should be unique per request.\nThe event.body.id is the ID of the actual trace and will be used for updates and will be visible within the Langfuse App.\nI.e. if you want to update a trace, you'd use the same body id, but separate event IDs.\n\nNotes:\n- Introduction to data model: https://langfuse.com/docs/observability/data-model\n- Batch sizes are limited to 3.5 MB in total. You need to adjust the number of events per batch accordingly.\n- The API does not return a 4xx status code for input errors. Instead, it responds with a 207 status code, which includes a list of the encountered errors.",
                 "url": {
                   "raw": "{{baseUrl}}/api/public/ingestion",
                   "host": [
@@ -1261,7 +1261,7 @@
               "status": "OK",
               "code": 200,
               "originalRequest": {
-                "description": "**Legacy endpoint for batch ingestion for Langfuse Observability.**\n\n-> Please use the OpenTelemetry endpoint (`/api/public/otel`). Learn more: https://langfuse.com/integrations/native/opentelemetry\n\nWithin each batch, there can be multiple events.\nEach event has a type, an id, a timestamp, metadata and a body.\nInternally, we refer to this as the \"event envelope\" as it tells us something about the event but not the trace.\nWe use the event id within this envelope to deduplicate messages to avoid processing the same event twice, i.e. the event id should be unique per request.\nThe event.body.id is the ID of the actual trace and will be used for updates and will be visible within the Langfuse App.\nI.e. if you want to update a trace, you'd use the same body id, but separate event IDs.\n\nNotes:\n- Introduction to data model: https://langfuse.com/docs/observability/data-model\n- Batch sizes are limited to 3.5 MB in total. You need to adjust the number of events per batch accordingly.\n- The API does not return a 4xx status code for input errors. Instead, it responds with a 207 status code, which includes a list of the encountered errors.",
+                "description": "**Legacy endpoint for batch ingestion for Langfuse Observability.**\n\n-> Please use the OpenTelemetry endpoint (`/api/public/otel/v1/traces`). Learn more: https://langfuse.com/integrations/native/opentelemetry\n\nWithin each batch, there can be multiple events.\nEach event has a type, an id, a timestamp, metadata and a body.\nInternally, we refer to this as the \"event envelope\" as it tells us something about the event but not the trace.\nWe use the event id within this envelope to deduplicate messages to avoid processing the same event twice, i.e. the event id should be unique per request.\nThe event.body.id is the ID of the actual trace and will be used for updates and will be visible within the Langfuse App.\nI.e. if you want to update a trace, you'd use the same body id, but separate event IDs.\n\nNotes:\n- Introduction to data model: https://langfuse.com/docs/observability/data-model\n- Batch sizes are limited to 3.5 MB in total. You need to adjust the number of events per batch accordingly.\n- The API does not return a 4xx status code for input errors. Instead, it responds with a 207 status code, which includes a list of the encountered errors.",
                 "url": {
                   "raw": "{{baseUrl}}/api/public/ingestion",
                   "host": [
@@ -1303,7 +1303,7 @@
               "status": "OK",
               "code": 200,
               "originalRequest": {
-                "description": "**Legacy endpoint for batch ingestion for Langfuse Observability.**\n\n-> Please use the OpenTelemetry endpoint (`/api/public/otel`). Learn more: https://langfuse.com/integrations/native/opentelemetry\n\nWithin each batch, there can be multiple events.\nEach event has a type, an id, a timestamp, metadata and a body.\nInternally, we refer to this as the \"event envelope\" as it tells us something about the event but not the trace.\nWe use the event id within this envelope to deduplicate messages to avoid processing the same event twice, i.e. the event id should be unique per request.\nThe event.body.id is the ID of the actual trace and will be used for updates and will be visible within the Langfuse App.\nI.e. if you want to update a trace, you'd use the same body id, but separate event IDs.\n\nNotes:\n- Introduction to data model: https://langfuse.com/docs/observability/data-model\n- Batch sizes are limited to 3.5 MB in total. You need to adjust the number of events per batch accordingly.\n- The API does not return a 4xx status code for input errors. Instead, it responds with a 207 status code, which includes a list of the encountered errors.",
+                "description": "**Legacy endpoint for batch ingestion for Langfuse Observability.**\n\n-> Please use the OpenTelemetry endpoint (`/api/public/otel/v1/traces`). Learn more: https://langfuse.com/integrations/native/opentelemetry\n\nWithin each batch, there can be multiple events.\nEach event has a type, an id, a timestamp, metadata and a body.\nInternally, we refer to this as the \"event envelope\" as it tells us something about the event but not the trace.\nWe use the event id within this envelope to deduplicate messages to avoid processing the same event twice, i.e. the event id should be unique per request.\nThe event.body.id is the ID of the actual trace and will be used for updates and will be visible within the Langfuse App.\nI.e. if you want to update a trace, you'd use the same body id, but separate event IDs.\n\nNotes:\n- Introduction to data model: https://langfuse.com/docs/observability/data-model\n- Batch sizes are limited to 3.5 MB in total. You need to adjust the number of events per batch accordingly.\n- The API does not return a 4xx status code for input errors. Instead, it responds with a 207 status code, which includes a list of the encountered errors.",
                 "url": {
                   "raw": "{{baseUrl}}/api/public/ingestion",
                   "host": [
@@ -1832,6 +1832,99 @@
             "body": null
           },
           "response": []
+        }
+      ]
+    },
+    {
+      "_type": "container",
+      "description": null,
+      "name": "Opentelemetry",
+      "item": [
+        {
+          "_type": "endpoint",
+          "name": "Export Traces",
+          "request": {
+            "description": "**OpenTelemetry Traces Ingestion Endpoint**\n\nThis endpoint implements the OTLP/HTTP specification for trace ingestion, providing native OpenTelemetry integration for Langfuse Observability.\n\n**Supported Formats:**\n- Binary Protobuf: `Content-Type: application/x-protobuf`\n- JSON Protobuf: `Content-Type: application/json`\n- Supports gzip compression via `Content-Encoding: gzip` header\n\n**Specification Compliance:**\n- Conforms to [OTLP/HTTP Trace Export](https://opentelemetry.io/docs/specs/otlp/#otlphttp)\n- Implements `ExportTraceServiceRequest` message format\n\n**Documentation:**\n- Integration guide: https://langfuse.com/integrations/native/opentelemetry\n- Data model: https://langfuse.com/docs/observability/data-model",
+            "url": {
+              "raw": "{{baseUrl}}/api/public/otel/v1/traces",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "public",
+                "otel",
+                "v1",
+                "traces"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "header": [
+              {
+                "type": "text",
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "auth": null,
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"resourceSpans\": [\n        {\n            \"resource\": {\n                \"attributes\": [\n                    {\n                        \"key\": \"service.name\",\n                        \"value\": {\n                            \"stringValue\": \"my-service\"\n                        }\n                    },\n                    {\n                        \"key\": \"service.version\",\n                        \"value\": {\n                            \"stringValue\": \"1.0.0\"\n                        }\n                    }\n                ]\n            },\n            \"scopeSpans\": [\n                {\n                    \"scope\": {\n                        \"name\": \"langfuse-sdk\",\n                        \"version\": \"2.60.3\"\n                    },\n                    \"spans\": [\n                        {\n                            \"traceId\": \"0123456789abcdef0123456789abcdef\",\n                            \"spanId\": \"0123456789abcdef\",\n                            \"name\": \"my-operation\",\n                            \"kind\": 1,\n                            \"startTimeUnixNano\": \"1747872000000000000\",\n                            \"endTimeUnixNano\": \"1747872001000000000\",\n                            \"attributes\": [\n                                {\n                                    \"key\": \"langfuse.observation.type\",\n                                    \"value\": {\n                                        \"stringValue\": \"generation\"\n                                    }\n                                }\n                            ],\n                            \"status\": {}\n                        }\n                    ]\n                }\n            ]\n        }\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [
+            {
+              "name": "Success",
+              "status": "OK",
+              "code": 200,
+              "originalRequest": {
+                "description": "**OpenTelemetry Traces Ingestion Endpoint**\n\nThis endpoint implements the OTLP/HTTP specification for trace ingestion, providing native OpenTelemetry integration for Langfuse Observability.\n\n**Supported Formats:**\n- Binary Protobuf: `Content-Type: application/x-protobuf`\n- JSON Protobuf: `Content-Type: application/json`\n- Supports gzip compression via `Content-Encoding: gzip` header\n\n**Specification Compliance:**\n- Conforms to [OTLP/HTTP Trace Export](https://opentelemetry.io/docs/specs/otlp/#otlphttp)\n- Implements `ExportTraceServiceRequest` message format\n\n**Documentation:**\n- Integration guide: https://langfuse.com/integrations/native/opentelemetry\n- Data model: https://langfuse.com/docs/observability/data-model",
+                "url": {
+                  "raw": "{{baseUrl}}/api/public/otel/v1/traces",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "public",
+                    "otel",
+                    "v1",
+                    "traces"
+                  ],
+                  "query": [],
+                  "variable": []
+                },
+                "header": [
+                  {
+                    "type": "text",
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "method": "POST",
+                "auth": null,
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"resourceSpans\": [\n        {\n            \"resource\": {\n                \"attributes\": [\n                    {\n                        \"key\": \"service.name\",\n                        \"value\": {\n                            \"stringValue\": \"my-service\"\n                        }\n                    },\n                    {\n                        \"key\": \"service.version\",\n                        \"value\": {\n                            \"stringValue\": \"1.0.0\"\n                        }\n                    }\n                ]\n            },\n            \"scopeSpans\": [\n                {\n                    \"scope\": {\n                        \"name\": \"langfuse-sdk\",\n                        \"version\": \"2.60.3\"\n                    },\n                    \"spans\": [\n                        {\n                            \"traceId\": \"0123456789abcdef0123456789abcdef\",\n                            \"spanId\": \"0123456789abcdef\",\n                            \"name\": \"my-operation\",\n                            \"kind\": 1,\n                            \"startTimeUnixNano\": \"1747872000000000000\",\n                            \"endTimeUnixNano\": \"1747872001000000000\",\n                            \"attributes\": [\n                                {\n                                    \"key\": \"langfuse.observation.type\",\n                                    \"value\": {\n                                        \"stringValue\": \"generation\"\n                                    }\n                                }\n                            ],\n                            \"status\": {}\n                        }\n                    ]\n                }\n            ]\n        }\n    ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "description": null,
+              "body": "{}",
+              "_postman_previewlanguage": "json"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
Fixes LFE-6195
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds OpenTelemetry API definition for trace ingestion and deprecates legacy batch ingestion endpoint.
> 
>   - **OpenTelemetry API Definition**:
>     - Adds `opentelemetry.yml` for OpenTelemetry traces ingestion endpoint.
>     - Implements OTLP/HTTP specification for trace ingestion.
>     - Supports Binary and JSON Protobuf formats, gzip compression.
>   - **Deprecation**:
>     - Marks `batch` endpoint in `ingestion.yml` as deprecated.
>     - Updates deprecation message to direct users to `/api/public/otel/v1/traces`.
>   - **Documentation**:
>     - Updates `openapi.yml` and `collection.json` to reflect new OpenTelemetry endpoint.
>     - Provides integration guide and data model links in endpoint documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1ad535e5a1304f53db8714590667b7410352b633. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->