### PR TITLE
fix(otel): parse langfuse usage details if available

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -884,7 +884,6 @@ export class OtelIngestionProcessor {
         null,
       usageDetails: this.extractUsageDetails(
         attributes,
-        isLangfuseSDKSpans,
         instrumentationScopeName,
       ) as any,
       costDetails: this.extractCostDetails(
@@ -1730,10 +1729,9 @@ export class OtelIngestionProcessor {
 
   private extractUsageDetails(
     attributes: Record<string, unknown>,
-    isLangfuseSDKSpan: boolean,
     instrumentationScopeName: string,
   ): Record<string, unknown> {
-    if (isLangfuseSDKSpan) {
+    if (attributes[LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS]) {
       try {
         return JSON.parse(
           attributes[


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplified `extractUsageDetails()` in `OtelIngestionProcessor.ts` by removing `isLangfuseSDKSpan` parameter and checking for `OBSERVATION_USAGE_DETAILS` in attributes.
> 
>   - **Behavior**:
>     - `extractUsageDetails()` in `OtelIngestionProcessor.ts` no longer requires `isLangfuseSDKSpan` parameter.
>     - Now checks for `LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS` in attributes to parse usage details.
>   - **Misc**:
>     - Removed `isLangfuseSDKSpans` parameter from `extractUsageDetails()` calls in `OtelIngestionProcessor.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1dc59bb181f1efcf06964eb8e11948f6c85755f7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->