### PR TITLE
fix: Use ChartConfig system for tooltip labels in distribution charts

### DIFF
--- a/web/src/features/scores/components/TimeseriesChart.tsx
+++ b/web/src/features/scores/components/TimeseriesChart.tsx
@@ -5,9 +5,17 @@ import {
 import { type TimeseriesChartProps } from "@/src/features/scores/types";
 
 function ChartWrapper(props: { title: string; children: React.ReactNode }) {
+  // Truncate title if longer than 16 characters
+  const truncateLabel = (label: string, maxLength: number = 16): string => {
+    if (label.length <= maxLength) return label;
+    return label.substring(0, 13) + "...";
+  };
+
   return (
     <div className="mb-2 flex max-h-full min-h-0 min-w-0 max-w-full flex-none flex-col overflow-hidden">
-      <div className="shrink-0 text-sm font-medium">{props.title}</div>
+      <div className="shrink-0 text-sm font-medium" title={props.title}>
+        {truncateLabel(props.title)}
+      </div>
       {props.children}
     </div>
   );

--- a/web/src/features/scores/components/score-analytics/components/cards/DistributionChartCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/DistributionChartCard.tsx
@@ -310,11 +310,7 @@ export function DistributionChartCard() {
                   : undefined
             }
             binLabels={distribution.binLabels}
-            categories={
-              activeTab === "score2" && distribution.score2Categories
-                ? distribution.score2Categories
-                : distribution.categories
-            }
+            categories={distribution.categories}
             stackedDistribution={stackedDistributionData}
             score2Categories={distribution.score2Categories}
             colors={chartColors}

--- a/web/src/features/scores/components/score-analytics/components/cards/DistributionChartCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/DistributionChartCard.tsx
@@ -302,6 +302,13 @@ export function DistributionChartCard() {
                   ? score2.name
                   : undefined
             }
+            score2Source={
+              activeTab === "score1" || activeTab === "score2"
+                ? undefined
+                : mode === "two" && score2
+                  ? score2.source
+                  : undefined
+            }
             binLabels={distribution.binLabels}
             categories={distribution.categories}
             stackedDistribution={stackedDistributionData}

--- a/web/src/features/scores/components/score-analytics/components/cards/DistributionChartCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/DistributionChartCard.tsx
@@ -213,20 +213,20 @@ export function DistributionChartCard() {
   const showTabs = mode === "two";
 
   // Helper function to truncate tab labels with max character limit
-  const truncateLabel = (label: string, maxLength: number = 12): string => {
-    if (label.length <= maxLength) return label;
-    return label.substring(0, 9) + "...";
+  const truncateLabel = (label: string): string => {
+    if (label.length <= 10) return label;
+    return label.substring(0, 7) + "...";
   };
 
   // Build full tab labels for title attribute (hover tooltip)
   const score1FullLabel =
     score1.name === score2?.name
-      ? `${score1.name} (${score1.source.toLowerCase()})`
+      ? `${score1.source} · ${score1.name}`
       : score1.name;
 
   const score2FullLabel = score2
     ? score2.name === score1.name
-      ? `${score2.name} (${score2.source.toLowerCase()})`
+      ? `${score2.source} · ${score2.name}`
       : score2.name
     : "Score 2";
 
@@ -310,11 +310,7 @@ export function DistributionChartCard() {
                   : undefined
             }
             binLabels={distribution.binLabels}
-            categories={
-              activeTab === "score2" && distribution.score2Categories
-                ? distribution.score2Categories
-                : distribution.categories
-            }
+            categories={distribution.categories}
             stackedDistribution={stackedDistributionData}
             score2Categories={distribution.score2Categories}
             colors={chartColors}

--- a/web/src/features/scores/components/score-analytics/components/cards/DistributionChartCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/DistributionChartCard.tsx
@@ -310,7 +310,11 @@ export function DistributionChartCard() {
                   : undefined
             }
             binLabels={distribution.binLabels}
-            categories={distribution.categories}
+            categories={
+              activeTab === "score2" && distribution.score2Categories
+                ? distribution.score2Categories
+                : distribution.categories
+            }
             stackedDistribution={stackedDistributionData}
             score2Categories={distribution.score2Categories}
             colors={chartColors}

--- a/web/src/features/scores/components/score-analytics/components/cards/DistributionChartCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/DistributionChartCard.tsx
@@ -213,9 +213,9 @@ export function DistributionChartCard() {
   const showTabs = mode === "two";
 
   // Helper function to truncate tab labels with max character limit
-  const truncateLabel = (label: string, maxLength: number = 16): string => {
+  const truncateLabel = (label: string, maxLength: number = 12): string => {
     if (label.length <= maxLength) return label;
-    return label.substring(0, 13) + "...";
+    return label.substring(0, 9) + "...";
   };
 
   // Build full tab labels for title attribute (hover tooltip)
@@ -310,7 +310,11 @@ export function DistributionChartCard() {
                   : undefined
             }
             binLabels={distribution.binLabels}
-            categories={distribution.categories}
+            categories={
+              activeTab === "score2" && distribution.score2Categories
+                ? distribution.score2Categories
+                : distribution.categories
+            }
             stackedDistribution={stackedDistributionData}
             score2Categories={distribution.score2Categories}
             colors={chartColors}

--- a/web/src/features/scores/components/score-analytics/components/cards/DistributionChartCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/DistributionChartCard.tsx
@@ -213,9 +213,9 @@ export function DistributionChartCard() {
   const showTabs = mode === "two";
 
   // Helper function to truncate tab labels with max character limit
-  const truncateLabel = (label: string, maxLength: number = 15): string => {
+  const truncateLabel = (label: string, maxLength: number = 16): string => {
     if (label.length <= maxLength) return label;
-    return label.substring(0, maxLength - 1) + "…";
+    return label.substring(0, 13) + "...";
   };
 
   // Build full tab labels for title attribute (hover tooltip)

--- a/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
@@ -164,7 +164,7 @@ export function HeatmapCard() {
           <CardTitle>Score Comparison</CardTitle>
           <CardDescription>Loading heatmap...</CardDescription>
         </CardHeader>
-        <CardContent className="flex flex-1 flex-col items-center justify-center pl-0">
+        <CardContent className="flex flex-1 flex-col items-center justify-center pl-1">
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
         </CardContent>
       </Card>
@@ -228,7 +228,7 @@ export function HeatmapCard() {
       : heatmap && "rows" in heatmap
         ? heatmap.rows
         : 10;
-  const calculatedCellHeight = Math.floor(230 / numRows);
+  const calculatedCellHeight = Math.floor(200 / numRows);
 
   return (
     <Card>

--- a/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
@@ -220,7 +220,7 @@ export function HeatmapCard() {
   const hasData = heatmap && heatmap.cells.length > 0;
 
   // Calculate dynamic cell height based on available space
-  // Magic number 248px represents approximate available height for grid
+  // Magic number 230px represents approximate available height for grid
   // (card height minus header, labels, legend, gaps)
   const numRows =
     dataType === "NUMERIC"
@@ -228,7 +228,7 @@ export function HeatmapCard() {
       : heatmap && "rows" in heatmap
         ? heatmap.rows
         : 10;
-  const calculatedCellHeight = Math.floor(248 / numRows);
+  const calculatedCellHeight = Math.floor(230 / numRows);
 
   return (
     <Card>

--- a/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
@@ -197,9 +197,13 @@ export function HeatmapCard() {
     dataType === "NUMERIC" ? "Score Comparison Heatmap" : "Confusion Matrix";
 
   const description =
-    dataType === "NUMERIC"
-      ? "Distribution of matched score pairs showing correlation patterns"
-      : "Agreement matrix between categorical scores";
+    mode === "single"
+      ? dataType === "NUMERIC"
+        ? "Distribution of matched score pairs showing correlation patterns"
+        : "Agreement matrix between categorical scores"
+      : dataType === "NUMERIC"
+        ? `${totalMatchedPairs.toLocaleString()} matched pairs showing correlation patterns`
+        : `${totalMatchedPairs.toLocaleString()} matched pairs showing agreement`;
 
   // Single score mode - show placeholder
   if (mode === "single") {

--- a/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
@@ -222,7 +222,8 @@ export function HeatmapCard() {
   // Calculate dynamic cell height based on available space
   // Magic number 248px represents approximate available height for grid
   // (card height minus header, labels, legend, gaps)
-  const numRows = dataType === "NUMERIC" ? 10 : (heatmap?.rows ?? 10);
+  const numRows =
+    dataType === "NUMERIC" ? 10 : "rows" in heatmap ? heatmap.rows : 10;
   const calculatedCellHeight = Math.floor(248 / numRows);
 
   return (

--- a/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
@@ -236,7 +236,7 @@ export function HeatmapCard() {
         <CardTitle>{title}</CardTitle>
         <CardDescription>{description}</CardDescription>
       </CardHeader>
-      <CardContent className="flex flex-1 flex-col items-center gap-4 pl-0">
+      <CardContent className="flex flex-1 flex-col items-center gap-4 pl-2">
         {hasData ? (
           <>
             <Heatmap
@@ -278,10 +278,9 @@ export function HeatmapCard() {
             <HeatmapLegend
               min={0}
               max={maxValue}
-              variant="accent"
-              title="Count"
+              scoreNumber={1}
               orientation="horizontal"
-              steps={10}
+              steps={5}
             />
           </>
         ) : (

--- a/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
@@ -233,48 +233,12 @@ export function HeatmapCard() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>{title}</CardTitle>
-        <CardDescription>{description}</CardDescription>
-      </CardHeader>
-      <CardContent className="flex flex-1 flex-col items-center gap-4 pl-2">
-        {hasData ? (
-          <>
-            <Heatmap
-              height="100%"
-              cellHeight={calculatedCellHeight}
-              data={heatmap.cells}
-              rows={
-                dataType === "NUMERIC"
-                  ? 10
-                  : "rows" in heatmap
-                    ? (heatmap.rows as number)
-                    : 0
-              }
-              cols={
-                dataType === "NUMERIC"
-                  ? 10
-                  : "cols" in heatmap
-                    ? (heatmap.cols as number)
-                    : 0
-              }
-              rowLabels={heatmap.rowLabels}
-              colLabels={heatmap.colLabels}
-              xAxisLabel={`${score2?.name} (${score2?.source})`}
-              yAxisLabel={`${score1.name} (${score1.source})`}
-              getColor={getColor}
-              showValues={false}
-              renderTooltip={(cell) => (
-                <HeatmapTooltipContent
-                  cell={cell}
-                  dataType={dataType}
-                  score1={score1}
-                  score2={score2}
-                  score1Color={getColorForScore(1)}
-                  score2Color={getColorForScore(2)}
-                  totalMatchedPairs={totalMatchedPairs}
-                />
-              )}
-            />
+        <div className="flex items-start justify-between">
+          <div>
+            <CardTitle>{title}</CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </div>
+          {hasData && (
             <HeatmapLegend
               min={0}
               max={maxValue}
@@ -282,7 +246,47 @@ export function HeatmapCard() {
               orientation="horizontal"
               steps={5}
             />
-          </>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col items-center gap-4 pl-0">
+        {hasData ? (
+          <Heatmap
+            height="100%"
+            cellHeight={calculatedCellHeight}
+            data={heatmap.cells}
+            rows={
+              dataType === "NUMERIC"
+                ? 10
+                : "rows" in heatmap
+                  ? (heatmap.rows as number)
+                  : 0
+            }
+            cols={
+              dataType === "NUMERIC"
+                ? 10
+                : "cols" in heatmap
+                  ? (heatmap.cols as number)
+                  : 0
+            }
+            rowLabels={heatmap.rowLabels}
+            colLabels={heatmap.colLabels}
+            xAxisLabel={`${score2?.name} (${score2?.source})`}
+            yAxisLabel={`${score1.name} (${score1.source})`}
+            getColor={getColor}
+            showValues={false}
+            renderTooltip={(cell) => (
+              <HeatmapTooltipContent
+                cell={cell}
+                dataType={dataType}
+                score1={score1}
+                score2={score2}
+                score1Color={getColorForScore(1)}
+                score2Color={getColorForScore(2)}
+                totalMatchedPairs={totalMatchedPairs}
+              />
+            )}
+          />
         ) : (
           <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
             No matched score pairs found for the selected time range

--- a/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
@@ -223,7 +223,11 @@ export function HeatmapCard() {
   // Magic number 248px represents approximate available height for grid
   // (card height minus header, labels, legend, gaps)
   const numRows =
-    dataType === "NUMERIC" ? 10 : "rows" in heatmap ? heatmap.rows : 10;
+    dataType === "NUMERIC"
+      ? 10
+      : heatmap && "rows" in heatmap
+        ? heatmap.rows
+        : 10;
   const calculatedCellHeight = Math.floor(248 / numRows);
 
   return (

--- a/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
@@ -219,6 +219,12 @@ export function HeatmapCard() {
   // Two score mode - show heatmap or empty state
   const hasData = heatmap && heatmap.cells.length > 0;
 
+  // Calculate dynamic cell height based on available space
+  // Magic number 248px represents approximate available height for grid
+  // (card height minus header, labels, legend, gaps)
+  const numRows = dataType === "NUMERIC" ? 10 : (heatmap?.rows ?? 10);
+  const calculatedCellHeight = Math.floor(248 / numRows);
+
   return (
     <Card>
       <CardHeader>
@@ -230,6 +236,7 @@ export function HeatmapCard() {
           <>
             <Heatmap
               height="100%"
+              cellHeight={calculatedCellHeight}
               data={heatmap.cells}
               rows={
                 dataType === "NUMERIC"

--- a/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/HeatmapCard.tsx
@@ -137,6 +137,7 @@ export function HeatmapCard() {
               xAxisLabel={`${score2?.name} (${score2?.source})`}
               yAxisLabel={`${score1.name} (${score1.source})`}
               getColor={getColor}
+              showValues={false}
               renderTooltip={(cell) => (
                 <div className="space-y-1">
                   <p className="font-semibold">Count: {cell.value}</p>

--- a/web/src/features/scores/components/score-analytics/components/cards/TimelineChartCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/TimelineChartCard.tsx
@@ -246,20 +246,20 @@ export function TimelineChartCard() {
   const showTabs = mode === "two";
 
   // Helper function to truncate tab labels with max character limit
-  const truncateLabel = (label: string, maxLength: number = 15): string => {
-    if (label.length <= maxLength) return label;
-    return label.substring(0, maxLength - 1) + "…";
+  const truncateLabel = (label: string): string => {
+    if (label.length <= 10) return label;
+    return label.substring(0, 7) + "...";
   };
 
   // Build full tab labels for title attribute (hover tooltip)
   const score1FullLabel =
     score1.name === score2?.name
-      ? `${score1.name} (${score1.source.toLowerCase()})`
+      ? `${score1.source} · ${score1.name}`
       : score1.name;
 
   const score2FullLabel = score2
     ? score2.name === score1.name
-      ? `${score2.name} (${score2.source.toLowerCase()})`
+      ? `${score2.source} · ${score2.name}`
       : score2.name
     : "Score 2";
 

--- a/web/src/features/scores/components/score-analytics/components/cards/TimelineChartCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/TimelineChartCard.tsx
@@ -311,7 +311,7 @@ export function TimelineChartCard() {
           )}
         </div>
       </CardHeader>
-      <CardContent className="flex h-[340px] flex-col pl-0">
+      <CardContent className="flex h-[340px] flex-col pl-1">
         {hasData ? (
           <ScoreTimeSeriesChart
             data={chartData}

--- a/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
@@ -100,8 +100,8 @@ export function Heatmap({
   return (
     <TooltipProvider delayDuration={0}>
       <div
-        className={cn("flex w-full flex-col gap-4", className)}
-        style={{ width }}
+        className={cn("flex w-full flex-1 flex-col gap-4", className)}
+        style={{ width, height }}
         role="img"
         aria-label={ariaLabel}
       >
@@ -114,7 +114,7 @@ export function Heatmap({
           </div>
         )}
 
-        <div className="flex items-stretch justify-center gap-2 sm:gap-4">
+        <div className="flex flex-1 items-stretch justify-center gap-2 sm:gap-4">
           {/* Row labels */}
           {rowLabels && rowLabels.length > 0 && (
             <div

--- a/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
@@ -164,7 +164,7 @@ export function Heatmap({
           {yAxisLabel && (
             <div className="flex items-center justify-center">
               <span
-                className="text-sm font-medium text-muted-foreground"
+                className="text-xs font-normal text-muted-foreground"
                 style={{
                   writingMode: "vertical-rl",
                   transform: "rotate(180deg)",
@@ -348,7 +348,7 @@ export function Heatmap({
 
         {/* X-axis label */}
         {xAxisLabel && (
-          <div className="text-center text-sm font-medium text-muted-foreground">
+          <div className="text-center text-xs font-normal text-muted-foreground">
             {xAxisLabel}
           </div>
         )}

--- a/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
@@ -131,9 +131,9 @@ export function Heatmap({
           {rowLabels && rowLabels.length > 0 && (
             <div
               className={cn(
-                "pr-1 text-right text-[10px] text-muted-foreground sm:pr-2 sm:text-xs",
+                "w-[60px] pr-1 text-right text-[10px] text-muted-foreground sm:w-[80px] sm:pr-2 sm:text-xs",
                 isDivisionPointMode
-                  ? "flex flex-1 flex-col justify-between self-stretch"
+                  ? "flex flex-col justify-between self-stretch"
                   : "grid gap-1",
               )}
               style={

--- a/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
@@ -101,6 +101,14 @@ export function Heatmap({
     ? `${cellHeightProp}px`
     : "minmax(24px, 40px)";
 
+  // Determine max label lengths based on grid dimensions
+  const maxYLabelLength = 8; // Y-axis allows up to 8 characters
+  const maxXLabelLength = useMemo(() => {
+    if (cols < 4) return 12; // Fewer columns, more space per label
+    if (cols < 8) return 10; // Medium number of columns
+    return 6; // Many columns, less space per label
+  }, [cols]);
+
   return (
     <TooltipProvider delayDuration={0}>
       <div
@@ -142,8 +150,12 @@ export function Heatmap({
                   return <div key={idx} className="h-0" />;
                 }
 
-                const shouldTruncate = !isDivisionPointMode && label.length > 3;
-                const truncated = shouldTruncate ? label.slice(0, 3) : label;
+                // Y-axis: truncate if > 8 chars, show first 5 + "..."
+                const shouldTruncate =
+                  !isDivisionPointMode && label.length > maxYLabelLength;
+                const truncated = shouldTruncate
+                  ? label.slice(0, 5) + "..."
+                  : label;
 
                 return (
                   <div
@@ -240,8 +252,12 @@ export function Heatmap({
                   return <div key={idx} className="w-0" />;
                 }
 
-                const shouldTruncate = !isDivisionPointMode && label.length > 3;
-                const truncated = shouldTruncate ? label.slice(0, 3) : label;
+                // X-axis: dynamic truncation based on number of columns
+                const shouldTruncate =
+                  !isDivisionPointMode && label.length > maxXLabelLength;
+                const truncated = shouldTruncate
+                  ? label.slice(0, maxXLabelLength - 3) + "..."
+                  : label;
 
                 return (
                   <div
@@ -262,7 +278,7 @@ export function Heatmap({
                           className="w-auto"
                         >
                           <div className="space-y-1">
-                            <p className="font-semibold">{label}</p>
+                            <p className="text-xs">{label}</p>
                           </div>
                         </HoverCardContent>
                       </HoverCard>

--- a/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
@@ -25,6 +25,7 @@ export interface HeatmapProps {
 
   // Styling
   cellClassName?: string;
+  cellHeight?: number; // Dynamic cell height in pixels
   width?: number | string;
   height?: number | string;
   className?: string;
@@ -55,6 +56,7 @@ export function Heatmap({
   xAxisLabel,
   yAxisLabel,
   cellClassName,
+  cellHeight: cellHeightProp,
   width = "100%",
   height,
   className,
@@ -95,7 +97,9 @@ export function Heatmap({
 
   // Calculate responsive cell size - width-biased for minimal vertical space
   const cellWidth = "minmax(32px, 1fr)"; // Can grow wide
-  const cellHeight = "minmax(24px, 40px)"; // Capped at 40px tall
+  const cellHeight = cellHeightProp
+    ? `${cellHeightProp}px`
+    : "minmax(24px, 40px)";
 
   return (
     <TooltipProvider delayDuration={0}>

--- a/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
@@ -133,12 +133,12 @@ export function Heatmap({
               className={cn(
                 "pr-1 text-right text-[10px] text-muted-foreground sm:pr-2 sm:text-xs",
                 isDivisionPointMode
-                  ? "flex flex-col justify-between"
+                  ? "flex flex-1 flex-col justify-between self-stretch"
                   : "grid gap-1",
               )}
               style={
                 isDivisionPointMode
-                  ? { height: "100%" }
+                  ? undefined
                   : { gridTemplateRows: `repeat(${rows}, ${cellHeight})` }
               }
             >

--- a/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
@@ -2,6 +2,11 @@ import { useMemo } from "react";
 import { type HeatmapCell } from "@/src/features/scores/lib/heatmap-utils";
 import { HeatmapCellComponent } from "./HeatmapCell";
 import { TooltipProvider } from "@/src/components/ui/tooltip";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/src/components/ui/hover-card";
 import { cn } from "@/src/utils/tailwind";
 
 export interface HeatmapProps {
@@ -99,13 +104,35 @@ export function Heatmap({
                 gridTemplateRows: `repeat(${rows}, ${cellHeight})`,
               }}
             >
-              {rowLabels.map((label, idx) => (
-                <div key={idx} className="flex items-center justify-end">
-                  <span className="max-w-[60px] truncate sm:max-w-[80px]">
-                    {label}
-                  </span>
-                </div>
-              ))}
+              {rowLabels.map((label, idx) => {
+                const shouldTruncate = label.length > 3;
+                const truncated = shouldTruncate ? label.slice(0, 3) : label;
+
+                return (
+                  <div key={idx} className="flex items-center justify-end">
+                    {shouldTruncate ? (
+                      <HoverCard>
+                        <HoverCardTrigger asChild>
+                          <span className="cursor-help text-right">
+                            {truncated}
+                          </span>
+                        </HoverCardTrigger>
+                        <HoverCardContent
+                          side="left"
+                          align="center"
+                          className="w-auto"
+                        >
+                          <div className="space-y-1">
+                            <p className="font-semibold">{label}</p>
+                          </div>
+                        </HoverCardContent>
+                      </HoverCard>
+                    ) : (
+                      <span>{label}</span>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           )}
 
@@ -157,15 +184,33 @@ export function Heatmap({
                 gridTemplateColumns: `repeat(${cols}, ${cellWidth})`,
               }}
             >
-              {colLabels.map((label, idx) => (
-                <div
-                  key={idx}
-                  className="flex items-center justify-center truncate"
-                  title={label}
-                >
-                  {label}
-                </div>
-              ))}
+              {colLabels.map((label, idx) => {
+                const shouldTruncate = label.length > 3;
+                const truncated = shouldTruncate ? label.slice(0, 3) : label;
+
+                return (
+                  <div key={idx} className="flex items-center justify-center">
+                    {shouldTruncate ? (
+                      <HoverCard>
+                        <HoverCardTrigger asChild>
+                          <span className="cursor-help">{truncated}</span>
+                        </HoverCardTrigger>
+                        <HoverCardContent
+                          side="bottom"
+                          align="center"
+                          className="w-auto"
+                        >
+                          <div className="space-y-1">
+                            <p className="font-semibold">{label}</p>
+                          </div>
+                        </HoverCardContent>
+                      </HoverCard>
+                    ) : (
+                      <span>{label}</span>
+                    )}
+                  </div>
+                );
+              })}
             </div>
 
             {/* Spacer for alignment */}

--- a/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
@@ -198,7 +198,7 @@ export function Heatmap({
 
           {/* Grid */}
           <div
-            className="grid w-full flex-1 gap-1"
+            className="grid w-full flex-1 gap-0.5"
             style={{
               gridTemplateColumns: `repeat(${cols}, ${cellWidth})`,
               gridTemplateRows: `repeat(${rows}, ${cellHeight})`,

--- a/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
@@ -115,15 +115,36 @@ export function Heatmap({
 
   useLayoutEffect(() => {
     if (rowLabelsRef.current && rowLabels && rowLabels.length > 0) {
-      // Measure the actual width needed for the labels
-      const width = rowLabelsRef.current.scrollWidth;
-      console.log("[Heatmap] Measured row labels scrollWidth:", width);
+      const container = rowLabelsRef.current;
 
-      // Add some padding (8px for pr-1, plus extra buffer)
-      const totalWidth = width + 16;
+      console.log("[Heatmap] Container measurements:", {
+        clientWidth: container.clientWidth,
+        scrollWidth: container.scrollWidth,
+        offsetWidth: container.offsetWidth,
+      });
+
+      // Find the widest label by measuring each label element
+      const labelElements = container.querySelectorAll("span");
+      let maxLabelWidth = 0;
+
+      labelElements.forEach((element, idx) => {
+        const width = element.offsetWidth;
+        console.log(
+          `[Heatmap] Label ${idx} width:`,
+          width,
+          "text:",
+          element.textContent,
+        );
+        maxLabelWidth = Math.max(maxLabelWidth, width);
+      });
+
+      console.log("[Heatmap] Max label width found:", maxLabelWidth);
+
+      // Add padding (pr-1 is 4px on small screens, pr-2 is 8px on larger)
+      const totalWidth = maxLabelWidth + 8;
       console.log("[Heatmap] Total width with padding:", totalWidth);
 
-      const finalWidth = Math.max(60, Math.min(totalWidth, 120)); // Min 60px, max 120px
+      const finalWidth = Math.max(36, Math.min(totalWidth, 120)); // Min 36px, max 120px
       console.log("[Heatmap] Final constrained width:", finalWidth);
 
       setRowLabelsWidth(finalWidth);
@@ -138,7 +159,7 @@ export function Heatmap({
         role="img"
         aria-label={ariaLabel}
       >
-        <div className="flex flex-1 items-stretch justify-center gap-2 sm:gap-4">
+        <div className="flex flex-1 items-stretch justify-center gap-1 sm:gap-2">
           {/* Y-axis label (vertical) */}
           {yAxisLabel && (
             <div className="flex items-center justify-center">

--- a/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
@@ -117,16 +117,21 @@ export function Heatmap({
         role="img"
         aria-label={ariaLabel}
       >
-        {/* Y-axis label (vertical) */}
-        {yAxisLabel && (
-          <div className="flex justify-center">
-            <span className="text-sm font-medium text-muted-foreground">
-              {yAxisLabel}
-            </span>
-          </div>
-        )}
-
         <div className="flex flex-1 items-stretch justify-center gap-2 sm:gap-4">
+          {/* Y-axis label (vertical) */}
+          {yAxisLabel && (
+            <div className="flex items-center justify-center">
+              <span
+                className="text-sm font-medium text-muted-foreground"
+                style={{
+                  writingMode: "vertical-rl",
+                  transform: "rotate(180deg)",
+                }}
+              >
+                {yAxisLabel}
+              </span>
+            </div>
+          )}
           {/* Row labels */}
           {rowLabels && rowLabels.length > 0 && (
             <div

--- a/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
@@ -117,9 +117,16 @@ export function Heatmap({
     if (rowLabelsRef.current && rowLabels && rowLabels.length > 0) {
       // Measure the actual width needed for the labels
       const width = rowLabelsRef.current.scrollWidth;
+      console.log("[Heatmap] Measured row labels scrollWidth:", width);
+
       // Add some padding (8px for pr-1, plus extra buffer)
       const totalWidth = width + 16;
-      setRowLabelsWidth(Math.max(60, Math.min(totalWidth, 120))); // Min 60px, max 120px
+      console.log("[Heatmap] Total width with padding:", totalWidth);
+
+      const finalWidth = Math.max(60, Math.min(totalWidth, 120)); // Min 60px, max 120px
+      console.log("[Heatmap] Final constrained width:", finalWidth);
+
+      setRowLabelsWidth(finalWidth);
     }
   }, [rowLabels, isDivisionPointMode]);
 

--- a/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
@@ -69,8 +69,9 @@ export function Heatmap({
     return map;
   }, [data]);
 
-  // Calculate responsive cell size
-  const cellMinSize = "minmax(24px, 1fr)";
+  // Calculate responsive cell size - width-biased for minimal vertical space
+  const cellWidth = "minmax(32px, 1fr)"; // Can grow wide
+  const cellHeight = "minmax(24px, 40px)"; // Capped at 40px tall
 
   return (
     <TooltipProvider>
@@ -95,7 +96,7 @@ export function Heatmap({
             <div
               className="grid gap-1 pr-1 text-right text-[10px] text-muted-foreground sm:pr-2 sm:text-xs"
               style={{
-                gridTemplateRows: `repeat(${rows}, ${cellMinSize})`,
+                gridTemplateRows: `repeat(${rows}, ${cellHeight})`,
               }}
             >
               {rowLabels.map((label, idx) => (
@@ -110,11 +111,10 @@ export function Heatmap({
 
           {/* Grid */}
           <div
-            className="grid max-w-full flex-1 gap-1 overflow-x-auto"
+            className="grid w-full flex-1 gap-1"
             style={{
-              gridTemplateColumns: `repeat(${cols}, ${cellMinSize})`,
-              gridTemplateRows: `repeat(${rows}, ${cellMinSize})`,
-              maxWidth: "600px",
+              gridTemplateColumns: `repeat(${cols}, ${cellWidth})`,
+              gridTemplateRows: `repeat(${rows}, ${cellHeight})`,
               height: height || "auto",
             }}
             role="grid"
@@ -152,10 +152,9 @@ export function Heatmap({
             )}
 
             <div
-              className="grid flex-1 gap-1 text-center text-[10px] text-muted-foreground sm:text-xs"
+              className="grid w-full flex-1 gap-1 text-center text-[10px] text-muted-foreground sm:text-xs"
               style={{
-                gridTemplateColumns: `repeat(${cols}, ${cellMinSize})`,
-                maxWidth: "600px",
+                gridTemplateColumns: `repeat(${cols}, ${cellWidth})`,
               }}
             >
               {colLabels.map((label, idx) => (

--- a/web/src/features/scores/components/score-analytics/components/charts/HeatmapCell.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/HeatmapCell.tsx
@@ -41,7 +41,7 @@ function EmptyCell({ cellClassName }: { cellClassName?: string }) {
       )}
       style={{
         backgroundColor: "hsl(var(--background))",
-        borderColor: "hsl(var(--border) / 0.34)",
+        borderColor: "hsl(var(--border) / 0.5)",
       }}
       aria-hidden="true"
     />

--- a/web/src/features/scores/components/score-analytics/components/charts/HeatmapCell.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/HeatmapCell.tsx
@@ -18,34 +18,49 @@ interface HeatmapCellProps {
   showValues?: boolean;
 }
 
-export function HeatmapCellComponent({
+interface CellWithDataProps {
+  cell: HeatmapCell;
+  color?: string;
+  onHover?: (cell: HeatmapCell | null) => void;
+  onClick?: (cell: HeatmapCell) => void;
+  renderTooltip?: (cell: HeatmapCell) => React.ReactNode;
+  cellClassName?: string;
+  showValues: boolean;
+}
+
+/**
+ * Empty cell component (no data)
+ */
+function EmptyCell({ cellClassName }: { cellClassName?: string }) {
+  return (
+    <div
+      className={cn(
+        "aspect-square rounded border-[0.5px] transition-all duration-150",
+        "hover:brightness-95",
+        cellClassName,
+      )}
+      style={{
+        backgroundColor: "hsl(var(--background))",
+        borderColor: "hsl(var(--border) / 0.34)",
+      }}
+      aria-hidden="true"
+    />
+  );
+}
+
+/**
+ * Cell with data component
+ */
+function CellWithData({
   cell,
   color,
   onHover,
   onClick,
   renderTooltip,
   cellClassName,
-  showValues = true,
-}: HeatmapCellProps) {
+  showValues,
+}: CellWithDataProps) {
   const [isHovered, setIsHovered] = useState(false);
-
-  // Empty cell (no data)
-  if (!cell) {
-    return (
-      <div
-        className={cn(
-          "aspect-square rounded border-[0.5px] transition-all duration-150",
-          "hover:brightness-95",
-          cellClassName,
-        )}
-        style={{
-          backgroundColor: "hsl(var(--background))",
-          borderColor: "hsl(var(--border) / 0.34)",
-        }}
-        aria-hidden="true"
-      />
-    );
-  }
 
   // Determine if cell is empty (value = 0)
   const isEmpty = cell.value === 0;
@@ -133,4 +148,34 @@ export function HeatmapCellComponent({
   }
 
   return cellContent;
+}
+
+/**
+ * Public routing component that determines which cell type to render
+ */
+export function HeatmapCellComponent({
+  cell,
+  color,
+  onHover,
+  onClick,
+  renderTooltip,
+  cellClassName,
+  showValues = true,
+}: HeatmapCellProps) {
+  // Route to appropriate component based on whether cell has data
+  if (!cell) {
+    return <EmptyCell cellClassName={cellClassName} />;
+  }
+
+  return (
+    <CellWithData
+      cell={cell}
+      color={color}
+      onHover={onHover}
+      onClick={onClick}
+      renderTooltip={renderTooltip}
+      cellClassName={cellClassName}
+      showValues={showValues}
+    />
+  );
 }

--- a/web/src/features/scores/components/score-analytics/components/charts/HeatmapCell.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/HeatmapCell.tsx
@@ -58,7 +58,7 @@ export function HeatmapCellComponent({
     : getContrastColor(cellColor);
 
   const sharedClassName = cn(
-    "aspect-square w-full rounded border-[0.5px]",
+    "w-full rounded border-[0.5px]",
     "flex items-center justify-center",
     "text-xs font-medium",
     "transition-all duration-150",

--- a/web/src/features/scores/components/score-analytics/components/charts/HeatmapCell.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/HeatmapCell.tsx
@@ -35,7 +35,7 @@ function EmptyCell({ cellClassName }: { cellClassName?: string }) {
   return (
     <div
       className={cn(
-        "rounded border-[0.5px] transition-all duration-150",
+        "rounded border transition-all duration-150",
         "hover:brightness-95",
         cellClassName,
       )}

--- a/web/src/features/scores/components/score-analytics/components/charts/HeatmapCell.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/HeatmapCell.tsx
@@ -35,7 +35,7 @@ function EmptyCell({ cellClassName }: { cellClassName?: string }) {
   return (
     <div
       className={cn(
-        "rounded border transition-all duration-150",
+        "h-full w-full rounded-sm border transition-all duration-150",
         "hover:brightness-95",
         cellClassName,
       )}
@@ -73,7 +73,7 @@ function CellWithData({
     : getContrastColor(cellColor);
 
   const sharedClassName = cn(
-    "w-full rounded border-[0.5px]",
+    "h-full w-full rounded-sm border-[0.5px]",
     "flex items-center justify-center",
     "text-xs font-medium",
     "transition-all duration-150",

--- a/web/src/features/scores/components/score-analytics/components/charts/HeatmapCell.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/HeatmapCell.tsx
@@ -35,7 +35,7 @@ function EmptyCell({ cellClassName }: { cellClassName?: string }) {
   return (
     <div
       className={cn(
-        "aspect-square rounded border-[0.5px] transition-all duration-150",
+        "rounded border-[0.5px] transition-all duration-150",
         "hover:brightness-95",
         cellClassName,
       )}

--- a/web/src/features/scores/components/score-analytics/components/charts/HeatmapLegend.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/HeatmapLegend.tsx
@@ -1,14 +1,10 @@
-import {
-  generateMonoColorScale,
-  HEATMAP_BASE_COLORS,
-  type HeatmapColorVariant,
-} from "@/src/features/scores/lib/color-scales";
+import { getHeatmapCellColor } from "@/src/features/scores/lib/color-scales";
 import { cn } from "@/src/utils/tailwind";
 
 export interface HeatmapLegendProps {
   min: number;
   max: number;
-  variant?: HeatmapColorVariant;
+  scoreNumber?: 1 | 2;
   title?: string;
   className?: string;
   orientation?: "horizontal" | "vertical";
@@ -18,14 +14,17 @@ export interface HeatmapLegendProps {
 export function HeatmapLegend({
   min,
   max,
-  variant = "chart1",
-  title = "Count",
+  scoreNumber = 1,
+  title,
   className,
   orientation = "horizontal",
   steps = 5,
 }: HeatmapLegendProps) {
-  const baseColor = HEATMAP_BASE_COLORS[variant];
-  const colors = generateMonoColorScale(baseColor, steps);
+  // Generate colors using the same function as the heatmap cells
+  const colors = Array.from({ length: steps }, (_, i) => {
+    const value = min + ((max - min) * i) / (steps - 1);
+    return getHeatmapCellColor(scoreNumber, value, min, max);
+  });
 
   // Generate labels
   const labels = Array.from({ length: steps }, (_, i) => {
@@ -66,25 +65,18 @@ export function HeatmapLegend({
 
   // Horizontal orientation
   return (
-    <div className={cn("flex flex-col gap-2", className)}>
-      {title && (
-        <div className="text-center text-xs font-medium text-muted-foreground">
-          {title}
-        </div>
-      )}
-      <div className="flex items-center gap-2">
-        <span className="text-xs text-muted-foreground">{min}</span>
-        <div className="flex h-3 flex-1 gap-0.5">
-          {colors.map((color, idx) => (
-            <div
-              key={idx}
-              className="aspect-square flex-1 border-[0.5px] border-border/30 first:rounded-l last:rounded-r"
-              style={{ backgroundColor: color }}
-            />
-          ))}
-        </div>
-        <span className="text-xs text-muted-foreground">{max}</span>
+    <div className={cn("flex items-center gap-2", className)}>
+      <span className="text-xs text-muted-foreground">{min}</span>
+      <div className="flex items-center gap-0.5">
+        {colors.map((color, idx) => (
+          <div
+            key={idx}
+            className="h-4 w-4 rounded-sm border-[0.5px] border-border/30"
+            style={{ backgroundColor: color }}
+          />
+        ))}
       </div>
+      <span className="text-xs text-muted-foreground">{max}</span>
     </div>
   );
 }

--- a/web/src/features/scores/components/score-analytics/components/charts/MetricCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/MetricCard.tsx
@@ -73,7 +73,7 @@ export function MetricCard({
       </div>
 
       {/* Value with interpretation badge */}
-      <div className="flex items-baseline gap-2">
+      <div className="flex items-center gap-2">
         {isNA ? (
           // Muted styling for N/A values - use em dash and reduced opacity
           <span className="text-sm text-muted-foreground/50">—</span>
@@ -94,7 +94,10 @@ export function MetricCard({
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Badge variant={getBadgeVariant(interpretation.color)}>
+                  <Badge
+                    variant={getBadgeVariant(interpretation.color)}
+                    className="px-1.5 py-0 text-[10px] font-normal opacity-70"
+                  >
                     {interpretation.strength}
                   </Badge>
                 </TooltipTrigger>

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionBooleanChart.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionBooleanChart.tsx
@@ -213,7 +213,7 @@ export function ScoreDistributionBooleanChart({
           stroke="hsl(var(--chart-grid))"
           fontSize={12}
           tickLine={false}
-          axisLine={false}
+          axisLine={{ stroke: "hsl(var(--border) / 0.5)" }}
           interval={0}
         />
         <YAxis

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionCategoricalChart.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionCategoricalChart.tsx
@@ -184,13 +184,13 @@ export function ScoreDistributionCategoricalChart({
       return stackConfig;
     }
 
-    // Single score mode: use category name for pv label
+    // Single score mode: use score name as label (category shown via custom tooltip)
     const firstColor = categories[0]
       ? colors[categories[0]]
       : Object.values(colors)[0];
     return {
       pv: {
-        label: (payload: any) => payload?.name ?? score1Name,
+        label: score1Name,
         color: firstColor,
       },
     };

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionCategoricalChart.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionCategoricalChart.tsx
@@ -18,6 +18,8 @@ interface CategoricalChartProps {
     count: number;
   }>;
   score2Categories?: string[];
+  score2Name?: string;
+  score2Source?: string;
   colors: Record<string, string>;
 }
 
@@ -33,6 +35,8 @@ export function ScoreDistributionCategoricalChart({
   score1Name,
   stackedDistribution,
   score2Categories,
+  score2Name,
+  score2Source,
   colors,
 }: CategoricalChartProps) {
   const hasStackedData = Boolean(
@@ -150,12 +154,31 @@ export function ScoreDistributionCategoricalChart({
       // Stacked mode: create config for all stack keys using color mappings
       const stackConfig: ChartConfig = {};
       allStackKeys.forEach((key) => {
-        stackConfig[key] = {
-          label: key === "__unmatched__" ? "Unmatched" : key,
-          color:
+        // Try namespaced key first (for when score1 and score2 have same category names)
+        // Format: "ScoreName (source): category"
+        let color: string | undefined;
+
+        if (key !== "__unmatched__" && score2Name && score2Source) {
+          const namespacedKey = `${score2Name} (${score2Source}): ${key}`;
+          color = colors[namespacedKey];
+        }
+
+        // Fallback to non-namespaced key
+        if (!color && key !== "__unmatched__") {
+          color = colors[key];
+        }
+
+        // Final fallback
+        if (!color) {
+          color =
             key === "__unmatched__"
               ? "hsl(var(--muted-foreground))"
-              : colors[key] || Object.values(colors)[0],
+              : Object.values(colors)[0];
+        }
+
+        stackConfig[key] = {
+          label: key === "__unmatched__" ? "Unmatched" : key,
+          color,
         };
       });
       return stackConfig;
@@ -171,7 +194,15 @@ export function ScoreDistributionCategoricalChart({
         color: firstColor,
       },
     };
-  }, [hasStackedData, allStackKeys, score1Name, colors, categories]);
+  }, [
+    hasStackedData,
+    allStackKeys,
+    score1Name,
+    score2Name,
+    score2Source,
+    colors,
+    categories,
+  ]);
 
   return (
     <ChartContainer

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionCategoricalChart.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionCategoricalChart.tsx
@@ -184,13 +184,13 @@ export function ScoreDistributionCategoricalChart({
       return stackConfig;
     }
 
-    // Single score mode: use first category color or fallback
+    // Single score mode: use category name for pv label
     const firstColor = categories[0]
       ? colors[categories[0]]
       : Object.values(colors)[0];
     return {
       pv: {
-        label: score1Name,
+        label: (payload: any) => payload?.name ?? score1Name,
         color: firstColor,
       },
     };

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionCategoricalChart.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionCategoricalChart.tsx
@@ -184,7 +184,7 @@ export function ScoreDistributionCategoricalChart({
           stroke="hsl(var(--chart-grid))"
           fontSize={12}
           tickLine={false}
-          axisLine={false}
+          axisLine={{ stroke: "hsl(var(--border) / 0.5)" }}
           interval={0}
         />
         <YAxis

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionChart.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionChart.tsx
@@ -8,6 +8,7 @@ export interface ScoreDistributionChartProps {
   dataType: "NUMERIC" | "CATEGORICAL" | "BOOLEAN";
   score1Name: string;
   score2Name?: string;
+  score2Source?: string;
   // For numeric scores, provide bin labels
   binLabels?: string[];
   // For categorical/boolean scores, provide category names
@@ -35,6 +36,7 @@ export function ScoreDistributionChart({
   dataType,
   score1Name,
   score2Name,
+  score2Source,
   binLabels,
   categories,
   stackedDistribution,
@@ -109,6 +111,8 @@ export function ScoreDistributionChart({
       score1Name={score1Name}
       stackedDistribution={stackedDistribution}
       score2Categories={score2Categories}
+      score2Name={score2Name}
+      score2Source={score2Source}
       colors={colors as Record<string, string>}
     />
   );

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionNumericChart.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionNumericChart.tsx
@@ -120,7 +120,7 @@ export function ScoreDistributionNumericChart({
           stroke="hsl(var(--chart-grid))"
           fontSize={12}
           tickLine={false}
-          axisLine={false}
+          axisLine={{ stroke: "hsl(var(--border) / 0.5)" }}
           interval={1}
         />
         <YAxis

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreTimeSeriesBooleanChart.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreTimeSeriesBooleanChart.tsx
@@ -156,7 +156,7 @@ export function ScoreTimeSeriesBooleanChart({
           stroke="hsl(var(--chart-grid))"
           fontSize={12}
           tickLine={false}
-          axisLine={false}
+          axisLine={{ stroke: "hsl(var(--border) / 0.34)" }}
           interval={0}
           angle={-45}
           textAnchor="end"

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreTimeSeriesBooleanChart.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreTimeSeriesBooleanChart.tsx
@@ -157,10 +157,7 @@ export function ScoreTimeSeriesBooleanChart({
           fontSize={12}
           tickLine={false}
           axisLine={{ stroke: "hsl(var(--border) / 0.5)" }}
-          interval={0}
-          angle={-45}
-          textAnchor="end"
-          height={80}
+          interval={1}
         />
         <YAxis
           stroke="hsl(var(--chart-grid))"

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreTimeSeriesBooleanChart.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreTimeSeriesBooleanChart.tsx
@@ -156,7 +156,7 @@ export function ScoreTimeSeriesBooleanChart({
           stroke="hsl(var(--chart-grid))"
           fontSize={12}
           tickLine={false}
-          axisLine={{ stroke: "hsl(var(--border) / 0.34)" }}
+          axisLine={{ stroke: "hsl(var(--border) / 0.5)" }}
           interval={0}
           angle={-45}
           textAnchor="end"

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreTimeSeriesCategoricalChart.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreTimeSeriesCategoricalChart.tsx
@@ -155,7 +155,7 @@ export function ScoreTimeSeriesCategoricalChart({
           stroke="hsl(var(--chart-grid))"
           fontSize={12}
           tickLine={false}
-          axisLine={{ stroke: "hsl(var(--border) / 0.34)" }}
+          axisLine={{ stroke: "hsl(var(--border) / 0.5)" }}
           interval={0}
           angle={-45}
           textAnchor="end"

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreTimeSeriesCategoricalChart.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreTimeSeriesCategoricalChart.tsx
@@ -155,7 +155,7 @@ export function ScoreTimeSeriesCategoricalChart({
           stroke="hsl(var(--chart-grid))"
           fontSize={12}
           tickLine={false}
-          axisLine={false}
+          axisLine={{ stroke: "hsl(var(--border) / 0.34)" }}
           interval={0}
           angle={-45}
           textAnchor="end"

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreTimeSeriesCategoricalChart.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreTimeSeriesCategoricalChart.tsx
@@ -156,10 +156,7 @@ export function ScoreTimeSeriesCategoricalChart({
           fontSize={12}
           tickLine={false}
           axisLine={{ stroke: "hsl(var(--border) / 0.5)" }}
-          interval={0}
-          angle={-45}
-          textAnchor="end"
-          height={80}
+          interval={1}
         />
         <YAxis
           stroke="hsl(var(--chart-grid))"

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreTimeSeriesNumericChart.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreTimeSeriesNumericChart.tsx
@@ -150,7 +150,7 @@ export function ScoreTimeSeriesNumericChart({
           stroke="hsl(var(--chart-grid))"
           fontSize={12}
           tickLine={false}
-          axisLine={false}
+          axisLine={{ stroke: "hsl(var(--border) / 0.34)" }}
           interval={1}
         />
         <YAxis

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreTimeSeriesNumericChart.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreTimeSeriesNumericChart.tsx
@@ -150,7 +150,7 @@ export function ScoreTimeSeriesNumericChart({
           stroke="hsl(var(--chart-grid))"
           fontSize={12}
           tickLine={false}
-          axisLine={{ stroke: "hsl(var(--border) / 0.34)" }}
+          axisLine={{ stroke: "hsl(var(--border) / 0.5)" }}
           interval={1}
         />
         <YAxis

--- a/web/src/features/scores/components/score-analytics/hooks/useScoreAnalyticsQuery.ts
+++ b/web/src/features/scores/components/score-analytics/hooks/useScoreAnalyticsQuery.ts
@@ -475,7 +475,17 @@ export function useScoreAnalyticsQuery(
         score2Matched: distribution2Matched,
         stackedDistribution: apiData.stackedDistribution,
         stackedDistributionMatched: apiData.stackedDistributionMatched,
-        score2Categories: apiData.score2Categories,
+        // For categorical/boolean scores, ensure score2Categories is populated
+        // API may return empty array [] when both scores have identical categories
+        // (e.g., boolean scores always have ["False", "True"])
+        // We need this populated so the UI can correctly display score2's categories
+        // when viewing the "score2" tab in the distribution card
+        score2Categories:
+          apiData.score2Categories && apiData.score2Categories.length > 0
+            ? apiData.score2Categories
+            : mode === "two" && categories
+              ? categories
+              : undefined,
       },
       timeSeries: {
         numeric: {

--- a/web/src/features/scores/components/score-analytics/hooks/useScoreAnalyticsQuery.ts
+++ b/web/src/features/scores/components/score-analytics/hooks/useScoreAnalyticsQuery.ts
@@ -236,8 +236,11 @@ export function useScoreAnalyticsQuery(
       ? fillDistributionBins(apiData.distribution1Individual, categories)
       : apiData.distribution1Individual;
 
-    const distribution2Individual = categories
-      ? fillDistributionBins(apiData.distribution2Individual, categories)
+    const distribution2Individual = apiData.score2Categories
+      ? fillDistributionBins(
+          apiData.distribution2Individual,
+          apiData.score2Categories,
+        )
       : apiData.distribution2Individual;
 
     const distribution1Matched = categories

--- a/web/src/features/scores/components/score-analytics/hooks/useScoreAnalyticsQuery.ts
+++ b/web/src/features/scores/components/score-analytics/hooks/useScoreAnalyticsQuery.ts
@@ -236,11 +236,8 @@ export function useScoreAnalyticsQuery(
       ? fillDistributionBins(apiData.distribution1Individual, categories)
       : apiData.distribution1Individual;
 
-    const distribution2Individual = apiData.score2Categories
-      ? fillDistributionBins(
-          apiData.distribution2Individual,
-          apiData.score2Categories,
-        )
+    const distribution2Individual = categories
+      ? fillDistributionBins(apiData.distribution2Individual, categories)
       : apiData.distribution2Individual;
 
     const distribution1Matched = categories

--- a/web/src/features/scores/components/score-analytics/libs/ScoreChartTooltip.tsx
+++ b/web/src/features/scores/components/score-analytics/libs/ScoreChartTooltip.tsx
@@ -4,6 +4,7 @@ import {
   type TimeRange,
 } from "@/src/utils/date-range-utils";
 import { formatChartTooltipTimestamp } from "./chart-formatters";
+import { useChart } from "@/src/components/ui/chart";
 
 /**
  * Props for the ScoreChartTooltip component.
@@ -58,6 +59,8 @@ export function ScoreChartTooltip({
   valueFormatter = (value: number) => value.toString(),
   labelFormatter,
 }: ScoreChartTooltipProps) {
+  const { config } = useChart();
+
   if (!active || !payload || payload.length === 0) {
     return null;
   }
@@ -106,6 +109,10 @@ export function ScoreChartTooltip({
       {/* Data series with values */}
       <div className={cn("space-y-1 px-3 py-1.5")}>
         {sortedPayload.map((entry, index) => {
+          // Get series label from config using the Bar's dataKey
+          const seriesKey = entry.name || entry.dataKey || "";
+          const seriesLabel = config[seriesKey]?.label || seriesKey;
+
           return (
             <div
               key={`${index}-${entry.name}`}
@@ -119,16 +126,9 @@ export function ScoreChartTooltip({
                 }}
               />
 
-              {/* Series name */}
+              {/* Series label from config */}
               <span className="flex-1 text-sm text-muted-foreground">
-                {sortedPayload.length === 1 && (
-                  // For non-stacked charts
-                  <>{entry.payload?.name ?? entry.dataKey ?? ""}</>
-                )}
-                {sortedPayload.length !== 1 && (
-                  // For stacked charts
-                  <>{entry.name?.toString() ?? entry.dataKey ?? ""}</>
-                )}
+                {seriesLabel?.toString() ?? ""}
               </span>
               {/* Formatted value */}
               <span className="text-sm font-medium text-foreground">

--- a/web/src/features/scores/components/score-analytics/libs/ScoreChartTooltip.tsx
+++ b/web/src/features/scores/components/score-analytics/libs/ScoreChartTooltip.tsx
@@ -105,28 +105,38 @@ export function ScoreChartTooltip({
 
       {/* Data series with values */}
       <div className={cn("space-y-1 px-3 py-1.5")}>
-        {sortedPayload.map((entry, index) => (
-          <div
-            key={`${index}-${entry.name}`}
-            className="flex items-center gap-2"
-          >
-            {/* Color indicator */}
+        {sortedPayload.map((entry, index) => {
+          return (
             <div
-              className="h-3 w-3 flex-shrink-0 rounded-sm"
-              style={{ backgroundColor: entry.color ?? "hsl(var(--primary))" }}
-            />
+              key={`${index}-${entry.name}`}
+              className="flex items-center gap-2"
+            >
+              {/* Color indicator */}
+              <div
+                className="h-3 w-3 flex-shrink-0 rounded-sm"
+                style={{
+                  backgroundColor: entry.color ?? "hsl(var(--primary))",
+                }}
+              />
 
-            {/* Series name */}
-            <span className="flex-1 text-sm text-muted-foreground">
-              {entry.name?.toString() ?? entry.dataKey ?? ""}
-            </span>
-
-            {/* Formatted value */}
-            <span className="text-sm font-medium text-foreground">
-              {valueFormatter(Number(entry.value ?? 0))}
-            </span>
-          </div>
-        ))}
+              {/* Series name */}
+              <span className="flex-1 text-sm text-muted-foreground">
+                {sortedPayload.length === 1 && (
+                  // For non-stacked charts
+                  <>{entry.payload?.name ?? entry.dataKey ?? ""}</>
+                )}
+                {sortedPayload.length !== 1 && (
+                  // For stacked charts
+                  <>{entry.name?.toString() ?? entry.dataKey ?? ""}</>
+                )}
+              </span>
+              {/* Formatted value */}
+              <span className="text-sm font-medium text-foreground">
+                {valueFormatter(Number(entry.value ?? 0))}
+              </span>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/web/src/features/scores/lib/heatmap-utils.ts
+++ b/web/src/features/scores/lib/heatmap-utils.ts
@@ -98,17 +98,18 @@ export function generateNumericHeatmapData({
     };
   });
 
-  // Generate labels
-  const rowLabels = Array.from({ length: nBins }, (_, i) => {
-    const start = min1 + i * binWidth1;
-    const end = min1 + (i + 1) * binWidth1;
-    return formatBinLabel(start, end);
+  // Generate division point labels (nBins + 1 points for nBins bins)
+  const range1 = max1 - min1;
+  const range2 = max2 - min2;
+
+  const rowLabels = Array.from({ length: nBins + 1 }, (_, i) => {
+    const divisionPoint = min1 + i * binWidth1;
+    return formatDivisionPoint(divisionPoint, range1);
   });
 
-  const colLabels = Array.from({ length: nBins }, (_, i) => {
-    const start = min2 + i * binWidth2;
-    const end = min2 + (i + 1) * binWidth2;
-    return formatBinLabel(start, end);
+  const colLabels = Array.from({ length: nBins + 1 }, (_, i) => {
+    const divisionPoint = min2 + i * binWidth2;
+    return formatDivisionPoint(divisionPoint, range2);
   });
 
   return { cells, rowLabels, colLabels, maxValue: maxCount };
@@ -217,25 +218,25 @@ export function generateConfusionMatrixData({
 }
 
 /**
- * Format a bin label for display
- * @param start - Start of the range
- * @param end - End of the range
- * @returns Formatted label string
+ * Format a single division point value
+ * @param value - The division point value
+ * @param range - The total range to determine precision
+ * @returns Formatted value string
  */
-function formatBinLabel(start: number, end: number): string {
-  // Determine precision based on range
-  const range = Math.abs(end - start);
+function formatDivisionPoint(value: number, range: number): string {
   let precision: number;
 
-  if (range >= 1) {
+  if (range >= 10) {
     precision = 1;
-  } else if (range >= 0.1) {
+  } else if (range >= 1) {
     precision = 2;
-  } else {
+  } else if (range >= 0.1) {
     precision = 3;
+  } else {
+    precision = 4;
   }
 
-  return `[${start.toFixed(precision)}, ${end.toFixed(precision)})`;
+  return value.toFixed(precision);
 }
 
 /**

--- a/web/src/features/scores/lib/statistics-utils.ts
+++ b/web/src/features/scores/lib/statistics-utils.ts
@@ -324,6 +324,13 @@ export function interpretCohensKappa(
     };
   }
 
+  if (kappa >= 1.0) {
+    return {
+      strength: "Perfect",
+      color: "green",
+      description: "perfect agreement between scores",
+    };
+  }
   if (kappa >= 0.81) {
     return {
       strength: "Almost Perfect",

--- a/web/src/features/scores/lib/statistics-utils.ts
+++ b/web/src/features/scores/lib/statistics-utils.ts
@@ -359,7 +359,7 @@ export function interpretCohensKappa(
       description: "Fair agreement between scores",
     };
   }
-  if (kappa >= 0) {
+  if (kappa > 0) {
     return {
       strength: "Slight",
       color: "red",


### PR DESCRIPTION
Fixes tooltip label display across all distribution chart types.

## Problem
Tooltips were showing technical identifiers ('pv', 'uv') instead of human-readable score names in distribution charts.

## Solution
- Import and use the `useChart` hook to access the ChartConfig
- Look up series labels from `config[dataKey].label` instead of using raw `entry.name`
- Removes conditional logic that checked `sortedPayload.length`

## Impact
Fixes tooltips across:
- ✅ Numeric single & comparison charts
- ✅ Boolean single & comparison charts (all tabs)
- ✅ Categorical single & comparison charts (all tabs)

## Related
Parent Issue: LF-1910
Issue: LF-1972
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves tooltip labels in distribution charts by using `ChartConfig` for human-readable labels across various chart types.
> 
>   - **Behavior**:
>     - Tooltips in distribution charts now use human-readable labels from `ChartConfig` instead of technical identifiers like 'pv', 'uv'.
>     - Applies to numeric, boolean, and categorical charts in both single and comparison modes.
>   - **Implementation**:
>     - Utilizes `useChart` hook to access `ChartConfig` for label retrieval in `ScoreChartTooltip`.
>     - Updates `useScoreAnalyticsQuery` to ensure `score2Categories` is populated for UI display.
>   - **Misc**:
>     - Removes conditional logic checking `sortedPayload.length` in `ScoreChartTooltip`.
>     - Adjusts label truncation logic in `TimeseriesChart.tsx` and `DistributionChartCard.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for aa2b86a7a8c7ab5614683b2c56bab2e9f25a6d99. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->