### PR TITLE
chore: increase limit for slack channel select

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -188,7 +188,7 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .optional()
-    .default(1_000)
+    .default(5_000)
     .describe(
       "How many records should be fetched from Slack, before we give up",
     ),

--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -998,6 +998,7 @@ export const getDatasetItemIdsByTraceIdCh = async (
   SELECT
     dri.dataset_item_id as dataset_item_id,
     dri.dataset_id as dataset_id
+    dri.observation_id as observation_id
   FROM dataset_run_items_rmt dri 
   WHERE ${appliedFilter.query}
   LIMIT 1 BY dri.project_id, dri.dataset_id, dri.dataset_run_id, dri.dataset_item_id;`;

--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -998,7 +998,6 @@ export const getDatasetItemIdsByTraceIdCh = async (
   SELECT
     dri.dataset_item_id as dataset_item_id,
     dri.dataset_id as dataset_id
-    dri.observation_id as observation_id
   FROM dataset_run_items_rmt dri 
   WHERE ${appliedFilter.query}
   LIMIT 1 BY dri.project_id, dri.dataset_id, dri.dataset_run_id, dri.dataset_item_id;`;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Increase `SLACK_FETCH_LIMIT` default from 1,000 to 5,000 in `env.ts`.
> 
>   - **Behavior**:
>     - Increase `SLACK_FETCH_LIMIT` default from 1,000 to 5,000 in `env.ts`.
>     - Affects how many records are fetched from Slack before giving up.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a0ce30e082e9304c232cb58014d6188c44a7eb30. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->