### PR TITLE
fix(filters): make metadata on observations work again

### DIFF
--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -290,8 +290,19 @@ export default function ObservationsTable({
     },
   );
 
-  const newFilterOptions = useMemo(
-    () => ({
+  const newFilterOptions = useMemo(() => {
+    const scoreCategories =
+      filterOptions.data?.score_categories?.reduce(
+        (acc, score) => {
+          acc[score.label] = score.values;
+          return acc;
+        },
+        {} as Record<string, string[]>,
+      ) || {};
+
+    const scoresNumeric = filterOptions.data?.scores_avg || [];
+
+    return {
       environment:
         environmentFilterOptions.data?.map((value) => value.environment) || [],
       name:
@@ -339,9 +350,10 @@ export default function ObservationsTable({
       inputCost: [],
       outputCost: [],
       totalCost: [],
-    }),
-    [environmentFilterOptions.data, filterOptions.data],
-  );
+      score_categories: scoreCategories,
+      scores_avg: scoresNumeric,
+    };
+  }, [environmentFilterOptions.data, filterOptions.data]);
 
   const queryFilter = useSidebarFilterState(
     observationFilterConfig,

--- a/web/src/features/filters/config/observations-config.ts
+++ b/web/src/features/filters/config/observations-config.ts
@@ -13,6 +13,8 @@ const OBSERVATION_COLUMN_TO_QUERY_KEY: ColumnToQueryKeyMap = {
   modelId: "modelId",
   promptName: "promptName",
   tags: "tags",
+  metadata: "metadata",
+  version: "version",
   timeToFirstToken: "timeToFirstToken",
   latency: "latency",
   tokensPerSecond: "tokensPerSecond",
@@ -22,6 +24,8 @@ const OBSERVATION_COLUMN_TO_QUERY_KEY: ColumnToQueryKeyMap = {
   inputTokens: "inputTokens",
   outputTokens: "outputTokens",
   totalTokens: "totalTokens",
+  score_categories: "score_categories",
+  scores_avg: "scores_avg",
 };
 
 /**
@@ -88,6 +92,16 @@ export const observationFilterConfig: FilterConfig = {
       label: "Trace Tags",
     },
     {
+      type: "stringKeyValue" as const,
+      column: "metadata",
+      label: "Metadata",
+    },
+    {
+      type: "string" as const,
+      column: "version",
+      label: "Version",
+    },
+    {
       type: "numeric" as const,
       column: "latency",
       label: "Latency",
@@ -147,6 +161,16 @@ export const observationFilterConfig: FilterConfig = {
       min: 0,
       max: 100,
       unit: "$",
+    },
+    {
+      type: "keyValue" as const,
+      column: "score_categories",
+      label: "Categorical Scores",
+    },
+    {
+      type: "numericKeyValue" as const,
+      column: "scores_avg",
+      label: "Numeric Scores",
     },
   ],
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes metadata handling in observations by updating filter configurations and options in `observations.tsx` and `observations-config.ts`.
> 
>   - **Behavior**:
>     - Fixes metadata handling in `ObservationsTable` by updating `newFilterOptions` to include `score_categories` and `scores_avg`.
>     - Adds `metadata` and `version` to `OBSERVATION_COLUMN_TO_QUERY_KEY` and `observationFilterConfig` in `observations-config.ts`.
>   - **Filters**:
>     - Updates `observations-config.ts` to include `metadata` and `version` in `OBSERVATION_COLUMN_TO_QUERY_KEY` and `observationFilterConfig`.
>     - Adds `score_categories` and `scores_avg` to `OBSERVATION_COLUMN_TO_QUERY_KEY` and `observationFilterConfig`.
>   - **Misc**:
>     - Refactors `newFilterOptions` in `observations.tsx` to handle score categories and averages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 92808fc0866c0fc141f6456c0a498507b4af3892. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->