### PR TITLE
fix(traces-ui): rendering of json output

### DIFF
--- a/web/src/components/trace/IOPreview.tsx
+++ b/web/src/components/trace/IOPreview.tsx
@@ -406,6 +406,17 @@ export const OpenAiMessageView: React.FC<{
     return message.type === "placeholder";
   };
 
+  const isOnlyJsonMessage = (message: ChatMlMessageSchema) => {
+    // Message parsed as ChatML but only has json field (non-ChatML object)
+    // Valid ChatML needs content OR tool_calls OR audio (role alone is insufficient)
+    const hasValidChatMlContent =
+      message.content != null ||
+      message.tool_calls != null ||
+      message.audio != null;
+
+    return !hasValidChatMlContent && message.json != null;
+  };
+
   const messagesToRender = useMemo(
     () =>
       messages.filter(
@@ -482,6 +493,14 @@ export const OpenAiMessageView: React.FC<{
                           />
                         </div>
                       </>
+                    ) : isOnlyJsonMessage(message) ? (
+                      // Non-ChatML object that parsed via passthrough - render as JSON
+                      <PrettyJsonView
+                        title={getMessageTitle(message) || "Output"}
+                        json={message.json}
+                        projectIdForPromptButtons={projectIdForPromptButtons}
+                        currentView={currentView}
+                      />
                     ) : (
                       <>
                         {shouldRenderContent(message) &&


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `isOnlyJsonMessage()` to render JSON-only messages correctly in `OpenAiMessageView`.
> 
>   - **Behavior**:
>     - Adds `isOnlyJsonMessage()` in `OpenAiMessageView` to identify messages with only JSON data.
>     - Renders messages identified by `isOnlyJsonMessage()` using `PrettyJsonView`.
>   - **Functions**:
>     - `isOnlyJsonMessage()` checks for absence of ChatML content but presence of JSON.
>     - Updates `messagesToRender` logic to include `isOnlyJsonMessage()` condition.
>   - **Rendering**:
>     - Handles non-ChatML objects by rendering them as JSON in `OpenAiMessageView`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 17179632674a752154cb6ba1a4cf72f4229e0cb0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->