### PR TITLE
feat(billing): add contact sales button for enterprise plan

### DIFF
--- a/web/src/ee/features/billing/components/BillingSwitchPlanDialog.tsx
+++ b/web/src/ee/features/billing/components/BillingSwitchPlanDialog.tsx
@@ -255,34 +255,46 @@ export const BillingSwitchPlanDialog = ({
                       </div>
                     ) : (
                       // The default behavior when the user is not on a paid plan.
-                      <ActionButton
-                        onClick={() => {
-                          if (organization) {
-                            setProcessingPlanId(product.stripeProductId);
+                      <div className="mt-2 flex gap-1">
+                        <ActionButton
+                          onClick={() => {
+                            if (organization) {
+                              setProcessingPlanId(product.stripeProductId);
 
-                            // idempotency key for mutation operations with the stripe api
-                            let opId = _opId;
-                            if (!opId) {
-                              opId = nanoid();
-                              setOpId(opId);
+                              // idempotency key for mutation operations with the stripe api
+                              let opId = _opId;
+                              if (!opId) {
+                                opId = nanoid();
+                                setOpId(opId);
+                              }
+
+                              mutCreateCheckoutSession.mutate({
+                                orgId: organization.id,
+                                stripeProductId: product.stripeProductId,
+                                opId: opId,
+                              });
                             }
-
-                            mutCreateCheckoutSession.mutate({
-                              orgId: organization.id,
-                              stripeProductId: product.stripeProductId,
-                              opId: opId,
-                            });
+                          }}
+                          disabled={
+                            organization?.cloudConfig?.stripe
+                              ?.activeProductId === product.stripeProductId
                           }
-                        }}
-                        disabled={
-                          organization?.cloudConfig?.stripe?.activeProductId ===
-                          product.stripeProductId
-                        }
-                        className="w-full"
-                        loading={processingPlanId === product.stripeProductId}
-                      >
-                        Select plan
-                      </ActionButton>
+                          className="w-full"
+                          loading={processingPlanId === product.stripeProductId}
+                        >
+                          {product.checkout?.cta ? "Select" : "Select plan"}
+                        </ActionButton>
+                        {/* Optional checkout CTA button for non-paid plan users */}
+                        {product.checkout?.cta && (
+                          <ActionButton
+                            variant="secondary"
+                            href={product.checkout.cta.href}
+                            className="w-full"
+                          >
+                            {product.checkout.cta.label}
+                          </ActionButton>
+                        )}
+                      </div>
                     )}
                   </div>
                 );

--- a/web/src/ee/features/billing/utils/stripeCatalogue.ts
+++ b/web/src/ee/features/billing/utils/stripeCatalogue.ts
@@ -16,6 +16,10 @@ type StripeProduct = {
     price: string;
     usagePrice: string;
     mainFeatures: string[];
+    cta?: {
+      label: string;
+      href: string;
+    };
   } | null;
 };
 
@@ -104,6 +108,10 @@ export const stripeProducts: StripeProduct[] = [
         "Support SLA",
         "Dedicated support engineer",
       ],
+      cta: {
+        label: "Contact Sales",
+        href: "https://langfuse.com/talk-to-us",
+      },
     },
   },
 ];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds 'Contact Sales' button for enterprise plan in billing dialog for non-paid users, with CTA details in `stripeCatalogue.ts`.
> 
>   - **Behavior**:
>     - Adds 'Contact Sales' button for enterprise plan in `BillingSwitchPlanDialog.tsx` for non-paid plan users.
>     - Button links to 'https://langfuse.com/talk-to-us'.
>   - **Data Model**:
>     - Updates `StripeProduct` type in `stripeCatalogue.ts` to include optional `cta` field.
>     - Adds `cta` details for enterprise plan in `stripeCatalogue.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 152c8e31c3c212852727e18d6ef41329068fb337. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->