### PR TITLE
fix(annotation): gracefully handle deleted parent objects for annotation queue items

### DIFF
--- a/web/src/components/ui/object-not-found-card.tsx
+++ b/web/src/components/ui/object-not-found-card.tsx
@@ -1,0 +1,17 @@
+import { Card } from "@/src/components/ui/card";
+import { SearchXIcon } from "lucide-react";
+
+export const ObjectNotFoundCard = ({
+  type,
+}: {
+  type: "TRACE" | "OBSERVATION" | "SESSION";
+}) => (
+  <Card className="flex h-full items-center justify-center p-6">
+    <div className="text-center">
+      <SearchXIcon className="mx-auto mb-2 h-8 w-8 text-muted-foreground" />
+      <p className="text-sm capitalize text-muted-foreground">
+        {type.toLowerCase()} not found. Likely deleted.
+      </p>
+    </div>
+  </Card>
+);

--- a/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
@@ -15,6 +15,7 @@ import { useAnnotationQueueData } from "./shared/hooks/useAnnotationQueueData";
 import { useAnnotationObjectData } from "./shared/hooks/useAnnotationObjectData";
 import { TraceAnnotationProcessor } from "./processors/TraceAnnotationProcessor";
 import { SessionAnnotationProcessor } from "./processors/SessionAnnotationProcessor";
+import { ObjectNotFoundCard } from "@/src/components/ui/object-not-found-card";
 
 export const AnnotationQueueItemPage: React.FC<{
   annotationQueueId: string;
@@ -177,6 +178,16 @@ export const AnnotationQueueItemPage: React.FC<{
   };
 
   const renderContent = () => {
+    // Handle deleted object (trace/observation/session not found)
+    if (objectData.isError && objectData.errorCode === "NOT_FOUND") {
+      return (
+        <ObjectNotFoundCard
+          type={relevantItem?.objectType ?? AnnotationQueueObjectType.TRACE}
+        />
+      );
+    }
+
+    // Handle deleted queue item
     if (!relevantItem) {
       return (
         <Card className="flex h-full w-full flex-col items-center justify-center overflow-hidden">
@@ -258,7 +269,9 @@ export const AnnotationQueueItemPage: React.FC<{
                 onClick={handleComplete}
                 size="lg"
                 className="w-full"
-                disabled={completeMutation.isPending || !hasAccess}
+                disabled={
+                  completeMutation.isPending || !hasAccess || objectData.isError
+                }
               >
                 {isSingleItem || progressIndex + 1 === totalItems
                   ? "Complete"

--- a/web/src/features/annotation-queues/components/shared/hooks/useAnnotationObjectData.ts
+++ b/web/src/features/annotation-queues/components/shared/hooks/useAnnotationObjectData.ts
@@ -7,6 +7,8 @@ import {
 export interface ObjectDataHook<TData> {
   data: TData | undefined;
   isLoading: boolean;
+  isError: boolean;
+  errorCode?: string;
 }
 
 export const useAnnotationObjectData = (
@@ -23,7 +25,11 @@ export const useAnnotationObjectData = (
         (item.objectType === AnnotationQueueObjectType.TRACE ||
           item.objectType === AnnotationQueueObjectType.OBSERVATION),
       retry(failureCount, error) {
-        if (error.data?.code === "UNAUTHORIZED") return false;
+        if (
+          error.data?.code === "UNAUTHORIZED" ||
+          error.data?.code === "NOT_FOUND"
+        )
+          return false;
         return failureCount < 3;
       },
     },
@@ -51,6 +57,7 @@ export const useAnnotationObjectData = (
     return {
       data: undefined,
       isLoading: false,
+      isError: false,
     };
   }
 
@@ -60,11 +67,15 @@ export const useAnnotationObjectData = (
       return {
         data: traceQuery.data,
         isLoading: traceQuery.isLoading,
+        isError: traceQuery.isError,
+        errorCode: traceQuery.error?.data?.code,
       };
     case AnnotationQueueObjectType.SESSION:
       return {
         data: sessionQuery.data,
         isLoading: sessionQuery.isLoading,
+        isError: sessionQuery.isError,
+        errorCode: sessionQuery.error?.data?.code,
       };
     default:
       // This should never happen as it's a DB enum


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces `ObjectNotFoundCard` to handle deleted parent objects in annotation queues, enhancing error handling and user feedback.
> 
>   - **Behavior**:
>     - Introduces `ObjectNotFoundCard` component in `object-not-found-card.tsx` to display a message when a parent object (trace, observation, session) is not found.
>     - Updates `AnnotationQueueItemPage.tsx` to use `ObjectNotFoundCard` when `objectData` indicates a "NOT_FOUND" error.
>     - Disables "Complete" button in `AnnotationQueueItemPage.tsx` if `objectData` has an error.
>   - **Hooks**:
>     - Adds `isError` and `errorCode` to `ObjectDataHook` in `useAnnotationObjectData.ts` to track errors.
>     - Updates `useAnnotationObjectData` to set `isError` and `errorCode` based on query results.
>   - **Server**:
>     - Removes try-catch blocks in `annotationQueueItemsRouter.ts` for cleaner error handling.
>     - Throws `LangfuseNotFoundError` in `byId` query if observation is not found.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 67cf8e7b030224ec831574190d3f7ee4bb02d83a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->