### PR TITLE
feat(filters): filter sidebar items and count respect selected time

### DIFF
--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -252,12 +252,16 @@ export default function ObservationsTable({
     modelIdFilter,
   );
 
-  const startTimeFilter = oldFilterState.find((f) => f.column === "Start Time");
+  const startTimeFilters = oldFilterState.filter(
+    (f) =>
+      (f.column === "Start Time" || f.column === "startTime") &&
+      f.type === "datetime",
+  );
   const filterOptions = api.generations.filterOptions.useQuery(
     {
       projectId,
       startTimeFilter:
-        startTimeFilter?.type === "datetime" ? startTimeFilter : undefined,
+        startTimeFilters.length > 0 ? startTimeFilters : undefined,
     },
     {
       trpc: {

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -26,6 +26,7 @@ import {
   TableViewPresetTableName,
   AnnotationQueueObjectType,
   BatchActionType,
+  type TimeFilter,
 } from "@langfuse/shared";
 import { cn } from "@/src/utils/tailwind";
 import { LevelColors } from "@/src/components/level-colors";
@@ -256,7 +257,7 @@ export default function ObservationsTable({
     (f) =>
       (f.column === "Start Time" || f.column === "startTime") &&
       f.type === "datetime",
-  );
+  ) as TimeFilter[];
   const filterOptions = api.generations.filterOptions.useQuery(
     {
       projectId,

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -198,10 +198,7 @@ export default function ScoresTable({
   const filterOptions = api.scores.filterOptions.useQuery(
     {
       projectId,
-      timestampFilter:
-        dateRangeFilter[0]?.type === "datetime"
-          ? dateRangeFilter[0]
-          : undefined,
+      timestampFilter: dateRangeFilter.length > 0 ? dateRangeFilter : undefined,
     },
     {
       trpc: {

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -30,6 +30,7 @@ import {
   BatchExportTableName,
   BatchActionType,
   TableViewPresetTableName,
+  type TimeFilter,
 } from "@langfuse/shared";
 import { useQueryParams, withDefault, NumberParam } from "use-query-params";
 import TagList from "@/src/features/tag/components/TagList";
@@ -198,7 +199,10 @@ export default function ScoresTable({
   const filterOptions = api.scores.filterOptions.useQuery(
     {
       projectId,
-      timestampFilter: dateRangeFilter.length > 0 ? dateRangeFilter : undefined,
+      timestampFilter:
+        dateRangeFilter.length > 0
+          ? (dateRangeFilter as TimeFilter[])
+          : undefined,
     },
     {
       trpc: {

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -21,6 +21,7 @@ import {
   TableViewPresetTableName,
   AnnotationQueueObjectType,
   BatchActionType,
+  type TimeFilter,
 } from "@langfuse/shared";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
 import { useOrderByState } from "@/src/features/orderBy/hooks/useOrderByState";
@@ -161,7 +162,10 @@ export default function SessionsTable({
   const filterOptions = api.sessions.filterOptions.useQuery(
     {
       projectId,
-      timestampFilter: dateRangeFilter.length > 0 ? dateRangeFilter : undefined,
+      timestampFilter:
+        dateRangeFilter.length > 0
+          ? (dateRangeFilter as TimeFilter[])
+          : undefined,
     },
     {
       trpc: {

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -157,14 +157,11 @@ export default function SessionsTable({
     order: "DESC",
   });
 
-  // Extract and type-check the datetime filter from dateRangeFilter
-  // API expects specifically a datetime filter, but dateRangeFilter is FilterState which can contain any filter type
-  const createdAtFilter = dateRangeFilter.find((f) => f.column === "createdAt");
+  // dateRangeFilter contains only createdAt datetime filters, pass directly to API
   const filterOptions = api.sessions.filterOptions.useQuery(
     {
       projectId,
-      timestampFilter:
-        createdAtFilter?.type === "datetime" ? createdAtFilter : undefined,
+      timestampFilter: dateRangeFilter.length > 0 ? dateRangeFilter : undefined,
     },
     {
       trpc: {

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -206,7 +206,10 @@ export default function TracesTable({
     );
 
   const traceFilterOptionsResponse = api.traces.filterOptions.useQuery(
-    { projectId },
+    {
+      projectId,
+      timestampFilter: dateRangeFilter.length > 0 ? dateRangeFilter : undefined,
+    },
     {
       trpc: { context: { skipBatch: true } },
       refetchOnMount: false,

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -38,6 +38,7 @@ import {
   AnnotationQueueObjectType,
   BatchActionType,
   TableViewPresetTableName,
+  type TimeFilter,
 } from "@langfuse/shared";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
 import { MemoizedIOTableCell } from "../../ui/IOTableCell";
@@ -208,7 +209,10 @@ export default function TracesTable({
   const traceFilterOptionsResponse = api.traces.filterOptions.useQuery(
     {
       projectId,
-      timestampFilter: dateRangeFilter.length > 0 ? dateRangeFilter : undefined,
+      timestampFilter:
+        dateRangeFilter.length > 0
+          ? (dateRangeFilter as TimeFilter[])
+          : undefined,
     },
     {
       trpc: { context: { skipBatch: true } },

--- a/web/src/server/api/routers/generations/filterOptionsQuery.ts
+++ b/web/src/server/api/routers/generations/filterOptionsQuery.ts
@@ -18,11 +18,22 @@ export const filterOptionsQuery = protectedProjectProcedure
   .input(
     z.object({
       projectId: z.string(),
-      startTimeFilter: timeFilter.optional(),
+      startTimeFilter: z.array(timeFilter).optional(),
     }),
   )
   .query(async ({ input }) => {
     const { startTimeFilter } = input;
+
+    // map startTimeFilter to Timestamp column for trace queries
+    const traceTimestampFilters =
+      startTimeFilter && startTimeFilter.length > 0
+        ? startTimeFilter.map((f) => ({
+            column: "Timestamp" as const,
+            operator: f.operator,
+            value: f.value,
+            type: "datetime" as const,
+          }))
+        : [];
 
     const getClickhouseTraceName = async (): Promise<
       Array<{ traceName: string }>
@@ -30,16 +41,7 @@ export const filterOptionsQuery = protectedProjectProcedure
       const traces = await getTracesGroupedByName(
         input.projectId,
         tracesTableUiColumnDefinitions,
-        startTimeFilter
-          ? [
-              {
-                column: "Timestamp",
-                operator: startTimeFilter.operator,
-                value: startTimeFilter.value,
-                type: "datetime",
-              },
-            ]
-          : [],
+        traceTimestampFilters,
       );
       return traces.map((i) => ({ traceName: i.name }));
     };
@@ -49,16 +51,7 @@ export const filterOptionsQuery = protectedProjectProcedure
     > => {
       const traces = await getTracesGroupedByTags({
         projectId: input.projectId,
-        filter: startTimeFilter
-          ? [
-              {
-                column: "Timestamp",
-                operator: startTimeFilter.operator,
-                value: startTimeFilter.value,
-                type: "datetime",
-              },
-            ]
-          : [],
+        filter: traceTimestampFilters,
       });
       return traces.map((i) => ({ tag: i.value }));
     };
@@ -74,57 +67,24 @@ export const filterOptionsQuery = protectedProjectProcedure
       modelId,
     ] = await Promise.all([
       // numeric scores
-      getNumericScoresGroupedByName(
-        input.projectId,
-        startTimeFilter
-          ? [
-              {
-                column: "Timestamp",
-                operator: startTimeFilter.operator,
-                value: startTimeFilter.value,
-                type: "datetime",
-              },
-            ]
-          : [],
-      ),
+      getNumericScoresGroupedByName(input.projectId, traceTimestampFilters),
       // categorical scores
-      getCategoricalScoresGroupedByName(
-        input.projectId,
-        startTimeFilter
-          ? [
-              {
-                column: "Timestamp",
-                operator: startTimeFilter.operator,
-                value: startTimeFilter.value,
-                type: "datetime",
-              },
-            ]
-          : [],
-      ),
+      getCategoricalScoresGroupedByName(input.projectId, traceTimestampFilters),
       //model
-      getObservationsGroupedByModel(
-        input.projectId,
-        startTimeFilter ? [startTimeFilter] : [],
-      ),
+      getObservationsGroupedByModel(input.projectId, startTimeFilter ?? []),
       //name
-      getObservationsGroupedByName(
-        input.projectId,
-        startTimeFilter ? [startTimeFilter] : [],
-      ),
+      getObservationsGroupedByName(input.projectId, startTimeFilter ?? []),
       //prompt name
       getObservationsGroupedByPromptName(
         input.projectId,
-        startTimeFilter ? [startTimeFilter] : [],
+        startTimeFilter ?? [],
       ),
       //trace name
       getClickhouseTraceName(),
       // trace tags
       getClickhouseTraceTags(),
       // modelId
-      getObservationsGroupedByModelId(
-        input.projectId,
-        startTimeFilter ? [startTimeFilter] : [],
-      ),
+      getObservationsGroupedByModelId(input.projectId, startTimeFilter ?? []),
     ]);
 
     // typecheck filter options, needs to include all columns with options

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -182,28 +182,25 @@ export const scoresRouter = createTRPCRouter({
     .input(
       z.object({
         projectId: z.string(),
-        timestampFilter: timeFilter.optional(),
+        timestampFilter: z.array(timeFilter).optional(),
       }),
     )
     .query(async ({ input }) => {
       const { timestampFilter } = input;
       const [names, tags, traceNames, userIds] = await Promise.all([
-        getScoreNames(
-          input.projectId,
-          timestampFilter ? [timestampFilter] : [],
-        ),
+        getScoreNames(input.projectId, timestampFilter ?? []),
         getTracesGroupedByTags({
           projectId: input.projectId,
-          filter: timestampFilter ? [timestampFilter] : [],
+          filter: timestampFilter ?? [],
         }),
         getTracesGroupedByName(
           input.projectId,
           tracesTableUiColumnDefinitions,
-          timestampFilter ? [timestampFilter] : [],
+          timestampFilter ?? [],
         ),
         getTracesGroupedByUsers(
           input.projectId,
-          timestampFilter ? [timestampFilter] : [],
+          timestampFilter ?? [],
           undefined,
           100, // limit to top 100 users
           0,

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -180,7 +180,7 @@ export const traceRouter = createTRPCRouter({
     .input(
       z.object({
         projectId: z.string(),
-        timestampFilter: timeFilter.optional(),
+        timestampFilter: z.array(timeFilter).optional(),
       }),
     )
     .query(async ({ input }) => {
@@ -194,33 +194,30 @@ export const traceRouter = createTRPCRouter({
         userIds,
         sessionIds,
       ] = await Promise.all([
-        getNumericScoresGroupedByName(
-          input.projectId,
-          timestampFilter ? [timestampFilter] : [],
-        ),
+        getNumericScoresGroupedByName(input.projectId, timestampFilter ?? []),
         getCategoricalScoresGroupedByName(
           input.projectId,
-          timestampFilter ? [timestampFilter] : [],
+          timestampFilter ?? [],
         ),
         getTracesGroupedByName(
           input.projectId,
           tracesTableUiColumnDefinitions,
-          timestampFilter ? [timestampFilter] : [],
+          timestampFilter ?? [],
         ),
         getTracesGroupedByTags({
           projectId: input.projectId,
-          filter: timestampFilter ? [timestampFilter] : [],
+          filter: timestampFilter ?? [],
         }),
         getTracesGroupedByUsers(
           input.projectId,
-          timestampFilter ? [timestampFilter] : [],
+          timestampFilter ?? [],
           undefined,
           100,
           0,
         ),
         getTracesGroupedBySessionId(
           input.projectId,
-          timestampFilter ? [timestampFilter] : [],
+          timestampFilter ?? [],
           undefined,
           100,
           0,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update filter logic to handle arrays of time filters, ensuring sidebar items and counts respect selected time range.
> 
>   - **Behavior**:
>     - Update `startTimeFilter` and `timestampFilter` to handle arrays of `TimeFilter` in `observations.tsx`, `scores.tsx`, `sessions.tsx`, and `traces.tsx`.
>     - Modify API queries in `filterOptionsQuery.ts`, `scores.ts`, `sessions.ts`, and `traces.ts` to accept arrays of `TimeFilter`.
>   - **Filter Logic**:
>     - Replace single `timeFilter` with array handling in `filterOptionsQuery.ts`, `scores.ts`, `sessions.ts`, and `traces.ts`.
>     - Use `?? []` to provide default empty array for filters in `filterOptionsQuery.ts`, `scores.ts`, `sessions.ts`, and `traces.ts`.
>   - **Misc**:
>     - Add `type TimeFilter` import in `observations.tsx`, `scores.tsx`, `sessions.tsx`, and `traces.tsx`.
>     - Minor refactoring for filter handling in `sessions.tsx` and `traces.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c6e5c4307503e785bb8a764c4ba61d82c0b7de7e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->