### PR TITLE
fix(annotation): filter server-side scores to score target

### DIFF
--- a/web/src/features/scores/lib/filterScoresByTarget.ts
+++ b/web/src/features/scores/lib/filterScoresByTarget.ts
@@ -1,0 +1,33 @@
+import type { AnnotationScore, ScoreTarget } from "@/src/features/scores/types";
+import type { APIScoreV2 } from "@langfuse/shared";
+
+/**
+ * Filter scores to match exact target based on mode
+ *
+ * @param scores - Scores to filter (must have traceId, observationId, sessionId properties)
+ * @param target - Target to match against
+ * @param mode - Filter mode: "target-scores-only" for exact match, "target-and-child-scores" for all
+ * @returns Filtered scores matching the target
+ */
+export function filterScoresByTarget<T extends APIScoreV2 | AnnotationScore>(
+  scores: T[],
+  target: ScoreTarget,
+  mode: "target-and-child-scores" | "target-scores-only",
+): T[] {
+  if (mode === "target-and-child-scores") {
+    // Include all scores for this trace/session
+    return scores;
+  }
+
+  // target-scores-only: filter to exact target match
+  return scores.filter((score) => {
+    if (target.type === "session") {
+      return score.sessionId === target.sessionId;
+    }
+    // Trace target: match both traceId AND observationId
+    return (
+      score.traceId === target.traceId &&
+      score.observationId === (target.observationId ?? null)
+    );
+  });
+}

--- a/web/src/features/scores/lib/filterScoresByTarget.ts
+++ b/web/src/features/scores/lib/filterScoresByTarget.ts
@@ -27,7 +27,7 @@ export function filterScoresByTarget<T extends APIScoreV2 | AnnotationScore>(
     // Trace target: match both traceId AND observationId
     return (
       score.traceId === target.traceId &&
-      score.observationId === (target.observationId ?? null)
+      (score.observationId ?? null) === (target.observationId ?? null)
     );
   });
 }

--- a/web/src/features/scores/lib/useMergedAnnotationScores.ts
+++ b/web/src/features/scores/lib/useMergedAnnotationScores.ts
@@ -5,6 +5,7 @@ import {
 } from "@/src/features/scores/types";
 import { useScoreCache } from "@/src/features/scores/contexts/ScoreCacheContext";
 import { mergeAnnotationScoresWithCache } from "@/src/features/scores/lib/mergeScoresWithCache";
+import { filterScoresByTarget } from "@/src/features/scores/lib/filterScoresByTarget";
 
 /**
  * Hook for merging server annotation scores with cached scores
@@ -34,22 +35,28 @@ export function useMergedAnnotationScores(
     sessionId: target.type === "session" ? target.sessionId : undefined,
   });
 
+  // Filter server scores based on mode and target
+  const filteredServerScores = useMemo(
+    () => filterScoresByTarget(serverAnnotationScores, target, mode),
+    [serverAnnotationScores, target, mode],
+  );
+
   // Build deletedIds Set
   const deletedIds = useMemo(() => {
     const ids = new Set<string>();
-    serverAnnotationScores.forEach((s) => {
+    filteredServerScores.forEach((s) => {
       if (s.id && isDeleted(s.id)) ids.add(s.id);
     });
     return ids;
-  }, [serverAnnotationScores, isDeleted]);
+  }, [filteredServerScores, isDeleted]);
 
   return useMemo(
     () =>
       mergeAnnotationScoresWithCache(
-        serverAnnotationScores,
+        filteredServerScores,
         cachedScores,
         deletedIds,
       ),
-    [serverAnnotationScores, cachedScores, deletedIds],
+    [filteredServerScores, cachedScores, deletedIds],
   );
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `filterScoresByTarget` function to filter scores by target and mode, integrating it into `useMergedAnnotationScores` and `useMergedScores`.
> 
>   - **Behavior**:
>     - Adds `filterScoresByTarget` function in `filterScoresByTarget.ts` to filter scores by `ScoreTarget` and mode.
>     - Integrates `filterScoresByTarget` into `useMergedAnnotationScores` and `useMergedScores` to filter server scores before merging with cache.
>   - **Functions**:
>     - `filterScoresByTarget` filters scores based on `target` and `mode`, supporting exact matches and child scores.
>     - Updates `useMergedAnnotationScores` and `useMergedScores` to use filtered scores for merging operations.
>   - **Misc**:
>     - Updates imports in `useMergedAnnotationScores.ts` and `useMergedScores.ts` to include `filterScoresByTarget`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1b8dc0fd19230c8bf6f819d12dfb0951f8e47e09. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->