### PR TITLE
fix(filters): allow multi clicking on saved views

### DIFF
--- a/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
+++ b/web/src/components/table/table-view-presets/components/data-table-view-presets-drawer.tsx
@@ -88,7 +88,7 @@ interface SystemPreset {
 const SYSTEM_PRESETS: { DEFAULT: SystemPreset } = {
   DEFAULT: {
     id: "__langfuse_default__",
-    name: "My view",
+    name: "My view (default)",
     isSystem: true,
   },
 };
@@ -322,27 +322,25 @@ export function TableViewPresetsDrawer({
           </Button>
         </DrawerTrigger>
         <DrawerContent overlayClassName="bg-primary/10">
-          <div className="mx-auto h-[80svh] w-full overflow-y-auto">
-            <div className="sticky top-0 z-10">
-              <DrawerHeader className="flex flex-row items-center justify-between rounded-sm bg-background px-3 py-2">
-                <DrawerTitle className="flex flex-row items-center gap-1">
-                  Saved Table Views{" "}
-                  <a
-                    href="https://github.com/orgs/langfuse/discussions/4657"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center"
-                    title="Saving table view presets is currently in beta. Click here to provide feedback!"
-                  ></a>
-                </DrawerTitle>
-                <DrawerClose asChild>
-                  <Button variant="outline" size="icon">
-                    <X className="h-4 w-4" />
-                  </Button>
-                </DrawerClose>
-              </DrawerHeader>
-              <Separator />
-            </div>
+          <div className="mx-auto w-full">
+            <DrawerHeader className="flex flex-row items-center justify-between rounded-sm bg-background px-3 py-2">
+              <DrawerTitle className="flex flex-row items-center gap-1">
+                Saved Table Views{" "}
+                <a
+                  href="https://github.com/orgs/langfuse/discussions/4657"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center"
+                  title="Saving table view presets is currently in beta. Click here to provide feedback!"
+                ></a>
+              </DrawerTitle>
+              <DrawerClose asChild>
+                <Button variant="outline" size="icon">
+                  <X className="h-4 w-4" />
+                </Button>
+              </DrawerClose>
+            </DrawerHeader>
+            <Separator />
 
             <Command className="h-fit rounded-none border-none pb-1 shadow-none">
               <CommandInput
@@ -351,7 +349,7 @@ export function TableViewPresetsDrawer({
                 onValueChange={setSearchQueryLocal}
                 className="h-12 border-none focus:ring-0"
               />
-              <CommandList>
+              <CommandList className="max-h-[calc(100vh-150px)]">
                 <CommandEmpty>No saved table views found</CommandEmpty>
                 <CommandGroup className="pb-0">
                   {/* System Preset: Langfuse Default */}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes multi-click issue on saved views and optimizes filter application logic in table view components.
> 
>   - **Behavior**:
>     - Allows multiple clicks on saved views without errors in `data-table-view-presets-drawer.tsx`.
>     - Adjusts filter application logic in `useTableViewManager.ts` to prevent unnecessary state updates when filters are already applied.
>   - **UI Changes**:
>     - Updates `SYSTEM_PRESETS` name to "My view (default)" in `data-table-view-presets-drawer.tsx`.
>     - Adjusts `DrawerContent` and `CommandList` layout in `data-table-view-presets-drawer.tsx` for better UI consistency.
>   - **Logic Changes**:
>     - Adds `filtersAlreadyApplied` check in `applyViewState` in `useTableViewManager.ts` to optimize filter application.
>     - Unlocks table immediately if filters are already applied in `useTableViewManager.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0bfb6f00759bd1c626af5dc941015d8f25b31751. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->