### PR TITLE
fix(score-analytics): categorical distribution improvements (LF-1987)

### DIFF
--- a/web/src/features/scores/components/score-analytics/components/cards/DistributionCategoricalCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/DistributionCategoricalCard.tsx
@@ -77,9 +77,9 @@ export function DistributionCategoricalCard() {
         };
       case "all":
         return {
-          distribution1: distribution.score1Individual,
+          distribution1: undefined, // Not used in stacked mode
           categories: distribution.categories ?? [],
-          stackedDistribution: undefined,
+          stackedDistribution: distribution.stackedDistribution, // Use full stacked data (includes __unmatched__)
           score2Categories: distribution.score2Categories ?? [],
           description: `${score1.name} (${statistics.score1.total.toLocaleString()}) vs ${score2?.name} (${statistics.score2?.total.toLocaleString()})`,
         };

--- a/web/src/features/scores/components/score-analytics/components/cards/DistributionCategoricalCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/DistributionCategoricalCard.tsx
@@ -155,13 +155,13 @@ export function DistributionCategoricalCard() {
         // Calculate unmatched score2 items and augment stackedDistribution
         const unmatchedScore2 = calculateUnmatchedScore2Distribution(
           distribution.score2Individual,
-          distribution.stackedDistribution,
+          distribution.stackedDistribution ?? [],
           distribution.score2Categories ?? [],
         );
 
         // Combine original stacked data with unmatched score2 items
         const augmentedStackedDistribution = [
-          ...distribution.stackedDistribution,
+          ...(distribution.stackedDistribution ?? []),
           ...unmatchedScore2,
         ];
 

--- a/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/Heatmap.tsx
@@ -117,35 +117,19 @@ export function Heatmap({
     if (rowLabelsRef.current && rowLabels && rowLabels.length > 0) {
       const container = rowLabelsRef.current;
 
-      console.log("[Heatmap] Container measurements:", {
-        clientWidth: container.clientWidth,
-        scrollWidth: container.scrollWidth,
-        offsetWidth: container.offsetWidth,
-      });
-
       // Find the widest label by measuring each label element
       const labelElements = container.querySelectorAll("span");
       let maxLabelWidth = 0;
 
-      labelElements.forEach((element, idx) => {
+      labelElements.forEach((element) => {
         const width = element.offsetWidth;
-        console.log(
-          `[Heatmap] Label ${idx} width:`,
-          width,
-          "text:",
-          element.textContent,
-        );
         maxLabelWidth = Math.max(maxLabelWidth, width);
       });
 
-      console.log("[Heatmap] Max label width found:", maxLabelWidth);
-
       // Add padding (pr-1 is 4px on small screens, pr-2 is 8px on larger)
       const totalWidth = maxLabelWidth + 8;
-      console.log("[Heatmap] Total width with padding:", totalWidth);
 
       const finalWidth = Math.max(36, Math.min(totalWidth, 120)); // Min 36px, max 120px
-      console.log("[Heatmap] Final constrained width:", finalWidth);
 
       setRowLabelsWidth(finalWidth);
     }

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreChartLegendContent.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreChartLegendContent.tsx
@@ -423,16 +423,10 @@ export const ScoreChartLegendContent = React.forwardRef<
                 ? (item.payload as { fill: string }).fill
                 : "hsl(var(--chart-1))");
 
-            // Special color for "unmatched" category
-            const isUnmatched = key === "__unmatched__" || key === "unmatched";
-            const finalColor = isUnmatched
-              ? "hsl(var(--muted-foreground))"
-              : color;
-
             return (
               <LegendItem
                 key={key}
-                color={finalColor}
+                color={color}
                 label={getFormattedLabel(item)}
                 visible={visible}
                 interactive={interactive}
@@ -493,19 +487,13 @@ export const ScoreChartLegendContent = React.forwardRef<
                                   ? (item.payload as { fill: string }).fill
                                   : "hsl(var(--chart-1))");
 
-                              const isUnmatched =
-                                key === "__unmatched__" || key === "unmatched";
-                              const finalColor = isUnmatched
-                                ? "hsl(var(--muted-foreground))"
-                                : color;
-
                               return (
                                 <div
                                   key={key}
                                   className="rounded-sm px-2 py-1.5 hover:bg-accent/50"
                                 >
                                   <LegendItem
-                                    color={finalColor}
+                                    color={color}
                                     label={getFormattedLabel(item)}
                                     visible={visible}
                                     interactive={interactive}

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionCategoricalChart.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionCategoricalChart.tsx
@@ -103,14 +103,19 @@ export function ScoreDistributionCategoricalChart({
 
       // Normalize: ensure every category has all stack keys, even if count is 0
       return Array.from(grouped.entries())
-        .sort()
+        .sort((a, b) => {
+          // Put __unmatched__ last (rightmost column)
+          if (a[0] === "__unmatched__") return 1;
+          if (b[0] === "__unmatched__") return -1;
+          return a[0].localeCompare(b[0]);
+        })
         .map(([category, stacks]) => {
           const normalizedStacks: Record<string, number> = {};
           allStackKeys.forEach((stackKey) => {
             normalizedStacks[stackKey] = stacks[stackKey] ?? 0;
           });
           return {
-            name: category,
+            name: category === "__unmatched__" ? "no match" : category,
             ...normalizedStacks,
           };
         });

--- a/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionCategoricalChart.tsx
+++ b/web/src/features/scores/components/score-analytics/components/charts/ScoreDistributionCategoricalChart.tsx
@@ -43,6 +43,14 @@ export function ScoreDistributionCategoricalChart({
     stackedDistribution && stackedDistribution.length > 0,
   );
 
+  // Helper: Check if a key represents an unmatched category
+  // Backend can send: "__unmatched__", "0", "", or null
+  const isUnmatchedKey = (key: string): boolean => {
+    return (
+      key === "__unmatched__" || key === "0" || key === "" || key === "null"
+    );
+  };
+
   // Calculate all possible stack keys from actual data
   // This ensures we include ALL categories present in the data, including those
   // not in score2Categories (e.g., "0" or other values) and __unmatched__
@@ -57,17 +65,21 @@ export function ScoreDistributionCategoricalChart({
       stacksFromData.add(item.score2Stack);
     });
 
+    // Normalize all unmatched variations to "__unmatched__" for consistent handling
+    const normalizedStacks = Array.from(stacksFromData).map((key) =>
+      isUnmatchedKey(key) ? "__unmatched__" : key,
+    );
+
     // Separate regular categories from __unmatched__
     // This ensures __unmatched__ is always last for consistent color assignment
     const regularStacks = Array.from(
-      new Set([...Array.from(stacksFromData), ...score2Categories]),
+      new Set([...normalizedStacks, ...score2Categories]),
     )
       .filter((key) => key !== "__unmatched__")
-      .sort();
+      .sort(); // Sort alphabetically for stable color assignment
 
     // Add __unmatched__ at the end if it exists in the actual data
-    // Don't add it based on score2Categories since that never includes __unmatched__
-    const hasUnmatched = stacksFromData.has("__unmatched__");
+    const hasUnmatched = normalizedStacks.includes("__unmatched__");
 
     return hasUnmatched ? [...regularStacks, "__unmatched__"] : regularStacks;
   }, [hasStackedData, stackedDistribution, score2Categories]);
@@ -82,7 +94,11 @@ export function ScoreDistributionCategoricalChart({
         if (!grouped.has(item.score1Category)) {
           grouped.set(item.score1Category, {});
         }
-        grouped.get(item.score1Category)![item.score2Stack] = item.count;
+        // Normalize unmatched keys to "__unmatched__"
+        const normalizedKey = isUnmatchedKey(item.score2Stack)
+          ? "__unmatched__"
+          : item.score2Stack;
+        grouped.get(item.score1Category)![normalizedKey] = item.count;
       });
 
       // Normalize: ensure every category has all stack keys, even if count is 0
@@ -154,30 +170,36 @@ export function ScoreDistributionCategoricalChart({
       // Stacked mode: create config for all stack keys using color mappings
       const stackConfig: ChartConfig = {};
       allStackKeys.forEach((key) => {
+        // Special handling for unmatched category
+        if (key === "__unmatched__") {
+          stackConfig[key] = {
+            label: "no match",
+            color: "hsl(var(--muted))", // Light grey for unmatched
+          };
+          return;
+        }
+
         // Try namespaced key first (for when score1 and score2 have same category names)
         // Format: "ScoreName (source): category"
         let color: string | undefined;
 
-        if (key !== "__unmatched__" && score2Name && score2Source) {
+        if (score2Name && score2Source) {
           const namespacedKey = `${score2Name} (${score2Source}): ${key}`;
           color = colors[namespacedKey];
         }
 
         // Fallback to non-namespaced key
-        if (!color && key !== "__unmatched__") {
+        if (!color) {
           color = colors[key];
         }
 
-        // Final fallback
+        // Final fallback to first available color
         if (!color) {
-          color =
-            key === "__unmatched__"
-              ? "hsl(var(--muted-foreground))"
-              : Object.values(colors)[0];
+          color = Object.values(colors)[0];
         }
 
         stackConfig[key] = {
-          label: key === "__unmatched__" ? "Unmatched" : key,
+          label: key,
           color,
         };
       });

--- a/web/src/features/scores/components/score-analytics/hooks/useScoreAnalyticsQuery.ts
+++ b/web/src/features/scores/components/score-analytics/hooks/useScoreAnalyticsQuery.ts
@@ -232,6 +232,15 @@ export function useScoreAnalyticsQuery(
       stackedDistribution: apiData.stackedDistribution,
     });
 
+    // Extract score2 categories for proper binning
+    // When comparing two different categorical scores, score2 may have different categories
+    const score2Categories =
+      apiData.score2Categories && apiData.score2Categories.length > 0
+        ? apiData.score2Categories
+        : mode === "two" && categories
+          ? categories // Fallback to score1 categories if score2Categories empty
+          : undefined;
+
     // ========================================================================
     // 2. Fill distribution bins (categorical/boolean only)
     // Note: Sort all distributions by binIndex to ensure deterministic ordering
@@ -253,8 +262,9 @@ export function useScoreAnalyticsQuery(
           .slice()
           .sort((a, b) => a.binIndex - b.binIndex);
 
-    const distribution2Individual = categories
-      ? fillDistributionBins(apiData.distribution2Individual, categories)
+    // Use score2Categories for score2Individual (not score1 categories)
+    const distribution2Individual = score2Categories
+      ? fillDistributionBins(apiData.distribution2Individual, score2Categories)
       : apiData.distribution2Individual
           .slice()
           .sort((a, b) => a.binIndex - b.binIndex);
@@ -265,8 +275,9 @@ export function useScoreAnalyticsQuery(
           .slice()
           .sort((a, b) => a.binIndex - b.binIndex);
 
-    const distribution2Matched = categories
-      ? fillDistributionBins(apiData.distribution2Matched, categories)
+    // Use score2Categories for score2Matched (not score1 categories)
+    const distribution2Matched = score2Categories
+      ? fillDistributionBins(apiData.distribution2Matched, score2Categories)
       : apiData.distribution2Matched
           .slice()
           .sort((a, b) => a.binIndex - b.binIndex);

--- a/web/src/features/scores/components/score-analytics/libs/ScoreChartTooltip.tsx
+++ b/web/src/features/scores/components/score-analytics/libs/ScoreChartTooltip.tsx
@@ -65,14 +65,31 @@ export function ScoreChartTooltip({
     return null;
   }
 
-  // Filter out duplicates and sort by value in descending order
+  // Filter out duplicates
   const uniquePayload = Array.from(
     new Map(payload.map((item) => [item.name ?? item.dataKey, item])).values(),
   );
 
-  const sortedPayload = uniquePayload.sort(
-    (a, b) => (Number(b.value) ?? 0) - (Number(a.value) ?? 0),
-  );
+  // Sort payload by config key order for stable tooltip across columns
+  // This maintains consistent ordering (e.g., alphabetical + unmatched last)
+  // REVERSED to mirror the visual stack order (bottom-to-top becomes top-to-bottom in tooltip)
+  // Falls back to value-based sorting if config keys not available
+  const configKeys = Object.keys(config);
+  const sortedPayload = uniquePayload.sort((a, b) => {
+    const keyA = a.name ?? a.dataKey ?? "";
+    const keyB = b.name ?? b.dataKey ?? "";
+
+    // If both keys exist in config, sort by config order (reversed)
+    const indexA = configKeys.indexOf(keyA);
+    const indexB = configKeys.indexOf(keyB);
+
+    if (indexA !== -1 && indexB !== -1) {
+      return indexB - indexA; // Reversed: mirror visual stack order
+    }
+
+    // Fallback to value-based sorting (descending) for non-config keys
+    return (Number(b.value) ?? 0) - (Number(a.value) ?? 0);
+  });
 
   // Format the label (timestamp)
   let formattedLabel: string;

--- a/web/src/features/scores/components/score-analytics/libs/color-scales.ts
+++ b/web/src/features/scores/components/score-analytics/libs/color-scales.ts
@@ -404,6 +404,11 @@ export function getMonochromeScale(
 /**
  * Get monochrome color mapping for categorical values
  * All categories of the same score use shades of the same base color
+ *
+ * IMPORTANT: Sorts categories alphabetically before assigning colors to ensure
+ * stable color assignment regardless of category order in the input array.
+ * This prevents colors from shifting when categories are hidden/shown.
+ *
  * @param scoreNumber - Which score (1 or 2)
  * @param categories - Array of category names
  * @param options - Optional configuration
@@ -417,17 +422,21 @@ export function getScoreCategoryColors(
   const baseColor =
     scoreNumber === 1 ? SCORE_BASE_COLORS.score1 : SCORE_BASE_COLORS.score2;
 
+  // Sort categories alphabetically for stable color assignment
+  // This ensures the same category always gets the same color
+  const sortedCategories = [...categories].sort();
+
   // Generate scale with even distribution across percentage range
   // Wider range (20%-100%) for better distinction between categories
-  const steps = Math.max(categories.length, 2);
+  const steps = Math.max(sortedCategories.length, 2);
   const colors = getMonochromeScale(baseColor, steps, "white", 0.2, 1.0);
 
   // Reverse if requested (for different visual ordering)
   const colorArray = options?.reverse ? [...colors].reverse() : colors;
 
-  // Map categories to colors
+  // Map categories to colors using sorted order
   const mapping: Record<string, string> = {};
-  categories.forEach((category, index) => {
+  sortedCategories.forEach((category, index) => {
     mapping[category] = colorArray[index] || colorArray[0];
   });
 


### PR DESCRIPTION
## Summary

Fixes for categorical score distribution charts to improve usability and consistency.

### Issues Fixed
- **LF-1987**: Wrong categories displayed when switching between score tabs

### Changes

#### 1. Fix wrong categories for score2 distributions
When comparing two categorical scores with different categories (e.g., "sentiment" vs "topic"), the score2 tab was incorrectly showing score1's category labels. Fixed by extracting and using score2Categories when filling score2's distributions.

#### 2. Stable color assignment
Colors now remain consistent when hiding/showing legend items. Categories are sorted alphabetically before color assignment, ensuring each category always gets the same color regardless of order or visibility state.

#### 3. Normalize unmatched variations  
Backend can send various representations of unmatched items ("__unmatched__", "0", "", "null"). All variations are now normalized and displayed as "no match" in light grey for consistent UX.

#### 4. Stacked "all" tab
Changed "all" tab to show stacked bars (like "matched" tab) instead of side-by-side bars. This automatically includes a "no match" category for score1 items without corresponding score2 values, providing better visibility into data completeness.

#### 5. Stable tooltip ordering
Tooltip now maintains consistent category order across all columns, making it easy to scan when hovering across different bars. Order is alphabetical + "no match" last, reversed to mirror the visual stack order (bottom-to-top in chart = top-to-bottom in tooltip).

## Test Plan

- [x] Switch between "sentiment" and "topic" tabs - each shows correct categories
- [x] Hide/show legend items - colors remain stable
- [x] Check "all" tab - shows stacked bars with "no match" category
- [x] Hover across different columns - tooltip order remains consistent and mirrors stack
- [x] Verify "no match" appears in light grey in both legend and tooltip

## Screenshots

_Screenshots would be helpful to show the before/after state_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves categorical score distribution charts by fixing category labels, ensuring stable color assignments, and maintaining consistent tooltip ordering.
> 
>   - **Behavior**:
>     - Fixes category label issue in `DistributionCategoricalCard.tsx` by using `score2Categories` for score2 tab.
>     - Ensures stable color assignment by sorting categories alphabetically in `ScoreDistributionCategoricalChart.tsx` and `color-scales.ts`.
>     - Normalizes unmatched variations to "no match" in `ScoreDistributionCategoricalChart.tsx` and `ScoreChartLegendContent.tsx`.
>     - Changes "all" tab to show stacked bars with "no match" category in `DistributionCategoricalCard.tsx`.
>     - Maintains consistent tooltip order in `ScoreChartTooltip.tsx` by sorting payload based on config keys.
>   - **Functions**:
>     - Adds `calculateUnmatchedScore2Distribution()` in `DistributionCategoricalCard.tsx` to handle unmatched score2 items.
>     - Updates `getScoreCategoryColors()` in `color-scales.ts` to sort categories for stable color assignment.
>   - **Misc**:
>     - Removes console logs from `Heatmap.tsx`.
>     - Adjusts legend item color handling in `ScoreChartLegendContent.tsx` to use consistent color logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cb4da78723380076b3b97438b3754df0167a67f2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->