### PR TITLE
fix(evals): trace table should be full width

### DIFF
--- a/web/src/components/table/resizable-filter-layout.tsx
+++ b/web/src/components/table/resizable-filter-layout.tsx
@@ -24,8 +24,13 @@ export function ResizableFilterLayout({ children }: PropsWithChildren) {
 
   // Extract filter sidebar and table content from children
   const childrenArray = Children.toArray(children).filter(Boolean);
-  const filterSidebar = childrenArray[0];
-  const tableContent = childrenArray.slice(1);
+
+  // If there's only one child, it's the table content (no filter sidebar)
+  const hasFilterSidebar = childrenArray.length > 1;
+  const filterSidebar = hasFilterSidebar ? childrenArray[0] : null;
+  const tableContent = hasFilterSidebar
+    ? childrenArray.slice(1)
+    : childrenArray;
 
   const filterDefault = 15;
   const tableDefault = 85;

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -116,7 +116,7 @@ const TracesPreview = memo(
             Sample over the last 24 hours that match these filters
           </FormDescription>
         </div>
-        <div className="mb-4 flex max-h-[30dvh] flex-col overflow-hidden border-b border-l border-r">
+        <div className="mb-4 flex max-h-[30dvh] w-full flex-col overflow-hidden border-b border-l border-r">
           <Suspense fallback={<Skeleton className="h-[30dvh] w-full" />}>
             <TracesTable
               projectId={projectId}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure trace table is full width by adjusting layout logic in `resizable-filter-layout.tsx` and updating CSS in `inner-evaluator-form.tsx`.
> 
>   - **Layout Logic**:
>     - In `resizable-filter-layout.tsx`, adjust logic to handle cases where there is only one child, ensuring the table content is displayed without a filter sidebar.
>   - **Styling**:
>     - In `inner-evaluator-form.tsx`, update the `TracesPreview` component to ensure the trace table div has `w-full` class for full width display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 235ddcd19cf2597f3fdff0ae1456813515117a13. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->