### PR TITLE
feat(trace-tree): toggle usage and latency individually

### DIFF
--- a/web/src/components/trace/SpanItem.tsx
+++ b/web/src/components/trace/SpanItem.tsx
@@ -18,7 +18,8 @@ export interface SpanItemProps {
   node: TreeNode;
   scores: APIScoreV2[];
   comments?: Map<string, number>;
-  showMetrics: boolean;
+  showDuration: boolean;
+  showCostTokens: boolean;
   showScores: boolean;
   colorCodeMetrics: boolean;
   parentTotalCost?: Decimal;
@@ -31,7 +32,8 @@ export const SpanItem: React.FC<SpanItemProps> = ({
   node,
   scores,
   comments,
-  showMetrics,
+  showDuration,
+  showCostTokens,
   showScores,
   colorCodeMetrics,
   parentTotalCost,
@@ -60,16 +62,16 @@ export const SpanItem: React.FC<SpanItemProps> = ({
         ? node.latency * 1000
         : undefined;
 
-  const shouldRenderMetrics =
-    showMetrics &&
+  const shouldRenderDuration =
+    showDuration && Boolean(duration || node.latency);
+
+  const shouldRenderCostTokens =
+    showCostTokens &&
     Boolean(
-      node.inputUsage ||
-        node.outputUsage ||
-        node.totalUsage ||
-        duration ||
-        totalCost ||
-        node.latency,
+      node.inputUsage || node.outputUsage || node.totalUsage || totalCost,
     );
+
+  const shouldRenderAnyMetrics = shouldRenderDuration || shouldRenderCostTokens;
 
   return (
     <div className={cn("flex min-w-0 flex-col", className)}>
@@ -96,9 +98,9 @@ export const SpanItem: React.FC<SpanItemProps> = ({
         </div>
       </div>
 
-      {shouldRenderMetrics && (
+      {shouldRenderAnyMetrics && (
         <div className="flex flex-wrap gap-x-2">
-          {duration || node.latency ? (
+          {shouldRenderDuration && (duration || node.latency) ? (
             <span
               title={
                 node.children.length > 0 || node.type === "TRACE"
@@ -120,7 +122,8 @@ export const SpanItem: React.FC<SpanItemProps> = ({
               )}
             </span>
           ) : null}
-          {node.inputUsage || node.outputUsage || node.totalUsage ? (
+          {shouldRenderCostTokens &&
+          (node.inputUsage || node.outputUsage || node.totalUsage) ? (
             <span className="text-xs text-muted-foreground">
               {formatTokenCounts(
                 node.inputUsage,
@@ -129,7 +132,7 @@ export const SpanItem: React.FC<SpanItemProps> = ({
               )}
             </span>
           ) : null}
-          {totalCost ? (
+          {shouldRenderCostTokens && totalCost ? (
             <span
               title={
                 node.children.length > 0 || node.type === "TRACE"

--- a/web/src/components/trace/TraceSearchList.tsx
+++ b/web/src/components/trace/TraceSearchList.tsx
@@ -23,7 +23,8 @@ export interface TraceSearchListProps {
   displayScores: APIScoreV2[];
   onSelect: (observationId: string | undefined) => void;
   comments?: Map<string, number>;
-  showMetrics: boolean;
+  showDuration: boolean;
+  showCostTokens: boolean;
   showScores: boolean;
   colorCodeMetrics: boolean;
   showComments?: boolean;
@@ -36,7 +37,8 @@ export const TraceSearchList: React.FC<TraceSearchListProps> = ({
   displayScores: scores,
   onSelect,
   comments,
-  showMetrics,
+  showDuration,
+  showCostTokens,
   showScores,
   colorCodeMetrics,
   showComments = true,
@@ -63,7 +65,8 @@ export const TraceSearchList: React.FC<TraceSearchListProps> = ({
                       node={node}
                       scores={scores}
                       comments={comments}
-                      showMetrics={showMetrics}
+                      showDuration={showDuration}
+                      showCostTokens={showCostTokens}
                       showScores={showScores}
                       colorCodeMetrics={colorCodeMetrics}
                       parentTotalCost={parentTotalCost}

--- a/web/src/components/trace/TraceSettingsDropdown.tsx
+++ b/web/src/components/trace/TraceSettingsDropdown.tsx
@@ -110,12 +110,7 @@ export const TraceSettingsDropdown = ({
               <span className="mr-2">Show Duration</span>
               <Switch
                 checked={durationOnObservationTree}
-                onCheckedChange={(e) => {
-                  capture("trace_detail:observation_tree_toggle_duration", {
-                    show: e,
-                  });
-                  setDurationOnObservationTree(e);
-                }}
+                onCheckedChange={setDurationOnObservationTree}
               />
             </div>
           </DropdownMenuItem>
@@ -125,12 +120,7 @@ export const TraceSettingsDropdown = ({
               <span className="mr-2">Show Cost/Tokens</span>
               <Switch
                 checked={costTokensOnObservationTree}
-                onCheckedChange={(e) => {
-                  capture("trace_detail:observation_tree_toggle_cost_tokens", {
-                    show: e,
-                  });
-                  setCostTokensOnObservationTree(e);
-                }}
+                onCheckedChange={setCostTokensOnObservationTree}
               />
             </div>
           </DropdownMenuItem>

--- a/web/src/components/trace/TraceSettingsDropdown.tsx
+++ b/web/src/components/trace/TraceSettingsDropdown.tsx
@@ -24,8 +24,10 @@ export interface TraceSettingsDropdownProps {
   setShowComments: (value: boolean) => void;
   scoresOnObservationTree: boolean;
   setScoresOnObservationTree: (value: boolean) => void;
-  metricsOnObservationTree: boolean;
-  setMetricsOnObservationTree: (value: boolean) => void;
+  durationOnObservationTree: boolean;
+  setDurationOnObservationTree: (value: boolean) => void;
+  costTokensOnObservationTree: boolean;
+  setCostTokensOnObservationTree: (value: boolean) => void;
   colorCodeMetricsOnObservationTree: boolean;
   setColorCodeMetricsOnObservationTree: (value: boolean) => void;
   minObservationLevel: ObservationLevelType;
@@ -40,8 +42,10 @@ export const TraceSettingsDropdown = ({
   setShowComments,
   scoresOnObservationTree,
   setScoresOnObservationTree,
-  metricsOnObservationTree,
-  setMetricsOnObservationTree,
+  durationOnObservationTree,
+  setDurationOnObservationTree,
+  costTokensOnObservationTree,
+  setCostTokensOnObservationTree,
   colorCodeMetricsOnObservationTree,
   setColorCodeMetricsOnObservationTree,
   minObservationLevel,
@@ -103,14 +107,29 @@ export const TraceSettingsDropdown = ({
 
           <DropdownMenuItem asChild onSelect={(e) => e.preventDefault()}>
             <div className="flex w-full items-center justify-between">
-              <span className="mr-2">Show Metrics</span>
+              <span className="mr-2">Show Duration</span>
               <Switch
-                checked={metricsOnObservationTree}
+                checked={durationOnObservationTree}
                 onCheckedChange={(e) => {
-                  capture("trace_detail:observation_tree_toggle_metrics", {
+                  capture("trace_detail:observation_tree_toggle_duration", {
                     show: e,
                   });
-                  setMetricsOnObservationTree(e);
+                  setDurationOnObservationTree(e);
+                }}
+              />
+            </div>
+          </DropdownMenuItem>
+
+          <DropdownMenuItem asChild onSelect={(e) => e.preventDefault()}>
+            <div className="flex w-full items-center justify-between">
+              <span className="mr-2">Show Cost/Tokens</span>
+              <Switch
+                checked={costTokensOnObservationTree}
+                onCheckedChange={(e) => {
+                  capture("trace_detail:observation_tree_toggle_cost_tokens", {
+                    show: e,
+                  });
+                  setCostTokensOnObservationTree(e);
                 }}
               />
             </div>
@@ -119,19 +138,29 @@ export const TraceSettingsDropdown = ({
           <DropdownMenuItem
             asChild
             onSelect={(e) => e.preventDefault()}
-            disabled={!metricsOnObservationTree}
-            className={cn(!metricsOnObservationTree && "cursor-not-allowed")}
+            disabled={
+              !durationOnObservationTree && !costTokensOnObservationTree
+            }
+            className={cn(
+              !durationOnObservationTree &&
+                !costTokensOnObservationTree &&
+                "cursor-not-allowed",
+            )}
           >
             <div
               className={cn(
                 "flex w-full items-center justify-between",
-                !metricsOnObservationTree && "cursor-not-allowed",
+                !durationOnObservationTree &&
+                  !costTokensOnObservationTree &&
+                  "cursor-not-allowed",
               )}
             >
               <span
                 className={cn(
                   "mr-2",
-                  !metricsOnObservationTree && "cursor-not-allowed",
+                  !durationOnObservationTree &&
+                    !costTokensOnObservationTree &&
+                    "cursor-not-allowed",
                 )}
               >
                 Color Code Metrics
@@ -139,9 +168,13 @@ export const TraceSettingsDropdown = ({
               <Switch
                 checked={colorCodeMetricsOnObservationTree}
                 onCheckedChange={(e) => setColorCodeMetricsOnObservationTree(e)}
-                disabled={!metricsOnObservationTree}
+                disabled={
+                  !durationOnObservationTree && !costTokensOnObservationTree
+                }
                 className={cn(
-                  !metricsOnObservationTree && "cursor-not-allowed",
+                  !durationOnObservationTree &&
+                    !costTokensOnObservationTree &&
+                    "cursor-not-allowed",
                 )}
               />
             </div>

--- a/web/src/components/trace/TraceTimelineView.tsx
+++ b/web/src/components/trace/TraceTimelineView.tsx
@@ -61,7 +61,8 @@ function TreeItemInner({
   name,
   hasChildren,
   isSelected,
-  showMetrics = true,
+  showDuration = true,
+  showCostTokens = true,
   showScores = true,
   showComments = true,
   colorCodeMetrics = false,
@@ -79,7 +80,8 @@ function TreeItemInner({
   name?: string | null;
   hasChildren: boolean;
   isSelected: boolean;
-  showMetrics?: boolean;
+  showDuration?: boolean;
+  showCostTokens?: boolean;
   showScores?: boolean;
   showComments?: boolean;
   colorCodeMetrics?: boolean;
@@ -142,7 +144,7 @@ function TreeItemInner({
                   {showComments && commentCount ? (
                     <CommentCountIcon count={commentCount} />
                   ) : null}
-                  {showMetrics && isPresent(latency) && (
+                  {showDuration && isPresent(latency) && (
                     <span
                       className={cn(
                         "text-xs text-muted-foreground",
@@ -158,7 +160,7 @@ function TreeItemInner({
                       {formatIntervalSeconds(latency)}
                     </span>
                   )}
-                  {showMetrics && totalCost && (
+                  {showCostTokens && totalCost && (
                     <span
                       className={cn(
                         "text-xs text-muted-foreground",
@@ -211,7 +213,7 @@ function TreeItemInner({
                   {showComments && commentCount ? (
                     <CommentCountIcon count={commentCount} />
                   ) : null}
-                  {showMetrics && isPresent(latency) && (
+                  {showDuration && isPresent(latency) && (
                     <span
                       className={cn(
                         "text-xs text-muted-foreground",
@@ -227,7 +229,7 @@ function TreeItemInner({
                       {formatIntervalSeconds(latency)}
                     </span>
                   )}
-                  {showMetrics && totalCost && (
+                  {showCostTokens && totalCost && (
                     <span
                       className={cn(
                         "text-xs text-muted-foreground",
@@ -269,7 +271,8 @@ function TraceTreeItem({
   commentCounts,
   currentObservationId,
   setCurrentObservationId,
-  showMetrics,
+  showDuration,
+  showCostTokens,
   showScores,
   showComments,
   colorCodeMetrics,
@@ -287,7 +290,8 @@ function TraceTreeItem({
   commentCounts?: Map<string, number>;
   currentObservationId: string | null;
   setCurrentObservationId: (id: string | null) => void;
-  showMetrics?: boolean;
+  showDuration?: boolean;
+  showCostTokens?: boolean;
   showScores?: boolean;
   showComments?: boolean;
   colorCodeMetrics?: boolean;
@@ -355,7 +359,8 @@ function TraceTreeItem({
           totalScaleSpan={totalScaleSpan}
           hasChildren={!!observation.children?.length}
           isSelected={observation.id === currentObservationId}
-          showMetrics={showMetrics}
+          showDuration={showDuration}
+          showCostTokens={showCostTokens}
           showScores={showScores}
           showComments={showComments}
           colorCodeMetrics={colorCodeMetrics}
@@ -382,7 +387,8 @@ function TraceTreeItem({
               commentCounts={commentCounts}
               currentObservationId={currentObservationId}
               setCurrentObservationId={setCurrentObservationId}
-              showMetrics={showMetrics}
+              showDuration={showDuration}
+              showCostTokens={showCostTokens}
               showScores={showScores}
               showComments={showComments}
               colorCodeMetrics={colorCodeMetrics}
@@ -405,7 +411,8 @@ export function TraceTimelineView({
   setCurrentObservationId,
   expandedItems,
   setExpandedItems,
-  showMetrics = true,
+  showDuration = true,
+  showCostTokens = true,
   showScores = true,
   showComments = true,
   colorCodeMetrics = true,
@@ -426,7 +433,8 @@ export function TraceTimelineView({
   setCurrentObservationId: (id: string | null) => void;
   expandedItems: string[];
   setExpandedItems: (items: string[]) => void;
-  showMetrics?: boolean;
+  showDuration?: boolean;
+  showCostTokens?: boolean;
   showScores?: boolean;
   showComments?: boolean;
   colorCodeMetrics?: boolean;
@@ -690,7 +698,8 @@ export function TraceTimelineView({
                           )}
                           currentObservationId={currentObservationId}
                           setCurrentObservationId={setCurrentObservationId}
-                          showMetrics={showMetrics}
+                          showDuration={showDuration}
+                          showCostTokens={showCostTokens}
                           showScores={showScores}
                           showComments={showComments}
                           colorCodeMetrics={colorCodeMetrics}

--- a/web/src/components/trace/TraceTimelineView.tsx
+++ b/web/src/components/trace/TraceTimelineView.tsx
@@ -668,7 +668,8 @@ export function TraceTimelineView({
                       type="TRACE"
                       hasChildren={!!nestedObservations.length}
                       isSelected={currentObservationId === null}
-                      showMetrics={showMetrics}
+                      showDuration={showDuration}
+                      showCostTokens={showCostTokens}
                       showScores={showScores}
                       showComments={showComments}
                       colorCodeMetrics={colorCodeMetrics}

--- a/web/src/components/trace/TraceTree.tsx
+++ b/web/src/components/trace/TraceTree.tsx
@@ -25,7 +25,8 @@ export const TraceTree = ({
   displayScores: scores,
   currentNodeId,
   setCurrentNodeId,
-  showMetrics,
+  showDuration,
+  showCostTokens,
   showScores,
   colorCodeMetrics,
   nodeCommentCounts,
@@ -44,7 +45,8 @@ export const TraceTree = ({
   displayScores: APIScoreV2[];
   currentNodeId: string | undefined;
   setCurrentNodeId: (id: string | undefined) => void;
-  showMetrics: boolean;
+  showDuration: boolean;
+  showCostTokens: boolean;
   showScores: boolean;
   colorCodeMetrics: boolean;
   nodeCommentCounts?: Map<string, number>;
@@ -109,7 +111,8 @@ export const TraceTree = ({
         indentationLevel={0}
         currentNodeId={currentNodeId}
         setCurrentNodeId={setCurrentNodeId}
-        showMetrics={showMetrics}
+        showDuration={showDuration}
+        showCostTokens={showCostTokens}
         showScores={showScores}
         colorCodeMetrics={colorCodeMetrics}
         parentTotalCost={totalCost}
@@ -151,7 +154,8 @@ type TreeNodeComponentProps = {
   indentationLevel: number;
   currentNodeId: string | undefined;
   setCurrentNodeId: (id: string | undefined) => void;
-  showMetrics: boolean;
+  showDuration: boolean;
+  showCostTokens: boolean;
   showScores: boolean;
   colorCodeMetrics: boolean;
   parentTotalCost?: Decimal;
@@ -171,7 +175,8 @@ const UnmemoizedTreeNodeComponent = ({
   indentationLevel,
   currentNodeId,
   setCurrentNodeId,
-  showMetrics,
+  showDuration,
+  showCostTokens,
   showScores,
   colorCodeMetrics,
   parentTotalCost,
@@ -291,7 +296,8 @@ const UnmemoizedTreeNodeComponent = ({
               node={node}
               scores={scores}
               comments={comments}
-              showMetrics={showMetrics}
+              showDuration={showDuration}
+              showCostTokens={showCostTokens}
               showScores={showScores}
               colorCodeMetrics={colorCodeMetrics}
               parentTotalCost={parentTotalCost}
@@ -354,7 +360,8 @@ const UnmemoizedTreeNodeComponent = ({
                   indentationLevel={indentationLevel + 1}
                   currentNodeId={currentNodeId}
                   setCurrentNodeId={setCurrentNodeId}
-                  showMetrics={showMetrics}
+                  showDuration={showDuration}
+                  showCostTokens={showCostTokens}
                   showScores={showScores}
                   colorCodeMetrics={colorCodeMetrics}
                   parentTotalCost={parentTotalCost}

--- a/web/src/components/trace/index.tsx
+++ b/web/src/components/trace/index.tsx
@@ -89,8 +89,10 @@ export function Trace(props: {
     StringParam,
   );
   const [viewTab] = useQueryParam("view", StringParam);
-  const [metricsOnObservationTree, setMetricsOnObservationTree] =
-    useLocalStorage("metricsOnObservationTree", true);
+  const [durationOnObservationTree, setDurationOnObservationTree] =
+    useLocalStorage("durationOnObservationTree", true);
+  const [costTokensOnObservationTree, setCostTokensOnObservationTree] =
+    useLocalStorage("costTokensOnObservationTree", true);
   const [scoresOnObservationTree, setScoresOnObservationTree] = useLocalStorage(
     "scoresOnObservationTree",
     true,
@@ -324,7 +326,8 @@ export function Trace(props: {
       displayScores={displayScores}
       onSelect={setCurrentObservationId}
       comments={commentsMap}
-      showMetrics={metricsOnObservationTree}
+      showDuration={durationOnObservationTree}
+      showCostTokens={costTokensOnObservationTree}
       showScores={scoresOnObservationTree}
       colorCodeMetrics={colorCodeMetricsOnObservationTree}
       showComments={showComments}
@@ -338,7 +341,8 @@ export function Trace(props: {
       displayScores={displayScores}
       currentNodeId={currentObservationId ?? undefined}
       setCurrentNodeId={setCurrentObservationId}
-      showMetrics={metricsOnObservationTree}
+      showDuration={durationOnObservationTree}
+      showCostTokens={costTokensOnObservationTree}
       showScores={scoresOnObservationTree}
       showComments={showComments}
       colorCodeMetrics={colorCodeMetricsOnObservationTree}
@@ -481,9 +485,15 @@ export function Trace(props: {
                         setShowComments={setShowComments}
                         scoresOnObservationTree={scoresOnObservationTree}
                         setScoresOnObservationTree={setScoresOnObservationTree}
-                        metricsOnObservationTree={metricsOnObservationTree}
-                        setMetricsOnObservationTree={
-                          setMetricsOnObservationTree
+                        durationOnObservationTree={durationOnObservationTree}
+                        setDurationOnObservationTree={
+                          setDurationOnObservationTree
+                        }
+                        costTokensOnObservationTree={
+                          costTokensOnObservationTree
+                        }
+                        setCostTokensOnObservationTree={
+                          setCostTokensOnObservationTree
                         }
                         colorCodeMetricsOnObservationTree={
                           colorCodeMetricsOnObservationTree
@@ -547,7 +557,8 @@ export function Trace(props: {
                         setCurrentObservationId={setCurrentObservationId}
                         expandedItems={expandedItems}
                         setExpandedItems={setExpandedItems}
-                        showMetrics={metricsOnObservationTree}
+                        showDuration={durationOnObservationTree}
+                        showCostTokens={costTokensOnObservationTree}
                         showScores={scoresOnObservationTree}
                         showComments={showComments}
                         colorCodeMetrics={colorCodeMetricsOnObservationTree}
@@ -727,9 +738,17 @@ export function Trace(props: {
                             setScoresOnObservationTree={
                               setScoresOnObservationTree
                             }
-                            metricsOnObservationTree={metricsOnObservationTree}
-                            setMetricsOnObservationTree={
-                              setMetricsOnObservationTree
+                            durationOnObservationTree={
+                              durationOnObservationTree
+                            }
+                            setDurationOnObservationTree={
+                              setDurationOnObservationTree
+                            }
+                            costTokensOnObservationTree={
+                              costTokensOnObservationTree
+                            }
+                            setCostTokensOnObservationTree={
+                              setCostTokensOnObservationTree
                             }
                             colorCodeMetricsOnObservationTree={
                               colorCodeMetricsOnObservationTree
@@ -835,7 +854,8 @@ export function Trace(props: {
                                   }
                                   expandedItems={expandedItems}
                                   setExpandedItems={setExpandedItems}
-                                  showMetrics={metricsOnObservationTree}
+                                  showDuration={durationOnObservationTree}
+                                  showCostTokens={costTokensOnObservationTree}
                                   showScores={scoresOnObservationTree}
                                   showComments={showComments}
                                   colorCodeMetrics={
@@ -876,7 +896,8 @@ export function Trace(props: {
                                 }
                                 expandedItems={expandedItems}
                                 setExpandedItems={setExpandedItems}
-                                showMetrics={metricsOnObservationTree}
+                                showDuration={durationOnObservationTree}
+                                showCostTokens={costTokensOnObservationTree}
                                 showScores={scoresOnObservationTree}
                                 showComments={showComments}
                                 colorCodeMetrics={


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Separate toggling of duration and cost/tokens in trace tree components, updating logic and UI to handle them independently.
> 
>   - **Behavior**:
>     - Separate toggling of `duration` and `cost/tokens` in trace tree components.
>     - Update logic to handle `showDuration` and `showCostTokens` independently in `SpanItem`, `TraceSearchList`, `TraceSettingsDropdown`, `TraceTimelineView`, `TraceTree`, and `index.tsx`.
>   - **Props and State**:
>     - Rename `showMetrics` to `showDuration` and `showCostTokens` in `SpanItemProps`, `TraceSearchListProps`, `TraceSettingsDropdownProps`, and `TraceTimelineView`.
>     - Update local storage keys to `durationOnObservationTree` and `costTokensOnObservationTree` in `index.tsx`.
>   - **UI Components**:
>     - Add separate switches for `Show Duration` and `Show Cost/Tokens` in `TraceSettingsDropdown`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 469147240df08793fcc316a2ecc0e0424fdb4cb6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->