### PR TITLE
fix(score-analytics): ensure boolean scores always show both False and True categories

### DIFF
--- a/web/src/features/scores/components/score-analytics/transformers/scoreAnalyticsTransformers.ts
+++ b/web/src/features/scores/components/score-analytics/transformers/scoreAnalyticsTransformers.ts
@@ -60,7 +60,15 @@ export function extractCategories(params: {
 }): string[] | undefined {
   if (params.dataType === "NUMERIC") return undefined;
 
-  // Try stackedDistribution first (for categorical comparisons)
+  // For boolean scores: ALWAYS return both categories
+  // This ensures confusion matrix, distributions, and time series show both False and True
+  // even when the data only contains one category (e.g., all True or all False)
+  // IMPORTANT: This check must come BEFORE stackedDistribution/confusionMatrix checks
+  // to prevent early returns with incomplete category lists
+  if (params.dataType === "BOOLEAN") {
+    return ["False", "True"];
+  }
+
   if (params.stackedDistribution && params.stackedDistribution.length > 0) {
     const uniqueCategories = new Set<string>();
     params.stackedDistribution.forEach((item) => {
@@ -76,11 +84,6 @@ export function extractCategories(params: {
       uniqueCategories.add(row.rowCategory);
     });
     return Array.from(uniqueCategories).sort();
-  }
-
-  // For boolean: hardcoded assumption
-  if (params.dataType === "BOOLEAN") {
-    return ["False", "True"];
   }
 
   return undefined;


### PR DESCRIPTION
## Summary
Fixes LF-1990, LF-1991, LF-1992: Boolean score charts now always display both "False" and "True" categories, even when data contains only one value.

## Problem
When boolean scores contained only "True" (or only "False") values:
- **Confusion matrix:** Showed 1×1 grid instead of 2×2
- **Distribution chart:** Showed 1 bar instead of 2
- **Time series chart:** Showed 1 line instead of 2

## Root Cause
The `extractCategories()` function in `scoreAnalyticsTransformers.ts` extracted categories dynamically from actual data. The boolean fallback `["False", "True"]` existed but was **never reached** because:
1. Function checked `confusionMatrix` or `stackedDistribution` first
2. When finding data (even if incomplete), it returned early
3. Boolean fallback at the end never executed

**Example:** All values are "True"
- Backend returns: `confusionMatrix = [{ rowCategory: "True", colCategory: "True", count: 100 }]`
- Frontend extracts: `["True"]` from confusionMatrix
- Returns early, never reaching boolean fallback
- Result: Only "True" displayed

## Solution
Moved the boolean check **before** data extraction logic:

**Before:**
```typescript
// 1. Extract from stackedDistribution → return
// 2. Extract from confusionMatrix → return (PROBLEM!)
// 3. Boolean fallback ["False", "True"] → never reached
```

**After:**
```typescript
// 1. Boolean check → return ["False", "True"] (FIXED!)
// 2. Extract from stackedDistribution → return
// 3. Extract from confusionMatrix → return
```

## Impact
**Single function change fixes all three issues:**
- ✅ **LF-1990:** Confusion matrix always shows 2×2 grid (4 cells)
- ✅ **LF-1991:** Distribution chart always shows 2 bars (False and True)
- ✅ **LF-1992:** Time series chart always shows 2 lines (False and True)

Missing categories now display with `count=0` instead of being hidden.

## Files Changed
- `web/src/features/scores/components/score-analytics/transformers/scoreAnalyticsTransformers.ts`
  - Modified `extractCategories()` function (lines 56-90)
  - Moved boolean check from line 82 to line 68

## Test Plan
- [x] Linter passes
- [ ] Test boolean score with all "True" values → shows both False (0) and True (N)
- [ ] Test boolean score with all "False" values → shows both False (N) and True (0)
- [ ] Test boolean score with mixed values → shows both False (X) and True (Y)
- [ ] Verify confusion matrix shows 2×2 grid
- [ ] Verify distribution chart shows 2 bars
- [ ] Verify time series chart shows 2 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reorders boolean check in `extractCategories()` to ensure both "False" and "True" categories are always displayed for boolean data types.
> 
>   - **Behavior**:
>     - `extractCategories()` in `scoreAnalyticsTransformers.ts` now always returns `['False', 'True']` for boolean data types, ensuring both categories are displayed.
>     - Fixes issues with confusion matrices, distribution charts, and time series charts not showing both categories when data is incomplete.
>   - **Implementation**:
>     - Moved boolean check in `extractCategories()` before data extraction logic to prevent early returns with incomplete categories.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 57fb67f715eb4eb9970873b6eea1b13a0cc00f0f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->