### PR TITLE
chore(ui): do not show success toast on annotation queue completed

### DIFF
--- a/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
@@ -1,6 +1,5 @@
 import { Card } from "@/src/components/ui/card";
 import { Skeleton } from "@/src/components/ui/skeleton";
-import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { api } from "@/src/utils/api";
 import { type RouterOutput } from "@/src/utils/types";
@@ -77,10 +76,6 @@ export const AnnotationQueueItemPage: React.FC<{
   const completeMutation = api.annotationQueueItems.complete.useMutation({
     onSuccess: async () => {
       utils.annotationQueueItems.invalidate();
-      showSuccessToast({
-        title: "Item marked as complete",
-        description: "The item is successfully marked as complete.",
-      });
       if (isSingleItem) {
         return;
       }

--- a/web/src/features/support-chat/SupportDrawer.tsx
+++ b/web/src/features/support-chat/SupportDrawer.tsx
@@ -38,7 +38,7 @@ export const SupportDrawer = ({
       ])}
     >
       <div className="bg-background">
-        <div className="flex min-h-12 w-full items-center justify-between gap-1 px-4 py-1">
+        <div className="flex min-h-11 w-full items-center justify-between gap-1 px-4 py-1">
           <Breadcrumb>
             <BreadcrumbList>
               {currentMode === "intro" ? (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove success toast notification in `AnnotationQueueItemPage.tsx` and adjust `min-h` in `SupportDrawer.tsx`.
> 
>   - **UI Changes**:
>     - Remove success toast notification in `AnnotationQueueItemPage.tsx` when an annotation queue item is completed.
>     - Adjust `min-h` from `12` to `11` in a `div` in `SupportDrawer.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 870d762ebd8c0ea28c5544789f7f8859659efcb2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->