### PR TITLE
Fix s3 multipart upload exceeding limit

### DIFF
--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -511,6 +511,11 @@ class S3StorageService implements StorageService {
           Body: data,
           ContentType: fileType,
         }),
+        // Set part size to 100 MB to stay within AWS's 10,000 part limit
+        // This supports files up to ~1 TB (100 MB × 10,000 parts)
+        // Default part size is 5 MB which only supports ~50 GB
+        partSize: 100 * 1024 * 1024, // 100 MB in bytes
+        queueSize: 4, // Number of concurrent part uploads
       }).done();
 
       return;


### PR DESCRIPTION
## What does this PR do?

The default 5MB part size for S3 multipart uploads was causing large CSV exports to exceed AWS's 10,000 part limit, leading to upload failures. This PR resolves the issue by increasing the S3 multipart upload part size to 100MB and configuring a queue size of 4 for concurrent uploads. This change supports file uploads up to ~1TB, well within AWS limits, and improves upload efficiency.

Fixes #LFE-7333

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] This change requires a documentation update
- [ ] I haven't added tests that prove my fix is effective or that my feature works

---
Linear Issue: [LFE-7333](https://linear.app/langfuse/issue/LFE-7333/s3-multi-part-upload-exceeds-aws-limit-of-10k)

<a href="https://cursor.com/background-agent?bcId=bc-6025e591-bc76-4eef-8410-7ff3d08cd41b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6025e591-bc76-4eef-8410-7ff3d08cd41b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

