### PR TITLE
chore: ignore observation level filters for trace csv export

### DIFF
--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -1502,4 +1502,187 @@ describe("batch export test suite", () => {
     expect(rowsByName[0].name).toBe("findable-trace-name");
     expect(rowsByName[0].id).toBe("search-test-id-1");
   });
+
+  it("should ignore observation-level filters when exporting traces", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    // Create traces with different names
+    const traces = [
+      createTrace({
+        project_id: projectId,
+        id: randomUUID(),
+        name: "trace-with-observations",
+        timestamp: new Date("2024-01-01").getTime(),
+      }),
+      createTrace({
+        project_id: projectId,
+        id: randomUUID(),
+        name: "another-trace",
+        timestamp: new Date("2024-01-02").getTime(),
+      }),
+      createTrace({
+        project_id: projectId,
+        id: randomUUID(),
+        name: "third-trace",
+        timestamp: new Date("2024-01-03").getTime(),
+      }),
+    ];
+
+    await createTracesCh(traces);
+
+    // Create observations with varying latencies
+    const observations = [
+      createObservation({
+        project_id: projectId,
+        trace_id: traces[0].id,
+        type: "GENERATION",
+        start_time: new Date("2024-01-01T00:00:00Z").getTime(),
+        end_time: new Date("2024-01-01T00:00:10Z").getTime(), // 10 seconds
+      }),
+      createObservation({
+        project_id: projectId,
+        trace_id: traces[1].id,
+        type: "GENERATION",
+        start_time: new Date("2024-01-02T00:00:00Z").getTime(),
+        end_time: new Date("2024-01-02T00:00:02Z").getTime(), // 2 seconds
+      }),
+    ];
+
+    await createObservationsCh(observations);
+
+    // Apply filters that include observation-level filters
+    // These should be ignored and all traces matching trace-level filters should be returned
+    const stream = await getTraceStream({
+      projectId: projectId,
+      cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      filter: [
+        // Observation-level filter (should be ignored)
+        {
+          type: "number",
+          operator: ">",
+          column: "Latency (s)",
+          value: 5,
+        },
+        // Trace-level filter (should be applied)
+        {
+          type: "stringOptions",
+          operator: "any of",
+          column: "Name",
+          value: ["trace-with-observations", "another-trace"],
+        },
+      ],
+    });
+
+    const rows: any[] = [];
+    for await (const chunk of stream) {
+      rows.push(chunk);
+    }
+
+    // Should return both traces matching the name filter
+    // Latency filter should be ignored since it's observation-level
+    expect(rows).toHaveLength(2);
+    const exportedNames = rows.map((row) => row.name).sort();
+    expect(exportedNames).toEqual([
+      "another-trace",
+      "trace-with-observations",
+    ]);
+  });
+
+  it("should successfully export traces with mixed trace-level and observation-level filters", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const traces = [
+      createTrace({
+        project_id: projectId,
+        id: randomUUID(),
+        name: "question_generator",
+        environment: "taboola-trs",
+        timestamp: new Date("2025-10-21T00:00:00Z").getTime(),
+      }),
+      createTrace({
+        project_id: projectId,
+        id: randomUUID(),
+        name: "question_generator",
+        environment: "kfc-search-engine-qna",
+        timestamp: new Date("2025-10-21T01:00:00Z").getTime(),
+      }),
+      createTrace({
+        project_id: projectId,
+        id: randomUUID(),
+        name: "other_trace",
+        environment: "taboola-trs",
+        timestamp: new Date("2025-10-21T02:00:00Z").getTime(),
+      }),
+      createTrace({
+        project_id: projectId,
+        id: randomUUID(),
+        name: "question_generator",
+        environment: "production",
+        timestamp: new Date("2025-10-21T03:00:00Z").getTime(),
+      }),
+    ];
+
+    await createTracesCh(traces);
+
+    // This mirrors the query from the issue
+    const stream = await getTraceStream({
+      projectId: projectId,
+      cutoffCreatedAt: new Date("2025-10-22T00:00:00Z"),
+      filter: [
+        // Observation-level filter (should be ignored)
+        {
+          type: "number",
+          column: "Latency (s)",
+          operator: ">",
+          value: 5,
+        },
+        // Trace-level filters (should be applied)
+        {
+          type: "stringOptions",
+          column: "Name",
+          operator: "any of",
+          value: ["question_generator"],
+        },
+        {
+          type: "datetime",
+          column: "timestamp",
+          operator: ">=",
+          value: new Date("2025-10-20T13:39:58.045Z"),
+        },
+        {
+          type: "datetime",
+          column: "timestamp",
+          operator: "<=",
+          value: new Date("2025-10-21T13:39:58.045Z"),
+        },
+        {
+          type: "stringOptions",
+          column: "environment",
+          operator: "any of",
+          value: ["taboola-trs", "kfc-search-engine-qna", "default"],
+        },
+      ],
+      searchQuery: "###",
+      searchType: ["id", "content"],
+    });
+
+    const rows: any[] = [];
+    for await (const chunk of stream) {
+      rows.push(chunk);
+    }
+
+    // Should only return traces matching all trace-level filters
+    // Observation-level latency filter should be ignored
+    expect(rows).toHaveLength(2);
+    const exportedEnvironments = rows.map((row) => row.environment).sort();
+    expect(exportedEnvironments).toEqual([
+      "kfc-search-engine-qna",
+      "taboola-trs",
+    ]);
+
+    // All should have the correct name
+    rows.forEach((row) => {
+      expect(row.name).toBe("question_generator");
+    });
+  });
 });

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -1659,8 +1659,6 @@ describe("batch export test suite", () => {
           value: ["taboola-trs", "kfc-search-engine-qna", "default"],
         },
       ],
-      searchQuery: "###",
-      searchType: ["id", "content"],
     });
 
     const rows: any[] = [];

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -1582,10 +1582,7 @@ describe("batch export test suite", () => {
     // Latency filter should be ignored since it's observation-level
     expect(rows).toHaveLength(2);
     const exportedNames = rows.map((row) => row.name).sort();
-    expect(exportedNames).toEqual([
-      "another-trace",
-      "trace-with-observations",
-    ]);
+    expect(exportedNames).toEqual(["another-trace", "trace-with-observations"]);
   });
 
   it("should successfully export traces with mixed trace-level and observation-level filters", async () => {

--- a/worker/src/features/database-read-stream/trace-stream.ts
+++ b/worker/src/features/database-read-stream/trace-stream.ts
@@ -44,11 +44,21 @@ export const getTraceStream = async (props: {
     join_algorithm: "partial_merge",
   };
 
+  // Filter out observation-level filters since we don't join the observations table
+  // This prevents batch export failures when observation-level filters are present
+  const traceOnlyFilters = (filter ?? []).filter((f) => {
+    const columnDef = tracesTableUiColumnDefinitions.find(
+      (col) => col.uiTableName === f.column || col.uiTableId === f.column,
+    );
+    // Keep the filter if it's not an observation-level filter
+    return columnDef?.clickhouseTableName !== "observations";
+  });
+
   // Get distinct score names for empty columns
   const distinctScoreNames = await getDistinctScoreNames({
     projectId,
     cutoffCreatedAt,
-    filter: filter ?? [],
+    filter: traceOnlyFilters,
     isTimestampFilter: isTraceTimestampFilter,
     clickhouseConfigs,
   });
@@ -64,7 +74,7 @@ export const getTraceStream = async (props: {
   tracesFilter.push(
     ...createFilterFromFilterState(
       [
-        ...(filter ?? []),
+        ...traceOnlyFilters,
         {
           column: "timestamp",
           operator: "<" as const,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `getTraceStream` now ignores observation-level filters, applying only trace-level filters during trace export, with tests added to verify this behavior.
> 
>   - **Behavior**:
>     - `getTraceStream` in `trace-stream.ts` now filters out observation-level filters, applying only trace-level filters during trace export.
>     - Ensures batch export does not fail due to observation-level filters.
>   - **Tests**:
>     - Added test cases in `batchExport.test.ts` to verify that observation-level filters are ignored and trace-level filters are applied correctly.
>     - Tests include scenarios with mixed trace-level and observation-level filters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a8d066c866282288eec7071f212b98c79560392b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->