### PR TITLE
fix: accept non-lowercased environments instead of rejecting

### DIFF
--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -202,6 +202,7 @@ const ENVIRONMENT_NAME_REGEX_ERROR_MESSAGE =
 
 const PublicEnvironmentName = z
   .string()
+  .toLowerCase()
   .max(40, "Maximum length is 40 characters")
   .regex(/^(?!langfuse)[a-z0-9-_]+$/, ENVIRONMENT_NAME_REGEX_ERROR_MESSAGE)
   .default("default");

--- a/web/src/__tests__/async/otel-api.servertest.ts
+++ b/web/src/__tests__/async/otel-api.servertest.ts
@@ -224,4 +224,82 @@ describe("/api/public/otel/v1/traces API Endpoint", () => {
 
     expect(response.status).toBe(200);
   });
+
+  it("should transform deployment.environment to lowercase", async () => {
+    const traceId = randomBytes(16);
+    const spanId = randomBytes(8);
+
+    const payload = {
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [
+              {
+                key: "deployment.environment",
+                value: { stringValue: "Production" },
+              },
+            ],
+          },
+          scopeSpans: [
+            {
+              scope: {
+                name: "langfuse-sdk",
+                version: "2.60.3",
+                attributes: [
+                  {
+                    key: "public_key",
+                    value: { stringValue: "pk-lf-1234567890" },
+                  },
+                ],
+              },
+              spans: [
+                {
+                  traceId: {
+                    type: "Buffer",
+                    data: traceId,
+                  },
+                  spanId: {
+                    type: "Buffer",
+                    data: spanId,
+                  },
+                  name: "test-span",
+                  kind: 1,
+                  startTimeUnixNano: {
+                    low: 466848096,
+                    high: 406528574,
+                    unsigned: true,
+                  },
+                  endTimeUnixNano: {
+                    low: 467248096,
+                    high: 406528574,
+                    unsigned: true,
+                  },
+                  attributes: [],
+                  status: {},
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const response = await makeAPICall(
+      "POST",
+      "/api/public/otel/v1/traces",
+      payload,
+    );
+
+    expect(response.status).toBe(200);
+
+    await waitForExpect(async () => {
+      const trace = await getTraceById({
+        projectId,
+        traceId: traceId.toString("hex"),
+      });
+      expect(trace).toBeDefined();
+      expect(trace!.id).toBe(traceId.toString("hex"));
+      expect(trace!.environment).toBe("production");
+    }, 25_000);
+  }, 30_000);
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Transforms environment names to lowercase to accept non-lowercased inputs and adds a test to verify this behavior.
> 
>   - **Behavior**:
>     - Transforms `PublicEnvironmentName` to lowercase in `types.ts` to accept non-lowercased environments.
>     - Adds test in `otel-api.servertest.ts` to verify `deployment.environment` is transformed to lowercase.
>   - **Tests**:
>     - New test case in `otel-api.servertest.ts` checks that `deployment.environment` is stored as lowercase.
>   - **Misc**:
>     - No changes to existing functionality, only adds support for non-lowercased environment names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b92f3d51f1a5c4648fce56ca17483a7459e3fc8c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->