### PR TITLE
fix: observation batch export trace filters

### DIFF
--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -1750,7 +1750,7 @@ describe("batch export test suite", () => {
         {
           type: "arrayOptions",
           operator: "any of",
-          column: "tags",
+          column: "Trace Tags",
           value: ["organizationSlug:karacare"],
         },
         // Observation-level filters (should be applied)
@@ -1868,13 +1868,13 @@ describe("batch export test suite", () => {
         {
           type: "arrayOptions",
           operator: "any of",
-          column: "tags",
+          column: "Trace Tags",
           value: ["organizationSlug:acme"],
         },
         {
           type: "string",
           operator: "=",
-          column: "userId",
+          column: "User ID",
           value: "user-123",
         },
         // Observation-level filters (should be applied)

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -1680,4 +1680,243 @@ describe("batch export test suite", () => {
       expect(row.name).toBe("question_generator");
     });
   });
+
+  it("should ignore trace-level filters when exporting observations", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    // Create traces with tags
+    const traces = [
+      createTrace({
+        project_id: projectId,
+        id: randomUUID(),
+        name: "trace-with-tag",
+        tags: ["organizationSlug:karacare"],
+        timestamp: new Date("2025-10-21T00:00:00Z").getTime(),
+      }),
+      createTrace({
+        project_id: projectId,
+        id: randomUUID(),
+        name: "trace-without-tag",
+        tags: [],
+        timestamp: new Date("2025-10-21T01:00:00Z").getTime(),
+      }),
+      createTrace({
+        project_id: projectId,
+        id: randomUUID(),
+        name: "trace-with-other-tag",
+        tags: ["organizationSlug:other"],
+        timestamp: new Date("2025-10-21T02:00:00Z").getTime(),
+      }),
+    ];
+
+    await createTracesCh(traces);
+
+    // Create observations for all traces with specific names
+    const observations = [
+      createObservation({
+        project_id: projectId,
+        trace_id: traces[0].id,
+        type: "GENERATION",
+        name: "makeRecommendations",
+        start_time: new Date("2025-10-21T00:00:00Z").getTime(),
+        end_time: new Date("2025-10-21T00:00:05Z").getTime(),
+      }),
+      createObservation({
+        project_id: projectId,
+        trace_id: traces[1].id,
+        type: "GENERATION",
+        name: "makeRecommendations",
+        start_time: new Date("2025-10-21T01:00:00Z").getTime(),
+        end_time: new Date("2025-10-21T01:00:03Z").getTime(),
+      }),
+      createObservation({
+        project_id: projectId,
+        trace_id: traces[2].id,
+        type: "EVENT",
+        name: "otherOperation",
+        start_time: new Date("2025-10-21T02:00:00Z").getTime(),
+      }),
+    ];
+
+    await createObservationsCh(observations);
+
+    // Apply filters that include trace-level filters (tags)
+    // These should be ignored and all observations matching observation-level filters should be returned
+    const stream = await getObservationStream({
+      projectId: projectId,
+      cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      filter: [
+        // Trace-level filter (should be ignored)
+        {
+          type: "arrayOptions",
+          operator: "any of",
+          column: "tags",
+          value: ["organizationSlug:karacare"],
+        },
+        // Observation-level filters (should be applied)
+        {
+          type: "stringOptions",
+          operator: "any of",
+          column: "type",
+          value: ["GENERATION"],
+        },
+        {
+          type: "datetime",
+          operator: ">=",
+          column: "startTime",
+          value: new Date("2025-10-20T22:00:00.000Z"),
+        },
+        {
+          type: "datetime",
+          operator: "<=",
+          column: "startTime",
+          value: new Date("2025-10-23T21:59:59.999Z"),
+        },
+      ],
+      searchQuery: "makeRecommendations",
+      searchType: ["id"],
+    });
+
+    const rows: any[] = [];
+    for await (const chunk of stream) {
+      rows.push(chunk);
+    }
+
+    // Should return both observations matching the observation-level filters
+    // Tags filter should be ignored since it's trace-level
+    expect(rows).toHaveLength(2);
+    const exportedNames = rows.map((row) => row.name).sort();
+    expect(exportedNames).toEqual([
+      "makeRecommendations",
+      "makeRecommendations",
+    ]);
+
+    // Verify both observations are included regardless of trace tags
+    const traceIds = rows.map((row) => row.traceId).sort();
+    expect(traceIds).toEqual([traces[0].id, traces[1].id].sort());
+  });
+
+  it("should successfully export observations with mixed observation-level and trace-level filters", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    // Create traces with various tags and user IDs
+    const traces = [
+      createTrace({
+        project_id: projectId,
+        id: randomUUID(),
+        name: "api-trace-1",
+        tags: ["organizationSlug:acme", "env:production"],
+        user_id: "user-123",
+        timestamp: new Date("2025-10-21T00:00:00Z").getTime(),
+      }),
+      createTrace({
+        project_id: projectId,
+        id: randomUUID(),
+        name: "api-trace-2",
+        tags: ["organizationSlug:acme"],
+        user_id: "user-456",
+        timestamp: new Date("2025-10-21T01:00:00Z").getTime(),
+      }),
+      createTrace({
+        project_id: projectId,
+        id: randomUUID(),
+        name: "api-trace-3",
+        tags: ["organizationSlug:other"],
+        user_id: "user-789",
+        timestamp: new Date("2025-10-21T02:00:00Z").getTime(),
+      }),
+    ];
+
+    await createTracesCh(traces);
+
+    // Create observations with specific properties
+    const observations = [
+      createObservation({
+        project_id: projectId,
+        trace_id: traces[0].id,
+        type: "GENERATION",
+        name: "llm-call",
+        environment: "production",
+        start_time: new Date("2025-10-21T00:00:00Z").getTime(),
+      }),
+      createObservation({
+        project_id: projectId,
+        trace_id: traces[1].id,
+        type: "GENERATION",
+        name: "llm-call",
+        environment: "production",
+        start_time: new Date("2025-10-21T01:00:00Z").getTime(),
+      }),
+      createObservation({
+        project_id: projectId,
+        trace_id: traces[2].id,
+        type: "GENERATION",
+        name: "llm-call",
+        environment: "staging",
+        start_time: new Date("2025-10-21T02:00:00Z").getTime(),
+      }),
+    ];
+
+    await createObservationsCh(observations);
+
+    // Apply a mix of trace-level and observation-level filters
+    const stream = await getObservationStream({
+      projectId: projectId,
+      cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      filter: [
+        // Trace-level filters (should be ignored)
+        {
+          type: "arrayOptions",
+          operator: "any of",
+          column: "tags",
+          value: ["organizationSlug:acme"],
+        },
+        {
+          type: "string",
+          operator: "=",
+          column: "userId",
+          value: "user-123",
+        },
+        // Observation-level filters (should be applied)
+        {
+          type: "stringOptions",
+          operator: "any of",
+          column: "type",
+          value: ["GENERATION"],
+        },
+        {
+          type: "stringOptions",
+          operator: "any of",
+          column: "environment",
+          value: ["production"],
+        },
+        {
+          type: "stringOptions",
+          operator: "any of",
+          column: "name",
+          value: ["llm-call"],
+        },
+      ],
+    });
+
+    const rows: any[] = [];
+    for await (const chunk of stream) {
+      rows.push(chunk);
+    }
+
+    // Should only return observations matching observation-level filters
+    // Trace-level filters (tags, userId) should be ignored
+    expect(rows).toHaveLength(2);
+
+    // Both observations should have production environment
+    rows.forEach((row) => {
+      expect(row.environment).toBe("production");
+      expect(row.name).toBe("llm-call");
+      expect(row.type).toBe("GENERATION");
+    });
+
+    // Should include observations from both traces with acme tag
+    const traceIds = rows.map((row) => row.traceId).sort();
+    expect(traceIds).toEqual([traces[0].id, traces[1].id].sort());
+  });
 });

--- a/worker/src/features/database-read-stream/observation-stream.ts
+++ b/worker/src/features/database-read-stream/observation-stream.ts
@@ -90,10 +90,20 @@ export const getObservationStream = async (props: {
     join_algorithm: "partial_merge",
   };
 
+  // Filter out trace-level filters since we don't join the traces table for filtering
+  // This prevents batch export failures when trace-level filters are present
+  const observationOnlyFilters = (filter ?? []).filter((f) => {
+    const columnDef = observationsTableUiColumnDefinitions.find(
+      (col) => col.uiTableName === f.column || col.uiTableId === f.column,
+    );
+    // Keep the filter if it's not a trace-level filter
+    return columnDef?.clickhouseTableName !== "traces";
+  });
+
   const distinctScoreNames = await getDistinctScoreNames({
     projectId,
     cutoffCreatedAt,
-    filter: filter ?? [],
+    filter: observationOnlyFilters,
     isTimestampFilter: (filter: FilterCondition): filter is TimeFilter => {
       return filter.column === "Start Time" && filter.type === "datetime";
     },
@@ -124,7 +134,7 @@ export const getObservationStream = async (props: {
   observationsFilter.push(
     ...createFilterFromFilterState(
       [
-        ...(filter ?? []),
+        ...observationOnlyFilters,
         {
           column: "startTime",
           operator: "<" as const,


### PR DESCRIPTION
This pull request contains changes generated by Cursor background composer.

<a href="https://cursor.com/background-agent?bcId=bc-80559fa0-2c30-477b-b77a-2372faa65c61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-80559fa0-2c30-477b-b77a-2372faa65c61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes observation export by filtering out trace-level filters in `getObservationStream` to prevent export failures.
> 
>   - **Behavior**:
>     - `getObservationStream` in `observation-stream.ts` now filters out trace-level filters to prevent batch export failures.
>     - Trace-level filters are ignored, and only observation-level filters are applied during observation exports.
>   - **Tests**:
>     - Added tests in `batchExport.test.ts` to verify that trace-level filters are ignored and observation-level filters are applied correctly.
>     - Tests include scenarios with mixed trace-level and observation-level filters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bb3eeae4e14105c822113486ac7cda416f5a83ec. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->