### PR TITLE
fix(trace-log): better behaviour for large traces

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
         version: 15.5.4(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next-auth:
         specifier: ^4.24.12
-        version: 4.24.12(next@15.5.4(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(nodemailer@7.0.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 4.24.12(next@15.5.4(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(nodemailer@7.0.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       zod:
         specifier: ^3.25.62
         version: 3.25.62
@@ -236,7 +236,7 @@ importers:
         version: 4.1.1
       next-auth:
         specifier: ^4.24.12
-        version: 4.24.12(next@15.5.4(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(nodemailer@7.0.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 4.24.12(next@15.5.4(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(nodemailer@7.0.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       nodemailer:
         specifier: ^7.0.10
         version: 7.0.10
@@ -633,7 +633,7 @@ importers:
         version: 15.5.4(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next-auth:
         specifier: ^4.24.12
-        version: 4.24.12(next@15.5.4(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(nodemailer@7.0.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 4.24.12(next@15.5.4(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(nodemailer@7.0.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next-query-params:
         specifier: ^5.1.0
         version: 5.1.0(next@15.5.4(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(use-query-params@2.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
@@ -17603,7 +17603,7 @@ snapshots:
   '@next-auth/prisma-adapter@1.0.7(@prisma/client@6.17.1(prisma@6.17.1(typescript@5.9.2))(typescript@5.9.2))(next-auth@4.24.12(next@15.5.4(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(nodemailer@7.0.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
     dependencies:
       '@prisma/client': 6.17.1(prisma@6.17.1(typescript@5.9.2))(typescript@5.9.2)
-      next-auth: 4.24.12(next@15.5.4(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(nodemailer@7.0.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next-auth: 4.24.12(next@15.5.4(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(nodemailer@7.0.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
   '@next/bundle-analyzer@15.5.4':
     dependencies:
@@ -21093,7 +21093,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 24.10.0
+      '@types/node': 24.3.0
     optional: true
 
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.9.2))(eslint@8.57.0)(typescript@5.9.2)':
@@ -24196,7 +24196,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.3
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -27037,7 +27037,7 @@ snapshots:
     dependencies:
       type-fest: 2.19.0
 
-  next-auth@4.24.12(next@15.5.4(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(nodemailer@7.0.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  next-auth@4.24.12(next@15.5.4(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(nodemailer@7.0.10)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@babel/runtime': 7.28.4
       '@panva/hkdf': 1.2.1

--- a/web/src/components/trace/TraceLogView.tsx
+++ b/web/src/components/trace/TraceLogView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect } from "react";
+import { useMemo, useEffect, useCallback } from "react";
 import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
 import { type ObservationReturnTypeWithMetadata } from "@/src/server/api/routers/traces";
 import { api } from "@/src/utils/api";
@@ -6,6 +6,9 @@ import { StringParam, useQueryParam } from "use-query-params";
 import { useQueries } from "@tanstack/react-query";
 import { type JsonNested } from "@langfuse/shared";
 import { useJsonExpansion } from "@/src/components/trace/JsonExpansionContext";
+import { Download } from "lucide-react";
+import { Button } from "@/src/components/ui/button";
+import { downloadTraceAsJson as downloadTraceUtil } from "@/src/components/trace/lib/helpers";
 
 // for Json Expansion Context State (keeps expanded/collapsed state across traces)
 
@@ -85,11 +88,16 @@ export const TraceLogView = ({
   traceId,
   projectId,
   currentView,
+  trace,
 }: {
   observations: ObservationReturnTypeWithMetadata[];
   traceId: string;
   projectId: string;
   currentView: "pretty" | "json";
+  trace: {
+    id: string;
+    [key: string]: unknown;
+  };
 }) => {
   const [currentObservationId] = useQueryParam("observation", StringParam);
   const [selectedTab] = useQueryParam("view", StringParam);
@@ -214,6 +222,25 @@ export const TraceLogView = ({
     [expansionState.log, observationKeys],
   );
 
+  // download includes trace + observations with full I/O
+  const downloadLogAsJson = useCallback(() => {
+    const observationsWithFullData = observations.map((obs, index) => {
+      const obsWithIO = observationsWithIO[index]?.data;
+      return {
+        ...obs,
+        input: obsWithIO?.input,
+        output: obsWithIO?.output,
+        metadata: obsWithIO?.metadata,
+      };
+    });
+
+    downloadTraceUtil({
+      trace,
+      observations: observationsWithFullData,
+      filename: `trace-with-observations-${traceId}.json`,
+    });
+  }, [trace, observations, observationsWithIO, traceId]);
+
   // Only render the actual log view when all data is loaded
   // prevents partial rendering and improves performance
   if (isLoading) {
@@ -246,6 +273,17 @@ export const TraceLogView = ({
           }
           stickyTopLevelKey={true}
           showObservationTypeBadge={true}
+          controlButtons={
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={downloadLogAsJson}
+              title="Download trace log as JSON"
+              className="-mr-2"
+            >
+              <Download className="h-3 w-3" />
+            </Button>
+          }
         />
       </div>
     </div>

--- a/web/src/components/trace/TraceLogView.tsx
+++ b/web/src/components/trace/TraceLogView.tsx
@@ -196,7 +196,7 @@ export const TraceLogView = ({
           `[data-observation-id="${keyPathFormat}"]`,
         );
         if (element) {
-          element.scrollIntoView({ behavior: "smooth", block: "center" });
+          element.scrollIntoView({ behavior: "smooth", block: "start" });
         }
       }
     }

--- a/web/src/components/trace/TraceLogView.tsx
+++ b/web/src/components/trace/TraceLogView.tsx
@@ -214,6 +214,22 @@ export const TraceLogView = ({
     [expansionState.log, observationKeys],
   );
 
+  // Only render the actual log view when all data is loaded
+  // prevents partial rendering and improves performance
+  if (isLoading) {
+    return (
+      <div className="flex h-full w-full flex-col overflow-hidden pr-3">
+        <div className="mb-2 flex max-h-full min-h-0 w-full flex-col gap-2 overflow-y-auto">
+          <div className="rounded-md border p-4">
+            <div className="text-sm text-muted-foreground">
+              Loading {observations.length} observations...
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex h-full w-full flex-col overflow-hidden pr-3">
       <div className="mb-2 flex max-h-full min-h-0 w-full flex-col gap-2 overflow-y-auto">
@@ -222,7 +238,7 @@ export const TraceLogView = ({
           title="Concatenated Observation Log"
           json={logData.data}
           currentView={currentView}
-          isLoading={isLoading}
+          isLoading={false}
           showNullValues={false}
           externalExpansionState={denormalizedState}
           onExternalExpansionChange={(expansion) =>

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -18,7 +18,7 @@ import { CommentDrawerButton } from "@/src/features/comments/CommentDrawerButton
 import { api } from "@/src/utils/api";
 import { NewDatasetItemFromExistingObject } from "@/src/features/datasets/components/NewDatasetItemFromExistingObject";
 import { CreateNewAnnotationQueueItem } from "@/src/features/annotation-queues/components/CreateNewAnnotationQueueItem";
-import { useMemo, useState, useEffect, useCallback } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { usdFormatter } from "@/src/utils/numbers";
 import { calculateDisplayTotalCost } from "@/src/components/trace/lib/helpers";
 import { useIsAuthenticatedAndProjectMember } from "@/src/features/auth/hooks";

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -282,7 +282,7 @@ export const TracePreview = ({
                   <TabsBarTrigger value="log" disabled={isLogViewDisabled}>
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <span>Log View (Beta)</span>
+                        <span>Log View</span>
                       </TooltipTrigger>
                       <TooltipContent className="text-xs">
                         {isLogViewDisabled

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -18,7 +18,7 @@ import { CommentDrawerButton } from "@/src/features/comments/CommentDrawerButton
 import { api } from "@/src/utils/api";
 import { NewDatasetItemFromExistingObject } from "@/src/features/datasets/components/NewDatasetItemFromExistingObject";
 import { CreateNewAnnotationQueueItem } from "@/src/features/annotation-queues/components/CreateNewAnnotationQueueItem";
-import { useMemo, useState, useEffect } from "react";
+import { useMemo, useState, useEffect, useCallback } from "react";
 import { usdFormatter } from "@/src/utils/numbers";
 import { calculateDisplayTotalCost } from "@/src/components/trace/lib/helpers";
 import { useIsAuthenticatedAndProjectMember } from "@/src/features/auth/hooks";
@@ -46,6 +46,16 @@ import {
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
 import TagList from "@/src/features/tag/components/TagList";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/src/components/ui/alert-dialog";
 
 export const TracePreview = ({
   trace,
@@ -116,13 +126,31 @@ export const TracePreview = ({
   );
 
   // For performance reasons, we preemptively disable the log view if there are too many observations.
-  const isLogViewDisabled = observations.length > 150;
+  const LOG_VIEW_CONFIRMATION_THRESHOLD = 150;
+  const LOG_VIEW_DISABLED_THRESHOLD = 350;
+  const isLogViewDisabled = observations.length > LOG_VIEW_DISABLED_THRESHOLD;
+  const requiresConfirmation =
+    observations.length > LOG_VIEW_CONFIRMATION_THRESHOLD && !isLogViewDisabled;
   const showLogViewTab = observations.length > 0;
+
+  const [hasLogViewConfirmed, setHasLogViewConfirmed] = useState(false);
+  const [showLogViewDialog, setShowLogViewDialog] = useState(false);
+
+  useEffect(() => {
+    setHasLogViewConfirmed(false);
+  }, [trace.id]);
+
   useEffect(() => {
     if ((isLogViewDisabled || !showLogViewTab) && selectedTab === "log") {
       setSelectedTab("preview");
     }
   }, [isLogViewDisabled, showLogViewTab, selectedTab, setSelectedTab]);
+
+  const handleConfirmLogView = () => {
+    setHasLogViewConfirmed(true);
+    setShowLogViewDialog(false);
+    setSelectedTab("log");
+  };
 
   return (
     <div className="col-span-2 flex h-full flex-1 flex-col overflow-hidden md:col-span-3">
@@ -270,6 +298,15 @@ export const TracePreview = ({
           }
           className="flex min-h-0 flex-1 flex-col overflow-hidden"
           onValueChange={(value) => {
+            // on tab click, is confirmation is needed?
+            if (
+              value === "log" &&
+              requiresConfirmation &&
+              !hasLogViewConfirmed
+            ) {
+              setShowLogViewDialog(true);
+              return;
+            }
             capture("trace_detail:view_mode_switch", { mode: value });
             setSelectedTab(value);
           }}
@@ -286,8 +323,10 @@ export const TracePreview = ({
                       </TooltipTrigger>
                       <TooltipContent className="text-xs">
                         {isLogViewDisabled
-                          ? `Log View is disabled for traces with more than 150 observations (this trace has ${observations.length})`
-                          : "Shows all observations concatenated. Great for quickly scanning through them. Nullish values are omitted."}
+                          ? `Log View is disabled for traces with more than ${LOG_VIEW_DISABLED_THRESHOLD} observations (this trace has ${observations.length})`
+                          : requiresConfirmation
+                            ? `Log View may be slow with ${observations.length} observations. Click to confirm.`
+                            : "Shows all observations concatenated. Great for quickly scanning through them. Nullish values are omitted."}
                       </TooltipContent>
                     </Tooltip>
                   </TabsBarTrigger>
@@ -410,6 +449,27 @@ export const TracePreview = ({
           )}
         </TabsBar>
       </div>
+
+      {/* Confirmation dialog for log view with many observations */}
+      <AlertDialog open={showLogViewDialog} onOpenChange={setShowLogViewDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Sluggish Performance Warning</AlertDialogTitle>
+            <AlertDialogDescription>
+              This trace has {observations.length} observations. The log view
+              may be slow to load and interact with. Do you want to continue?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setShowLogViewDialog(false)}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmLogView}>
+              Show Log View
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 };

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -57,6 +57,9 @@ import {
   AlertDialogTitle,
 } from "@/src/components/ui/alert-dialog";
 
+const LOG_VIEW_CONFIRMATION_THRESHOLD = 150;
+const LOG_VIEW_DISABLED_THRESHOLD = 350;
+
 export const TracePreview = ({
   trace,
   observations,
@@ -126,8 +129,6 @@ export const TracePreview = ({
   );
 
   // For performance reasons, we preemptively disable the log view if there are too many observations.
-  const LOG_VIEW_CONFIRMATION_THRESHOLD = 150;
-  const LOG_VIEW_DISABLED_THRESHOLD = 350;
   const isLogViewDisabled = observations.length > LOG_VIEW_DISABLED_THRESHOLD;
   const requiresConfirmation =
     observations.length > LOG_VIEW_CONFIRMATION_THRESHOLD && !isLogViewDisabled;
@@ -429,6 +430,7 @@ export const TracePreview = ({
               traceId={trace.id}
               projectId={trace.projectId}
               currentView={currentView}
+              trace={trace}
             />
           </TabsBarContent>
           {showScoresTab && (

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -32,7 +32,10 @@ import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/utils/tailwind";
 import useSessionStorage from "@/src/components/useSessionStorage";
 import { JsonExpansionProvider } from "@/src/components/trace/JsonExpansionContext";
-import { buildTraceUiData } from "@/src/components/trace/lib/helpers";
+import {
+  buildTraceUiData,
+  downloadTraceAsJson as downloadTraceUtil,
+} from "@/src/components/trace/lib/helpers";
 import {
   ResizablePanelGroup,
   ResizablePanel,
@@ -260,24 +263,11 @@ export function Trace(props: {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const downloadTraceAsJson = useCallback(() => {
-    const exportData = {
+  const handleDownloadTrace = useCallback(() => {
+    downloadTraceUtil({
       trace: props.trace,
       observations: props.observations,
-    };
-
-    const jsonString = JSON.stringify(exportData, null, 2);
-    const blob = new Blob([jsonString], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = `trace-${props.trace.id}.json`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-
+    });
     capture("trace_detail:download_button_click");
   }, [props.trace, props.observations, capture]);
 
@@ -505,7 +495,7 @@ export function Trace(props: {
                       <Button
                         variant="ghost"
                         size="icon"
-                        onClick={downloadTraceAsJson}
+                        onClick={handleDownloadTrace}
                         title="Download trace as JSON"
                       >
                         <Download className="h-4 w-4" />
@@ -745,7 +735,7 @@ export function Trace(props: {
                           <Button
                             variant="ghost"
                             size="icon"
-                            onClick={downloadTraceAsJson}
+                            onClick={handleDownloadTrace}
                             title="Download trace as JSON"
                           >
                             <Download className="h-4 w-4" />

--- a/web/src/components/trace/lib/helpers.ts
+++ b/web/src/components/trace/lib/helpers.ts
@@ -342,3 +342,37 @@ export function buildTraceUiData(
 
   return { tree, hiddenObservationsCount, searchItems: out };
 }
+
+/**
+ * Download trace data with optionally observations as JSON file
+ * @param trace - Trace object to download
+ * @param observations - Array of observations (can be basic or with full I/O data)
+ * @param filename - Optional custom filename (defaults to trace-{traceId}.json)
+ */
+export function downloadTraceAsJson(params: {
+  trace: {
+    id: string;
+    [key: string]: unknown;
+  };
+  observations: unknown[];
+  filename?: string;
+}) {
+  const { trace, observations, filename } = params;
+
+  const exportData = {
+    trace,
+    observations,
+  };
+
+  const jsonString = JSON.stringify(exportData, null, 2);
+  const blob = new Blob([jsonString], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename || `trace-${trace.id}.json`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/web/src/components/ui/alert-dialog.tsx
+++ b/web/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+
+import { cn } from "@/src/utils/tailwind";
+import { buttonVariants } from "@/src/components/ui/button";
+
+const AlertDialog = AlertDialogPrimitive.Root;
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className,
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className,
+    )}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves handling of large traces by adding confirmation dialogs, optimizing rendering, and enabling trace data download.
> 
>   - **Behavior**:
>     - Adds confirmation dialog in `TracePreview.tsx` for traces with more than 150 observations, warning users about potential sluggish performance.
>     - Disables log view for traces with more than 350 observations in `TracePreview.tsx`.
>     - Optimizes rendering in `TraceLogView.tsx` by only rendering when all data is loaded.
>     - Adds download button in `TraceLogView.tsx` to download trace and observations as JSON.
>   - **Helpers**:
>     - Refactors `downloadTraceAsJson` in `helpers.ts` to handle trace and observations download.
>   - **UI Components**:
>     - Introduces `AlertDialog` components in `alert-dialog.tsx` for confirmation dialogs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 07356e76d6840e148c623ccca3c9304d2464e473. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->