### PR TITLE
fix(filters): add on hover for truncated values

### DIFF
--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -1144,7 +1144,10 @@ function TextFilterSection({
               <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
                 {f.operator === "contains" ? "contains" : "does not contain"}
               </span>
-              <span className="min-w-0 flex-1 truncate font-medium">
+              <span
+                className="min-w-0 flex-1 truncate font-medium"
+                title={f.value}
+              >
                 {f.value}
               </span>
               <Button
@@ -1213,7 +1216,9 @@ export function FilterValueCheckbox({
         )}
         onClick={onLabelClick}
       >
-        <span className="min-w-0 flex-1 truncate text-xs">{label}</span>
+        <span className="min-w-0 flex-1 truncate text-xs" title={label}>
+          {label}
+        </span>
 
         {/* "Only" or "All" indicator when hovering label */}
         {onLabelClick && !disabled && (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `title` attribute to truncated text spans in `data-table-controls.tsx` for hover display of full text.
> 
>   - **Behavior**:
>     - Add `title` attribute to truncated text spans in `TextFilterSection` and `FilterValueCheckbox` to show full text on hover.
>   - **Files**:
>     - `data-table-controls.tsx`: Updated `TextFilterSection` and `FilterValueCheckbox` components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8218372b0b550b3b6426a801d782ea42c380e790. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->