### PR TITLE
fix(playground): don't crash if tools not stringified

### DIFF
--- a/web/src/utils/chatml/playgroundConverter.ts
+++ b/web/src/utils/chatml/playgroundConverter.ts
@@ -6,6 +6,17 @@ import {
   type PlaceholderMessage,
 } from "@langfuse/shared";
 
+// convert content to string format expected by playground
+function contentToString(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (content === null || content === undefined) {
+    return "";
+  }
+  return JSON.stringify(content);
+}
+
 export function convertChatMlToPlayground(
   msg: ChatMlMessageSchema,
 ): ChatMessage | PlaceholderMessage | null {
@@ -61,7 +72,7 @@ export function convertChatMlToPlayground(
 
     return {
       role: ChatMessageRole.Assistant,
-      content: (msg.content as string) || "",
+      content: contentToString(msg.content),
       type: ChatMessageType.AssistantToolCall,
       toolCalls,
     };
@@ -74,23 +85,16 @@ export function convertChatMlToPlayground(
   if (toolCallId) {
     return {
       role: ChatMessageRole.Tool,
-      content: (msg.content as string) || "",
+      content: contentToString(msg.content),
       type: ChatMessageType.ToolResult,
       toolCallId: toolCallId as string,
     };
   }
 
   // Handle regular messages
-  const content =
-    typeof msg.content === "string"
-      ? msg.content
-      : msg.content === null || msg.content === undefined
-        ? ""
-        : JSON.stringify(msg.content);
-
   return {
     role: (msg.role as ChatMessageRole) || ChatMessageRole.Assistant,
-    content,
+    content: contentToString(msg.content),
     type: ChatMessageType.PublicAPICreated,
   };
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix crash by ensuring tool result content is stringified in `convertChatMlToPlayground()` and add tests for verification.
> 
>   - **Behavior**:
>     - Fix crash by ensuring tool result content is stringified in `convertChatMlToPlayground()` in `playgroundConverter.ts`.
>     - Adds `contentToString()` function to handle stringification of content.
>   - **Tests**:
>     - Adds test case in `jumptoplayground.clienttest.ts` to verify stringification of multimodal array content in tool results.
>     - Verifies that `tool-result` messages have string content to prevent CodeMirror errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 30c03ccc3c926cd0a9775f8e7e8b8d009bde7f76. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->