### PR TITLE
feat(annotation-ui): rollback optimistic score writes on error

### DIFF
--- a/web/src/features/scores/components/AnnotationForm.tsx
+++ b/web/src/features/scores/components/AnnotationForm.tsx
@@ -271,20 +271,49 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
     deleteMutation.isPending,
   ]);
 
+  const rollbackDeleteError = (
+    index: number,
+    field: (typeof controlledFields)[number],
+    previousScore: {
+      id: string | null;
+      value?: number | null;
+      stringValue?: string | null;
+      comment?: string | null;
+      timestamp?: Date | null;
+    },
+  ) => {
+    // Rollback field array
+    update(index, {
+      name: field.name,
+      dataType: field.dataType,
+      configId: field.configId,
+      ...previousScore,
+    });
+    // Rollback form values directly to ensure sync
+    form.setValue(`scoreData.${index}.id`, previousScore.id);
+    form.setValue(`scoreData.${index}.value`, previousScore.value);
+    form.setValue(`scoreData.${index}.stringValue`, previousScore.stringValue);
+    form.setValue(`scoreData.${index}.comment`, previousScore.comment);
+    form.setValue(`scoreData.${index}.timestamp`, previousScore.timestamp);
+    form.setError(`scoreData.${index}.value`, {
+      type: "server",
+      message: "Failed to delete score",
+    });
+  };
+
   const handleDeleteScore = (index: number) => {
     const field = controlledFields[index];
 
-    if (field.id) {
-      deleteMutation.mutate({
-        id: field.id,
-        projectId: scoreMetadata.projectId,
-      });
-    }
+    // Capture previous state for rollback
+    const previousScore = {
+      id: field.id,
+      value: field.value,
+      stringValue: field.stringValue,
+      comment: field.comment,
+      timestamp: field.timestamp,
+    };
 
-    // Capture delete event
-    capture("score:delete", analyticsData);
-
-    // Remove from form
+    // Optimistically clear form
     form.clearErrors(`scoreData.${index}.value`);
     update(index, {
       name: field.name,
@@ -294,6 +323,52 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
       value: null,
       stringValue: null,
       comment: null,
+    });
+
+    // Fire mutation with rollback
+    if (previousScore.id) {
+      deleteMutation.mutate(
+        {
+          id: previousScore.id,
+          projectId: scoreMetadata.projectId,
+        },
+        {
+          onError: () => rollbackDeleteError(index, field, previousScore),
+        },
+      );
+    }
+
+    // Capture delete event
+    capture("score:delete", analyticsData);
+  };
+
+  const rollbackUpdateError = (
+    index: number,
+    previousValue?: number | null,
+    previousStringValue?: string | null,
+  ) => {
+    form.setValue(`scoreData.${index}.value`, previousValue);
+    form.setValue(`scoreData.${index}.stringValue`, previousStringValue);
+    form.setError(`scoreData.${index}.value`, {
+      type: "server",
+      message: "Failed to update score",
+    });
+  };
+
+  const rollbackCreateError = (
+    index: number,
+    previousValue?: number | null,
+    previousStringValue?: string | null,
+    previousId?: string | null,
+    previousTimestamp?: Date | null,
+  ) => {
+    form.setValue(`scoreData.${index}.id`, previousId);
+    form.setValue(`scoreData.${index}.timestamp`, previousTimestamp);
+    form.setValue(`scoreData.${index}.value`, previousValue);
+    form.setValue(`scoreData.${index}.stringValue`, previousStringValue);
+    form.setError(`scoreData.${index}.value`, {
+      type: "server",
+      message: "Failed to create score",
     });
   };
 
@@ -311,10 +386,8 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
     const previousId = field.id;
     const previousTimestamp = field.timestamp;
 
-    // Clear errors
+    // Clear errors and update form optimistically
     form.clearErrors(`scoreData.${index}.value`);
-
-    // Keep form state in sync - update both value and stringValue
     form.setValue(`scoreData.${index}.value`, value);
     form.setValue(`scoreData.${index}.stringValue`, stringValue);
 
@@ -341,23 +414,13 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
           timestamp: scoreTimestamp ?? undefined,
         } as UpdateAnnotationScoreData,
         {
-          onError: () => {
-            // Rollback form to previous state
-            form.setValue(`scoreData.${index}.value`, previousValue);
-            form.setValue(
-              `scoreData.${index}.stringValue`,
-              previousStringValue,
-            );
-            form.setError(`scoreData.${index}.value`, {
-              message: "Update failed",
-            });
-          },
+          onError: () =>
+            rollbackUpdateError(index, previousValue, previousStringValue),
         },
       );
     } else {
       const id = uuid();
       const timestamp = new Date();
-      // Update scoreId and timestamp in form for future updates
       form.setValue(`scoreData.${index}.id`, id);
       form.setValue(`scoreData.${index}.timestamp`, timestamp);
       createMutation.mutate(
@@ -367,19 +430,14 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
           timestamp,
         } as CreateAnnotationScoreData,
         {
-          onError: () => {
-            // Rollback form to empty state (was a create)
-            form.setValue(`scoreData.${index}.id`, previousId);
-            form.setValue(`scoreData.${index}.timestamp`, previousTimestamp);
-            form.setValue(`scoreData.${index}.value`, previousValue);
-            form.setValue(
-              `scoreData.${index}.stringValue`,
+          onError: () =>
+            rollbackCreateError(
+              index,
+              previousValue,
               previousStringValue,
-            );
-            form.setError(`scoreData.${index}.value`, {
-              message: "Create failed",
-            });
-          },
+              previousId,
+              previousTimestamp,
+            ),
         },
       );
     }
@@ -429,20 +487,34 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
     handleUpsert(index, numericCategoryValue, stringValue);
   };
 
+  const rollbackCommentError = (
+    index: number,
+    field: (typeof controlledFields)[number],
+    previousComment?: string | null,
+  ) => {
+    update(index, {
+      ...field,
+      comment: previousComment,
+    });
+    form.setError(`scoreData.${index}.comment`, {
+      type: "server",
+      message: "Failed to update comment",
+    });
+  };
+
   const handleCommentUpdate = (index: number, newComment: string | null) => {
     const field = controlledFields[index];
     if (!field || !field.id) return;
 
-    // Capture previous comment for rollback
     const previousComment = field.comment;
 
-    // Update form with the new comment value
+    // Optimistically update form
     update(index, {
       ...field,
       comment: newComment,
     });
 
-    // Fire mutation with new comment (only pass necessary fields)
+    // Fire mutation
     updateMutation.mutate(
       {
         ...field,
@@ -451,17 +523,7 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
         comment: newComment,
       } as UpdateAnnotationScoreData,
       {
-        onError: () => {
-          // Rollback form comment to previous state
-          update(index, {
-            ...field,
-            comment: previousComment,
-          });
-          form.setError(`scoreData.${index}.comment`, {
-            type: "server",
-            message: "Failed to update comment",
-          });
-        },
+        onError: () => rollbackCommentError(index, field, previousComment),
       },
     );
   };

--- a/web/src/features/scores/components/AnnotationForm.tsx
+++ b/web/src/features/scores/components/AnnotationForm.tsx
@@ -353,6 +353,10 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
 
     if (!config || !field) return;
 
+    if (field.value === null || field.value === undefined) {
+      return; // Don't create/update score with empty value
+    }
+
     // Client-side validation - don't fire mutation if invalid
     const errorMessage = validateNumericScore({
       value: field.value,

--- a/web/src/features/scores/contexts/ScoreCacheContext.tsx
+++ b/web/src/features/scores/contexts/ScoreCacheContext.tsx
@@ -41,6 +41,7 @@ type ScoreCacheContextValue = {
   set: (id: string, score: CachedScore) => void;
   get: (id: string) => CachedScore | undefined;
   delete: (id: string) => void;
+  remove: (id: string) => void;
   isDeleted: (id: string) => boolean;
   clear: () => void;
 
@@ -93,6 +94,16 @@ export function ScoreCacheProvider({ children }: { children: ReactNode }) {
       return newSet;
     });
     // Also remove from cache if present
+    setCache((prev) => {
+      if (!prev.has(id)) return prev;
+      const newCache = new Map(prev);
+      newCache.delete(id);
+      return newCache;
+    });
+  }, []);
+
+  const remove = useCallback((id: string) => {
+    // Remove from cache without marking as deleted
     setCache((prev) => {
       if (!prev.has(id)) return prev;
       const newCache = new Map(prev);
@@ -175,6 +186,7 @@ export function ScoreCacheProvider({ children }: { children: ReactNode }) {
         set,
         get,
         delete: deleteScore,
+        remove,
         isDeleted,
         clear,
         getAllForTarget,

--- a/web/src/features/scores/hooks/useScoreMutations.ts
+++ b/web/src/features/scores/hooks/useScoreMutations.ts
@@ -5,6 +5,7 @@ import {
 } from "@/src/features/scores/lib/helpers";
 import { useScoreCache } from "@/src/features/scores/contexts/ScoreCacheContext";
 import { type ScoreTarget } from "@langfuse/shared";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 
 export function useScoreMutations({
   scoreTarget,
@@ -21,13 +22,9 @@ export function useScoreMutations({
     set: cacheSet,
     get: cacheGet,
     delete: cacheDelete,
+    remove: cacheRemove,
     setColumn: cacheSetColumn,
   } = useScoreCache();
-
-  // Rather than rolling back optimistic updates, we reload the page to clear the cache and invalidate trpc queries
-  const onError = () => {
-    window.location.reload();
-  };
 
   // Create mutations with cache writes
   const createMutation = api.scores.createAnnotationScore.useMutation({
@@ -60,15 +57,22 @@ export function useScoreMutations({
         comment: variables.comment ?? null,
         timestamp: variables.timestamp ?? new Date(),
       });
+
+      return { scoreId: variables.id! };
     },
-    onError,
+    onError: (err, variables) => {
+      if (!variables.id) return;
+      // Remove failed create from cache
+      cacheRemove(variables.id);
+      showErrorToast("Failed to create score", err.message, "WARNING");
+    },
   });
 
   const updateMutation = api.scores.updateAnnotationScore.useMutation({
     onMutate: (variables) => {
-      const existing = cacheGet(variables.id);
+      const previousCacheValue = cacheGet(variables.id);
 
-      if (!existing) {
+      if (!previousCacheValue) {
         // Write to cache for optimistic update
         cacheSet(variables.id, {
           id: variables.id,
@@ -91,14 +95,27 @@ export function useScoreMutations({
       } else {
         // Merge update into existing cache entry
         cacheSet(variables.id, {
-          ...existing,
-          value: variables.value ?? existing.value,
-          stringValue: variables.stringValue ?? existing.stringValue,
+          ...previousCacheValue,
+          value: variables.value ?? previousCacheValue.value,
+          stringValue: variables.stringValue ?? previousCacheValue.stringValue,
           comment: variables.comment ?? null,
         });
       }
+
+      return { previousCacheValue };
     },
-    onError,
+    onError: (err, variables, context) => {
+      // Rollback cache
+      if (context?.previousCacheValue) {
+        // Had cache entry → restore previous value
+        cacheSet(variables.id, context.previousCacheValue);
+      } else {
+        // No cache entry → was DB-persisted → remove optimistic update
+        cacheRemove(variables.id);
+      }
+
+      showErrorToast("Failed to update score", err.message, "WARNING");
+    },
   });
 
   const deleteMutation = api.scores.deleteAnnotationScore.useMutation({
@@ -106,7 +123,9 @@ export function useScoreMutations({
       // Mark score as deleted
       cacheDelete(variables.id);
     },
-    onError,
+    onError: () => {
+      window.location.reload();
+    },
   });
 
   return {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add rollback mechanisms for optimistic score writes in `AnnotationForm.tsx`, ensuring cache consistency and user feedback on errors.
> 
>   - **Behavior**:
>     - Add rollback mechanisms for optimistic score writes in `AnnotationForm.tsx`.
>     - Rollback on create, update, and delete errors using `rollbackCreateError`, `rollbackUpdateError`, and `rollbackDeleteError`.
>     - Show error toasts on mutation failures in `useScoreMutations.ts`.
>   - **Cache Management**:
>     - Add `rollbackSet` and `rollbackDelete` functions to `ScoreCacheContext.tsx` for cache consistency.
>     - Use these functions in `useScoreMutations.ts` to handle cache rollbacks on errors.
>   - **Misc**:
>     - Update `useScoreMutations.ts` to integrate rollback logic and error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d645f66b19ea6a8363777f1964bff4fcabcb0a4e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->