### PR TITLE
chore: imporve dd spans for events table trpc

### DIFF
--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -116,10 +116,12 @@ export const addAttributesToSpan = ({
     );
 
     if (startTimeFilter?.value && endTimeFilter?.value) {
-      span.setAttribute(
-        "duration_minutes",
-        dateDiff(startTimeFilter.value as Date, endTimeFilter.value as Date),
+      const durationMs = dateDiff(
+        startTimeFilter.value as Date,
+        endTimeFilter.value as Date,
       );
+      // Convert milliseconds to minutes
+      span.setAttribute("duration_minutes", durationMs / 60000);
     }
 
     input.filter.forEach((f) => {

--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -4,13 +4,15 @@ import {
   createTRPCRouter,
   protectedProjectProcedure,
 } from "@/src/server/api/trpc";
-import { paginationZod, timeFilter } from "@langfuse/shared";
+import { type OrderByState, paginationZod, timeFilter } from "@langfuse/shared";
 import { EventsTableOptions } from "./types";
 import {
   getEventList,
   getEventCount,
   getEventFilterOptions,
 } from "./eventsService";
+import { instrumentAsync } from "@langfuse/shared/src/server";
+import type * as opentelemetry from "@opentelemetry/api";
 
 const GetAllEventsInput = EventsTableOptions.extend({
   ...paginationZod,
@@ -18,30 +20,56 @@ const GetAllEventsInput = EventsTableOptions.extend({
 
 export type GetAllEventsInput = z.infer<typeof GetAllEventsInput>;
 
+const GetEventFilterOptionsInput = zodSchema.object({
+  projectId: zodSchema.string(),
+  startTimeFilter: zodSchema.array(timeFilter).optional(),
+});
+
+export type GetEventFilterOptionsInput = z.infer<
+  typeof GetEventFilterOptionsInput
+>;
+
 export const eventsRouter = createTRPCRouter({
   all: protectedProjectProcedure
     .input(GetAllEventsInput)
     .query(async ({ input, ctx }) => {
-      return getEventList({
-        projectId: ctx.session.projectId,
-        filter: input.filter ?? [],
-        searchQuery: input.searchQuery ?? undefined,
-        searchType: input.searchType,
-        orderBy: input.orderBy,
-        page: input.page,
-        limit: input.limit,
-      });
+      return instrumentAsync(
+        {
+          name: "get-event-list-trpc",
+        },
+        async (span) => {
+          addAttributesToSpan({ span, input, orderBy: input.orderBy });
+
+          return getEventList({
+            projectId: ctx.session.projectId,
+            filter: input.filter ?? [],
+            searchQuery: input.searchQuery ?? undefined,
+            searchType: input.searchType,
+            orderBy: input.orderBy,
+            page: input.page,
+            limit: input.limit,
+          });
+        },
+      );
     }),
   countAll: protectedProjectProcedure
     .input(GetAllEventsInput)
     .query(async ({ input, ctx }) => {
-      return getEventCount({
-        projectId: ctx.session.projectId,
-        filter: input.filter ?? [],
-        searchQuery: input.searchQuery ?? undefined,
-        searchType: input.searchType,
-        orderBy: input.orderBy,
-      });
+      return instrumentAsync(
+        {
+          name: "get-event-count-trpc",
+        },
+        async (span) => {
+          addAttributesToSpan({ span, input, orderBy: input.orderBy });
+          return getEventCount({
+            projectId: ctx.session.projectId,
+            filter: input.filter ?? [],
+            searchQuery: input.searchQuery ?? undefined,
+            searchType: input.searchType,
+            orderBy: input.orderBy,
+          });
+        },
+      );
     }),
   filterOptions: protectedProjectProcedure
     .input(
@@ -51,9 +79,60 @@ export const eventsRouter = createTRPCRouter({
       }),
     )
     .query(async ({ input }) => {
-      return getEventFilterOptions({
-        projectId: input.projectId,
-        startTimeFilter: input.startTimeFilter,
-      });
+      return instrumentAsync(
+        {
+          name: "get-event-filter-options-trpc",
+        },
+
+        async (span) => {
+          addAttributesToSpan({ span, input, orderBy: undefined });
+          return getEventFilterOptions({
+            projectId: input.projectId,
+            startTimeFilter: input.startTimeFilter,
+          });
+        },
+      );
     }),
 });
+
+export const addAttributesToSpan = ({
+  span,
+  input,
+  orderBy,
+}: {
+  span: opentelemetry.Span;
+  input: GetAllEventsInput | GetEventFilterOptionsInput;
+  orderBy?: OrderByState;
+}) => {
+  span.setAttribute("project_id", input.projectId);
+
+  // Only process filter if it exists (not present in GetEventFilterOptionsInput)
+  if ("filter" in input && input.filter) {
+    const startTimeFilter = input.filter.find(
+      (f) => f.column === "startTime" && f.type === "datetime",
+    );
+    const endTimeFilter = input.filter.find(
+      (f) => f.column === "endTime" && f.type === "datetime",
+    );
+
+    if (startTimeFilter?.value && endTimeFilter?.value) {
+      span.setAttribute(
+        "duration_minutes",
+        dateDiff(startTimeFilter.value as Date, endTimeFilter.value as Date),
+      );
+    }
+
+    input.filter.forEach((f) => {
+      span.setAttribute(f.column, f.value.toString());
+    });
+  }
+
+  if (orderBy) {
+    span.setAttribute("order_by_column", orderBy.column);
+    span.setAttribute("order_by_order", orderBy.order ?? "DESC");
+  }
+};
+
+export const dateDiff = (date1: Date, date2: Date) => {
+  return Math.abs(date2.getTime() - date1.getTime());
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances tracing for events table in `eventsRouter.ts` by adding OpenTelemetry spans and attributes.
> 
>   - **Tracing Enhancements**:
>     - Wraps `getEventList`, `getEventCount`, and `getEventFilterOptions` in `instrumentAsync` for tracing in `eventsRouter.ts`.
>     - Adds `addAttributesToSpan` function to set attributes on spans, including `project_id`, `duration_minutes`, and filter attributes.
>   - **Input Types**:
>     - Defines `GetEventFilterOptionsInput` type for `filterOptions` procedure.
>   - **Utility Functions**:
>     - Adds `dateDiff` function to calculate duration between two dates in milliseconds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9cfcb9e0017c2247c73709c45a0241a58fe4041a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->