### PR TITLE
feat(metrics): add timestampDay field to scoresNumericView and scoresCategoricalView

### DIFF
--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -524,6 +524,12 @@ export const scoresNumericView: ViewDeclarationType = {
       type: "string",
       description: "Month of the score timestamp in YYYY-MM format.",
     },
+    timestampDay: {
+      sql: "formatDateTime(scores_numeric.timestamp, '%Y-%m-%d')",
+      alias: "timestampDay",
+      type: "string",
+      description: "Day of the score timestamp in YYYY-MM-DD format.",
+    },
     observationId: {
       sql: "scores_numeric.observation_id",
       alias: "observationId",
@@ -633,6 +639,12 @@ export const scoresCategoricalView: ViewDeclarationType = {
       alias: "timestampMonth",
       type: "string",
       description: "Month of the score timestamp in YYYY-MM format.",
+    },
+    timestampDay: {
+      sql: "formatDateTime(scores_categorical.timestamp, '%Y-%m-%d')",
+      alias: "timestampDay",
+      type: "string",
+      description: "Day of the score timestamp in YYYY-MM-DD format.",
     },
     observationId: {
       sql: "scores_categorical.observation_id",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `timestampDay` field to `scoresNumericView` and `scoresCategoricalView` in `dataModel.ts` to capture the day of the score timestamp.
> 
>   - **Behavior**:
>     - Add `timestampDay` field to `scoresNumericView` and `scoresCategoricalView` in `dataModel.ts`.
>     - `timestampDay` captures the day of the score timestamp in `YYYY-MM-DD` format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 47d063bc9e9ab4d4907f070bd43646e8e830f227. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->