### PR TITLE
fix(trace-ui): tool call ordering

### DIFF
--- a/web/src/utils/chatml/adapters/langgraph.ts
+++ b/web/src/utils/chatml/adapters/langgraph.ts
@@ -291,7 +291,11 @@ export const langgraphAdapter: ProviderAdapter = {
 
     // Check wrapped messages format
     if (LangGraphWrappedSchema.safeParse(ctx.metadata).success) {
-      const wrapped = ctx.metadata as { messages: unknown[] };
+      const wrapped = ctx.metadata as { messages: unknown[]; tools?: unknown };
+      // reject OpenAI Chat Completions format {tools: [...], messages: [...]}
+      if (Array.isArray(wrapped.tools)) {
+        return false;
+      }
       if (LangChainMessageSchema.safeParse(wrapped.messages).success)
         return true;
       if (LangGraphMessageSchema.safeParse(wrapped.messages).success)
@@ -304,7 +308,11 @@ export const langgraphAdapter: ProviderAdapter = {
 
     // Check wrapped messages format on data
     if (LangGraphWrappedSchema.safeParse(ctx.data).success) {
-      const wrapped = ctx.data as { messages: unknown[] };
+      const wrapped = ctx.data as { messages: unknown[]; tools?: unknown };
+      // reject OpenAI Chat Completions format {tools: [...], messages: [...]}
+      if (Array.isArray(wrapped.tools)) {
+        return false;
+      }
       if (LangChainMessageSchema.safeParse(wrapped.messages).success)
         return true;
       if (LangGraphMessageSchema.safeParse(wrapped.messages).success)

--- a/web/src/utils/chatml/adapters/openai.clienttest.ts
+++ b/web/src/utils/chatml/adapters/openai.clienttest.ts
@@ -223,6 +223,57 @@ describe("OpenAI Adapter", () => {
       );
     });
 
+    it("should handle request format with multiple tools and multiple messages", () => {
+      const input = {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "tool_a",
+              description: "First tool",
+              parameters: {
+                type: "object",
+                properties: { param1: { type: "string" } },
+                required: ["param1"],
+              },
+            },
+          },
+          {
+            type: "function",
+            function: {
+              name: "tool_b",
+              description: "Second tool",
+              parameters: {
+                type: "object",
+                properties: { param2: { type: "string" } },
+                required: ["param2"],
+              },
+            },
+          },
+        ],
+        messages: [
+          { role: "system", content: "You are a helpful assistant" },
+          { role: "user", content: "test query" },
+        ],
+      };
+
+      const result = normalizeInput(input, { framework: "openai" });
+      expect(result.success).toBe(true);
+
+      // Tools should be attached to ALL messages
+      expect(result.data).toHaveLength(2);
+      expect(result.data?.[0].tools).toHaveLength(2);
+      expect(result.data?.[1].tools).toHaveLength(2);
+
+      // Check tool definitions are properly flattened
+      expect(result.data?.[0].tools?.[0].name).toBe("tool_a");
+      expect(result.data?.[0].tools?.[0].description).toBe("First tool");
+      expect(result.data?.[0].tools?.[0].parameters).toBeDefined();
+
+      expect(result.data?.[0].tools?.[1].name).toBe("tool_b");
+      expect(result.data?.[0].tools?.[1].description).toBe("Second tool");
+    });
+
     it("should handle response format with tool calls", () => {
       const output = {
         role: "assistant",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix tool call ordering in `IOPreview.tsx` by numbering only output messages and sorting tools by call status and count.
> 
>   - **Behavior**:
>     - In `IOPreview.tsx`, tool call numbering is restricted to output messages only, ensuring historical input messages are not numbered.
>     - Tools are sorted by call status and count, with called tools appearing first.
>   - **Detection**:
>     - In `langgraph.ts`, detection logic updated to reject OpenAI Chat Completions format if `tools` array is present.
>   - **Testing**:
>     - In `openai.clienttest.ts`, added test for handling request format with multiple tools and messages, ensuring tools are attached to all messages and definitions are flattened.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b835b7c92293450e178cbf62f2eb0641f8010fa5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->