### PR TITLE
chore(ui): show month as letters in invoicing table

### DIFF
--- a/web/src/ee/features/billing/components/BillingInvoiceTable.tsx
+++ b/web/src/ee/features/billing/components/BillingInvoiceTable.tsx
@@ -6,7 +6,6 @@ import { Badge } from "@/src/components/ui/badge";
 import { api } from "@/src/utils/api";
 import { usdFormatter } from "@/src/utils/numbers";
 import { Download, ExternalLink } from "lucide-react";
-import { formatLocalIsoDate } from "@/src/components/LocalIsoDate";
 import { useEffect, useMemo, useState } from "react";
 
 import { useBillingInformation } from "./useBillingInformation";
@@ -117,9 +116,12 @@ export function BillingInvoiceTable() {
       header: "Date",
       cell: ({ row }) => {
         const value = row.getValue("created") as InvoiceRow["created"];
-        return value
-          ? formatLocalIsoDate(new Date(value), false, "day")
-          : undefined;
+        if (!value) return undefined;
+        const date = new Date(value);
+        const year = date.getFullYear();
+        const month = date.toLocaleDateString("en-US", { month: "short" });
+        const day = String(date.getDate()).padStart(2, "0");
+        return `${year}-${month}-${day}`;
       },
       size: 90,
     },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change date format in `BillingInvoiceTable` to 'YYYY-MMM-DD' and remove `formatLocalIsoDate`.
> 
>   - **Behavior**:
>     - In `BillingInvoiceTable`, change date format to 'YYYY-MMM-DD' using `toLocaleDateString` for month abbreviation.
>     - Remove `formatLocalIsoDate` import and usage.
>   - **Misc**:
>     - Minor refactor in date formatting logic in `BillingInvoiceTable`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7000846f45498d9ee1adbebcdaff3a9d41521060. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->