### PR TITLE
fix(filters): scores filtering from saved views

### DIFF
--- a/packages/shared/src/server/tableMappings/mapEventsTable.ts
+++ b/packages/shared/src/server/tableMappings/mapEventsTable.ts
@@ -202,13 +202,13 @@ export const eventsTableUiColumnDefinitions: UiColumnMappings = [
   },
   {
     uiTableName: "Scores (numeric)",
-    uiTableId: "scores",
+    uiTableId: "scores_avg",
     clickhouseTableName: "scores",
     clickhouseSelect: "s.scores_avg",
   },
   {
     uiTableName: "Scores (categorical)",
-    uiTableId: "scores",
+    uiTableId: "score_categories",
     clickhouseTableName: "scores",
     clickhouseSelect: "s.score_categories",
   },

--- a/packages/shared/src/server/tableMappings/mapObservationsTable.ts
+++ b/packages/shared/src/server/tableMappings/mapObservationsTable.ts
@@ -199,13 +199,13 @@ export const observationsTableUiColumnDefinitions: UiColumnMappings = [
   },
   {
     uiTableName: "Scores (numeric)",
-    uiTableId: "scores",
+    uiTableId: "scores_avg",
     clickhouseTableName: "scores",
     clickhouseSelect: "s.scores_avg",
   },
   {
     uiTableName: "Scores (categorical)",
-    uiTableId: "scores",
+    uiTableId: "score_categories",
     clickhouseTableName: "scores",
     clickhouseSelect: "s.score_categories",
   },

--- a/packages/shared/src/server/tableMappings/mapSessionTable.ts
+++ b/packages/shared/src/server/tableMappings/mapSessionTable.ts
@@ -140,13 +140,13 @@ export const sessionCols: UiColumnMappings = [
   },
   {
     uiTableName: "Scores (numeric)",
-    uiTableId: "scores",
+    uiTableId: "scores_avg",
     clickhouseTableName: "scores",
     clickhouseSelect: "scores_avg",
   },
   {
     uiTableName: "Scores (categorical)",
-    uiTableId: "scores",
+    uiTableId: "score_categories",
     clickhouseTableName: "scores",
     clickhouseSelect: "score_categories",
   },

--- a/packages/shared/src/server/tableMappings/mapTracesTable.ts
+++ b/packages/shared/src/server/tableMappings/mapTracesTable.ts
@@ -153,13 +153,13 @@ export const tracesTableUiColumnDefinitions: UiColumnMappings = [
   },
   {
     uiTableName: "Scores (numeric)",
-    uiTableId: "scores",
+    uiTableId: "scores_avg",
     clickhouseTableName: "scores",
     clickhouseSelect: "s.scores_avg",
   },
   {
     uiTableName: "Scores (categorical)",
-    uiTableId: "scores",
+    uiTableId: "score_categories",
     clickhouseTableName: "scores",
     clickhouseSelect: "s.score_categories",
   },

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -257,8 +257,8 @@ export default function TracesTable({
       inputCost: [],
       outputCost: [],
       totalCost: [],
-      "Scores (categorical)": scoreCategories,
-      "Scores (numeric)": scoresNumeric,
+      score_categories: scoreCategories,
+      scores_avg: scoresNumeric,
     };
   }, [environmentFilterOptions.data, traceFilterOptionsResponse.data]);
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renames `uiTableId` for scores in multiple files to `scores_avg` and `score_categories` for clarity and updates related frontend components.
> 
>   - **Renames**:
>     - `uiTableId` for "Scores (numeric)" from `scores` to `scores_avg` in `mapEventsTable.ts`, `mapObservationsTable.ts`, `mapSessionTable.ts`, and `mapTracesTable.ts`.
>     - `uiTableId` for "Scores (categorical)" from `scores` to `score_categories` in `mapEventsTable.ts`, `mapObservationsTable.ts`, `mapSessionTable.ts`, and `mapTracesTable.ts`.
>     - In `traces.tsx`, updates `filterOptions` to use `score_categories` and `scores_avg` instead of `Scores (categorical)` and `Scores (numeric)`.
>   - **Misc**:
>     - Adjusts `filterOptions` in `traces.tsx` to align with new `uiTableId` names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cb5a4f9031b9034b41305a1d4cd2a75ccf9a4462. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->