### PR TITLE
feat(table-presets): add default option that clears saved view

### DIFF
--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -8,6 +8,7 @@ import {
   Pen,
   Lock,
 } from "lucide-react";
+import { LangfuseIcon } from "@/src/components/LangfuseLogo";
 import {
   DrawerTrigger,
   DrawerContent,
@@ -78,6 +79,20 @@ import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { useUniqueNameValidation } from "@/src/hooks/useUniqueNameValidation";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+
+interface SystemPreset {
+  id: string;
+  name: string;
+  isSystem: true;
+}
+
+const SYSTEM_PRESETS: { DEFAULT: SystemPreset } = {
+  DEFAULT: {
+    id: "__langfuse_default__",
+    name: "Langfuse Default",
+    isSystem: true,
+  },
+};
 
 interface TableViewPresetsDrawerProps {
   viewConfig: {
@@ -153,6 +168,13 @@ export function TableViewPresetsDrawer({
   });
 
   const handleSelectView = async (viewId: string) => {
+    // Handle system preset
+    if (viewId === SYSTEM_PRESETS.DEFAULT.id) {
+      // Clear selection
+      handleSetViewId(null);
+      return;
+    }
+
     capture("saved_views:view_selected", {
       tableName,
       viewId,
@@ -338,6 +360,26 @@ export function TableViewPresetsDrawer({
               <CommandList>
                 <CommandEmpty>No saved table views found</CommandEmpty>
                 <CommandGroup className="pb-0">
+                  {/* System Preset: Langfuse Default */}
+                  <CommandItem
+                    key={SYSTEM_PRESETS.DEFAULT.id}
+                    onSelect={() => handleSelectView(SYSTEM_PRESETS.DEFAULT.id)}
+                    className={cn(
+                      "group mt-1 flex cursor-pointer items-center justify-between rounded-md p-2 transition-colors hover:bg-muted/50",
+                      selectedViewId === null && "bg-muted font-medium",
+                    )}
+                  >
+                    <div className="flex flex-col">
+                      <span className="text-sm font-medium">
+                        {SYSTEM_PRESETS.DEFAULT.name}
+                      </span>
+                    </div>
+                    <div className="flex items-center">
+                      <LangfuseIcon size={32} />
+                    </div>
+                  </CommandItem>
+
+                  {/* User Presets */}
                   {TableViewPresetsList?.map((view) => (
                     <CommandItem
                       key={view.id}

--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -7,8 +7,8 @@ import {
   MoreVertical,
   Pen,
   Lock,
+  RotateCcw,
 } from "lucide-react";
-import { LangfuseIcon } from "@/src/components/LangfuseLogo";
 import {
   DrawerTrigger,
   DrawerContent,
@@ -89,7 +89,7 @@ interface SystemPreset {
 const SYSTEM_PRESETS: { DEFAULT: SystemPreset } = {
   DEFAULT: {
     id: "__langfuse_default__",
-    name: "Langfuse Default",
+    name: "My view",
     isSystem: true,
   },
 };
@@ -102,6 +102,7 @@ interface TableViewPresetsDrawerProps {
       selectedViewId: string | null;
       handleSetViewId: (viewId: string | null) => void;
       applyViewState: (viewData: TableViewPresetDomain) => void;
+      resetToDefaults: () => void;
     };
   };
   currentState: {
@@ -123,7 +124,8 @@ export function TableViewPresetsDrawer({
 }: TableViewPresetsDrawerProps) {
   const [searchQuery, setSearchQueryLocal] = useState("");
   const { tableName, projectId, controllers } = viewConfig;
-  const { handleSetViewId, applyViewState, selectedViewId } = controllers;
+  const { handleSetViewId, applyViewState, selectedViewId, resetToDefaults } =
+    controllers;
   const { TableViewPresetsList } = useViewData({ tableName, projectId });
   const {
     createMutation,
@@ -168,9 +170,8 @@ export function TableViewPresetsDrawer({
   });
 
   const handleSelectView = async (viewId: string) => {
-    // Handle system preset
+    // Handle system preset - just select it like any view
     if (viewId === SYSTEM_PRESETS.DEFAULT.id) {
-      // Clear selection
       handleSetViewId(null);
       return;
     }
@@ -370,12 +371,25 @@ export function TableViewPresetsDrawer({
                     )}
                   >
                     <div className="flex flex-col">
-                      <span className="text-sm font-medium">
+                      <span className="text-sm font-medium text-muted-foreground">
                         {SYSTEM_PRESETS.DEFAULT.name}
                       </span>
                     </div>
-                    <div className="flex items-center">
-                      <LangfuseIcon size={32} />
+                    <div className="flex h-8 items-center">
+                      {selectedViewId === null && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            resetToDefaults();
+                          }}
+                          className="h-8 w-8 opacity-0 group-hover:opacity-100"
+                          title="Reset to Langfuse defaults"
+                        >
+                          <RotateCcw className="h-4 w-4" />
+                        </Button>
+                      )}
                     </div>
                   </CommandItem>
 

--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -7,7 +7,6 @@ import {
   MoreVertical,
   Pen,
   Lock,
-  RotateCcw,
 } from "lucide-react";
 import {
   DrawerTrigger,

--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -363,13 +363,14 @@ export function TableViewPresetsDrawer({
                       "group mt-1 flex cursor-pointer items-center justify-between rounded-md p-2 transition-colors hover:bg-muted/50",
                       selectedViewId === null && "bg-muted font-medium",
                     )}
+                    title="Reflects your current table settings without applying any saved custom table views"
                   >
                     <div className="flex flex-col">
                       <span className="text-sm font-medium text-muted-foreground">
                         {SYSTEM_PRESETS.DEFAULT.name}
                       </span>
-                      <span className="w-fit pl-0 text-xs">
-                        Your default view
+                      <span className="w-fit pl-0 text-xs text-muted-foreground">
+                        Your working view
                       </span>
                     </div>
                   </CommandItem>
@@ -580,7 +581,7 @@ export function TableViewPresetsDrawer({
                 className="w-full justify-start px-1"
               >
                 <Plus className="mr-2 h-4 w-4" />
-                Create New View
+                Create Custom View
               </Button>
             </div>
           </div>

--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -102,7 +102,6 @@ interface TableViewPresetsDrawerProps {
       selectedViewId: string | null;
       handleSetViewId: (viewId: string | null) => void;
       applyViewState: (viewData: TableViewPresetDomain) => void;
-      resetToDefaults: () => void;
     };
   };
   currentState: {
@@ -124,8 +123,7 @@ export function TableViewPresetsDrawer({
 }: TableViewPresetsDrawerProps) {
   const [searchQuery, setSearchQueryLocal] = useState("");
   const { tableName, projectId, controllers } = viewConfig;
-  const { handleSetViewId, applyViewState, selectedViewId, resetToDefaults } =
-    controllers;
+  const { handleSetViewId, applyViewState, selectedViewId } = controllers;
   const { TableViewPresetsList } = useViewData({ tableName, projectId });
   const {
     createMutation,
@@ -336,11 +334,7 @@ export function TableViewPresetsDrawer({
                     rel="noopener noreferrer"
                     className="inline-flex items-center"
                     title="Saving table view presets is currently in beta. Click here to provide feedback!"
-                  >
-                    <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
-                      Beta
-                    </span>
-                  </a>
+                  ></a>
                 </DrawerTitle>
                 <DrawerClose asChild>
                   <Button variant="outline" size="icon">
@@ -374,22 +368,9 @@ export function TableViewPresetsDrawer({
                       <span className="text-sm font-medium text-muted-foreground">
                         {SYSTEM_PRESETS.DEFAULT.name}
                       </span>
-                    </div>
-                    <div className="flex h-8 items-center">
-                      {selectedViewId === null && (
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            resetToDefaults();
-                          }}
-                          className="h-8 w-8 opacity-0 group-hover:opacity-100"
-                          title="Reset to Langfuse defaults"
-                        >
-                          <RotateCcw className="h-4 w-4" />
-                        </Button>
-                      )}
+                      <span className="w-fit pl-0 text-xs">
+                        Your default view
+                      </span>
                     </div>
                   </CommandItem>
 

--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -66,6 +66,12 @@ export function useTableViewManager({
   // Keep track of the viewId in session storage and in the query params
   const handleSetViewId = useCallback(
     (viewId: string | null) => {
+      if (viewId === null) {
+        // When clearing, remove from URL first to prevent sync loop
+        const url = new URL(window.location.href);
+        url.searchParams.delete("viewId");
+        window.history.replaceState({}, "", url.toString());
+      }
       setStoredViewId(viewId);
       setSelectedViewId(viewId);
     },
@@ -243,5 +249,6 @@ export function useTableViewManager({
     applyViewState,
     handleSetViewId,
     selectedViewId,
+    resetToDefaults: () => handleSetViewId(null),
   };
 }

--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -249,6 +249,5 @@ export function useTableViewManager({
     applyViewState,
     handleSetViewId,
     selectedViewId,
-    resetToDefaults: () => handleSetViewId(null),
   };
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a default system preset to clear saved views and updates UI and URL handling for table view presets.
> 
>   - **Behavior**:
>     - Adds a default system preset `SYSTEM_PRESETS.DEFAULT` in `data-table-view-presets-drawer.tsx` to clear saved views and revert to default settings.
>     - Updates `handleSelectView` in `data-table-view-presets-drawer.tsx` to handle the default preset by setting `viewId` to `null`.
>     - Modifies `handleSetViewId` in `useTableViewManager.ts` to remove `viewId` from URL when set to `null`.
>   - **UI**:
>     - Adds UI elements in `data-table-view-presets-drawer.tsx` to display and select the default system preset.
>     - Removes "Beta" label from the drawer title in `data-table-view-presets-drawer.tsx`.
>     - Changes button text from "Create New View" to "Create Custom View" in `data-table-view-presets-drawer.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 94eb23ac86dcc6fb4fa5d16235e9b8a27e901682. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->