### PR TITLE
fix(support): add support form max file size error toast

### DIFF
--- a/web/src/features/support-chat/plain/plainConstants.ts
+++ b/web/src/features/support-chat/plain/plainConstants.ts
@@ -1,0 +1,10 @@
+/**
+ * Client-safe constants for Plain API integration
+ * These can be safely imported in both client and server code
+ */
+
+/**
+ * Maximum file size allowed by Plain API for attachments
+ * This is enforced by Plain's API, so we must match it on client and server
+ */
+export const PLAIN_MAX_FILE_SIZE_BYTES = 6 * 1024 * 1024; // 6MB

--- a/web/src/features/support-chat/trpc/plainRouter.ts
+++ b/web/src/features/support-chat/trpc/plainRouter.ts
@@ -31,6 +31,7 @@ import {
   type SessionUser,
   type Organization,
 } from "../plain/plainClient";
+import { PLAIN_MAX_FILE_SIZE_BYTES } from "../plain/plainConstants";
 
 // =========================
 // Input Schemas
@@ -57,7 +58,19 @@ const PrepareAttachmentUploadsInput = z.object({
         fileSizeBytes: z.number().int().positive(),
       }),
     )
-    .max(100)
+    .max(5, "Maximum 5 files allowed")
+    .refine(
+      (files) =>
+        files.every((f) => f.fileSizeBytes <= PLAIN_MAX_FILE_SIZE_BYTES),
+      {
+        message: `Each file must be ≤ ${(PLAIN_MAX_FILE_SIZE_BYTES / (1024 * 1024)).toFixed(0)}MB`,
+      },
+    )
+    .refine(
+      (files) =>
+        files.reduce((sum, f) => sum + f.fileSizeBytes, 0) <= 50 * 1024 * 1024,
+      { message: "Total attachment size must be ≤ 50MB" },
+    )
     .optional()
     .default([]),
 });

--- a/web/src/features/support-chat/trpc/plainRouter.ts
+++ b/web/src/features/support-chat/trpc/plainRouter.ts
@@ -58,7 +58,10 @@ const PrepareAttachmentUploadsInput = z.object({
         fileSizeBytes: z.number().int().positive(),
       }),
     )
-    .max(5, "Maximum 5 files allowed")
+    .max(
+      5,
+      `Maximum 5 files allowed (each ≤ ${(PLAIN_MAX_FILE_SIZE_BYTES / (1024 * 1024)).toFixed(0)}MB)`,
+    )
     .refine(
       (files) =>
         files.every((f) => f.fileSizeBytes <= PLAIN_MAX_FILE_SIZE_BYTES),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Centralizes file upload validation and error handling in support form, enhancing user feedback and consistency.
> 
>   - **Behavior**:
>     - Adds centralized file validation in `SupportFormSection.tsx` using `validateFiles()` and `formatFileError()`.
>     - Displays error toasts for file upload errors using `showErrorToast()`.
>     - Updates `Dropzone` to use centralized constraints from `FILE_UPLOAD_CONSTRAINTS`.
>   - **Constants**:
>     - Introduces `PLAIN_MAX_FILE_SIZE_BYTES` in `plainConstants.ts` for consistent file size limits.
>   - **Error Handling**:
>     - Adds `formatPlainError()` in `plainClient.ts` for user-friendly error messages.
>     - Updates `createAttachmentUploadUrls()` in `plainClient.ts` to handle errors with `formatPlainError()`.
>   - **Validation**:
>     - Updates `PrepareAttachmentUploadsInput` in `plainRouter.ts` to use centralized file size and count constraints.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9f0d1d5f38fd084308ae53b279b7a6aec4874e7b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->