### PR TITLE
refactor(scores): Improve beta feature badge with hover card (LF-1978)

### DIFF
--- a/packages/shared/scripts/seed-score-analytics-demo.ts
+++ b/packages/shared/scripts/seed-score-analytics-demo.ts
@@ -72,7 +72,7 @@ function generateRealisticTimestamp(): number {
     daysAgo = 90 + Math.random() * 275;
   }
 
-  const timestamp = now - daysAgo * 24 * 60 * 60 * 1000;
+  const timestamp = now - Math.floor(daysAgo * 24 * 60 * 60 * 1000);
 
   // Apply weekly pattern (lower on weekends)
   const date = new Date(timestamp);
@@ -83,13 +83,13 @@ function generateRealisticTimestamp(): number {
     // 30% chance to skip weekend data
     if (Math.random() < 0.3) {
       // Shift to Monday
-      return timestamp + (8 - dayOfWeek) * 24 * 60 * 60 * 1000;
+      return Math.floor(timestamp + (8 - dayOfWeek) * 24 * 60 * 60 * 1000);
     }
   }
 
-  // Add some random minutes/hours within the day
-  const hourJitter = Math.random() * 24 * 60 * 60 * 1000;
-  return Math.floor(timestamp + hourJitter);
+  // Add some random minutes/hours within the day (ensure integer)
+  const hourJitter = Math.floor(Math.random() * 24 * 60 * 60 * 1000);
+  return timestamp + hourJitter;
 }
 
 async function seedBooleanScores(projectId: string) {
@@ -184,6 +184,7 @@ async function seedBooleanScores(projectId: string) {
         id: randomUUID(),
         project_id: projectId,
         trace_id: trace.id,
+        observation_id: null,
         timestamp: trace.timestamp + randomInt(1000, 60000), // 1-60 seconds after trace
         name: "has_tool_use",
         value: null,
@@ -203,6 +204,7 @@ async function seedBooleanScores(projectId: string) {
         id: randomUUID(),
         project_id: projectId,
         trace_id: trace.id,
+        observation_id: null,
         timestamp: trace.timestamp + randomInt(1000, 60000),
         name: "has_hallucination",
         value: null,

--- a/web/src/features/scores/components/score-analytics/components/ScoreAnalyticsHeader.tsx
+++ b/web/src/features/scores/components/score-analytics/components/ScoreAnalyticsHeader.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { Info } from "lucide-react";
 import { ScoreCombobox } from "./charts/ScoreCombobox";
 import { ObjectTypeFilter } from "./charts/ObjectTypeFilter";
 import { TimeRangePicker } from "@/src/components/date-picker";
@@ -72,6 +73,15 @@ export function ScoreAnalyticsHeader({
           disabled={!urlState.score1}
           className="h-8 w-[200px]"
         />
+        <a
+          href="https://langfuse.com/discussions"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center"
+          title="Score analytics is currently in beta. Click here to provide feedback!"
+        >
+          <Info className="h-4 w-4 text-muted-foreground" />
+        </a>
       </div>
 
       {/* Middle: Spacer (hidden on mobile) */}

--- a/web/src/features/scores/components/score-analytics/components/ScoreAnalyticsHeader.tsx
+++ b/web/src/features/scores/components/score-analytics/components/ScoreAnalyticsHeader.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { Info } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { ScoreCombobox } from "./charts/ScoreCombobox";
 import { ObjectTypeFilter } from "./charts/ObjectTypeFilter";
 import { TimeRangePicker } from "@/src/components/date-picker";
@@ -7,6 +7,12 @@ import { DASHBOARD_AGGREGATION_OPTIONS } from "@/src/utils/date-range-utils";
 import { useAnalyticsUrlState } from "@/src/features/scores/lib/analytics-url-state";
 import { type TimeRange } from "@/src/utils/date-range-utils";
 import { type ScoreOption } from "./charts/ScoreCombobox";
+import { Badge } from "@/src/components/ui/badge";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/src/components/ui/hover-card";
 
 export interface ScoreAnalyticsHeaderProps {
   scoreOptions: ScoreOption[];
@@ -73,15 +79,31 @@ export function ScoreAnalyticsHeader({
           disabled={!urlState.score1}
           className="h-8 w-[200px]"
         />
-        <a
-          href="https://langfuse.com/discussions"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center"
-          title="Score analytics is currently in beta. Click here to provide feedback!"
-        >
-          <Info className="h-4 w-4 text-muted-foreground" />
-        </a>
+        <HoverCard>
+          <HoverCardTrigger asChild>
+            <Badge variant="warning" className="cursor-help">
+              Beta Feature
+            </Badge>
+          </HoverCardTrigger>
+          <HoverCardContent className="w-80">
+            <div className="space-y-2">
+              <h4 className="text-sm font-semibold">Beta Feature</h4>
+              <p className="text-sm text-muted-foreground">
+                Score analytics is currently in beta. We're actively improving
+                this feature and would love to hear your feedback.
+              </p>
+              <a
+                href="https://langfuse.com/discussions"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+              >
+                Share feedback on GitHub Discussions
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </div>
+          </HoverCardContent>
+        </HoverCard>
       </div>
 
       {/* Middle: Spacer (hidden on mobile) */}


### PR DESCRIPTION
## Summary
Replaces the simple Info icon with a clear "Beta Feature" badge and detailed hover card. This makes the beta status more visible and provides better context for users.

## Changes
- **Removed**: Simple Info icon with tooltip
- **Added**: 
  - Yellow "Beta Feature" badge with warning variant
  - HoverCard that appears on hover with:
    - "Beta Feature" heading
    - Explanation: "Score analytics is currently in beta. We're actively improving this feature and would love to hear your feedback."
    - Link to GitHub Discussions with ExternalLink icon

## Visual Improvements
- ✅ Clear, visible "Beta Feature" label that reads as text
- ✅ Hover card provides context without cluttering the UI
- ✅ Direct link to feedback with visual indicator (external link icon)
- ✅ Cursor changes to help cursor indicating interactive element

## Testing
- ✅ Badge appears next to score2 selector
- ✅ Hover card displays on hover with proper content
- ✅ Link opens GitHub Discussions in new tab
- ✅ Visual styling matches UI patterns

## Related Issues
- Part of LF-1910 (Score Analytics Dashboard)
- Updates LF-1978 implementation based on feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances beta feature visibility in score analytics with a badge and hover card, and ensures integer timestamps in demo data script.
> 
>   - **UI Enhancements**:
>     - Replaces info icon with a yellow "Beta Feature" badge and hover card in `ScoreAnalyticsHeader.tsx`.
>     - Hover card includes a heading, explanation, and link to GitHub Discussions with an `ExternalLink` icon.
>   - **Behavior**:
>     - Badge appears next to score2 selector, hover card displays on hover, and link opens in a new tab.
>   - **Code Changes**:
>     - Ensures timestamps are integers in `generateRealisticTimestamp()` in `seed-score-analytics-demo.ts`.
>     - Adds `observation_id: null` to score creation in `seedBooleanScores()` in `seed-score-analytics-demo.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c67927fab7b32b592c09a784a657644391f3f111. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->