### PR TITLE
chore: increase part size for csv exports

### DIFF
--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -198,6 +198,8 @@ export const handleBatchExportJob = async (
       exportOptions[jobDetails.format as BatchExportFileFormat].fileType,
     data: fileStream,
     expiresInSeconds,
+    partSize: 100 * 1024 * 1024, // 100 MB for CSV
+    queueSize: 4,
   });
 
   logger.info(`Batch export file ${fileName} uploaded to S3`);

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -153,10 +153,17 @@ const processBlobStorageExport = async (config: {
     );
 
     // Upload the file to cloud storage
+    // For CSV exports, use larger part size to handle big files
+    // 100 MB parts support files up to ~1 TB (100 MB × 10,000 AWS limit)
+    // This prevents hitting AWS's 10,000 part limit on large exports
+    const isLargeExport =
+      config.fileType === BlobStorageIntegrationFileType.CSV;
     await storageService.uploadFile({
       fileName: filePath,
       fileType: blobStorageProps.contentType,
       data: fileStream,
+      partSize: isLargeExport ? 100 * 1024 * 1024 : undefined, // 100 MB for CSV
+      queueSize: isLargeExport ? 4 : undefined, // 4 concurrent uploads for CSV
     });
 
     logger.info(

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -156,14 +156,12 @@ const processBlobStorageExport = async (config: {
     // For CSV exports, use larger part size to handle big files
     // 100 MB parts support files up to ~1 TB (100 MB × 10,000 AWS limit)
     // This prevents hitting AWS's 10,000 part limit on large exports
-    const isLargeExport =
-      config.fileType === BlobStorageIntegrationFileType.CSV;
+
     await storageService.uploadFile({
       fileName: filePath,
       fileType: blobStorageProps.contentType,
       data: fileStream,
-      partSize: isLargeExport ? 100 * 1024 * 1024 : undefined, // 100 MB for CSV
-      queueSize: isLargeExport ? 4 : undefined, // 4 concurrent uploads for CSV
+      partSize: 100 * 1024 * 1024, // 100 MB for CSV
     });
 
     logger.info(

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -161,7 +161,7 @@ const processBlobStorageExport = async (config: {
       fileName: filePath,
       fileType: blobStorageProps.contentType,
       data: fileStream,
-      partSize: 100 * 1024 * 1024, // 100 MB for CSV
+      partSize: 100 * 1024 * 1024, // 100 MB part size
     });
 
     logger.info(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Increase part size to 100 MB for CSV exports in `StorageService.ts`, `handleBatchExportJob.ts`, and `handleBlobStorageIntegrationProjectJob.ts` to handle large files efficiently.
> 
>   - **Behavior**:
>     - Adds optional `partSize` and `queueSize` parameters to `UploadFile` type in `StorageService.ts` for multipart uploads.
>     - Updates `S3StorageService.uploadFile()` to use `partSize` and `queueSize` for S3 uploads.
>     - Sets `partSize` to 100 MB and `queueSize` to 4 for CSV exports in `handleBatchExportJob.ts` and `handleBlobStorageIntegrationProjectJob.ts`.
>   - **Misc**:
>     - Comments added to explain default and recommended `partSize` values for large files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 059c20d1c8d4a7b778fd0bf126a126886c3eb818. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->