### PR TITLE
chore(datatable): position horizontal scroll-bar at bottom

### DIFF
--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -291,7 +291,7 @@ export function DataTable<TData extends object, TValue>({
         )}
       >
         <div
-          className={cn("relative w-full overflow-auto border-t")}
+          className={cn("relative min-h-full w-full overflow-auto border-t")}
           style={{ ...columnSizeVars }}
         >
           <Table>
@@ -431,7 +431,6 @@ export function DataTable<TData extends object, TValue>({
             )}
           </Table>
         </div>
-        <div className="grow"></div>
       </div>
       {peekView && <TablePeekView peekView={peekView} />}
       {!hidePagination && pagination !== undefined ? (


### PR DESCRIPTION
When showing lists with fewer items than vertical space on the screen, the datatable would previously show the scrollbar directly under the last row creating an unfinished look.

<img width="1703" height="1065" alt="CleanShot 2025-10-21 at 13 35 54" src="https://github.com/user-attachments/assets/96670b0e-30d6-422a-849c-315efd8de1a9" />

Now the scrollbar is placed at the bottom of the page.

<img width="1703" height="1065" alt="CleanShot 2025-10-21 at 13 35 06" src="https://github.com/user-attachments/assets/47776ea3-83f5-41d3-a5c5-2c37ba60d457" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adjusts horizontal scrollbar position to the bottom of the page in `DataTable` for better visual alignment.
> 
>   - **Behavior**:
>     - Adjusts horizontal scrollbar position to the bottom of the page in `DataTable` when fewer rows than vertical space.
>   - **Code Changes**:
>     - Modifies CSS class in `data-table.tsx` to `min-h-full` for the container div.
>     - Removes unnecessary `div` with `grow` class in `data-table.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2fff843172d17be51c953b1ba49451550e57d2f0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->