### PR TITLE
fix(search): immediately update url when cleared

### DIFF
--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -199,7 +199,14 @@ export function DataTableToolbar<TData, TValue>({
                     : `Search (${searchConfig.metadataSearchFields.join(", ")})`
                 }
                 value={searchString}
-                onChange={(event) => setSearchString(event.currentTarget.value)}
+                onChange={(event) => {
+                  const newValue = event.currentTarget.value;
+                  setSearchString(newValue);
+                  // If user cleared the search, update URL immediately
+                  if (newValue === "") {
+                    searchConfig.updateQuery("");
+                  }
+                }}
                 onKeyDown={(event) => {
                   if (event.key === "Enter") {
                     capture("table:search_submit");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Immediately updates URL when search input is cleared in `DataTableToolbar`.
> 
>   - **Behavior**:
>     - In `DataTableToolbar`, immediately updates URL when search input is cleared by calling `searchConfig.updateQuery("")` in `onChange` handler.
>   - **Misc**:
>     - No changes to other functionalities or components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e63abfd57bc6447e928ee6155d35fd424b14b3d2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->