### PR TITLE
feat(auth): render IdP callback error message on sign-in page

### DIFF
--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -1,4 +1,5 @@
 import { getAuthOptions } from "@/src/server/auth";
+import { env } from "@/src/env.mjs";
 import type { NextApiRequest, NextApiResponse } from "next";
 import NextAuth from "next-auth";
 
@@ -8,6 +9,34 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === "HEAD") {
     return res.status(200).end();
   }
+
+  // Intercept OAuth callback errors to preserve error_description from IdP
+  // This happens before NextAuth processes the callback, allowing us to preserve
+  // the IdP's error_description which NextAuth would otherwise strip
+  // Only intercept if this is an OAuth callback request (path starts with 'callback')
+  const isCallbackRequest =
+    Array.isArray(req.query.nextauth) &&
+    req.query.nextauth.length > 0 &&
+    req.query.nextauth[0] === "callback";
+
+  if (
+    isCallbackRequest &&
+    req.query.error &&
+    req.query.error_description &&
+    typeof req.query.error === "string" &&
+    typeof req.query.error_description === "string"
+  ) {
+    const error = req.query.error;
+    const errorDescription = req.query.error_description;
+    const basePath = env.NEXT_PUBLIC_BASE_PATH ?? "";
+
+    // Redirect directly to sign-in with error and error_description preserved
+    // This bypasses NextAuth's error page which strips error_description
+    return res.redirect(
+      `${basePath}/auth/sign-in?error=${encodeURIComponent(error)}&error_description=${encodeURIComponent(errorDescription)}`,
+    );
+  }
+
   // Do whatever you want here, before the request is passed down to `NextAuth`
   const authOptions = await getAuthOptions();
   // https://github.com/nextauthjs/next-auth/issues/2408#issuecomment-1382629234


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Preserves IdP OAuth callback error_description and surfaces it on the sign-in page with refined error handling/logging.
> 
> - **Auth API (`web/src/pages/api/auth/[...nextauth].ts`)**
>   - Intercepts OAuth callback requests with errors and redirects to `auth/sign-in`, preserving `error` and `error_description` via query params (uses `NEXT_PUBLIC_BASE_PATH`).
> - **Sign-in UI (`web/src/pages/auth/sign-in.tsx`)**
>   - Reads `error_description` from query and prioritizes it for display; falls back to mapped error or code.
>   - Refines Sentry logging to only log unexpected errors (not mapped and without `error_description`).
>   - Initializes credentials form error with the computed error message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84eddf8ee064a9ea3f3bceabc82b0e3c7ca07b7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Intercepts OAuth callback errors to preserve IdP error descriptions and render them on the sign-in page, enhancing error handling and user feedback.
> 
>   - **Behavior**:
>     - Intercepts OAuth callback errors in `auth()` in `[...nextauth].ts` to preserve `error_description` from IdP and redirects to sign-in page with error details.
>     - Updates `SignIn` component in `sign-in.tsx` to display `error_description` from IdP if available, otherwise uses mapped error or error code.
>   - **Error Handling**:
>     - Logs unexpected sign-in errors to Sentry in `SignIn` component if not mapped and no `error_description` is available.
>   - **Misc**:
>     - Adds `env` import in `[...nextauth].ts` for base path configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 84eddf8ee064a9ea3f3bceabc82b0e3c7ca07b7e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->