### PR TITLE
chore: order by unix timestamp row

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -439,7 +439,7 @@ const getObservationByIdFromEventsTableInternal = async ({
     .when(Boolean(traceId), (b) =>
       b.whereRaw("trace_id = {traceId: String}", { traceId }),
     )
-    .orderBy("ORDER BY start_time_Unix DESC, event_ts DESC")
+    .orderBy("ORDER BY start_time_unix DESC, event_ts DESC")
     .limit(1, 0);
 
   const { query, params } = queryBuilder.buildWithParams();

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -257,7 +257,7 @@ const getObservationsFromEventsTableInternal = async <T>(
   const needsTraceJoin =
     traceTableFilter.length > 0 || orderByTraces || search.query;
 
-  // When we have default ordering by time, we order by toUnixTimestamp(e.start_time)
+  // When we have default ordering by time, we order by (e.start_time_unix)
   // This way, clickhouse is able to read more efficiently directly from disk without ordering
   const newDefaultOrder =
     orderBy?.column === "startTime"
@@ -270,7 +270,7 @@ const getObservationsFromEventsTableInternal = async <T>(
       uiTableName: "order_by_unix",
       uiTableId: "order_by_unix",
       clickhouseTableName: "events",
-      clickhouseSelect: "toUnixTimestamp(e.start_time)",
+      clickhouseSelect: "e.start_time_unix",
     },
   ]);
 
@@ -439,7 +439,7 @@ const getObservationByIdFromEventsTableInternal = async ({
     .when(Boolean(traceId), (b) =>
       b.whereRaw("trace_id = {traceId: String}", { traceId }),
     )
-    .orderBy("ORDER BY toUnixTimestamp(start_time) DESC, event_ts DESC")
+    .orderBy("ORDER BY start_time_Unix DESC, event_ts DESC")
     .limit(1, 0);
 
   const { query, params } = queryBuilder.buildWithParams();
@@ -643,7 +643,7 @@ const getObservationsFromEventsTableForPublicApiInternal = async <T>(
 
   if (opts.select === "rows") {
     queryBuilder
-      .orderBy("ORDER BY toUnixTimestamp(e.start_time) DESC")
+      .orderBy("ORDER BY e.start_time_unix DESC")
       .limit(limit, (page - 1) * limit);
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimize event ordering by using `e.start_time_unix` instead of `toUnixTimestamp(e.start_time)` for improved ClickHouse query performance.
> 
>   - **Behavior**:
>     - Change default ordering in `getObservationsFromEventsTableInternal` to use `e.start_time_unix` instead of `toUnixTimestamp(e.start_time)`.
>     - Update `orderBy` clause in `getObservationByIdFromEventsTableInternal` to use `start_time_unix`.
>     - Modify `orderBy` in `getObservationsFromEventsTableForPublicApiInternal` to use `e.start_time_unix`.
>   - **Comments**:
>     - Update comments to reflect the change from `toUnixTimestamp(e.start_time)` to `e.start_time_unix`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e0169536eb53b4a271f634b8f283f1650f6cc37e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->