### PR TITLE
feat(scores): Foundation & Routing for Score Analytics

### DIFF
--- a/web/src/features/navigation/utils/scores-tabs.ts
+++ b/web/src/features/navigation/utils/scores-tabs.ts
@@ -1,0 +1,19 @@
+export const SCORES_TABS = {
+  SCORES: "scores",
+  ANALYTICS: "analytics",
+} as const;
+
+export type ScoresTab = (typeof SCORES_TABS)[keyof typeof SCORES_TABS];
+
+export const getScoresTabs = (projectId: string) => [
+  {
+    value: SCORES_TABS.SCORES,
+    label: "Scores",
+    href: `/project/${projectId}/scores`,
+  },
+  {
+    value: SCORES_TABS.ANALYTICS,
+    label: "Analytics",
+    href: `/project/${projectId}/scores/analytics`,
+  },
+];

--- a/web/src/pages/project/[projectId]/scores/analytics.tsx
+++ b/web/src/pages/project/[projectId]/scores/analytics.tsx
@@ -16,7 +16,7 @@ export default function ScoresAnalyticsPage() {
         breadcrumb: [{ name: "Scores", href: `/project/${projectId}/scores` }],
         help: {
           description:
-            "A scores is an evaluation of a traces or observations. It can be created from user feedback, model-based evaluations, or manual review. See docs to learn more.",
+            "A score is an evaluation of a trace or observation. It can be created from user feedback, model-based evaluations, or manual review. See docs to learn more.",
           href: "https://langfuse.com/docs/evaluation/overview",
         },
         tabsProps: {

--- a/web/src/pages/project/[projectId]/scores/analytics.tsx
+++ b/web/src/pages/project/[projectId]/scores/analytics.tsx
@@ -1,0 +1,33 @@
+import { useRouter } from "next/router";
+import Page from "@/src/components/layouts/page";
+import {
+  getScoresTabs,
+  SCORES_TABS,
+} from "@/src/features/navigation/utils/scores-tabs";
+
+export default function ScoresAnalyticsPage() {
+  const router = useRouter();
+  const projectId = router.query.projectId as string;
+
+  return (
+    <Page
+      headerProps={{
+        title: "Scores",
+        breadcrumb: [{ name: "Scores", href: `/project/${projectId}/scores` }],
+        help: {
+          description:
+            "A scores is an evaluation of a traces or observations. It can be created from user feedback, model-based evaluations, or manual review. See docs to learn more.",
+          href: "https://langfuse.com/docs/evaluation/overview",
+        },
+        tabsProps: {
+          tabs: getScoresTabs(projectId),
+          activeTab: SCORES_TABS.ANALYTICS,
+        },
+      }}
+    >
+      <div className="flex items-center justify-center p-8">
+        <p className="text-muted-foreground">Score Analytics - Coming Soon</p>
+      </div>
+    </Page>
+  );
+}

--- a/web/src/pages/project/[projectId]/scores/index.tsx
+++ b/web/src/pages/project/[projectId]/scores/index.tsx
@@ -3,6 +3,10 @@ import ScoresTable from "@/src/components/table/use-cases/scores";
 import Page from "@/src/components/layouts/page";
 import { api } from "@/src/utils/api";
 import { ScoresOnboarding } from "@/src/components/onboarding/ScoresOnboarding";
+import {
+  getScoresTabs,
+  SCORES_TABS,
+} from "@/src/features/navigation/utils/scores-tabs";
 
 export default function ScoresPage() {
   const router = useRouter();
@@ -32,6 +36,10 @@ export default function ScoresPage() {
           description:
             "A scores is an evaluation of a traces or observations. It can be created from user feedback, model-based evaluations, or manual review. See docs to learn more.",
           href: "https://langfuse.com/docs/evaluation/overview",
+        },
+        tabsProps: {
+          tabs: getScoresTabs(projectId),
+          activeTab: SCORES_TABS.SCORES,
         },
       }}
       scrollable={showOnboarding}


### PR DESCRIPTION
## Summary

Implements the foundation and routing structure for the Score Analytics feature (LF-1916).

<img width="2358" height="1628" alt="CleanShot 2025-10-27 at 21 53 34@2x" src="https://github.com/user-attachments/assets/df3a4df3-ff19-417d-8bb4-763d6a9848f7" />


### Changes

- ✅ Created tab navigation utility (`scores-tabs.ts`) following dataset pattern
- ✅ Restructured scores page into `/scores/index.tsx`
- ✅ Added `/scores/analytics.tsx` with placeholder content
- ✅ Implemented tab navigation between Scores and Analytics pages
- ✅ Added breadcrumb navigation
- ✅ Verified routing and navigation works correctly

### Testing

- [x] Linting passed (`pnpm --filter=web run lint`)
- [x] Build completed successfully (`pnpm --filter=web run build`)
- [x] Routes generated correctly:
  - `/project/[projectId]/scores`
  - `/project/[projectId]/scores/analytics`

### Navigation Structure

Users can now:
- Navigate between Scores and Analytics tabs
- Direct URL access to both pages works
- Current tab highlighting works correctly
- Back button navigation works as expected

### Related

- Issue: [LF-1916](https://linear.app/langfuse/issue/LF-1916/foundation-and-routing)
- Parent: [LF-1910 - Score Analytics V0](https://linear.app/langfuse/issue/LF-1910/score-analytics-v0)
- Project: [Score Analytics Dashboard](https://linear.app/langfuse/project/score-analytics-dashboard-8d16edcd18a1)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces tab navigation for Scores and Analytics pages with new routing and placeholder content for Score Analytics.
> 
>   - **Navigation**:
>     - Adds `scores-tabs.ts` for tab navigation utility, defining `SCORES_TABS` and `getScoresTabs()`.
>     - Implements tab navigation in `scores/index.tsx` and `scores/analytics.tsx` using `getScoresTabs()`.
>     - Adds breadcrumb navigation in `scores/analytics.tsx`.
>   - **Pages**:
>     - Creates `analytics.tsx` with placeholder content for Score Analytics.
>     - Restructures `scores.tsx` to `scores/index.tsx` and integrates tab navigation.
>   - **Routing**:
>     - Verifies routes `/project/[projectId]/scores` and `/project/[projectId]/scores/analytics` work correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c2cca56aa6e6851430010ab6e6a2a5e197e62405. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->