### PR TITLE
chore(experiments): silence 404 error notifications for experiment item trace/observation output

### DIFF
--- a/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
+++ b/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
@@ -16,13 +16,13 @@ import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAcces
 import { useMergedAggregates } from "@/src/features/scores/lib/useMergedAggregates";
 import { useMergeScoreColumns } from "@/src/features/scores/lib/mergeScoreColumns";
 import { useTrpcError } from "@/src/hooks/useTrpcError";
-import { Card } from "@/src/components/ui/card";
 import { type ScoreAggregate } from "@langfuse/shared";
 import { computeScoreDiffs } from "@/src/features/datasets/lib/computeScoreDiffs";
 import { useMemo } from "react";
 import { type BaselineDiff } from "@/src/features/datasets/lib/calculateBaselineDiff";
 import { DiffLabel } from "@/src/features/datasets/components/DiffLabel";
 import { useResourceMetricsDiff } from "@/src/features/datasets/hooks/useResourceMetricsDiff";
+import { NotFoundCard } from "@/src/features/datasets/components/NotFoundCard";
 
 const DatasetAggregateCellContent = ({
   projectId,
@@ -154,13 +154,10 @@ const DatasetAggregateCellContent = ({
         )}
       >
         {isSilentError ? (
-          <Card className="flex h-full w-full flex-col items-center justify-center">
-            <h2 className="mb-2 text-lg font-bold">Not found</h2>
-            <p className="mb-6 text-center">
-              The {value.observation ? "observation" : "trace"} is either still
-              being processed or has been deleted.
-            </p>
-          </Card>
+          <NotFoundCard
+            itemType={value.observation ? "observation" : "trace"}
+            singleLine={false}
+          />
         ) : (
           <MemoizedIOTableCell
             isLoading={isLoading || !data}

--- a/web/src/features/datasets/components/DatasetIOCells.tsx
+++ b/web/src/features/datasets/components/DatasetIOCells.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/src/utils/tailwind";
 import { MemoizedIOTableCell } from "@/src/components/ui/IOTableCell";
 import { IOTableCell } from "@/src/components/ui/IOTableCell";
 import { useTrpcError } from "@/src/hooks/useTrpcError";
-import { Card } from "@/src/components/ui/card";
+import { NotFoundCard } from "@/src/features/datasets/components/NotFoundCard";
 
 export const DatasetItemIOCell = ({
   projectId,
@@ -103,13 +103,10 @@ export const TraceObservationIOCell = ({
   const data = observationId === undefined ? trace.data : observation.data;
 
   return isSilentError ? (
-    <Card className="flex h-full w-full flex-col items-center justify-center">
-      <h2 className="mb-2 text-lg font-bold">Not found</h2>
-      <p className="mb-6 text-center">
-        The {!!observationId ? "observation" : "trace"} is either still being
-        processed or has been deleted.
-      </p>
-    </Card>
+    <NotFoundCard
+      itemType={!!observationId ? "observation" : "trace"}
+      singleLine={singleLine}
+    />
   ) : (
     <MemoizedIOTableCell
       isLoading={isLoading || !data}

--- a/web/src/features/datasets/components/NotFoundCard.tsx
+++ b/web/src/features/datasets/components/NotFoundCard.tsx
@@ -1,0 +1,31 @@
+import { Card } from "@/src/components/ui/card";
+
+export const NotFoundCard = ({
+  itemType,
+  singleLine = false,
+}: {
+  itemType: "trace" | "observation";
+  singleLine?: boolean;
+}) => {
+  if (singleLine) {
+    return (
+      <Card className="flex h-full w-full items-center justify-start overflow-hidden rounded-sm px-2">
+        <p
+          className="truncate text-xs text-muted-foreground"
+          title={`The ${itemType} is either still being processed or has been deleted.`}
+        >
+          The {itemType} is either still being processed or has been deleted.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="flex h-full w-full flex-col items-center justify-center overflow-hidden rounded-sm p-3">
+      <h2 className="mb-1.5 text-sm font-semibold">Not found</h2>
+      <p className="max-w-xs text-center text-xs text-muted-foreground">
+        The {itemType} is either still being processed or has been deleted.
+      </p>
+    </Card>
+  );
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Silences 404 error notifications for trace/observation outputs by introducing a `NotFoundCard` component for user-friendly error handling.
> 
>   - **Behavior**:
>     - Introduces `NotFoundCard` component to display a user-friendly message when a trace or observation is not found.
>     - Silences 404 error notifications for trace/observation outputs in `DatasetAggregateTableCell.tsx` and `DatasetIOCells.tsx`.
>     - Uses `NotFoundCard` in `TraceObservationIOCell` and `DatasetAggregateCellContent` to handle silent 404 errors.
>   - **Components**:
>     - Adds `NotFoundCard` component to handle not found cases for traces and observations with single-line and multi-line display options.
>   - **Error Handling**:
>     - Utilizes `useTrpcError` hook to determine if an error should be silent based on HTTP status codes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2112b7bb1dd4dcaae81d72b9393085b235f432e7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->