### PR TITLE
fix(datasets): add sanitization for control characters in JSON data processing

### DIFF
--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -61,11 +61,50 @@ import {
 } from "@langfuse/shared/src/server";
 import { type BulkDatasetItemValidationError } from "@langfuse/shared";
 
+/**
+ * Remove problematic C0 and C1 control characters from string values.
+ * PostgreSQL TEXT columns cannot store NULL byte (\u0000) and other control characters.
+ * Preserves common characters like newlines and tabs.
+ */
+const cleanControlChars = (input: string): string => {
+  if (!input) return input;
+
+  // Remove control characters:
+  // \u0000-\u0008: NULL through backspace
+  // \u000B: vertical tab (preserve \n=\u000A, \t=\u0009, \r=\u000D)
+  // \u000E-\u001F: shift out through unit separator
+  // \u007F-\u009F: DEL + C1 controls
+  return input.replace(/[\u0000-\u0008\u000B\u000E-\u001F\u007F-\u009F]/g, "");
+};
+
+/**
+ * Recursively clean control characters from all string values in a JSON structure.
+ * This handles strings within objects and arrays after JSON.parse.
+ */
+const sanitizeJsonValue = (value: unknown): unknown => {
+  if (typeof value === "string") {
+    return cleanControlChars(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(sanitizeJsonValue);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([k, v]) => [k, sanitizeJsonValue(v)]),
+    );
+  }
+  return value;
+};
+
 const formatDatasetItemData = (data: string | null | undefined) => {
   if (data === "") return Prisma.DbNull;
 
   try {
-    return !!data ? (JSON.parse(data) as Prisma.InputJsonObject) : undefined;
+    const parsed = !!data ? JSON.parse(data) : undefined;
+    // Sanitize control characters from parsed object before sending to PostgreSQL
+    return parsed
+      ? (sanitizeJsonValue(parsed) as Prisma.InputJsonObject)
+      : undefined;
   } catch (e) {
     logger.info(
       "[trpc.datasets.formatDatasetItemData] failed to parse dataset item data",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds sanitization for control characters in JSON data processing to ensure compatibility with PostgreSQL TEXT columns.
> 
>   - **Behavior**:
>     - Adds `cleanControlChars` function to remove C0 and C1 control characters from strings, preserving newlines and tabs.
>     - Adds `sanitizeJsonValue` function to recursively clean control characters from JSON structures.
>     - Integrates `sanitizeJsonValue` into `formatDatasetItemData` to sanitize JSON data before sending to PostgreSQL.
>   - **Functions**:
>     - `cleanControlChars` removes problematic control characters from strings.
>     - `sanitizeJsonValue` cleans control characters from JSON objects and arrays.
>     - `formatDatasetItemData` now sanitizes parsed JSON data using `sanitizeJsonValue`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 812521114a8ea08ae599c33370df9e72ca2e0a2d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->