### PR TITLE
fix(ui): main content scrolling should not bounce

### DIFF
--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -379,7 +379,9 @@ export function ResizableContent({ children }: PropsWithChildren) {
   if (!isDesktop) {
     return (
       <>
-        <main className="h-full flex-1" style={{ overscrollBehaviorY: 'none' }}>{children}</main>
+        <main className="h-full flex-1" style={{ overscrollBehaviorY: "none" }}>
+          {children}
+        </main>
 
         <Drawer open={open} onOpenChange={setOpen} forceDirection="bottom">
           <DrawerContent
@@ -408,7 +410,11 @@ export function ResizableContent({ children }: PropsWithChildren) {
 
   // 👉 DESKTOP: if drawer isn't open, render only the main content (like before)
   if (isDesktop && !open) {
-    return <main className="h-full flex-1" style={{ overscrollBehaviorY: 'none' }}>{children}</main>;
+    return (
+      <main className="h-full flex-1" style={{ overscrollBehaviorY: "none" }}>
+        {children}
+      </main>
+    );
   }
 
   const mainDefault = 70;
@@ -417,7 +423,10 @@ export function ResizableContent({ children }: PropsWithChildren) {
   return (
     <ResizablePanelGroup direction="horizontal" className="flex h-full w-full">
       <ResizablePanel defaultSize={mainDefault} minSize={30}>
-        <main className="relative h-full w-full overflow-scroll" style={{ overscrollBehaviorY: 'none' }}>
+        <main
+          className="relative h-full w-full overflow-scroll"
+          style={{ overscrollBehaviorY: "none" }}
+        >
           {children}
         </main>
       </ResizablePanel>

--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -379,7 +379,7 @@ export function ResizableContent({ children }: PropsWithChildren) {
   if (!isDesktop) {
     return (
       <>
-        <main className="h-full flex-1">{children}</main>
+        <main className="h-full flex-1" style={{ overscrollBehaviorY: 'none' }}>{children}</main>
 
         <Drawer open={open} onOpenChange={setOpen} forceDirection="bottom">
           <DrawerContent
@@ -408,7 +408,7 @@ export function ResizableContent({ children }: PropsWithChildren) {
 
   // 👉 DESKTOP: if drawer isn't open, render only the main content (like before)
   if (isDesktop && !open) {
-    return <main className="h-full flex-1">{children}</main>;
+    return <main className="h-full flex-1" style={{ overscrollBehaviorY: 'none' }}>{children}</main>;
   }
 
   const mainDefault = 70;
@@ -417,7 +417,7 @@ export function ResizableContent({ children }: PropsWithChildren) {
   return (
     <ResizablePanelGroup direction="horizontal" className="flex h-full w-full">
       <ResizablePanel defaultSize={mainDefault} minSize={30}>
-        <main className="relative h-full w-full overflow-scroll">
+        <main className="relative h-full w-full overflow-scroll" style={{ overscrollBehaviorY: 'none' }}>
           {children}
         </main>
       </ResizablePanel>

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -177,6 +177,7 @@
     --color-4: oklch(80.2% 0.134 225);
     --color-5: oklch(90.7% 0.231 133);
   }
+
   .theme {
     --animate-rainbow: rainbow var(--speed, 2s) infinite linear;
   }
@@ -241,6 +242,7 @@
     0% {
       background-position: 0%;
     }
+
     100% {
       background-position: 200%;
     }

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -185,6 +185,7 @@
 @layer base {
   * {
     @apply border-border;
+    overscroll-behavior-y: none;
   }
 
   body {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes main content scrolling bounce by setting `overscroll-behavior-y: none` in `layout.tsx` and `globals.css`.
> 
>   - **Behavior**:
>     - Prevents main content scrolling bounce by setting `overscroll-behavior-y: none` in `ResizableContent` in `layout.tsx`.
>     - Applies `overscroll-behavior-y: none` globally in `globals.css` to all elements.
>   - **UI**:
>     - Ensures consistent scrolling behavior across mobile and desktop views in `layout.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 939f84a4bbde46827efee25ba70195af0ed2a3f7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->