### PR TITLE
fix(filters): observations table tags not working

### DIFF
--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -10,7 +10,11 @@ import { TokenUsageBadge } from "@/src/components/token-usage-badge";
 import { NumberParam, useQueryParams, withDefault } from "use-query-params";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
 import { useSidebarFilterState } from "@/src/features/filters/hooks/useSidebarFilterState";
-import { observationFilterConfig } from "@/src/features/filters/config/observations-config";
+import {
+  observationFilterConfig,
+  OBSERVATION_COLUMN_TO_BACKEND_KEY,
+} from "@/src/features/filters/config/observations-config";
+import { transformFiltersForBackend } from "@/src/features/filters/lib/filter-transform";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
@@ -352,9 +356,14 @@ export default function ObservationsTable({
     environmentFilter,
   );
 
+  const backendFilterState = transformFiltersForBackend(
+    filterState,
+    OBSERVATION_COLUMN_TO_BACKEND_KEY,
+  );
+
   const getCountPayload = {
     projectId,
-    filter: filterState,
+    filter: backendFilterState,
     searchQuery,
     searchType,
     page: 0,
@@ -442,7 +451,7 @@ export default function ObservationsTable({
       queueId: targetId,
       isBatchAction: selectAll,
       query: {
-        filter: filterState,
+        filter: backendFilterState,
         orderBy: orderByState,
       },
     });

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -11,7 +11,11 @@ import { TokenUsageBadge } from "@/src/components/token-usage-badge";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
 import { useSidebarFilterState } from "@/src/features/filters/hooks/useSidebarFilterState";
-import { sessionFilterConfig } from "@/src/features/filters/config/sessions-config";
+import {
+  sessionFilterConfig,
+  SESSION_COLUMN_TO_BACKEND_KEY,
+} from "@/src/features/filters/config/sessions-config";
+import { transformFiltersForBackend } from "@/src/features/filters/lib/filter-transform";
 import {
   type FilterState,
   BatchExportTableName,
@@ -163,6 +167,11 @@ export default function SessionsTable({
     environmentFilter,
   );
 
+  const backendFilterState = transformFiltersForBackend(
+    filterState,
+    SESSION_COLUMN_TO_BACKEND_KEY,
+  );
+
   const { selectAll, setSelectAll } = useSelectAll(projectId, "sessions");
 
   const [paginationState, setPaginationState] = useQueryParams({
@@ -179,7 +188,7 @@ export default function SessionsTable({
 
   const payloadCount = {
     projectId,
-    filter: filterState,
+    filter: backendFilterState,
     orderBy: null,
     page: 0,
     limit: 1,
@@ -294,7 +303,7 @@ export default function SessionsTable({
       queueId: targetId,
       isBatchAction: selectAll,
       query: {
-        filter: filterState,
+        filter: backendFilterState,
         orderBy: orderByState,
       },
     });

--- a/web/src/features/filters/config/observations-config.ts
+++ b/web/src/features/filters/config/observations-config.ts
@@ -1,6 +1,7 @@
 import { observationsTableCols } from "@langfuse/shared";
 import type { FilterConfig } from "@/src/features/filters/lib/filter-config";
 import type { ColumnToQueryKeyMap } from "@/src/features/filters/lib/filter-query-encoding";
+import type { ColumnToBackendKeyMap } from "@/src/features/filters/lib/filter-transform";
 
 const OBSERVATION_COLUMN_TO_QUERY_KEY: ColumnToQueryKeyMap = {
   environment: "environment",
@@ -21,6 +22,14 @@ const OBSERVATION_COLUMN_TO_QUERY_KEY: ColumnToQueryKeyMap = {
   inputTokens: "inputTokens",
   outputTokens: "outputTokens",
   totalTokens: "totalTokens",
+};
+
+/**
+ * Maps frontend column IDs to backend-expected column IDs
+ * Frontend uses "tags" but backend CH mapping expects "traceTags" for trace tags on observations table
+ */
+export const OBSERVATION_COLUMN_TO_BACKEND_KEY: ColumnToBackendKeyMap = {
+  tags: "traceTags",
 };
 
 export const observationFilterConfig: FilterConfig = {

--- a/web/src/features/filters/config/sessions-config.ts
+++ b/web/src/features/filters/config/sessions-config.ts
@@ -1,6 +1,7 @@
 import { sessionsViewCols } from "@langfuse/shared";
 import type { FilterConfig } from "@/src/features/filters/lib/filter-config";
 import type { ColumnToQueryKeyMap } from "@/src/features/filters/lib/filter-query-encoding";
+import type { ColumnToBackendKeyMap } from "@/src/features/filters/lib/filter-transform";
 
 const SESSION_COLUMN_TO_QUERY_KEY: ColumnToQueryKeyMap = {
   bookmarked: "bookmarked",
@@ -12,6 +13,14 @@ const SESSION_COLUMN_TO_QUERY_KEY: ColumnToQueryKeyMap = {
   inputTokens: "inputTokens",
   outputTokens: "outputTokens",
   totalTokens: "totalTokens",
+};
+
+/**
+ * Maps frontend column IDs to backend-expected column IDs
+ * Frontend uses "tags" but backend CH mapping expects "traceTags" for trace tags on sessions table
+ */
+export const SESSION_COLUMN_TO_BACKEND_KEY: ColumnToBackendKeyMap = {
+  tags: "traceTags",
 };
 
 export const sessionFilterConfig: FilterConfig = {

--- a/web/src/features/filters/lib/filter-transform.ts
+++ b/web/src/features/filters/lib/filter-transform.ts
@@ -1,0 +1,32 @@
+import { type FilterState } from "@langfuse/shared";
+
+/**
+ * Maps frontend column IDs to backend-expected column IDs
+ * Used when frontend table definitions use different IDs than backend CH mappings
+ * such as for tags on the observations table (they are called traceTags in CH)
+ */
+export type ColumnToBackendKeyMap = Record<string, string>;
+
+/**
+ * Transforms FilterState column IDs to backend-expected IDs
+ * This is needed when frontend uses different column IDs than backend expects
+ *
+ * @param filters - FilterState from frontend
+ * @param columnMap - Mapping of frontend column ID -> backend column ID
+ * @returns Transformed FilterState with backend column IDs
+ */
+export function transformFiltersForBackend(
+  filters: FilterState,
+  columnMap: ColumnToBackendKeyMap,
+): FilterState {
+  return filters.map((filter) => {
+    const backendColumnId = columnMap[filter.column];
+    if (backendColumnId && backendColumnId !== filter.column) {
+      return {
+        ...filter,
+        column: backendColumnId,
+      };
+    }
+    return filter;
+  });
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes tag filtering in observations and sessions tables by mapping frontend `tags` to backend `traceTags`.
> 
>   - **Behavior**:
>     - Fixes tag filtering in `ObservationsTable` and `SessionsTable` by mapping frontend `tags` to backend `traceTags`.
>     - Uses `transformFiltersForBackend()` in `observations.tsx` and `sessions.tsx` to apply the mapping.
>   - **Config**:
>     - Adds `OBSERVATION_COLUMN_TO_BACKEND_KEY` and `SESSION_COLUMN_TO_BACKEND_KEY` in `observations-config.ts` and `sessions-config.ts` respectively.
>   - **Library**:
>     - Introduces `transformFiltersForBackend()` in `filter-transform.ts` to handle column ID transformation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 56c04a6752721b8df9d5cc894a8336d56b315d2c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->