### PR TITLE
feat(score-analytics): improve single-score mode UX with proper preflight and mode-specific UI

### DIFF
--- a/web/src/features/scores/components/score-analytics/components/ScoreAnalyticsNoticeBanner.tsx
+++ b/web/src/features/scores/components/score-analytics/components/ScoreAnalyticsNoticeBanner.tsx
@@ -53,8 +53,9 @@ export function ScoreAnalyticsNoticeBanner() {
             </div>
             {estimate && (
               <div className="text-sm text-muted-foreground">
-                Analyzing ~{estimate.score1Count.toLocaleString()} (Score 1) and
-                ~{estimate.score2Count.toLocaleString()} (Score 2) scores
+                {estimate.mode === "single"
+                  ? `Analyzing ~${estimate.score1Count.toLocaleString()} scores`
+                  : `Analyzing ~${estimate.score1Count.toLocaleString()} (Score 1) and ~${estimate.score2Count.toLocaleString()} (Score 2) scores`}
                 {estimate.willSample && " • Sampling will be applied"}
                 {estimate.estimatedQueryTime && (
                   <> • Est. time: {estimate.estimatedQueryTime}</>
@@ -78,16 +79,13 @@ export function ScoreAnalyticsNoticeBanner() {
               Sampled Data
               <SamplingDetailsHoverCard
                 samplingMetadata={data.samplingMetadata}
+                mode={data.metadata.mode}
               />
             </div>
             <div className="text-sm text-muted-foreground">
-              Results based on a{" "}
-              {(data.samplingMetadata.samplingRate * 100).toFixed(2)}% sample of
-              ~
-              {data.samplingMetadata.preflightEstimates?.score1Count.toLocaleString()}{" "}
-              Score 1 and ~
-              {data.samplingMetadata.preflightEstimates?.score2Count.toLocaleString()}{" "}
-              Score 2 data.
+              {data.metadata.mode === "single"
+                ? `Results based on a ${(data.samplingMetadata.samplingRate * 100).toFixed(2)}% sample of ~${data.samplingMetadata.preflightEstimates?.score1Count.toLocaleString()} scores.`
+                : `Results based on a ${(data.samplingMetadata.samplingRate * 100).toFixed(2)}% sample of ~${data.samplingMetadata.preflightEstimates?.score1Count.toLocaleString()} Score 1 and ~${data.samplingMetadata.preflightEstimates?.score2Count.toLocaleString()} Score 2 data.`}
             </div>
           </div>
         </div>
@@ -101,6 +99,7 @@ export function ScoreAnalyticsNoticeBanner() {
 
 function SamplingDetailsHoverCard({
   samplingMetadata,
+  mode = "two",
   showLabel = false,
 }: {
   samplingMetadata: {
@@ -115,6 +114,7 @@ function SamplingDetailsHoverCard({
       reason: string;
     };
   };
+  mode?: "single" | "two";
   showLabel?: boolean;
 }) {
   return (
@@ -137,29 +137,45 @@ function SamplingDetailsHoverCard({
       <HoverCardContent className="w-80" align="start">
         <div className="space-y-3">
           <div>
-            <h4 className="mb-2 text-sm font-semibold">Estimated Scores</h4>
+            <h4 className="mb-2 text-sm font-semibold">
+              {mode === "single" ? "Estimated Score Count" : "Estimated Scores"}
+            </h4>
             <dl className="space-y-1 text-sm">
-              <div className="flex justify-between">
-                <dt className="text-muted-foreground">Score 1:</dt>
-                <dd className="font-medium">
-                  ~
-                  {samplingMetadata.preflightEstimates?.score1Count.toLocaleString()}
-                </dd>
-              </div>
-              <div className="flex justify-between">
-                <dt className="text-muted-foreground">Score 2:</dt>
-                <dd className="font-medium">
-                  ~
-                  {samplingMetadata.preflightEstimates?.score2Count.toLocaleString()}
-                </dd>
-              </div>
-              <div className="flex justify-between">
-                <dt className="text-muted-foreground">Estimated Matches:</dt>
-                <dd className="font-medium">
-                  ~
-                  {samplingMetadata.preflightEstimates?.estimatedMatchedCount.toLocaleString()}
-                </dd>
-              </div>
+              {mode === "single" ? (
+                <div className="flex justify-between">
+                  <dt className="text-muted-foreground">Total Scores:</dt>
+                  <dd className="font-medium">
+                    ~
+                    {samplingMetadata.preflightEstimates?.score1Count.toLocaleString()}
+                  </dd>
+                </div>
+              ) : (
+                <>
+                  <div className="flex justify-between">
+                    <dt className="text-muted-foreground">Score 1:</dt>
+                    <dd className="font-medium">
+                      ~
+                      {samplingMetadata.preflightEstimates?.score1Count.toLocaleString()}
+                    </dd>
+                  </div>
+                  <div className="flex justify-between">
+                    <dt className="text-muted-foreground">Score 2:</dt>
+                    <dd className="font-medium">
+                      ~
+                      {samplingMetadata.preflightEstimates?.score2Count.toLocaleString()}
+                    </dd>
+                  </div>
+                  <div className="flex justify-between">
+                    <dt className="text-muted-foreground">
+                      Estimated Matches:
+                    </dt>
+                    <dd className="font-medium">
+                      ~
+                      {samplingMetadata.preflightEstimates?.estimatedMatchedCount.toLocaleString()}
+                    </dd>
+                  </div>
+                </>
+              )}
             </dl>
           </div>
 

--- a/web/src/features/scores/components/score-analytics/components/ScoreAnalyticsProvider.tsx
+++ b/web/src/features/scores/components/score-analytics/components/ScoreAnalyticsProvider.tsx
@@ -63,6 +63,7 @@ export interface EstimateData {
   willSample: boolean;
   willSkipFinal: boolean;
   estimatedQueryTime: string;
+  mode: "single" | "two";
 }
 
 export interface ScoreAnalyticsContextValue
@@ -112,6 +113,9 @@ export function ScoreAnalyticsProvider({
   // and sampling transparency
   const canEstimate = params.score1 !== undefined;
 
+  // Determine mode: "single" when only score1 selected, "two" when score2 explicitly provided
+  const mode: "single" | "two" = params.score2 === undefined ? "single" : "two";
+
   const estimateQuery = api.scores.estimateScoreComparisonSize.useQuery(
     {
       projectId: params.projectId,
@@ -122,6 +126,7 @@ export function ScoreAnalyticsProvider({
       fromTimestamp: params.fromTimestamp,
       toTimestamp: params.toTimestamp,
       objectType: params.objectType ?? "all",
+      mode, // Pass explicit mode to backend
     },
     {
       enabled: canEstimate,

--- a/web/src/features/scores/components/score-analytics/components/ScoreAnalyticsProvider.tsx
+++ b/web/src/features/scores/components/score-analytics/components/ScoreAnalyticsProvider.tsx
@@ -108,14 +108,17 @@ export function ScoreAnalyticsProvider({
   children,
 }: ScoreAnalyticsProviderProps) {
   // Step 1: Run estimate query first
-  const canEstimate =
-    params.score1 !== undefined && params.score2 !== undefined;
+  // Enable for both single-score and two-score modes to provide loading indicators
+  // and sampling transparency
+  const canEstimate = params.score1 !== undefined;
 
   const estimateQuery = api.scores.estimateScoreComparisonSize.useQuery(
     {
       projectId: params.projectId,
       score1: params.score1 ?? { name: "", dataType: "", source: "" },
-      score2: params.score2 ?? { name: "", dataType: "", source: "" },
+      // For single-score mode, pass score1 as score2 (backend will detect identical scores)
+      score2: params.score2 ??
+        params.score1 ?? { name: "", dataType: "", source: "" },
       fromTimestamp: params.fromTimestamp,
       toTimestamp: params.toTimestamp,
       objectType: params.objectType ?? "all",
@@ -127,8 +130,8 @@ export function ScoreAnalyticsProvider({
     },
   );
 
-  // Step 2: Only run main query after estimate succeeds (two-score mode)
-  // For single-score mode, run immediately without estimate
+  // Step 2: Only run main query after estimate succeeds
+  // This applies to both single-score and two-score modes now
   const queryResult = useScoreAnalyticsQuery(params, {
     enabled: !canEstimate || estimateQuery.isSuccess,
   });

--- a/web/src/features/scores/components/score-analytics/components/cards/StatisticsCard.tsx
+++ b/web/src/features/scores/components/score-analytics/components/cards/StatisticsCard.tsx
@@ -113,6 +113,7 @@ export function StatisticsCard() {
           {data.samplingMetadata.isSampled && (
             <SamplingDetailsHoverCard
               samplingMetadata={data.samplingMetadata}
+              mode={data.metadata.mode}
               showLabel
             />
           )}

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -931,6 +931,7 @@ export const scoresRouter = createTRPCRouter({
         objectType: z
           .enum(["all", "trace", "session", "observation", "dataset_run"])
           .default("all"),
+        mode: z.enum(["single", "two"]).optional(), // Frontend passes "single" when only score1 selected
       }),
     )
     .query(async ({ input }) => {
@@ -997,6 +998,7 @@ export const scoresRouter = createTRPCRouter({
         willSample,
         willSkipFinal,
         estimatedQueryTime,
+        mode: input.mode ?? "two", // Echo back the mode from frontend
       };
     }),
 
@@ -1018,6 +1020,7 @@ export const scoresRouter = createTRPCRouter({
           dataType: z.string(),
           source: z.string(),
         }),
+        mode: z.enum(["single", "two"]).optional(), // Frontend passes "single" when only score1 selected
         fromTimestamp: z.date(),
         toTimestamp: z.date(),
         interval: z
@@ -2323,6 +2326,12 @@ export const scoresRouter = createTRPCRouter({
               ? "Small dataset - using FINAL for accuracy"
               : "Large dataset - skipping FINAL for performance",
           },
+        },
+        // Metadata about query mode and score comparison
+        metadata: {
+          mode: input.mode ?? "two", // Echo back the mode from frontend
+          isSameScore: isIdenticalScores,
+          dataType: score1.dataType,
         },
       };
     }),


### PR DESCRIPTION
## Summary

This PR improves the UX for single-score mode in score analytics by:
1. Enabling preflight query and sampling indicators for single-score mode
2. Distinguishing single-score from two-score mode in UI text

## Changes

### Part 1: Enable preflight for single-score mode (commit d191cd27f)

**Problem**: When selecting only one score, the UI didn't run the preflight query, so users didn't see loading banners or sampling indicators.

**Solution**: 
- Modified `ScoreAnalyticsProvider` to enable estimate query for single-score mode
- Pass `score1` as `score2` fallback (backend detects identical scores)
- Now shows "Processing large dataset..." banner and sampling transparency

### Part 2: Mode-specific UI text (commit 26e900585)

**Problem**: Single-score mode showed misleading text mentioning "Score 1 and Score 2" even though only one score was selected.

**Solution**:
- Added optional `mode` parameter ("single" | "two") to estimate and analytics endpoints
- Backend echoes mode back in responses (frontend is authoritative source)
- Frontend determines mode based on `score2 === undefined`
- UI conditionally renders based on mode:
  - **Single-score**: "Analyzing ~X scores", "Total Scores: ~X"
  - **Two-score**: "Analyzing ~X (Score 1) and ~Y (Score 2)", "Score 1: ~X, Score 2: ~Y, Estimated Matches: ~Z"

## Important Note

This preserves the valid use case of intentionally comparing a score to itself (selecting the same score for both score1 and score2). That scenario still shows two-score UI as expected.

## Testing

- ✅ Build passes
- ✅ Linter passes
- ✅ Single-score mode: Shows correct single-score text and preflight indicators
- ✅ Two-score mode: Shows correct two-score text
- ✅ Identical score comparison: Shows two-score UI (preserved behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve single-score mode UX in score analytics with preflight query support and mode-specific UI text.
> 
>   - **Behavior**:
>     - Enable preflight query for single-score mode in `ScoreAnalyticsProvider.tsx`, showing loading banners and sampling indicators.
>     - Add `mode` parameter to distinguish single-score from two-score mode in UI text in `ScoreAnalyticsNoticeBanner.tsx`.
>     - Preserve behavior for identical score comparisons to show two-score UI.
>   - **Backend**:
>     - Add `mode` parameter to `estimateScoreComparisonSize` and `getScoreComparisonAnalytics` in `scores.ts` to support mode-specific responses.
>   - **UI**:
>     - Update UI text in `ScoreAnalyticsNoticeBanner.tsx` and `StatisticsCard.tsx` to reflect single-score mode.
>     - Add `mode` handling in `SamplingDetailsHoverCard` in `ScoreAnalyticsNoticeBanner.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 26e9005850a84b21418ca1f75b9fcaa96c15be44. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->