### PR TITLE
fix(trpc-toast): stop event propagation of `dismissToast`

### DIFF
--- a/web/src/features/notifications/ErrorNotification.tsx
+++ b/web/src/features/notifications/ErrorNotification.tsx
@@ -71,6 +71,14 @@ export const ErrorNotification: React.FC<ErrorNotificationProps> = ({
       <button
         className={`flex h-6 w-6 cursor-pointer items-start justify-end border-none bg-transparent p-0 ${textColor} transition-colors duration-200`}
         onClick={() => dismissToast(toast)}
+        onPointerDown={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+        }}
+        onMouseDown={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+        }}
         aria-label="Close"
       >
         <X size={14} />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds event handlers to stop propagation and prevent default on dismiss button in `ErrorNotification.tsx`.
> 
>   - **Behavior**:
>     - Adds `onPointerDown` and `onMouseDown` event handlers to the dismiss button in `ErrorNotification.tsx` to stop event propagation and prevent default behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 60da9bcaad6902dac13300afb52f1b937ae4c115. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->