### PR TITLE
chore: reduce observations_batch_staging primary key size

### DIFF
--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -113,6 +113,7 @@ CREATE TABLE IF NOT EXISTS observations_batch_staging
     environment LowCardinality(String) DEFAULT 'default',
 ) ENGINE = ReplacingMergeTree(event_ts, is_deleted)
 PARTITION BY toStartOfInterval(s3_first_seen_timestamp, INTERVAL 3 MINUTE)
+PRIMARY KEY (project_id, toDate(s3_first_seen_timestamp))
 ORDER BY (
     project_id,
     toDate(s3_first_seen_timestamp),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add primary key to `observations_batch_staging` table in `dev-tables.sh` for improved performance and integrity.
> 
>   - **Database Schema**:
>     - Add `PRIMARY KEY (project_id, toDate(s3_first_seen_timestamp))` to `observations_batch_staging` table in `dev-tables.sh` to optimize query performance and data integrity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c6e2aa0e08c7405caf21085ef39c94d507a9b626. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->