### PR TITLE
feat(ui): auto-apply ellipsis to small row height strings, align start for larger row heights

### DIFF
--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -549,7 +549,7 @@ function TableBodyComponent<TData>({
             {row.getVisibleCells().map((cell) => {
               const cellValue = cell.getValue();
               const isStringCell = typeof cellValue === "string";
-              const isSmallRowHeight = rowHeight === "s";
+              const isSmallRowHeight = (rowHeight ?? "s") === "s";
 
               return (
                 <TableCell

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -406,6 +406,7 @@ export function DataTable<TData extends object, TValue>({
               <MemoizedTableBody
                 table={table}
                 rowheighttw={rowheighttw}
+                rowHeight={rowHeight}
                 columns={columns}
                 data={data}
                 help={help}
@@ -422,6 +423,7 @@ export function DataTable<TData extends object, TValue>({
               <TableBodyComponent
                 table={table}
                 rowheighttw={rowheighttw}
+                rowHeight={rowHeight}
                 columns={columns}
                 data={data}
                 help={help}
@@ -466,6 +468,7 @@ function renderOrderingIndicator(orderBy?: OrderByState) {
 interface TableBodyComponentProps<TData> {
   table: ReturnType<typeof useReactTable<TData>>;
   rowheighttw?: string;
+  rowHeight?: RowHeight;
   columns: LangfuseColumnDef<TData, any>[];
   data: AsyncTableData<TData[]>;
   help?: { description: string; href: string };
@@ -517,6 +520,7 @@ function TableRowComponent<TData>({
 function TableBodyComponent<TData>({
   table,
   rowheighttw,
+  rowHeight,
   columns,
   data,
   help,
@@ -542,24 +546,54 @@ function TableBodyComponent<TData>({
             onRowClick={onRowClick}
             getRowClassName={getRowClassName}
           >
-            {row.getVisibleCells().map((cell) => (
-              <TableCell
-                key={cell.id}
-                className={cn(
-                  "overflow-hidden border-b p-1 text-xs first:pl-2",
-                  rowheighttw === "s" && "whitespace-nowrap",
-                  getPinningClasses(cell.column),
-                )}
-                style={{
-                  width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
-                  ...getCommonPinningStyles(cell.column),
-                }}
-              >
-                <div className={cn("flex items-center", rowheighttw)}>
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </div>
-              </TableCell>
-            ))}
+            {row.getVisibleCells().map((cell) => {
+              const cellValue = cell.getValue();
+              const isStringCell = typeof cellValue === "string";
+              const isSmallRowHeight = rowHeight === "s";
+
+              return (
+                <TableCell
+                  key={cell.id}
+                  className={cn(
+                    "overflow-hidden border-b p-1 text-xs first:pl-2",
+                    isSmallRowHeight && "whitespace-nowrap",
+                    getPinningClasses(cell.column),
+                  )}
+                  style={{
+                    width: `calc(var(--col-${cell.column.id}-size) * 1px)`,
+                    ...getCommonPinningStyles(cell.column),
+                  }}
+                >
+                  <div
+                    className={cn(
+                      "flex",
+                      isStringCell && !isSmallRowHeight
+                        ? "items-start"
+                        : "items-center",
+                      rowheighttw,
+                    )}
+                  >
+                    {isStringCell && isSmallRowHeight ? (
+                      <div className="min-w-0 flex-1 truncate">
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
+                      </div>
+                    ) : isStringCell && !isSmallRowHeight ? (
+                      <div className="min-w-0 flex-1 overflow-hidden text-ellipsis">
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
+                      </div>
+                    ) : (
+                      flexRender(cell.column.columnDef.cell, cell.getContext())
+                    )}
+                  </div>
+                </TableCell>
+              );
+            })}
           </TableRowComponent>
         ))
       ) : (
@@ -608,6 +642,7 @@ const MemoizedTableBody = React.memo(TableBodyComponent, (prev, next) => {
   if (prev.table.options.data !== next.table.options.data) return false;
   if (prev.data.isLoading !== next.data.isLoading) return false;
   if (prev.rowheighttw !== next.rowheighttw) return false;
+  if (prev.rowHeight !== next.rowHeight) return false;
 
   // Then do more expensive deep equality checks
   if (

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -567,21 +567,20 @@ function TableBodyComponent<TData>({
                   <div
                     className={cn(
                       "flex",
-                      isStringCell && !isSmallRowHeight
-                        ? "items-start"
-                        : "items-center",
+                      "items-start",
+                      isSmallRowHeight && "items-center",
                       rowheighttw,
                     )}
                   >
                     {isStringCell && isSmallRowHeight ? (
-                      <div className="min-w-0 flex-1 truncate">
+                      <div className="min-w-0 truncate">
                         {flexRender(
                           cell.column.columnDef.cell,
                           cell.getContext(),
                         )}
                       </div>
                     ) : isStringCell && !isSmallRowHeight ? (
-                      <div className="min-w-0 flex-1 overflow-hidden text-ellipsis">
+                      <div className="min-w-0 overflow-hidden text-ellipsis">
                         {flexRender(
                           cell.column.columnDef.cell,
                           cell.getContext(),

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -518,11 +518,7 @@ export default function ObservationsTable({
       enableSorting: true,
       cell: ({ row }) => {
         const value: ObservationsTableRow["name"] = row.getValue("name");
-        return value ? (
-          <span className="truncate" title={value}>
-            {value}
-          </span>
-        ) : undefined;
+        return value ?? undefined;
       },
     },
     {

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -542,11 +542,7 @@ export default function TracesTable({
       enableSorting,
       cell: ({ row }) => {
         const value: TracesTableRow["name"] = row.getValue("name");
-        return value ? (
-          <span className="truncate" title={value}>
-            {value}
-          </span>
-        ) : undefined;
+        return value ?? undefined;
       },
     },
     {

--- a/web/src/features/datasets/components/DatasetRunItemsByItemTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsByItemTable.tsx
@@ -198,7 +198,7 @@ export function DatasetRunItemsByItemTable(props: {
       cell: ({ row }) => {
         const totalCost: DatasetRunItemByItemRowData["totalCost"] =
           row.getValue("totalCost");
-        return <>{totalCost}</>;
+        return totalCost ?? undefined;
       },
     },
     {

--- a/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
@@ -166,7 +166,7 @@ export function DatasetRunItemsByRunTable(props: {
       cell: ({ row }) => {
         const totalCost: DatasetRunItemByRunRowData["totalCost"] =
           row.getValue("totalCost");
-        return <>{totalCost}</>;
+        return totalCost ?? undefined;
       },
     },
     {

--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -421,11 +421,7 @@ export function DatasetRunsTable(props: {
       cell: ({ row }) => {
         const description: DatasetRunRowData["description"] =
           row.getValue("description");
-        return (
-          <div className="max-h-full max-w-full overflow-y-auto overflow-x-hidden break-words">
-            {description}
-          </div>
-        );
+        return description;
       },
     },
     {

--- a/web/src/features/datasets/components/DatasetsTable.tsx
+++ b/web/src/features/datasets/components/DatasetsTable.tsx
@@ -159,11 +159,7 @@ export function DatasetsTable(props: { projectId: string }) {
       cell: ({ row }) => {
         const description: DatasetTableRow["description"] =
           row.getValue("description");
-        return (
-          <div className="max-h-full max-w-full overflow-y-auto overflow-x-hidden break-words">
-            {description}
-          </div>
-        );
+        return description;
       },
     },
     {

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -444,11 +444,7 @@ export default function ObservationsEventsTable({
       enableSorting: true,
       cell: ({ row }) => {
         const value: EventsTableRow["name"] = row.getValue("name");
-        return value ? (
-          <span className="truncate" title={value}>
-            {value}
-          </span>
-        ) : undefined;
+        return value ?? undefined;
       },
     },
     {

--- a/web/src/pages/project/[projectId]/users.tsx
+++ b/web/src/pages/project/[projectId]/users.tsx
@@ -265,9 +265,7 @@ const UsersTable = () => {
         if (!userMetrics.isSuccess) {
           return <Skeleton className="h-3 w-1/2" />;
         }
-        if (typeof value === "string") {
-          return <>{value}</>;
-        }
+        return typeof value === "string" ? value : undefined;
       },
     },
     {
@@ -282,9 +280,7 @@ const UsersTable = () => {
         if (!userMetrics.isSuccess) {
           return <Skeleton className="h-3 w-1/2" />;
         }
-        if (typeof value === "string") {
-          return <>{value}</>;
-        }
+        return typeof value === "string" ? value : undefined;
       },
     },
     {
@@ -301,9 +297,7 @@ const UsersTable = () => {
         if (!userMetrics.isSuccess) {
           return <Skeleton className="h-3 w-1/2" />;
         }
-        if (typeof value === "string") {
-          return <>{value}</>;
-        }
+        return typeof value === "string" ? value : undefined;
       },
     },
     {
@@ -320,9 +314,7 @@ const UsersTable = () => {
         if (!userMetrics.isSuccess) {
           return <Skeleton className="h-3 w-1/2" />;
         }
-        if (typeof value === "string") {
-          return <>{value}</>;
-        }
+        return typeof value === "string" ? value : undefined;
       },
     },
     {
@@ -338,9 +330,7 @@ const UsersTable = () => {
         if (!userMetrics.isSuccess) {
           return <Skeleton className="h-3 w-1/2" />;
         }
-        if (typeof value === "string") {
-          return <>{value}</>;
-        }
+        return typeof value === "string" ? value : undefined;
       },
     },
   ];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Automatically apply ellipsis to string cells with small row height in tables and remove redundant JSX elements.
> 
>   - **Behavior**:
>     - Automatically applies ellipsis to string cells in `TableBodyComponent` in `data-table.tsx` when `rowHeight` is small.
>     - Removes redundant JSX elements in `observations.tsx`, `traces.tsx`, `DatasetRunItemsByItemTable.tsx`, `DatasetRunItemsByRunTable.tsx`, `DatasetRunsTable.tsx`, `DatasetsTable.tsx`, `EventsTable.tsx`, and `users.tsx`.
>   - **Props**:
>     - Adds `rowHeight` prop to `TableBodyComponent` and `MemoizedTableBody` in `data-table.tsx`.
>   - **Memoization**:
>     - Updates `MemoizedTableBody` in `data-table.tsx` to consider `rowHeight` in memoization logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4715dbea2b12ca6ad4e34b2d2a9f4e830b0274a2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->