### PR TITLE
feat(ui): in api key .env show actual base_url and show .env in new api key modal

### DIFF
--- a/web/src/features/public-api/components/ApiKeyList.tsx
+++ b/web/src/features/public-api/components/ApiKeyList.tsx
@@ -29,22 +29,20 @@ import { TrashIcon } from "lucide-react";
 import { useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 import { startCase } from "lodash";
+import { useLangfuseEnvCode } from "@/src/features/public-api/hooks/useLangfuseEnvCode";
 
 type ApiKeyScope = "project" | "organization";
 type ApiKeyEntity = { id: string; note: string | null };
 
 export function ApiKeyList(props: { entityId: string; scope: ApiKeyScope }) {
   const { entityId, scope } = props;
+  const envCode = useLangfuseEnvCode();
+
   if (!entityId) {
     throw new Error(
       `${scope}Id is required for ApiKeyList with scope ${scope}`,
     );
   }
-
-  const envCode = `LANGFUSE_SECRET_KEY = "sk-lf-..."
-LANGFUSE_PUBLIC_KEY = "pk-lf-..."
-LANGFUSE_BASE_URL = "https://cloud.langfuse.com" # 🇪🇺 EU region
-# LANGFUSE_BASE_URL = "https://us.cloud.langfuse.com" # 🇺🇸 US region`;
 
   const hasProjectAccess = useHasProjectAccess({
     projectId: props.entityId,

--- a/web/src/features/public-api/components/CreateApiKeyButton.tsx
+++ b/web/src/features/public-api/components/CreateApiKeyButton.tsx
@@ -15,9 +15,8 @@ import { CodeView } from "@/src/components/ui/CodeJsonViewer";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
-import { useUiCustomization } from "@/src/ee/features/ui-customization/useUiCustomization";
-import { env } from "@/src/env.mjs";
 import { Input } from "@/src/components/ui/input";
+import { useLangfuseEnvCode } from "@/src/features/public-api/hooks/useLangfuseEnvCode";
 import { Label } from "@/src/components/ui/label";
 import { cn } from "@/src/utils/tailwind";
 import { SubHeader } from "@/src/components/layouts/header";
@@ -167,7 +166,8 @@ export const ApiKeyRender = ({
   generatedKeys?: { secretKey: string; publicKey: string };
   className?: string;
 }) => {
-  const uiCustomization = useUiCustomization();
+  const envCode = useLangfuseEnvCode(generatedKeys);
+
   return (
     <div className={cn("space-y-6", className)}>
       <div>
@@ -189,11 +189,8 @@ export const ApiKeyRender = ({
         />
       </div>
       <div>
-        <SubHeader title="Host" />
-        <CodeView
-          content={`${uiCustomization?.hostname ?? window.origin}${env.NEXT_PUBLIC_BASE_PATH ?? ""}`}
-          className="mt-2"
-        />
+        <SubHeader title=".env" />
+        <CodeView content={envCode} className="mt-2" />
       </div>
     </div>
   );

--- a/web/src/features/public-api/hooks/useLangfuseEnvCode.ts
+++ b/web/src/features/public-api/hooks/useLangfuseEnvCode.ts
@@ -1,0 +1,20 @@
+import { useUiCustomization } from "@/src/ee/features/ui-customization/useUiCustomization";
+import { env } from "@/src/env.mjs";
+
+export function useLangfuseEnvCode(keys?: {
+  secretKey: string;
+  publicKey: string;
+}): string {
+  const uiCustomization = useUiCustomization();
+  const baseUrl = `${uiCustomization?.hostname ?? window.origin}${env.NEXT_PUBLIC_BASE_PATH ?? ""}`;
+
+  if (keys) {
+    return `LANGFUSE_SECRET_KEY = "${keys.secretKey}"
+LANGFUSE_PUBLIC_KEY = "${keys.publicKey}"
+LANGFUSE_BASE_URL = "${baseUrl}"`;
+  }
+
+  return `LANGFUSE_SECRET_KEY = "sk-lf-..."
+LANGFUSE_PUBLIC_KEY = "pk-lf-..."
+LANGFUSE_BASE_URL = "${baseUrl}"`;
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Display actual `base_url` in `.env` and show `.env` in new API key modal using `useLangfuseEnvCode`.
> 
>   - **Behavior**:
>     - Display actual `base_url` in `.env` file using `useLangfuseEnvCode` in `ApiKeyList.tsx` and `CreateApiKeyButton.tsx`.
>     - Show `.env` content in new API key modal in `CreateApiKeyButton.tsx`.
>   - **Hooks**:
>     - Add `useLangfuseEnvCode` in `useLangfuseEnvCode.ts` to generate `.env` content with `LANGFUSE_SECRET_KEY`, `LANGFUSE_PUBLIC_KEY`, and `LANGFUSE_BASE_URL`.
>   - **Misc**:
>     - Remove hardcoded `.env` content from `ApiKeyList.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 132e1f09ef95092b2b1d93e03800a471c449afdc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->