### PR TITLE
fix: add guiding error for SSO sign in issues

### DIFF
--- a/web/src/features/auth-credentials/server/signupApiHandler.ts
+++ b/web/src/features/auth-credentials/server/signupApiHandler.ts
@@ -63,7 +63,7 @@ export async function signupApiHandler(
   const multiTenantSsoProvider = await getSsoAuthProviderIdForDomain(domain);
   if (multiTenantSsoProvider) {
     res.status(422).json({
-      message: "You must sign in via SSO for this domain.",
+      message: "You must sign in via SSO for this domain. Enter your email on the sign-in page and press Continue.",
     });
     return;
   }

--- a/web/src/features/auth-credentials/server/signupApiHandler.ts
+++ b/web/src/features/auth-credentials/server/signupApiHandler.ts
@@ -63,7 +63,8 @@ export async function signupApiHandler(
   const multiTenantSsoProvider = await getSsoAuthProviderIdForDomain(domain);
   if (multiTenantSsoProvider) {
     res.status(422).json({
-      message: "You must sign in via SSO for this domain. Enter your email on the sign-in page and press Continue.",
+      message:
+        "You must sign in via SSO for this domain. Enter your email on the sign-in page and press Continue.",
     });
     return;
   }

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -700,7 +700,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             console.log(
               "Custom SSO provider enforced for domain, user signed in with other provider",
             );
-            throw new Error(`You must sign in via SSO for this domain.`);
+            throw new Error(`You must sign in via SSO for this domain. Enter your email on the sign-in page and press Continue.`);
           }
 
           // EE: Check that provider is only used for the associated domain

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -700,7 +700,9 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
             console.log(
               "Custom SSO provider enforced for domain, user signed in with other provider",
             );
-            throw new Error(`You must sign in via SSO for this domain. Enter your email on the sign-in page and press Continue.`);
+            throw new Error(
+              `You must sign in via SSO for this domain. Enter your email on the sign-in page and press Continue.`,
+            );
           }
 
           // EE: Check that provider is only used for the associated domain


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance SSO sign-in error messages in `signupApiHandler.ts` and `auth.ts` to guide users to "Enter your email on the sign-in page and press Continue."
> 
>   - **Behavior**:
>     - Update error message in `signupApiHandler.ts` to guide users to "Enter your email on the sign-in page and press Continue" when SSO is required.
>     - Update error message in `auth.ts` to guide users to "Enter your email on the sign-in page and press Continue" when SSO is required.
>   - **Misc**:
>     - Consistent error messaging across `signupApiHandler.ts` and `auth.ts` for SSO sign-in issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fced4117a1433c6e27d285d731546910eeb7f927. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->