### PR TITLE
feat: public flag via events table

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -167,7 +167,7 @@ const EVENTS_AGGREGATION_FIELDS = {
 
   bookmarked:
     "argMaxIf(bookmarked, event_ts, parent_span_id = '') AS bookmarked",
-  public: "argMaxIf(public, event_ts, parent_span_id = '') AS public",
+  public: "max(public) AS public",
   // Legacy fields for backward compatibility
   tags: "array() AS tags",
   release: "'' AS release",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change `public` flag handling in events table and add tests for setting/unsetting it.
> 
>   - **Behavior**:
>     - Change `public` field aggregation in `event-query-builder.ts` from `argMaxIf` to `max`.
>     - Add tests for setting/unsetting `public` flag in `event-repository.servertest.ts` and `traces-trpc.servertest.ts`.
>   - **API**:
>     - Update `traces.ts` to handle `public` flag in `publish` mutation, updating both Clickhouse and events table if `LANGFUSE_ENABLE_EVENTS_TABLE_FLAGS` is true.
>   - **Tests**:
>     - Modify `traces-trpc.servertest.ts` to test `publish` mutation for public flag handling.
>     - Update `event-repository.servertest.ts` to include tests for `public` flag behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 36809ca9941e251caa073321d58ad2d0ad282422. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->