### PR TITLE
chore: skip start_time clamping with new table layout

### DIFF
--- a/worker/src/backgroundMigrations/backfillEventsHistoric.ts
+++ b/worker/src/backgroundMigrations/backfillEventsHistoric.ts
@@ -302,7 +302,7 @@ export default class BackfillEventsHistoric implements IBackgroundMigration {
             WHEN o.id = concat('t-', o.trace_id) THEN ''
             ELSE coalesce(o.parent_observation_id, concat('t-', o.trace_id))
           END AS parent_span_id,
-          greatest(o.start_time, toDateTime64('1970-01-01', 3)) AS start_time,
+          o.start_time AS start_time,
           o.end_time,
           o.name,
           o.type,

--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -299,8 +299,7 @@ export const handleEventPropagationJob = async (
             ELSE coalesce(obs.parent_observation_id, concat('t-', obs.trace_id))
           END AS parent_span_id,
           -- Convert timestamps from DateTime64(3) to DateTime64(6) via implicit conversion
-          -- Clamp start_time to 1970-01-01 or later (Unix epoch minimum) to avoid toUnixTimestamp() errors
-          greatest(obs.start_time, toDateTime64('1970-01-01', 3)) AS start_time,
+          obs.start_time,
           obs.end_time,
           obs.name,
           obs.type,

--- a/worker/src/features/eventPropagation/handleExperimentBackfill.ts
+++ b/worker/src/features/eventPropagation/handleExperimentBackfill.ts
@@ -179,8 +179,8 @@ export async function getRelevantObservations(
         WHEN o.id = concat('t-', o.trace_id) THEN ''
         ELSE coalesce(o.parent_observation_id, concat('t-', o.trace_id))
       END AS parent_span_id,
-      greatest(o.start_time, toDateTime64('1970-01-01', 3)) AS start_time,
-      o.end_time AS end_time,
+      o.start_time,
+      o.end_time,
       o.name,
       o.type,
       coalesce(o.environment, '') AS environment,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes clamping of `start_time` to `1970-01-01` in three files, reflecting changes in timestamp handling due to a new table layout.
> 
>   - **Behavior**:
>     - Removes clamping of `start_time` to `1970-01-01` in `backfillEventsHistoric.ts`, `handleEventPropagationJob.ts`, and `handleExperimentBackfill.ts`.
>     - Directly uses `o.start_time` and `obs.start_time` without `greatest()` function.
>   - **Files**:
>     - `backfillEventsHistoric.ts`: Updates `start_time` handling in `BackfillEventsHistoric` class.
>     - `handleEventPropagationJob.ts`: Updates `start_time` handling in `handleEventPropagationJob` function.
>     - `handleExperimentBackfill.ts`: Updates `start_time` handling in `getRelevantObservations` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 283ca12572c3edeb71ceff34022788a8736fb39a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->