### PR TITLE
fix: allow compare button even if just one row selected

### DIFF
--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -115,16 +115,12 @@ const DatasetRunTableMultiSelectAction = ({
         <DropdownMenuContent key="dropdown-menu-content">
           <Link
             key="compare"
-            href={
-              selectedRunIds.length < 2
-                ? "#"
-                : {
-                    pathname: `/project/${projectId}/datasets/${datasetId}/compare`,
-                    query: { runs: selectedRunIds },
-                  }
-            }
+            href={{
+              pathname: `/project/${projectId}/datasets/${datasetId}/compare`,
+              query: { runs: selectedRunIds },
+            }}
           >
-            <DropdownMenuItem disabled={selectedRunIds.length < 2}>
+            <DropdownMenuItem>
               <Columns3 className="mr-2 h-4 w-4" />
               <span>Compare</span>
             </DropdownMenuItem>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enables 'Compare' button in `DatasetRunsTable.tsx` when at least one row is selected, removing the previous two-row requirement.
> 
>   - **Behavior**:
>     - Enables 'Compare' button when at least one row is selected in `DatasetRunTableMultiSelectAction` in `DatasetRunsTable.tsx`.
>     - Removes condition disabling 'Compare' button for less than two selected rows.
>   - **UI**:
>     - `DropdownMenuItem` for 'Compare' no longer has a `disabled` attribute based on row selection count.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4e489f7f7912abeb168b2f8bb065d74a7e7d1bf6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->