### PR TITLE
fix(evaluation): prevent setting job status to canceled for completed evaluations

### DIFF
--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -581,7 +581,8 @@ export const createEvalJobs = async ({
           `Cancelling eval job for config ${config.id} and trace ${event.traceId}`,
         );
 
-        await prisma.jobExecution.update({
+        // Note: we use updateMany to gracefully handle case where execution is already completed; we silently skip the update.
+        await prisma.jobExecution.updateMany({
           where: {
             id: existingJob[0].id,
             projectId: event.projectId,

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -585,6 +585,9 @@ export const createEvalJobs = async ({
           where: {
             id: existingJob[0].id,
             projectId: event.projectId,
+            status: {
+              not: JobExecutionStatus.COMPLETED,
+            },
           },
           data: {
             status: JobExecutionStatus.CANCELLED,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Prevents setting job status to `CANCELLED` if already `COMPLETED` in `createEvalJobs` in `evalService.ts`.
> 
>   - **Behavior**:
>     - Prevents setting job status to `CANCELLED` if already `COMPLETED` in `createEvalJobs` in `evalService.ts`.
>     - Uses `updateMany` with condition to skip update if status is `COMPLETED`.
>   - **Misc**:
>     - Adds comment explaining the use of `updateMany` for graceful handling of completed executions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7fbbe3f6b7f44ee2675057b3a13bbcfe7cbb5612. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->