### PR TITLE
feat(trace): prefetch observation IO on hover

### DIFF
--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -346,6 +346,8 @@ export function Trace(props: {
       hiddenObservationsCount={hiddenObservationsCount}
       minLevel={minObservationLevel}
       setMinLevel={setMinObservationLevel}
+      projectId={props.projectId}
+      traceId={props.trace.id}
     />
   );
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds prefetching of observation data on hover in `TraceTree` to improve performance by reducing fetch times.
> 
>   - **Behavior**:
>     - Adds `handleObservationHover` in `TraceTree.tsx` to prefetch observation data on hover using `utils.observations.byId.prefetch`.
>     - Prefetching is skipped for nodes of type `TRACE`.
>   - **Components**:
>     - Updates `TraceTree` and `TreeNodeComponent` to include `onObservationHover` prop for hover functionality.
>     - Passes `projectId` and `traceId` to `TraceTree` in `index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7e4a3dd5042be5a2b062418484f2bde46d58436a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->