### PR TITLE
fix(playground): don't stringify ai sdk messages

### DIFF
--- a/web/src/utils/chatml/jumptoplayground.clienttest.ts
+++ b/web/src/utils/chatml/jumptoplayground.clienttest.ts
@@ -505,6 +505,27 @@ describe("Playground Jump Full Pipeline", () => {
     }
   });
 
+  it("should extract text from Vercel AI SDK content array format", () => {
+    // Vercel AI SDK format: content as array with type/text structure
+    const input = {
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Hello world" }],
+        },
+      ],
+    };
+
+    const inResult = normalizeInput(input, {});
+    expect(inResult.success).toBe(true);
+
+    const playgroundMsg = convertChatMlToPlayground(inResult.data![0]);
+
+    // Should extract text, not stringify array
+    expect(playgroundMsg?.content).toBe("Hello world");
+    expect(playgroundMsg?.content).not.toContain("[{");
+  });
+
   it("should extract tools from Microsoft Agent Framework metadata", () => {
     // Microsoft Agent Framework stores tools in metadata.attributes["gen_ai.tool.definitions"]
     const input = [

--- a/web/src/utils/chatml/jumptoplayground.clienttest.ts
+++ b/web/src/utils/chatml/jumptoplayground.clienttest.ts
@@ -522,8 +522,12 @@ describe("Playground Jump Full Pipeline", () => {
     const playgroundMsg = convertChatMlToPlayground(inResult.data![0]);
 
     // Should extract text, not stringify array
-    expect(playgroundMsg?.content).toBe("Hello world");
-    expect(playgroundMsg?.content).not.toContain("[{");
+    expect(
+      playgroundMsg && "content" in playgroundMsg && playgroundMsg.content,
+    ).toBe("Hello world");
+    expect(
+      playgroundMsg && "content" in playgroundMsg && playgroundMsg.content,
+    ).not.toContain("[{");
   });
 
   it("should extract tools from Microsoft Agent Framework metadata", () => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes text extraction from Vercel AI SDK content arrays in playground by updating `contentToString()` in `playgroundConverter.ts`.
> 
>   - **Behavior**:
>     - Update `contentToString()` in `playgroundConverter.ts` to extract text from Vercel AI SDK content arrays instead of stringifying them.
>     - Handles `text`, `image`, and `input_audio` types, extracting text and using placeholders for non-text types.
>   - **Tests**:
>     - Add test case in `jumptoplayground.clienttest.ts` to verify text extraction from Vercel AI SDK content arrays.
>     - Ensure extracted text is not stringified and matches expected output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e61b4f6ba3dde17b0a0b3592b647f90c88c5a6c5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->