### PR TITLE
fix(trace-tree): more compact UI

### DIFF
--- a/web/src/components/trace/ObservationPreview.tsx
+++ b/web/src/components/trace/ObservationPreview.tsx
@@ -138,7 +138,7 @@ export const ObservationPreview = ({
   return (
     <div className="col-span-2 flex h-full flex-1 flex-col overflow-hidden md:col-span-3">
       <div className="flex h-full flex-1 flex-col items-start gap-1 overflow-hidden">
-        <div className="mt-3 grid w-full grid-cols-[auto,auto] items-start justify-between gap-2">
+        <div className="mt-2 grid w-full grid-cols-[auto,auto] items-start justify-between gap-2">
           <div className="flex w-full flex-row items-start gap-1">
             <div className="mt-1.5">
               <ItemBadge type={preloadedObservation.type} isSmall />

--- a/web/src/components/trace/SpanItem.tsx
+++ b/web/src/components/trace/SpanItem.tsx
@@ -76,7 +76,7 @@ export const SpanItem: React.FC<SpanItemProps> = ({
       <div className="flex min-w-0 items-center gap-2 overflow-hidden">
         <span className="flex-shrink truncate text-xs">{node.name}</span>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-x-2">
           {comments && showComments ? (
             <CommentCountIcon count={comments.get(node.id)} />
           ) : null}
@@ -97,7 +97,7 @@ export const SpanItem: React.FC<SpanItemProps> = ({
       </div>
 
       {shouldRenderMetrics && (
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-x-2">
           {duration || node.latency ? (
             <span
               title={

--- a/web/src/components/trace/TracePreview.tsx
+++ b/web/src/components/trace/TracePreview.tsx
@@ -156,7 +156,7 @@ export const TracePreview = ({
   return (
     <div className="col-span-2 flex h-full flex-1 flex-col overflow-hidden md:col-span-3">
       <div className="flex h-full flex-1 flex-col items-start gap-1 overflow-hidden">
-        <div className="mt-3 grid w-full grid-cols-[auto,auto] items-start justify-between gap-2">
+        <div className="mt-2 grid w-full grid-cols-[auto,auto] items-start justify-between gap-2">
           <div className="flex w-full flex-row items-start gap-1">
             <div className="mt-1.5">
               <ItemBadge type="TRACE" isSmall />

--- a/web/src/components/trace/TraceTree.tsx
+++ b/web/src/components/trace/TraceTree.tsx
@@ -16,11 +16,6 @@ import {
 } from "@/src/components/trace/lib/helpers";
 import type Decimal from "decimal.js";
 import { SpanItem } from "@/src/components/trace/SpanItem";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/src/components/ui/tooltip";
 import { api } from "@/src/utils/api";
 
 export const TraceTree = ({
@@ -277,43 +272,37 @@ const UnmemoizedTreeNodeComponent = ({
           </div>
 
           {/* 4. Content button: just the text/metrics content */}
-          <Tooltip delayDuration={750}>
-            <TooltipTrigger asChild>
-              {/* eslint-disable-next-line jsx-a11y/role-supports-aria-props */}
-              <button
-                type="button"
-                aria-selected={isSelected}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setCurrentNodeId(node.type === "TRACE" ? undefined : node.id);
-                }}
-                onMouseEnter={() => onObservationHover(node)}
-                className={cn(
-                  "peer relative flex min-w-0 flex-1 items-start rounded-md py-1.5 pl-2 pr-2 text-left",
-                )}
-                ref={currentNodeRef}
-              >
-                <SpanItem
-                  node={node}
-                  scores={scores}
-                  comments={comments}
-                  showMetrics={showMetrics}
-                  showScores={showScores}
-                  colorCodeMetrics={colorCodeMetrics}
-                  parentTotalCost={parentTotalCost}
-                  parentTotalDuration={parentTotalDuration}
-                  showComments={showComments}
-                />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="top" align="start">
-              <p className="max-w-md break-words">{node.name}</p>
-            </TooltipContent>
-          </Tooltip>
+          {/* eslint-disable-next-line jsx-a11y/role-supports-aria-props */}
+          <button
+            type="button"
+            aria-selected={isSelected}
+            onClick={(e) => {
+              e.stopPropagation();
+              setCurrentNodeId(node.type === "TRACE" ? undefined : node.id);
+            }}
+            onMouseEnter={() => onObservationHover(node)}
+            title={node.name}
+            className={cn(
+              "peer relative flex min-w-0 flex-1 items-start rounded-md py-0.5 pl-1 pr-2 text-left",
+            )}
+            ref={currentNodeRef}
+          >
+            <SpanItem
+              node={node}
+              scores={scores}
+              comments={comments}
+              showMetrics={showMetrics}
+              showScores={showScores}
+              colorCodeMetrics={colorCodeMetrics}
+              parentTotalCost={parentTotalCost}
+              parentTotalDuration={parentTotalDuration}
+              showComments={showComments}
+            />
+          </button>
 
           {/* 5. Expand/Collapse button */}
           {node.children.length > 0 && (
-            <div className="flex items-center justify-end py-1 pr-2">
+            <div className="flex items-center justify-end py-1 pr-1">
               <Button
                 data-expand-button
                 size="icon"

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -386,11 +386,11 @@ export function Trace(props: {
         {isMobile && (
           <div className="flex h-full w-full flex-col overflow-y-auto md:hidden">
             {/* Tree Panel - Mobile */}
-            <div className="flex-shrink-0 border-b pb-4">
-              <Command className="mt-2 flex flex-col gap-2 overflow-hidden rounded-none border-0">
-                <div className="flex flex-row justify-between px-3 pl-5">
+            <div className="flex-shrink-0 border-b pb-2">
+              <Command className="mt-1 flex flex-col gap-1 overflow-hidden rounded-none border-0">
+                <div className="flex flex-row justify-between pl-1 pr-2">
                   {props.selectedTab?.includes("timeline") ? (
-                    <span className="whitespace-nowrap px-1 py-2 text-sm text-muted-foreground">
+                    <span className="whitespace-nowrap px-1 py-1.5 text-sm text-muted-foreground">
                       Node display
                     </span>
                   ) : (
@@ -403,7 +403,7 @@ export function Trace(props: {
                     />
                   )}
                   {viewType === "detailed" && (
-                    <div className="flex flex-row items-center gap-2">
+                    <div className="flex flex-row items-center gap-0.5">
                       {/* Expand/Collapse All Button */}
                       {props.selectedTab?.includes("timeline") ? (
                         <Button
@@ -427,11 +427,12 @@ export function Trace(props: {
                               ? "Collapse all"
                               : "Expand all"
                           }
+                          className="h-7 w-7"
                         >
                           {expandedItems.includes(`trace-${props.trace.id}`) ? (
-                            <FoldVertical className="h-4 w-4" />
+                            <FoldVertical className="h-3.5 w-3.5" />
                           ) : (
-                            <UnfoldVertical className="h-4 w-4" />
+                            <UnfoldVertical className="h-3.5 w-3.5" />
                           )}
                         </Button>
                       ) : (
@@ -459,13 +460,14 @@ export function Trace(props: {
                               ? "Expand all"
                               : "Collapse all"
                           }
+                          className="h-7 w-7"
                         >
                           {collapsedNodes.includes(
                             `trace-${props.trace.id}`,
                           ) ? (
-                            <UnfoldVertical className="h-4 w-4" />
+                            <UnfoldVertical className="h-3.5 w-3.5" />
                           ) : (
-                            <FoldVertical className="h-4 w-4" />
+                            <FoldVertical className="h-3.5 w-3.5" />
                           )}
                         </Button>
                       )}
@@ -499,8 +501,9 @@ export function Trace(props: {
                         size="icon"
                         onClick={handleDownloadTrace}
                         title="Download trace as JSON"
+                        className="h-7 w-7"
                       >
-                        <Download className="h-4 w-4" />
+                        <Download className="h-3.5 w-3.5" />
                       </Button>
 
                       {/* Timeline Toggle Button */}
@@ -520,11 +523,12 @@ export function Trace(props: {
                           )
                         }
                         className={cn(
+                          "h-7 px-2 text-xs",
                           props.selectedTab?.includes("timeline") &&
                             "bg-primary text-primary-foreground",
                         )}
                       >
-                        <span className="text-sm">Timeline</span>
+                        <span className="text-xs">Timeline</span>
                       </Button>
                       {/* Note: No panel collapse button on mobile */}
                     </div>
@@ -618,23 +622,23 @@ export function Trace(props: {
                     </Button>
                   </div>
                 ) : (
-                  <Command className="mt-2 flex h-full flex-col gap-2 overflow-hidden rounded-none border-0">
-                    <div className="flex flex-row justify-between px-3 pl-5">
+                  <Command className="mt-1 flex h-full flex-col gap-1 overflow-hidden rounded-none border-0">
+                    <div className="flex flex-row justify-between pl-1 pr-2">
                       {props.selectedTab?.includes("timeline") ? (
-                        <span className="whitespace-nowrap px-1 py-3 text-sm text-muted-foreground">
+                        <span className="whitespace-nowrap px-1 py-1.5 text-sm text-muted-foreground">
                           Node display
                         </span>
                       ) : (
                         <CommandInput
                           showBorder={false}
                           placeholder="Search"
-                          className="h-9 min-w-20 border-0 pr-0 focus:ring-0"
+                          className="h-7 min-w-20 border-0 pr-0 focus:ring-0"
                           value={searchQuery}
                           onValueChange={setSearchQuery}
                         />
                       )}
                       {viewType === "detailed" && (
-                        <div className="flex flex-row items-center gap-2">
+                        <div className="flex flex-row items-center gap-0.5">
                           {props.selectedTab?.includes("timeline") ? (
                             <Button
                               onClick={() => {
@@ -662,13 +666,14 @@ export function Trace(props: {
                                   ? "Collapse all"
                                   : "Expand all"
                               }
+                              className="h-7 w-7"
                             >
                               {expandedItems.includes(
                                 `trace-${props.trace.id}`,
                               ) ? (
-                                <FoldVertical className="h-4 w-4" />
+                                <FoldVertical className="h-3.5 w-3.5" />
                               ) : (
-                                <UnfoldVertical className="h-4 w-4" />
+                                <UnfoldVertical className="h-3.5 w-3.5" />
                               )}
                             </Button>
                           ) : (
@@ -701,11 +706,12 @@ export function Trace(props: {
                                       ? "Expand all"
                                       : "Collapse all"
                                   }
+                                  className="h-7 w-7"
                                 >
                                   {isEverythingCollapsed ? (
-                                    <UnfoldVertical className="h-4 w-4" />
+                                    <UnfoldVertical className="h-3.5 w-3.5" />
                                   ) : (
-                                    <FoldVertical className="h-4 w-4" />
+                                    <FoldVertical className="h-3.5 w-3.5" />
                                   )}
                                 </Button>
                               );
@@ -739,8 +745,9 @@ export function Trace(props: {
                             size="icon"
                             onClick={handleDownloadTrace}
                             title="Download trace as JSON"
+                            className="h-7 w-7"
                           >
-                            <Download className="h-4 w-4" />
+                            <Download className="h-3.5 w-3.5" />
                           </Button>
                           <Button
                             variant={
@@ -758,11 +765,12 @@ export function Trace(props: {
                               )
                             }
                             className={cn(
+                              "h-7 px-2 text-xs",
                               props.selectedTab?.includes("timeline") &&
                                 "bg-primary text-primary-foreground",
                             )}
                           >
-                            <span className="text-sm">Timeline</span>
+                            <span className="text-xs">Timeline</span>
                           </Button>
                           <Button
                             variant="ghost"
@@ -784,12 +792,15 @@ export function Trace(props: {
                                 ? "Show trace tree"
                                 : "Hide trace tree"
                             }
-                            className={cn(shouldPulseToggle && "animate-pulse")}
+                            className={cn(
+                              "h-7 w-7",
+                              shouldPulseToggle && "animate-pulse",
+                            )}
                           >
                             {isTreePanelCollapsed ? (
-                              <PanelLeftOpen className="h-4 w-4" />
+                              <PanelLeftOpen className="h-3.5 w-3.5" />
                             ) : (
-                              <PanelLeftClose className="h-4 w-4" />
+                              <PanelLeftClose className="h-3.5 w-3.5" />
                             )}
                           </Button>
                         </div>
@@ -889,7 +900,7 @@ export function Trace(props: {
                                 defaultSize={treeGraphSizes[0]}
                                 minSize={5}
                                 maxSize={95}
-                                className="flex flex-col overflow-hidden px-2"
+                                className="flex flex-col overflow-hidden pl-0 pr-2"
                               >
                                 <div className="min-h-0 flex-1 overflow-y-auto pb-2">
                                   {treeOrSearchContent}
@@ -911,7 +922,7 @@ export function Trace(props: {
                               </ResizablePanel>
                             </ResizablePanelGroup>
                           ) : (
-                            <div className="flex h-full w-full flex-col overflow-hidden px-2">
+                            <div className="flex h-full w-full flex-col overflow-hidden pl-0 pr-2">
                               <div className="min-h-0 flex-1 overflow-y-auto pb-2">
                                 {treeOrSearchContent}
                               </div>

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -21,7 +21,7 @@ import {
 import { Portal } from "@radix-ui/react-tooltip";
 
 const SIDEBAR_STORAGE_KEY = "sidebar:state";
-const SIDEBAR_WIDTH = "11rem";
+const SIDEBAR_WIDTH = "11.5rem";
 const SIDEBAR_WIDTH_MOBILE = "12rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> This pull request refines the trace visualization UI for compactness by adjusting margins, padding, and removing tooltips, and slightly increases the sidebar width.
> 
>   - **UI Adjustments**:
>     - Reduce top margin from `mt-3` to `mt-2` in `ObservationPreview.tsx` and `TracePreview.tsx`.
>     - Change `gap-2` to `gap-x-2` in `SpanItem.tsx` for more compact horizontal spacing.
>     - Remove `Tooltip` components in `TraceTree.tsx` and replace with `title` attribute for hover text.
>     - Adjust padding and icon sizes in `index.tsx` for more compact UI.
>   - **Sidebar**:
>     - Increase `SIDEBAR_WIDTH` from `11rem` to `11.5rem` in `sidebar.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 03719a1d9e8f0529cb6cf378ea32356c14b3d4cb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->