### PR TITLE
chore(trpc): resolve trpc errors from instances of BaseErrors

### DIFF
--- a/web/src/server/utils/trpc-utils.ts
+++ b/web/src/server/utils/trpc-utils.ts
@@ -1,6 +1,6 @@
 import type { TRPC_ERROR_CODE_KEY } from "@trpc/server";
 
-// Note: copied from official documentation: https://trpc.io/docs/v9/error-handling
+// Note: copied from official documentation: https://trpc.io/docs/server/error-handling#error-codes
 const HTTP_STATUS_CODE_TO_TRPC_ERROR_CODE: Record<number, TRPC_ERROR_CODE_KEY> =
   {
     400: "BAD_REQUEST",

--- a/web/src/server/utils/trpc-utils.ts
+++ b/web/src/server/utils/trpc-utils.ts
@@ -1,4 +1,4 @@
-import { TRPC_ERROR_CODE_KEY } from "@trpc/server";
+import type { TRPC_ERROR_CODE_KEY } from "@trpc/server";
 
 // Note: copied from official documentation: https://trpc.io/docs/v9/error-handling
 const HTTP_STATUS_CODE_TO_TRPC_ERROR_CODE: Record<number, TRPC_ERROR_CODE_KEY> =

--- a/web/src/server/utils/trpc-utils.ts
+++ b/web/src/server/utils/trpc-utils.ts
@@ -1,0 +1,33 @@
+import { TRPC_ERROR_CODE_KEY } from "@trpc/server";
+
+// Note: copied from official documentation: https://trpc.io/docs/v9/error-handling
+const HTTP_STATUS_CODE_TO_TRPC_ERROR_CODE: Record<number, TRPC_ERROR_CODE_KEY> =
+  {
+    400: "BAD_REQUEST",
+    401: "UNAUTHORIZED",
+    402: "PAYMENT_REQUIRED",
+    403: "FORBIDDEN",
+    404: "NOT_FOUND",
+    405: "METHOD_NOT_SUPPORTED",
+    408: "TIMEOUT",
+    409: "CONFLICT",
+    412: "PRECONDITION_FAILED",
+    413: "PAYLOAD_TOO_LARGE",
+    415: "UNSUPPORTED_MEDIA_TYPE",
+    422: "UNPROCESSABLE_CONTENT",
+    429: "TOO_MANY_REQUESTS",
+    499: "CLIENT_CLOSED_REQUEST",
+    500: "INTERNAL_SERVER_ERROR",
+    501: "NOT_IMPLEMENTED",
+    502: "BAD_GATEWAY",
+    503: "SERVICE_UNAVAILABLE",
+    504: "GATEWAY_TIMEOUT",
+  };
+
+const DEFAULT_ERROR_CODE: TRPC_ERROR_CODE_KEY = "INTERNAL_SERVER_ERROR";
+
+export const getTRPCErrorCodeFromHTTPStatusCode = (
+  httpStatus: number,
+): TRPC_ERROR_CODE_KEY => {
+  return HTTP_STATUS_CODE_TO_TRPC_ERROR_CODE[httpStatus] ?? DEFAULT_ERROR_CODE;
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces error resolution for `BaseError` instances in tRPC by mapping HTTP status codes to tRPC error codes using a new utility function.
> 
>   - **Error Handling**:
>     - Introduces `resolveError` function in `trpc.ts` to map `BaseError` instances to tRPC error codes using `getTRPCErrorCodeFromHTTPStatusCode`.
>     - Updates `withErrorHandling` middleware in `trpc.ts` to use `resolveError` for error code and status resolution.
>   - **Utilities**:
>     - Adds `trpc-utils.ts` with `getTRPCErrorCodeFromHTTPStatusCode` function to map HTTP status codes to tRPC error codes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8cafc61542afabe3860e765ba2f0abc766f237e5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->