### PR TITLE
fix(filters): re-enable filters for score table

### DIFF
--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -236,11 +236,7 @@ export default function ScoresTable({
           value: u.value,
           count: u.count !== undefined ? Number(u.count) : undefined,
         })) || [],
-      tags:
-        filterOptions.data?.tags?.map((t) => ({
-          value: t.value,
-          count: t.count !== undefined ? Number(t.count) : undefined,
-        })) || [],
+      tags: filterOptions.data?.tags?.map((t) => t.value) || [], // tags don't have counts
     }),
     [filterOptions.data],
   );

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -226,6 +226,16 @@ export default function ScoresTable({
       source: ["ANNOTATION", "API", "EVAL"],
       dataType: ["NUMERIC", "CATEGORICAL", "BOOLEAN"],
       value: [],
+      traceName:
+        filterOptions.data?.traceName?.map((tn) => ({
+          value: tn.value,
+          count: tn.count !== undefined ? Number(tn.count) : undefined,
+        })) || [],
+      userId:
+        filterOptions.data?.userId?.map((u) => ({
+          value: u.value,
+          count: u.count !== undefined ? Number(u.count) : undefined,
+        })) || [],
       tags:
         filterOptions.data?.tags?.map((t) => ({
           value: t.value,

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -11,7 +11,10 @@ import { IOTableCell } from "../../ui/IOTableCell";
 import { Avatar, AvatarImage } from "@/src/components/ui/avatar";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import { useSidebarFilterState } from "@/src/features/filters/hooks/useSidebarFilterState";
-import { scoreFilterConfig } from "@/src/features/filters/config/scores-config";
+import {
+  scoreFilterConfig,
+  SCORE_COLUMN_TO_BACKEND_KEY,
+} from "@/src/features/filters/config/scores-config";
 import { transformFiltersForBackend } from "@/src/features/filters/lib/filter-transform";
 import { isNumericDataType } from "@/src/features/scores/lib/helpers";
 import { useOrderByState } from "@/src/features/orderBy/hooks/useOrderByState";
@@ -223,6 +226,11 @@ export default function ScoresTable({
       source: ["ANNOTATION", "API", "EVAL"],
       dataType: ["NUMERIC", "CATEGORICAL", "BOOLEAN"],
       value: [],
+      tags:
+        filterOptions.data?.tags?.map((t) => ({
+          value: t.value,
+          count: t.count !== undefined ? Number(t.count) : undefined,
+        })) || [],
     }),
     [filterOptions.data],
   );
@@ -254,7 +262,7 @@ export default function ScoresTable({
 
   const backendFilterState = transformFiltersForBackend(
     filterState,
-    {}, // No backend column remapping needed for scores
+    SCORE_COLUMN_TO_BACKEND_KEY,
     scoreFilterConfig.columnDefinitions,
   );
 

--- a/web/src/features/filters/config/scores-config.ts
+++ b/web/src/features/filters/config/scores-config.ts
@@ -61,7 +61,7 @@ export const scoreFilterConfig: FilterConfig = {
       label: "Trace ID",
     },
     {
-      type: "string" as const,
+      type: "categorical" as const,
       column: "traceName",
       label: "Trace Name",
     },
@@ -71,7 +71,7 @@ export const scoreFilterConfig: FilterConfig = {
       label: "Observation ID",
     },
     {
-      type: "string" as const,
+      type: "categorical" as const,
       column: "userId",
       label: "User ID",
     },

--- a/web/src/features/filters/config/scores-config.ts
+++ b/web/src/features/filters/config/scores-config.ts
@@ -1,12 +1,24 @@
 import { scoresTableCols } from "@/src/server/api/definitions/scoresTable";
 import type { FilterConfig } from "@/src/features/filters/lib/filter-config";
 import type { ColumnToQueryKeyMap } from "@/src/features/filters/lib/filter-query-encoding";
+import type { ColumnToBackendKeyMap } from "@/src/features/filters/lib/filter-transform";
 
 const SCORE_COLUMN_TO_QUERY_KEY: ColumnToQueryKeyMap = {
+  traceId: "traceId",
+  traceName: "traceName",
+  observationId: "observationId",
+  userId: "userId",
+  tags: "tags",
   source: "source",
   dataType: "dataType",
   name: "name",
   value: "value",
+};
+
+// Maps frontend column IDs to backend-expected column IDs
+// Frontend uses "tags" but backend CH mapping expects "trace_tags" for trace tags on scores table
+export const SCORE_COLUMN_TO_BACKEND_KEY: ColumnToBackendKeyMap = {
+  tags: "trace_tags",
 };
 
 export const scoreFilterConfig: FilterConfig = {
@@ -42,6 +54,31 @@ export const scoreFilterConfig: FilterConfig = {
       label: "Value",
       min: -100,
       max: 100,
+    },
+    {
+      type: "string" as const,
+      column: "traceId",
+      label: "Trace ID",
+    },
+    {
+      type: "string" as const,
+      column: "traceName",
+      label: "Trace Name",
+    },
+    {
+      type: "string" as const,
+      column: "observationId",
+      label: "Observation ID",
+    },
+    {
+      type: "string" as const,
+      column: "userId",
+      label: "User ID",
+    },
+    {
+      type: "categorical" as const,
+      column: "tags",
+      label: "Trace Tags",
     },
   ],
 };

--- a/web/src/server/api/definitions/scoresTable.ts
+++ b/web/src/server/api/definitions/scoresTable.ts
@@ -16,8 +16,9 @@ export const scoresTableCols: ColumnDefinition[] = [
   {
     name: "Trace Name",
     id: "traceName",
-    type: "string",
+    type: "stringOptions",
     internal: 't."name"',
+    options: [], // to be added at runtime
     nullable: true,
   },
   {
@@ -57,8 +58,9 @@ export const scoresTableCols: ColumnDefinition[] = [
   {
     name: "User ID",
     id: "userId",
-    type: "string",
+    type: "stringOptions",
     internal: 't."user_id"',
+    options: [], // to be added at runtime
     nullable: true,
   },
   {
@@ -74,6 +76,8 @@ export const scoresTableCols: ColumnDefinition[] = [
 export type ScoreOptions = {
   name: Array<SingleValueOption>;
   tags: Array<SingleValueOption>;
+  traceName: Array<SingleValueOption>;
+  userId: Array<SingleValueOption>;
 };
 
 export function scoresTableColsWithOptions(
@@ -85,6 +89,12 @@ export function scoresTableColsWithOptions(
     }
     if (col.id === "tags") {
       return formatColumnOptions(col, options?.tags ?? []);
+    }
+    if (col.id === "traceName") {
+      return formatColumnOptions(col, options?.traceName ?? []);
+    }
+    if (col.id === "userId") {
+      return formatColumnOptions(col, options?.userId ?? []);
     }
     return col;
   });

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -34,6 +34,9 @@ import {
   getScoresUiTable,
   getScoreNames,
   getTracesGroupedByTags,
+  getTracesGroupedByName,
+  getTracesGroupedByUsers,
+  tracesTableUiColumnDefinitions,
   upsertScore,
   logger,
   getTraceById,
@@ -184,7 +187,7 @@ export const scoresRouter = createTRPCRouter({
     )
     .query(async ({ input }) => {
       const { timestampFilter } = input;
-      const [names, tags] = await Promise.all([
+      const [names, tags, traceNames, userIds] = await Promise.all([
         getScoreNames(
           input.projectId,
           timestampFilter ? [timestampFilter] : [],
@@ -193,11 +196,28 @@ export const scoresRouter = createTRPCRouter({
           projectId: input.projectId,
           filter: timestampFilter ? [timestampFilter] : [],
         }),
+        getTracesGroupedByName(
+          input.projectId,
+          tracesTableUiColumnDefinitions,
+          timestampFilter ? [timestampFilter] : [],
+        ),
+        getTracesGroupedByUsers(
+          input.projectId,
+          timestampFilter ? [timestampFilter] : [],
+          undefined,
+          100, // limit to top 100 users
+          0,
+        ),
       ]);
 
       return {
         name: names.map((i) => ({ value: i.name, count: i.count })),
         tags: tags,
+        traceName: traceNames.map((tn) => ({
+          value: tn.name,
+          count: tn.count,
+        })),
+        userId: userIds.map((u) => ({ value: u.user, count: u.count })),
       };
     }),
   deleteMany: protectedProjectProcedure


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Re-enables filters for the score table by updating filter configurations, backend mappings, and API support for `traceName`, `userId`, and `tags`.
> 
>   - **Behavior**:
>     - Re-enables filters for the score table in `scores.tsx` by updating `filterOptions` to include `traceName`, `userId`, and `tags`.
>     - Updates `transformFiltersForBackend` to use `SCORE_COLUMN_TO_BACKEND_KEY` for backend column remapping.
>   - **Configurations**:
>     - Adds `traceName`, `userId`, and `tags` to `scoreFilterConfig` in `scores-config.ts`.
>     - Defines `SCORE_COLUMN_TO_BACKEND_KEY` to map frontend "tags" to backend "trace_tags".
>   - **API**:
>     - Updates `filterOptions` query in `scores.ts` to fetch `traceName` and `userId` using `getTracesGroupedByName` and `getTracesGroupedByUsers`.
>     - Modifies `scoresTableCols` in `scoresTable.ts` to include runtime options for `traceName` and `userId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4dda90c891703f04e352e08000080f6319d8473e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->