### PR TITLE
fix(seeder): gemini trace

### DIFF
--- a/packages/shared/scripts/seeder/utils/framework-traces/google-vertex-tools-2025-09-19.json
+++ b/packages/shared/scripts/seeder/utils/framework-traces/google-vertex-tools-2025-09-19.json
@@ -1,20 +1,18 @@
 {
-  "traces": [
-    {
-      "id": "vertex-gemini-trace-001",
-      "name": "Google Vertex AI Gemini Test Trace",
-      "projectId": "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
-      "timestamp": "2025-09-19T21:59:59.005Z",
-      "environment": "default",
-      "tags": [],
-      "bookmarked": false,
-      "release": null,
-      "version": null,
-      "userId": null,
-      "sessionId": null,
-      "public": false
-    }
-  ],
+  "trace": {
+    "id": "vertex-gemini-trace-001",
+    "name": "Google Vertex AI Gemini Test Trace",
+    "projectId": "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+    "timestamp": "2025-09-19T21:59:59.005Z",
+    "environment": "default",
+    "tags": [],
+    "bookmarked": false,
+    "release": null,
+    "version": null,
+    "userId": null,
+    "sessionId": null,
+    "public": false
+  },
   "observations": [
     {
       "id": "vertex-gemini-obs-001",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change top-level key from `traces` to `trace` in `google-vertex-tools-2025-09-19.json`.
> 
>   - **JSON Structure**:
>     - Change top-level key from `traces` to `trace` in `google-vertex-tools-2025-09-19.json`.
>     - Affects how trace data is accessed and processed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3e9e917b9f9a1902deb277af2755925ed8eb53a3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->