### PR TITLE
fix(ui): remove 2nd scrollbar

### DIFF
--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -437,7 +437,7 @@ export function ResizableContent({ children }: PropsWithChildren) {
     <ResizablePanelGroup direction="horizontal" className="flex h-full w-full">
       <ResizablePanel ref={mainPanelRef} defaultSize={100} minSize={30}>
         <main
-          className="relative h-full w-full overflow-scroll"
+          className="relative h-full w-full"
           style={{ overscrollBehaviorY: "none" }}
         >
           {children}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `overflow-scroll` class from `main` in `ResizableContent` to eliminate second scrollbar.
> 
>   - **UI Fix**:
>     - Remove `overflow-scroll` class from `main` element in `ResizableContent` in `layout.tsx` to eliminate second scrollbar.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1873f3eaf9ba51b65deb29e382f440298e3b17b6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->