### PR TITLE
fix: restore tracesUiColumnDefinitions in traces API

### DIFF
--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -24,7 +24,6 @@ export {
   convertApiProvidedFilterToClickhouseFilter,
   createPublicApiObservationsColumnMapping,
   createPublicApiTracesColumnMapping,
-  createTracesUiColumnDefinitions,
   deriveFilters,
   type ApiColumnMapping,
 } from "./public-api-filter-builder";

--- a/packages/shared/src/server/queries/public-api-filter-builder.ts
+++ b/packages/shared/src/server/queries/public-api-filter-builder.ts
@@ -124,24 +124,6 @@ export function createPublicApiTracesColumnMapping(
 }
 
 /**
- * Convenience function: Get just the UI column definitions for advanced filters
- */
-export function createTracesUiColumnDefinitions(
-  tableName: "traces" | "events",
-  tablePrefix: "t" | "e",
-) {
-  return TRACES_COLUMN_DEFINITIONS.map((def) => {
-    return {
-      uiTableName: def.name,
-      uiTableId: def.id,
-      clickhouseTableName: tableName,
-      clickhouseSelect: def.column,
-      queryPrefix: tablePrefix,
-    };
-  });
-}
-
-/**
  * Factory function to create public API column mappings for events/observations tables.
  * Eliminates duplication between events and observations filter mappings.
  */

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -17,7 +17,6 @@ import {
   orderByToClickhouseSql,
   createPublicApiObservationsColumnMapping,
   createPublicApiTracesColumnMapping,
-  createTracesUiColumnDefinitions,
   deriveFilters,
   type ApiColumnMapping,
   ObservationPriceFields,
@@ -34,6 +33,7 @@ import {
   eventsTableLegacyTraceUiColumnDefinitions,
   eventsTableUiColumnDefinitions,
 } from "../tableMappings/mapEventsTable";
+import { tracesTableUiColumnDefinitions } from "../tableMappings/mapTracesTable";
 import { DEFAULT_RENDERING_PROPS, RenderingProps } from "../utils/rendering";
 import { queryClickhouse } from "./clickhouse";
 import { ObservationRecordReadType } from "./definitions";
@@ -149,8 +149,7 @@ const PUBLIC_API_TRACES_COLUMN_MAPPING = createPublicApiTracesColumnMapping(
   "t",
 );
 
-const TRACES_FROM_EVENTS_UI_COLUMN_DEFINITIONS =
-  createTracesUiColumnDefinitions("traces", "t");
+const TRACES_FROM_EVENTS_UI_COLUMN_DEFINITIONS = tracesTableUiColumnDefinitions;
 
 /**
  * Order by columns for traces CTE (post-aggregation)

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -9,7 +9,7 @@ import {
   measureAndReturn,
   deriveFilters,
   createPublicApiTracesColumnMapping,
-  createTracesUiColumnDefinitions,
+  tracesTableUiColumnDefinitions,
 } from "@langfuse/shared/src/server";
 import { type OrderByState } from "@langfuse/shared";
 import {
@@ -65,7 +65,7 @@ export const generateTracesForPublicApi = async ({
     props,
     filterParams,
     advancedFilters,
-    tracesUiColumnDefinitions,
+    tracesTableUiColumnDefinitions,
   );
   const appliedFilter = filter.apply();
 
@@ -265,7 +265,7 @@ export const getTracesCountForPublicApi = async ({
     props,
     filterParams,
     advancedFilters,
-    tracesUiColumnDefinitions,
+    tracesTableUiColumnDefinitions,
   );
   const appliedFilter = filter.apply();
 
@@ -326,7 +326,3 @@ const orderByColumns = [
 
 // Use factory functions to create column mappings (eliminates duplication with events table)
 const filterParams = createPublicApiTracesColumnMapping("traces", "t");
-const tracesUiColumnDefinitions = createTracesUiColumnDefinitions(
-  "traces",
-  "t",
-);


### PR DESCRIPTION
In my attempt to DRY I inadvertedly changed the set of filters
usable via the filter= option.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restores `tracesUiColumnDefinitions` in traces API by replacing `createTracesUiColumnDefinitions` with `tracesTableUiColumnDefinitions`.
> 
>   - **Behavior**:
>     - Restores `tracesUiColumnDefinitions` in `traces.ts` and `events.ts` by replacing `createTracesUiColumnDefinitions` with `tracesTableUiColumnDefinitions`.
>   - **Functions**:
>     - Removes `createTracesUiColumnDefinitions` from `public-api-filter-builder.ts`.
>   - **Imports**:
>     - Updates imports in `index.ts`, `events.ts`, and `traces.ts` to use `tracesTableUiColumnDefinitions` instead of `createTracesUiColumnDefinitions`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ccd175a77c91b5da69bf977089f09930b3918820. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->