### PR TITLE
chore(cloud): refer to calculator on in-app billing page

### DIFF
--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -99,7 +99,7 @@ const DialogHeader = ({
     )}
     {...props}
   >
-    <div className="flex w-full items-start justify-between gap-4 text-center sm:text-left">
+    <div className="flex w-full items-center justify-between gap-4 text-center sm:text-left">
       <div className="min-w-0 flex-1">{children}</div>
       <DialogPrimitive.Close
         className="z-20 ml-4 mt-1 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"

--- a/web/src/ee/features/billing/components/BillingSwitchPlanDialog.tsx
+++ b/web/src/ee/features/billing/components/BillingSwitchPlanDialog.tsx
@@ -72,13 +72,16 @@ export const BillingSwitchPlanDialog = ({
         <Button disabled={disabled}>Change plan</Button>
       </DialogTrigger>
       <DialogContent className="max-w-5xl">
-        <DialogHeader className="flex flex-row items-center justify-between">
-          <DialogTitle>Plans</DialogTitle>
-          <Button variant="secondary" asChild>
-            <Link href="https://langfuse.com/pricing" target="_blank">
+        <DialogHeader>
+          <div className="flex flex-row items-center justify-between">
+            <DialogTitle>Plans</DialogTitle>
+            <ActionButton
+              variant="secondary"
+              href="https://langfuse.com/pricing"
+            >
               Comparison of plans ↗
-            </Link>
-          </Button>
+            </ActionButton>
+          </div>
         </DialogHeader>
         <DialogBody>
           <div className="mb-3 grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">

--- a/web/src/ee/features/billing/components/BillingSwitchPlanDialog.tsx
+++ b/web/src/ee/features/billing/components/BillingSwitchPlanDialog.tsx
@@ -130,7 +130,15 @@ export const BillingSwitchPlanDialog = ({
                           {product.checkout?.price}
                         </div>
                         <div className="text-sm text-muted-foreground">
-                          + {product.checkout?.usagePrice}
+                          + {product.checkout?.usagePrice},{" "}
+                          <a
+                            href="https://langfuse.com/pricing#pricing-calculator"
+                            target="_blank"
+                            rel="noreferrer"
+                            className="underline"
+                          >
+                            usage calculator ↗
+                          </a>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a link to the usage calculator on the billing page and updates UI elements in the billing dialog.
> 
>   - **Behavior**:
>     - Adds a link to the usage calculator on the billing page in `BillingSwitchPlanDialog`.
>     - Updates the "Comparison of plans" button to use `ActionButton` in `BillingSwitchPlanDialog`.
>   - **UI Changes**:
>     - Changes `DialogHeader` in `dialog.tsx` to use `items-center` instead of `items-start`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f23bb6ad8d02c2248f31d02af68206d8e8b35155. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->