### PR TITLE
chore: make event propagation follow-up scheduling configurable

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -197,7 +197,7 @@ const EnvSchema = z.object({
   LANGFUSE_EVENT_PROPAGATION_WORKER_GLOBAL_CONCURRENCY: z.coerce
     .number()
     .positive()
-    .default(5),
+    .default(10),
 
   LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_MS: z.coerce
     .number()

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -224,6 +224,11 @@ const EnvSchema = z.object({
     .enum(["true", "false"])
     .default("false"),
 
+  LANGFUSE_EVENT_PROPAGATION_WORKER_GLOBAL_CONCURRENCY: z.coerce
+    .number()
+    .positive()
+    .default(10),
+
   // Core data S3 upload - Langfuse Cloud
   LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED: z
     .enum(["true", "false"])

--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -380,7 +380,8 @@ export const handleEventPropagationJob = async (
     );
 
     if (partitions.length > 3) {
-      let additionalSchedules = 5;
+      let additionalSchedules =
+        env.LANGFUSE_EVENT_PROPAGATION_WORKER_GLOBAL_CONCURRENCY;
       const queue = EventPropagationQueue.getInstance();
       while (queue && partitions.length > 3 && additionalSchedules > 0) {
         const internalPartition = partitions.pop()!;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make event propagation follow-up scheduling configurable with `LANGFUSE_EVENT_PROPAGATION_WORKER_GLOBAL_CONCURRENCY`.
> 
>   - **Configuration**:
>     - Introduce `LANGFUSE_EVENT_PROPAGATION_WORKER_GLOBAL_CONCURRENCY` in `packages/shared/src/env.ts` and `worker/src/env.ts` with a default value of 10.
>   - **Functionality**:
>     - Update `handleEventPropagationJob` in `handleEventPropagationJob.ts` to use `LANGFUSE_EVENT_PROPAGATION_WORKER_GLOBAL_CONCURRENCY` for determining additional schedules for event propagation jobs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 08710f9c070660d55e9ca369903a255fceb317e4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->