### PR TITLE
fix(prompts): notify user that prompt renaming is not possible

### DIFF
--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -106,7 +106,7 @@ const PageHeader = ({
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <span
-                              className="break-words cursor-help"
+                              className="cursor-help break-words"
                               title={title}
                               data-testid="page-header-title"
                             >

--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -3,6 +3,12 @@ import { ItemBadge, type LangfuseItemType } from "@/src/components/ItemBadge";
 import BreadcrumbComponent from "@/src/components/layouts/breadcrumb";
 import DocPopup from "@/src/components/layouts/doc-popup";
 import { SidebarTrigger } from "@/src/components/ui/sidebar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
 import { cn } from "@/src/utils/tailwind";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -32,6 +38,7 @@ export type PageHeaderProps = {
   actionButtonsLeft?: React.ReactNode; // Right-side actions (buttons, etc.)
   actionButtonsRight?: React.ReactNode; // Right-side actions (buttons, etc.)
   help?: { description: string; href?: string; className?: string };
+  titleTooltip?: string; // Tooltip to show on hover of the title
   itemType?: LangfuseItemType;
   container?: boolean;
   tabsProps?: PageTabsProps;
@@ -45,6 +52,7 @@ const PageHeader = ({
   actionButtonsRight,
   breadcrumb,
   help,
+  titleTooltip,
   tabsProps,
   container = false,
   className,
@@ -93,23 +101,52 @@ const PageHeader = ({
                 )}
                 <div className="relative inline-block max-w-md md:max-w-none">
                   <h2 className="line-clamp-1 text-lg font-semibold leading-7">
-                    <span
-                      className="break-words"
-                      title={title}
-                      data-testid="page-header-title"
-                    >
-                      {title}
-                      {help && (
-                        <span className="whitespace-nowrap">
-                          &nbsp;
-                          <DocPopup
-                            description={help.description}
-                            href={help.href}
-                            className={help.className}
-                          />
-                        </span>
-                      )}
-                    </span>
+                    {titleTooltip ? (
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span
+                              className="break-words cursor-help"
+                              title={title}
+                              data-testid="page-header-title"
+                            >
+                              {title}
+                              {help && (
+                                <span className="whitespace-nowrap">
+                                  &nbsp;
+                                  <DocPopup
+                                    description={help.description}
+                                    href={help.href}
+                                    className={help.className}
+                                  />
+                                </span>
+                              )}
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" className="max-w-xs">
+                            {titleTooltip}
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    ) : (
+                      <span
+                        className="break-words"
+                        title={title}
+                        data-testid="page-header-title"
+                      >
+                        {title}
+                        {help && (
+                          <span className="whitespace-nowrap">
+                            &nbsp;
+                            <DocPopup
+                              description={help.description}
+                              href={help.href}
+                              className={help.className}
+                            />
+                          </span>
+                        )}
+                      </span>
+                    )}
                   </h2>
                 </div>
               </div>

--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -38,7 +38,7 @@ export type PageHeaderProps = {
   actionButtonsLeft?: React.ReactNode; // Right-side actions (buttons, etc.)
   actionButtonsRight?: React.ReactNode; // Right-side actions (buttons, etc.)
   help?: { description: string; href?: string; className?: string };
-  titleTooltip?: string; // Tooltip to show on hover of the title
+  titleTooltip?: string;
   itemType?: LangfuseItemType;
   container?: boolean;
   tabsProps?: PageTabsProps;

--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -107,7 +107,6 @@ const PageHeader = ({
                           <TooltipTrigger asChild>
                             <span
                               className="cursor-help break-words"
-                              title={title}
                               data-testid="page-header-title"
                             >
                               {title}

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -274,6 +274,8 @@ export const PromptDetail = ({
     <Page
       headerProps={{
         title: prompt.name,
+        titleTooltip:
+          "Prompt names cannot be changed. To create a prompt with a new name, duplicate this prompt using the button on the right.",
         itemType: "PROMPT",
         help: {
           description:

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -275,7 +275,7 @@ export const PromptDetail = ({
       headerProps={{
         title: prompt.name,
         titleTooltip:
-          "Prompt names cannot be changed. To create a prompt with a new name, duplicate this prompt using the button on the right.",
+          "Prompt names cannot be changed. Instead, duplicate this prompt to a different name using the button on the right.",
         itemType: "PROMPT",
         help: {
           description:

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -275,7 +275,7 @@ export const PromptDetail = ({
       headerProps={{
         title: prompt.name,
         titleTooltip:
-          "Prompt names cannot be changed. Instead, duplicate this prompt to a different name using the button on the right.",
+          "Prompt names cannot be changed. Instead, duplicate this prompt to a different name.",
         itemType: "PROMPT",
         help: {
           description:

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -38,12 +38,6 @@ import {
 } from "@/src/components/ui/breadcrumb";
 import { Slash, Folder, Home } from "lucide-react";
 import { useFullTextSearch } from "@/src/components/table/use-cases/useFullTextSearch";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/src/components/ui/tooltip";
 
 type PromptTableRow = {
   id: string;
@@ -316,23 +310,11 @@ export function PromptTable() {
         }
 
         return name ? (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div>
-                  <TableLink
-                    path={`/project/${projectId}/prompts/${encodeURIComponent(rowData.fullPath)}`}
-                    value={name}
-                    title={rowData.fullPath} // Show full prompt path on hover
-                  />
-                </div>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" className="max-w-xs">
-                Prompt names cannot be changed. To create a prompt with a new
-                name, duplicate this prompt.
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <TableLink
+            path={`/project/${projectId}/prompts/${encodeURIComponent(rowData.fullPath)}`}
+            value={name}
+            title={rowData.fullPath} // Show full prompt path on hover
+          />
         ) : undefined;
       },
     }),

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -38,6 +38,12 @@ import {
 } from "@/src/components/ui/breadcrumb";
 import { Slash, Folder, Home } from "lucide-react";
 import { useFullTextSearch } from "@/src/components/table/use-cases/useFullTextSearch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
 
 type PromptTableRow = {
   id: string;
@@ -310,11 +316,23 @@ export function PromptTable() {
         }
 
         return name ? (
-          <TableLink
-            path={`/project/${projectId}/prompts/${encodeURIComponent(rowData.fullPath)}`}
-            value={name}
-            title={rowData.fullPath} // Show full prompt path on hover
-          />
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div>
+                  <TableLink
+                    path={`/project/${projectId}/prompts/${encodeURIComponent(rowData.fullPath)}`}
+                    value={name}
+                    title={rowData.fullPath} // Show full prompt path on hover
+                  />
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="max-w-xs">
+                Prompt names cannot be changed. To create a prompt with a new
+                name, duplicate this prompt.
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         ) : undefined;
       },
     }),


### PR DESCRIPTION
## What does this PR do?

This PR implements a hover hint for prompt names, both in the prompt detail page header and within the prompts table. The tooltip informs users that prompt names cannot be changed and suggests duplicating the prompt as an alternative.

Fixes # LFE-5771

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`npm run lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-5771](https://linear.app/langfuse/issue/LFE-5771/nudge-to-duplicate-when-trying-to-rename-a-prompt)

<a href="https://cursor.com/background-agent?bcId=bc-a4f82931-ab96-4973-891e-0dfbf5649a6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a4f82931-ab96-4973-891e-0dfbf5649a6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a tooltip in `PageHeader` to inform users that prompt names cannot be changed, suggesting duplication instead, used in `PromptDetail`.
> 
>   - **Behavior**:
>     - Adds a tooltip in `PageHeader` to inform users that prompt names cannot be changed, suggesting duplication instead.
>     - Tooltip is displayed on hover over prompt names in `PromptDetail`.
>   - **Components**:
>     - Updates `PageHeader` to accept `titleTooltip` prop for displaying tooltips.
>     - Uses `titleTooltip` in `PromptDetail` to provide guidance on prompt name immutability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1d3ece265dbf6a83d1af2f6e45ceb8254d0a8468. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->