### PR TITLE
fix(ci): always run llm tests if on tagged release

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -386,7 +386,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - pre-job
-    if: needs.pre-job.outputs.should_skip != 'true' && (needs.pre-job.outputs.llm_connections_changed == 'true' || github.event_name == 'workflow_dispatch')
+    if: startsWith(github.ref, 'refs/tags/') || (needs.pre-job.outputs.should_skip != 'true' && (needs.pre-job.outputs.llm_connections_changed == 'true' || github.event_name == 'workflow_dispatch'))
     name: test-worker-llm-connections (node24, pg15)
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modified `test-worker-llm-connections` job in `pipeline.yml` to always run on tagged releases.
> 
>   - **CI Workflow**:
>     - In `pipeline.yml`, modified `test-worker-llm-connections` job condition to always run on tagged releases by adding `startsWith(github.ref, 'refs/tags/')` to the `if` condition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9d91f1ee4ecbdb9cc3c4b8a2aa3c72e647b42a15. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->