### PR TITLE
feat(dataset-compare): allow baseline selection

### DIFF
--- a/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
+++ b/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
@@ -199,8 +199,8 @@ const DatasetAggregateCellContent = ({
           !selectedFields.includes("scores") && "hidden",
         )}
       >
-        <div className="mt-1 w-full min-w-0 overflow-hidden">
-          <div className="grid max-h-full w-full grid-cols-2 gap-1 overflow-y-auto">
+        <div className="mt-1 w-full min-w-0 overflow-hidden @container">
+          <div className="grid max-h-full w-full grid-cols-1 gap-1 overflow-y-auto @[400px]:grid-cols-2">
             {mergedScoreColumns.length > 0 ? (
               mergedScoreColumns.map((scoreColumn) => (
                 <ScoreRow

--- a/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
+++ b/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
@@ -200,7 +200,7 @@ const DatasetAggregateCellContent = ({
         )}
       >
         <div className="mt-1 w-full min-w-0 overflow-hidden">
-          <div className="flex max-h-full w-full flex-wrap gap-1 overflow-y-auto">
+          <div className="grid max-h-full w-full grid-cols-2 gap-1 overflow-y-auto">
             {mergedScoreColumns.length > 0 ? (
               mergedScoreColumns.map((scoreColumn) => (
                 <ScoreRow

--- a/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
+++ b/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
@@ -133,17 +133,21 @@ function RunAggregateHeader({
   );
 
   return (
-    <div className="flex w-full flex-row items-center justify-between gap-1">
-      <span>{runName}</span>
-      <PopoverFilterBuilder
-        buttonType="icon"
-        columns={columns}
-        filterState={getFiltersForRun(runId)}
-        onChange={(filters: FilterState) =>
-          debouncedUpdateRunFilters(runId, filters)
-        }
-      />
-      <BaselineToggle runId={runId} />
+    <div className="flex w-full flex-row items-center gap-1">
+      <span className="flex-1 truncate" title={runName}>
+        {runName}
+      </span>
+      <div className="flex w-fit flex-shrink-0 gap-1">
+        <PopoverFilterBuilder
+          buttonType="icon"
+          columns={columns}
+          filterState={getFiltersForRun(runId)}
+          onChange={(filters: FilterState) =>
+            debouncedUpdateRunFilters(runId, filters)
+          }
+        />
+        <BaselineToggle runId={runId} />
+      </div>
     </div>
   );
 }

--- a/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
+++ b/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
@@ -14,6 +14,37 @@ import { Toggle } from "@/src/components/ui/toggle";
 import { useRouter } from "next/router";
 import { cn } from "@/src/utils/tailwind";
 
+function DatasetAggregateCellWithBaselineDetection({
+  value,
+  runData,
+  runId,
+  projectId,
+  serverScoreColumns,
+}: {
+  value: EnrichedDatasetRunItem;
+  runData: Record<string, EnrichedDatasetRunItem>;
+  runId: string;
+  projectId: string;
+  serverScoreColumns?: ScoreColumn[];
+}) {
+  const router = useRouter();
+  const baselineRunId = router.query.baseline as string | undefined;
+
+  const baselineRunValue = baselineRunId ? runData[baselineRunId] : undefined;
+  const isBaselineRun = baselineRunId === runId;
+
+  return (
+    <DatasetAggregateTableCell
+      key={baselineRunId ?? runId}
+      value={value}
+      projectId={projectId}
+      serverScoreColumns={serverScoreColumns ?? []}
+      isBaselineRun={isBaselineRun}
+      baselineRunValue={baselineRunValue}
+    />
+  );
+}
+
 function BaselineToggle({ runId }: { runId: string }) {
   const router = useRouter();
   const [isHovered, setIsHovered] = useState(false);
@@ -137,7 +168,6 @@ export const constructDatasetRunAggregateColumns = ({
   updateRunFilters,
   getFiltersForRun,
   serverScoreColumns,
-  baselineRunId,
 }: {
   runAggregateColumnProps: RunAggregateColumnProps[];
   projectId: string;
@@ -145,7 +175,6 @@ export const constructDatasetRunAggregateColumns = ({
   updateRunFilters: (runId: string, filters: FilterState) => void;
   getFiltersForRun: (runId: string) => FilterState;
   serverScoreColumns?: ScoreColumn[];
-  baselineRunId?: string;
 }): LangfuseColumnDef<DatasetCompareRunRowData>[] => {
   const isDataLoading = !isScoreColumnsAvailable(serverScoreColumns);
 
@@ -180,19 +209,16 @@ export const constructDatasetRunAggregateColumns = ({
         if (!runData.hasOwnProperty(id)) return null;
 
         const value: EnrichedDatasetRunItem | undefined = runData[id];
-        const baselineRunValue = baselineRunId
-          ? runData[baselineRunId]
-          : undefined;
 
         if (!value) return null;
+
         return (
-          <DatasetAggregateTableCell
-            key={baselineRunId ?? id}
+          <DatasetAggregateCellWithBaselineDetection
             value={value}
+            runData={runData}
+            runId={id}
             projectId={projectId}
             serverScoreColumns={serverScoreColumns}
-            isBaselineRun={baselineRunId === id}
-            baselineRunValue={baselineRunValue}
           />
         );
       },

--- a/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
+++ b/web/src/features/datasets/components/DatasetRunAggregateColumnHelpers.tsx
@@ -7,9 +7,79 @@ import { type ColumnDefinition } from "@langfuse/shared";
 import { type FilterState } from "@langfuse/shared";
 import { type EnrichedDatasetRunItem } from "@langfuse/shared/src/server";
 import { type Row } from "@tanstack/react-table";
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useDebounce } from "@/src/hooks/useDebounce";
 import { type ScoreColumn } from "@/src/features/scores/types";
+import { Toggle } from "@/src/components/ui/toggle";
+import { useRouter } from "next/router";
+import { cn } from "@/src/utils/tailwind";
+
+function BaselineToggle({ runId }: { runId: string }) {
+  const router = useRouter();
+  const [isHovered, setIsHovered] = useState(false);
+  const justSetBaselineRef = useRef(false);
+  const previousBaselineRef = useRef<string | undefined>(undefined);
+
+  const baselineRunId = router.query.baseline as string | undefined;
+  const hasBaseline = Boolean(baselineRunId);
+  const isBaseline = baselineRunId === runId;
+
+  useEffect(() => {
+    if (baselineRunId === runId && previousBaselineRef.current !== runId) {
+      justSetBaselineRef.current = true;
+    }
+    previousBaselineRef.current = baselineRunId;
+  }, [baselineRunId, runId]);
+
+  const handleClick = () => {
+    if (isBaseline) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { baseline, ...restQuery } = router.query;
+      void router.push({
+        pathname: router.pathname,
+        query: restQuery,
+      });
+    } else {
+      void router.push({
+        pathname: router.pathname,
+        query: { ...router.query, baseline: runId },
+      });
+    }
+  };
+
+  const handleMouseEnter = () => {
+    setIsHovered(true);
+  };
+
+  const handleMouseLeave = () => {
+    setIsHovered(false);
+    justSetBaselineRef.current = false;
+  };
+
+  let text: string;
+  if (!hasBaseline) {
+    text = "Set as baseline";
+  } else if (isBaseline) {
+    text =
+      isHovered && !justSetBaselineRef.current ? "Clear baseline" : "Baseline";
+  } else {
+    text = isHovered ? "Set as baseline" : "Comparison";
+  }
+
+  return (
+    <Toggle
+      className={cn(
+        "p-1 text-muted-foreground/50 hover:bg-background hover:text-primary-accent data-[state=on]:bg-transparent data-[state=on]:text-current",
+        isBaseline && "text-primary-accent",
+      )}
+      onClick={handleClick}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {text}
+    </Toggle>
+  );
+}
 
 function RunAggregateHeader({
   runId,
@@ -32,7 +102,7 @@ function RunAggregateHeader({
   );
 
   return (
-    <div className="flex w-full flex-row items-center justify-between gap-2">
+    <div className="flex w-full flex-row items-center justify-between gap-1">
       <span>{runName}</span>
       <PopoverFilterBuilder
         buttonType="icon"
@@ -42,6 +112,7 @@ function RunAggregateHeader({
           debouncedUpdateRunFilters(runId, filters)
         }
       />
+      <BaselineToggle runId={runId} />
     </div>
   );
 }
@@ -66,6 +137,7 @@ export const constructDatasetRunAggregateColumns = ({
   updateRunFilters,
   getFiltersForRun,
   serverScoreColumns,
+  baselineRunId,
 }: {
   runAggregateColumnProps: RunAggregateColumnProps[];
   projectId: string;
@@ -73,6 +145,7 @@ export const constructDatasetRunAggregateColumns = ({
   updateRunFilters: (runId: string, filters: FilterState) => void;
   getFiltersForRun: (runId: string) => FilterState;
   serverScoreColumns?: ScoreColumn[];
+  baselineRunId?: string;
 }): LangfuseColumnDef<DatasetCompareRunRowData>[] => {
   const isDataLoading = !isScoreColumnsAvailable(serverScoreColumns);
 
@@ -107,13 +180,19 @@ export const constructDatasetRunAggregateColumns = ({
         if (!runData.hasOwnProperty(id)) return null;
 
         const value: EnrichedDatasetRunItem | undefined = runData[id];
+        const baselineRunValue = baselineRunId
+          ? runData[baselineRunId]
+          : undefined;
 
         if (!value) return null;
         return (
           <DatasetAggregateTableCell
+            key={baselineRunId ?? id}
             value={value}
             projectId={projectId}
             serverScoreColumns={serverScoreColumns}
+            isBaselineRun={baselineRunId === id}
+            baselineRunValue={baselineRunValue}
           />
         );
       },

--- a/web/src/features/datasets/hooks/useDatasetRunAggregateColumns.ts
+++ b/web/src/features/datasets/hooks/useDatasetRunAggregateColumns.ts
@@ -6,6 +6,7 @@ import {
   type FilterState,
 } from "@langfuse/shared";
 import { scoreFilters } from "@/src/features/scores/lib/scoreColumns";
+import { useRouter } from "next/router";
 
 export function useDatasetRunAggregateColumns({
   projectId,
@@ -20,6 +21,8 @@ export function useDatasetRunAggregateColumns({
   updateRunFilters: (runId: string, filters: FilterState) => void;
   getFiltersForRun: (runId: string) => FilterState;
 }) {
+  const router = useRouter();
+  const baselineRunId = router.query.baseline as string | undefined;
   const datasetRunItemsFilterOptionsResponse =
     api.datasets.runItemFilterOptions.useQuery({
       projectId,
@@ -76,6 +79,7 @@ export function useDatasetRunAggregateColumns({
       serverScoreColumns: scoreKeysAndProps.data?.scoreColumns,
       updateRunFilters,
       getFiltersForRun,
+      baselineRunId,
     });
   }, [
     runAggregateColumnProps,
@@ -84,6 +88,7 @@ export function useDatasetRunAggregateColumns({
     scoreKeysAndProps.data?.scoreColumns,
     updateRunFilters,
     getFiltersForRun,
+    baselineRunId,
   ]);
 
   return {

--- a/web/src/features/datasets/hooks/useDatasetRunAggregateColumns.ts
+++ b/web/src/features/datasets/hooks/useDatasetRunAggregateColumns.ts
@@ -6,7 +6,6 @@ import {
   type FilterState,
 } from "@langfuse/shared";
 import { scoreFilters } from "@/src/features/scores/lib/scoreColumns";
-import { useRouter } from "next/router";
 
 export function useDatasetRunAggregateColumns({
   projectId,
@@ -21,8 +20,6 @@ export function useDatasetRunAggregateColumns({
   updateRunFilters: (runId: string, filters: FilterState) => void;
   getFiltersForRun: (runId: string) => FilterState;
 }) {
-  const router = useRouter();
-  const baselineRunId = router.query.baseline as string | undefined;
   const datasetRunItemsFilterOptionsResponse =
     api.datasets.runItemFilterOptions.useQuery({
       projectId,
@@ -79,7 +76,6 @@ export function useDatasetRunAggregateColumns({
       serverScoreColumns: scoreKeysAndProps.data?.scoreColumns,
       updateRunFilters,
       getFiltersForRun,
-      baselineRunId,
     });
   }, [
     runAggregateColumnProps,
@@ -88,7 +84,6 @@ export function useDatasetRunAggregateColumns({
     scoreKeysAndProps.data?.scoreColumns,
     updateRunFilters,
     getFiltersForRun,
-    baselineRunId,
   ]);
 
   return {

--- a/web/src/features/datasets/lib/calculateScoreDiff.ts
+++ b/web/src/features/datasets/lib/calculateScoreDiff.ts
@@ -1,0 +1,60 @@
+import { type AggregatedScoreData } from "@langfuse/shared";
+
+export type NumericDiff = {
+  type: "NUMERIC";
+  absoluteDifference: number;
+  direction: "+" | "-";
+};
+
+export type CategoricalDiff = {
+  type: "CATEGORICAL";
+  isDifferent: true;
+};
+
+export type ScoreDiff = NumericDiff | CategoricalDiff | null;
+
+/**
+ * Calculate diff between current and baseline score aggregate
+ * Returns null if diff cannot be calculated
+ */
+export function calculateScoreDiff(
+  current: AggregatedScoreData | null,
+  baseline: AggregatedScoreData | null,
+): ScoreDiff {
+  // Missing data → no diff
+  if (!current || !baseline) return null;
+
+  // Aggregate scores (no id) → skip
+  if (!current.id || !baseline.id) return null;
+
+  // Type mismatch → no diff
+  if (current.type !== baseline.type) return null;
+
+  if (current.type === "NUMERIC" && baseline.type === "NUMERIC") {
+    const diff = current.average - baseline.average;
+
+    // Same value → no diff
+    if (diff === 0) return null;
+
+    return {
+      type: "NUMERIC",
+      absoluteDifference: Math.abs(diff),
+      direction: diff > 0 ? "+" : "-",
+    };
+  }
+
+  if (current.type === "CATEGORICAL" && baseline.type === "CATEGORICAL") {
+    const currentValue = current.values[0];
+    const baselineValue = baseline.values[0];
+
+    // Same value → no diff
+    if (currentValue === baselineValue) return null;
+
+    return {
+      type: "CATEGORICAL",
+      isDifferent: true,
+    };
+  }
+
+  return null;
+}

--- a/web/src/features/datasets/lib/computeScoreDiffs.ts
+++ b/web/src/features/datasets/lib/computeScoreDiffs.ts
@@ -1,0 +1,26 @@
+import { type ScoreAggregate } from "@langfuse/shared";
+import { calculateScoreDiff, type ScoreDiff } from "./calculateScoreDiff";
+
+/**
+ * Compute diffs for all scores between current and baseline aggregates
+ * Returns a map of scoreColumnKey → diff for efficient O(1) lookup during render
+ */
+export function computeScoreDiffs(
+  currentScores: ScoreAggregate,
+  baselineScores: ScoreAggregate | null,
+): Record<string, ScoreDiff> {
+  if (!baselineScores) return {};
+
+  const diffs: Record<string, ScoreDiff> = {};
+
+  for (const [key, currentAgg] of Object.entries(currentScores)) {
+    const baselineAgg = baselineScores[key];
+    const diff = calculateScoreDiff(currentAgg, baselineAgg ?? null);
+
+    if (diff !== null) {
+      diffs[key] = diff;
+    }
+  }
+
+  return diffs;
+}

--- a/web/src/features/scores/components/ScoreRow.tsx
+++ b/web/src/features/scores/components/ScoreRow.tsx
@@ -46,64 +46,47 @@ const ScoreDetailRow = ({
   </div>
 );
 
-const ScoreRowContent = ({
-  name,
+const ScoreValueSection = ({
   aggregate,
   diff,
 }: {
-  name: string;
   aggregate: AggregatedScoreData | null;
   diff?: ScoreDiff | null;
 }) => {
   return (
-    <div
-      className={cn(
-        "flex w-full items-center gap-2",
-        aggregate && "cursor-pointer",
-      )}
-    >
-      <span
-        className={cn(
-          "w-32 truncate",
-          aggregate ? "font-medium" : "text-muted-foreground",
-        )}
-      >
-        {name}
-      </span>
-      <div className="flex flex-shrink-0 items-center gap-1">
-        {aggregate ? (
-          <>
-            <span className="line-clamp-1 font-medium">
-              {resolveScoreValue(aggregate)}
+    <div className="flex flex-shrink-0 items-center gap-1">
+      {aggregate ? (
+        <>
+          <span className="line-clamp-1 font-medium">
+            {resolveScoreValue(aggregate)}
+          </span>
+          {diff && diff.type === "NUMERIC" && (
+            <span
+              className={cn(
+                "rounded px-1.5 py-0.5 text-xs font-semibold",
+                diff.direction === "+"
+                  ? "bg-light-green text-dark-green"
+                  : "bg-light-red text-dark-red",
+              )}
+            >
+              {diff.direction}
+              {diff.absoluteDifference.toFixed(2)}
             </span>
-            {diff && diff.type === "NUMERIC" && (
-              <span
-                className={cn(
-                  "rounded px-1.5 py-0.5 text-xs font-semibold",
-                  diff.direction === "+"
-                    ? "bg-light-green text-dark-green"
-                    : "bg-light-red text-dark-red",
-                )}
-              >
-                {diff.direction}
-                {diff.absoluteDifference.toFixed(2)}
-              </span>
-            )}
-            {diff && diff.type === "CATEGORICAL" && diff.isDifferent && (
-              <span className="rounded bg-light-yellow px-1.5 py-0.5 text-xs font-semibold text-dark-yellow">
-                Varies
-              </span>
-            )}
-          </>
-        ) : (
-          <span className="text-sm text-muted-foreground">-</span>
-        )}
-        {aggregate?.comment && (
-          <div className="flex h-3 w-3 items-center justify-center">
-            <MessageCircleMore size={12} className="text-muted-foreground" />
-          </div>
-        )}
-      </div>
+          )}
+          {diff && diff.type === "CATEGORICAL" && diff.isDifferent && (
+            <span className="rounded bg-light-yellow px-1.5 py-0.5 text-xs font-semibold text-dark-yellow">
+              Varies
+            </span>
+          )}
+        </>
+      ) : (
+        <span className="text-sm text-muted-foreground">-</span>
+      )}
+      {aggregate?.comment && (
+        <div className="flex h-3 w-3 items-center justify-center">
+          <MessageCircleMore size={12} className="text-muted-foreground" />
+        </div>
+      )}
     </div>
   );
 };
@@ -141,22 +124,30 @@ export const ScoreRow = ({
   );
 
   if (!aggregate) {
-    return <ScoreRowContent name={name} aggregate={aggregate} diff={diff} />;
+    return (
+      <div className="flex w-full items-center gap-2">
+        <span className="w-32 truncate text-muted-foreground">{name}</span>
+        <ScoreValueSection aggregate={aggregate} diff={diff} />
+      </div>
+    );
   }
 
   return (
     <HoverCard openDelay={700} closeDelay={100} onOpenChange={setIsHovered}>
-      <HoverCardTrigger asChild>
-        <div className="group/io-cell relative h-full w-full">
-          <ScoreRowContent name={name} aggregate={aggregate} diff={diff} />
-        </div>
-      </HoverCardTrigger>
+      <div className="flex w-full items-center gap-2">
+        <span className="w-32 truncate font-medium">{name}</span>
+        <HoverCardTrigger asChild>
+          <div className="cursor-pointer">
+            <ScoreValueSection aggregate={aggregate} diff={diff} />
+          </div>
+        </HoverCardTrigger>
+      </div>
       <HoverCardContent
-        className="max-h-[40vh] w-[300px] overflow-y-auto"
+        className="max-h-[40vh] w-[300px] cursor-pointer overflow-y-auto"
         side="top"
         align="start"
       >
-        <div className="space-y-3">
+        <div className="cursor-pointer space-y-3">
           <h4 className="text-sm font-medium">{name}</h4>
 
           <div className="space-y-2 text-xs">

--- a/web/src/features/scores/components/ScoreRow.tsx
+++ b/web/src/features/scores/components/ScoreRow.tsx
@@ -58,13 +58,13 @@ const ScoreRowContent = ({
   return (
     <div
       className={cn(
-        "flex w-full items-center justify-between gap-2",
+        "flex w-full items-center gap-2",
         aggregate && "cursor-pointer",
       )}
     >
       <span
         className={cn(
-          "min-w-16 flex-1 truncate",
+          "w-32 truncate",
           aggregate ? "font-medium" : "text-muted-foreground",
         )}
       >
@@ -91,18 +91,18 @@ const ScoreRowContent = ({
             )}
             {diff && diff.type === "CATEGORICAL" && diff.isDifferent && (
               <span className="rounded bg-light-yellow px-1.5 py-0.5 text-xs font-semibold text-dark-yellow">
-                Mismatch
+                Varies
               </span>
             )}
           </>
         ) : (
           <span className="text-sm text-muted-foreground">-</span>
         )}
-        <div className="flex h-3 w-3 items-center justify-center">
-          {aggregate?.comment && (
+        {aggregate?.comment && (
+          <div className="flex h-3 w-3 items-center justify-center">
             <MessageCircleMore size={12} className="text-muted-foreground" />
-          )}
-        </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/features/scores/components/ScoreRow.tsx
+++ b/web/src/features/scores/components/ScoreRow.tsx
@@ -18,6 +18,7 @@ import {
 import { api } from "@/src/utils/api";
 import { JSONView } from "@/src/components/ui/CodeJsonViewer";
 import { Skeleton } from "@/src/components/ui/skeleton";
+import { type ScoreDiff } from "@/src/features/datasets/lib/calculateScoreDiff";
 
 const resolveScoreValue = (aggregate: AggregatedScoreData): string => {
   if (aggregate.type === "NUMERIC") {
@@ -48,9 +49,11 @@ const ScoreDetailRow = ({
 const ScoreRowContent = ({
   name,
   aggregate,
+  diff,
 }: {
   name: string;
   aggregate: AggregatedScoreData | null;
+  diff?: ScoreDiff | null;
 }) => {
   return (
     <div
@@ -69,9 +72,29 @@ const ScoreRowContent = ({
       </span>
       <div className="flex flex-shrink-0 items-center gap-1">
         {aggregate ? (
-          <span className="line-clamp-1 font-medium">
-            {resolveScoreValue(aggregate)}
-          </span>
+          <>
+            <span className="line-clamp-1 font-medium">
+              {resolveScoreValue(aggregate)}
+            </span>
+            {diff && diff.type === "NUMERIC" && (
+              <span
+                className={cn(
+                  "rounded px-1.5 py-0.5 text-xs font-semibold",
+                  diff.direction === "+"
+                    ? "bg-light-green text-dark-green"
+                    : "bg-light-red text-dark-red",
+                )}
+              >
+                {diff.direction}
+                {diff.absoluteDifference.toFixed(2)}
+              </span>
+            )}
+            {diff && diff.type === "CATEGORICAL" && diff.isDifferent && (
+              <span className="rounded bg-light-yellow px-1.5 py-0.5 text-xs font-semibold text-dark-yellow">
+                Mismatch
+              </span>
+            )}
+          </>
         ) : (
           <span className="text-sm text-muted-foreground">-</span>
         )}
@@ -90,11 +113,13 @@ export const ScoreRow = ({
   name,
   source,
   aggregate,
+  diff,
 }: {
   projectId: string;
   name: string;
   source: ScoreSourceType;
   aggregate: AggregatedScoreData | null;
+  diff?: ScoreDiff | null;
 }) => {
   const [isHovered, setIsHovered] = React.useState(false);
 
@@ -116,14 +141,14 @@ export const ScoreRow = ({
   );
 
   if (!aggregate) {
-    return <ScoreRowContent name={name} aggregate={aggregate} />;
+    return <ScoreRowContent name={name} aggregate={aggregate} diff={diff} />;
   }
 
   return (
     <HoverCard openDelay={700} closeDelay={100} onOpenChange={setIsHovered}>
       <HoverCardTrigger asChild>
         <div className="group/io-cell relative h-full w-full">
-          <ScoreRowContent name={name} aggregate={aggregate} />
+          <ScoreRowContent name={name} aggregate={aggregate} diff={diff} />
         </div>
       </HoverCardTrigger>
       <HoverCardContent

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/compare/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/compare/index.tsx
@@ -162,9 +162,23 @@ function DatasetCompareInternal() {
                     setLocalRuns([]);
                   } else {
                     capture("dataset_run:compare_run_removed");
-                    setRunState({
-                      runs: runIds?.filter((id) => id !== changedValueId) ?? [],
-                    });
+                    const newRunIds =
+                      runIds?.filter((id) => id !== changedValueId) ?? [];
+
+                    // Clear baseline if the removed run was the baseline
+                    const baselineRunId = router.query.baseline as
+                      | string
+                      | undefined;
+                    if (baselineRunId === changedValueId) {
+                      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                      const { baseline, ...restQuery } = router.query;
+                      void router.push({
+                        pathname: router.pathname,
+                        query: { ...restQuery, runs: newRunIds },
+                      });
+                    } else {
+                      setRunState({ runs: newRunIds });
+                    }
                     setLocalRuns([]);
                   }
                 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds baseline selection for dataset comparison, enabling score difference visualization between current and baseline runs.
> 
>   - **Behavior**:
>     - Adds baseline selection feature in `DatasetCompareInternal` to compare dataset runs against a baseline.
>     - Updates `DatasetAggregateTableCell` to handle baseline and non-baseline runs, displaying score differences.
>     - Introduces `BaselineToggle` in `DatasetRunAggregateColumnHelpers.tsx` for setting/clearing baseline runs.
>   - **Functions**:
>     - Adds `calculateScoreDiff` in `calculateScoreDiff.ts` to compute differences between current and baseline scores.
>     - Adds `computeScoreDiffs` in `computeScoreDiffs.ts` to generate score differences map for rendering.
>   - **UI Components**:
>     - Updates `ScoreRow` in `ScoreRow.tsx` to display score differences with visual indicators.
>     - Modifies `DatasetAggregateCellContent` to include score differences in the UI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4df78d16c3d8b4b9fdf4277b0c71fe89fcb1aaa6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->