### PR TITLE
feat(traceui): parse python dicts

### DIFF
--- a/packages/shared/src/utils/json.ts
+++ b/packages/shared/src/utils/json.ts
@@ -26,6 +26,9 @@ function tryParsePythonDict(str: string): unknown {
       .replace(/\bTrue\b/g, "true")
       .replace(/\bFalse\b/g, "false")
       .replace(/\bNone\b/g, "null")
+      // NOTE: this converts all ' indiscriminately and might break some JSONs with escaped '
+      // not that bad, because we only call this function, after JSON.parse has already failed
+      // therefore, the failure case is the default already.
       .replace(/'/g, '"');
 
     return JSON.parse(jsonStr);

--- a/packages/shared/src/utils/json.ts
+++ b/packages/shared/src/utils/json.ts
@@ -1,6 +1,39 @@
 import { JsonNested } from "./zod";
 import { parse, isSafeNumber, isNumber } from "lossless-json";
 
+// attempts to parse Python dict/list string to JSON object
+// LangChain/LangGraph v1 tool calls are logged as python dicts for example
+function tryParsePythonDict(str: string): unknown {
+  // performance: early terminate unless has single quotes AND dict/list structure chars
+  if (!str.includes("'") || !(str.includes("{") || str.includes("["))) {
+    return str;
+  }
+
+  if (str.length > 1_000_000) {
+    return str;
+  }
+
+  const trimmed = str.trim();
+  if (trimmed[0] !== "{" && trimmed[0] !== "[") {
+    return str;
+  }
+
+  try {
+    // Convert Python syntax to JSON:
+    // 1. Replace Python boolean/null literals (with word boundaries)
+    // 2. Replace single quotes with double quotes
+    const jsonStr = trimmed
+      .replace(/\bTrue\b/g, "true")
+      .replace(/\bFalse\b/g, "false")
+      .replace(/\bNone\b/g, "null")
+      .replace(/'/g, '"');
+
+    return JSON.parse(jsonStr);
+  } catch (e) {
+    return str;
+  }
+}
+
 /**
  * Deeply parses a JSON string or object for nested stringified JSON
  * @param json JSON string or object to parse
@@ -13,6 +46,10 @@ export function deepParseJson(json: unknown): unknown {
       if (typeof parsed === "number") return json; // numbers that were strings in the input should remain as strings
       return deepParseJson(parsed); // Recursively parse parsed value
     } catch (e) {
+      const pythonParsed = tryParsePythonDict(json);
+      if (pythonParsed !== json) {
+        return deepParseJson(pythonParsed);
+      }
       return json; // If it's not a valid JSON string, just return the original string
     }
   } else if (typeof json === "object" && json !== null) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `tryParsePythonDict` to convert Python dicts/lists to JSON in `json.ts`, updating `deepParseJson` to use it when JSON parsing fails.
> 
>   - **Functionality**:
>     - Adds `tryParsePythonDict` function in `json.ts` to convert Python dict/list strings to JSON objects.
>     - Updates `deepParseJson` in `json.ts` to use `tryParsePythonDict` when JSON parsing fails.
>   - **Behavior**:
>     - Handles Python boolean and null literals by converting them to JSON equivalents.
>     - Replaces single quotes with double quotes in Python dicts/lists.
>     - Limits parsing to strings with single quotes and dict/list structure characters, and strings shorter than 1,000,000 characters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a465ad515d0ecf8b3769ed72ff49987c29bd19f1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->