### PR TITLE
feat(annotation): add SESSION enum to annotation queues in YAML and OpenAPI definitions

### DIFF
--- a/fern/apis/server/definition/annotation-queues.yml
+++ b/fern/apis/server/definition/annotation-queues.yml
@@ -144,6 +144,7 @@ types:
     enum:
       - TRACE
       - OBSERVATION
+      - SESSION
 
   AnnotationQueue:
     properties:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -4933,6 +4933,7 @@ components:
       enum:
         - TRACE
         - OBSERVATION
+        - SESSION
     AnnotationQueue:
       title: AnnotationQueue
       type: object


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `SESSION` to `AnnotationQueueObjectType` enum in YAML and OpenAPI definitions.
> 
>   - **Enums**:
>     - Add `SESSION` to `AnnotationQueueObjectType` enum in `annotation-queues.yml` and `openapi.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6613b457c2b1df4ab98ff6200c6633b8e1dd6693. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->