### PR TITLE
fix(scores): rename score note to score comment

### DIFF
--- a/web/src/features/scores/components/AnnotationForm.tsx
+++ b/web/src/features/scores/components/AnnotationForm.tsx
@@ -101,7 +101,7 @@ function CommentField({
   return (
     <div className="relative">
       <div className="mb-1 flex items-center justify-between">
-        <FormLabel className="text-sm">Score Notes</FormLabel>
+        <FormLabel className="text-sm">Score Comment</FormLabel>
         <div className="relative">
           {savedComment && (
             <PopoverClose asChild>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change label from 'Score Notes' to 'Score Comment' in `AnnotationForm.tsx`.
> 
>   - **UI Update**:
>     - In `AnnotationForm.tsx`, change label from 'Score Notes' to 'Score Comment' in `CommentField` component.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c77d2b73fe9898aa1a19b279924426206df195de. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->