### PR TITLE
fix(pretty-json-view): prevent spread operator stack overflow

### DIFF
--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -273,7 +273,7 @@ function findOptimalExpansionLevel(
     }
 
     // Get all children for next level
-    const childRows: JsonTableRow[] = [];
+    let childRows: JsonTableRow[] = [];
 
     for (const row of rows) {
       if (row.hasChildren && row.rawChildData) {
@@ -290,7 +290,8 @@ function findOptimalExpansionLevel(
         visitedData.add(row.rawChildData);
 
         const children = getRowChildren(row);
-        childRows.push(...children);
+        // Use concat instead of spread to avoid stack overflow with large arrays
+        childRows = childRows.concat(children);
       }
     }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace spread operator with `concat` in `findOptimalExpansionLevel` in `PrettyJsonView.tsx` to prevent stack overflow with large arrays.
> 
>   - **Fix**:
>     - Replace spread operator with `concat` in `findOptimalExpansionLevel` in `PrettyJsonView.tsx` to prevent stack overflow with large arrays.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b193a2eaad91d2752d6e2ac0aced585abcca1725. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->