### PR TITLE
Pin ClickHouse image version to 25.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       LANGFUSE_INIT_USER_PASSWORD: ${LANGFUSE_INIT_USER_PASSWORD:-}
 
   clickhouse:
-    image: docker.io/clickhouse/clickhouse-server
+    image: docker.io/clickhouse/clickhouse-server:25.8
     restart: always
     user: "101:101"
     environment:


### PR DESCRIPTION
## What does this PR do?

The latest version (25.9) of clickhouse seems to be broken (I can't run Langfuse with it, at least). I see some errors with occupied port numbers, not sure where they are coming from.

The dev docker config pins the version of clickhouse to 25.8, so you may want to stick with it in the prod too.
Running podman-compose with 25.8 solved the problem on my machine.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Pins ClickHouse image version to 25.8 in `docker-compose.yml` to ensure stability and avoid issues with version 25.9.
> 
>   - **Behavior**:
>     - Pins ClickHouse image version to `25.8` in `docker-compose.yml` to avoid issues with the latest version `25.9`.
>   - **Misc**:
>     - Ensures compatibility and stability for Langfuse by using a known working version of ClickHouse.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b2485c56b3648df6ddfdbc39c501e9a4b4f579da. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->