### PR TITLE
fix(comments): add pagination meta object to API response

### DIFF
--- a/web/src/__tests__/async/comments-api.servertest.ts
+++ b/web/src/__tests__/async/comments-api.servertest.ts
@@ -209,6 +209,12 @@ describe("GET /api/public/comments API Endpoint", () => {
       "/api/public/comments",
     );
     expect(comments.body.data).toHaveLength(5);
+    expect(comments.body.meta).toMatchObject({
+      page: 1,
+      limit: 50,
+      totalItems: 5,
+      totalPages: 1,
+    });
   });
 
   it("should return comments for a specific objectId and objectType", async () => {
@@ -222,6 +228,12 @@ describe("GET /api/public/comments API Endpoint", () => {
     );
 
     expect(comments.body.data).toHaveLength(4);
+    expect(comments.body.meta).toMatchObject({
+      page: 1,
+      limit: 50,
+      totalItems: 4,
+      totalPages: 1,
+    });
     expect(comments.body.data.map((comment) => comment.id)).toEqual([
       "comment-2021-01-01",
       "comment-2021-03-01",
@@ -242,6 +254,12 @@ describe("GET /api/public/comments API Endpoint", () => {
     );
 
     expect(comments.body.data).toHaveLength(2);
+    expect(comments.body.meta).toMatchObject({
+      page: 1,
+      limit: 50,
+      totalItems: 2,
+      totalPages: 1,
+    });
     expect(comments.body.data.map((comment) => comment.id)).toEqual([
       "comment-2021-01-01",
       "comment-2021-03-01",
@@ -256,6 +274,12 @@ describe("GET /api/public/comments API Endpoint", () => {
     );
 
     expect(comments.body.data).toHaveLength(0);
+    expect(comments.body.meta).toMatchObject({
+      page: 1,
+      limit: 50,
+      totalItems: 0,
+      totalPages: 1,
+    });
   });
 
   it("should throw 400 error with descriptive error message if objectType is provided but invalid", async () => {
@@ -282,6 +306,12 @@ describe("GET /api/public/comments API Endpoint", () => {
       "/api/public/comments?objectType=TRACE",
     );
     expect(comments.body.data).toHaveLength(4);
+    expect(comments.body.meta).toMatchObject({
+      page: 1,
+      limit: 50,
+      totalItems: 4,
+      totalPages: 1,
+    });
     expect(comments.body.data.map((comment) => comment.id)).toEqual([
       "comment-2021-01-01",
       "comment-2021-03-01",

--- a/web/src/__tests__/async/comments-api.servertest.ts
+++ b/web/src/__tests__/async/comments-api.servertest.ts
@@ -278,7 +278,7 @@ describe("GET /api/public/comments API Endpoint", () => {
       page: 1,
       limit: 50,
       totalItems: 0,
-      totalPages: 1,
+      totalPages: 0,
     });
   });
 

--- a/web/src/features/public-api/types/comments.ts
+++ b/web/src/features/public-api/types/comments.ts
@@ -1,6 +1,7 @@
 import {
   CommentObjectType,
   CreateCommentData,
+  paginationMetaResponseZod,
   publicApiPaginationZod,
 } from "@langfuse/shared";
 import { z } from "zod/v4";
@@ -54,6 +55,7 @@ export const GetCommentsV1Query = z
 export const GetCommentsV1Response = z
   .object({
     data: z.array(APIComment),
+    meta: paginationMetaResponseZod,
   })
   .strict();
 

--- a/web/src/pages/api/public/comments/index.ts
+++ b/web/src/pages/api/public/comments/index.ts
@@ -66,7 +66,24 @@ export default withMiddlewares({
         skip: (page - 1) * limit,
       });
 
-      return { data: comments };
+      const totalItems = await prisma.comment.count({
+        where: {
+          projectId: auth.scope.projectId,
+          objectType: objectType ?? undefined,
+          objectId: objectId ?? undefined,
+          authorUserId: authorUserId ?? undefined,
+        },
+      });
+
+      return {
+        data: comments,
+        meta: {
+          page: query.page,
+          limit: query.limit,
+          totalItems,
+          totalPages: Math.ceil(totalItems / query.limit),
+        },
+      };
     },
   }),
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add pagination metadata to `GET /api/public/comments` response and update tests to validate it.
> 
>   - **Behavior**:
>     - Adds pagination metadata (`page`, `limit`, `totalItems`, `totalPages`) to the response of `GET /api/public/comments` in `index.ts`.
>     - Updates test cases in `comments-api.servertest.ts` to validate the presence and correctness of pagination metadata.
>   - **Types**:
>     - Updates `GetCommentsV1Response` in `comments.ts` to include `meta` field for pagination metadata.
>   - **Tests**:
>     - Adds assertions for pagination metadata in multiple test cases in `comments-api.servertest.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a92e130ad781e34a5038cd1dd5208f1d54b1c80f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->