### PR TITLE
perf: add opt-in perf improvements for self-hosters on otel SDKs

### DIFF
--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -301,6 +301,19 @@ export const env = createEnv({
     LANGFUSE_AI_FEATURES_SECRET_KEY: z.string().optional(),
     LANGFUSE_AI_FEATURES_PROJECT_ID: z.string().optional(),
 
+    // API Performance Flags
+    // Whether to add a `FINAL` modifier to the observations CTE in GET /api/public/traces.
+    // Can be used to improve performance for self-hosters that are fully on the new OTel SDKs.
+    LANGFUSE_API_CLICKHOUSE_DISABLE_OBSERVATIONS_FINAL: z
+      .enum(["true", "false"])
+      .default("false"),
+    // Whether to propagate the toTimestamp restriction (including a server-side offset)
+    // onto the observations CTE in GET /api/public/traces. Can be used to improve performance
+    // for self-hosters that have a trace known trace duration of less than multiple hours.
+    LANGFUSE_API_CLICKHOUSE_PROPAGATE_OBSERVATIONS_TIME_BOUNDS: z
+      .enum(["true", "false"])
+      .default("false"),
+
     // Events table migration
     LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS: z
       .enum(["true", "false"])
@@ -423,7 +436,8 @@ export const env = createEnv({
     AUTH_ONELOGIN_ISSUER: process.env.AUTH_ONELOGIN_ISSUER,
     AUTH_ONELOGIN_ALLOW_ACCOUNT_LINKING:
       process.env.AUTH_ONELOGIN_ALLOW_ACCOUNT_LINKING,
-    AUTH_ONELOGIN_CLIENT_AUTH_METHOD: process.env.AUTH_ONELOGIN_CLIENT_AUTH_METHOD,
+    AUTH_ONELOGIN_CLIENT_AUTH_METHOD:
+      process.env.AUTH_ONELOGIN_CLIENT_AUTH_METHOD,
     AUTH_ONELOGIN_CHECKS: process.env.AUTH_ONELOGIN_CHECKS,
     AUTH_AUTH0_CLIENT_ID: process.env.AUTH_AUTH0_CLIENT_ID,
     AUTH_AUTH0_CLIENT_SECRET: process.env.AUTH_AUTH0_CLIENT_SECRET,
@@ -597,6 +611,12 @@ export const env = createEnv({
 
     // Langfuse Tracing AI Features
     LANGFUSE_AI_FEATURES_HOST: process.env.LANGFUSE_AI_FEATURES_HOST,
+
+    // Api Performance Flags
+    LANGFUSE_API_CLICKHOUSE_PROPAGATE_OBSERVATIONS_TIME_BOUNDS:
+      process.env.LANGFUSE_API_CLICKHOUSE_PROPAGATE_OBSERVATIONS_TIME_BOUNDS,
+    LANGFUSE_API_CLICKHOUSE_DISABLE_OBSERVATIONS_FINAL:
+      process.env.LANGFUSE_API_CLICKHOUSE_DISABLE_OBSERVATIONS_FINAL,
 
     // Natural Language Filters
     LANGFUSE_AI_FEATURES_PUBLIC_KEY:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add performance optimizations for self-hosters using OTel SDKs by introducing environment variables to conditionally modify ClickHouse queries in `traces.ts`.
> 
>   - **Environment Variables**:
>     - Add `LANGFUSE_API_CLICKHOUSE_DISABLE_OBSERVATIONS_FINAL` and `LANGFUSE_API_CLICKHOUSE_PROPAGATE_OBSERVATIONS_TIME_BOUNDS` to `env.mjs` for performance tuning.
>   - **Query Optimization**:
>     - In `generateTracesForPublicApi` in `traces.ts`, conditionally apply `FINAL` modifier and time bounds to ClickHouse queries based on new environment variables.
>     - Modify CTEs to include time bounds and `FINAL` conditionally for observations and metrics.
>   - **Misc**:
>     - Minor formatting changes in `env.mjs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1e8c2713e5115cfb5bce64ee08bb6c3464238432. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->