### PR TITLE
fix(blob-storage): Don't override storage engine if set

### DIFF
--- a/docker-compose.dev-azure.yml
+++ b/docker-compose.dev-azure.yml
@@ -23,6 +23,29 @@ services:
     volumes:
       - langfuse_azurite_data:/data
 
+  minio:
+    image: docker.io/minio/minio
+    container_name: ${MINIO_CONTAINER_NAME:-langfuse-minio}
+    entrypoint: sh
+    # create the 'langfuse' bucket before starting the service
+    command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" --console-address ":9001" /data'
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minio}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-miniosecret}
+    ports:
+      - ${HOST_IP:-127.0.0.1}:${MINIO_API_PORT:-9090}:9000
+      - ${HOST_IP:-127.0.0.1}:${MINIO_CONSOLE_PORT:-9091}:9001
+    volumes:
+      - langfuse_minio_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 1s
+      timeout: 5s
+      retries: 5
+      start_period: 1s
+    networks:
+      - default
+
   redis:
     image: docker.io/redis:7.2.4
     restart: always
@@ -59,4 +82,7 @@ volumes:
   langfuse_clickhouse_logs:
     driver: local
   langfuse_azurite_data:
+    driver: local
+  langfuse_minio_data:
+    name: ${MINIO_VOLUME_NAME:-langfuse_minio_data}
     driver: local

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -115,12 +115,17 @@ export class StorageServiceFactory {
     awsSse: string | undefined;
     awsSseKmsKeyId: string | undefined;
   }): StorageService {
-    if (params.useAzureBlob || env.LANGFUSE_USE_AZURE_BLOB === "true") {
+    if (
+      params.useAzureBlob !== undefined
+        ? params.useAzureBlob
+        : env.LANGFUSE_USE_AZURE_BLOB === "true"
+    ) {
       return new AzureBlobStorageService(params);
     }
     if (
-      params.useGoogleCloudStorage ||
-      env.LANGFUSE_USE_GOOGLE_CLOUD_STORAGE === "true"
+      params.useGoogleCloudStorage !== undefined
+        ? params.useGoogleCloudStorage
+        : env.LANGFUSE_USE_GOOGLE_CLOUD_STORAGE === "true"
     ) {
       // Use provided credentials or fall back to environment variable
       const googleParams = {


### PR DESCRIPTION
## What does this PR do?

If we explicitly define the type of storage for StorageService (by passing false to azure and gcs flags), we shouldn't fallback to env

Fixes #10241

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `StorageServiceFactory.getInstance()` to prioritize explicit storage type parameters over environment variables.
> 
>   - **Behavior**:
>     - In `StorageServiceFactory.getInstance()`, if `params.useAzureBlob` or `params.useGoogleCloudStorage` is explicitly set, it takes precedence over environment variables `LANGFUSE_USE_AZURE_BLOB` and `LANGFUSE_USE_GOOGLE_CLOUD_STORAGE`.
>   - **Misc**:
>     - Fixes issue #10241.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e770c4ccb79948cffb2444522fd93950a62795bc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->