### PR TITLE
fix: traceid filter for trace exports

### DIFF
--- a/packages/shared/src/server/tableMappings/mapTracesTable.ts
+++ b/packages/shared/src/server/tableMappings/mapTracesTable.ts
@@ -21,6 +21,12 @@ export const tracesTableUiColumnDefinitions: UiColumnMappings = [
     clickhouseSelect: "id",
   },
   {
+    uiTableName: "Trace ID",
+    uiTableId: "traceId",
+    clickhouseTableName: "traces",
+    clickhouseSelect: "id",
+  },
+  {
     uiTableName: "Name",
     uiTableId: "name",
     clickhouseTableName: "traces",


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where the "Trace ID" filter was ignored during trace exports, leading to excessively large export files. The problem occurred because "Trace ID" was not correctly defined as a filterable column for traces, causing it to be erroneously removed from the filter set.

To resolve this, "Trace ID" has been added to the `tracesTableUiColumnDefinitions` in `mapTracesTable.ts`, mapping it to the trace's `id` field. This ensures the filter is correctly applied during trace export. A new test case has also been added to `batchExport.test.ts` to verify the fix.

Fixes # LFE-7527

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [ ] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my PR needs changes to the documentation
- [ ] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [ ] I haven't added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-7527](https://linear.app/langfuse/issue/LFE-7527/traceid-filter-ignored-for-trace-exports)

<a href="https://cursor.com/background-agent?bcId=bc-996ed5d1-7f0c-4ecf-8f8b-552ee4923024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-996ed5d1-7f0c-4ecf-8f8b-552ee4923024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes 'Trace ID' filter application during trace exports by updating column definitions and adding a test case.
> 
>   - **Behavior**:
>     - Fixes issue where 'Trace ID' filter was ignored during trace exports, causing large export files.
>     - Adds 'Trace ID' to `tracesTableUiColumnDefinitions` in `mapTracesTable.ts`, mapping to trace's `id` field.
>     - New test case in `batchExport.test.ts` verifies 'Trace ID' filter application.
>   - **Tests**:
>     - Adds test in `batchExport.test.ts` to ensure 'Trace ID' filter works using both `uiTableName` and `uiTableId` variants.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c206ca6f9f9f5af27984268eaa1f76cb6a46c578. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->