### PR TITLE
fix: useEventsTable shouldn't default to true when it is not specified.

### DIFF
--- a/web/src/__tests__/async/observations-api.servertest.ts
+++ b/web/src/__tests__/async/observations-api.servertest.ts
@@ -113,9 +113,7 @@ describe("/api/public/observations API Endpoint", () => {
     const suiteName = useEventsTable
       ? "with events table"
       : "with observations table";
-    const queryParam = useEventsTable
-      ? "?useEventsTable=true"
-      : "?useEventsTable=false";
+    const queryParam = useEventsTable ? "?useEventsTable=true&" : "?";
 
     describe(`GET /api/public/observations ${suiteName}`, () => {
       it("should fetch all observations with basic data structure", async () => {
@@ -457,7 +455,7 @@ describe("/api/public/observations API Endpoint", () => {
         const debugResponse = await makeZodVerifiedAPICall(
           GetObservationsV1Response,
           "GET",
-          `/api/public/observations${queryParam}&traceId=${traceId}&level=DEBUG`,
+          `/api/public/observations${queryParam}traceId=${traceId}&level=DEBUG`,
         );
 
         expect(debugResponse.body.data.length).toBe(1);
@@ -469,7 +467,7 @@ describe("/api/public/observations API Endpoint", () => {
         const defaultResponse = await makeZodVerifiedAPICall(
           GetObservationsV1Response,
           "GET",
-          `/api/public/observations${queryParam}&traceId=${traceId}&level=DEFAULT`,
+          `/api/public/observations${queryParam}traceId=${traceId}&level=DEFAULT`,
         );
 
         expect(defaultResponse.body.data.length).toBe(1);
@@ -481,7 +479,7 @@ describe("/api/public/observations API Endpoint", () => {
         const warningResponse = await makeZodVerifiedAPICall(
           GetObservationsV1Response,
           "GET",
-          `/api/public/observations${queryParam}&traceId=${traceId}&level=WARNING`,
+          `/api/public/observations${queryParam}traceId=${traceId}&level=WARNING`,
         );
 
         expect(warningResponse.body.data.length).toBe(1);
@@ -493,7 +491,7 @@ describe("/api/public/observations API Endpoint", () => {
         const errorResponse = await makeZodVerifiedAPICall(
           GetObservationsV1Response,
           "GET",
-          `/api/public/observations${queryParam}&traceId=${traceId}&level=ERROR`,
+          `/api/public/observations${queryParam}traceId=${traceId}&level=ERROR`,
         );
 
         expect(errorResponse.body.data.length).toBe(1);
@@ -541,7 +539,7 @@ describe("/api/public/observations API Endpoint", () => {
         const errorResponse = await makeZodVerifiedAPICall(
           GetObservationsV1Response,
           "GET",
-          `/api/public/observations${queryParam}&traceId=${traceId}&level=ERROR`,
+          `/api/public/observations${queryParam}traceId=${traceId}&level=ERROR`,
         );
 
         expect(errorResponse.body.data.length).toBe(0);
@@ -563,9 +561,7 @@ describe("/api/public/observations API Endpoint", () => {
       const suiteName = useEventsTable
         ? "with events table"
         : "with observations table";
-      const queryParam = useEventsTable
-        ? "?useEventsTable=true"
-        : "?useEventsTable=false";
+      const queryParam = useEventsTable ? "?useEventsTable=true&" : "?";
 
       describe(`${suiteName}`, () => {
         it("should support metadata field filtering with contains", async () => {

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -164,8 +164,8 @@ export const transformDbToApiObservation = (
 
 const useEventsTableSchema = z
   .union([z.literal("true"), z.literal("false"), z.boolean()])
-  .transform((val) => val === "true" || val === true)
-  .nullish();
+  .optional()
+  .transform((val) => val === "true" || val === true);
 
 // GET /observations
 export const GetObservationsV1Query = z.object({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `useEventsTable` parameter handling to be optional and default to environment variable if not specified, updating schema and tests accordingly.
> 
>   - **Behavior**:
>     - `useEventsTable` parameter in `GetObservationsV1Query` is now optional and defaults to the environment variable `LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS` if not specified.
>     - Adjusts query parameter construction in `observations-api.servertest.ts` to handle optional `useEventsTable`.
>   - **Schema**:
>     - Updates `useEventsTableSchema` in `observations.ts` to be optional and transform values to boolean.
>   - **Tests**:
>     - Modifies `observations-api.servertest.ts` to reflect changes in `useEventsTable` parameter handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1c11e8830c79f250d7795cbe06c7307a3b9e6720. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->