### PR TITLE
perf: reduce dual write memory consumption via join order

### DIFF
--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -338,8 +338,8 @@ export const handleEventPropagationJob = async (
           obs.updated_at,
           obs.event_ts,
           obs.is_deleted
-        FROM relevant_traces t
-        RIGHT JOIN observations_batch_staging obs FINAL
+        FROM observations_batch_staging obs FINAL
+        LEFT JOIN relevant_traces t
         ON (
           obs.project_id = t.project_id AND
           obs.trace_id = t.id


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize memory usage in `handleEventPropagationJob` by changing SQL join order from `RIGHT JOIN` to `LEFT JOIN`.
> 
>   - **SQL Query Optimization**:
>     - In `handleEventPropagationJob` in `handleEventPropagationJob.ts`, change join order in SQL query from `RIGHT JOIN` to `LEFT JOIN` between `observations_batch_staging` and `relevant_traces` to reduce memory consumption.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 42fd4c4891b5d8c52652d04c8b2d1a992c3d1f4c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->