### PR TITLE
chore: retry recent csv exports

### DIFF
--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -56,6 +56,35 @@ export const handleBatchExportJob = async (
       `Job not found for project: ${projectId} and export ${batchExportId}`,
     );
   }
+
+  // Check if the batch export is older than 30 days
+  const thirtyDaysAgo = new Date();
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+  if (jobDetails.createdAt < thirtyDaysAgo) {
+    // For old exports, mark as failed with an informative message
+    const improvedExportMessage =
+      "We have improved the batch export feature. Please retry your export to benefit from the latest enhancements.";
+
+    await prisma.batchExport.update({
+      where: {
+        id: batchExportId,
+        projectId,
+      },
+      data: {
+        status: BatchExportStatus.FAILED,
+        finishedAt: new Date(),
+        log: improvedExportMessage,
+      },
+    });
+
+    logger.info(
+      `Batch export ${batchExportId} is older than 30 days. Marked as failed with retry message.`,
+    );
+
+    return; // Exit early without processing
+  }
+
   if (jobDetails.status !== BatchExportStatus.QUEUED) {
     logger.warn(
       `Job ${batchExportId} has invalid status: ${jobDetails.status}. Retrying anyway.`,

--- a/worker/src/queues/batchExportQueue.ts
+++ b/worker/src/queues/batchExportQueue.ts
@@ -5,7 +5,7 @@ import {
   BatchExportStatus,
   LangfuseNotFoundError,
 } from "@langfuse/shared";
-import { kyselyPrisma } from "@langfuse/shared/src/db";
+import { kyselyPrisma, prisma } from "@langfuse/shared/src/db";
 
 import { traceException, logger } from "@langfuse/shared/src/server";
 import { QueueName, TQueueJobTypes } from "@langfuse/shared/src/server";
@@ -28,6 +28,50 @@ export const batchExportQueueProcessor = async (
       );
       return true;
     }
+
+    // Check if the batch export is older than 30 days
+    const batchExport = await prisma.batchExport.findFirst({
+      where: {
+        id: job.data.payload.batchExportId,
+        projectId: job.data.payload.projectId,
+      },
+      select: {
+        createdAt: true,
+      },
+    });
+
+    if (batchExport) {
+      const thirtyDaysAgo = new Date();
+      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+      const isOlderThan30Days = batchExport.createdAt < thirtyDaysAgo;
+
+      if (isOlderThan30Days) {
+        // For old exports, acknowledge with an informative message
+        const improvedExportMessage =
+          "This export failed because it was created before recent improvements to the batch export system. Please retry your export to benefit from the latest enhancements.";
+
+        await prisma.batchExport.update({
+          where: {
+            id: job.data.payload.batchExportId,
+            projectId: job.data.payload.projectId,
+          },
+          data: {
+            status: BatchExportStatus.FAILED,
+            finishedAt: new Date(),
+            log: improvedExportMessage,
+          },
+        });
+
+        logger.info(
+          `Batch export ${job.data.payload.batchExportId} is older than 30 days. Marked as failed with retry message and acknowledged.`,
+        );
+
+        return true; // Acknowledge the job without throwing
+      }
+    }
+
+    // For recent exports, handle errors normally
     const displayError =
       e instanceof BaseError ? e.message : "An internal error occurred";
 

--- a/worker/src/queues/batchExportQueue.ts
+++ b/worker/src/queues/batchExportQueue.ts
@@ -5,7 +5,7 @@ import {
   BatchExportStatus,
   LangfuseNotFoundError,
 } from "@langfuse/shared";
-import { kyselyPrisma, prisma } from "@langfuse/shared/src/db";
+import { kyselyPrisma } from "@langfuse/shared/src/db";
 
 import { traceException, logger } from "@langfuse/shared/src/server";
 import { QueueName, TQueueJobTypes } from "@langfuse/shared/src/server";
@@ -28,50 +28,6 @@ export const batchExportQueueProcessor = async (
       );
       return true;
     }
-
-    // Check if the batch export is older than 30 days
-    const batchExport = await prisma.batchExport.findFirst({
-      where: {
-        id: job.data.payload.batchExportId,
-        projectId: job.data.payload.projectId,
-      },
-      select: {
-        createdAt: true,
-      },
-    });
-
-    if (batchExport) {
-      const thirtyDaysAgo = new Date();
-      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-
-      const isOlderThan30Days = batchExport.createdAt < thirtyDaysAgo;
-
-      if (isOlderThan30Days) {
-        // For old exports, acknowledge with an informative message
-        const improvedExportMessage =
-          "This export failed because it was created before recent improvements to the batch export system. Please retry your export to benefit from the latest enhancements.";
-
-        await prisma.batchExport.update({
-          where: {
-            id: job.data.payload.batchExportId,
-            projectId: job.data.payload.projectId,
-          },
-          data: {
-            status: BatchExportStatus.FAILED,
-            finishedAt: new Date(),
-            log: improvedExportMessage,
-          },
-        });
-
-        logger.info(
-          `Batch export ${job.data.payload.batchExportId} is older than 30 days. Marked as failed with retry message and acknowledged.`,
-        );
-
-        return true; // Acknowledge the job without throwing
-      }
-    }
-
-    // For recent exports, handle errors normally
     const displayError =
       e instanceof BaseError ? e.message : "An internal error occurred";
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> In `handleBatchExportJob`, batch exports older than 30 days are marked as failed with a retry message and processing is skipped.
> 
>   - **Behavior**:
>     - In `handleBatchExportJob`, batch exports older than 30 days are marked as failed with a message to retry for latest enhancements.
>     - Logs an info message when marking old exports as failed.
>     - Exits early without processing if the export is older than 30 days.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a04275b4d0ee2e276b9b9d8ae679e0265c429dfb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->