### PR TITLE
fix(filters-ui): add disableUrlPersistence option to prevent filter state from being persisted in embedded tables

### DIFF
--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -278,6 +278,7 @@ export default function TracesTable({
     filterOptions,
     projectId,
     traceFilterOptionsResponse.isPending || environmentFilterOptions.isPending,
+    hideControls, // Disable URL persistence for embedded preview tables
   );
 
   const combinedFilterState = queryFilter.filterState.concat(

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -342,6 +342,7 @@ export function useSidebarFilterState(
     defaultsApplied,
     config.facets,
     options,
+    disableUrlPersistence,
     setFilterState,
     setDefaultsApplied,
   ]);

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -244,6 +244,12 @@ export function useSidebarFilterState(
   >,
   projectId?: string,
   loading?: boolean,
+  /**
+   * If true, prevents filter state from being persisted to/read from URL query params.
+   * Use this for embedded tables (e.g., preview tables in forms) to avoid polluting
+   * the parent page's URL with filters that don't apply to the parent context.
+   */
+  disableUrlPersistence?: boolean,
 ) {
   const FILTER_EXPANDED_STORAGE_KEY = `${config.tableName}-filters-expanded`;
   const DEFAULT_EXPANDED_FILTERS = config.defaultExpanded ?? [];
@@ -268,15 +274,19 @@ export function useSidebarFilterState(
   );
 
   const filterState: FilterState = useMemo(() => {
+    // If URL persistence is disabled, return empty filter state
+    if (disableUrlPersistence) return [];
     return decodeAndNormalizeFilters(filtersQuery, config.columnDefinitions);
-  }, [filtersQuery, config.columnDefinitions]);
+  }, [filtersQuery, config.columnDefinitions, disableUrlPersistence]);
 
   const setFilterState = useCallback(
     (newFilters: FilterState) => {
+      // Don't modify URL if persistence is disabled
+      if (disableUrlPersistence) return;
       const encoded = encodeFiltersGeneric(newFilters);
       setFiltersQuery(encoded || null);
     },
-    [setFiltersQuery],
+    [setFiltersQuery, disableUrlPersistence],
   );
 
   // track if defaults have been applied before, versioned to support future changes
@@ -291,6 +301,8 @@ export function useSidebarFilterState(
 
   // init default env filters on first load to deselect envs prefixed with "langfuse-"
   useEffect(() => {
+    // Skip auto-applying defaults for embedded tables
+    if (disableUrlPersistence) return;
     if (filterState.length > 0 || defaultsApplied) return;
 
     // only if there is an environment facet


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `disableUrlPersistence` option to `useSidebarFilterState` to prevent URL persistence of filter states in embedded tables, used in `TracesTable`.
> 
>   - **Behavior**:
>     - Adds `disableUrlPersistence` option to `useSidebarFilterState` in `useSidebarFilterState.tsx` to prevent filter state from being persisted to/read from URL query params.
>     - Utilized in `TracesTable` in `traces.tsx` to disable URL persistence for embedded preview tables.
>   - **Functions**:
>     - Updates `useSidebarFilterState` to handle `disableUrlPersistence` by returning an empty filter state and avoiding URL modifications when true.
>     - Modifies `setFilterState` and `filterState` logic in `useSidebarFilterState` to respect `disableUrlPersistence`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 26aad0bd055db6e6d31efeb5be91cd6c73d8ba3a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->