### PR TITLE
fix(ui): background on unauthenticated pages should span the full height

### DIFF
--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -306,9 +306,13 @@ export default function Layout(props: PropsWithChildren) {
     router.pathname.startsWith("/public/");
   if (hideNavigation)
     return (
-      <main className="w-full bg-primary-foreground p-3 px-4 py-4 sm:px-6 lg:px-8">
-        <SidebarProvider>{props.children}</SidebarProvider>
-      </main>
+      <div className="bg-primary-foreground">
+        <SidebarProvider>
+          <main className="min-h-dvh w-full p-3 px-4 py-4 sm:px-6 lg:px-8">
+            {props.children}
+          </main>
+        </SidebarProvider>
+      </div>
     );
   return (
     <>

--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -306,11 +306,9 @@ export default function Layout(props: PropsWithChildren) {
     router.pathname.startsWith("/public/");
   if (hideNavigation)
     return (
-      <SidebarProvider>
-        <main className="h-dvh w-full bg-primary-foreground p-3 px-4 py-4 sm:px-6 lg:px-8">
-          {props.children}
-        </main>
-      </SidebarProvider>
+      <main className="w-full bg-primary-foreground p-3 px-4 py-4 sm:px-6 lg:px-8">
+        <SidebarProvider>{props.children}</SidebarProvider>
+      </main>
     );
   return (
     <>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjust unauthenticated layout structure and classes so the background spans the full viewport height.
> 
> - **Layout (`web/src/components/layouts/layout.tsx`)**
>   - For `hideNavigation` branch:
>     - Wrap content with an outer `div` using `bg-primary-foreground` and place `SidebarProvider` inside it.
>     - Update `main` classes: switch `h-dvh` to `min-h-dvh` and add `w-full`; move background color from `main` to wrapper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d464553da6b5a7dc2992ddea7892b6690238b74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `layout.tsx` to ensure full-height background on unauthenticated pages by adjusting `SidebarProvider` and `main` structure.
> 
>   - **Layout (`layout.tsx`)**:
>     - For `hideNavigation` true:
>       - Wrap `props.children` with `SidebarProvider` inside `main`.
>       - Update `main` classes: remove `h-dvh`, add `w-full`.
>       - Add `div` with `bg-primary-foreground` around `SidebarProvider`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e37e8a078202f45fee02ff51854003c50dd2e4e4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->