### PR TITLE
feat: allow predefined api keys on create api route

### DIFF
--- a/fern/apis/server/definition/projects.yml
+++ b/fern/apis/server/definition/projects.yml
@@ -80,6 +80,12 @@ service:
             note:
               type: optional<string>
               docs: Optional note for the API key
+            publicKey:
+              type: optional<string>
+              docs: Optional predefined public key. Must start with 'pk-lf-'. If provided, secretKey must also be provided.
+            secretKey:
+              type: optional<string>
+              docs: Optional predefined secret key. Must start with 'sk-lf-'. If provided, publicKey must also be provided.
       response: ApiKeyResponse
 
     deleteApiKey:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3246,6 +3246,18 @@ paths:
                   type: string
                   nullable: true
                   description: Optional note for the API key
+                publicKey:
+                  type: string
+                  nullable: true
+                  description: >-
+                    Optional predefined public key. Must start with 'pk-lf-'. If
+                    provided, secretKey must also be provided.
+                secretKey:
+                  type: string
+                  nullable: true
+                  description: >-
+                    Optional predefined secret key. Must start with 'sk-lf-'. If
+                    provided, publicKey must also be provided.
   /api/public/projects/{projectId}/apiKeys/{apiKeyId}:
     delete:
       description: Delete an API key for a project (requires organization-scoped API key)

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -2374,7 +2374,7 @@
             "auth": null,
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"note\": \"example\"\n}",
+              "raw": "{\n    \"note\": \"example\",\n    \"publicKey\": \"example\",\n    \"secretKey\": \"example\"\n}",
               "options": {
                 "raw": {
                   "language": "json"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for creating API keys with predefined keys, including validation and tests.
> 
>   - **Behavior**:
>     - Allow predefined `publicKey` and `secretKey` on `POST /api/public/projects/{projectId}/apiKeys`.
>     - Both keys must be provided together and follow specific prefixes (`pk-lf-` and `sk-lf-`).
>     - Returns 400 if only one key is provided or if keys do not follow the prefix format.
>     - Returns 409 if a key with the same `publicKey` already exists.
>   - **Tests**:
>     - Added tests in `projects-api.servertest.ts` for creating API keys with predefined keys.
>     - Tests for validation errors when keys are missing or incorrectly formatted.
>     - Tests for handling duplicate `publicKey` scenarios.
>   - **Misc**:
>     - Updated `projects.yml`, `openapi.yml`, and `collection.json` to include new API key fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f6f7546f1edf36d3f14d6699971ed1710b15ba34. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->