### PR TITLE
chore: include primary key condition for traces on dual write

### DIFF
--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -206,6 +206,7 @@ export const handleEventPropagationJob = async (
         with batch_stats as (
           select
             groupUniqArray(project_id) as project_ids,
+            groupUniqArray(trace_id) as trace_ids,
             min(start_time) as min_start_time,
             max(start_time) as max_start_time
           from observations_batch_staging
@@ -219,6 +220,7 @@ export const handleEventPropagationJob = async (
             t.metadata
           from traces t
           where t.project_id in (select arrayJoin(project_ids) from batch_stats)
+            and t.id in (select arrayJoin(trace_ids) from batch_stats)
             and t.timestamp >= (select min(min_start_time) - interval 1 day from batch_stats)
             and t.timestamp <= (select max(max_start_time) + interval 1 day from batch_stats)
           order by t.event_ts desc


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `trace_id` filtering in `handleEventPropagationJob` to ensure only relevant traces are processed during event propagation.
> 
>   - **Behavior**:
>     - Adds `trace_id` condition in `handleEventPropagationJob` to filter relevant traces during event propagation.
>     - Ensures only traces with `trace_id` from `observations_batch_staging` are processed.
>   - **SQL Query**:
>     - Modifies SQL query in `handleEventPropagationJob` to include `trace_id` filtering in `relevant_traces` CTE.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1bdc8563d8a3722ed5e9d69e7288b442a832857f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->