### PR TITLE
feat(ui): make filtersidebar resizable and add sticky header

### DIFF
--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -132,11 +132,11 @@ export function DataTableControls({
   return (
     <div
       className={cn(
-        "flex h-full w-full flex-col border-t bg-background",
+        "flex h-full w-full flex-col overflow-auto border-t bg-background",
         "group-data-[expanded=false]/controls:hidden",
       )}
     >
-      <div className="sticky top-0 z-10 mb-2 flex h-10 shrink-0 items-center justify-between border-b bg-background px-3">
+      <div className="sticky top-0 z-20 mb-2 flex h-10 shrink-0 items-center justify-between border-b bg-background px-3">
         <span className="text-sm font-medium">Filters</span>
         {filterWithAI && isLangfuseCloud && (
           <Popover open={aiPopoverOpen} onOpenChange={setAiPopoverOpen}>
@@ -156,7 +156,7 @@ export function DataTableControls({
           </Popover>
         )}
       </div>
-      <div className="flex-1 overflow-auto pb-10">
+      <div className="pb-10">
         <Accordion
           type="multiple"
           className="w-full"
@@ -358,7 +358,7 @@ const FilterAccordionTrigger = ({
   children,
   ...props
 }: React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>) => (
-  <AccordionPrimitive.Header className="flex">
+  <AccordionPrimitive.Header className="sticky top-10 z-10 flex bg-background">
     <AccordionPrimitive.Trigger
       className={cn(
         "flex flex-1 items-center justify-between font-medium hover:underline [&[data-state=open]>svg]:rotate-180",
@@ -401,7 +401,7 @@ export function FilterAccordionItem({
 }: FilterAccordionItemProps) {
   return (
     <FilterAccordionItemPrimitive value={filterKey} className="border-none">
-      <FilterAccordionTrigger className="px-4 py-2 text-sm font-normal text-muted-foreground hover:text-foreground hover:no-underline">
+      <FilterAccordionTrigger className="px-4 py-1.5 text-sm font-normal text-muted-foreground hover:text-foreground hover:no-underline">
         <div className="flex grow items-center gap-1.5 pr-2">
           <span className="flex grow items-baseline gap-1">
             {label}

--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -131,33 +131,31 @@ export function DataTableControls({
   return (
     <div
       className={cn(
-        "h-full w-full border-r border-t bg-background sm:block sm:min-w-52 sm:max-w-52 md:min-w-64 md:max-w-64",
+        "flex h-full w-full flex-col border-t bg-background",
         "group-data-[expanded=false]/controls:hidden",
       )}
     >
-      <div className="flex h-full flex-col overflow-auto pb-10">
-        <div className="mb-2 flex h-10 shrink-0 items-center justify-between border-b px-3">
-          <span className="text-sm font-medium">Filters</span>
-          {filterWithAI && isLangfuseCloud && (
-            <Popover open={aiPopoverOpen} onOpenChange={setAiPopoverOpen}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <PopoverTrigger asChild>
-                    <Button variant="ghost" size="icon" className="h-8 w-8">
-                      <WandSparkles className="h-4 w-4" />
-                    </Button>
-                  </PopoverTrigger>
-                </TooltipTrigger>
-                <TooltipContent>Filter with AI</TooltipContent>
-              </Tooltip>
-              <PopoverContent align="center" className="w-[400px]">
-                <DataTableAIFilters
-                  onFiltersGenerated={handleFiltersGenerated}
-                />
-              </PopoverContent>
-            </Popover>
-          )}
-        </div>
+      <div className="sticky top-0 z-10 mb-2 flex h-10 shrink-0 items-center justify-between border-b bg-background px-3">
+        <span className="text-sm font-medium">Filters</span>
+        {filterWithAI && isLangfuseCloud && (
+          <Popover open={aiPopoverOpen} onOpenChange={setAiPopoverOpen}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <PopoverTrigger asChild>
+                  <Button variant="ghost" size="icon" className="h-8 w-8">
+                    <WandSparkles className="h-4 w-4" />
+                  </Button>
+                </PopoverTrigger>
+              </TooltipTrigger>
+              <TooltipContent>Filter with AI</TooltipContent>
+            </Tooltip>
+            <PopoverContent align="center" className="w-[400px]">
+              <DataTableAIFilters onFiltersGenerated={handleFiltersGenerated} />
+            </PopoverContent>
+          </Popover>
+        )}
+      </div>
+      <div className="flex-1 overflow-auto pb-10">
         <Accordion
           type="multiple"
           className="w-full"

--- a/web/src/components/table/resizable-filter-layout.tsx
+++ b/web/src/components/table/resizable-filter-layout.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { type PropsWithChildren, Children } from "react";
+import { useMediaQuery } from "react-responsive";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/src/components/ui/resizable";
+import { useDataTableControls } from "./data-table-controls";
+
+/** Resizable layout for filter sidebar and table content.
+ *  On mobile, renders a stacked layout instead of resizable panels.
+ *  Expects exactly 2 children: filter sidebar (DataTableControls) and table content.
+ */
+export function ResizableFilterLayout({ children }: PropsWithChildren) {
+  const { open } = useDataTableControls();
+  const isDesktop = useMediaQuery({ query: "(min-width: 768px)" });
+
+  // On mobile, render children as-is (stacked layout)
+  if (!isDesktop) {
+    return <div className="flex flex-1 overflow-hidden">{children}</div>;
+  }
+
+  // Extract filter sidebar and table content from children
+  const childrenArray = Children.toArray(children).filter(Boolean);
+  const filterSidebar = childrenArray[0];
+  const tableContent = childrenArray.slice(1);
+
+  const filterDefault = 15;
+  const tableDefault = 85;
+
+  // If sidebar is collapsed or doesn't exist, render only the table content
+  if (!open || !filterSidebar) {
+    return (
+      <div className="flex flex-1 flex-col overflow-hidden">{tableContent}</div>
+    );
+  }
+
+  return (
+    <ResizablePanelGroup direction="horizontal" className="flex h-full w-full">
+      <ResizablePanel defaultSize={filterDefault} minSize={15} maxSize={50}>
+        <div className="h-full w-full">{filterSidebar}</div>
+      </ResizablePanel>
+      <ResizableHandle />
+      <ResizablePanel defaultSize={tableDefault} minSize={50}>
+        <div className="flex h-full flex-col overflow-hidden">
+          {tableContent}
+        </div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  );
+}

--- a/web/src/components/table/resizable-filter-layout.tsx
+++ b/web/src/components/table/resizable-filter-layout.tsx
@@ -27,8 +27,8 @@ export function ResizableFilterLayout({ children }: PropsWithChildren) {
   const filterSidebar = childrenArray[0];
   const tableContent = childrenArray.slice(1);
 
-  const filterDefault = 15;
-  const tableDefault = 85;
+  const filterDefault = 25;
+  const tableDefault = 75;
 
   // If sidebar is collapsed or doesn't exist, render only the table content
   if (!open || !filterSidebar) {
@@ -39,8 +39,8 @@ export function ResizableFilterLayout({ children }: PropsWithChildren) {
 
   return (
     <ResizablePanelGroup direction="horizontal" className="flex h-full w-full">
-      <ResizablePanel defaultSize={filterDefault} minSize={15} maxSize={50}>
-        <div className="h-full w-full">{filterSidebar}</div>
+      <ResizablePanel defaultSize={filterDefault} minSize={20} maxSize={50}>
+        {filterSidebar}
       </ResizablePanel>
       <ResizableHandle />
       <ResizablePanel defaultSize={tableDefault} minSize={50}>

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -5,6 +5,7 @@ import {
   DataTableControlsProvider,
   DataTableControls,
 } from "@/src/components/table/data-table-controls";
+import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import { useEffect, useMemo, useState, useRef, useCallback } from "react";
 import { TokenUsageBadge } from "@/src/components/token-usage-badge";
 import { NumberParam, useQueryParams, withDefault } from "use-query-params";
@@ -1209,7 +1210,7 @@ export default function ObservationsTable({
         />
 
         {/* Content area with sidebar and table */}
-        <div className="flex flex-1 overflow-hidden">
+        <ResizableFilterLayout>
           <DataTableControls queryFilter={queryFilter} />
 
           <div className="flex flex-1 flex-col overflow-hidden">
@@ -1276,7 +1277,7 @@ export default function ObservationsTable({
               }}
             />
           </div>
-        </div>
+        </ResizableFilterLayout>
       </div>
     </DataTableControlsProvider>
   );

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -5,6 +5,7 @@ import {
   DataTableControlsProvider,
   DataTableControls,
 } from "@/src/components/table/data-table-controls";
+import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import TableLink from "@/src/components/table/table-link";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { IOTableCell } from "../../ui/IOTableCell";
@@ -754,7 +755,7 @@ export default function ScoresTable({
         />
 
         {/* Content area with sidebar and table */}
-        <div className="flex flex-1 overflow-hidden">
+        <ResizableFilterLayout>
           <DataTableControls queryFilter={queryFilter} />
 
           <div className="flex flex-1 flex-col overflow-hidden">
@@ -792,7 +793,7 @@ export default function ScoresTable({
               rowHeight={rowHeight}
             />
           </div>
-        </div>
+        </ResizableFilterLayout>
       </div>
     </DataTableControlsProvider>
   );

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -5,6 +5,7 @@ import {
   DataTableControlsProvider,
   DataTableControls,
 } from "@/src/components/table/data-table-controls";
+import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import TableLink from "@/src/components/table/table-link";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { TokenUsageBadge } from "@/src/components/token-usage-badge";
@@ -736,7 +737,7 @@ export default function SessionsTable({
         />
 
         {/* Content area with sidebar and table */}
-        <div className="flex flex-1 overflow-hidden">
+        <ResizableFilterLayout>
           <DataTableControls queryFilter={queryFilter} />
 
           <div className="flex flex-1 flex-col overflow-hidden">
@@ -799,7 +800,7 @@ export default function SessionsTable({
               rowHeight={rowHeight}
             />
           </div>
-        </div>
+        </ResizableFilterLayout>
       </div>
     </DataTableControlsProvider>
   );

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -5,6 +5,7 @@ import {
   DataTableControlsProvider,
   DataTableControls,
 } from "@/src/components/table/data-table-controls";
+import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import { Badge } from "@/src/components/ui/badge";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { TokenUsageBadge } from "@/src/components/token-usage-badge";
@@ -1228,7 +1229,7 @@ export default function TracesTable({
         )}
 
         {/* Content area with sidebar and table */}
-        <div className="flex flex-1 overflow-hidden">
+        <ResizableFilterLayout>
           {!hideControls && (
             <DataTableControls queryFilter={queryFilter} filterWithAI />
           )}
@@ -1274,7 +1275,7 @@ export default function TracesTable({
               tableName={"traces"}
             />
           </div>
-        </div>
+        </ResizableFilterLayout>
       </div>
     </DataTableControlsProvider>
   );

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -6,6 +6,7 @@ import {
   DataTableControlsProvider,
   DataTableControls,
 } from "@/src/components/table/data-table-controls";
+import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import { InlineFilterState } from "@/src/features/filters/components/filter-builder";
@@ -416,7 +417,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
         />
 
         {/* Content area with sidebar and table */}
-        <div className="flex flex-1 overflow-hidden">
+        <ResizableFilterLayout>
           <DataTableControls queryFilter={queryFilter} />
 
           <div className="flex flex-1 flex-col overflow-hidden">
@@ -468,7 +469,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
               onColumnVisibilityChange={setColumnVisibility}
             />
           </div>
-        </div>
+        </ResizableFilterLayout>
       </div>
       <Dialog
         open={!!editConfigId && existingEvaluator.isSuccess}

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -5,6 +5,7 @@ import {
   DataTableControlsProvider,
   DataTableControls,
 } from "@/src/components/table/data-table-controls";
+import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import { useEffect, useMemo, useState, useRef, useCallback } from "react";
 import { NumberParam, useQueryParams, withDefault } from "use-query-params";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
@@ -1092,7 +1093,7 @@ export default function ObservationsEventsTable({
         />
 
         {/* Content area with sidebar and table */}
-        <div className="flex flex-1 overflow-hidden">
+        <ResizableFilterLayout>
           <DataTableControls queryFilter={queryFilter} />
 
           <div className="flex flex-1 flex-col overflow-hidden">
@@ -1174,7 +1175,7 @@ export default function ObservationsEventsTable({
               }}
             />
           </div>
-        </div>
+        </ResizableFilterLayout>
       </div>
     </DataTableControlsProvider>
   );

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -4,6 +4,7 @@ import {
   DataTableControlsProvider,
   DataTableControls,
 } from "@/src/components/table/data-table-controls";
+import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import TableLink from "@/src/components/table/table-link";
 import { type LangfuseColumnDef } from "@/src/components/table/types";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
@@ -396,7 +397,7 @@ export function PromptTable() {
         />
 
         {/* Content area with sidebar and table */}
-        <div className="flex flex-1 overflow-hidden">
+        <ResizableFilterLayout>
           <DataTableControls queryFilter={queryFilter} />
 
           <div className="flex flex-1 flex-col overflow-hidden">
@@ -437,7 +438,7 @@ export function PromptTable() {
               }}
             />
           </div>
-        </div>
+        </ResizableFilterLayout>
       </div>
     </DataTableControlsProvider>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance UI with resizable filter sidebar and sticky header, integrating `ResizableFilterLayout` across multiple table components.
> 
>   - **UI Enhancements**:
>     - Add `ResizableFilterLayout` in `resizable-filter-layout.tsx` for resizable filter sidebar and table content.
>     - Update `DataTableControls` in `data-table-controls.tsx` to include a sticky header for filters.
>   - **Integration**:
>     - Replace content area divs with `ResizableFilterLayout` in `observations.tsx`, `scores.tsx`, `sessions.tsx`, `traces.tsx`, `evaluator-table.tsx`, `EventsTable.tsx`, and `prompts-table.tsx`.
>   - **Styling**:
>     - Modify CSS classes in `data-table-controls.tsx` for sticky header and layout adjustments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7d68975770c244ce3b56bacf3e5e0f077e7908d0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->