### PR TITLE
fix(filters): allow restoring saved views with metdata

### DIFF
--- a/packages/shared/src/observationsTable.ts
+++ b/packages/shared/src/observationsTable.ts
@@ -46,6 +46,14 @@ export const observationsTableCols: ColumnDefinition[] = [
     nullable: true,
   },
   {
+    name: "Environment",
+    id: "environment",
+    type: "stringOptions",
+    internal: 'o."environment"',
+    options: [], // to be added at runtime
+    nullable: true,
+  },
+  {
     name: "Start Time",
     id: "startTime",
     type: "datetime",
@@ -219,6 +227,7 @@ export type ObservationOptions = {
   modelId: Array<SingleValueOption>;
   name: Array<SingleValueOption>;
   traceName: Array<SingleValueOption>;
+  environment: Array<SingleValueOption>;
   scores_avg: Array<string>;
   score_categories: Array<MultiValueOption>;
   promptName: Array<SingleValueOption>;
@@ -241,6 +250,9 @@ export function observationsTableColsWithOptions(
     }
     if (col.id === "traceName") {
       return formatColumnOptions(col, options?.traceName ?? []);
+    }
+    if (col.id === "environment") {
+      return formatColumnOptions(col, options?.environment ?? []);
     }
     if (col.id === "scores_avg") {
       return formatColumnOptions(col, options?.scores_avg ?? []);

--- a/web/src/features/filters/config/traces-config.ts
+++ b/web/src/features/filters/config/traces-config.ts
@@ -20,9 +20,9 @@ const TRACE_COLUMN_TO_QUERY_KEY: ColumnToQueryKeyMap = {
   inputCost: "inputCost",
   outputCost: "outputCost",
   totalCost: "totalCost",
-  "Scores (categorical)": "score_categories",
-  "Scores (numeric)": "scores_avg",
-  Metadata: "metadata",
+  score_categories: "score_categories",
+  scores_avg: "scores_avg",
+  metadata: "metadata",
 };
 
 export const traceFilterConfig: FilterConfig = {
@@ -62,7 +62,7 @@ export const traceFilterConfig: FilterConfig = {
     },
     {
       type: "stringKeyValue" as const,
-      column: "Metadata",
+      column: "metadata",
       label: "Metadata",
     },
     {
@@ -147,12 +147,12 @@ export const traceFilterConfig: FilterConfig = {
     },
     {
       type: "keyValue" as const,
-      column: "Scores (categorical)",
+      column: "score_categories",
       label: "Categorical Scores",
     },
     {
       type: "numericKeyValue" as const,
-      column: "Scores (numeric)",
+      column: "scores_avg",
       label: "Numeric Scores",
     },
   ],

--- a/web/src/server/api/routers/generations/filterOptionsQuery.ts
+++ b/web/src/server/api/routers/generations/filterOptionsQuery.ts
@@ -171,6 +171,7 @@ export const filterOptionsQuery = protectedProjectProcedure
       ].map((i) => ({
         value: i,
       })),
+      environment: [], // Environment is fetched separately via api.projects.environmentFilterOptions
     };
 
     return res;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance filter functionality to support restoring saved views with metadata and environment filters, ensuring backward compatibility and correct encoding/decoding.
> 
>   - **Behavior**:
>     - Add `environment` column to `observationsTableCols` in `observationsTable.ts`.
>     - Update `ObservationOptions` type to include `environment`.
>     - Modify `observationsTableColsWithOptions()` to handle `environment` options.
>     - Ensure `filterOptionsQuery` in `filterOptionsQuery.ts` includes `environment` as an empty array.
>   - **Config**:
>     - Change `traces-config.ts` to use column IDs instead of display names for `metadata`, `score_categories`, and `scores_avg`.
>   - **Tests**:
>     - Add tests in `filter-integration.clienttest.ts` to validate handling of old saved views with metadata and score filters using display names.
>     - Ensure backward compatibility for old saved views without environment or timestamp filters.
>     - Validate that traces and observations configs use column IDs, not display names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d4207b7e150d29de8589f7505d8d238e0befff0c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->