### PR TITLE
fix(next): react resizable import for dev server

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -70,7 +70,7 @@ const nextConfig = {
       // the dev server. The CSS is included in the non-turbopack based prod build anyways.
       // Also not needed for the non-turbopack based dev server.
       "react-resizable/css/styles.css":
-        "../node_modules/.pnpm/react-resizable@3.0.5_react-dom@19.1.1_react@19.1.1__react@19.1.1/node_modules/react-resizable/css/styles.css",
+        "../node_modules/.pnpm/react-resizable@3.0.5_react-dom@19.2.0_react@19.2.0__react@19.2.0/node_modules/react-resizable/css/styles.css",
     },
   },
   experimental: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `react-resizable` CSS import path in `next.config.mjs` for Turbopack dev server compatibility with `react-dom@19.2.0`.
> 
>   - **Configuration**:
>     - Update import path for `react-resizable/css/styles.css` in `next.config.mjs` to use `react-dom@19.2.0` and `react@19.2.0` for Turbopack dev server.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 774be1b22fa44f38c593f1399c1d2a418ed45991. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->