### PR TITLE
chore: fix allInvitesFromProject

### DIFF
--- a/web/src/features/rbac/components/MembershipInvitesPage.tsx
+++ b/web/src/features/rbac/components/MembershipInvitesPage.tsx
@@ -63,7 +63,6 @@ export function MembershipInvitesPage({
   const invites = projectId
     ? api.members.allInvitesFromProject.useQuery(
         {
-          orgId,
           projectId,
           page: paginationState.pageIndex,
           limit: paginationState.pageSize,

--- a/web/src/features/rbac/server/allInvitesRoutes.ts
+++ b/web/src/features/rbac/server/allInvitesRoutes.ts
@@ -91,9 +91,10 @@ export const allInvitesRoutes = {
   allInvitesFromProject: protectedProjectProcedure
     .input(projectLevelInviteQuery)
     .query(async ({ input, ctx }) => {
+      const orgId = ctx.session.orgId;
       const orgAccess = hasOrganizationAccess({
         session: ctx.session,
-        organizationId: ctx.session.orgId,
+        organizationId: orgId,
         scope: "organizationMembers:read",
       });
       const projectAccess = hasProjectAccess({
@@ -111,7 +112,7 @@ export const allInvitesRoutes = {
         ctx.prisma,
         {
           ...input,
-          orgId: ctx.session.orgId,
+          orgId,
         },
         orgAccess,
       );

--- a/web/src/features/rbac/server/allInvitesRoutes.ts
+++ b/web/src/features/rbac/server/allInvitesRoutes.ts
@@ -15,14 +15,15 @@ const orgLevelInviteQuery = z.object({
   orgId: z.string(),
   ...paginationZod,
 });
-const projectLevelInviteQuery = orgLevelInviteQuery.extend({
+const projectLevelInviteQuery = z.object({
   projectId: z.string(),
+  ...paginationZod,
 });
 async function getInvites(
   prisma: PrismaClient,
   query:
     | z.infer<typeof orgLevelInviteQuery>
-    | z.infer<typeof projectLevelInviteQuery>,
+    | (z.infer<typeof projectLevelInviteQuery> & { orgId: string }),
   showAllOrgMembers: boolean = true,
 ) {
   const invitations = await prisma.membershipInvitation.findMany({
@@ -92,7 +93,7 @@ export const allInvitesRoutes = {
     .query(async ({ input, ctx }) => {
       const orgAccess = hasOrganizationAccess({
         session: ctx.session,
-        organizationId: input.orgId,
+        organizationId: ctx.session.orgId,
         scope: "organizationMembers:read",
       });
       const projectAccess = hasProjectAccess({
@@ -106,6 +107,13 @@ export const allInvitesRoutes = {
           message: "You do not have the required access rights",
         });
       }
-      return getInvites(ctx.prisma, input, orgAccess);
+      return getInvites(
+        ctx.prisma,
+        {
+          ...input,
+          orgId: ctx.session.orgId,
+        },
+        orgAccess,
+      );
     }),
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes `allInvitesFromProject` by correctly handling `orgId` in query parameters and access checks.
> 
>   - **Behavior**:
>     - Fixes `allInvitesFromProject` query in `MembershipInvitesPage.tsx` by removing `orgId` from query parameters.
>     - Adjusts `allInvitesFromProject` in `allInvitesRoutes.ts` to include `orgId` when calling `getInvites`.
>   - **Validation**:
>     - Updates `projectLevelInviteQuery` in `allInvitesRoutes.ts` to require `orgId` for `getInvites` function.
>   - **Access Control**:
>     - Ensures `orgId` is derived from session in `allInvitesFromProject` to check organization access.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 22c344acde96ef952eb03653acde131c7ec571d9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->