### PR TITLE
fix: correct conditional score filter in generations table queries

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -232,7 +232,7 @@ const getObservationsFromEventsTableInternal = async <T>(
 
   const startTimeFrom = extractTimeFilter(observationsFilter);
   const hasScoresFilter = filter.some((f) =>
-    f.column.toLowerCase().includes("scores"),
+    f.column.toLowerCase().includes("score"),
   );
   const appliedObservationsFilter = observationsFilter.apply();
   const search = clickhouseSearchCondition(

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -661,7 +661,7 @@ const getObservationsTableInternal = async <T>(
   ]);
 
   const hasScoresFilter = filter.some((f) =>
-    f.column.toLowerCase().includes("scores"),
+    f.column.toLowerCase().includes("score"),
   );
 
   // query optimisation: joining traces onto observations is expensive. Hence, only join if the UI table contains filters on traces.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes score filter condition in `events.ts` and `observations.ts` to correctly check for 'score'.
> 
>   - **Bug Fix**:
>     - Corrects conditional score filter by changing `includes("scores")` to `includes("score")` in `getObservationsFromEventsTableInternal()` in `events.ts` and `getObservationsTableInternal()` in `observations.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bd87969781518e402a02a9919e80ba2b4af88587. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->