### PR TITLE
fix(db-schema): make schema match prod db state (json instead of jsonb)

### DIFF
--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -598,8 +598,8 @@ model Dataset {
   metadata                Json?
   remoteExperimentUrl     String?       @map("remote_experiment_url")
   remoteExperimentPayload Json?         @map("remote_experiment_payload")
-  inputSchema             Json?         @map("input_schema")
-  expectedOutputSchema    Json?         @map("expected_output_schema")
+  inputSchema             Json?   @db.Json @map("input_schema")
+  expectedOutputSchema    Json?   @db.Json @map("expected_output_schema")
   project                 Project       @relation(fields: [projectId], references: [id], onDelete: Cascade)
   createdAt               DateTime      @default(now()) @map("created_at")
   updatedAt               DateTime      @default(now()) @updatedAt @map("updated_at")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `inputSchema` and `expectedOutputSchema` fields in `Dataset` model to use `@db.Json` in `schema.prisma`.
> 
>   - **Schema Update**:
>     - In `schema.prisma`, update `inputSchema` and `expectedOutputSchema` fields in `Dataset` model to use `@db.Json` to match production database state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 35b4c9a4f56db9f6c247937323a47f122d4362c4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->