### PR TITLE
fix(ui): header positioning with active PaymentBanner

### DIFF
--- a/web/src/components/layouts/container-page.tsx
+++ b/web/src/components/layouts/container-page.tsx
@@ -13,7 +13,7 @@ const ContainerPage = ({ children, headerProps }: SettingsContainerProps) => {
     <div
       className={cn("relative flex min-h-screen-with-banner flex-1 flex-col")}
     >
-      <header className={cn("sticky top-0 z-50 w-full")}>
+      <header className="sticky top-0 z-50 w-full">
         <PageHeader {...headerProps} container />
       </header>
       <main

--- a/web/src/components/layouts/container-page.tsx
+++ b/web/src/components/layouts/container-page.tsx
@@ -2,7 +2,6 @@ import PageHeader, {
   type PageHeaderProps,
 } from "@/src/components/layouts/page-header";
 import { cn } from "@/src/utils/tailwind";
-import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
 
 type SettingsContainerProps = {
   children: React.ReactNode;
@@ -10,18 +9,11 @@ type SettingsContainerProps = {
 };
 
 const ContainerPage = ({ children, headerProps }: SettingsContainerProps) => {
-  const { open: supportDrawerIsOpen } = useSupportDrawer();
-
   return (
     <div
       className={cn("relative flex min-h-screen-with-banner flex-1 flex-col")}
     >
-      <header
-        className={cn(
-          "sticky z-50 w-full",
-          supportDrawerIsOpen ? "top-0" : "top-banner-offset", // if the support drawer is open the parent element changes (see layout.tsx) and we need to adjust the top position
-        )}
-      >
+      <header className={cn("sticky top-0 z-50 w-full")}>
         <PageHeader {...headerProps} container />
       </header>
       <main

--- a/web/src/components/layouts/page.tsx
+++ b/web/src/components/layouts/page.tsx
@@ -2,7 +2,6 @@ import PageHeader, {
   type PageHeaderProps,
 } from "@/src/components/layouts/page-header";
 import { cn } from "@/src/utils/tailwind";
-import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
 
 type PageContainerProps = {
   children: React.ReactNode;
@@ -17,8 +16,6 @@ const Page = ({
   scrollable = false,
   withPadding = false,
 }: PageContainerProps) => {
-  const { open: supportDrawerIsOpen } = useSupportDrawer();
-
   return (
     <div
       className={cn(
@@ -27,12 +24,7 @@ const Page = ({
       )}
       id="page"
     >
-      <header
-        className={cn(
-          "sticky z-50 w-full",
-          supportDrawerIsOpen ? "top-0" : "top-banner-offset", // if the support drawer is open the parent element changes (see layout.tsx) and we need to adjust the top position
-        )}
-      >
+      <header className={cn("sticky top-0 z-50 w-full")}>
         <PageHeader {...headerProps} container={false} className={"top-0"} />
       </header>
       <main

--- a/web/src/components/layouts/page.tsx
+++ b/web/src/components/layouts/page.tsx
@@ -24,7 +24,7 @@ const Page = ({
       )}
       id="page"
     >
-      <header className={cn("sticky top-0 z-50 w-full")}>
+      <header className="sticky top-0 z-50 w-full">
         <PageHeader {...headerProps} container={false} className={"top-0"} />
       </header>
       <main


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Simplifies header positioning in `ContainerPage` and `Page` by removing `useSupportDrawer` dependency, setting header `top` position to `top-0`.
> 
>   - **Behavior**:
>     - Simplifies header positioning in `ContainerPage` and `Page` by removing `useSupportDrawer` dependency.
>     - Header `top` position is now consistently `top-0`, regardless of support drawer state.
>   - **Code Removal**:
>     - Removes `useSupportDrawer` import and usage in `container-page.tsx` and `page.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 15d7f9daacf5c78aecd7434ba6575eb0f884d2cb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->