### PR TITLE
chore: link blob storage integration to correct docs page

### DIFF
--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -80,7 +80,7 @@ export default function BlobStorageIntegrationSettings() {
         actionButtonsRight: (
           <Button asChild variant="secondary">
             <Link
-              href="https://langfuse.com/docs/query-traces#blob-storage"
+              href="https://langfuse.com/docs/api-and-data-platform/features/export-to-blob-storage"
               target="_blank"
             >
               Integration Docs ↗


### PR DESCRIPTION
## What does this PR do?

Fixes link to blob storage docs. Previous SDK page doesn't talk about blobs now

-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update link in `blobstorage.tsx` to correct blob storage documentation page.
> 
>   - **Link Update**:
>     - In `blobstorage.tsx`, update the `href` in the `Link` component from `https://langfuse.com/docs/query-traces#blob-storage` to `https://langfuse.com/docs/api-and-data-platform/features/export-to-blob-storage`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ad68202513e9372613e48fcec16d57c0de75da7a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->