### PR TITLE
feat: add ai.model.id parsing in otel processor

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1730,6 +1730,7 @@ export class OtelIngestionProcessor {
   ): string | undefined {
     const modelNameKeys = [
       LangfuseOtelSpanAttributes.OBSERVATION_MODEL,
+      "ai.model.id",
       "gen_ai.request.model",
       "gen_ai.response.model",
       "llm.response.model",

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -1698,6 +1698,16 @@ describe("OTel Resource Span Mapping", () => {
         },
       ],
       [
+        "should extract providedModelName from ai.model.id",
+        {
+          entity: "observation",
+          otelAttributeKey: "ai.model.id",
+          otelAttributeValue: { stringValue: "gemini-embedding-001" },
+          entityAttributeKey: "model",
+          entityAttributeValue: "gemini-embedding-001",
+        },
+      ],
+      [
         "should extract providedModelName from llm.model_name",
         {
           entity: "observation",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for parsing `ai.model.id` in `OtelIngestionProcessor` to extract model names from OpenTelemetry spans.
> 
>   - **Behavior**:
>     - Add `ai.model.id` to `modelNameKeys` in `OtelIngestionProcessor.ts` to extract model names from OpenTelemetry spans.
>   - **Tests**:
>     - Add test case in `otelMapping.servertest.ts` to verify extraction of `providedModelName` from `ai.model.id` attribute.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 670d9367681cad902d7e39e25805fa16b0422aa4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->