### PR TITLE
style(compare-view): filter button as ghost

### DIFF
--- a/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
+++ b/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
@@ -35,7 +35,7 @@ function RunAggregateHeader({
     <div className="flex w-full flex-row items-center justify-between gap-2">
       <span>{runName}</span>
       <PopoverFilterBuilder
-        buttonVariant="ghost"
+        buttonType="icon"
         columns={columns}
         filterState={getFiltersForRun(runId)}
         onChange={(filters: FilterState) =>

--- a/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
+++ b/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
@@ -35,6 +35,7 @@ function RunAggregateHeader({
     <div className="flex w-full flex-row items-center justify-between gap-2">
       <span>{runName}</span>
       <PopoverFilterBuilder
+        buttonVariant="ghost"
         columns={columns}
         filterState={getFiltersForRun(runId)}
         onChange={(filters: FilterState) =>

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -63,6 +63,7 @@ export function PopoverFilterBuilder({
   onChange,
   columnsWithCustomSelect = [],
   filterWithAI = false,
+  buttonVariant = "outline",
 }: {
   columns: ColumnDefinition[];
   filterState: FilterState;
@@ -71,6 +72,7 @@ export function PopoverFilterBuilder({
     | ((newState: FilterState) => void);
   columnsWithCustomSelect?: string[];
   filterWithAI?: boolean;
+  buttonVariant?: "outline" | "ghost";
 }) {
   const capture = usePostHogClientCapture();
   const [wipFilterState, _setWipFilterState] =
@@ -125,7 +127,7 @@ export function PopoverFilterBuilder({
         }}
       >
         <PopoverTrigger asChild>
-          <Button variant="outline" type="button">
+          <Button variant={buttonVariant} type="button">
             <span>Filters</span>
             {filterState.length > 0 && filterState.length < 3 ? (
               <InlineFilterState

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -16,6 +16,7 @@ import {
   Check,
   ChevronDown,
   ExternalLink,
+  FilterIcon,
   Info,
   Plus,
   WandSparkles,
@@ -63,7 +64,7 @@ export function PopoverFilterBuilder({
   onChange,
   columnsWithCustomSelect = [],
   filterWithAI = false,
-  buttonVariant = "outline",
+  buttonType = "default",
 }: {
   columns: ColumnDefinition[];
   filterState: FilterState;
@@ -72,7 +73,7 @@ export function PopoverFilterBuilder({
     | ((newState: FilterState) => void);
   columnsWithCustomSelect?: string[];
   filterWithAI?: boolean;
-  buttonVariant?: "outline" | "ghost";
+  buttonType?: "default" | "icon";
 }) {
   const capture = usePostHogClientCapture();
   const [wipFilterState, _setWipFilterState] =
@@ -127,27 +128,47 @@ export function PopoverFilterBuilder({
         }}
       >
         <PopoverTrigger asChild>
-          <Button variant={buttonVariant} type="button">
-            <span>Filters</span>
-            {filterState.length > 0 && filterState.length < 3 ? (
-              <InlineFilterState
-                filterState={filterState}
-                className="hidden @6xl:block"
-              />
-            ) : null}
-            {filterState.length > 0 ? (
-              <span
-                className={cn(
-                  "ml-1.5 rounded-sm bg-input px-1 text-xs shadow-sm @6xl:hidden",
-                  filterState.length > 2 && "@6xl:inline",
-                )}
-              >
-                {filterState.length}
-              </span>
-            ) : (
-              <ChevronDown className="ml-1 h-4 w-4 opacity-50" />
-            )}
-          </Button>
+          {buttonType === "default" ? (
+            <Button variant="outline" type="button">
+              <span>Filters</span>
+              {filterState.length > 0 && filterState.length < 3 ? (
+                <InlineFilterState
+                  filterState={filterState}
+                  className="hidden @6xl:block"
+                />
+              ) : null}
+              {filterState.length > 0 ? (
+                <span
+                  className={cn(
+                    "ml-1.5 rounded-sm bg-input px-1 text-xs shadow-sm @6xl:hidden",
+                    filterState.length > 2 && "@6xl:inline",
+                  )}
+                >
+                  {filterState.length}
+                </span>
+              ) : (
+                <ChevronDown className="ml-1 h-4 w-4 opacity-50" />
+              )}
+            </Button>
+          ) : (
+            <Button
+              size="icon"
+              type="button"
+              variant="ghost"
+              className="relative"
+            >
+              <FilterIcon className="h-4 w-4" />
+              {filterState.length > 0 && (
+                <span
+                  className={cn(
+                    "absolute -right-1 top-0 flex h-4 min-w-4 items-center justify-center rounded-sm bg-input px-1 text-xs shadow-sm",
+                  )}
+                >
+                  {filterState.length}
+                </span>
+              )}
+            </Button>
+          )}
         </PopoverTrigger>
         <PopoverContent
           className="w-fit max-w-[90vw] overflow-x-auto"
@@ -163,15 +184,27 @@ export function PopoverFilterBuilder({
         </PopoverContent>
       </Popover>
       {filterState.length > 0 ? (
-        <Button
-          onClick={() => setWipFilterState([])}
-          variant="ghost"
-          type="button"
-          size="icon"
-          className="ml-0.5"
-        >
-          <X className="h-4 w-4" />
-        </Button>
+        buttonType === "default" ? (
+          <Button
+            onClick={() => setWipFilterState([])}
+            variant="ghost"
+            type="button"
+            size="icon"
+            className="ml-0.5"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        ) : (
+          <Button
+            onClick={() => setWipFilterState([])}
+            variant="ghost"
+            type="button"
+            size="icon-xs"
+            className="ml-0.5 hover:bg-background"
+          >
+            <X className="h-3 w-3" />
+          </Button>
+        )
       ) : null}
     </div>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `buttonType` prop to `PopoverFilterBuilder` for ghost icon button support in `DatasetRunAggregateColumnHelpers.tsx`.
> 
>   - **Behavior**:
>     - `PopoverFilterBuilder` in `filter-builder.tsx` now supports `buttonType` prop with values `default` or `icon`.
>     - In `DatasetRunAggregateColumnHelpers.tsx`, `PopoverFilterBuilder` is used with `buttonType="icon"`.
>   - **UI Changes**:
>     - When `buttonType` is `icon`, the filter button is a ghost icon button with a `FilterIcon`.
>     - Adjusts button size and appearance based on `buttonType` in `filter-builder.tsx`.
>   - **Misc**:
>     - Adds `FilterIcon` import in `filter-builder.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 44442c162f5e056ede0949d047a072e9e6507f01. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->