### PR TITLE
feat(trpc): support silencing error notifications based on query metadata

### DIFF
--- a/web/src/hooks/useTrpcError.tsx
+++ b/web/src/hooks/useTrpcError.tsx
@@ -1,0 +1,12 @@
+import { TRPCClientError } from "@trpc/client";
+
+export function useTrpcError(
+  error: unknown | null,
+  silentHttpCodes: number[],
+): { isSilentError: boolean } {
+  return {
+    isSilentError:
+      error instanceof TRPCClientError &&
+      silentHttpCodes.includes(error.data.httpStatus),
+  };
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add feature to silence error notifications based on HTTP status codes, with implementation in `useTrpcError.tsx` and `api.ts`, and usage in `DatasetAggregateTableCell.tsx`.
> 
>   - **Behavior**:
>     - Add support for silencing error notifications based on HTTP status codes in `useTrpcError.tsx` and `api.ts`.
>     - `DatasetAggregateTableCell.tsx` uses `useTrpcError` to handle 404 errors silently, displaying a custom message instead.
>   - **Functions**:
>     - `useTrpcError` in `useTrpcError.tsx` checks if an error should be silent based on `silentHttpCodes`.
>     - `handleTrpcError` in `api.ts` modified to accept `shouldSilenceError` parameter.
>     - `shouldSilenceError` function in `api.ts` determines if an error should be silenced based on metadata.
>   - **UI Changes**:
>     - In `DatasetAggregateTableCell.tsx`, buttons and data display are conditionally rendered based on error silence status.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0c7a07aedf2b3c47fc70478763bd0c678577c4c0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->