### PR TITLE
chore: don't run llm tests unless required to avoid throttling on CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,12 +21,28 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      llm_connections_changed: ${{ steps.filter.outputs.llm_connections }}
     timeout-minutes: 15
+    permissions:
+      pull-requests: read
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
         with:
           do_not_skip: '["workflow_dispatch"]'
+      - uses: actions/checkout@v4
+        with:
+          # Recommended for paths-filter action
+          # may save additional git fetch roundtrip if
+          # merge-base is found within latest N commits
+          fetch-depth: 20
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            llm_connections:
+              - 'packages/shared/package.json'
+              - 'packages/shared/src/server/llm/fetchLLMCompletion.ts'
 
   lint:
     runs-on: ubuntu-latest
@@ -370,7 +386,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - pre-job
-    if: needs.pre-job.outputs.should_skip != 'true'
+    if: needs.pre-job.outputs.should_skip != 'true' && (needs.pre-job.outputs.llm_connections_changed == 'true' || github.event_name == 'workflow_dispatch')
     name: test-worker-llm-connections (node24, pg15)
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modifies CI/CD pipeline to conditionally run LLM connection tests based on file changes or manual trigger to prevent unnecessary runs.
> 
>   - **CI/CD Pipeline**:
>     - Adds `llm_connections_changed` output in `pre-job` to track changes in `packages/shared/package.json` and `packages/shared/src/server/llm/fetchLLMCompletion.ts`.
>     - Updates `test-worker-llm-connections` job to run only if `llm_connections_changed` is true or if triggered by `workflow_dispatch`.
>     - Uses `dorny/paths-filter@v3` to detect changes in specific files related to LLM connections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 943c824d27df3d9b2d141ad60efa3d800a2197a2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->