### PR TITLE
fix(filters): session filtering with old state

### DIFF
--- a/packages/shared/src/server/repositories/trace-sessions.ts
+++ b/packages/shared/src/server/repositories/trace-sessions.ts
@@ -9,7 +9,9 @@ export const getPublicSessionsFilter = async (
   // Theoretically we should also filter the sessions by environment here. As this would return a huge list that's probably not feasible.
   // I.e. we only perform the environment check on the ClickHouse queries.
 
-  const sessionsBookmarkedFilter = filter?.find((f) => f.column === "⭐️");
+  const sessionsBookmarkedFilter = filter?.find(
+    (f) => f.column === "⭐️" || f.column === "bookmarked",
+  );
 
   let additionalBookmarkFilter: z.infer<typeof singleFilter>[] = [];
   if (sessionsBookmarkedFilter) {
@@ -65,7 +67,12 @@ export const getPublicSessionsFilter = async (
   }
 
   return filter
-    ? [...filter.filter((f) => f.column !== "⭐️"), ...additionalBookmarkFilter]
+    ? [
+        ...filter.filter(
+          (f) => f.column !== "⭐️" && f.column !== "bookmarked",
+        ),
+        ...additionalBookmarkFilter,
+      ]
     : [...additionalBookmarkFilter];
 };
 

--- a/web/src/hooks/use-environment-filter.tsx
+++ b/web/src/hooks/use-environment-filter.tsx
@@ -13,13 +13,8 @@ export function convertSelectedEnvironmentsToFilter(
   selectedEnvironments: string[],
 ) {
   if (selectedEnvironments.length === 0) {
-    // No environments selected = show nothing
-    return environmentColumns.map((column) => ({
-      type: "stringOptions" as const,
-      column,
-      operator: "any of" as const,
-      value: ["__NEVER_MATCH_ANYTHING__"], // Impossible value to match
-    }));
+    // No environments selected = no filter (show all)
+    return [];
   }
 
   return environmentColumns.map((column) => ({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix session filtering by normalizing filter column names and ensuring backward compatibility, with added tests for verification.
> 
>   - **Behavior**:
>     - `getPublicSessionsFilter` in `trace-sessions.ts` now supports filtering by both "⭐️" and "bookmarked" columns.
>     - `convertSelectedEnvironmentsToFilter` in `use-environment-filter.tsx` now returns an empty array when no environments are selected, showing all.
>   - **Normalization**:
>     - `normalizeFilterColumnNames` in `filter-transform.ts` normalizes display names to column IDs for backward compatibility.
>     - `decodeAndNormalizeFilters` in `useSidebarFilterState.tsx` decodes filters from URL and normalizes column names.
>   - **Testing**:
>     - Added integration tests in `filter-integration.clienttest.ts` to verify URL encoding/decoding and backward compatibility.
>     - Tests ensure filters are preserved and correctly mapped to backend IDs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bc639af8eb9eb97a2c8d89a3d575962feb970a96. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->