### PR TITLE
fix(filers): make sidebar tighter

### DIFF
--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -136,7 +136,7 @@ export function DataTableControls({
         "group-data-[expanded=false]/controls:hidden",
       )}
     >
-      <div className="sticky top-0 z-20 mb-2 flex h-10 shrink-0 items-center justify-between border-b bg-background px-3">
+      <div className="sticky top-0 z-20 mb-1 flex h-10 shrink-0 items-center justify-between border-b bg-background px-3">
         <span className="text-sm font-medium">Filters</span>
         {filterWithAI && isLangfuseCloud && (
           <Popover open={aiPopoverOpen} onOpenChange={setAiPopoverOpen}>
@@ -401,7 +401,7 @@ export function FilterAccordionItem({
 }: FilterAccordionItemProps) {
   return (
     <FilterAccordionItemPrimitive value={filterKey} className="border-none">
-      <FilterAccordionTrigger className="px-4 py-1.5 text-sm font-normal text-muted-foreground hover:text-foreground hover:no-underline">
+      <FilterAccordionTrigger className="px-3 py-1.5 text-sm font-normal text-muted-foreground hover:text-foreground hover:no-underline">
         <div className="flex grow items-center gap-1.5 pr-2">
           <span className="flex grow items-baseline gap-1">
             {label}
@@ -633,14 +633,16 @@ export function CategoricalFacet({
                       />
                     ))}
                     {hasMoreFilteredOptions && !showAll && (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => setShowAll(true)}
-                        className="text-normal mt-1 h-auto justify-start px-2 py-1 pl-8 text-xs"
-                      >
-                        Show more values
-                      </Button>
+                      <div className="px-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setShowAll(true)}
+                          className="text-normal mt-1 h-auto w-full justify-start py-1 pl-7 text-xs"
+                        >
+                          Show more values
+                        </Button>
+                      </div>
                     )}
                   </>
                 )}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjusts UI spacing in `data-table-controls.tsx` to make the sidebar more compact.
> 
>   - **UI Adjustments**:
>     - Reduce bottom margin from `mb-2` to `mb-1` in `DataTableControls` header.
>     - Decrease padding-left from `px-4` to `px-3` in `FilterAccordionTrigger`.
>     - Wrap `Show more values` button in a `div` with `px-2` padding in `CategoricalFacet` and adjust button class to `w-full` and `pl-7`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f190bde6cc5c7ec938c7160a4ea03c14f14402c9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->