### PR TITLE
fix: only show non null facets for metrics in events table

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -21,6 +21,8 @@ const EVENTS_FIELDS = {
   version: "e.version as version",
   bookmarked: "e.bookmarked as bookmarked",
   public: "e.public as public",
+  userId: 'e.user_id as "user_id"',
+  sessionId: 'e.session_id as "session_id"',
 
   // Time fields
   startTime: 'e.start_time as "start_time"',
@@ -54,9 +56,9 @@ const EVENTS_FIELDS = {
 
   // Calculated fields
   latency:
-    "if(isNull(end_time), NULL, date_diff('millisecond', start_time, end_time)) as latency",
+    "if(isNull(e.end_time), NULL, date_diff('millisecond', e.start_time, e.end_time)) as latency",
   timeToFirstToken:
-    "if(isNull(completion_start_time), NULL, date_diff('millisecond', start_time, completion_start_time)) as \"time_to_first_token\"",
+    "if(isNull(e.completion_start_time), NULL, date_diff('millisecond', e.start_time, e.completion_start_time)) as \"time_to_first_token\"",
 } as const;
 
 /**

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -995,6 +995,9 @@ export const getEventsGroupedByModel = async (
     selectExpression: "e.provided_model_name as name, count() as count",
   })
     .where(appliedEventsFilter)
+    .whereRaw(
+      "e.provided_model_name IS NOT NULL AND length(e.provided_model_name) > 0",
+    )
     .orderBy("ORDER BY count() DESC")
     .limit(1000, 0);
 
@@ -1033,6 +1036,7 @@ export const getEventsGroupedByModelId = async (
     selectExpression: "e.model_id as modelId, count() as count",
   })
     .where(appliedEventsFilter)
+    .whereRaw("e.model_id IS NOT NULL AND length(e.model_id) > 0")
     .orderBy("ORDER BY count() DESC")
     .limit(1000, 0);
 
@@ -1071,6 +1075,7 @@ export const getEventsGroupedByName = async (
     selectExpression: "e.name as name, count() as count",
   })
     .where(appliedEventsFilter)
+    .whereRaw("e.name IS NOT NULL AND length(e.name) > 0")
     .orderBy("ORDER BY count() DESC")
     .limit(1000, 0);
 
@@ -1150,6 +1155,7 @@ export const getEventsGroupedByType = async (
     selectExpression: "e.type as type, count() as count",
   })
     .where(appliedEventsFilter)
+    .whereRaw("e.type IS NOT NULL AND length(e.type) > 0")
     .orderBy("ORDER BY count() DESC")
     .limit(1000, 0);
 
@@ -1190,6 +1196,7 @@ export const getEventsGroupedByUserId = async (
     selectExpression: "e.user_id as userId, count() as count",
   })
     .where(appliedEventsFilter)
+    .whereRaw("e.user_id IS NOT NULL AND length(e.user_id) > 0")
     .orderBy("ORDER BY count() DESC")
     .limit(1000, 0);
 
@@ -1230,6 +1237,7 @@ export const getEventsGroupedByVersion = async (
     selectExpression: "e.version as version, count() as count",
   })
     .where(appliedEventsFilter)
+    .whereRaw("e.version IS NOT NULL AND length(e.version) > 0")
     .orderBy("ORDER BY count() DESC")
     .limit(1000, 0);
 
@@ -1270,6 +1278,7 @@ export const getEventsGroupedBySessionId = async (
     selectExpression: "e.session_id as sessionId, count() as count",
   })
     .where(appliedEventsFilter)
+    .whereRaw("e.session_id IS NOT NULL AND length(e.session_id) > 0")
     .orderBy("ORDER BY count() DESC")
     .limit(1000, 0);
 
@@ -1310,6 +1319,7 @@ export const getEventsGroupedByLevel = async (
     selectExpression: "e.level as level, count() as count",
   })
     .where(appliedEventsFilter)
+    .whereRaw("e.level IS NOT NULL AND length(e.level) > 0")
     .orderBy("ORDER BY count() DESC")
     .limit(1000, 0);
 
@@ -1350,6 +1360,7 @@ export const getEventsGroupedByEnvironment = async (
     selectExpression: "e.environment as environment, count() as count",
   })
     .where(appliedEventsFilter)
+    .whereRaw("e.environment IS NOT NULL AND length(e.environment) > 0")
     .orderBy("ORDER BY count() DESC")
     .limit(1000, 0);
 

--- a/packages/shared/src/server/tableMappings/mapEventsTable.ts
+++ b/packages/shared/src/server/tableMappings/mapEventsTable.ts
@@ -89,7 +89,7 @@ export const eventsTableUiColumnDefinitions: UiColumnMappings = [
     uiTableId: "timeToFirstToken",
     clickhouseTableName: "events",
     clickhouseSelect:
-      "if(isNull(completion_start_time), NULL,  date_diff('millisecond', start_time, completion_start_time) / 1000)",
+      "if(isNull(e.completion_start_time), NULL,  date_diff('millisecond', e.start_time, e.completion_start_time) / 1000)",
     // If we use the default of Decimal64(12), we cannot filter for more than ~40min due to an overflow
     clickhouseTypeOverwrite: "Decimal64(3)",
   },
@@ -98,7 +98,7 @@ export const eventsTableUiColumnDefinitions: UiColumnMappings = [
     uiTableId: "latency",
     clickhouseTableName: "events",
     clickhouseSelect:
-      "if(isNull(end_time), NULL, date_diff('millisecond', start_time, end_time) / 1000)",
+      "if(isNull(e.end_time), NULL, date_diff('millisecond', e.start_time, e.end_time) / 1000)",
     // If we use the default of Decimal64(12), we cannot filter for more than ~40min due to an overflow
     clickhouseTypeOverwrite: "Decimal64(3)",
   },
@@ -229,5 +229,17 @@ export const eventsTableUiColumnDefinitions: UiColumnMappings = [
     uiTableId: "promptVersion",
     clickhouseTableName: "events",
     clickhouseSelect: "e.prompt_version",
+  },
+  {
+    uiTableName: "User ID",
+    uiTableId: "userId",
+    clickhouseTableName: "events",
+    clickhouseSelect: 'e."user_id"',
+  },
+  {
+    uiTableName: "Session ID",
+    uiTableId: "sessionId",
+    clickhouseTableName: "events",
+    clickhouseSelect: 'e."session_id"',
   },
 ];

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -241,7 +241,7 @@ export const traceRouter = createTRPCRouter({
         })),
       };
     }),
-  byId: protectedGetTraceProcedure
+  byzId: protectedGetTraceProcedure
     .input(
       z.object({
         traceId: z.string(), // used for security check

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -241,7 +241,7 @@ export const traceRouter = createTRPCRouter({
         })),
       };
     }),
-  byzId: protectedGetTraceProcedure
+  byId: protectedGetTraceProcedure
     .input(
       z.object({
         traceId: z.string(), // used for security check


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add filtering for non-null facets in events table queries and include `userId` and `sessionId` fields.
> 
>   - **Behavior**:
>     - Add `whereRaw` conditions in `events.ts` to filter out null or empty values for `provided_model_name`, `model_id`, `name`, `type`, `user_id`, `version`, `session_id`, `level`, and `environment`.
>     - Add `userId` and `sessionId` fields to `EVENTS_FIELDS` in `event-query-builder.ts`.
>   - **Table Mappings**:
>     - Add `userId` and `sessionId` to `eventsTableUiColumnDefinitions` in `mapEventsTable.ts`.
>   - **Misc**:
>     - Update `latency` and `timeToFirstToken` calculations in `event-query-builder.ts` to use prefixed field names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e415617d430cd0e6d1f5bf362972bef237eaa072. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->