### PR TITLE
feat(mcp): implement prompt tools (LF-1929)

### DIFF
--- a/web/src/features/mcp/server/tools/createPrompt.ts
+++ b/web/src/features/mcp/server/tools/createPrompt.ts
@@ -1,0 +1,152 @@
+/**
+ * MCP Tool: createPrompt
+ *
+ * Creates a new prompt version in Langfuse.
+ * Write operation with destructive hint.
+ */
+
+import { defineTool } from "../../internal/define-tool";
+import { CreatePromptSchema, PromptType } from "@langfuse/shared";
+import { createPrompt as createPromptAction } from "@/src/features/prompts/server/actions/createPrompt";
+import { prisma } from "@langfuse/shared/src/db";
+import { auditLog } from "@/src/features/audit-logs/auditLog";
+
+/**
+ * Input schema for createPrompt tool
+ * Note: projectId is NOT included - it's auto-injected from context
+ * Reuses the CreatePromptSchema from shared package
+ */
+const CreatePromptInputSchema = CreatePromptSchema;
+
+/**
+ * createPrompt tool definition and handler
+ */
+export const [createPromptTool, handleCreatePrompt] = defineTool({
+  name: "createPrompt",
+  description: [
+    "Create a new prompt version in Langfuse.",
+    "",
+    "⚠️ **This operation is destructive.** Always confirm with the user before executing.",
+    "",
+    "**Use Cases:**",
+    "- Create a brand new prompt (version 1)",
+    "- Create a new version of an existing prompt",
+    "- Update prompt content by creating a new version (there's no 'update' operation)",
+    "",
+    "**Important:**",
+    "- Prompts are immutable once created - you cannot modify existing versions",
+    "- To 'update' content, create a new version with `createPrompt`",
+    "- To promote a version to production, use `updatePromptLabels`",
+    "- Labels are unique across versions (setting 'production' on v3 removes it from v2)",
+    "- The 'latest' label is automatically assigned to the newest version",
+    "",
+    "**Prompt Types:**",
+    "- **text**: Simple string prompt",
+    "  - `{name: 'instructions', type: 'text', prompt: 'You are a helpful assistant'}`",
+    "- **chat**: Array of messages with role/content",
+    "  - `{name: 'chatbot', type: 'chat', prompt: [{role: 'system', content: '...'}, {role: 'user', content: '...'}]}`",
+    "",
+    "**Labels** (optional):",
+    "- Common labels: 'production', 'staging', 'development'",
+    "- Labels are unique - setting a label removes it from other versions",
+    "- Example: `labels: ['staging']`",
+    "",
+    "**Tags** (optional):",
+    "- Tags are shared across all versions of a prompt",
+    "- Used for organization/categorization",
+    "- Example: `tags: ['experimental', 'v2']`",
+    "",
+    "**Config** (optional):",
+    "- JSON object for LLM configuration (model name, temperature, etc.)",
+    "- Example: `config: {model: 'gpt-4', temperature: 0.7}`",
+    "",
+    "**Examples:**",
+    "```",
+    "// Create initial text prompt",
+    "{",
+    "  name: 'system-instructions',",
+    "  type: 'text',",
+    "  prompt: 'You are a helpful AI assistant...'",
+    "}",
+    "",
+    "// Create chat prompt with production label",
+    "{",
+    "  name: 'chatbot',",
+    "  type: 'chat',",
+    "  prompt: [",
+    "    {role: 'system', content: 'You are a coding assistant'},",
+    "    {role: 'user', content: 'Help me debug {{code}}'}",
+    "  ],",
+    "  labels: ['production'],",
+    "  config: {model: 'gpt-4', temperature: 0.3}",
+    "}",
+    "",
+    "// Create new version with commit message",
+    "{",
+    "  name: 'chatbot',",
+    "  type: 'chat',",
+    "  prompt: [...],",
+    "  labels: ['staging'],",
+    "  commitMessage: 'Added better error handling instructions'",
+    "}",
+    "```",
+  ].join("\n"),
+  inputSchema: CreatePromptInputSchema,
+  handler: async (input, context) => {
+    // Create prompt using existing action
+    // Handle discriminated union by building complete params object based on type
+    const createdPrompt = await createPromptAction(
+      input.type === PromptType.Chat
+        ? {
+            projectId: context.projectId,
+            name: input.name,
+            type: PromptType.Chat,
+            prompt: input.prompt, // TypeScript knows this is the chat array type
+            labels: input.labels,
+            config: input.config,
+            tags: input.tags,
+            commitMessage: input.commitMessage,
+            createdBy: "API",
+            prisma,
+          }
+        : {
+            projectId: context.projectId,
+            name: input.name,
+            type: PromptType.Text,
+            prompt: input.prompt, // TypeScript knows this is a string
+            labels: input.labels,
+            config: input.config,
+            tags: input.tags,
+            commitMessage: input.commitMessage,
+            createdBy: "API",
+            prisma,
+          },
+    );
+
+    // Audit log the creation (following pattern from promptsHandler.ts)
+    await auditLog({
+      action: "create",
+      resourceType: "prompt",
+      resourceId: createdPrompt.id,
+      projectId: context.projectId,
+      orgId: context.orgId,
+      apiKeyId: context.apiKeyId,
+      after: createdPrompt,
+    });
+
+    // Return formatted response
+    return {
+      id: createdPrompt.id,
+      name: createdPrompt.name,
+      version: createdPrompt.version,
+      type: createdPrompt.type,
+      labels: createdPrompt.labels,
+      tags: createdPrompt.tags,
+      config: createdPrompt.config,
+      createdAt: createdPrompt.createdAt,
+      createdBy: createdPrompt.createdBy,
+      message: `Successfully created prompt '${createdPrompt.name}' version ${createdPrompt.version}${createdPrompt.labels.length > 0 ? ` with labels: ${createdPrompt.labels.join(", ")}` : ""}`,
+    };
+  },
+  destructiveHint: true,
+});

--- a/web/src/features/mcp/server/tools/getPrompt.ts
+++ b/web/src/features/mcp/server/tools/getPrompt.ts
@@ -1,0 +1,90 @@
+/**
+ * MCP Tool: getPrompt
+ *
+ * Fetches a specific prompt by name with optional label or version.
+ * Read-only operation.
+ */
+
+import { z } from "zod/v4";
+import { defineTool } from "../../internal/define-tool";
+import {
+  ParamPromptName,
+  ParamPromptLabel,
+  ParamPromptVersion,
+} from "../../internal/validation";
+import { getPromptByName } from "@/src/features/prompts/server/actions/getPromptByName";
+import { UserInputError } from "../../internal/errors";
+
+/**
+ * Input schema for getPrompt tool
+ * Note: projectId is NOT included - it's auto-injected from context
+ */
+const GetPromptInputSchema = z
+  .object({
+    name: ParamPromptName,
+    label: ParamPromptLabel,
+    version: ParamPromptVersion,
+  })
+  .refine((data) => !(data.label && data.version), {
+    message:
+      "Cannot specify both label and version - they are mutually exclusive",
+  });
+
+/**
+ * getPrompt tool definition and handler
+ */
+export const [getPromptTool, handleGetPrompt] = defineTool({
+  name: "getPrompt",
+  description: [
+    "Fetch a specific prompt by name.",
+    "",
+    "You can retrieve a prompt by:",
+    "- **Label**: Get the prompt with a specific label (e.g., 'production', 'staging')",
+    "- **Version**: Get a specific version number (e.g., 1, 2, 3)",
+    "- **Default**: If neither label nor version is specified, returns the 'production' version",
+    "",
+    "⚠️ **Note**: `label` and `version` are mutually exclusive - specify only one.",
+    "",
+    "**Examples:**",
+    "- Get production prompt: `{name: 'chatbot'}`",
+    "- Get staging prompt: `{name: 'chatbot', label: 'staging'}`",
+    "- Get specific version: `{name: 'chatbot', version: 3}`",
+    "",
+    "**Returns:** Full prompt content including compiled templates with resolved dependencies.",
+  ].join("\n"),
+  inputSchema: GetPromptInputSchema,
+  handler: async (input, context) => {
+    const { name, label, version } = input;
+
+    // Fetch prompt using existing service
+    const prompt = await getPromptByName({
+      promptName: name,
+      projectId: context.projectId, // Auto-injected from authenticated API key
+      label,
+      version,
+    });
+
+    if (!prompt) {
+      throw new UserInputError(
+        `Prompt '${name}' not found${label ? ` with label '${label}'` : ""}${version ? ` with version ${version}` : ""}`,
+      );
+    }
+
+    // Return formatted response
+    return {
+      id: prompt.id,
+      name: prompt.name,
+      version: prompt.version,
+      type: prompt.type,
+      prompt: prompt.prompt,
+      labels: prompt.labels,
+      tags: prompt.tags,
+      config: prompt.config,
+      createdAt: prompt.createdAt,
+      updatedAt: prompt.updatedAt,
+      createdBy: prompt.createdBy,
+      projectId: prompt.projectId,
+    };
+  },
+  readOnlyHint: true,
+});

--- a/web/src/features/mcp/server/tools/index.ts
+++ b/web/src/features/mcp/server/tools/index.ts
@@ -2,14 +2,18 @@
  * MCP Tools
  *
  * Export all MCP tool definitions and handlers.
- * Tools will be implemented in LF-1929.
  *
- * Planned tools:
- * - getPrompt: Fetch a prompt by name and version/label
- * - listPrompts: List and filter prompts
- * - createPrompt: Create a new prompt version
- * - updatePromptLabels: Update labels on a prompt version
+ * Tools (4/25 - within MCP best practice limit):
+ * - getPrompt (read): Fetch specific prompt by name/label/version
+ * - listPrompts (read): List and filter prompts
+ * - createPrompt (write): Create new prompt version
+ * - updatePromptLabels (write): Update labels only
  */
 
-// Placeholder - tools will be exported here in LF-1929
-export {};
+export { getPromptTool, handleGetPrompt } from "./getPrompt";
+export { listPromptsTool, handleListPrompts } from "./listPrompts";
+export { createPromptTool, handleCreatePrompt } from "./createPrompt";
+export {
+  updatePromptLabelsTool,
+  handleUpdatePromptLabels,
+} from "./updatePromptLabels";

--- a/web/src/features/mcp/server/tools/listPrompts.ts
+++ b/web/src/features/mcp/server/tools/listPrompts.ts
@@ -1,0 +1,100 @@
+/**
+ * MCP Tool: listPrompts
+ *
+ * Lists and filters prompts in the project.
+ * Read-only operation.
+ */
+
+import { z } from "zod/v4";
+import { defineTool } from "../../internal/define-tool";
+import {
+  ParamPromptName,
+  ParamPromptLabel,
+  ParamPromptTag,
+  ParamLimit,
+  ParamPage,
+} from "../../internal/validation";
+import { getPromptsMeta } from "@/src/features/prompts/server/actions/getPromptsMeta";
+
+/**
+ * Input schema for listPrompts tool
+ * Note: projectId is NOT included - it's auto-injected from context
+ */
+const ListPromptsInputSchema = z.object({
+  name: ParamPromptName.optional().describe(
+    "Filter by exact prompt name match",
+  ),
+  label: ParamPromptLabel.describe(
+    "Filter by label (e.g., 'production', 'staging')",
+  ),
+  tag: ParamPromptTag.describe("Filter by tag (e.g., 'experimental', 'v1')"),
+  page: ParamPage,
+  limit: ParamLimit,
+});
+
+/**
+ * listPrompts tool definition and handler
+ */
+export const [listPromptsTool, handleListPrompts] = defineTool({
+  name: "listPrompts",
+  description: [
+    "List and filter prompts in the project.",
+    "",
+    "Returns metadata about prompts including:",
+    "- All available versions",
+    "- All labels applied to any version",
+    "- Tags",
+    "- Last updated timestamp",
+    "- Prompt type (text or chat)",
+    "",
+    "**Filters** (all optional):",
+    "- `name`: Filter by exact prompt name",
+    "- `label`: Filter to prompts that have this label on any version",
+    "- `tag`: Filter to prompts with this tag",
+    "",
+    "**Pagination:**",
+    "- `page`: Page number (default: 1)",
+    "- `limit`: Items per page (1-100, default: 50)",
+    "",
+    "**Examples:**",
+    "- List all prompts: `{}`",
+    "- List production prompts: `{label: 'production'}`",
+    "- List experimental prompts: `{tag: 'experimental'}`",
+    "- Get specific prompt metadata: `{name: 'chatbot'}`",
+    "- Paginate results: `{page: 2, limit: 20}`",
+  ].join("\n"),
+  inputSchema: ListPromptsInputSchema,
+  handler: async (input, context) => {
+    const { name, label, tag, page, limit } = input;
+
+    // Fetch prompts metadata using existing service
+    const result = await getPromptsMeta({
+      projectId: context.projectId, // Auto-injected from authenticated API key
+      name,
+      label,
+      tag,
+      page, // Default handled by Zod schema
+      limit, // Default handled by Zod schema
+    });
+
+    // Return formatted response
+    return {
+      data: result.data.map((prompt) => ({
+        name: prompt.name,
+        type: prompt.type,
+        versions: prompt.versions,
+        labels: prompt.labels,
+        tags: prompt.tags,
+        lastUpdatedAt: prompt.lastUpdatedAt,
+        lastConfig: prompt.lastConfig,
+      })),
+      pagination: {
+        page: result.pagination.page,
+        limit: result.pagination.limit,
+        totalPages: result.pagination.totalPages,
+        totalItems: result.pagination.totalItems,
+      },
+    };
+  },
+  readOnlyHint: true,
+});

--- a/web/src/features/mcp/server/tools/updatePromptLabels.ts
+++ b/web/src/features/mcp/server/tools/updatePromptLabels.ts
@@ -1,0 +1,139 @@
+/**
+ * MCP Tool: updatePromptLabels
+ *
+ * Updates labels for a specific prompt version.
+ * Write operation with destructive hint.
+ * This is the ONLY way to modify existing prompts (labels only).
+ */
+
+import { z } from "zod/v4";
+import { defineTool } from "../../internal/define-tool";
+import { ParamPromptName, ParamNewLabels } from "../../internal/validation";
+import { updatePrompt } from "@/src/features/prompts/server/actions/updatePrompts";
+import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { prisma } from "@langfuse/shared/src/db";
+import { UserInputError } from "../../internal/errors";
+
+/**
+ * Input schema for updatePromptLabels tool
+ * Note: projectId is NOT included - it's auto-injected from context
+ */
+const UpdatePromptLabelsInputSchema = z.object({
+  name: ParamPromptName,
+  version: z.coerce
+    .number()
+    .int()
+    .positive()
+    .describe("The version number to update (required)"),
+  newLabels: ParamNewLabels,
+});
+
+/**
+ * updatePromptLabels tool definition and handler
+ */
+export const [updatePromptLabelsTool, handleUpdatePromptLabels] = defineTool({
+  name: "updatePromptLabels",
+  description: [
+    "Update labels for a specific prompt version.",
+    "",
+    "⚠️ **This operation is destructive.** Always confirm with the user before executing.",
+    "",
+    "**Important Behavior:**",
+    "- This is the ONLY way to modify existing prompts (labels only)",
+    "- Labels are unique across versions - setting 'production' on v3 removes it from v2",
+    "- You cannot modify prompt content - create a new version instead with `createPrompt`",
+    "- The 'latest' label is automatically managed and cannot be set manually",
+    "",
+    "**Common Use Cases:**",
+    "- **Promote to production**: Move 'production' label to a new version",
+    "- **Demote from production**: Remove 'production' label (set to [])",
+    "- **Stage for testing**: Add 'staging' label to a version",
+    "",
+    "**Label Uniqueness:**",
+    "When you set labels on a version, those labels are automatically removed from",
+    "all other versions of the same prompt. This ensures each label points to exactly",
+    "one version.",
+    "",
+    "**Examples:**",
+    "```",
+    "// Promote version 3 to production",
+    "// (automatically removes 'production' from other versions)",
+    "{",
+    "  name: 'chatbot',",
+    "  version: 3,",
+    "  newLabels: ['production']",
+    "}",
+    "",
+    "// Add multiple labels to version 2",
+    "{",
+    "  name: 'system-prompt',",
+    "  version: 2,",
+    "  newLabels: ['staging', 'testing']",
+    "}",
+    "",
+    "// Remove all labels from version 1",
+    "{",
+    "  name: 'instructions',",
+    "  version: 1,",
+    "  newLabels: []",
+    "}",
+    "```",
+    "",
+    "**What You CANNOT Do:**",
+    "- ❌ Set 'latest' label (it's auto-managed)",
+    "- ❌ Modify prompt content (use `createPrompt` to create a new version)",
+    "- ❌ Change prompt type (use `createPrompt` with a new name)",
+    "- ❌ Modify tags (tags are managed via `createPrompt`)",
+  ].join("\n"),
+  inputSchema: UpdatePromptLabelsInputSchema,
+  handler: async (input, context) => {
+    const { name, version, newLabels } = input;
+
+    // Fetch existing prompt to capture "before" state for audit log
+    const existingPrompt = await prisma.prompt.findUnique({
+      where: {
+        projectId_name_version: {
+          projectId: context.projectId,
+          name,
+          version,
+        },
+      },
+    });
+
+    if (!existingPrompt) {
+      throw new UserInputError(
+        `Prompt '${name}' version ${version} not found in project`,
+      );
+    }
+
+    // Update prompt labels using existing action
+    const updatedPrompt = await updatePrompt({
+      promptName: name,
+      projectId: context.projectId, // Auto-injected from authenticated API key
+      promptVersion: version,
+      newLabels,
+    });
+
+    // Audit log the update with both before and after states
+    await auditLog({
+      action: "update",
+      resourceType: "prompt",
+      resourceId: updatedPrompt.id,
+      projectId: context.projectId,
+      orgId: context.orgId,
+      apiKeyId: context.apiKeyId,
+      before: existingPrompt,
+      after: updatedPrompt,
+    });
+
+    // Return formatted response
+    return {
+      id: updatedPrompt.id,
+      name: updatedPrompt.name,
+      version: updatedPrompt.version,
+      labels: updatedPrompt.labels,
+      message: `Successfully updated labels for '${updatedPrompt.name}' version ${updatedPrompt.version}. Labels are now: ${updatedPrompt.labels.length > 0 ? updatedPrompt.labels.join(", ") : "(none)"}`,
+    };
+  },
+  destructiveHint: true,
+});


### PR DESCRIPTION
## Summary

Implements 4 MCP tools for prompt management following Sentry MCP patterns (LF-1929).

**Read-only tools:**
- `getPrompt`: Fetch specific prompt by name/label/version
- `listPrompts`: List and filter prompts with pagination

**Write tools:**
- `createPrompt`: Create new prompt versions (the only way to update content)
- `updatePromptLabels`: Update labels on specific versions (promotion workflow)

## Implementation Details

- Uses `defineTool` helper for consistent tool definitions with Zod validation
- Auto-injects `projectId` from authenticated API key context
- Includes proper annotations (`readOnlyHint` for reads, `destructiveHint` for writes)
- Complete audit logging for all write operations with before/after states
- Reuses existing Langfuse actions (getPromptByName, getPromptsMeta, createPrompt, updatePrompt)
- Comprehensive LLM-friendly descriptions with examples
- Schema-level validation for mutually exclusive parameters
- Proper TypeScript discriminated union handling

## Code Review Feedback Addressed

✅ Added "before" state to updatePromptLabels audit log for complete audit trail
✅ Improved type safety in createPrompt discriminated union handling (removed type assertions)
✅ Removed redundant pagination defaults (let Zod schemas be single source of truth)
✅ Added schema validation for mutually exclusive label/version parameters

## Files Changed

### New Files
- `web/src/features/mcp/server/tools/getPrompt.ts` - Read tool to fetch prompts
- `web/src/features/mcp/server/tools/listPrompts.ts` - Read tool to list/filter prompts
- `web/src/features/mcp/server/tools/createPrompt.ts` - Write tool to create prompt versions
- `web/src/features/mcp/server/tools/updatePromptLabels.ts` - Write tool to update labels

### Modified Files
- `web/src/features/mcp/server/tools/index.ts` - Export all tools
- `web/src/features/mcp/server/mcpServer.ts` - Register tools with ListToolsRequestSchema and CallToolRequestSchema handlers

## Test Plan

- [x] Build passes (`pnpm --filter=web run build`)
- [x] Linter passes (`pnpm --filter=web run lint`)
- [x] Code formatter passes (`pnpm -w run format`)
- [x] Code review agent feedback addressed
- [ ] Manual testing with MCP client (to be done during integration testing)

## Relates To

- Part of: LF-1924 (MCP Server Integration)
- Implements: LF-1929 (Implement prompt tools)
- Depends on: LF-1925 (SDK setup), LF-1926 (API route), LF-1927 (auth), LF-1928 (resources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implements four MCP tools for prompt management with validation, logging, and server integration.
> 
>   - **Tools Implemented**:
>     - `getPrompt`: Fetch prompt by name/label/version in `getPrompt.ts`.
>     - `listPrompts`: List and filter prompts with pagination in `listPrompts.ts`.
>     - `createPrompt`: Create new prompt versions in `createPrompt.ts`.
>     - `updatePromptLabels`: Update labels on specific versions in `updatePromptLabels.ts`.
>   - **Server Integration**:
>     - Registers tools in `mcpServer.ts` with `ListToolsRequestSchema` and `CallToolRequestSchema` handlers.
>   - **Validation and Logging**:
>     - Uses `defineTool` for consistent tool definitions with Zod validation.
>     - Auto-injects `projectId` from API key context.
>     - Complete audit logging for write operations with before/after states.
>   - **Miscellaneous**:
>     - Exports all tools in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2e8b49f3408ce99e3063c3a702f17f77cdd527ae. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->