### PR TITLE
chore(sso): return 409 when config for domain already exists

### DIFF
--- a/.cursor/commands/review.md
+++ b/.cursor/commands/review.md
@@ -1,0 +1,29 @@
+# Code Review Checklist
+
+## Overview
+
+Comprehensive checklist for conducting thorough code reviews to ensure quality, security, and maintainability.
+
+## Review Categories
+
+### Functionality
+
+- [ ] Code does what it's supposed to do
+- [ ] Edge cases are handled
+- [ ] Error handling is appropriate
+- [ ] No obvious bugs or logic errors
+
+### Code Quality
+
+- [ ] Code is readable and well-structured
+- [ ] Functions are small and focused
+- [ ] Variable names are descriptive
+- [ ] No code duplication
+- [ ] Follows project conventions
+
+### Security
+
+- [ ] No obvious security vulnerabilities
+- [ ] Input validation is present
+- [ ] Sensitive data is handled properly
+- [ ] No hardcoded secrets

--- a/web/src/ee/features/multi-tenant-sso/createNewSsoConfigHandler.ts
+++ b/web/src/ee/features/multi-tenant-sso/createNewSsoConfigHandler.ts
@@ -53,6 +53,20 @@ export async function createNewSsoConfigHandler(
 
     const { domain, authProvider, authConfig } = body.data;
 
+    // Preemptive check: Verify that SSO config doesn't already exist for this domain
+    const existingConfig = await prisma.ssoConfig.findUnique({
+      where: { domain },
+    });
+    if (existingConfig) {
+      logger.info(
+        `Attempt to create duplicate SSO configuration for domain: ${domain}`,
+      );
+      res.status(409).json({
+        error: `An SSO configuration already exists for domain '${domain}'`,
+      });
+      return;
+    }
+
     const encryptedClientSecret = authConfig
       ? {
           ...authConfig,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add 409 response for existing SSO config in `createNewSsoConfigHandler` and include a code review checklist.
> 
>   - **Behavior**:
>     - In `createNewSsoConfigHandler`, added a check to return 409 if SSO config for a domain already exists.
>     - Logs an info message when a duplicate SSO configuration attempt is made.
>   - **Misc**:
>     - Added `.cursor/commands/review.md` with a code review checklist.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3a665096c10c4ac7c7888362753ac9c6d19c3c1b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->