### PR TITLE
fix(support-sidebar): prevent rerender of main content on-open of sidebar

### DIFF
--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -1,5 +1,11 @@
 import { type Route } from "@/src/components/layouts/routes";
-import { type PropsWithChildren, useEffect, useState } from "react";
+import {
+  type PropsWithChildren,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { useRouter } from "next/router";
 import { getSession, signOut, useSession } from "next-auth/react";
 import Head from "next/head";
@@ -22,6 +28,7 @@ import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
+  type ImperativePanelHandle,
 } from "@/src/components/ui/resizable";
 import {
   PaymentBanner,
@@ -376,6 +383,25 @@ export function ResizableContent({ children }: PropsWithChildren) {
   const { open, setOpen } = useSupportDrawer();
   const isDesktop = useMediaQuery({ query: "(min-width: 768px)" });
 
+  // 👉 DESKTOP: Always render ResizablePanelGroup to prevent remounting children
+  // Use refs to programmatically control panel sizes when drawer opens/closes
+  const drawerPanelRef = useRef<ImperativePanelHandle>(null);
+  const mainPanelRef = useRef<ImperativePanelHandle>(null);
+
+  useLayoutEffect(() => {
+    if (!isDesktop) return;
+
+    if (open) {
+      // Open drawer: resize main to 70%, drawer to 30%
+      drawerPanelRef.current?.resize(30);
+      mainPanelRef.current?.resize(70);
+    } else {
+      // Close drawer: resize main to 100%, drawer to 0%
+      drawerPanelRef.current?.resize(0);
+      mainPanelRef.current?.resize(100);
+    }
+  }, [open, isDesktop]);
+
   if (!isDesktop) {
     return (
       <>
@@ -406,24 +432,23 @@ export function ResizableContent({ children }: PropsWithChildren) {
     );
   }
 
-  // 👉 DESKTOP: if drawer isn't open, render only the main content (like before)
-  if (isDesktop && !open) {
-    return <main className="h-full flex-1">{children}</main>;
-  }
-
-  const mainDefault = 70;
-  const drawerDefault = 30;
-
   return (
     <ResizablePanelGroup direction="horizontal" className="flex h-full w-full">
-      <ResizablePanel defaultSize={mainDefault} minSize={30}>
+      <ResizablePanel ref={mainPanelRef} defaultSize={100} minSize={30}>
         <main className="relative h-full w-full overflow-scroll">
           {children}
         </main>
       </ResizablePanel>
-      <ResizableHandle withHandle />
-      <ResizablePanel defaultSize={drawerDefault} minSize={20} maxSize={60}>
-        <SupportDrawer />
+      {open && <ResizableHandle withHandle />}
+      <ResizablePanel
+        ref={drawerPanelRef}
+        defaultSize={0}
+        minSize={0}
+        maxSize={60}
+        collapsible={true}
+        collapsedSize={0}
+      >
+        {open && <SupportDrawer />}
       </ResizablePanel>
     </ResizablePanelGroup>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevents rerender of main content on desktop when support sidebar opens/closes by using `ResizablePanelGroup` and refs in `ResizableContent`.
> 
>   - **Behavior**:
>     - Prevents rerender of main content when support sidebar opens/closes on desktop by always rendering `ResizablePanelGroup` in `ResizableContent`.
>     - Uses `useLayoutEffect` and refs (`drawerPanelRef`, `mainPanelRef`) to resize panels programmatically based on `open` state.
>   - **Desktop Specific**:
>     - On open, resizes main panel to 70% and drawer to 30%.
>     - On close, resizes main panel to 100% and drawer to 0%.
>   - **Mobile Specific**:
>     - No changes; continues to use `Drawer` for support sidebar.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0ff61142bd0f61315df1a2856073d07f3013ced8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->