### PR TITLE
fix(llm): add Google AI Studio to single system message conversion list

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -52,6 +52,7 @@ const isLangfuseCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 
 const PROVIDERS_WITH_REQUIRED_USER_MESSAGE = [
   LLMAdapter.VertexAI,
+  LLMAdapter.GoogleAIStudio,
   LLMAdapter.Anthropic,
 ];
 


### PR DESCRIPTION
## What does this PR do?

Fixes text prompt experiments failing with Google AI Studio (Gemini) when using datasets.

**Problem:** Text prompts create a single system message, but Google AI Studio requires at least one user message in the contents array, causing `GenerateContentRequest.contents is not specified` errors.

**Solution:** Added `LLMAdapter.GoogleAIStudio` to `PROVIDERS_WITH_REQUIRED_USER_MESSAGE` to automatically convert single system messages to user messages, matching existing behavior for VertexAI and Anthropic.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Google AI Studio to the list of providers requiring user messages, ensuring system messages are converted to user messages to prevent errors.
> 
>   - **Behavior**:
>     - Adds `LLMAdapter.GoogleAIStudio` to `PROVIDERS_WITH_REQUIRED_USER_MESSAGE` in `fetchLLMCompletion.ts` to convert single system messages to user messages.
>     - Ensures Google AI Studio does not throw `GenerateContentRequest.contents is not specified` errors.
>   - **Tests**:
>     - Adds test `single system message is converted to user message` in `llmConnections.test.ts` to verify conversion for Google AI Studio.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 699363f1a71b4284f7d70f4535289ada692d149d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->