### PR TITLE
Update sidebar counts to respect time filter

### DIFF
--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -205,8 +205,13 @@ export default function TracesTable({
       },
     );
 
+  const timestampFilter = dateRangeFilter.find((f) => f.column === "timestamp");
   const traceFilterOptionsResponse = api.traces.filterOptions.useQuery(
-    { projectId },
+    {
+      projectId,
+      timestampFilter:
+        timestampFilter?.type === "datetime" ? timestampFilter : undefined,
+    },
     {
       trpc: { context: { skipBatch: true } },
       refetchOnMount: false,


### PR DESCRIPTION
## What does this PR do?

This PR updates the traces table's filter sidebar to ensure that the counts displayed for filter options (e.g., status, name) correctly reflect the currently selected time range. Previously, these counts were general and did not respect the time filter. This change aligns the behavior with other tables and mimics Datadog's time selector functionality.

Fixes #LFE-7387

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [ ] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my PR needs changes to the documentation
- [x] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [ ] I haven't added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-7387](https://linear.app/langfuse/issue/LFE-7387/filter-sidebar-count-on-items-should-respect-time-filter)

<a href="https://cursor.com/background-agent?bcId=bc-c9d58a47-10ff-4a4e-ab7a-62ca10e3d744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c9d58a47-10ff-4a4e-ab7a-62ca10e3d744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

