### PR TITLE
feat(eval-table): increase cost lookback to 7d

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1677,7 +1677,7 @@ export const getObservationCountsByProjectAndDay = async ({
 };
 
 /**
- * Get total cost grouped by evaluator ID (job_configuration_id) for the last day.
+ * Get total cost grouped by evaluator ID (job_configuration_id) for the last week.
  *
  * @param projectId - Project ID
  * @param evaluatorIds - Array of evaluator IDs (job_configuration_id from metadata)
@@ -1696,7 +1696,7 @@ export const getCostByEvaluatorIds = async (
     FROM observations FINAL
     WHERE project_id = {projectId: String}
       AND metadata['job_configuration_id'] IN ({evaluatorIds: Array(String)})
-      AND start_time > now() - INTERVAL 24 HOURS
+      AND start_time > today() - 7
     GROUP BY metadata['job_configuration_id']
   `;
 

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -182,7 +182,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       },
     }),
     columnHelper.accessor("totalCost", {
-      header: "Total Cost (1d)",
+      header: "Total Cost (7d)",
       id: "totalCost",
       size: 120,
       cell: (row) => {
@@ -190,7 +190,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
 
         if (!costs.data) return <Skeleton className="h-4 w-16" />;
 
-        if (totalCost != null) return usdFormatter(totalCost, 2, 6);
+        if (totalCost != null) return usdFormatter(totalCost, 2, 4);
 
         return "–";
       },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase cost lookback period to 7 days in `observations.ts` and update `EvaluatorTable` to reflect this change.
> 
>   - **Behavior**:
>     - Change cost lookback period from 1 day to 7 days in `getCostByEvaluatorIds` in `observations.ts`.
>     - Update `EvaluatorTable` in `evaluator-table.tsx` to reflect 7-day cost in the "Total Cost" column header.
>   - **Formatting**:
>     - Adjust `usdFormatter` precision in `evaluator-table.tsx` from 6 to 4 decimal places.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bdcaed9ccda587a7f97eef7f8a04fbc5873c7533. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->