### PR TITLE
feat(scores): Two Score Comparison Analytics (LF-1936)

### DIFF
--- a/web/src/__tests__/async/score-comparison-analytics.servertest.ts
+++ b/web/src/__tests__/async/score-comparison-analytics.servertest.ts
@@ -1061,14 +1061,14 @@ describe("Score Comparison Analytics tRPC", () => {
 
       await createScoresCh(scores);
 
-      // Test week interval
+      // Test 7-day interval (week equivalent)
       const weekResult = await caller.scores.getScoreComparisonAnalytics({
         projectId,
         score1: { name: scoreName1, dataType: "NUMERIC", source: "API" },
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: { count: 1, unit: "week" },
+        interval: { count: 7, unit: "day" },
         nBins: 10,
       });
 

--- a/web/src/__tests__/async/score-comparison-analytics.servertest.ts
+++ b/web/src/__tests__/async/score-comparison-analytics.servertest.ts
@@ -112,7 +112,7 @@ describe("Score Comparison Analytics tRPC", () => {
         },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
       });
 
@@ -163,7 +163,7 @@ describe("Score Comparison Analytics tRPC", () => {
         },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
       });
 
@@ -196,7 +196,7 @@ describe("Score Comparison Analytics tRPC", () => {
           },
           fromTimestamp: now,
           toTimestamp: now,
-          interval: "day",
+          interval: { count: 1, unit: "day" },
           nBins: 3, // Too small
         }),
       ).rejects.toThrow();
@@ -216,7 +216,7 @@ describe("Score Comparison Analytics tRPC", () => {
           },
           fromTimestamp: now,
           toTimestamp: now,
-          interval: "day",
+          interval: { count: 1, unit: "day" },
           nBins: 100, // Too large
         }),
       ).rejects.toThrow();
@@ -293,7 +293,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
       });
 
@@ -351,7 +351,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
       });
 
@@ -409,7 +409,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
       });
 
@@ -482,7 +482,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 5,
       });
 
@@ -498,7 +498,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 20,
       });
 
@@ -558,7 +558,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
       });
 
@@ -622,7 +622,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "BOOLEAN", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
       });
 
@@ -696,7 +696,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "CATEGORICAL", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
       });
 
@@ -773,7 +773,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
       });
 
@@ -833,7 +833,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
       });
 
@@ -927,7 +927,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "hour",
+        interval: { count: 1, unit: "hour" },
         nBins: 10,
       });
 
@@ -1009,7 +1009,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
       });
 
@@ -1068,7 +1068,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "week",
+        interval: { count: 1, unit: "week" },
         nBins: 10,
       });
 
@@ -1081,7 +1081,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "month",
+        interval: { count: 1, unit: "month" },
         nBins: 10,
       });
 
@@ -1134,7 +1134,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
       });
 
@@ -1201,7 +1201,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
       });
 
@@ -1275,7 +1275,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
       });
 
@@ -1357,7 +1357,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
       });
 
@@ -1417,7 +1417,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
       });
 
@@ -1471,7 +1471,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
         maxMatchedScoresLimit: 100,
       });
@@ -1566,7 +1566,7 @@ describe("Score Comparison Analytics tRPC", () => {
         score2: { name: scoreName2, dataType: "NUMERIC", source: "API" },
         fromTimestamp,
         toTimestamp,
-        interval: "day",
+        interval: { count: 1, unit: "day" },
         nBins: 10,
       });
 

--- a/web/src/features/scores/components/analytics/ScoreDistributionBooleanChart.tsx
+++ b/web/src/features/scores/components/analytics/ScoreDistributionBooleanChart.tsx
@@ -1,0 +1,121 @@
+import { useMemo } from "react";
+import { Bar, BarChart, XAxis, YAxis } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/src/components/ui/chart";
+import {
+  getSingleScoreColor,
+  getTwoScoreColors,
+} from "@/src/features/scores/lib/color-scales";
+
+interface BooleanChartProps {
+  distribution1: Array<{ binIndex: number; count: number }>;
+  distribution2?: Array<{ binIndex: number; count: number }>;
+  categories: string[]; // Should always be ["False", "True"]
+  score1Name: string;
+  score2Name?: string;
+}
+
+/**
+ * Boolean distribution chart component
+ * Renders bar charts for boolean score distributions
+ * - Single score: One bar per value (False/True)
+ * - Two scores: Grouped bars for comparison
+ */
+export function ScoreDistributionBooleanChart({
+  distribution1,
+  distribution2,
+  categories,
+  score1Name,
+  score2Name,
+}: BooleanChartProps) {
+  const isComparisonMode = Boolean(distribution2 && score2Name);
+
+  // Transform data for Recharts - grouped bars
+  const chartData = useMemo(() => {
+    const dist2Map = distribution2
+      ? new Map(distribution2.map((d) => [d.binIndex, d.count]))
+      : null;
+
+    return distribution1.map((item) => {
+      const label = categories[item.binIndex] ?? `Value ${item.binIndex}`;
+
+      if (isComparisonMode && dist2Map) {
+        return {
+          name: label,
+          pv: item.count,
+          uv: dist2Map.get(item.binIndex) ?? 0,
+        };
+      } else {
+        return {
+          name: label,
+          pv: item.count,
+        };
+      }
+    });
+  }, [distribution1, distribution2, categories, isComparisonMode]);
+
+  // Configure chart colors
+  const colors = getTwoScoreColors();
+  const config: ChartConfig = isComparisonMode
+    ? {
+        pv: {
+          label: score1Name,
+          theme: {
+            light: colors.score1,
+            dark: colors.score1,
+          },
+        },
+        uv: {
+          label: score2Name,
+          theme: {
+            light: colors.score2,
+            dark: colors.score2,
+          },
+        },
+      }
+    : {
+        pv: {
+          label: score1Name,
+          theme: {
+            light: getSingleScoreColor(),
+            dark: getSingleScoreColor(),
+          },
+        },
+      };
+
+  return (
+    <ChartContainer
+      config={config}
+      className="[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-transparent"
+    >
+      <BarChart accessibilityLayer data={chartData} margin={{ bottom: 20 }}>
+        <XAxis
+          dataKey="name"
+          stroke="hsl(var(--chart-grid))"
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          stroke="hsl(var(--chart-grid))"
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+        />
+        <ChartTooltip
+          content={<ChartTooltipContent />}
+          contentStyle={{ backgroundColor: "hsl(var(--background))" }}
+          itemStyle={{ color: "hsl(var(--foreground))" }}
+        />
+        <Bar dataKey="pv" fill="hsl(var(--chart-3))" radius={[4, 4, 0, 0]} />
+        {isComparisonMode && (
+          <Bar dataKey="uv" fill="hsl(var(--chart-2))" radius={[4, 4, 0, 0]} />
+        )}
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/web/src/features/scores/components/analytics/ScoreDistributionCategoricalChart.tsx
+++ b/web/src/features/scores/components/analytics/ScoreDistributionCategoricalChart.tsx
@@ -1,12 +1,5 @@
-import { useMemo, useState } from "react";
-import {
-  Bar,
-  BarChart,
-  Cell,
-  ResponsiveContainer,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { useMemo } from "react";
+import { Bar, BarChart, XAxis, YAxis } from "recharts";
 import {
   ChartContainer,
   ChartTooltip,
@@ -14,10 +7,8 @@ import {
   type ChartConfig,
 } from "@/src/components/ui/chart";
 import {
-  getSingleScoreChartConfig,
   getSingleScoreColor,
   getTwoScoreColors,
-  getBarChartHoverOpacity,
 } from "@/src/features/scores/lib/color-scales";
 
 interface CategoricalChartProps {
@@ -41,8 +32,6 @@ export function ScoreDistributionCategoricalChart({
   score1Name,
   score2Name,
 }: CategoricalChartProps) {
-  const [activeIndex, setActiveIndex] = useState<number | null>(null);
-
   const isComparisonMode = Boolean(distribution2 && score2Name);
 
   // Transform data for Recharts
@@ -109,7 +98,6 @@ export function ScoreDistributionCategoricalChart({
         accessibilityLayer
         data={chartData}
         margin={{ bottom: hasManyCategories ? 60 : 20 }}
-        onMouseLeave={() => setActiveIndex(null)}
       >
         <XAxis
           dataKey="name"
@@ -132,19 +120,9 @@ export function ScoreDistributionCategoricalChart({
           contentStyle={{ backgroundColor: "hsl(var(--background))" }}
           itemStyle={{ color: "hsl(var(--foreground))" }}
         />
-        <Bar
-          dataKey="pv"
-          fill="hsl(var(--chart-3))"
-          radius={[4, 4, 0, 0]}
-          onMouseEnter={(_, index) => setActiveIndex(index)}
-        />
+        <Bar dataKey="pv" fill="hsl(var(--chart-3))" radius={[4, 4, 0, 0]} />
         {isComparisonMode && (
-          <Bar
-            dataKey="uv"
-            fill="hsl(var(--chart-2))"
-            radius={[4, 4, 0, 0]}
-            onMouseEnter={(_, index) => setActiveIndex(index)}
-          />
+          <Bar dataKey="uv" fill="hsl(var(--chart-2))" radius={[4, 4, 0, 0]} />
         )}
       </BarChart>
     </ChartContainer>

--- a/web/src/features/scores/components/analytics/ScoreDistributionCategoricalChart.tsx
+++ b/web/src/features/scores/components/analytics/ScoreDistributionCategoricalChart.tsx
@@ -74,6 +74,9 @@ export function ScoreDistributionCategoricalChart({
 
   // Configure colors and chart config
   const colors = getTwoScoreColors();
+  console.log("colors", colors);
+  console.log(score1Name);
+  console.log(score2Name);
   const singleColor = getSingleScoreColor();
   const config: ChartConfig = isComparisonMode
     ? getTwoScoreChartConfig(score1Name, score2Name!)

--- a/web/src/features/scores/components/analytics/ScoreDistributionCategoricalChart.tsx
+++ b/web/src/features/scores/components/analytics/ScoreDistributionCategoricalChart.tsx
@@ -1,0 +1,155 @@
+import { useMemo, useState } from "react";
+import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/src/components/ui/chart";
+import {
+  getSingleScoreChartConfig,
+  getTwoScoreChartConfig,
+  getSingleScoreColor,
+  getTwoScoreColors,
+  getBarChartHoverOpacity,
+} from "@/src/features/scores/lib/color-scales";
+
+interface CategoricalChartProps {
+  distribution1: Array<{ binIndex: number; count: number }>;
+  distribution2?: Array<{ binIndex: number; count: number }>;
+  categories: string[];
+  score1Name: string;
+  score2Name?: string;
+}
+
+/**
+ * Categorical distribution chart component
+ * Renders bar charts for categorical/boolean score distributions
+ * - Single score: One bar per category with hover effects
+ * - Two scores: Stacked bars for comparison
+ */
+export function ScoreDistributionCategoricalChart({
+  distribution1,
+  distribution2,
+  categories,
+  score1Name,
+  score2Name,
+}: CategoricalChartProps) {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  const isComparisonMode = Boolean(distribution2 && score2Name);
+
+  // Transform data for Recharts
+  const chartData = useMemo(() => {
+    const dist2Map = distribution2
+      ? new Map(distribution2.map((d) => [d.binIndex, d.count]))
+      : null;
+
+    return distribution1.map((item) => {
+      const label = categories[item.binIndex] ?? `Category ${item.binIndex}`;
+
+      if (isComparisonMode && dist2Map) {
+        // Two score mode: create object with both scores (for stacking)
+        return {
+          dimension: label,
+          [score1Name]: item.count,
+          [score2Name!]: dist2Map.get(item.binIndex) ?? 0,
+        };
+      } else {
+        // Single score mode
+        return {
+          dimension: label,
+          metric: item.count,
+        };
+      }
+    });
+  }, [
+    distribution1,
+    distribution2,
+    categories,
+    score1Name,
+    score2Name,
+    isComparisonMode,
+  ]);
+
+  // Configure colors and chart config
+  const colors = getTwoScoreColors();
+  const singleColor = getSingleScoreColor();
+  const config: ChartConfig = isComparisonMode
+    ? getTwoScoreChartConfig(score1Name, score2Name!)
+    : getSingleScoreChartConfig("metric");
+
+  const hasManyCategories = chartData.length > 10;
+
+  return (
+    <ChartContainer config={config}>
+      <BarChart
+        accessibilityLayer
+        data={chartData}
+        margin={{ bottom: hasManyCategories ? 60 : 20 }}
+        onMouseLeave={() => setActiveIndex(null)}
+      >
+        <XAxis
+          dataKey="dimension"
+          stroke="hsl(var(--chart-grid))"
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+          angle={hasManyCategories ? -45 : 0}
+          textAnchor={hasManyCategories ? "end" : "middle"}
+          height={hasManyCategories ? 90 : 30}
+        />
+        <YAxis
+          stroke="hsl(var(--chart-grid))"
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+        />
+
+        {isComparisonMode ? (
+          // Stacked bars for comparison mode
+          <>
+            <Bar
+              dataKey={score1Name}
+              stackId="comparison"
+              fill={colors.score1}
+              radius={[0, 0, 0, 0]}
+              onMouseEnter={(_, index) => setActiveIndex(index)}
+            />
+            <Bar
+              dataKey={score2Name!}
+              stackId="comparison"
+              fill={colors.score2}
+              radius={[4, 4, 0, 0]}
+              onMouseEnter={(_, index) => setActiveIndex(index)}
+            />
+          </>
+        ) : (
+          // Single bar with hover effect
+          <Bar
+            dataKey="metric"
+            radius={[4, 4, 0, 0]}
+            onMouseEnter={(_, index) => setActiveIndex(index)}
+          >
+            {chartData.map((_, index) => (
+              <Cell
+                key={`cell-${index}`}
+                fill={singleColor}
+                fillOpacity={getBarChartHoverOpacity(
+                  index === activeIndex,
+                  activeIndex !== null,
+                )}
+              />
+            ))}
+          </Bar>
+        )}
+
+        <ChartTooltip
+          content={<ChartTooltipContent />}
+          contentStyle={{ backgroundColor: "hsl(var(--background))" }}
+          itemStyle={{ color: "hsl(var(--foreground))" }}
+        />
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/web/src/features/scores/components/analytics/ScoreDistributionCategoricalChart.tsx
+++ b/web/src/features/scores/components/analytics/ScoreDistributionCategoricalChart.tsx
@@ -6,17 +6,12 @@ import {
   ChartTooltipContent,
   type ChartConfig,
 } from "@/src/components/ui/chart";
-import {
-  getSingleScoreColor,
-  getTwoScoreColors,
-} from "@/src/features/scores/lib/color-scales";
+import { getSingleScoreColor } from "@/src/features/scores/lib/color-scales";
 
 interface CategoricalChartProps {
   distribution1: Array<{ binIndex: number; count: number }>;
-  distribution2?: Array<{ binIndex: number; count: number }>;
   categories: string[];
   score1Name: string;
-  score2Name?: string;
   stackedDistribution?: Array<{
     score1Category: string;
     score2Stack: string;
@@ -27,27 +22,24 @@ interface CategoricalChartProps {
 
 /**
  * Categorical distribution chart component
- * Renders bar charts for categorical/boolean score distributions
- * - Single score: One bar per category with hover effects
- * - Two scores: Stacked bars for comparison
+ * Renders stacked bar charts for categorical score distributions
+ * - Single score: One bar per category
+ * - Two scores: Stacked bars showing score2 category breakdown within each score1 category
  */
 export function ScoreDistributionCategoricalChart({
   distribution1,
-  distribution2,
   categories,
   score1Name,
-  score2Name,
   stackedDistribution,
   score2Categories,
 }: CategoricalChartProps) {
-  const isComparisonMode = Boolean(distribution2 && score2Name);
   const hasStackedData = Boolean(
     stackedDistribution && stackedDistribution.length > 0,
   );
 
   // Transform data for Recharts
   const chartData = useMemo(() => {
-    // Use stacked distribution if available (categorical comparison)
+    // If we have stacked distribution data (two-score comparison)
     if (hasStackedData && stackedDistribution) {
       const grouped = new Map<string, Record<string, number>>();
 
@@ -66,44 +58,22 @@ export function ScoreDistributionCategoricalChart({
         }));
     }
 
-    // Fallback to old grouped bar approach (for boolean or old behavior)
-    const dist2Map = distribution2
-      ? new Map(distribution2.map((d) => [d.binIndex, d.count]))
-      : null;
-
+    // Single score: simple bar chart
     return distribution1.map((item) => {
       const label = categories[item.binIndex] ?? `Category ${item.binIndex}`;
-
-      if (isComparisonMode && dist2Map) {
-        return {
-          name: label,
-          pv: item.count,
-          uv: dist2Map.get(item.binIndex) ?? 0,
-        };
-      } else {
-        return {
-          name: label,
-          pv: item.count,
-        };
-      }
+      return {
+        name: label,
+        pv: item.count,
+      };
     });
-  }, [
-    distribution1,
-    distribution2,
-    categories,
-    isComparisonMode,
-    hasStackedData,
-    stackedDistribution,
-  ]);
+  }, [distribution1, categories, hasStackedData, stackedDistribution]);
 
   const hasManyCategories = chartData.length > 10;
 
   // Configure chart colors and config
-  const colors = getTwoScoreColors();
-
-  // For stacked charts: create config for all stack keys
   const config: ChartConfig = useMemo(() => {
     if (hasStackedData && score2Categories) {
+      // Stacked mode: create config for all score2 categories + unmatched
       const stackKeys = [...score2Categories, "__unmatched__"];
       const chartColors = [
         "hsl(var(--chart-1))",
@@ -132,41 +102,17 @@ export function ScoreDistributionCategoricalChart({
       return stackConfig;
     }
 
-    // Fallback to grouped bar config
-    return isComparisonMode
-      ? {
-          pv: {
-            label: score1Name,
-            theme: {
-              light: colors.score1,
-              dark: colors.score1,
-            },
-          },
-          uv: {
-            label: score2Name,
-            theme: {
-              light: colors.score2,
-              dark: colors.score2,
-            },
-          },
-        }
-      : {
-          pv: {
-            label: score1Name,
-            theme: {
-              light: getSingleScoreColor(),
-              dark: getSingleScoreColor(),
-            },
-          },
-        };
-  }, [
-    hasStackedData,
-    score2Categories,
-    isComparisonMode,
-    score1Name,
-    score2Name,
-    colors,
-  ]);
+    // Single score mode: simple config
+    return {
+      pv: {
+        label: score1Name,
+        theme: {
+          light: getSingleScoreColor(),
+          dark: getSingleScoreColor(),
+        },
+      },
+    };
+  }, [hasStackedData, score2Categories, score1Name]);
 
   // Get stack keys for stacked mode
   const stackKeys = useMemo(() => {
@@ -187,7 +133,7 @@ export function ScoreDistributionCategoricalChart({
         <XAxis
           dataKey="name"
           stroke="hsl(var(--chart-grid))"
-          fontSize={12}
+          fontSize={8}
           tickLine={false}
           axisLine={false}
           angle={hasManyCategories ? -45 : 0}
@@ -196,7 +142,7 @@ export function ScoreDistributionCategoricalChart({
         />
         <YAxis
           stroke="hsl(var(--chart-grid))"
-          fontSize={12}
+          fontSize={8}
           tickLine={false}
           axisLine={false}
         />
@@ -206,168 +152,25 @@ export function ScoreDistributionCategoricalChart({
           itemStyle={{ color: "hsl(var(--foreground))" }}
         />
 
-        {hasStackedData ? (
-          // Stacked bars - one Bar component per score2 category
-          <>
-            {stackKeys.map((stackKey) => (
-              <Bar
-                key={stackKey}
-                dataKey={stackKey}
-                stackId="stack"
-                fill={config[stackKey]?.theme?.light ?? "hsl(var(--chart-1))"}
-                radius={[0, 0, 0, 0]}
-              />
-            ))}
-          </>
-        ) : (
-          // Grouped bars (old behavior for boolean or when no stacked data)
-          <>
+        {hasStackedData &&
+          stackKeys.map((stackKey) => (
             <Bar
-              dataKey="pv"
-              fill="hsl(var(--chart-3))"
-              radius={[4, 4, 0, 0]}
-            />
-            {isComparisonMode && (
-              <Bar
-                dataKey="uv"
-                fill="hsl(var(--chart-2))"
-                radius={[4, 4, 0, 0]}
-              />
-            )}
-          </>
-        )}
-      </BarChart>
-    </ChartContainer>
-  );
-
-  /* COMMENTED OUT - Original implementation
-  const [activeIndex, setActiveIndex] = useState<number | null>(null);
-
-  const isComparisonMode = Boolean(distribution2 && score2Name);
-
-  // Transform data for Recharts
-  const chartData = useMemo(() => {
-    const dist2Map = distribution2
-      ? new Map(distribution2.map((d) => [d.binIndex, d.count]))
-      : null;
-
-    return distribution1.map((item) => {
-      const label = categories[item.binIndex] ?? `Category ${item.binIndex}`;
-
-      if (isComparisonMode && dist2Map) {
-        // Two score mode: use simple keys to avoid CSS variable name issues
-        return {
-          dimension: label,
-          score1: item.count,
-          score2: dist2Map.get(item.binIndex) ?? 0,
-        };
-      } else {
-        // Single score mode
-        return {
-          dimension: label,
-          metric: item.count,
-        };
-      }
-    });
-  }, [distribution1, distribution2, categories, isComparisonMode]);
-
-  // Configure colors and chart config
-  const colors = getTwoScoreColors();
-  const singleColor = getSingleScoreColor();
-  const config: ChartConfig = isComparisonMode
-    ? {
-        score1: {
-          label: score1Name,
-          theme: {
-            light: colors.score1,
-            dark: colors.score1,
-          },
-        },
-        score2: {
-          label: score2Name,
-          theme: {
-            light: colors.score2,
-            dark: colors.score2,
-          },
-        },
-      }
-    : getSingleScoreChartConfig("metric");
-
-  const hasManyCategories = chartData.length > 10;
-
-  return (
-    <ChartContainer
-      config={config}
-      className="[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-transparent"
-    >
-      <BarChart
-        accessibilityLayer
-        data={chartData}
-        margin={{ bottom: hasManyCategories ? 60 : 20 }}
-        onMouseLeave={() => setActiveIndex(null)}
-      >
-        <XAxis
-          dataKey="dimension"
-          stroke="hsl(var(--chart-grid))"
-          fontSize={12}
-          tickLine={false}
-          axisLine={false}
-          angle={hasManyCategories ? -45 : 0}
-          textAnchor={hasManyCategories ? "end" : "middle"}
-          height={hasManyCategories ? 90 : 30}
-        />
-        <YAxis
-          stroke="hsl(var(--chart-grid))"
-          fontSize={12}
-          tickLine={false}
-          axisLine={false}
-        />
-
-        {isComparisonMode ? (
-          // Stacked bars for comparison mode
-          <>
-            <Bar
-              dataKey="score1"
-              stackId="comparison"
-              fill={colors.score1}
+              key={stackKey}
+              dataKey={stackKey}
+              stackId="stack"
+              fill={config[stackKey]?.theme?.light ?? "hsl(var(--chart-1))"}
               radius={[0, 0, 0, 0]}
-              onMouseEnter={(_, index) => setActiveIndex(index)}
             />
-            <Bar
-              dataKey="score2"
-              stackId="comparison"
-              fill={colors.score2}
-              radius={[4, 4, 0, 0]}
-              onMouseEnter={(_, index) => setActiveIndex(index)}
-            />
-          </>
-        ) : (
-          // Single bar with hover effect
+          ))}
+        {!hasStackedData && (
           <Bar
-            dataKey="metric"
+            key="pv"
+            dataKey="pv"
+            fill="hsl(var(--chart-3))"
             radius={[4, 4, 0, 0]}
-            onMouseEnter={(_, index) => setActiveIndex(index)}
-          >
-            {chartData.map((_, index) => (
-              <Cell
-                key={`cell-${index}`}
-                fill={singleColor}
-                fillOpacity={getBarChartHoverOpacity(
-                  index === activeIndex,
-                  activeIndex !== null,
-                )}
-              />
-            ))}
-          </Bar>
+          />
         )}
-
-        <ChartTooltip
-          content={<ChartTooltipContent />}
-          contentStyle={{ backgroundColor: "hsl(var(--background))" }}
-          itemStyle={{ color: "hsl(var(--foreground))" }}
-        />
       </BarChart>
     </ChartContainer>
   );
-  */
 }

--- a/web/src/features/scores/components/analytics/ScoreDistributionCategoricalChart.tsx
+++ b/web/src/features/scores/components/analytics/ScoreDistributionCategoricalChart.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from "react";
-import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
+import { useMemo } from "react";
+import { Bar, BarChart, XAxis, YAxis } from "recharts";
 import {
   ChartContainer,
   ChartTooltip,
@@ -9,9 +9,7 @@ import {
 import {
   getSingleScoreChartConfig,
   getTwoScoreChartConfig,
-  getSingleScoreColor,
   getTwoScoreColors,
-  getBarChartHoverOpacity,
 } from "@/src/features/scores/lib/color-scales";
 
 interface CategoricalChartProps {
@@ -35,8 +33,6 @@ export function ScoreDistributionCategoricalChart({
   score1Name,
   score2Name,
 }: CategoricalChartProps) {
-  const [activeIndex, setActiveIndex] = useState<number | null>(null);
-
   const isComparisonMode = Boolean(distribution2 && score2Name);
 
   // Transform data for Recharts
@@ -74,10 +70,6 @@ export function ScoreDistributionCategoricalChart({
 
   // Configure colors and chart config
   const colors = getTwoScoreColors();
-  console.log("colors", colors);
-  console.log(score1Name);
-  console.log(score2Name);
-  const singleColor = getSingleScoreColor();
   const config: ChartConfig = isComparisonMode
     ? getTwoScoreChartConfig(score1Name, score2Name!)
     : getSingleScoreChartConfig("metric");
@@ -90,7 +82,6 @@ export function ScoreDistributionCategoricalChart({
         accessibilityLayer
         data={chartData}
         margin={{ bottom: hasManyCategories ? 60 : 20 }}
-        onMouseLeave={() => setActiveIndex(null)}
       >
         <XAxis
           dataKey="dimension"
@@ -117,34 +108,17 @@ export function ScoreDistributionCategoricalChart({
               stackId="comparison"
               fill={colors.score1}
               radius={[0, 0, 0, 0]}
-              onMouseEnter={(_, index) => setActiveIndex(index)}
             />
             <Bar
               dataKey={score2Name!}
               stackId="comparison"
               fill={colors.score2}
               radius={[4, 4, 0, 0]}
-              onMouseEnter={(_, index) => setActiveIndex(index)}
             />
           </>
         ) : (
-          // Single bar with hover effect
-          <Bar
-            dataKey="metric"
-            radius={[4, 4, 0, 0]}
-            onMouseEnter={(_, index) => setActiveIndex(index)}
-          >
-            {chartData.map((_, index) => (
-              <Cell
-                key={`cell-${index}`}
-                fill={singleColor}
-                fillOpacity={getBarChartHoverOpacity(
-                  index === activeIndex,
-                  activeIndex !== null,
-                )}
-              />
-            ))}
-          </Bar>
+          // Single bar
+          <Bar dataKey="metric" radius={[4, 4, 0, 0]} />
         )}
 
         <ChartTooltip

--- a/web/src/features/scores/components/analytics/ScoreDistributionCategoricalChart.tsx
+++ b/web/src/features/scores/components/analytics/ScoreDistributionCategoricalChart.tsx
@@ -1,5 +1,12 @@
 import { useMemo, useState } from "react";
-import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
+import {
+  Bar,
+  BarChart,
+  Cell,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+} from "recharts";
 import {
   ChartContainer,
   ChartTooltip,
@@ -8,7 +15,6 @@ import {
 } from "@/src/components/ui/chart";
 import {
   getSingleScoreChartConfig,
-  getTwoScoreChartConfig,
   getSingleScoreColor,
   getTwoScoreColors,
   getBarChartHoverOpacity,
@@ -49,11 +55,121 @@ export function ScoreDistributionCategoricalChart({
       const label = categories[item.binIndex] ?? `Category ${item.binIndex}`;
 
       if (isComparisonMode && dist2Map) {
-        // Two score mode: create object with both scores (for stacking)
+        return {
+          name: label,
+          pv: item.count,
+          uv: dist2Map.get(item.binIndex) ?? 0,
+        };
+      } else {
+        return {
+          name: label,
+          pv: item.count,
+        };
+      }
+    });
+  }, [distribution1, distribution2, categories, isComparisonMode]);
+
+  const hasManyCategories = chartData.length > 10;
+
+  // Configure chart labels for tooltip
+  const colors = getTwoScoreColors();
+  const config: ChartConfig = isComparisonMode
+    ? {
+        pv: {
+          label: score1Name,
+          theme: {
+            light: colors.score1,
+            dark: colors.score1,
+          },
+        },
+        uv: {
+          label: score2Name,
+          theme: {
+            light: colors.score2,
+            dark: colors.score2,
+          },
+        },
+      }
+    : {
+        pv: {
+          label: score1Name,
+          theme: {
+            light: getSingleScoreColor(),
+            dark: getSingleScoreColor(),
+          },
+        },
+      };
+
+  return (
+    <ChartContainer
+      config={config}
+      className="[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-transparent"
+    >
+      <BarChart
+        accessibilityLayer
+        data={chartData}
+        margin={{ bottom: hasManyCategories ? 60 : 20 }}
+        onMouseLeave={() => setActiveIndex(null)}
+      >
+        <XAxis
+          dataKey="name"
+          stroke="hsl(var(--chart-grid))"
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+          angle={hasManyCategories ? -45 : 0}
+          textAnchor={hasManyCategories ? "end" : "middle"}
+          height={hasManyCategories ? 90 : 30}
+        />
+        <YAxis
+          stroke="hsl(var(--chart-grid))"
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+        />
+        <ChartTooltip
+          content={<ChartTooltipContent />}
+          contentStyle={{ backgroundColor: "hsl(var(--background))" }}
+          itemStyle={{ color: "hsl(var(--foreground))" }}
+        />
+        <Bar
+          dataKey="pv"
+          fill="hsl(var(--chart-3))"
+          radius={[4, 4, 0, 0]}
+          onMouseEnter={(_, index) => setActiveIndex(index)}
+        />
+        {isComparisonMode && (
+          <Bar
+            dataKey="uv"
+            fill="hsl(var(--chart-2))"
+            radius={[4, 4, 0, 0]}
+            onMouseEnter={(_, index) => setActiveIndex(index)}
+          />
+        )}
+      </BarChart>
+    </ChartContainer>
+  );
+
+  /* COMMENTED OUT - Original implementation
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  const isComparisonMode = Boolean(distribution2 && score2Name);
+
+  // Transform data for Recharts
+  const chartData = useMemo(() => {
+    const dist2Map = distribution2
+      ? new Map(distribution2.map((d) => [d.binIndex, d.count]))
+      : null;
+
+    return distribution1.map((item) => {
+      const label = categories[item.binIndex] ?? `Category ${item.binIndex}`;
+
+      if (isComparisonMode && dist2Map) {
+        // Two score mode: use simple keys to avoid CSS variable name issues
         return {
           dimension: label,
-          [score1Name]: item.count,
-          [score2Name!]: dist2Map.get(item.binIndex) ?? 0,
+          score1: item.count,
+          score2: dist2Map.get(item.binIndex) ?? 0,
         };
       } else {
         // Single score mode
@@ -63,23 +179,28 @@ export function ScoreDistributionCategoricalChart({
         };
       }
     });
-  }, [
-    distribution1,
-    distribution2,
-    categories,
-    score1Name,
-    score2Name,
-    isComparisonMode,
-  ]);
+  }, [distribution1, distribution2, categories, isComparisonMode]);
 
   // Configure colors and chart config
   const colors = getTwoScoreColors();
-  console.log("colors", colors);
-  console.log(score1Name);
-  console.log(score2Name);
   const singleColor = getSingleScoreColor();
   const config: ChartConfig = isComparisonMode
-    ? getTwoScoreChartConfig(score1Name, score2Name!)
+    ? {
+        score1: {
+          label: score1Name,
+          theme: {
+            light: colors.score1,
+            dark: colors.score1,
+          },
+        },
+        score2: {
+          label: score2Name,
+          theme: {
+            light: colors.score2,
+            dark: colors.score2,
+          },
+        },
+      }
     : getSingleScoreChartConfig("metric");
 
   const hasManyCategories = chartData.length > 10;
@@ -116,14 +237,14 @@ export function ScoreDistributionCategoricalChart({
           // Stacked bars for comparison mode
           <>
             <Bar
-              dataKey={score1Name}
+              dataKey="score1"
               stackId="comparison"
               fill={colors.score1}
               radius={[0, 0, 0, 0]}
               onMouseEnter={(_, index) => setActiveIndex(index)}
             />
             <Bar
-              dataKey={score2Name!}
+              dataKey="score2"
               stackId="comparison"
               fill={colors.score2}
               radius={[4, 4, 0, 0]}
@@ -158,4 +279,5 @@ export function ScoreDistributionCategoricalChart({
       </BarChart>
     </ChartContainer>
   );
+  */
 }

--- a/web/src/features/scores/components/analytics/ScoreDistributionChart.tsx
+++ b/web/src/features/scores/components/analytics/ScoreDistributionChart.tsx
@@ -1,5 +1,6 @@
 import { ScoreDistributionNumericChart } from "./ScoreDistributionNumericChart";
 import { ScoreDistributionCategoricalChart } from "./ScoreDistributionCategoricalChart";
+import { ScoreDistributionBooleanChart } from "./ScoreDistributionBooleanChart";
 
 export interface ScoreDistributionChartProps {
   distribution1: Array<{ binIndex: number; count: number }>;
@@ -9,7 +10,7 @@ export interface ScoreDistributionChartProps {
   score2Name?: string;
   // For numeric scores, provide bin labels
   binLabels?: string[];
-  // For categorical scores, provide category names
+  // For categorical/boolean scores, provide category names
   categories?: string[];
   // For categorical comparison, provide stacked distribution data
   stackedDistribution?: Array<{
@@ -24,7 +25,8 @@ export interface ScoreDistributionChartProps {
  * Orchestrator component for score distribution charts
  * Routes to specialized components based on data type:
  * - Numeric: ScoreDistributionNumericChart (grouped bars for comparison)
- * - Categorical/Boolean: ScoreDistributionCategoricalChart (stacked bars for comparison)
+ * - Categorical: ScoreDistributionCategoricalChart (stacked bars for comparison)
+ * - Boolean: ScoreDistributionBooleanChart (grouped bars for comparison)
  */
 export function ScoreDistributionChart({
   distribution1,
@@ -46,7 +48,7 @@ export function ScoreDistributionChart({
     );
   }
 
-  // Route to appropriate chart component
+  // Route to appropriate chart component based on data type
   if (dataType === "NUMERIC") {
     if (!binLabels || binLabels.length === 0) {
       return (
@@ -67,7 +69,27 @@ export function ScoreDistributionChart({
     );
   }
 
-  // Categorical or Boolean
+  if (dataType === "BOOLEAN") {
+    if (!categories || categories.length === 0) {
+      return (
+        <div className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+          No categories available for boolean distribution
+        </div>
+      );
+    }
+
+    return (
+      <ScoreDistributionBooleanChart
+        distribution1={distribution1}
+        distribution2={distribution2}
+        categories={categories}
+        score1Name={score1Name}
+        score2Name={score2Name}
+      />
+    );
+  }
+
+  // Categorical
   if (!categories || categories.length === 0) {
     return (
       <div className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
@@ -79,10 +101,8 @@ export function ScoreDistributionChart({
   return (
     <ScoreDistributionCategoricalChart
       distribution1={distribution1}
-      distribution2={distribution2}
       categories={categories}
       score1Name={score1Name}
-      score2Name={score2Name}
       stackedDistribution={stackedDistribution}
       score2Categories={score2Categories}
     />

--- a/web/src/features/scores/components/analytics/ScoreDistributionChart.tsx
+++ b/web/src/features/scores/components/analytics/ScoreDistributionChart.tsx
@@ -1,75 +1,35 @@
-import { useMemo, useState } from "react";
-import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
-import {
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-  type ChartConfig,
-} from "@/src/components/ui/chart";
-import {
-  getSingleScoreChartConfig,
-  getSingleScoreColor,
-  getBarChartHoverOpacity,
-} from "@/src/features/scores/lib/color-scales";
+import { ScoreDistributionNumericChart } from "./ScoreDistributionNumericChart";
+import { ScoreDistributionCategoricalChart } from "./ScoreDistributionCategoricalChart";
 
 export interface ScoreDistributionChartProps {
-  data: Array<{ binIndex: number; count: number }>;
+  distribution1: Array<{ binIndex: number; count: number }>;
+  distribution2?: Array<{ binIndex: number; count: number }>;
   dataType: "NUMERIC" | "CATEGORICAL" | "BOOLEAN";
-  scoreName: string;
-  totalCount: number;
+  score1Name: string;
+  score2Name?: string;
   // For numeric scores, provide bin labels
   binLabels?: string[];
   // For categorical scores, provide category names
   categories?: string[];
 }
 
+/**
+ * Orchestrator component for score distribution charts
+ * Routes to specialized components based on data type:
+ * - Numeric: ScoreDistributionNumericChart (grouped bars for comparison)
+ * - Categorical/Boolean: ScoreDistributionCategoricalChart (stacked bars for comparison)
+ */
 export function ScoreDistributionChart({
-  data,
+  distribution1,
+  distribution2,
   dataType,
+  score1Name,
+  score2Name,
   binLabels,
   categories,
 }: ScoreDistributionChartProps) {
-  const [activeIndex, setActiveIndex] = useState<number | null>(null);
-
-  // Debug logging
-  console.log("[ScoreDistributionChart] Rendering:", {
-    dataLength: data.length,
-    dataType,
-    binLabels: binLabels?.length,
-    categories: categories?.length,
-  });
-
-  // Transform data for Recharts
-  const chartData = useMemo(() => {
-    const transformed = data.map((item) => {
-      let label: string;
-
-      if (dataType === "NUMERIC" && binLabels) {
-        // Use bin labels for numeric scores
-        label = binLabels[item.binIndex] ?? `Bin ${item.binIndex}`;
-      } else if (
-        (dataType === "CATEGORICAL" || dataType === "BOOLEAN") &&
-        categories
-      ) {
-        // Use category names for categorical/boolean scores
-        label = categories[item.binIndex] ?? `Category ${item.binIndex}`;
-      } else {
-        // Fallback
-        label = `${item.binIndex}`;
-      }
-
-      return {
-        dimension: label,
-        metric: item.count,
-      };
-    });
-    console.log("[ScoreDistributionChart] Transformed data:", transformed);
-    return transformed;
-  }, [data, dataType, binLabels, categories]);
-
-  const config: ChartConfig = getSingleScoreChartConfig("metric");
-
-  if (chartData.length === 0) {
+  // Empty state check
+  if (distribution1.length === 0) {
     return (
       <div className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
         No distribution data available
@@ -77,55 +37,43 @@ export function ScoreDistributionChart({
     );
   }
 
-  // Use angled labels if there are many categories
-  const hasManyCategories = chartData.length > 10;
+  // Route to appropriate chart component
+  if (dataType === "NUMERIC") {
+    if (!binLabels || binLabels.length === 0) {
+      return (
+        <div className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+          No bin labels available for numeric distribution
+        </div>
+      );
+    }
+
+    return (
+      <ScoreDistributionNumericChart
+        distribution1={distribution1}
+        distribution2={distribution2}
+        binLabels={binLabels}
+        score1Name={score1Name}
+        score2Name={score2Name}
+      />
+    );
+  }
+
+  // Categorical or Boolean
+  if (!categories || categories.length === 0) {
+    return (
+      <div className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+        No categories available for categorical distribution
+      </div>
+    );
+  }
 
   return (
-    <ChartContainer config={config}>
-      <BarChart
-        accessibilityLayer
-        data={chartData}
-        margin={{ bottom: hasManyCategories ? 60 : 20 }}
-        onMouseLeave={() => setActiveIndex(null)}
-      >
-        <XAxis
-          dataKey="dimension"
-          stroke="hsl(var(--chart-grid))"
-          fontSize={12}
-          tickLine={false}
-          axisLine={false}
-          angle={hasManyCategories ? -45 : 0}
-          textAnchor={hasManyCategories ? "end" : "middle"}
-          height={hasManyCategories ? 90 : 30}
-        />
-        <YAxis
-          stroke="hsl(var(--chart-grid))"
-          fontSize={12}
-          tickLine={false}
-          axisLine={false}
-        />
-        <Bar
-          dataKey="metric"
-          radius={[4, 4, 0, 0]}
-          onMouseEnter={(_, index) => setActiveIndex(index)}
-        >
-          {chartData.map((_, index) => (
-            <Cell
-              key={`cell-${index}`}
-              fill={getSingleScoreColor()}
-              fillOpacity={getBarChartHoverOpacity(
-                index === activeIndex,
-                activeIndex !== null,
-              )}
-            />
-          ))}
-        </Bar>
-        <ChartTooltip
-          content={<ChartTooltipContent />}
-          contentStyle={{ backgroundColor: "hsl(var(--background))" }}
-          itemStyle={{ color: "hsl(var(--foreground))" }}
-        />
-      </BarChart>
-    </ChartContainer>
+    <ScoreDistributionCategoricalChart
+      distribution1={distribution1}
+      distribution2={distribution2}
+      categories={categories}
+      score1Name={score1Name}
+      score2Name={score2Name}
+    />
   );
 }

--- a/web/src/features/scores/components/analytics/ScoreDistributionChart.tsx
+++ b/web/src/features/scores/components/analytics/ScoreDistributionChart.tsx
@@ -11,6 +11,13 @@ export interface ScoreDistributionChartProps {
   binLabels?: string[];
   // For categorical scores, provide category names
   categories?: string[];
+  // For categorical comparison, provide stacked distribution data
+  stackedDistribution?: Array<{
+    score1Category: string;
+    score2Stack: string;
+    count: number;
+  }>;
+  score2Categories?: string[];
 }
 
 /**
@@ -27,6 +34,8 @@ export function ScoreDistributionChart({
   score2Name,
   binLabels,
   categories,
+  stackedDistribution,
+  score2Categories,
 }: ScoreDistributionChartProps) {
   // Empty state check
   if (distribution1.length === 0) {
@@ -74,6 +83,8 @@ export function ScoreDistributionChart({
       categories={categories}
       score1Name={score1Name}
       score2Name={score2Name}
+      stackedDistribution={stackedDistribution}
+      score2Categories={score2Categories}
     />
   );
 }

--- a/web/src/features/scores/components/analytics/ScoreDistributionNumericChart.tsx
+++ b/web/src/features/scores/components/analytics/ScoreDistributionNumericChart.tsx
@@ -82,7 +82,10 @@ export function ScoreDistributionNumericChart({
   const hasManyBins = chartData.length > 10;
 
   return (
-    <ChartContainer config={config}>
+    <ChartContainer
+      config={config}
+      className="[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-transparent"
+    >
       <BarChart
         accessibilityLayer
         data={chartData}

--- a/web/src/features/scores/components/analytics/ScoreDistributionNumericChart.tsx
+++ b/web/src/features/scores/components/analytics/ScoreDistributionNumericChart.tsx
@@ -1,0 +1,153 @@
+import { useMemo, useState } from "react";
+import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/src/components/ui/chart";
+import {
+  getSingleScoreChartConfig,
+  getTwoScoreChartConfig,
+  getSingleScoreColor,
+  getTwoScoreColors,
+  getBarChartHoverOpacity,
+} from "@/src/features/scores/lib/color-scales";
+
+interface NumericChartProps {
+  distribution1: Array<{ binIndex: number; count: number }>;
+  distribution2?: Array<{ binIndex: number; count: number }>;
+  binLabels: string[];
+  score1Name: string;
+  score2Name?: string;
+}
+
+/**
+ * Numeric distribution chart component
+ * Renders bar charts for numeric score distributions
+ * - Single score: One bar per bin with hover effects
+ * - Two scores: Grouped bars (side-by-side) for comparison
+ */
+export function ScoreDistributionNumericChart({
+  distribution1,
+  distribution2,
+  binLabels,
+  score1Name,
+  score2Name,
+}: NumericChartProps) {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  const isComparisonMode = Boolean(distribution2 && score2Name);
+
+  // Transform data for Recharts
+  const chartData = useMemo(() => {
+    const dist2Map = distribution2
+      ? new Map(distribution2.map((d) => [d.binIndex, d.count]))
+      : null;
+
+    return distribution1.map((item) => {
+      const label = binLabels[item.binIndex] ?? `Bin ${item.binIndex}`;
+
+      if (isComparisonMode && dist2Map) {
+        // Two score mode: create object with both scores
+        return {
+          dimension: label,
+          [score1Name]: item.count,
+          [score2Name!]: dist2Map.get(item.binIndex) ?? 0,
+        };
+      } else {
+        // Single score mode
+        return {
+          dimension: label,
+          metric: item.count,
+        };
+      }
+    });
+  }, [
+    distribution1,
+    distribution2,
+    binLabels,
+    score1Name,
+    score2Name,
+    isComparisonMode,
+  ]);
+
+  // Configure colors and chart config
+  const colors = getTwoScoreColors();
+  const singleColor = getSingleScoreColor();
+  const config: ChartConfig = isComparisonMode
+    ? getTwoScoreChartConfig(score1Name, score2Name!)
+    : getSingleScoreChartConfig("metric");
+
+  const hasManyBins = chartData.length > 10;
+
+  return (
+    <ChartContainer config={config}>
+      <BarChart
+        accessibilityLayer
+        data={chartData}
+        margin={{ bottom: hasManyBins ? 60 : 20 }}
+        onMouseLeave={() => setActiveIndex(null)}
+      >
+        <XAxis
+          dataKey="dimension"
+          stroke="hsl(var(--chart-grid))"
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+          angle={hasManyBins ? -45 : 0}
+          textAnchor={hasManyBins ? "end" : "middle"}
+          height={hasManyBins ? 90 : 30}
+        />
+        <YAxis
+          stroke="hsl(var(--chart-grid))"
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+        />
+
+        {isComparisonMode ? (
+          // Grouped bars for comparison mode
+          <>
+            <Bar
+              dataKey={score1Name}
+              fill={colors.score1}
+              radius={[4, 4, 0, 0]}
+              onMouseEnter={(_, index) => setActiveIndex(index)}
+            />
+            <Bar
+              dataKey={score2Name!}
+              fill={colors.score2}
+              radius={[4, 4, 0, 0]}
+              onMouseEnter={(_, index) => setActiveIndex(index)}
+            />
+          </>
+        ) : (
+          // Single bar with hover effect
+          <Bar
+            dataKey="metric"
+            radius={[4, 4, 0, 0]}
+            onMouseEnter={(_, index) => setActiveIndex(index)}
+          >
+            {chartData.map((_, index) => (
+              <Cell
+                key={`cell-${index}`}
+                fill={singleColor}
+                fillOpacity={getBarChartHoverOpacity(
+                  index === activeIndex,
+                  activeIndex !== null,
+                )}
+              />
+            ))}
+          </Bar>
+        )}
+
+        <ChartTooltip
+          content={<ChartTooltipContent />}
+          contentStyle={{ backgroundColor: "hsl(var(--background))" }}
+          itemStyle={{ color: "hsl(var(--foreground))" }}
+        />
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/web/src/features/scores/components/analytics/ScoreSelector.tsx
+++ b/web/src/features/scores/components/analytics/ScoreSelector.tsx
@@ -22,7 +22,7 @@ interface ScoreSelectorProps {
   onChange: (value: string | undefined) => void;
   options: ScoreOption[];
   placeholder?: string;
-  filterByDataType?: string; // When set, only show scores matching this data type
+  filterByDataType?: string | string[]; // Single type or array of compatible types
   className?: string;
 }
 
@@ -35,7 +35,12 @@ export function ScoreSelector({
   className,
 }: ScoreSelectorProps) {
   const filteredOptions = filterByDataType
-    ? options.filter((opt) => opt.dataType === filterByDataType)
+    ? options.filter((opt) => {
+        if (Array.isArray(filterByDataType)) {
+          return filterByDataType.includes(opt.dataType);
+        }
+        return opt.dataType === filterByDataType;
+      })
     : options;
 
   const handleClear = () => {

--- a/web/src/features/scores/components/analytics/ScoreSelector.tsx
+++ b/web/src/features/scores/components/analytics/ScoreSelector.tsx
@@ -72,7 +72,10 @@ export function ScoreSelector({
 
   return (
     <div className="flex items-center gap-2">
-      <Select value={value} onValueChange={onChange}>
+      <Select
+        value={value ?? ""}
+        onValueChange={(val) => onChange(val === "" ? undefined : val)}
+      >
         <SelectTrigger className={className}>
           <SelectValue placeholder={placeholder} className="p-0" />
         </SelectTrigger>

--- a/web/src/features/scores/components/analytics/ScoreTimeSeriesChart.tsx
+++ b/web/src/features/scores/components/analytics/ScoreTimeSeriesChart.tsx
@@ -29,12 +29,6 @@ export function ScoreTimeSeriesChart({
   scoreName,
   interval,
 }: ScoreTimeSeriesChartProps) {
-  console.log("[ScoreTimeSeriesChart] Rendering:", {
-    dataLength: data.length,
-    scoreName,
-    interval,
-  });
-
   // Transform data for Recharts
   const chartData = useMemo(() => {
     const transformed = data.map((item) => {
@@ -46,7 +40,6 @@ export function ScoreTimeSeriesChart({
         [scoreName]: item.avg1,
       };
     });
-    console.log("[ScoreTimeSeriesChart] Transformed data:", transformed);
     return transformed;
   }, [data, scoreName, interval]);
 

--- a/web/src/features/scores/components/analytics/SingleScoreAnalytics.tsx
+++ b/web/src/features/scores/components/analytics/SingleScoreAnalytics.tsx
@@ -36,16 +36,6 @@ export function SingleScoreAnalytics({
   fromDate,
   toDate,
 }: SingleScoreAnalyticsProps) {
-  // TODO: REMOVE BEFORE MERGING - Debug component render
-  console.log("[SingleScoreAnalytics] Rendering with:", {
-    scoreName,
-    dataType,
-    source,
-    distributionLength: analytics.distribution1.length,
-    timeSeriesLength: analytics.timeSeries.length,
-    totalCount: analytics.counts.score1Total,
-  });
-
   // Use distribution1 for single score
   const distribution = analytics.distribution1;
   const totalCount = analytics.counts.score1Total;
@@ -148,10 +138,9 @@ export function SingleScoreAnalytics({
         <CardContent className="h-[300px]">
           {distribution.length > 0 ? (
             <ScoreDistributionChart
-              data={distribution}
+              distribution1={distribution}
               dataType={dataType}
-              scoreName={scoreName}
-              totalCount={totalCount}
+              score1Name={scoreName}
               binLabels={binLabels}
               categories={categories}
             />

--- a/web/src/features/scores/components/analytics/TwoScoreAnalytics.tsx
+++ b/web/src/features/scores/components/analytics/TwoScoreAnalytics.tsx
@@ -1,0 +1,164 @@
+import { useMemo } from "react";
+import { type RouterOutputs } from "@/src/utils/api";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/src/components/ui/card";
+import { ScoreDistributionChart } from "./ScoreDistributionChart";
+import { type IntervalConfig } from "@/src/utils/date-range-utils";
+
+interface TwoScoreAnalyticsProps {
+  score1: {
+    name: string;
+    dataType: "NUMERIC" | "CATEGORICAL" | "BOOLEAN";
+    source: string;
+  };
+  score2: {
+    name: string;
+    dataType: "NUMERIC" | "CATEGORICAL" | "BOOLEAN";
+    source: string;
+  };
+  analytics: RouterOutputs["scores"]["getScoreComparisonAnalytics"];
+  interval: IntervalConfig;
+  nBins: number;
+}
+
+export function TwoScoreAnalytics({
+  score1,
+  score2,
+  analytics,
+  nBins,
+}: TwoScoreAnalyticsProps) {
+  // Extract categories for categorical/boolean scores
+  const categories = useMemo(() => {
+    if (score1.dataType === "NUMERIC") return undefined;
+
+    // Get unique categories from confusion matrix (use row categories for score1)
+    const uniqueCategories = new Set<string>();
+    analytics.confusionMatrix.forEach((row) => {
+      uniqueCategories.add(row.rowCategory);
+    });
+
+    return Array.from(uniqueCategories).sort();
+  }, [score1.dataType, analytics.confusionMatrix]);
+
+  // Fill missing bins for categorical/boolean data
+  const distribution1 = useMemo(() => {
+    const raw = analytics.distribution1;
+
+    if (score1.dataType === "NUMERIC" || !categories) {
+      return raw;
+    }
+
+    const binMap = new Map(raw.map((item) => [item.binIndex, item.count]));
+    return categories.map((_, index) => ({
+      binIndex: index,
+      count: binMap.get(index) ?? 0,
+    }));
+  }, [analytics.distribution1, score1.dataType, categories]);
+
+  const distribution2 = useMemo(() => {
+    const raw = analytics.distribution2;
+
+    if (score1.dataType === "NUMERIC" || !categories) {
+      return raw;
+    }
+
+    const binMap = new Map(raw.map((item) => [item.binIndex, item.count]));
+    return categories.map((_, index) => ({
+      binIndex: index,
+      count: binMap.get(index) ?? 0,
+    }));
+  }, [analytics.distribution2, score1.dataType, categories]);
+
+  // Generate bin labels for numeric scores
+  const binLabels = useMemo(() => {
+    if (score1.dataType !== "NUMERIC" || !analytics.statistics)
+      return undefined;
+
+    const heatmapRow = analytics.heatmap[0];
+    if (!heatmapRow) return undefined;
+
+    const min = heatmapRow.min1;
+    const max = heatmapRow.max1;
+    const binWidth = (max - min) / nBins;
+
+    return Array.from({ length: nBins }, (_, i) => {
+      const start = min + i * binWidth;
+      const end = min + (i + 1) * binWidth;
+      return formatBinLabel(start, end);
+    });
+  }, [score1.dataType, analytics.heatmap, analytics.statistics, nBins]);
+
+  const totalCount1 = analytics.counts.score1Total;
+  const totalCount2 = analytics.counts.score2Total;
+
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      {/* Distribution Card */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Distribution Comparison</CardTitle>
+          <CardDescription>
+            {score1.name} ({totalCount1.toLocaleString()}) vs {score2.name} (
+            {totalCount2.toLocaleString()})
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="h-[300px]">
+          {distribution1.length > 0 ? (
+            <ScoreDistributionChart
+              distribution1={distribution1}
+              distribution2={distribution2}
+              dataType={score1.dataType}
+              score1Name={`${score1.name} (${score1.source})`}
+              score2Name={`${score2.name} (${score2.source})`}
+              binLabels={binLabels}
+              categories={categories}
+            />
+          ) : (
+            <div className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+              No distribution data available for the selected time range
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Time Series Card Placeholder */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Scores Over Time</CardTitle>
+          <CardDescription>
+            Time series comparison (coming soon)
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex h-[300px] items-center justify-center text-sm text-muted-foreground">
+          Two-score time series chart coming in next phase
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+/**
+ * Format a bin label for display
+ * @param start - Start of the range
+ * @param end - End of the range
+ * @returns Formatted label string
+ */
+function formatBinLabel(start: number, end: number): string {
+  const range = Math.abs(end - start);
+  let precision: number;
+
+  if (range >= 1) {
+    precision = 1;
+  } else if (range >= 0.1) {
+    precision = 2;
+  } else {
+    precision = 3;
+  }
+
+  return `[${start.toFixed(precision)}, ${end.toFixed(precision)})`;
+}

--- a/web/src/features/scores/components/analytics/TwoScoreAnalytics.tsx
+++ b/web/src/features/scores/components/analytics/TwoScoreAnalytics.tsx
@@ -38,6 +38,13 @@ export function TwoScoreAnalytics({
 
   // Extract categories for categorical/boolean scores
   const categories = useMemo(() => {
+    console.log("[TwoScoreAnalytics] Category extraction:", {
+      dataType: score1.dataType,
+      hasStackedDistribution,
+      stackedDistributionLength: analytics.stackedDistribution?.length ?? 0,
+      confusionMatrixLength: analytics.confusionMatrix?.length ?? 0,
+    });
+
     if (score1.dataType === "NUMERIC") return undefined;
 
     // For categorical scores with stacked distribution, extract from stackedDistribution
@@ -46,7 +53,12 @@ export function TwoScoreAnalytics({
       analytics.stackedDistribution!.forEach((item) => {
         uniqueCategories.add(item.score1Category);
       });
-      return Array.from(uniqueCategories).sort();
+      const result = Array.from(uniqueCategories).sort();
+      console.log(
+        "[TwoScoreAnalytics] Categories from stackedDistribution:",
+        result,
+      );
+      return result;
     }
 
     // Fallback: Try confusionMatrix (for backward compatibility or boolean scores)
@@ -55,16 +67,23 @@ export function TwoScoreAnalytics({
       analytics.confusionMatrix.forEach((row) => {
         uniqueCategories.add(row.rowCategory);
       });
-      return Array.from(uniqueCategories).sort();
+      const result = Array.from(uniqueCategories).sort();
+      console.log(
+        "[TwoScoreAnalytics] Categories from confusionMatrix:",
+        result,
+      );
+      return result;
     }
 
     // For boolean: assume alphabetical order ["False", "True"]
     if (score1.dataType === "BOOLEAN") {
+      console.log("[TwoScoreAnalytics] Categories for boolean (hardcoded)");
       return ["False", "True"];
     }
 
     // For categorical: we can't reliably determine category names without stackedDistribution or confusionMatrix
     // The distribution only has binIndex, not actual category strings
+    console.log("[TwoScoreAnalytics] No categories found, returning undefined");
     return undefined;
   }, [
     score1.dataType,

--- a/web/src/features/scores/components/analytics/TwoScoreAnalytics.tsx
+++ b/web/src/features/scores/components/analytics/TwoScoreAnalytics.tsx
@@ -96,8 +96,10 @@ export function TwoScoreAnalytics({
     const heatmapRow = analytics.heatmap[0];
     if (!heatmapRow) return undefined;
 
-    const min = heatmapRow.min1;
-    const max = heatmapRow.max1;
+    // Backend now returns global bounds (min/max across BOTH scores) in min1/max1
+    // This ensures both distributions use the same bins for meaningful comparison
+    const min = heatmapRow.min1; // global_min from backend
+    const max = heatmapRow.max1; // global_max from backend
     const binWidth = (max - min) / nBins;
 
     return Array.from({ length: nBins }, (_, i) => {

--- a/web/src/features/scores/lib/color-scales.ts
+++ b/web/src/features/scores/lib/color-scales.ts
@@ -180,7 +180,7 @@ export function getDiagonalColor(
  * @returns HSL color string using CSS variable
  */
 export function getSingleScoreColor(): string {
-  return "hsl(var(--chart-2))";
+  return "hsl(var(--chart-3))";
 }
 
 /**

--- a/web/src/features/scores/lib/color-scales.ts
+++ b/web/src/features/scores/lib/color-scales.ts
@@ -180,7 +180,7 @@ export function getDiagonalColor(
  * @returns HSL color string using CSS variable
  */
 export function getSingleScoreColor(): string {
-  return "hsl(var(--dark-green))";
+  return "hsl(var(--chart-2))";
 }
 
 /**
@@ -193,8 +193,8 @@ export function getTwoScoreColors(): {
   score2: string;
 } {
   return {
-    score1: "hsl(var(--chart-1))", // dark-green
-    score2: "hsl(var(--chart-2))", // Another distinct color
+    score1: "hsl(var(--chart-3))",
+    score2: "hsl(var(--chart-2))",
   };
 }
 

--- a/web/src/pages/project/[projectId]/scores/analytics.tsx
+++ b/web/src/pages/project/[projectId]/scores/analytics.tsx
@@ -23,6 +23,7 @@ import {
   HeatmapLegend,
 } from "@/src/features/scores/components/analytics";
 import { SingleScoreAnalytics } from "@/src/features/scores/components/analytics/SingleScoreAnalytics";
+import { TwoScoreAnalytics } from "@/src/features/scores/components/analytics/TwoScoreAnalytics";
 import {
   generateNumericHeatmapData,
   generateConfusionMatrixData,
@@ -392,36 +393,31 @@ export default function ScoresAnalyticsPage() {
                 toDate={absoluteTimeRange!.to}
               />
             ) : hasTwoScores && parsedScore1 && parsedScore2 ? (
-              // Two score comparison (existing logic)
+              // Two score comparison
               <>
-                {/* 2x2 Grid Layout */}
+                {/* Distribution and Time Series Charts */}
+                <TwoScoreAnalytics
+                  score1={{
+                    ...parsedScore1,
+                    dataType: parsedScore1.dataType as
+                      | "NUMERIC"
+                      | "CATEGORICAL"
+                      | "BOOLEAN",
+                  }}
+                  score2={{
+                    ...parsedScore2,
+                    dataType: parsedScore2.dataType as
+                      | "NUMERIC"
+                      | "CATEGORICAL"
+                      | "BOOLEAN",
+                  }}
+                  analytics={analyticsData}
+                  interval={interval}
+                  nBins={10}
+                />
+
+                {/* 2x2 Grid Layout for Heatmap and Stats */}
                 <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-                  {/* Row 1, Col 1: Distribution Placeholder */}
-                  <Card>
-                    <CardHeader>
-                      <CardTitle>Score Distribution</CardTitle>
-                      <CardDescription>
-                        Distribution of selected scores (coming soon)
-                      </CardDescription>
-                    </CardHeader>
-                    <CardContent className="flex h-[300px] items-center justify-center text-sm text-muted-foreground">
-                      Histogram visualization coming soon
-                    </CardContent>
-                  </Card>
-
-                  {/* Row 1, Col 2: Score Over Time Placeholder */}
-                  <Card>
-                    <CardHeader>
-                      <CardTitle>Scores Over Time</CardTitle>
-                      <CardDescription>
-                        Time series of selected scores (coming soon)
-                      </CardDescription>
-                    </CardHeader>
-                    <CardContent className="flex h-[300px] items-center justify-center text-sm text-muted-foreground">
-                      Time series chart coming soon
-                    </CardContent>
-                  </Card>
-
                   {/* Row 2, Col 1: Heatmap / Confusion Matrix */}
                   <Card>
                     <CardHeader>

--- a/web/src/pages/project/[projectId]/scores/analytics.tsx
+++ b/web/src/pages/project/[projectId]/scores/analytics.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { useMemo, useEffect } from "react";
+import { useMemo, useEffect, useRef } from "react";
 import Page from "@/src/components/layouts/page";
 import {
   getScoresTabs,
@@ -101,6 +101,23 @@ export default function ScoresAnalyticsPage() {
     const selected = scoreOptions.find((opt) => opt.value === urlState.score1);
     return selected?.dataType;
   }, [urlState.score1, scoreOptions]);
+
+  // Clear score2 when score1's dataType changes
+  const prevScore1DataTypeRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    // Skip on initial render
+    if (prevScore1DataTypeRef.current === undefined) {
+      prevScore1DataTypeRef.current = score1DataType;
+      return;
+    }
+
+    // If dataType has changed and there's a score2 selected, clear it
+    if (prevScore1DataTypeRef.current !== score1DataType && urlState.score2) {
+      setScore2(undefined);
+    }
+
+    prevScore1DataTypeRef.current = score1DataType;
+  }, [score1DataType, urlState.score2, setScore2]);
 
   // Parse score identifiers (format: "name-dataType-source")
   const parsedScore1 = useMemo(() => {

--- a/web/src/pages/project/[projectId]/scores/analytics.tsx
+++ b/web/src/pages/project/[projectId]/scores/analytics.tsx
@@ -223,6 +223,7 @@ export default function ScoresAnalyticsPage() {
       fromTimestamp: absoluteTimeRange?.from!,
       toTimestamp: absoluteTimeRange?.to!,
       interval,
+      objectType: urlState.objectType,
     },
     {
       enabled: shouldFetchAnalytics,

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -865,11 +865,11 @@ export const scoresRouter = createTRPCRouter({
               (SELECT max(value) FROM score2_filtered) as max2
           ),
 
-          -- CTE 5: Heatmap (numeric only, NxN grid using global bounds)
+          -- CTE 5: Heatmap (numeric only, NxN grid using independent bounds per score)
           heatmap AS (
             SELECT
-              floor((m.value1 - b.global_min) / ((b.global_max - b.global_min + 0.0001) / {nBins: UInt8})) as bin_x,
-              floor((m.value2 - b.global_min) / ((b.global_max - b.global_min + 0.0001) / {nBins: UInt8})) as bin_y,
+              floor((m.value1 - b.min1) / ((b.max1 - b.min1 + 0.0001) / {nBins: UInt8})) as bin_x,
+              floor((m.value2 - b.min2) / ((b.max2 - b.min2 + 0.0001) / {nBins: UInt8})) as bin_y,
               count() as count,
               b.global_min, b.global_max,
               b.min1, b.max1, b.min2, b.max2


### PR DESCRIPTION
## Summary

Implements two-score comparison analytics with distribution charts, heatmaps, and cross-type score comparisons.

## Features Implemented

### 1. Stacked Bar Visualization for Categorical Scores
- Categorical comparison shows stacked bars with score2 category breakdown within each score1 category
- Backend LEFT JOIN query to create stacked distribution data
- Handles "unmatched" category for scores without pairs

### 2. Separate Chart Components
- `ScoreDistributionNumericChart`: Grouped bars for numeric comparison
- `ScoreDistributionBooleanChart`: Grouped bars for boolean comparison  
- `ScoreDistributionCategoricalChart`: Stacked bars for categorical comparison
- Router component selects appropriate chart based on data type

### 3. Independent Heatmap Binning
- Heatmap uses independent bounds per score (min1/max1, min2/max2)
- Distribution uses global bounds for consistent comparison
- Ensures accurate visualization when scores have different scales

### 4. Cross-Type Score Comparisons
- Allow Boolean + Categorical/Numeric comparisons (treat as categorical)
- Allow Categorical + Numeric comparisons (convert numeric to string)
- Backend COALESCE logic handles cross-type data extraction
- Frontend detects cross-type and uses categorical rendering

### 5. Object Type Filter
- Filter scores by trace/observation/session/run
- Backend SQL WHERE clauses based on object type selection
- Applied to both score CTEs for consistent filtering

### 6. Bug Fixes
- Fixed score2 clear button (Select component undefined handling)
- Fixed numeric chart rendering with proper color configuration
- Auto-clear incompatible score selections when score1 type changes

## Technical Details

**Backend Changes:**
- Enhanced ClickHouse queries with stacked distribution CTEs
- Object type filtering in score1_filtered/score2_filtered
- Cross-type support with COALESCE(string_value, toString(value))
- Independent vs global bounds for different visualizations

**Frontend Changes:**
- Separated chart components by data type
- Cross-type compatibility logic in ScoreSelector
- Enhanced TwoScoreAnalytics with cross-type detection
- Proper undefined/empty string handling for Select components

## Testing

Tested with:
- ✅ Numeric vs Numeric (grouped bars, heatmap, correlation stats)
- ✅ Boolean vs Boolean (grouped bars, confusion matrix)
- ✅ Categorical vs Categorical (stacked bars, confusion matrix)
- ✅ Boolean vs Categorical (stacked bars as categorical)
- ✅ Boolean vs Numeric (stacked bars, numeric converted to categories)
- ✅ Categorical vs Numeric (stacked bars, numeric converted to categories)
- ✅ Object type filtering (traces/observations/sessions/runs)

Relates to LF-1936
Parent: michael/lf-1919

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implements two-score comparison analytics with distribution charts, heatmaps, and cross-type comparisons, including backend and frontend enhancements.
> 
>   - **Features**:
>     - Implements two-score comparison analytics with distribution charts, heatmaps, and cross-type score comparisons.
>     - Supports Boolean, Categorical, and Numeric score comparisons.
>     - Adds object type filtering (trace/observation/session/run) in `scores.ts`.
>   - **Backend**:
>     - Enhances ClickHouse queries in `scores.ts` for stacked distribution and cross-type support.
>     - Adds SQL WHERE clauses for object type filtering.
>   - **Frontend**:
>     - Adds `ScoreDistributionBooleanChart`, `ScoreDistributionCategoricalChart`, and `ScoreDistributionNumericChart` components.
>     - Updates `ScoreDistributionChart` to route to specific chart components based on data type.
>     - Modifies `ScoreSelector` to handle multiple data types.
>     - Introduces `TwoScoreAnalytics` for rendering comparison analytics.
>   - **Testing**:
>     - Updates `score-comparison-analytics.servertest.ts` to test new analytics features and edge cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4355fe76ff28eaf7396c41302c86f5d81bff5d32. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->