### PR TITLE
fix(trace-ui): handle null attributes in AI SDK and Langgraph adapters

### DIFF
--- a/web/src/utils/chatml/adapters/aisdk.ts
+++ b/web/src/utils/chatml/adapters/aisdk.ts
@@ -401,8 +401,9 @@ export const aisdkAdapter: ProviderAdapter = {
       }
 
       if ("attributes" in meta && typeof meta.attributes === "object") {
-        const attrs = meta.attributes as Record<string, unknown>;
+        const attrs = meta.attributes as Record<string, unknown> | null;
         if (
+          attrs &&
           typeof attrs["operation.name"] === "string" &&
           attrs["operation.name"].startsWith("ai.")
         ) {

--- a/web/src/utils/chatml/adapters/langgraph.ts
+++ b/web/src/utils/chatml/adapters/langgraph.ts
@@ -294,8 +294,9 @@ export const langgraphAdapter: ProviderAdapter = {
 
       // Check attributes["operation.name"] for AI SDK pattern
       if ("attributes" in meta && typeof meta.attributes === "object") {
-        const attrs = meta.attributes as Record<string, unknown>;
+        const attrs = meta.attributes as Record<string, unknown> | null;
         if (
+          attrs &&
           typeof attrs["operation.name"] === "string" &&
           attrs["operation.name"].startsWith("ai.")
         ) {


### PR DESCRIPTION
Fixes bug that caused client-side exception for Langgraph traces on single trace view. 
 
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix null attribute handling in `aisdkAdapter` and `langgraphAdapter` to prevent runtime errors.
> 
>   - **Behavior**:
>     - In `aisdkAdapter` in `aisdk.ts`, handle null `attributes` in `meta` by checking `attrs` before accessing `operation.name`.
>     - In `langgraphAdapter` in `langgraph.ts`, handle null `attributes` in `meta` by checking `attrs` before accessing `operation.name`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4f50950e94ac950c489970f145fb0e1c3671dfc8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->