### PR TITLE
fix(filters): hide on evaluator form

### DIFF
--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -1226,7 +1226,9 @@ export default function TracesTable({
 
         {/* Content area with sidebar and table */}
         <div className="flex flex-1 overflow-hidden">
-          <DataTableControls queryFilter={queryFilter} filterWithAI />
+          {!hideControls && (
+            <DataTableControls queryFilter={queryFilter} filterWithAI />
+          )}
 
           <div className="flex flex-1 flex-col overflow-hidden">
             <DataTable


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Conditionally render `DataTableControls` in `traces.tsx` based on `hideControls` prop.
> 
>   - **Behavior**:
>     - `DataTableControls` in `traces.tsx` is now conditionally rendered based on `hideControls` prop.
>     - If `hideControls` is `true`, `DataTableControls` is not displayed.
>   - **Props**:
>     - Adds `hideControls` prop to `TracesTableProps` in `traces.tsx` to control visibility of table controls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 52b533c816c4ae0ab6ef3b577bb282ccfa2747f3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->