### PR TITLE
feat(ui): show loading state for categorical filters in filter sidebar

### DIFF
--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -22,6 +22,7 @@ import {
 import { Slider } from "@/src/components/ui/slider";
 import { Input } from "@/src/components/ui/input";
 import { Label } from "@/src/components/ui/label";
+import { Skeleton } from "@/src/components/ui/skeleton";
 import { X as IconX, Search, WandSparkles } from "lucide-react";
 import type {
   UIFilter,
@@ -573,11 +574,21 @@ export function CategoricalFacet({
 
             {/* Loading / Empty / Options */}
             {loading ? (
-              <div className="pl-4 text-sm text-muted-foreground">
-                Loading...
-              </div>
+              <>
+                {[1, 2].map((i) => (
+                  <div key={i} className="relative flex items-center px-2">
+                    <div className="group/checkbox flex items-center rounded-sm p-1">
+                      <Skeleton className="h-4 w-4 rounded-sm" />
+                    </div>
+                    <div className="group/label flex min-w-0 flex-1 items-center rounded-sm px-1 py-1">
+                      <Skeleton className="h-3 w-24" />
+                      <Skeleton className="ml-auto h-3 w-8" />
+                    </div>
+                  </div>
+                ))}
+              </>
             ) : options.length === 0 ? (
-              <div className="py-1 text-center text-sm text-muted-foreground">
+              <div className="py-1 text-center text-xs text-muted-foreground">
                 No options found
               </div>
             ) : (

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -285,49 +285,50 @@ export default function ObservationsTable({
           return acc;
         },
         {} as Record<string, string[]>,
-      ) || {};
+      ) ?? undefined;
 
-    const scoresNumeric = filterOptions.data?.scores_avg || [];
+    const scoresNumeric = filterOptions.data?.scores_avg ?? undefined;
 
     return {
       environment:
-        environmentFilterOptions.data?.map((value) => value.environment) || [],
+        environmentFilterOptions.data?.map((value) => value.environment) ??
+        undefined,
       name:
         filterOptions.data?.name?.map((n) => ({
           value: n.value,
           count: n.count !== undefined ? Number(n.count) : undefined,
-        })) || [],
+        })) ?? undefined,
       type:
         filterOptions.data?.type?.map((t) => ({
           value: t.value,
           count: t.count !== undefined ? Number(t.count) : undefined,
-        })) || [],
+        })) ?? undefined,
       traceName:
         filterOptions.data?.traceName?.map((tn) => ({
           value: tn.value,
           count: tn.count !== undefined ? Number(tn.count) : undefined,
-        })) || [],
+        })) ?? undefined,
       level: ["DEFAULT", "DEBUG", "WARNING", "ERROR"],
       model:
         filterOptions.data?.model?.map((m) => ({
           value: m.value,
           count: m.count !== undefined ? Number(m.count) : undefined,
-        })) || [],
+        })) ?? undefined,
       modelId:
         filterOptions.data?.modelId?.map((mid) => ({
           value: mid.value,
           count: mid.count !== undefined ? Number(mid.count) : undefined,
-        })) || [],
+        })) ?? undefined,
       promptName:
         filterOptions.data?.promptName?.map((pn) => ({
           value: pn.value,
           count: pn.count !== undefined ? Number(pn.count) : undefined,
-        })) || [],
+        })) ?? undefined,
       tags:
         filterOptions.data?.tags?.map((t) => ({
           value: t.value,
           count: t.count !== undefined ? Number(t.count) : undefined,
-        })) || [],
+        })) ?? undefined,
       latency: [],
       timeToFirstToken: [],
       tokensPerSecond: [],
@@ -346,7 +347,7 @@ export default function ObservationsTable({
     observationFilterConfig,
     newFilterOptions,
     projectId,
-    filterOptions.isPending,
+    filterOptions.isPending || environmentFilterOptions.isPending,
   );
 
   // Create ref-based wrapper to avoid stale closure when queryFilter updates

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -346,6 +346,7 @@ export default function ObservationsTable({
     observationFilterConfig,
     newFilterOptions,
     projectId,
+    filterOptions.isPending,
   );
 
   // Create ref-based wrapper to avoid stale closure when queryFilter updates

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -161,7 +161,8 @@ export default function ScoresTable({
 
   const environmentOptions = React.useMemo(
     () =>
-      environmentFilterOptions.data?.map((value) => value.environment) || [],
+      environmentFilterOptions.data?.map((value) => value.environment) ??
+      undefined,
     [environmentFilterOptions.data],
   );
 
@@ -229,7 +230,7 @@ export default function ScoresTable({
         filterOptions.data?.name?.map((n) => ({
           value: n.value,
           count: n.count !== undefined ? Number(n.count) : undefined,
-        })) || [],
+        })) ?? undefined,
       source: ["ANNOTATION", "API", "EVAL"],
       dataType: ["NUMERIC", "CATEGORICAL", "BOOLEAN"],
       value: [],
@@ -237,18 +238,18 @@ export default function ScoresTable({
         filterOptions.data?.stringValue?.map((sv) => ({
           value: sv.value,
           count: sv.count !== undefined ? Number(sv.count) : undefined,
-        })) || [],
+        })) ?? undefined,
       traceName:
         filterOptions.data?.traceName?.map((tn) => ({
           value: tn.value,
           count: tn.count !== undefined ? Number(tn.count) : undefined,
-        })) || [],
+        })) ?? undefined,
       userId:
         filterOptions.data?.userId?.map((u) => ({
           value: u.value,
           count: u.count !== undefined ? Number(u.count) : undefined,
-        })) || [],
-      tags: filterOptions.data?.tags?.map((t) => t.value) || [], // tags don't have counts
+        })) ?? undefined,
+      tags: filterOptions.data?.tags?.map((t) => t.value) ?? undefined, // tags don't have counts
       environment: environmentOptions,
     }),
     [filterOptions.data, environmentOptions],
@@ -258,7 +259,7 @@ export default function ScoresTable({
     scoreFilterConfig,
     newFilterOptions,
     projectId,
-    filterOptions.isPending,
+    filterOptions.isPending || environmentFilterOptions.isPending,
   );
 
   // Create ref-based wrapper to avoid stale closure when queryFilter updates

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -258,6 +258,7 @@ export default function ScoresTable({
     scoreFilterConfig,
     newFilterOptions,
     projectId,
+    filterOptions.isPending,
   );
 
   // Create ref-based wrapper to avoid stale closure when queryFilter updates

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -214,6 +214,7 @@ export default function SessionsTable({
     sessionFilterConfig,
     newFilterOptions,
     projectId,
+    filterOptions.isPending,
   );
 
   // Create ref-based wrapper to avoid stale closure when queryFilter updates

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -140,7 +140,8 @@ export default function SessionsTable({
 
   const environmentOptions = useMemo(
     () =>
-      environmentFilterOptions.data?.map((value) => value.environment) || [],
+      environmentFilterOptions.data?.map((value) => value.environment) ??
+      undefined,
     [environmentFilterOptions.data],
   );
 
@@ -184,9 +185,9 @@ export default function SessionsTable({
           return acc;
         },
         {} as Record<string, string[]>,
-      ) || {};
+      ) ?? undefined;
 
-    const scoresNumeric = filterOptions.data?.scores_avg || [];
+    const scoresNumeric = filterOptions.data?.scores_avg ?? undefined;
 
     return {
       bookmarked: ["Bookmarked", "Not bookmarked"],
@@ -195,8 +196,8 @@ export default function SessionsTable({
         filterOptions.data?.userIds.map((u) => ({
           value: u.value,
           count: Number(u.count),
-        })) || [],
-      tags: filterOptions.data?.tags.map((t) => t.value) || [], // tags don't have counts
+        })) ?? undefined,
+      tags: filterOptions.data?.tags.map((t) => t.value) ?? undefined, // tags don't have counts
       sessionDuration: [],
       countTraces: [],
       inputTokens: [],
@@ -214,7 +215,7 @@ export default function SessionsTable({
     sessionFilterConfig,
     newFilterOptions,
     projectId,
-    filterOptions.isPending,
+    filterOptions.isPending || environmentFilterOptions.isPending,
   );
 
   // Create ref-based wrapper to avoid stale closure when queryFilter updates

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -231,32 +231,35 @@ export default function TracesTable({
           return acc;
         },
         {} as Record<string, string[]>,
-      ) || {};
+      ) ?? undefined;
 
-    const scoresNumeric = traceFilterOptionsResponse.data?.scores_avg || [];
+    const scoresNumeric =
+      traceFilterOptionsResponse.data?.scores_avg ?? undefined;
 
     return {
       name:
         traceFilterOptionsResponse.data?.name?.map((n) => ({
           value: n.value,
           count: Number(n.count),
-        })) || [],
+        })) ?? undefined,
       // tags don't have counts
-      tags: traceFilterOptionsResponse.data?.tags?.map((t) => t.value) || [],
+      tags:
+        traceFilterOptionsResponse.data?.tags?.map((t) => t.value) ?? undefined,
       environment:
-        environmentFilterOptions.data?.map((value) => value.environment) || [],
+        environmentFilterOptions.data?.map((value) => value.environment) ??
+        undefined,
       level: ["DEFAULT", "DEBUG", "WARNING", "ERROR"],
       bookmarked: ["Bookmarked", "Not bookmarked"],
       userId:
         traceFilterOptionsResponse.data?.users?.map((u) => ({
           value: u.value,
           count: Number(u.count),
-        })) || [],
+        })) ?? undefined,
       sessionId:
         traceFilterOptionsResponse.data?.sessions?.map((s) => ({
           value: s.value,
           count: Number(s.count),
-        })) || [],
+        })) ?? undefined,
       latency: [],
       inputTokens: [],
       outputTokens: [],
@@ -273,7 +276,7 @@ export default function TracesTable({
     traceFilterConfig,
     filterOptions,
     projectId,
-    traceFilterOptionsResponse.isPending,
+    traceFilterOptionsResponse.isPending || environmentFilterOptions.isPending,
   );
 
   const combinedFilterState = queryFilter.filterState.concat(

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -273,6 +273,7 @@ export default function TracesTable({
     traceFilterConfig,
     filterOptions,
     projectId,
+    traceFilterOptionsResponse.isPending,
   );
 
   const combinedFilterState = queryFilter.filterState.concat(

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -107,6 +107,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
     evaluatorFilterConfig,
     newFilterOptions,
     projectId,
+    false,
   );
 
   const evaluators = api.evals.allConfigs.useQuery({

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -280,6 +280,7 @@ export default function ObservationsEventsTable({
     observationEventsFilterConfig,
     newFilterOptions,
     projectId,
+    filterOptions.isPending,
   );
 
   // Create ref-based wrapper to avoid stale closure when queryFilter updates

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -246,22 +246,22 @@ export default function ObservationsEventsTable({
           return acc;
         },
         {} as Record<string, string[]>,
-      ) || {};
+      ) ?? undefined;
 
-    const scoresNumeric = filterOptions.data?.scores_avg || [];
+    const scoresNumeric = filterOptions.data?.scores_avg ?? undefined;
 
     return {
-      environment: filterOptions.data?.environment ?? [],
-      name: filterOptions.data?.name ?? [],
-      type: filterOptions.data?.type ?? [],
-      level: filterOptions.data?.level ?? [],
-      providedModelName: filterOptions.data?.providedModelName ?? [],
-      modelId: filterOptions.data?.modelId ?? [],
-      promptName: filterOptions.data?.promptName ?? [],
-      traceTags: filterOptions.data?.traceTags ?? [],
-      userId: filterOptions.data?.userId ?? [],
-      sessionId: filterOptions.data?.sessionId ?? [],
-      version: filterOptions.data?.version ?? [],
+      environment: filterOptions.data?.environment ?? undefined,
+      name: filterOptions.data?.name ?? undefined,
+      type: filterOptions.data?.type ?? undefined,
+      level: filterOptions.data?.level ?? undefined,
+      providedModelName: filterOptions.data?.providedModelName ?? undefined,
+      modelId: filterOptions.data?.modelId ?? undefined,
+      promptName: filterOptions.data?.promptName ?? undefined,
+      traceTags: filterOptions.data?.traceTags ?? undefined,
+      userId: filterOptions.data?.userId ?? undefined,
+      sessionId: filterOptions.data?.sessionId ?? undefined,
+      version: filterOptions.data?.version ?? undefined,
       latency: [],
       timeToFirstToken: [],
       tokensPerSecond: [],

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -240,7 +240,7 @@ export function useSidebarFilterState(
   config: FilterConfig,
   options: Record<
     string,
-    (string | SingleValueOption)[] | Record<string, string[]>
+    (string | SingleValueOption)[] | Record<string, string[]> | undefined
   >,
   projectId?: string,
   loading?: boolean,

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -209,7 +209,7 @@ export function PromptTable() {
             value: item.value,
             count: item.count !== undefined ? Number(item.count) : undefined,
           };
-        }) || [],
+        }) ?? undefined,
       tags:
         promptFilterOptions.data?.tags?.map((t) => {
           // API type says { value: string }[], but for some items, there is an optional count
@@ -218,7 +218,7 @@ export function PromptTable() {
             value: item.value,
             count: item.count !== undefined ? Number(item.count) : undefined,
           };
-        }) || [],
+        }) ?? undefined,
       version: [],
     }),
     [promptFilterOptions.data],

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -228,6 +228,7 @@ export function PromptTable() {
     promptFilterConfig,
     newFilterOptions,
     projectId,
+    promptFilterOptions.isPending,
   );
 
   useEffect(() => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds loading state for categorical filters in the filter sidebar, improving user feedback during data fetching.
> 
>   - **Behavior**:
>     - Adds loading state to `CategoricalFacet` in `data-table-controls.tsx` using `Skeleton` components for visual feedback during data fetching.
>     - Updates `useSidebarFilterState` to determine loading state based on data availability for filters.
>   - **Data Handling**:
>     - Replaces `|| []` with `?? undefined` in `observations.tsx`, `scores.tsx`, `sessions.tsx`, `traces.tsx`, `EventsTable.tsx`, and `prompts-table.tsx` to handle undefined data more explicitly.
>   - **Misc**:
>     - Adjusts text size in `data-table-controls.tsx` for empty state message from `text-sm` to `text-xs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 683b50cb693586419a4295ffb6ca4c18d3b58339. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->