### PR TITLE
fix(ui): increase HoverCard openDelay for IOTableCell and ScoreRow components

### DIFF
--- a/web/src/components/ui/IOTableCell.tsx
+++ b/web/src/components/ui/IOTableCell.tsx
@@ -99,7 +99,7 @@ export const IOTableCell = ({
   }
 
   return (
-    <HoverCard openDelay={300} closeDelay={100}>
+    <HoverCard openDelay={700} closeDelay={100}>
       <HoverCardTrigger asChild>
         <div className="group/io-cell relative h-full w-full">
           <IOTableCellContent

--- a/web/src/features/scores/components/ScoreRow.tsx
+++ b/web/src/features/scores/components/ScoreRow.tsx
@@ -120,7 +120,7 @@ export const ScoreRow = ({
   }
 
   return (
-    <HoverCard openDelay={300} closeDelay={100} onOpenChange={setIsHovered}>
+    <HoverCard openDelay={700} closeDelay={100} onOpenChange={setIsHovered}>
       <HoverCardTrigger asChild>
         <div className="group/io-cell relative h-full w-full">
           <ScoreRowContent name={name} aggregate={aggregate} />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase `HoverCard` `openDelay` to 700ms in `IOTableCell` and `ScoreRow` components.
> 
>   - **Behavior**:
>     - Increase `HoverCard` `openDelay` from 300ms to 700ms in `IOTableCell.tsx` and `ScoreRow.tsx`.
>   - **Components**:
>     - Affects `IOTableCell` and `ScoreRow` components by changing hover card delay.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bc34273684ae53b4606df1e7312a7eab6a37f821. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->