### PR TITLE
Fix image preview inline error

### DIFF
--- a/web/src/components/ui/LangfuseMediaView.tsx
+++ b/web/src/components/ui/LangfuseMediaView.tsx
@@ -56,7 +56,7 @@ export const LangfuseMediaView = ({
       </div>
     );
 
-  const { data } = api.media.getById.useQuery(
+  const { data, error } = api.media.getById.useQuery(
     {
       mediaId: mediaData.id,
       projectId: projectId as string,
@@ -67,10 +67,27 @@ export const LangfuseMediaView = ({
       refetchOnMount: false,
       refetchOnReconnect: false,
       staleTime: 55 * 60 * 1000, // 55 minutes, s3 links expire after 1 hour
+      onError: () => {
+        // Suppress toast notification - we'll show an inline error instead
+      },
     },
   );
 
   const mediaUrl = data?.url;
+
+  // Show inline error if media couldn't be loaded
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-2">
+        <span title={error.message}>
+          <ImageOff className="h-4 w-4 text-destructive" />
+        </span>
+        <span className="truncate text-sm text-destructive">
+          {error.message || "Media asset not found"}
+        </span>
+      </div>
+    );
+  }
 
   if (!mediaUrl) return null;
 

--- a/web/src/components/ui/LangfuseMediaView.tsx
+++ b/web/src/components/ui/LangfuseMediaView.tsx
@@ -67,8 +67,8 @@ export const LangfuseMediaView = ({
       refetchOnMount: false,
       refetchOnReconnect: false,
       staleTime: 55 * 60 * 1000, // 55 minutes, s3 links expire after 1 hour
-      onError: () => {
-        // Suppress toast notification - we'll show an inline error instead
+      meta: {
+        suppressErrorToast: true, // Show inline error instead of toast
       },
     },
   );

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -164,7 +164,11 @@ export const api = createTRPCNext<AppRouter>({
           },
         },
         queryCache: new QueryCache({
-          onError: (error) => {
+          onError: (error, query) => {
+            // Skip toast if query has suppressErrorToast meta flag
+            if (query.meta?.suppressErrorToast) {
+              return;
+            }
             handleTrpcError(error);
           },
         }),


### PR DESCRIPTION
## What does this PR do?

Replaces disruptive toast notifications with a clear inline error message when a referenced media asset (image/file) cannot be retrieved in the `LangfuseMediaView` component. This improves user experience by showing the error directly where the media should be, without interrupting the workflow with a toast.

Fixes # LFE-5571

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-5571](https://linear.app/langfuse/issue/LFE-5571/render-better-inline-error-of-image-preview-when-mediaid-is-not-found)

<a href="https://cursor.com/background-agent?bcId=bc-a7854972-69a0-46e4-977e-ef33cba9e50a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a7854972-69a0-46e4-977e-ef33cba9e50a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

