### PR TITLE
feat(scores): Score Selection & Filters UI

### DIFF
--- a/web/src/features/scores/components/analytics/ObjectTypeFilter.tsx
+++ b/web/src/features/scores/components/analytics/ObjectTypeFilter.tsx
@@ -8,34 +8,36 @@ import {
 import { type ObjectType } from "@/src/features/scores/lib/analytics-url-state";
 
 const OBJECT_TYPE_OPTIONS: Array<{ value: ObjectType; label: string }> = [
-  { value: "all", label: "All" },
-  { value: "trace", label: "Trace" },
-  { value: "session", label: "Session" },
-  { value: "observation", label: "Observation" },
-  { value: "run", label: "Run" },
+  { value: "all", label: "All Objects" },
+  { value: "trace", label: "Traces" },
+  { value: "session", label: "Sessions" },
+  { value: "observation", label: "Observations" },
+  { value: "run", label: "Runs" },
 ];
 
 interface ObjectTypeFilterProps {
   value: ObjectType;
   onChange: (value: ObjectType) => void;
+  className?: string;
 }
 
-export function ObjectTypeFilter({ value, onChange }: ObjectTypeFilterProps) {
+export function ObjectTypeFilter({
+  value,
+  onChange,
+  className,
+}: ObjectTypeFilterProps) {
   return (
-    <div className="flex items-center gap-2">
-      <span className="text-sm font-medium">Object Type:</span>
-      <Select value={value} onValueChange={onChange}>
-        <SelectTrigger className="w-[160px]">
-          <SelectValue placeholder="Select type" />
-        </SelectTrigger>
-        <SelectContent>
-          {OBJECT_TYPE_OPTIONS.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className={className}>
+        <SelectValue placeholder="Object type" />
+      </SelectTrigger>
+      <SelectContent>
+        {OBJECT_TYPE_OPTIONS.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 }

--- a/web/src/features/scores/components/analytics/ObjectTypeFilter.tsx
+++ b/web/src/features/scores/components/analytics/ObjectTypeFilter.tsx
@@ -1,0 +1,41 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/src/components/ui/select";
+import { type ObjectType } from "@/src/features/scores/lib/analytics-url-state";
+
+const OBJECT_TYPE_OPTIONS: Array<{ value: ObjectType; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "trace", label: "Trace" },
+  { value: "session", label: "Session" },
+  { value: "observation", label: "Observation" },
+  { value: "run", label: "Run" },
+];
+
+interface ObjectTypeFilterProps {
+  value: ObjectType;
+  onChange: (value: ObjectType) => void;
+}
+
+export function ObjectTypeFilter({ value, onChange }: ObjectTypeFilterProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm font-medium">Object Type:</span>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger className="w-[160px]">
+          <SelectValue placeholder="Select type" />
+        </SelectTrigger>
+        <SelectContent>
+          {OBJECT_TYPE_OPTIONS.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/web/src/features/scores/components/analytics/ObjectTypeFilter.tsx
+++ b/web/src/features/scores/components/analytics/ObjectTypeFilter.tsx
@@ -28,7 +28,7 @@ export function ObjectTypeFilter({
 }: ObjectTypeFilterProps) {
   return (
     <Select value={value} onValueChange={onChange}>
-      <SelectTrigger className={className}>
+      <SelectTrigger className={className} aria-label="Object type">
         <SelectValue placeholder="Object type" />
       </SelectTrigger>
       <SelectContent>

--- a/web/src/features/scores/components/analytics/ScoreSelector.tsx
+++ b/web/src/features/scores/components/analytics/ScoreSelector.tsx
@@ -1,0 +1,83 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/src/components/ui/select";
+import { Button } from "@/src/components/ui/button";
+import { X } from "lucide-react";
+
+export interface ScoreOption {
+  value: string; // Format: "name-type-source"
+  name: string;
+  dataType: string;
+  source: string;
+}
+
+interface ScoreSelectorProps {
+  label: string;
+  value?: string;
+  onChange: (value: string | undefined) => void;
+  options: ScoreOption[];
+  placeholder?: string;
+  filterByDataType?: string; // When set, only show scores matching this data type
+}
+
+export function ScoreSelector({
+  label,
+  value,
+  onChange,
+  options,
+  placeholder = "Select a score",
+  filterByDataType,
+}: ScoreSelectorProps) {
+  const filteredOptions = filterByDataType
+    ? options.filter((opt) => opt.dataType === filterByDataType)
+    : options;
+
+  const handleClear = () => {
+    onChange(undefined);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="text-sm font-medium">{label}</label>
+      <div className="flex items-center gap-2">
+        <Select value={value} onValueChange={onChange}>
+          <SelectTrigger className="w-full md:w-[300px]">
+            <SelectValue placeholder={placeholder} />
+          </SelectTrigger>
+          <SelectContent>
+            {filteredOptions.length === 0 ? (
+              <div className="p-2 text-sm text-muted-foreground">
+                No scores available
+              </div>
+            ) : (
+              filteredOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  <div className="flex flex-col">
+                    <span>{option.name}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {option.dataType} • {option.source}
+                    </span>
+                  </div>
+                </SelectItem>
+              ))
+            )}
+          </SelectContent>
+        </Select>
+        {value && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleClear}
+            title="Clear selection"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/scores/components/analytics/ScoreSelector.tsx
+++ b/web/src/features/scores/components/analytics/ScoreSelector.tsx
@@ -16,21 +16,21 @@ export interface ScoreOption {
 }
 
 interface ScoreSelectorProps {
-  label: string;
   value?: string;
   onChange: (value: string | undefined) => void;
   options: ScoreOption[];
   placeholder?: string;
   filterByDataType?: string; // When set, only show scores matching this data type
+  className?: string;
 }
 
 export function ScoreSelector({
-  label,
   value,
   onChange,
   options,
   placeholder = "Select a score",
   filterByDataType,
+  className,
 }: ScoreSelectorProps) {
   const filteredOptions = filterByDataType
     ? options.filter((opt) => opt.dataType === filterByDataType)
@@ -41,43 +41,41 @@ export function ScoreSelector({
   };
 
   return (
-    <div className="flex flex-col gap-2">
-      <label className="text-sm font-medium">{label}</label>
-      <div className="flex items-center gap-2">
-        <Select value={value} onValueChange={onChange}>
-          <SelectTrigger className="w-full md:w-[300px]">
-            <SelectValue placeholder={placeholder} />
-          </SelectTrigger>
-          <SelectContent>
-            {filteredOptions.length === 0 ? (
-              <div className="p-2 text-sm text-muted-foreground">
-                No scores available
-              </div>
-            ) : (
-              filteredOptions.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  <div className="flex flex-col">
-                    <span>{option.name}</span>
-                    <span className="text-xs text-muted-foreground">
-                      {option.dataType} • {option.source}
-                    </span>
-                  </div>
-                </SelectItem>
-              ))
-            )}
-          </SelectContent>
-        </Select>
-        {value && (
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={handleClear}
-            title="Clear selection"
-          >
-            <X className="h-4 w-4" />
-          </Button>
-        )}
-      </div>
+    <div className="flex items-center gap-2">
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger className={className}>
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {filteredOptions.length === 0 ? (
+            <div className="p-2 text-sm text-muted-foreground">
+              No scores available
+            </div>
+          ) : (
+            filteredOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                <div className="flex flex-col">
+                  <span>{option.name}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {option.dataType} • {option.source}
+                  </span>
+                </div>
+              </SelectItem>
+            ))
+          )}
+        </SelectContent>
+      </Select>
+      {value && (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={handleClear}
+          title="Clear selection"
+          className="h-8 w-8"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      )}
     </div>
   );
 }

--- a/web/src/features/scores/components/analytics/ScoreSelector.tsx
+++ b/web/src/features/scores/components/analytics/ScoreSelector.tsx
@@ -44,7 +44,7 @@ export function ScoreSelector({
     <div className="flex items-center gap-2">
       <Select value={value} onValueChange={onChange}>
         <SelectTrigger className={className}>
-          <SelectValue placeholder={placeholder} />
+          <SelectValue placeholder={placeholder} className="p-0" />
         </SelectTrigger>
         <SelectContent>
           {filteredOptions.length === 0 ? (

--- a/web/src/features/scores/lib/analytics-url-state.ts
+++ b/web/src/features/scores/lib/analytics-url-state.ts
@@ -1,0 +1,67 @@
+import { useQueryParams, StringParam, withDefault } from "use-query-params";
+
+export type ObjectType = "all" | "trace" | "session" | "observation" | "run";
+
+export interface ScoreAnalyticsUrlState {
+  score1?: string;
+  score2?: string;
+  dateRange: string;
+  objectType: ObjectType;
+}
+
+const DEFAULT_DATE_RANGE = "1d";
+const DEFAULT_OBJECT_TYPE: ObjectType = "all";
+
+/**
+ * Hook to manage URL state for the Score Analytics page
+ * Uses use-query-params for URL synchronization
+ */
+export function useAnalyticsUrlState() {
+  const [query, setQuery] = useQueryParams({
+    score1: StringParam,
+    score2: StringParam,
+    dateRange: withDefault(StringParam, DEFAULT_DATE_RANGE),
+    objectType: withDefault(StringParam, DEFAULT_OBJECT_TYPE),
+  });
+
+  const state: ScoreAnalyticsUrlState = {
+    score1: query.score1 ?? undefined,
+    score2: query.score2 ?? undefined,
+    dateRange: query.dateRange,
+    objectType: query.objectType as ObjectType,
+  };
+
+  const setState = (newState: Partial<ScoreAnalyticsUrlState>) => {
+    setQuery(newState as any, "pushIn");
+  };
+
+  const setScore1 = (score: string | undefined) => {
+    setState({ score1: score });
+  };
+
+  const setScore2 = (score: string | undefined) => {
+    setState({ score2: score });
+  };
+
+  const setDateRange = (dateRange: string) => {
+    setState({ dateRange });
+  };
+
+  const setObjectType = (objectType: ObjectType) => {
+    setState({ objectType });
+  };
+
+  const clearScores = () => {
+    setState({ score1: undefined, score2: undefined });
+  };
+
+  return {
+    state,
+    setState,
+    setScore1,
+    setScore2,
+    setDateRange,
+    setObjectType,
+    clearScores,
+  };
+}

--- a/web/src/pages/project/[projectId]/scores/analytics.tsx
+++ b/web/src/pages/project/[projectId]/scores/analytics.tsx
@@ -58,37 +58,42 @@ export default function ScoresAnalyticsPage() {
       }}
     >
       <div className="flex flex-col gap-6">
-        {/* Controls Section */}
-        <div className="flex flex-col gap-4 rounded-lg border bg-card p-4">
-          {/* Top row: Time range and Object type */}
-          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <TimeRangePicker
-              timeRange={timeRange}
-              onTimeRangeChange={setTimeRange}
-              timeRangePresets={DASHBOARD_AGGREGATION_OPTIONS}
-            />
-            <ObjectTypeFilter
-              value={urlState.objectType}
-              onChange={setObjectType}
-            />
-          </div>
-
-          {/* Score selectors */}
-          <div className="grid gap-4 md:grid-cols-2">
+        {/* Controls Section - Compact Toolbar */}
+        <div className="flex h-8 flex-col gap-2 md:flex-row md:items-center md:gap-4">
+          {/* Left: Score Selectors */}
+          <div className="flex items-center gap-2">
             <ScoreSelector
-              label="Score 1"
               value={urlState.score1}
               onChange={setScore1}
               options={scoreOptions}
               placeholder="Select first score"
+              className="h-8 w-[200px]"
             />
             <ScoreSelector
-              label="Score 2 (optional)"
               value={urlState.score2}
               onChange={setScore2}
               options={scoreOptions}
-              placeholder="Select second score"
+              placeholder="Select second score (optional)"
               filterByDataType={score1DataType}
+              className="h-8 w-[200px]"
+            />
+          </div>
+
+          {/* Middle: Spacer (hidden on mobile) */}
+          <div className="hidden flex-1 md:block" />
+
+          {/* Right: Filters */}
+          <div className="flex items-center gap-2">
+            <ObjectTypeFilter
+              value={urlState.objectType}
+              onChange={setObjectType}
+              className="h-8 w-[140px]"
+            />
+            <TimeRangePicker
+              timeRange={timeRange}
+              onTimeRangeChange={setTimeRange}
+              timeRangePresets={DASHBOARD_AGGREGATION_OPTIONS}
+              className="my-0"
             />
           </div>
         </div>

--- a/web/src/pages/project/[projectId]/scores/analytics.tsx
+++ b/web/src/pages/project/[projectId]/scores/analytics.tsx
@@ -57,30 +57,30 @@ export default function ScoresAnalyticsPage() {
         },
       }}
     >
-      <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
         {/* Controls Section - Compact Toolbar */}
-        <div className="flex h-8 flex-col gap-2 md:flex-row md:items-center md:gap-4">
+        <div className="flex flex-col gap-1 border-b border-border p-2 lg:flex-row lg:items-center lg:gap-4">
           {/* Left: Score Selectors */}
           <div className="flex items-center gap-2">
             <ScoreSelector
               value={urlState.score1}
               onChange={setScore1}
               options={scoreOptions}
-              placeholder="Select first score"
-              className="h-8 w-[200px]"
+              placeholder="First score"
+              className="h-8 w-[160px]"
             />
             <ScoreSelector
               value={urlState.score2}
               onChange={setScore2}
               options={scoreOptions}
-              placeholder="Select second score (optional)"
+              placeholder="Second score"
               filterByDataType={score1DataType}
-              className="h-8 w-[200px]"
+              className="h-8 w-[160px]"
             />
           </div>
 
           {/* Middle: Spacer (hidden on mobile) */}
-          <div className="hidden flex-1 md:block" />
+          <div className="hidden flex-1 lg:block" />
 
           {/* Right: Filters */}
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

Implements the UI components for score selection, filtering, and URL state management (LF-1917).

<img width="2380" height="1638" alt="CleanShot 2025-10-27 at 22 54 37@2x" src="https://github.com/user-attachments/assets/4d567000-e1e4-4253-a66a-ee435ea7b9aa" />

### Changes

**Components Created:**
- ✅ `ScoreSelector.tsx` - Dropdown for selecting scores with type filtering
- ✅ `ObjectTypeFilter.tsx` - Filter for object types (All/Trace/Session/Observation/Run)
- ✅ `analytics-url-state.ts` - URL state management hook using `use-query-params`

**Analytics Page Updates:**
- ✅ Integrated TimeRangePicker with dashboard presets
- ✅ Added controls section with time range, object type, and score selectors
- ✅ Implemented responsive layout (stacks on mobile)
- ✅ Added empty states for no scores and no selection
- ✅ Clear selection functionality

**Features:**
- URL parameters sync (score1, score2, dateRange, objectType)
- Score 2 dropdown filters by Score 1 data type when selected
- Responsive grid layout for score selectors
- Clear buttons for each score selector
- Helpful empty states with icons and instructions

### Testing

- [x] Linting passed (`pnpm --filter=web run lint`)
- [x] Build completed successfully (`pnpm --filter=web run build`)
- [x] Route generated: `/project/[projectId]/scores/analytics`
- [x] All components render correctly
- [x] URL state management works

### Next Steps

- Data will be populated in LF-1918 (tRPC API Endpoints)
- Visualizations will be added in LF-1919, LF-1920, LF-1921

### UI Preview

**Controls Section:**
- Time range picker with preset options
- Object type filter (dropdown)
- Two score selectors with type filtering
- Clear buttons for selections

**Empty States:**
- "No Scores Available" - when no scores exist in the project
- "Select a Score" - helpful message explaining single vs two-score analytics

### Related

- Issue: [LF-1917](https://linear.app/langfuse/issue/LF-1917/score-selection-and-filters-ui)
- Parent: [LF-1910 - Score Analytics V0](https://linear.app/langfuse/issue/LF-1910/score-analytics-v0)
- Project: [Score Analytics Dashboard](https://linear.app/langfuse/project/score-analytics-dashboard-8d16edcd18a1)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds UI components for score selection and filtering with URL state management on the analytics page.
> 
>   - **Components**:
>     - `ScoreSelector.tsx`: Dropdown for selecting scores with type filtering and clear button.
>     - `ObjectTypeFilter.tsx`: Dropdown for filtering object types (All/Trace/Session/Observation/Run).
>     - `analytics-url-state.ts`: Hook for URL state management using `use-query-params`.
>   - **Analytics Page**:
>     - Integrates `TimeRangePicker` with dashboard presets.
>     - Adds controls section with time range, object type, and score selectors.
>     - Implements responsive layout and empty states for no scores and no selection.
>   - **Features**:
>     - URL parameters sync for `score1`, `score2`, `dateRange`, `objectType`.
>     - Score 2 dropdown filters by Score 1 data type.
>     - Clear buttons for each score selector.
>     - Empty states with icons and instructions for no scores or selection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 50d87c7ae6acd776202ff4845746d34c00246df5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->