### PR TITLE
fix(otel): map ai sdk events if functionID is appended to operation.name

### DIFF
--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -1217,6 +1217,8 @@ describe("OTel Resource Span Mapping", () => {
       ["ai.embed.doEmbed", "embedding-create"],
       ["ai.embedMany", "embedding-create"],
       ["ai.embedMany.doEmbed", "embedding-create"],
+      ["ai.embed generate-document-embedding", "embedding-create"],
+      ["ai.embed.doEmbed generate-document-embedding", "embedding-create"],
       ["ai.toolCall", "tool-create"],
     ])(
       "should map AI SDK %s operation to %s event",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces `SimpleAttributeMapper` with `CustomAttributeMapper` in `ObservationTypeMapperRegistry` to handle AI SDK operations with appended function IDs, and adds corresponding tests.
> 
>   - **Behavior**:
>     - Replaces `SimpleAttributeMapper` with `CustomAttributeMapper` for `Vercel_AI_SDK_Operation` in `ObservationTypeMapperRegistry` to handle function ID appended to `operation.name`.
>     - Checks if `operation.name` starts with known prefixes instead of exact match.
>   - **Tests**:
>     - Adds test cases in `otelMapping.servertest.ts` to verify mapping of operations with appended function IDs, such as `ai.embed generate-document-embedding`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6e63d5ee2152ec045abac096ba221adc53da843e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->