### PR TITLE
fix(trace): don't refetch observations on click

### DIFF
--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -87,12 +87,17 @@ export const ObservationPreview = ({
     (s) => s.observationId === currentObservationId,
   );
 
-  const observationWithInputAndOutput = api.observations.byId.useQuery({
-    observationId: currentObservationId,
-    startTime: currentObservation?.startTime,
-    traceId: traceId,
-    projectId: projectId,
-  });
+  const observationWithInputAndOutput = api.observations.byId.useQuery(
+    {
+      observationId: currentObservationId,
+      startTime: currentObservation?.startTime,
+      traceId: traceId,
+      projectId: projectId,
+    },
+    {
+      staleTime: 5 * 60 * 1000, // 5 minutes - matches prefetch staleTime
+    },
+  );
 
   const observationMedia = api.media.getByTraceOrObservationId.useQuery(
     {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `staleTime` to `useQuery` in `ObservationPreview.tsx` to prevent refetching observations on click.
> 
>   - **Behavior**:
>     - Adds `staleTime` option to `useQuery` in `ObservationPreview.tsx` to prevent refetching observations on click.
>     - Sets `staleTime` to 5 minutes to match prefetch settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2dd267b47838cb97e21ad6984ee1860915f68307. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->