### PR TITLE
chore(comment): add comment preview + counter to prompt-detail view

### DIFF
--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -226,14 +226,13 @@ export const PromptDetail = ({
     ).data?.tags ?? []
   ).map((t) => t.value);
 
-  const commentCounts = api.comments.getCountByObjectId.useQuery(
+  const commentCounts = api.comments.getCountByObjectType.useQuery(
     {
       projectId: projectId as string,
-      objectId: prompt?.id as string,
       objectType: "PROMPT",
     },
     {
-      enabled: Boolean(projectId) && Boolean(prompt?.id),
+      enabled: Boolean(projectId),
       trpc: {
         context: {
           skipBatch: true,
@@ -353,6 +352,7 @@ export const PromptDetail = ({
                 setCurrentPromptLabel(null);
               }}
               totalCount={promptHistory.data.totalCount}
+              commentCounts={commentCounts.data}
             />
           </div>
         </Command>

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -226,13 +226,19 @@ export const PromptDetail = ({
     ).data?.tags ?? []
   ).map((t) => t.value);
 
-  const commentCounts = api.comments.getCountByObjectType.useQuery(
+  const promptIds = useMemo(
+    () => promptHistory.data?.promptVersions.map((p) => p.id) ?? [],
+    [promptHistory.data?.promptVersions],
+  );
+
+  const commentCounts = api.comments.getCountByObjectIds.useQuery(
     {
       projectId: projectId as string,
       objectType: "PROMPT",
+      objectIds: promptIds,
     },
     {
-      enabled: Boolean(projectId),
+      enabled: Boolean(projectId) && promptIds.length > 0,
       trpc: {
         context: {
           skipBatch: true,

--- a/web/src/features/prompts/components/prompt-history.tsx
+++ b/web/src/features/prompts/components/prompt-history.tsx
@@ -6,6 +6,7 @@ import { Timeline, TimelineItem } from "@/src/components/ui/timeline";
 import { Badge } from "@/src/components/ui/badge";
 import { CommandItem } from "@/src/components/ui/command";
 import { SetPromptVersionLabels } from "@/src/features/prompts/components/SetPromptVersionLabels";
+import { CommentCountIcon } from "@/src/features/comments/CommentCountIcon";
 
 const PromptHistoryTraceNode = (props: {
   index: number;
@@ -16,6 +17,7 @@ const PromptHistoryTraceNode = (props: {
   router: NextRouter;
   projectId: string;
   totalCount: number;
+  commentCounts?: Map<string, number>;
 }) => {
   const [isHovered, setIsHovered] = useState(false);
   const [isPromptDiffOpen, setIsPromptDiffOpen] = useState(false);
@@ -103,6 +105,31 @@ const PromptHistoryTraceNode = (props: {
               setIsOpen={setIsLabelPopoverOpen}
               showOnlyOnHover
             />
+            {props.commentCounts?.get(prompt.id) ? (
+              <span
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void props.router.push(
+                    {
+                      pathname: props.router.pathname,
+                      query: {
+                        ...props.router.query,
+                        version: prompt.version,
+                        comments: "open",
+                        commentObjectType: "PROMPT",
+                        commentObjectId: prompt.id,
+                      },
+                    },
+                    undefined,
+                    { shallow: true },
+                  );
+                }}
+                className="cursor-pointer"
+                role="button"
+              >
+                <CommentCountIcon count={props.commentCounts.get(prompt.id)} />
+              </span>
+            ) : null}
           </div>
 
           <div className="grid w-full grid-cols-1 items-start justify-between gap-1 md:grid-cols-[1fr,auto]">
@@ -150,6 +177,7 @@ export const PromptHistoryNode = (props: {
   currentPromptVersion: number | undefined;
   setCurrentPromptVersion: (id: number | undefined) => void;
   totalCount: number;
+  commentCounts?: Map<string, number>;
 }) => {
   const router = useRouter();
   const projectId = router.query.projectId as string;
@@ -170,6 +198,7 @@ export const PromptHistoryNode = (props: {
           router={router}
           projectId={projectId}
           totalCount={props.totalCount}
+          commentCounts={props.commentCounts}
         />
       ))}
     </Timeline>


### PR DESCRIPTION
## What does this PR do?

Add comment preview + counter to prompt-detail view.

<img width="2540" height="1742" alt="CleanShot 2025-10-24 at 22 20 40@2x" src="https://github.com/user-attachments/assets/c1d50650-03bf-4645-bc25-e943f4001a5e" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add comment preview and counter to prompt-detail view, with new API endpoint for fetching comment counts by object IDs.
> 
>   - **Behavior**:
>     - Add comment preview and counter to `PromptDetail` in `prompt-detail.tsx`.
>     - Display comment counts in `PromptHistoryNode` in `prompt-history.tsx`.
>     - Clicking comment count icon navigates to comments section.
>   - **API**:
>     - Add `getCountByObjectIds` to `comments.ts` to fetch comment counts for multiple object IDs.
>   - **UI Components**:
>     - Use `CommentCountIcon` in `prompt-history.tsx` to display comment counts.
>     - Pass `commentCounts` prop to `PromptHistoryNode` and `PromptHistoryTraceNode`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d2da81e167acc6fea1f6463e8eabbfc5c221dd3c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->