### PR TITLE
chore(prompt-experiments): move shared dataset item input validation to shared

### DIFF
--- a/packages/shared/src/features/experiments/utils.ts
+++ b/packages/shared/src/features/experiments/utils.ts
@@ -13,3 +13,59 @@ export const datasetItemMatchesVariable = (
     return false;
   return Object.keys(input).includes(variable);
 };
+
+const isValidPrismaJsonObject = (
+  input: Prisma.JsonValue,
+): input is Prisma.JsonObject =>
+  typeof input === "object" &&
+  input !== null &&
+  input !== undefined &&
+  !Array.isArray(input);
+
+/**
+ * Validate dataset item input against prompt variables.
+ * Allows plain strings if exactly one variable exists.
+ */
+export const validateDatasetItem = (
+  itemInput: Prisma.JsonValue,
+  variables: string[],
+): boolean => {
+  // String allowed if exactly 1 variable
+  if (
+    typeof itemInput === "string" &&
+    itemInput !== "" &&
+    variables.length === 1
+  ) {
+    return true;
+  }
+
+  // Object validation: must have at least one matching variable
+  if (!isValidPrismaJsonObject(itemInput)) {
+    return false;
+  }
+
+  return variables.some((variable) =>
+    datasetItemMatchesVariable(itemInput, variable),
+  );
+};
+
+/**
+ * Normalize dataset item input to object format.
+ * Auto-wraps strings into {variableName: string} for single-variable prompts.
+ */
+export const normalizeDatasetItemInput = (
+  itemInput: Prisma.JsonValue,
+  variables: string[],
+): Prisma.JsonObject => {
+  // Auto-wrap string for single variable
+  if (typeof itemInput === "string" && variables.length === 1) {
+    return { [variables[0]]: itemInput };
+  }
+
+  // Pass through objects
+  if (isValidPrismaJsonObject(itemInput)) {
+    return itemInput;
+  }
+
+  throw new Error("Invalid dataset item input");
+};

--- a/worker/src/features/experiments/utils.ts
+++ b/worker/src/features/experiments/utils.ts
@@ -3,7 +3,6 @@ import {
   ChatMessageRole,
   ChatMessageType,
   compileChatMessages,
-  datasetItemMatchesVariable,
   extractPlaceholderNames,
   extractVariables,
   MessagePlaceholderValues,
@@ -26,26 +25,6 @@ import {
 import { prisma } from "@langfuse/shared/src/db";
 import z from "zod/v4";
 import { UnrecoverableError } from "../../errors/UnrecoverableError";
-
-const isValidPrismaJsonObject = (
-  input: Prisma.JsonValue,
-): input is Prisma.JsonObject =>
-  typeof input === "object" &&
-  input !== null &&
-  input !== undefined &&
-  !Array.isArray(input);
-
-export const validateDatasetItem = (
-  itemInput: Prisma.JsonValue,
-  variables: string[],
-): itemInput is Prisma.JsonObject => {
-  if (!isValidPrismaJsonObject(itemInput)) {
-    return false;
-  }
-  return variables.some((variable) =>
-    datasetItemMatchesVariable(itemInput, variable),
-  );
-};
 
 export const parseDatasetItemInput = (
   itemInput: Prisma.JsonObject,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor dataset item input validation by moving logic to shared utilities, introducing `validateDatasetItem` and `normalizeDatasetItemInput`, and updating existing code to use these functions.
> 
>   - **Behavior**:
>     - Moves dataset item input validation to shared utilities in `utils.ts`.
>     - Introduces `validateDatasetItem` and `normalizeDatasetItemInput` in `shared/src/features/experiments/utils.ts`.
>     - Updates `countValidDatasetItems` in `router.ts` to use `validateDatasetItem`.
>     - Updates `getItemsToProcess` in `experimentServiceClickhouse.ts` to use `normalizeDatasetItemInput`.
>   - **Functions**:
>     - `validateDatasetItem`: Validates dataset item input against prompt variables, allowing strings if one variable exists.
>     - `normalizeDatasetItemInput`: Normalizes input to object format, wrapping strings for single-variable prompts.
>   - **Misc**:
>     - Removes `validateDatasetItem` and `isValidPrismaJsonObject` from `worker/src/features/experiments/utils.ts`.
>     - Renames `validateDatasetItems` to `countValidDatasetItems` in `router.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 62cb576d73a302c481a43d967505cd2b89808a54. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->