### PR TITLE
chore: V2 of don't run llm tests unless required to avoid throttling on CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,12 +21,28 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      llm_connections_changed: ${{ steps.filter.outputs.llm_connections }}
     timeout-minutes: 15
+    permissions:
+      pull-requests: read
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
         with:
           do_not_skip: '["workflow_dispatch"]'
+      - uses: actions/checkout@v4
+        with:
+          # Recommended for paths-filter action
+          # may save additional git fetch roundtrip if
+          # merge-base is found within latest N commits
+          fetch-depth: 20
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            llm_connections:
+              - 'packages/shared/package.json'
+              - 'packages/shared/src/server/llm/fetchLLMCompletion.ts'
 
   lint:
     runs-on: ubuntu-latest
@@ -370,7 +386,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - pre-job
-    if: needs.pre-job.outputs.should_skip != 'true'
+    if: startsWith(github.ref, 'refs/tags/') || (needs.pre-job.outputs.should_skip != 'true' && (needs.pre-job.outputs.llm_connections_changed == 'true' || github.event_name == 'workflow_dispatch'))
     name: test-worker-llm-connections (node24, pg15)
     steps:
       - uses: actions/checkout@v4
@@ -579,7 +595,17 @@ jobs:
         tests-web-async,
       ]
     if: always()
+    outputs:
+      success: ${{ steps.set-success-output.outputs.success }}
     steps:
+      - name: Set check result as an output
+        id: set-success-output
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "success=false" >> $GITHUB_OUTPUT
+          else
+            echo "success=true" >> $GITHUB_OUTPUT
+          fi
       - name: Successful deploy
         if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
         run: exit 0
@@ -596,10 +622,14 @@ jobs:
           notify_when: "failure"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Output job results
+        run: |
+          echo "Job results: ${{ steps.set-success-output.outputs.success }}"
 
   push-docker-image:
     needs: all-ci-passed
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    # if something inside all-ci-passed was skipped, but everything that ran passed, we still want to deploy
+    if: always() && needs.all-ci-passed.outputs.success == 'true' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     environment: "protected branches"
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimize CI/CD pipeline to run LLM connection tests only when necessary, reducing CI throttling.
> 
>   - **CI/CD Pipeline**:
>     - Adds `llm_connections_changed` output in `pre-job` to track changes in `packages/shared/package.json` and `packages/shared/src/server/llm/fetchLLMCompletion.ts`.
>     - Modifies `test-worker-llm-connections` job to run only if LLM connections change, a tag is pushed, or the workflow is manually triggered.
>   - **Job Outputs**:
>     - Adds `success` output in `all-ci-passed` to determine if all jobs passed or were skipped.
>     - Updates `push-docker-image` job to check `success` output before proceeding with deployment.
>   - **Misc**:
>     - Adds `Set check result as an output` step in `all-ci-passed` to determine overall job success.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 439b7e26032197199146e915651a726a0b27150c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->