### PR TITLE
fix(trace): only show full message if available

### DIFF
--- a/web/src/components/trace/IOPreview.tsx
+++ b/web/src/components/trace/IOPreview.tsx
@@ -398,6 +398,10 @@ export const OpenAiMessageView: React.FC<{
     return messageKeys.length > 0;
   };
 
+  const hasPassthroughJson = (message: ChatMlMessageSchema) => {
+    return message.json != null;
+  };
+
   const isPlaceholderMessage = (message: ChatMlMessageSchema) => {
     return message.type === "placeholder";
   };
@@ -501,14 +505,14 @@ export const OpenAiMessageView: React.FC<{
                                   )}
                                   audio={message.audio}
                                   controlButtons={
-                                    hasAdditionalData(message) ? (
+                                    hasPassthroughJson(message) ? (
                                       <Button
                                         variant="ghost"
                                         size="icon-xs"
                                         onClick={() =>
                                           toggleTableView(originalIndex)
                                         }
-                                        title="Show full message data"
+                                        title="Show passthrough JSON data"
                                         className="-mr-2 hover:bg-border"
                                       >
                                         <ListChevronsUpDown className="h-3 w-3" />
@@ -544,14 +548,14 @@ export const OpenAiMessageView: React.FC<{
                                   }
                                   currentView={currentView}
                                   controlButtons={
-                                    hasAdditionalData(message) ? (
+                                    hasPassthroughJson(message) ? (
                                       <Button
                                         variant="ghost"
                                         size="icon-xs"
                                         onClick={() =>
                                           toggleTableView(originalIndex)
                                         }
-                                        title="Show full message data"
+                                        title="Show passthrough JSON data"
                                         className="-mr-2 hover:bg-border"
                                       >
                                         <ListChevronsUpDown className="h-3 w-3" />
@@ -575,10 +579,10 @@ export const OpenAiMessageView: React.FC<{
                             </>
                           )}
                         {isShowingTable ? (
-                          // User clicked toggle - show full JSON
+                          // User clicked toggle - show passthrough JSON
                           <PrettyJsonView
                             title={getMessageTitle(message)}
-                            json={message}
+                            json={message.json}
                             projectIdForPromptButtons={
                               projectIdForPromptButtons
                             }
@@ -613,15 +617,19 @@ export const OpenAiMessageView: React.FC<{
                                 void copyTextToClipboard(rawText);
                               }}
                               controlButtons={
-                                <Button
-                                  variant="ghost"
-                                  size="icon-xs"
-                                  onClick={() => toggleTableView(originalIndex)}
-                                  title="Show full message data"
-                                  className="-mr-2 hover:bg-border"
-                                >
-                                  <ListChevronsUpDown className="h-3 w-3" />
-                                </Button>
+                                hasPassthroughJson(message) ? (
+                                  <Button
+                                    variant="ghost"
+                                    size="icon-xs"
+                                    onClick={() =>
+                                      toggleTableView(originalIndex)
+                                    }
+                                    title="Show passthrough JSON data"
+                                    className="-mr-2 hover:bg-border"
+                                  >
+                                    <ListChevronsUpDown className="h-3 w-3" />
+                                  </Button>
+                                ) : undefined
                               }
                             />
                             <ToolCallInvocationsView


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `OpenAiMessageView` to show passthrough JSON data only if available, with updated button titles and logic.
> 
>   - **Behavior**:
>     - In `OpenAiMessageView`, replace `hasAdditionalData()` with `hasPassthroughJson()` to conditionally show control buttons only if `message.json` is available.
>     - Change button title from "Show full message data" to "Show passthrough JSON data" in `OpenAiMessageView`.
>     - Modify `PrettyJsonView` to display `message.json` instead of the entire `message` when toggled.
>   - **Functions**:
>     - Add `hasPassthroughJson()` function to check for `message.json` presence in `IOPreview.tsx`.
>   - **Misc**:
>     - Update comments to reflect changes in JSON display logic in `IOPreview.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 477bdc8156bc4dfa24a3cc9ed21fc7e59cb8b3bb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->