### PR TITLE
fix(filters): reenable env tags filtering

### DIFF
--- a/packages/shared/src/tableDefinitions/sessionsView.ts
+++ b/packages/shared/src/tableDefinitions/sessionsView.ts
@@ -22,6 +22,14 @@ export const sessionsViewCols: ColumnDefinition[] = [
     nullable: true,
   },
   {
+    name: "Environment",
+    id: "environment",
+    type: "stringOptions",
+    internal: 't."environment"',
+    options: [], // to be filled in at runtime
+    nullable: true,
+  },
+  {
     name: "Session Duration (s)",
     id: "sessionDuration",
     type: "number",
@@ -106,6 +114,7 @@ export const sessionsViewCols: ColumnDefinition[] = [
 
 export type SessionOptions = {
   userIds: Array<SingleValueOption>;
+  environment: Array<SingleValueOption>;
   tags: Array<SingleValueOption>;
   scores_avg?: Array<string>;
   score_categories?: Array<MultiValueOption>;
@@ -117,6 +126,9 @@ export function sessionsTableColsWithOptions(
   return sessionsViewCols.map((col) => {
     if (col.id === "userIds") {
       return formatColumnOptions(col, options?.userIds ?? []);
+    }
+    if (col.id === "environment") {
+      return formatColumnOptions(col, options?.environment ?? []);
     }
     if (col.id === "tags") {
       return formatColumnOptions(col, options?.tags ?? []);

--- a/web/src/features/filters/config/sessions-config.ts
+++ b/web/src/features/filters/config/sessions-config.ts
@@ -5,6 +5,9 @@ import type { ColumnToBackendKeyMap } from "@/src/features/filters/lib/filter-tr
 
 const SESSION_COLUMN_TO_QUERY_KEY: ColumnToQueryKeyMap = {
   bookmarked: "bookmarked",
+  environment: "environment",
+  userIds: "userIds",
+  tags: "tags",
   sessionDuration: "sessionDuration",
   countTraces: "countTraces",
   inputCost: "inputCost",
@@ -13,6 +16,8 @@ const SESSION_COLUMN_TO_QUERY_KEY: ColumnToQueryKeyMap = {
   inputTokens: "inputTokens",
   outputTokens: "outputTokens",
   totalTokens: "totalTokens",
+  score_categories: "score_categories",
+  scores_avg: "scores_avg",
 };
 
 /**
@@ -30,7 +35,7 @@ export const sessionFilterConfig: FilterConfig = {
 
   columnDefinitions: sessionsViewCols,
 
-  defaultExpanded: ["bookmarked"],
+  defaultExpanded: ["environment", "bookmarked"],
 
   facets: [
     {
@@ -39,6 +44,21 @@ export const sessionFilterConfig: FilterConfig = {
       label: "Bookmarked",
       trueLabel: "Bookmarked",
       falseLabel: "Not bookmarked",
+    },
+    {
+      type: "categorical" as const,
+      column: "environment",
+      label: "Environment",
+    },
+    {
+      type: "categorical" as const,
+      column: "userIds",
+      label: "User IDs",
+    },
+    {
+      type: "categorical" as const,
+      column: "tags",
+      label: "Trace Tags",
     },
     {
       type: "numeric" as const,
@@ -99,6 +119,16 @@ export const sessionFilterConfig: FilterConfig = {
       min: 0,
       max: 100,
       unit: "$",
+    },
+    {
+      type: "keyValue" as const,
+      column: "score_categories",
+      label: "Categorical Scores",
+    },
+    {
+      type: "numericKeyValue" as const,
+      column: "scores_avg",
+      label: "Numeric Scores",
     },
   ],
 };

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -366,10 +366,10 @@ export const sessionRouter = createTRPCRouter({
         return {
           userIds: userIds.map((row) => ({
             value: row.user,
+            count: Number(row.count),
           })),
-          tags: tags.map((row) => ({
-            value: row.value,
-          })),
+          environment: [], // Environment is fetched separately via api.projects.environmentFilterOptions
+          tags: tags,
           scores_avg: numericScoreNames.map((s) => s.name),
           score_categories: categoricalScoreNames,
         };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reenables environment filtering in sessions view by updating table definitions, API, and filter configurations.
> 
>   - **Behavior**:
>     - Reenables environment filtering in sessions view by adding `environment` column to `sessionsViewCols` in `sessionsView.ts`.
>     - Updates `SessionOptions` and `sessionsTableColsWithOptions()` to handle `environment` options.
>     - Integrates environment filter in `SessionsTable` component in `sessions.tsx`.
>   - **API**:
>     - Modifies `sessionRouter` in `sessions.ts` to include `environment` in session data.
>     - Updates `filterOptions` query to handle environment separately.
>   - **Config**:
>     - Adds `environment` to `SESSION_COLUMN_TO_QUERY_KEY` and `sessionFilterConfig` in `sessions-config.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3853254441e99c7abcca19c16d91791e150aff3d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->