### PR TITLE
chore(seeder): implement bulk/synthetic mode for data generation

### DIFF
--- a/packages/shared/scripts/seeder/load-seed-clickhouse.ts
+++ b/packages/shared/scripts/seeder/load-seed-clickhouse.ts
@@ -116,7 +116,6 @@ async function main() {
 
     await prepareClickhouse(createdProjectIds, {
       numberOfDays,
-      totalObservations: totalObservations ?? 1000,
       numberOfRuns: 3,
     });
 

--- a/packages/shared/scripts/seeder/prepare-clickhouse.ts
+++ b/packages/shared/scripts/seeder/prepare-clickhouse.ts
@@ -9,7 +9,6 @@ export const prepareClickhouse = async (
   projectIds: string[],
   opts: {
     numberOfDays: number;
-    totalObservations: number;
     numberOfRuns?: number;
   },
 ) => {
@@ -18,8 +17,8 @@ export const prepareClickhouse = async (
   );
 
   const formattedOpts: SeederOptions = {
+    mode: "bulk",
     numberOfDays: opts.numberOfDays,
-    totalObservations: opts.totalObservations,
     numberOfRuns: opts.numberOfRuns || 1,
   };
 

--- a/packages/shared/scripts/seeder/seed-clickhouse.ts
+++ b/packages/shared/scripts/seeder/seed-clickhouse.ts
@@ -14,7 +14,6 @@ async function main() {
     }
     await prepareClickhouse(projectIds, {
       numberOfDays: 3,
-      totalObservations: 100000,
       numberOfRuns: 3,
     });
 

--- a/packages/shared/scripts/seeder/utils/types.ts
+++ b/packages/shared/scripts/seeder/utils/types.ts
@@ -1,8 +1,22 @@
+/**
+ * Seeder mode controls data generation strategy:
+ * - "bulk": SQL-level generation, fast, high-volume (100k observations). Default.
+ * - "synthetic": Memory-based generation, slower, realistic structure (1k observations).
+ */
+export type SeederMode = "bulk" | "synthetic";
+
 export interface SeederOptions {
+  mode: SeederMode;
   numberOfDays: number;
   numberOfRuns?: number;
-  totalObservations?: number;
 }
+
+/**
+ * Resolves total observations based on seeder mode
+ */
+export const getTotalObservationsForMode = (mode: SeederMode): number => {
+  return mode === "bulk" ? 100000 : 1000;
+};
 
 export interface DatasetItemInput {
   datasetName: string;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Implements bulk and synthetic modes for data generation in the seeder, introducing a `mode` option in `SeederOptions` and removing `totalObservations`.
> 
>   - **Behavior**:
>     - Introduces `mode` option in `SeederOptions` to control data generation strategy (`bulk` or `synthetic`).
>     - Removes `totalObservations` parameter from `prepareClickhouse` and related functions.
>     - Defaults to `bulk` mode in `prepareClickhouse`.
>   - **Functions**:
>     - Adds `getTotalObservationsForMode()` in `types.ts` to determine observations based on mode.
>     - Updates `executeFullSeed()` in `SeederOrchestrator` to use new mode logic.
>   - **Misc**:
>     - Logging updates in `SeederOrchestrator` to reflect mode and observation count.
>     - Minor refactoring in `load-seed-clickhouse.ts` and `seed-clickhouse.ts` to align with new mode logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d652432243064190d0e3d69074e18c8e050b36d8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->