### PR TITLE
chore: use single timestamp for event table sorting, simplify PK

### DIFF
--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -132,7 +132,6 @@ CREATE TABLE IF NOT EXISTS events
       parent_span_id String,
 
       start_time DateTime64(6),
-      start_time_unix UInt32 MATERIALIZED toUnixTimestamp(start_time),
       end_time Nullable(DateTime64(6)),
 
       -- Core properties
@@ -265,7 +264,8 @@ CREATE TABLE IF NOT EXISTS events
   ENGINE = ReplacingMergeTree(event_ts, is_deleted)
   -- ENGINE = (Replicated)ReplacingMergeTree(event_ts, is_deleted)
   PARTITION BY toYYYYMM(start_time)
-  ORDER BY (project_id, start_time_unix, xxHash32(trace_id), span_id)
+  PRIMARY KEY (project_id, start_time, xxHash32(trace_id))
+  ORDER BY (project_id, start_time, xxHash32(trace_id), span_id)
   SAMPLE BY xxHash32(trace_id)
   SETTINGS
     index_granularity = 8192,

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -257,22 +257,10 @@ const getObservationsFromEventsTableInternal = async <T>(
   const needsTraceJoin =
     traceTableFilter.length > 0 || orderByTraces || search.query;
 
-  // When we have default ordering by time, we order by (e.start_time_unix)
-  // This way, clickhouse is able to read more efficiently directly from disk without ordering
-  const newDefaultOrder =
-    orderBy?.column === "startTime"
-      ? [{ column: "order_by_unix", order: orderBy.order }]
-      : [orderBy ?? null];
-
-  const chOrderBy = orderByToClickhouseSql(newDefaultOrder, [
-    ...eventsTableUiColumnDefinitions,
-    {
-      uiTableName: "order_by_unix",
-      uiTableId: "order_by_unix",
-      clickhouseTableName: "events",
-      clickhouseSelect: "e.start_time_unix",
-    },
-  ]);
+  const chOrderBy = orderByToClickhouseSql(
+    [orderBy ?? null],
+    eventsTableUiColumnDefinitions,
+  );
 
   // Build query using EventsQueryBuilder
   const queryBuilder = new EventsQueryBuilder({ projectId });
@@ -439,7 +427,7 @@ const getObservationByIdFromEventsTableInternal = async ({
     .when(Boolean(traceId), (b) =>
       b.whereRaw("trace_id = {traceId: String}", { traceId }),
     )
-    .orderBy("ORDER BY start_time_unix DESC, event_ts DESC")
+    .orderBy("ORDER BY start_time DESC, event_ts DESC")
     .limit(1, 0);
 
   const { query, params } = queryBuilder.buildWithParams();
@@ -643,7 +631,7 @@ const getObservationsFromEventsTableForPublicApiInternal = async <T>(
 
   if (opts.select === "rows") {
     queryBuilder
-      .orderBy("ORDER BY e.start_time_unix DESC")
+      .orderBy("ORDER BY e.start_time DESC")
       .limit(limit, (page - 1) * limit);
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplified `events` table sorting by removing `start_time_unix` and using `start_time` directly, updating schema and query logic.
> 
>   - **Schema Changes**:
>     - Removed `start_time_unix` column from `events` table in `dev-tables.sh`.
>     - Updated `PRIMARY KEY` to `(project_id, start_time, xxHash32(trace_id))` in `dev-tables.sh`.
>   - **Query Changes**:
>     - Updated ordering logic in `getObservationsFromEventsTableInternal()` and `getObservationByIdFromEventsTableInternal()` in `events.ts` to use `start_time` instead of `start_time_unix`.
>     - Modified `getObservationsFromEventsTableForPublicApiInternal()` to order by `start_time` in `events.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 505bdf2c98a4e02d8f18d344f5a4e704c19c0a99. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->