### PR TITLE
chore(dataset-runs-ui): show total trace cost in tables for observation-level-linked-dataset-run-items

### DIFF
--- a/web/src/features/datasets/lib/convertRunItemDataToUiTableRow.ts
+++ b/web/src/features/datasets/lib/convertRunItemDataToUiTableRow.ts
@@ -19,11 +19,9 @@ export const convertRunItemToItemsByItemUiTableRow = (
         }
       : undefined,
     scores: item.scores,
-    totalCost: !!item.observation?.calculatedTotalCost
-      ? usdFormatter(item.observation.calculatedTotalCost.toNumber())
-      : !!item.trace?.totalCost
-        ? usdFormatter(item.trace.totalCost)
-        : undefined,
+    totalCost: !!item.trace?.totalCost
+      ? usdFormatter(item.trace.totalCost)
+      : undefined,
     latency: item.observation?.latency ?? item.trace?.duration ?? undefined,
   };
 };
@@ -42,11 +40,9 @@ export const convertRunItemToItemsByRunUiTableRow = (
         }
       : undefined,
     scores: item.scores,
-    totalCost: !!item.observation?.calculatedTotalCost
-      ? usdFormatter(item.observation.calculatedTotalCost.toNumber())
-      : !!item.trace?.totalCost
-        ? usdFormatter(item.trace.totalCost)
-        : undefined,
+    totalCost: !!item.trace?.totalCost
+      ? usdFormatter(item.trace.totalCost)
+      : undefined,
     latency: item.observation?.latency ?? item.trace?.duration ?? undefined,
   };
 };

--- a/web/src/features/datasets/lib/convertRunItemDataToUiTableRow.ts
+++ b/web/src/features/datasets/lib/convertRunItemDataToUiTableRow.ts
@@ -4,6 +4,7 @@ import {
   type DatasetRunItemByItemRowData,
 } from "./types";
 import { type EnrichedDatasetRunItem } from "@langfuse/shared/src/server";
+import { isPresent } from "@langfuse/shared";
 
 export const convertRunItemToItemsByItemUiTableRow = (
   item: EnrichedDatasetRunItem,
@@ -19,7 +20,7 @@ export const convertRunItemToItemsByItemUiTableRow = (
         }
       : undefined,
     scores: item.scores,
-    totalCost: !!item.trace?.totalCost
+    totalCost: isPresent(item.trace?.totalCost)
       ? usdFormatter(item.trace.totalCost)
       : undefined,
     latency: item.observation?.latency ?? item.trace?.duration ?? undefined,
@@ -40,7 +41,7 @@ export const convertRunItemToItemsByRunUiTableRow = (
         }
       : undefined,
     scores: item.scores,
-    totalCost: !!item.trace?.totalCost
+    totalCost: isPresent(item.trace?.totalCost)
       ? usdFormatter(item.trace.totalCost)
       : undefined,
     latency: item.observation?.latency ?? item.trace?.duration ?? undefined,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Simplifies `totalCost` calculation in dataset run item UI tables by using `trace.totalCost` only.
> 
>   - **Behavior**:
>     - Simplifies `totalCost` calculation in `convertRunItemToItemsByItemUiTableRow` and `convertRunItemToItemsByRunUiTableRow` by using `trace.totalCost` only.
>     - Removes fallback to `observation.calculatedTotalCost` for `totalCost`.
>   - **Functions**:
>     - Uses `isPresent()` to check `trace.totalCost` presence in `convertRunItemToItemsByItemUiTableRow` and `convertRunItemToItemsByRunUiTableRow`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e22824b154f86dd698c8eebb9f5e65df83ee9898. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->