### PR TITLE
style(scores): always display scores as aggregates in dataset runs table

### DIFF
--- a/web/src/components/scores-table-cell.tsx
+++ b/web/src/components/scores-table-cell.tsx
@@ -43,18 +43,18 @@ const ScoreValueCounts = ({
 
 export const ScoresTableCell = ({
   aggregate,
-  showSingleValue = false,
+  displayFormat,
   wrap = true,
   hasMetadata,
 }: {
   aggregate: AggregatedScoreData;
-  showSingleValue?: boolean;
+  displayFormat?: "smart" | "aggregate";
   wrap?: boolean;
   hasMetadata?: boolean;
 }) => {
   const projectId = useProjectIdFromURL();
 
-  if (showSingleValue && aggregate.values.length === 1 && projectId) {
+  if (displayFormat === "smart" && aggregate.values.length === 1 && projectId) {
     const value =
       aggregate.type === "NUMERIC"
         ? aggregate.average.toFixed(4)

--- a/web/src/components/scores-table-cell.tsx
+++ b/web/src/components/scores-table-cell.tsx
@@ -48,7 +48,7 @@ export const ScoresTableCell = ({
   hasMetadata,
 }: {
   aggregate: AggregatedScoreData;
-  displayFormat?: "smart" | "aggregate";
+  displayFormat: "smart" | "aggregate";
   wrap?: boolean;
   hasMetadata?: boolean;
 }) => {

--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -276,6 +276,7 @@ export function DatasetRunsTable(props: {
 
   const { scoreColumns, isLoading: isColumnLoading } =
     useScoreColumns<DatasetRunRowData>({
+      displayFormat: "aggregate",
       scoreColumnKey: "runItemScores",
       projectId: props.projectId,
       filter: runs.data?.runs?.length

--- a/web/src/features/scores/hooks/useScoreColumns.ts
+++ b/web/src/features/scores/hooks/useScoreColumns.ts
@@ -20,6 +20,7 @@ function createScoreColumns<T extends Record<string, any>>(
   }>,
   scoreColumnKey: keyof T & string,
   prefix?: string,
+  displayFormat?: "smart" | "aggregate",
 ): LangfuseColumnDef<T>[] {
   return scoreColumns.map(({ key, name, source, dataType }) => {
     // Apply prefix to both column ID/accessor and header
@@ -43,7 +44,7 @@ function createScoreColumns<T extends Record<string, any>>(
 
         return ScoresTableCell({
           aggregate: value,
-          showSingleValue: true,
+          displayFormat,
           hasMetadata: value.hasMetadata ?? false,
         });
       },
@@ -51,6 +52,13 @@ function createScoreColumns<T extends Record<string, any>>(
   });
 }
 
+/**
+ * Hook to fetch and create score columns for tables.
+ *
+ * @param displayFormat Controls how scores are displayed:
+ *   - "smart" (default): Shows single value when there's only one score, aggregate stats when multiple
+ *   - "aggregate": Always shows aggregate format (count, avg, etc.) regardless of score count
+ */
 export function useScoreColumns<T extends Record<string, any>>({
   projectId,
   scoreColumnKey,
@@ -59,6 +67,7 @@ export function useScoreColumns<T extends Record<string, any>>({
   toTimestamp,
   prefix,
   isFilterDataPending = false,
+  displayFormat = "smart",
 }: {
   projectId: string;
   scoreColumnKey: keyof T & string;
@@ -67,6 +76,7 @@ export function useScoreColumns<T extends Record<string, any>>({
   toTimestamp?: Date;
   prefix?: string;
   isFilterDataPending?: boolean;
+  displayFormat?: "smart" | "aggregate";
 }) {
   const scoreColumnsQuery = api.scores.getScoreColumns.useQuery(
     {
@@ -87,6 +97,7 @@ export function useScoreColumns<T extends Record<string, any>>({
       toOrderedScoresList(scoreColumnsQuery.data.scoreColumns),
       scoreColumnKey,
       prefix,
+      displayFormat,
     );
   }, [scoreColumnsQuery.data?.scoreColumns, scoreColumnKey, prefix]);
 

--- a/web/src/features/scores/hooks/useScoreColumns.ts
+++ b/web/src/features/scores/hooks/useScoreColumns.ts
@@ -19,8 +19,8 @@ function createScoreColumns<T extends Record<string, any>>(
     dataType: ScoreDataType;
   }>,
   scoreColumnKey: keyof T & string,
+  displayFormat: "smart" | "aggregate",
   prefix?: string,
-  displayFormat?: "smart" | "aggregate",
 ): LangfuseColumnDef<T>[] {
   return scoreColumns.map(({ key, name, source, dataType }) => {
     // Apply prefix to both column ID/accessor and header
@@ -96,10 +96,15 @@ export function useScoreColumns<T extends Record<string, any>>({
     return createScoreColumns<T>(
       toOrderedScoresList(scoreColumnsQuery.data.scoreColumns),
       scoreColumnKey,
-      prefix,
       displayFormat,
+      prefix,
     );
-  }, [scoreColumnsQuery.data?.scoreColumns, scoreColumnKey, prefix]);
+  }, [
+    scoreColumnsQuery.data?.scoreColumns,
+    scoreColumnKey,
+    prefix,
+    displayFormat,
+  ]);
 
   return {
     scoreColumns,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces `displayFormat` parameter to control score display format in dataset runs table, defaulting to "aggregate".
> 
>   - **Behavior**:
>     - Introduces `displayFormat` parameter in `ScoresTableCell` to control score display format.
>     - Default `displayFormat` set to "aggregate" in `DatasetRunsTable`.
>     - `useScoreColumns` updated to accept `displayFormat` parameter.
>   - **Code Changes**:
>     - Replaces `showSingleValue` with `displayFormat` in `ScoresTableCell`.
>     - Updates `createScoreColumns` in `useScoreColumns.ts` to use `displayFormat`.
>     - Modifies `DatasetRunsTable` to pass `displayFormat: "aggregate"` to `useScoreColumns`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6c60ae5f986fc8d8ad431c89001e747ec463f2c8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->