### PR TITLE
 chore(trpc): implement debouncing for toast notifications

### DIFF
--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -59,7 +59,7 @@ const CLIENT_STALE_CACHE_CODES = [404, 400];
 
 // Cache to store hashes of recently shown errors (client-side only)
 const recentErrorCache = new Set<string>();
-const ERROR_DEBOUNCE_MS = 30000;
+const ERROR_DEBOUNCE_MS = 20000;
 
 /**
  * Creates a unique hash for an error to track it for debouncing; implementation hashes based on the tRPC path and http status


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add error toast debouncing in `api.ts` to suppress repeated error notifications within 20 seconds.
> 
>   - **Behavior**:
>     - Introduces error toast debouncing in `api.ts` using `recentErrorCache` and `ERROR_DEBOUNCE_MS`.
>     - Adds `getErrorHash()` to generate unique error identifiers based on tRPC path and HTTP status.
>     - Adds `shouldShowToast()` to manage toast display logic, suppressing repeated errors within 20 seconds.
>   - **Integration**:
>     - Modifies `handleTrpcError()` to use `shouldShowToast()` for error toast display control.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cab503569bffd57d2a4664eb22213143f3bea7d7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->