### PR TITLE
feat(trace-ui): pretty render Vercel AI SDK Tools

### DIFF
--- a/web/src/utils/chatml/adapters/aisdk.clienttest.ts
+++ b/web/src/utils/chatml/adapters/aisdk.clienttest.ts
@@ -9,7 +9,7 @@ jest.mock("@langfuse/shared", () => ({
   },
 }));
 
-import { normalizeInput, normalizeOutput } from "./index";
+import { normalizeInput } from "./index";
 import { aisdkAdapter } from "./aisdk";
 
 describe("AI SDK Adapter", () => {

--- a/web/src/utils/chatml/adapters/aisdk.clienttest.ts
+++ b/web/src/utils/chatml/adapters/aisdk.clienttest.ts
@@ -1,0 +1,450 @@
+jest.mock("@langfuse/shared", () => ({
+  ChatMessageRole: {
+    System: "system",
+    Developer: "developer",
+    User: "user",
+    Assistant: "assistant",
+    Tool: "tool",
+    Model: "model",
+  },
+}));
+
+import { normalizeInput, normalizeOutput } from "./index";
+import { aisdkAdapter } from "./aisdk";
+
+describe("AI SDK Adapter", () => {
+  describe("detection", () => {
+    it("should detect AI SDK via metadata attributes", () => {
+      // operation.name starting with "ai."
+      expect(
+        aisdkAdapter.detect({
+          metadata: {
+            attributes: {
+              "operation.name": "ai.generateText.doGenerate",
+            },
+          },
+        }),
+      ).toBe(true);
+
+      // scope.name === "ai"
+      expect(
+        aisdkAdapter.detect({
+          metadata: {
+            scope: {
+              name: "ai",
+            },
+          },
+        }),
+      ).toBe(true);
+
+      // Both indicators together
+      expect(
+        aisdkAdapter.detect({
+          metadata: {
+            scope: {
+              name: "ai",
+            },
+            attributes: {
+              "operation.name": "ai.generateText.doGenerate",
+              "ai.model.provider": "openai.responses",
+            },
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it("should detect AI SDK via framework hint", () => {
+      expect(aisdkAdapter.detect({ framework: "aisdk" })).toBe(true);
+      expect(aisdkAdapter.detect({ framework: "aisdk-v5" })).toBe(true);
+    });
+
+    it("should not detect non-AI SDK formats", () => {
+      // LangGraph scope
+      expect(
+        aisdkAdapter.detect({
+          metadata: {
+            scope: { name: "langfuse-sdk" },
+          },
+        }),
+      ).toBe(false);
+
+      // No AI SDK markers
+      expect(
+        aisdkAdapter.detect({
+          metadata: {
+            attributes: {
+              "operation.name": "custom.operation",
+            },
+          },
+        }),
+      ).toBe(false);
+
+      // Empty metadata
+      expect(aisdkAdapter.detect({ metadata: {} })).toBe(false);
+    });
+
+    it("should detect AI SDK via structural patterns (fallback)", () => {
+      // Tool-call content structure
+      const toolCallData = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call_123",
+              toolName: "get_weather",
+              input: { city: "SF" },
+            },
+          ],
+        },
+      ];
+      expect(aisdkAdapter.detect({ data: toolCallData })).toBe(true);
+
+      // Tool-result content structure
+      const toolResultData = [
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call_123",
+              toolName: "get_weather",
+              output: { type: "text", value: "sunny" },
+            },
+          ],
+        },
+      ];
+      expect(aisdkAdapter.detect({ data: toolResultData })).toBe(true);
+    });
+  });
+
+  describe("preprocessing - provider field variations", () => {
+    it("should normalize tool calls (input/args variants)", () => {
+      // OpenAI uses 'input' field
+      const openaiInput = {
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: "call_abc",
+                toolName: "get_weather",
+                input: { city: "NYC" },
+              },
+            ],
+          },
+        ],
+      };
+
+      const openaiResult = normalizeInput(openaiInput, { framework: "aisdk" });
+      expect(openaiResult.success).toBe(true);
+      expect(openaiResult.data?.[0].tool_calls?.[0].id).toBe("call_abc");
+      expect(openaiResult.data?.[0].tool_calls?.[0].name).toBe("get_weather");
+      expect(openaiResult.data?.[0].tool_calls?.[0].arguments).toBe(
+        '{"city":"NYC"}',
+      );
+
+      // Bedrock uses 'args' field
+      const bedrockInput = {
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: "tooluse_abc",
+                toolName: "agentResponse",
+                args: {
+                  response: "Processing...",
+                  reasoning: "Need to respond",
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const bedrockResult = normalizeInput(bedrockInput, {
+        framework: "aisdk",
+      });
+      expect(bedrockResult.success).toBe(true);
+      expect(bedrockResult.data?.[0].tool_calls?.[0].id).toBe("tooluse_abc");
+      expect(bedrockResult.data?.[0].tool_calls?.[0].name).toBe(
+        "agentResponse",
+      );
+      expect(bedrockResult.data?.[0].tool_calls?.[0].arguments).toContain(
+        "response",
+      );
+      expect(bedrockResult.data?.[0].tool_calls?.[0].arguments).toContain(
+        "reasoning",
+      );
+    });
+
+    it("should normalize tool results (output/result variants)", () => {
+      // OpenAI uses 'output' field with nested {type: "text", value: "..."}
+      const openaiInput = {
+        messages: [
+          {
+            role: "tool",
+            content: [
+              {
+                type: "tool-result",
+                toolCallId: "call_abc",
+                toolName: "get_weather",
+                output: {
+                  type: "text",
+                  value: "72°F, sunny",
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const openaiResult = normalizeInput(openaiInput, { framework: "aisdk" });
+      expect(openaiResult.success).toBe(true);
+      expect(openaiResult.data?.[0].tool_call_id).toBe("call_abc");
+      expect(openaiResult.data?.[0].content).toBe("72°F, sunny");
+
+      // Bedrock uses 'result' field with array/object
+      const bedrockInput = {
+        messages: [
+          {
+            role: "tool",
+            content: [
+              {
+                type: "tool-result",
+                toolCallId: "tooluse_abc",
+                toolName: "agentResponse",
+                result: [
+                  {
+                    id: "some_id",
+                    code: "SOME_CODE",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const bedrockResult = normalizeInput(bedrockInput, {
+        framework: "aisdk",
+      });
+      expect(bedrockResult.success).toBe(true);
+      expect(bedrockResult.data?.[0].tool_call_id).toBe("tooluse_abc");
+      expect(typeof bedrockResult.data?.[0].content).toBe("string");
+    });
+
+    it("should strip provider-specific metadata", () => {
+      // OpenAI providerOptions
+      const openaiInput = {
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: "call_123",
+                toolName: "test",
+                input: {},
+                providerOptions: {
+                  openai: { itemId: "fc_456" },
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const openaiResult = normalizeInput(openaiInput, { framework: "aisdk" });
+      expect(openaiResult.success).toBe(true);
+      const toolCall = openaiResult.data?.[0].tool_calls?.[0];
+      expect(toolCall).toBeDefined();
+      expect(toolCall).not.toHaveProperty("providerOptions");
+
+      // Bedrock providerMetadata
+      const bedrockInput = {
+        messages: [
+          {
+            role: "system",
+            content: "You are a helpful assistant",
+            providerMetadata: {
+              bedrock: {
+                cachePoint: { type: "default" },
+              },
+            },
+          },
+        ],
+      };
+
+      const bedrockResult = normalizeInput(bedrockInput, {
+        framework: "aisdk",
+      });
+      expect(bedrockResult.success).toBe(true);
+      expect(bedrockResult.data?.[0].role).toBe("system");
+      expect(bedrockResult.data?.[0].content).toBe(
+        "You are a helpful assistant",
+      );
+      expect(bedrockResult.data?.[0]).not.toHaveProperty("providerMetadata");
+    });
+  });
+
+  describe("tool handling", () => {
+    it("should attach tools to messages when present", () => {
+      const input = {
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Test" }],
+          },
+        ],
+        tools: [
+          {
+            type: "function",
+            name: "get_weather",
+            description: "Get weather info",
+            inputSchema: {
+              type: "object",
+              properties: {
+                city: { type: "string" },
+              },
+            },
+          },
+        ],
+      };
+
+      const result = normalizeInput(input, { framework: "aisdk" });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.[0].tools).toBeDefined();
+      expect(result.data?.[0].tools?.[0].name).toBe("get_weather");
+      expect(result.data?.[0].tools?.[0].parameters).toBeDefined();
+    });
+
+    it("should stringify simple tool result objects (1-2 scalar keys)", () => {
+      const input = {
+        messages: [
+          {
+            role: "tool",
+            content: [
+              {
+                type: "tool-result",
+                toolCallId: "call_123",
+                toolName: "get_weather",
+                output: {
+                  type: "text",
+                  value: '{"temperature":72,"conditions":"sunny"}',
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = normalizeInput(input, { framework: "aisdk" });
+      expect(result.success).toBe(true);
+      expect(typeof result.data?.[0].content).toBe("string");
+      expect(result.data?.[0].content).toContain("temperature");
+    });
+  });
+
+  describe("mixed content", () => {
+    it("should extract text from single text item", () => {
+      const input = {
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "What's the weather?",
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = normalizeInput(input, { framework: "aisdk" });
+      expect(result.success).toBe(true);
+      expect(result.data?.[0].content).toBe("What's the weather?");
+    });
+
+    it("should concatenate multiple text items", () => {
+      const input = {
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              { type: "text", text: "Hello " },
+              { type: "text", text: "world!" },
+            ],
+          },
+        ],
+      };
+
+      const result = normalizeInput(input, { framework: "aisdk" });
+      expect(result.success).toBe(true);
+      expect(result.data?.[0].content).toBe("Hello world!");
+    });
+
+    it("should handle messages with both text and tool calls", () => {
+      const input = {
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "text",
+                text: "Let me check that for you.",
+              },
+              {
+                type: "tool-call",
+                toolCallId: "call_123",
+                toolName: "get_weather",
+                input: { city: "SF" },
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = normalizeInput(input, { framework: "aisdk" });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.[0].content).toBe("Let me check that for you.");
+      expect(result.data?.[0].tool_calls).toBeDefined();
+      expect(result.data?.[0].tool_calls?.[0].name).toBe("get_weather");
+    });
+  });
+
+  describe("array handling", () => {
+    it("should handle array of messages without wrapper", () => {
+      const input = [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Hello" }],
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call_123",
+              toolName: "test",
+              input: {},
+            },
+          ],
+        },
+      ];
+
+      const result = normalizeInput(input, { framework: "aisdk" });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.length).toBe(2);
+      expect(result.data?.[0].content).toBe("Hello");
+      expect(result.data?.[1].tool_calls).toBeDefined();
+    });
+  });
+});

--- a/web/src/utils/chatml/adapters/aisdk.ts
+++ b/web/src/utils/chatml/adapters/aisdk.ts
@@ -169,40 +169,42 @@ function normalizeMessage(msg: unknown): Record<string, unknown> {
       });
 
       // Convert tool-call content items to tool_calls array
-      const toolCallItems = normalized.content.filter(
-        (item: unknown) =>
-          item &&
-          typeof item === "object" &&
-          (item as Record<string, unknown>).type === "tool-call",
-      );
-
-      if (toolCallItems.length > 0) {
-        normalized.tool_calls = toolCallItems.map((item: unknown) => {
-          const tc = item as Record<string, unknown>;
-          return {
-            id: tc.toolCallId,
-            name: tc.toolName,
-            arguments: tc.arguments,
-            type: "function",
-          };
-        });
-
-        // Remove tool-call items from content, keep only text items
-        const textItems = normalized.content.filter(
+      if (Array.isArray(normalized.content)) {
+        const toolCallItems = normalized.content.filter(
           (item: unknown) =>
             item &&
             typeof item === "object" &&
-            (item as Record<string, unknown>).type === "text",
+            (item as Record<string, unknown>).type === "tool-call",
         );
 
-        if (textItems.length > 0) {
-          const texts = textItems.map(
-            (item: unknown) => (item as Record<string, unknown>).text ?? "",
+        if (toolCallItems.length > 0) {
+          normalized.tool_calls = toolCallItems.map((item: unknown) => {
+            const tc = item as Record<string, unknown>;
+            return {
+              id: tc.toolCallId,
+              name: tc.toolName,
+              arguments: tc.arguments,
+              type: "function",
+            };
+          });
+
+          // Remove tool-call items from content, keep only text items
+          const textItems = normalized.content.filter(
+            (item: unknown) =>
+              item &&
+              typeof item === "object" &&
+              (item as Record<string, unknown>).type === "text",
           );
-          normalized.content = texts.join("");
-        } else {
-          // No text content, remove content field
-          delete normalized.content;
+
+          if (textItems.length > 0) {
+            const texts = textItems.map(
+              (item: unknown) => (item as Record<string, unknown>).text ?? "",
+            );
+            normalized.content = texts.join("");
+          } else {
+            // No text content, remove content field
+            delete normalized.content;
+          }
         }
       }
 

--- a/web/src/utils/chatml/adapters/aisdk.ts
+++ b/web/src/utils/chatml/adapters/aisdk.ts
@@ -1,0 +1,432 @@
+import type { NormalizerContext, ProviderAdapter } from "../types";
+import {
+  removeNullFields,
+  stringifyToolResultContent,
+  parseMetadata,
+  isRichToolResult,
+} from "../helpers";
+import { z } from "zod/v4";
+
+/**
+ * AI SDK v5 Adapter
+ *
+ * Handles traces from Vercel AI SDK v5 with any model provider
+ *
+ * Key characteristics:
+ * - Observation names: ai.generateText.doGenerate, ai.generateObject.doGenerate
+ * - Metadata: ai.operationId, ai.model.provider, ai.model.id
+ * - Message structure: {role, content: [{type, text/toolCallId/...}]}
+ * - Tool calls: {type: "tool-call", toolCallId, toolName, input|args}
+ * - Tool results: {type: "tool-result", toolCallId, toolName, output|result}
+ */
+
+// Message with AI SDK v5 tool-call content structure
+const AISDKToolCallMessageSchema = z.looseObject({
+  role: z.string(),
+  content: z.array(
+    z.looseObject({
+      type: z.literal("tool-call"),
+      toolCallId: z.string(),
+      toolName: z.string(),
+    }),
+  ),
+});
+
+// Message with AI SDK v5 tool-result content structure
+const AISDKToolResultMessageSchema = z.looseObject({
+  role: z.literal("tool"),
+  content: z.array(
+    z.looseObject({
+      type: z.literal("tool-result"),
+      toolCallId: z.string(),
+      toolName: z.string(),
+    }),
+  ),
+});
+
+// Message array with AI SDK v5 patterns
+const AISDKMessagesArraySchema = z
+  .array(
+    z.looseObject({
+      role: z.string(),
+      content: z
+        .union([z.string(), z.array(z.looseObject({ type: z.string() }))])
+        .optional(),
+    }),
+  )
+  .refine(
+    (messages) => {
+      // Must have at least one message with AI SDK v5 structured content
+      return messages.some(
+        (msg) =>
+          Array.isArray(msg.content) &&
+          msg.content.some(
+            (item: unknown) =>
+              (item &&
+                typeof item === "object" &&
+                "type" in item &&
+                (item as Record<string, unknown>).type === "tool-call") ||
+              (item as Record<string, unknown>).type === "tool-result",
+          ),
+      );
+    },
+    { message: "Must have AI SDK v5 tool-call or tool-result patterns" },
+  );
+
+// normalize a single AI SDK v5 message to ChatML format
+// we don't want additional fields here to get clean rendering
+function normalizeMessage(msg: unknown): Record<string, unknown> {
+  if (!msg || typeof msg !== "object") return {};
+
+  let working = msg as Record<string, unknown>;
+
+  // Strip provider-specific metadata (Bedrock, OpenAI, etc.)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { providerMetadata, providerOptions, ...withoutProviderFields } =
+    working;
+  working = withoutProviderFields;
+
+  let normalized = removeNullFields(working);
+
+  // Normalize content: [{type: "text", text: "..."}] → string
+  if (
+    normalized.content &&
+    Array.isArray(normalized.content) &&
+    normalized.content.length > 0
+  ) {
+    // all text already or do owe need to normalize further?
+    const allTextItems = normalized.content.every(
+      (item: unknown) =>
+        item &&
+        typeof item === "object" &&
+        (item as Record<string, unknown>).type === "text" &&
+        typeof (item as Record<string, unknown>).text === "string",
+    );
+
+    if (allTextItems && normalized.content.length === 1) {
+      // Single text item: extract the text
+      const firstItem = normalized.content[0] as Record<string, unknown>;
+      normalized.content = firstItem.text;
+    } else if (allTextItems && normalized.content.length > 1) {
+      // Multiple text items: concatenate
+      const texts = normalized.content.map(
+        (item: unknown) => (item as Record<string, unknown>).text,
+      );
+      normalized.content = texts.join("");
+    } else {
+      // Mixed content or tool-calls/tool-results: normalize each item
+      normalized.content = normalized.content.map((item: unknown) => {
+        if (!item || typeof item !== "object") return item;
+
+        const contentItem = item as Record<string, unknown>;
+
+        // Handle tool-call content item
+        // {type: "tool-call", toolCallId, toolName, input|args, providerOptions}
+        if (contentItem.type === "tool-call") {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { providerOptions: _po, ...cleanedItem } = contentItem;
+
+          // Normalize args|input to arguments
+          const args = contentItem.args ?? contentItem.input;
+          return {
+            ...cleanedItem,
+            arguments:
+              typeof args === "string" ? args : JSON.stringify(args ?? {}),
+          };
+        }
+
+        // Handle tool-result content item
+        // {type: "tool-result", toolCallId, toolName, output|result}
+        if (contentItem.type === "tool-result") {
+          // Normalize output|result to content
+          const resultValue = contentItem.output ?? contentItem.result;
+
+          // If result has nested {type: "text", value: "..."}, extract value
+          if (
+            resultValue &&
+            typeof resultValue === "object" &&
+            !Array.isArray(resultValue) &&
+            (resultValue as Record<string, unknown>).type === "text" &&
+            "value" in (resultValue as Record<string, unknown>)
+          ) {
+            return {
+              ...contentItem,
+              content: (resultValue as Record<string, unknown>).value,
+            };
+          }
+
+          // Otherwise stringify the result
+          return {
+            ...contentItem,
+            content:
+              typeof resultValue === "string"
+                ? resultValue
+                : JSON.stringify(resultValue ?? ""),
+          };
+        }
+
+        return contentItem;
+      });
+
+      // Convert tool-call content items to tool_calls array
+      const toolCallItems = normalized.content.filter(
+        (item: unknown) =>
+          item &&
+          typeof item === "object" &&
+          (item as Record<string, unknown>).type === "tool-call",
+      );
+
+      if (toolCallItems.length > 0) {
+        normalized.tool_calls = toolCallItems.map((item: unknown) => {
+          const tc = item as Record<string, unknown>;
+          return {
+            id: tc.toolCallId,
+            name: tc.toolName,
+            arguments: tc.arguments,
+            type: "function",
+          };
+        });
+
+        // Remove tool-call items from content, keep only text items
+        const textItems = normalized.content.filter(
+          (item: unknown) =>
+            item &&
+            typeof item === "object" &&
+            (item as Record<string, unknown>).type === "text",
+        );
+
+        if (textItems.length > 0) {
+          const texts = textItems.map(
+            (item: unknown) => (item as Record<string, unknown>).text ?? "",
+          );
+          normalized.content = texts.join("");
+        } else {
+          // No text content, remove content field
+          delete normalized.content;
+        }
+      }
+
+      // Handle tool-result content items for tool role messages
+      // Only process if content is still an array (wasn't converted to string above)
+      if (Array.isArray(normalized.content)) {
+        const toolResultItems = normalized.content.filter(
+          (item: unknown) =>
+            item &&
+            typeof item === "object" &&
+            (item as Record<string, unknown>).type === "tool-result",
+        );
+
+        if (toolResultItems.length > 0 && normalized.role === "tool") {
+          // For single tool result, extract tool_call_id and content
+          if (toolResultItems.length === 1) {
+            const result = toolResultItems[0] as Record<string, unknown>;
+            normalized.tool_call_id = result.toolCallId;
+            normalized.content = result.content;
+          } else {
+            // Multiple tool results: keep as array (less common)
+            normalized.content = toolResultItems;
+          }
+        }
+      }
+    }
+  }
+
+  // For tool messages with rich object content, spread into message
+  // so it goes to json passthrough field and renders as PrettyJsonView.
+  // Rich = nested structure OR 3+ keys. Simple <=2 scalar keys.
+  if (
+    normalized.role === "tool" &&
+    typeof normalized.content === "object" &&
+    normalized.content !== null &&
+    !Array.isArray(normalized.content)
+  ) {
+    if (isRichToolResult(normalized.content)) {
+      // Rich object: spread for table rendering
+      const { content, ...rest } = normalized;
+      return { ...rest, ...content };
+    } else {
+      // Simple object: stringify for text rendering
+      normalized.content = stringifyToolResultContent(normalized.content);
+    }
+  }
+
+  return normalized;
+}
+
+function flattenToolDefinition(tool: unknown): Record<string, unknown> {
+  if (typeof tool !== "object" || !tool) return {};
+
+  const t = tool as Record<string, unknown>;
+
+  const toolDef: Record<string, unknown> = {
+    name: t.name,
+    description: t.description ?? "",
+  };
+
+  // AI SDK uses inputSchema instead of parameters
+  if (t.inputSchema != null) {
+    toolDef.parameters = t.inputSchema;
+  } else if (t.parameters != null) {
+    toolDef.parameters = t.parameters;
+  }
+
+  return toolDef;
+}
+
+/**
+ * Split tool result messages with multiple results into separate messages
+ * AI SDK can have: {role: "tool", content: [{type: "tool-result", ...}, {type: "tool-result", ...}]}
+ * ChatML expects: [{role: "tool", tool_call_id: "...", content: "..."}, ...]
+ */
+function splitToolResultMessages(messages: unknown[]): unknown[] {
+  const result: unknown[] = [];
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      result.push(msg);
+      continue;
+    }
+
+    const message = msg as Record<string, unknown>;
+
+    // Check if this is a tool message with array content containing multiple tool-result items
+    if (
+      message.role === "tool" &&
+      Array.isArray(message.content) &&
+      message.content.length > 1 &&
+      message.content.every(
+        (item: unknown) =>
+          item &&
+          typeof item === "object" &&
+          (item as Record<string, unknown>).type === "tool-result",
+      )
+    ) {
+      // Split into separate messages, one per tool result
+      for (const item of message.content) {
+        const toolResult = item as Record<string, unknown>;
+        result.push({
+          role: "tool",
+          tool_call_id: toolResult.toolCallId,
+          content: toolResult.content,
+        });
+      }
+    } else {
+      result.push(message);
+    }
+  }
+
+  return result;
+}
+
+function preprocessData(data: unknown, ctx?: NormalizerContext): unknown {
+  if (!data) return data;
+
+  // Extract tools from context metadata (observation.metadata.tools)
+  let toolsFromContext: unknown[] | undefined;
+  if (ctx?.metadata && typeof ctx.metadata === "object") {
+    const meta = ctx.metadata as Record<string, unknown>;
+    if (Array.isArray(meta.tools)) {
+      toolsFromContext = meta.tools.map(flattenToolDefinition);
+    }
+  }
+
+  // Handle wrapped format with messages and tools
+  // {messages: [...], tools: [...]} or {messages: [...], providerOptions: {...}}
+  if (typeof data === "object" && !Array.isArray(data) && "messages" in data) {
+    const obj = data as Record<string, unknown>;
+    const messagesArray = obj.messages as unknown[];
+
+    if (Array.isArray(messagesArray)) {
+      let tools: unknown[] | undefined;
+
+      if (Array.isArray(obj.tools)) {
+        tools = (obj.tools as unknown[]).map(flattenToolDefinition);
+      }
+
+      const normalized = messagesArray.map(normalizeMessage);
+
+      const split = splitToolResultMessages(normalized);
+
+      // Attach tools to messages if present
+      if (tools && tools.length > 0) {
+        return split.map((msg) => ({
+          ...(msg as Record<string, unknown>),
+          tools,
+        }));
+      }
+
+      return split;
+    }
+  }
+
+  if (Array.isArray(data)) {
+    const normalized = data.map(normalizeMessage);
+    const split = splitToolResultMessages(normalized);
+
+    // Attach tools from context metadata if present
+    if (toolsFromContext && toolsFromContext.length > 0) {
+      return split.map((msg) => ({
+        ...(msg as Record<string, unknown>),
+        tools: toolsFromContext,
+      }));
+    }
+
+    return split;
+  }
+
+  // if it's not an array but just a single message
+  if (typeof data === "object" && "role" in data) {
+    return normalizeMessage(data);
+  }
+
+  return data;
+}
+
+export const aisdkAdapter: ProviderAdapter = {
+  id: "aisdk",
+
+  detect(ctx: NormalizerContext): boolean {
+    const meta = parseMetadata(ctx.metadata);
+
+    // EXPLICIT: Framework hint
+    if (ctx.framework === "aisdk" || ctx.framework === "aisdk-v5") return true;
+
+    // STRONG INDICATORS: AI SDK v5 telemetry markers
+    if (meta && typeof meta === "object") {
+      if ("scope" in meta && typeof meta.scope === "object") {
+        const scope = meta.scope as Record<string, unknown>;
+        if (scope.name === "ai") return true;
+      }
+
+      if ("attributes" in meta && typeof meta.attributes === "object") {
+        const attrs = meta.attributes as Record<string, unknown>;
+        if (
+          typeof attrs["operation.name"] === "string" &&
+          attrs["operation.name"].startsWith("ai.")
+        ) {
+          return true;
+        }
+      }
+    }
+
+    // STRUCTURAL: Schema-based detection (for edge cases without metadata)
+    if (AISDKToolCallMessageSchema.safeParse(ctx.metadata).success) return true;
+    if (AISDKToolResultMessageSchema.safeParse(ctx.metadata).success)
+      return true;
+    if (AISDKMessagesArraySchema.safeParse(ctx.metadata).success) return true;
+
+    if (AISDKToolCallMessageSchema.safeParse(ctx.data).success) return true;
+    if (AISDKToolResultMessageSchema.safeParse(ctx.data).success) return true;
+    if (AISDKMessagesArraySchema.safeParse(ctx.data).success) return true;
+
+    return false;
+  },
+
+  preprocess(
+    data: unknown,
+    _kind: "input" | "output",
+    ctx: NormalizerContext,
+  ): unknown {
+    return preprocessData(data, ctx);
+  },
+};

--- a/web/src/utils/chatml/adapters/index.ts
+++ b/web/src/utils/chatml/adapters/index.ts
@@ -1,6 +1,7 @@
 import type { NormalizerContext, ProviderAdapter } from "../types";
 import { mapToChatMl, mapOutputToChatMl } from "../core";
 import { langgraphAdapter } from "./langgraph";
+import { aisdkAdapter } from "./aisdk";
 import { openAIAdapter } from "./openai";
 import { geminiAdapter } from "./gemini";
 import { microsoftAgentAdapter } from "./microsoft-agent";
@@ -8,6 +9,7 @@ import { genericAdapter } from "./generic";
 
 const adapters: ProviderAdapter[] = [
   langgraphAdapter, // Must be before openAI (both use langfuse-sdk scope)
+  aisdkAdapter, // Vercel AI SDK v5 (for all LLM providers like OpenAI, Bedrock, Anthropic, etc.)
   openAIAdapter, // OpenAI (Chat Completions & Responses API)
   geminiAdapter, // Gemini/VertexAI format
   microsoftAgentAdapter, // Microsoft Agent Framework

--- a/web/src/utils/chatml/adapters/langgraph.ts
+++ b/web/src/utils/chatml/adapters/langgraph.ts
@@ -273,14 +273,31 @@ export const langgraphAdapter: ProviderAdapter = {
     // EXPLICIT: Framework hint
     if (ctx.framework === "langgraph") return true;
 
-    // REJECTIONS: Reject OpenAI Agents SDK format
+    // REJECTIONS: Reject AI SDK v5 and OpenAI Agents SDK formats
     if (meta && typeof meta === "object") {
+      // Check scope.name for AI SDK or OpenAI Agents
       if ("scope" in meta && typeof meta.scope === "object") {
         const scope = meta.scope as Record<string, unknown>;
+
+        // Reject AI SDK v5 (scope.name === "ai")
+        if (scope.name === "ai") return false;
+
+        // Reject OpenAI Agents SDK
         if (
           scope.name === "openinference.instrumentation.openai_agents" ||
           (typeof scope.name === "string" &&
             scope.name.includes("openai_agents"))
+        ) {
+          return false;
+        }
+      }
+
+      // Check attributes["operation.name"] for AI SDK pattern
+      if ("attributes" in meta && typeof meta.attributes === "object") {
+        const attrs = meta.attributes as Record<string, unknown>;
+        if (
+          typeof attrs["operation.name"] === "string" &&
+          attrs["operation.name"].startsWith("ai.")
         ) {
           return false;
         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `aisdkAdapter` for Vercel AI SDK v5, including detection, preprocessing, and tests, and updates adapter index.
> 
>   - **New Adapter**:
>     - Adds `aisdkAdapter` in `aisdk.ts` to handle Vercel AI SDK v5 traces.
>     - Detects AI SDK via metadata attributes, framework hints, and structural patterns.
>     - Normalizes tool calls and results, strips provider-specific metadata, and handles mixed content.
>   - **Tests**:
>     - Adds `aisdk.clienttest.ts` with tests for detection, preprocessing, tool handling, and mixed content.
>   - **Integration**:
>     - Updates `index.ts` to include `aisdkAdapter` in the adapter list.
>     - Modifies `langgraph.ts` to reject AI SDK v5 formats.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e88b831190b12b9598c2732d6228eb8fabe6b634. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->