### PR TITLE
fix(scores): enable filtering by environment

### DIFF
--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -159,6 +159,12 @@ export default function ScoresTable({
       },
     );
 
+  const environmentOptions = React.useMemo(
+    () =>
+      environmentFilterOptions.data?.map((value) => value.environment) || [],
+    [environmentFilterOptions.data],
+  );
+
   const [orderByState, setOrderByState] = useOrderByState({
     column: "timestamp",
     order: "DESC",
@@ -238,8 +244,9 @@ export default function ScoresTable({
           count: u.count !== undefined ? Number(u.count) : undefined,
         })) || [],
       tags: filterOptions.data?.tags?.map((t) => t.value) || [], // tags don't have counts
+      environment: environmentOptions,
     }),
-    [filterOptions.data],
+    [filterOptions.data, environmentOptions],
   );
 
   const queryFilter = useSidebarFilterState(

--- a/web/src/features/filters/config/scores-config.ts
+++ b/web/src/features/filters/config/scores-config.ts
@@ -13,11 +13,16 @@ export const scoreFilterConfig: FilterConfig = {
 
   columnDefinitions: scoresTableCols,
 
-  defaultExpanded: ["name"],
+  defaultExpanded: ["environment", "name"],
 
   defaultSidebarCollapsed: true,
 
   facets: [
+    {
+      type: "categorical" as const,
+      column: "environment",
+      label: "Environment",
+    },
     {
       type: "categorical" as const,
       column: "name",

--- a/web/src/server/api/definitions/scoresTable.ts
+++ b/web/src/server/api/definitions/scoresTable.ts
@@ -22,6 +22,13 @@ export const scoresTableCols: ColumnDefinition[] = [
     nullable: true,
   },
   {
+    name: "Environment",
+    id: "environment",
+    type: "stringOptions",
+    internal: 's."environment"',
+    options: [], // to be added at runtime
+  },
+  {
     name: "Observation ID",
     id: "observationId",
     type: "string",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable filtering by environment in scores table with updates to filter configuration and column definitions.
> 
>   - **Behavior**:
>     - Enables filtering by `environment` in `ScoresTable` in `scores.tsx`.
>     - Adds `environment` to `newFilterOptions` and `queryFilter` in `scores.tsx`.
>   - **Configuration**:
>     - Updates `scoreFilterConfig` in `scores-config.ts` to include `environment` in `defaultExpanded` and `facets`.
>   - **Column Definitions**:
>     - Adds `environment` column to `scoresTableCols` in `scoresTable.ts` with `stringOptions` type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3da7ce98c89da10778eae76ad3b0d441f06fe17a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->