### PR TITLE
chore(comments): increase comment character limit

### DIFF
--- a/fern/apis/server/definition/comments.yml
+++ b/fern/apis/server/definition/comments.yml
@@ -58,7 +58,7 @@ types:
         docs: The id of the object to attach the comment to. If this does not reference a valid existing object, an error will be thrown.
       content:
         type: string
-        docs: The content of the comment. May include markdown. Currently limited to 3000 characters.
+        docs: The content of the comment. May include markdown. Currently limited to 5000 characters.
       authorUserId:
         type: optional<string>
         docs: The id of the user who created the comment.

--- a/packages/shared/src/features/comments/types.ts
+++ b/packages/shared/src/features/comments/types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod/v4";
 
-const MAX_COMMENT_LENGTH = 3000;
+const MAX_COMMENT_LENGTH = 5000;
 
 const COMMENT_OBJECT_TYPES = [
   "TRACE",

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -5290,7 +5290,7 @@ components:
           type: string
           description: >-
             The content of the comment. May include markdown. Currently limited
-            to 3000 characters.
+            to 5000 characters.
         authorUserId:
           type: string
           nullable: true

--- a/web/src/__tests__/async/comments-api.servertest.ts
+++ b/web/src/__tests__/async/comments-api.servertest.ts
@@ -106,7 +106,7 @@ describe("Create and get comments", () => {
     }
   });
 
-  it("should fail to create comment if content is larger than 3000 characters", async () => {
+  it("should fail to create comment if content is larger than 5000 characters", async () => {
     try {
       await makeZodVerifiedAPICall(
         z.object({
@@ -116,7 +116,7 @@ describe("Create and get comments", () => {
         "POST",
         "/api/public/comments",
         {
-          content: "a".repeat(3001),
+          content: "a".repeat(5001),
           objectId: "1234",
           objectType: "TRACE",
           projectId: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
@@ -124,7 +124,7 @@ describe("Create and get comments", () => {
       );
     } catch (error) {
       expect((error as Error).message).toBe(
-        `API call did not return 200, returned status 400, body {\"message\":\"Invalid request data\",\"error\":[{\"origin\":\"string\",\"code\":\"too_big\",\"maximum\":3000,\"inclusive\":true,\"path\":[\"content\"],\"message\":\"Too big: expected string to have <=3000 characters\"}]}`,
+        `API call did not return 200, returned status 400, body {\"message\":\"Invalid request data\",\"error\":[{\"origin\":\"string\",\"code\":\"too_big\",\"maximum\":5000,\"inclusive\":true,\"path\":[\"content\"],\"message\":\"Too big: expected string to have <=5000 characters\"}]}`,
       );
     }
   });

--- a/web/src/features/public-api/types/comments.ts
+++ b/web/src/features/public-api/types/comments.ts
@@ -18,7 +18,7 @@ const APIComment = z
     updatedAt: z.coerce.date(),
     objectType: z.enum(CommentObjectType),
     objectId: z.string(),
-    content: z.string().min(1).max(3000),
+    content: z.string().min(1).max(5000),
     authorUserId: z.string().nullish(),
   })
   .strict();


### PR DESCRIPTION
## What does this PR do?

This PR increases the character limit for comments from the existing 3000 characters to 5000 characters. This change provides users with more flexibility for detailed comments and reduces the likelihood of needing further adjustments in the near future.

The update includes:
- Modifying the `MAX_COMMENT_LENGTH` constant in the shared package.
- Updating the validation schema for the public API.
- Reflecting the new limit in the API documentation (`fern/apis/server/definition/comments.yml`).
- Adjusting an existing test case to validate the new 5000-character limit.

Fixes # LF-1905

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [ ] I haven't commented my code, particularly in hard-to-understand areas
- [x] I haven't checked if my PR needs changes to the documentation (User-facing documentation on langfuse.com needs to be updated to reflect the new limit.)
- [x] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [x] I haven't added tests that prove my fix is effective or that my feature works (An existing test was updated, but new tests were not added.)
- [x] I haven't checked if new and existing unit tests pass locally with my changes (Tests could not be run due to environment setup issues.)

---
Linear Issue: [LF-1905](https://linear.app/langfuse/issue/LF-1905/comments-increase-character-limit)

<a href="https://cursor.com/background-agent?bcId=bc-7e6dd710-f30e-4d52-9c80-5995e7b2b64b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7e6dd710-f30e-4d52-9c80-5995e7b2b64b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Increase comment character limit from 3000 to 5000 characters and update related documentation and tests.
> 
>   - **Behavior**:
>     - Increase comment character limit from 3000 to 5000 in `MAX_COMMENT_LENGTH` in `types.ts`.
>     - Update API documentation in `openapi.yml` and `comments.yml` to reflect new limit.
>     - Adjust validation schema in `comments.ts` to enforce new limit.
>   - **Tests**:
>     - Update test case in `comments-api.servertest.ts` to validate 5000-character limit.
>   - **Misc**:
>     - Fixes issue LF-1905.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 77d310f434887f181ddd5846d6c38b1c07b1ed08. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->