### PR TITLE
fix(ui): show sign-in separator only if email/password and sso buttons are available

### DIFF
--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -208,19 +208,24 @@ export function SSOButtons({
       });
   };
 
+  // Only show separator if credentials are enabled (for sign-in) or if action is sign-up (which always has the form)
+  const showSeparator = authProviders.credentials || action !== "sign in";
+
   return (
     // any authprovider from props is enabled
     Object.entries(authProviders).some(
       ([name, enabled]) => enabled && name !== "credentials",
     ) ? (
       <div>
-        {action === "sign in" ? (
-          <div className="my-6 border-t border-border"></div>
-        ) : (
-          <div className="my-6 text-center text-xs text-muted-foreground">
-            or {action} with
-          </div>
-        )}
+        {showSeparator ? (
+          action === "sign in" ? (
+            <div className="my-6 border-t border-border"></div>
+          ) : (
+            <div className="my-6 text-center text-xs text-muted-foreground">
+              or {action} with
+            </div>
+          )
+        ) : null}
         <div className="flex flex-row flex-wrap items-center justify-center gap-2">
           {authProviders.google && (
             <AuthProviderButton


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> UI updates in `sign-in.tsx` and `layout.tsx` to conditionally show separators and resize panels based on drawer state.
> 
>   - **UI Behavior**:
>     - In `sign-in.tsx`, show separator only if credentials are enabled or action is not "sign in".
>     - In `layout.tsx`, use `useLayoutEffect` to resize panels when the support drawer opens/closes on desktop.
>   - **Components**:
>     - `ResizableContent` in `layout.tsx` now uses refs to control panel sizes, preventing remounting children.
>     - Adjusted `ResizablePanel` and `ResizableHandle` rendering based on `open` state.
>   - **Misc**:
>     - Added `useRef` and `useLayoutEffect` imports in `layout.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 887ecdd24f0939b1b4677e38cdfd16e00d44ccc6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->