### PR TITLE
fix: content too large error in dataset trpc uploads

### DIFF
--- a/web/src/pages/api/trpc/[trpc].ts
+++ b/web/src/pages/api/trpc/[trpc].ts
@@ -6,6 +6,11 @@ import { logger, traceException } from "@langfuse/shared/src/server";
 
 export const config = {
   maxDuration: 240,
+  api: {
+    bodyParser: {
+      sizeLimit: "4.5mb",
+    },
+  },
 };
 
 // export API handler


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `bodyParser.sizeLimit` to `4.5mb` in `trpc.ts` to prevent content too large errors in dataset uploads.
> 
>   - **Configuration**:
>     - Set `bodyParser.sizeLimit` to `4.5mb` in `trpc.ts` to handle large dataset uploads.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1af0bd416fb3be7aba899a4bf811521f6dc90120. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->