### PR TITLE
chore: revert webhook redirect

### DIFF
--- a/worker/src/__tests__/webhooks.test.ts
+++ b/worker/src/__tests__/webhooks.test.ts
@@ -82,16 +82,6 @@ class WebhookTestServer {
       http.post("https://webhook-timeout.example.com/*", () => {
         return HttpResponse.error();
       }),
-
-      // Redirect endpoint (should not be followed)
-      http.post("https://webhook-redirect.example.com/*", () => {
-        return new Response(null, {
-          status: 301,
-          headers: {
-            Location: "https://internal.private.network/webhook",
-          },
-        });
-      }),
     );
   }
 
@@ -1111,84 +1101,6 @@ describe("Webhook Integration Tests", () => {
       });
 
       expect(failures).toBe(0);
-    });
-
-    it("should reject redirects to prevent SSRF attacks", async () => {
-      const fullPrompt = await prisma.prompt.findUnique({
-        where: { id: promptId },
-      });
-
-      const action = await prisma.action.findUnique({
-        where: { id: actionId },
-      });
-
-      if (!action) {
-        throw new Error("Action not found");
-      }
-
-      // Update action to point to redirect endpoint
-      await prisma.action.update({
-        where: { id: actionId },
-        data: {
-          config: {
-            ...(action.config as WebhookActionConfigWithSecrets),
-            url: "https://webhook-redirect.example.com/test",
-          },
-        },
-      });
-
-      const newExecutionId = v4();
-
-      await prisma.automationExecution.create({
-        data: {
-          id: newExecutionId,
-          projectId,
-          triggerId,
-          automationId,
-          actionId,
-          status: ActionExecutionStatus.PENDING,
-          sourceId: v4(),
-          input: {
-            promptName: "test-prompt",
-            promptVersion: 1,
-            action: "created",
-            type: "prompt-version",
-          },
-        },
-      });
-
-      const webhookInput: WebhookInput = {
-        projectId,
-        automationId,
-        executionId: newExecutionId,
-        payload: {
-          prompt: PromptDomainSchema.parse(fullPrompt),
-          action: "created",
-          type: "prompt-version",
-        },
-      };
-
-      // Execute webhook - should fail due to redirect
-      await executeWebhook(webhookInput, { skipValidation: true });
-
-      // Verify execution was marked as error
-      const execution = await prisma.automationExecution.findUnique({
-        where: { id: newExecutionId },
-      });
-
-      expect(execution?.status).toBe(ActionExecutionStatus.ERROR);
-      expect(execution?.error).toBeDefined();
-
-      // Verify error message doesn't leak internal IP information
-      expect(execution?.error).toContain("Webhook redirect not allowed");
-      expect(execution?.error).not.toContain("internal.private.network");
-
-      // Verify no requests were received at the redirect target
-      const requests = webhookServer.getReceivedRequests();
-      const redirectTargetRequests = requests.filter((r) =>
-        r.url.includes("internal.private.network"),
-      );
-      expect(redirectTargetRequests).toHaveLength(0);
     });
 
     it(

--- a/worker/src/queues/webhooks.ts
+++ b/worker/src/queues/webhooks.ts
@@ -201,7 +201,6 @@ async function executeWebhookAction({
             body: webhookPayload,
             headers: requestHeaders,
             signal: abortController.signal,
-            redirect: "error", // Prevent following redirects to avoid SSRF
           });
 
           httpStatus = res.status;
@@ -224,22 +223,6 @@ async function executeWebhookAction({
               `Webhook timeout after ${env.LANGFUSE_WEBHOOK_TIMEOUT_MS}ms for url ${webhookConfig.url} and project ${projectId}`,
             );
           }
-
-          // Handle redirect errors to prevent information leakage
-          // When redirect: "error" is set, fetch throws a TypeError for redirects
-          if (
-            error instanceof TypeError &&
-            (error.message.toLowerCase().includes("redirect") ||
-              error.message.toLowerCase().includes("failed to fetch"))
-          ) {
-            logger.warn(
-              `Webhook redirect detected for url ${webhookConfig.url} and project ${projectId}`,
-            );
-            throw new Error(
-              `Webhook redirect not allowed for url ${webhookConfig.url} and project ${projectId}`,
-            );
-          }
-
           throw error;
         } finally {
           clearTimeout(timeoutId);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reverts webhook redirect handling logic and associated tests in `webhooks.ts` and `webhooks.test.ts`.
> 
>   - **Behavior**:
>     - Removes logic in `executeWebhookAction()` in `webhooks.ts` that prevented following redirects to avoid SSRF.
>     - Deletes test case in `webhooks.test.ts` that verified rejection of redirects to prevent SSRF attacks.
>   - **Misc**:
>     - Removes `redirect: "error"` option from fetch call in `webhooks.ts` to allow redirects.
>     - Deletes logging and error handling related to redirects in `webhooks.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 44791bfb70bf0f191014571eba07ade3505207ba. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->