### PR TITLE
chore(comments): switch to defensive projectId

### DIFF
--- a/web/src/server/api/routers/commentReactions.ts
+++ b/web/src/server/api/routers/commentReactions.ts
@@ -43,6 +43,8 @@ export const commentReactionsRouter = createTRPCRouter({
         }
 
         // Upsert reaction (idempotent)
+        // Use comment.projectId (verified DB record) instead of input.projectId
+        // to guard against edge cases where input could be undefined despite validation
         const reaction = await ctx.prisma.commentReaction.upsert({
           where: {
             commentId_userId_emoji: {
@@ -52,7 +54,7 @@ export const commentReactionsRouter = createTRPCRouter({
             },
           },
           create: {
-            projectId: input.projectId,
+            projectId: comment.projectId,
             commentId: input.commentId,
             userId: ctx.session.user.id,
             emoji: input.emoji,
@@ -105,12 +107,13 @@ export const commentReactionsRouter = createTRPCRouter({
         }
 
         // Delete reaction with project safety check
+        // Use comment.projectId (verified DB record) instead of input.projectId
         const deletedReaction = await ctx.prisma.commentReaction.deleteMany({
           where: {
             commentId: input.commentId,
             userId: ctx.session.user.id,
             emoji: input.emoji,
-            projectId: input.projectId,
+            projectId: comment.projectId,
           },
         });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switch `commentReactionsRouter` to use verified `comment.projectId` instead of `input.projectId` for safer reaction operations.
> 
>   - **Behavior**:
>     - In `commentReactionsRouter`, use `comment.projectId` instead of `input.projectId` for `upsert` and `deleteMany` operations to ensure project ID is verified from the database.
>     - Guards against edge cases where `input.projectId` could be undefined despite validation.
>   - **Functions**:
>     - Affects `add` and `remove` mutations in `commentReactionsRouter`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0cfd373c0f92cb352765cf0ea72f201daa008a72. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->