### PR TITLE
fix(otel): parse tool call name for ai sdk

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1468,6 +1468,10 @@ export class OtelIngestionProcessor {
     }
 
     // Vercel AI SDK
+    if ("ai.toolCall.name" in attributes) {
+      return attributes["ai.toolCall.name"] as string;
+    }
+
     const functionIdAttribute = "ai.telemetry.functionId";
     const operationIdAttribute = "ai.operationId";
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add parsing for `ai.toolCall.name` attribute in `OtelIngestionProcessor` to extract tool call names from Vercel AI SDK.
> 
>   - **Behavior**:
>     - In `OtelIngestionProcessor.ts`, added parsing for `ai.toolCall.name` attribute in `OtelIngestionProcessor` class to extract tool call names from Vercel AI SDK attributes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e79b59c5d78897ff434eaa8a5dc3d6b3ad5cfbfa. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->