### PR TITLE
fix(ui): more compact header

### DIFF
--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -71,7 +71,7 @@ const PageHeader = ({
         <div className="border-b">
           <div
             className={cn(
-              "flex min-h-12 items-center gap-3 px-3 py-2",
+              "flex min-h-11 items-center gap-3 px-3 py-2",
               container && "lg:container",
             )}
           >
@@ -87,7 +87,7 @@ const PageHeader = ({
         <div className="bg-header">
           <div
             className={cn(
-              "flex min-h-12 w-full flex-wrap items-center justify-between gap-1 px-3 py-1 md:flex-nowrap",
+              "flex min-h-11 w-full flex-wrap items-center justify-between gap-1 px-3 py-1 md:flex-nowrap",
               container && "lg:container",
             )}
           >

--- a/web/src/components/nav/app-sidebar.tsx
+++ b/web/src/components/nav/app-sidebar.tsx
@@ -49,7 +49,7 @@ export function AppSidebar({
   return (
     <Sidebar collapsible="icon" variant="sidebar" {...props}>
       <SidebarHeader>
-        <div className="flex min-h-10 items-center gap-2 px-2 py-2 group-data-[collapsible=icon]:p-3">
+        <div className="flex min-h-9 items-center gap-2 px-2 py-2 group-data-[collapsible=icon]:p-3">
           <LangfuseLogo version />
         </div>
         <div className="h-1 flex-1 border-b" />

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -372,7 +372,7 @@ const SidebarHeader = React.forwardRef<
     <div
       ref={ref}
       data-sidebar="header"
-      className={cn("flex min-h-12 flex-col pt-2 md:h-fit", className)}
+      className={cn("flex min-h-11 flex-col pt-2 md:h-fit", className)}
       {...props}
     />
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce minimum height of header components for a more compact UI in `PageHeader`, `AppSidebar`, and `SidebarHeader`.
> 
>   - **UI Changes**:
>     - Reduce `min-h-12` to `min-h-11` in `PageHeader` for both top and bottom rows.
>     - Reduce `min-h-10` to `min-h-9` in `AppSidebar` for the `SidebarHeader`.
>     - Reduce `min-h-12` to `min-h-11` in `SidebarHeader` component.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e84587bf1b72a19cac68176c6a78bb6fddc4005d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->