### PR TITLE
fix: convertApiProvidedFilterToClickhouseFilter shouldn't ignore filters with falsy strings

### DIFF
--- a/packages/shared/src/server/queries/public-api-filter-builder.ts
+++ b/packages/shared/src/server/queries/public-api-filter-builder.ts
@@ -223,7 +223,7 @@ export function convertApiProvidedFilterToClickhouseFilter(
   columnMapping.forEach((columnMapping) => {
     const value = filter[columnMapping.id as keyof BaseQueryType];
 
-    if (value) {
+    if (value !== undefined) {
       let filterInstance;
       switch (columnMapping.filterType) {
         case "DateTimeFilter": {


### PR DESCRIPTION
as of today it is practically impossible to use `string == ''` in public API filters 

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `convertApiProvidedFilterToClickhouseFilter` to handle filters with falsy string values by checking for `undefined`.
> 
>   - **Behavior**:
>     - Fixes `convertApiProvidedFilterToClickhouseFilter` in `public-api-filter-builder.ts` to handle filters with falsy string values (e.g., empty strings) by checking for `undefined` instead of falsy values.
>   - **Misc**:
>     - No other files or functions are affected by this change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3af1d8f0ebccbe499228781d67b3f3e5744640f0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->