### PR TITLE
fix: metadata filters on events table should use correct columns (LFE-7278)

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -280,7 +280,7 @@ class EventsQueryBuilder {
       startTimeFrom: options?.startTimeFrom ?? null,
     };
 
-    if (generator && !!options) {
+    if (generator && Boolean(options)) {
       this.ctes.push(`${name} AS (${generator(params)})`);
 
       // Track CTE parameters
@@ -657,13 +657,13 @@ const getObservationsFromEventsTableInternal = async <T>(
         startTimeFrom,
       }),
     )
-    .when(!!needsTraceJoin, (b) =>
+    .when(Boolean(needsTraceJoin), (b) =>
       b.withCTE("traces", eventsTracesAggregation, {
         projectId,
         startTimeFrom,
       }),
     )
-    .when(!!needsTraceJoin, (b) =>
+    .when(Boolean(needsTraceJoin), (b) =>
       b.leftJoin(
         "traces t",
         "ON t.id = e.trace_id AND t.project_id = e.project_id",

--- a/packages/shared/src/server/test-utils/tracing-factory.ts
+++ b/packages/shared/src/server/test-utils/tracing-factory.ts
@@ -185,6 +185,24 @@ export const createEvent = (
 ): EventRecordInsertType => {
   const spanId = v4();
   const now = Date.now() * 1000; // Convert to micro
+
+  // Default metadata to populate arrays from
+  const defaultMetadata: Record<string, string> = {
+    source: "API",
+    server: "Node",
+  };
+
+  // Merge default metadata with any provided metadata
+  const finalMetadata: Record<string, string> = {
+    ...defaultMetadata,
+    ...event.metadata,
+  };
+
+  // Extract metadata keys and values in sorted order for deterministic array population
+  const sortedKeys = Object.keys(finalMetadata).sort();
+  const metadataNames = sortedKeys;
+  const metadataValues = sortedKeys.map((key) => finalMetadata[key]);
+
   return {
     // Identifiers
     org_id: null,
@@ -227,10 +245,10 @@ export const createEvent = (
     input: "Hello World",
     output: "Hello John",
 
-    // Metadata
-    metadata: { source: "API", server: "Node" },
-    metadata_names: [],
-    metadata_values: [],
+    // Metadata - populate both JSON and array columns
+    metadata: finalMetadata,
+    metadata_names: metadataNames,
+    metadata_values: metadataValues,
     metadata_string_names: [],
     metadata_string_values: [],
     metadata_number_names: [],


### PR DESCRIPTION
- chore: reinstante !! -> Boolean that was lost in a rebase of #9781
- fix: metadata filters on events table should use correct columns

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes metadata filtering on events table to use correct array columns and reinstates boolean conversion lost in rebase.
> 
>   - **Behavior**:
>     - Fixes metadata filtering on `events` table to use array columns `metadata_names` and `metadata_values` in `clickhouse-filter.ts`.
>     - Reinstates `!!` to `Boolean` conversion in `events.ts` for `options` and `needsTraceJoin`.
>   - **Tests**:
>     - Adds test case for `StringObjectFilter` metadata filtering in `event-repository.servertest.ts`.
>     - Updates `createEvent` in `tracing-factory.ts` to populate metadata arrays for testing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4b78455783d08d3f42a6de6dc44822933a8ef298. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->