### PR TITLE
refactor(score-analytics): eliminate duplicate preflight query

### DIFF
--- a/web/src/features/score-analytics/components/ScoreAnalyticsProvider.tsx
+++ b/web/src/features/score-analytics/components/ScoreAnalyticsProvider.tsx
@@ -137,9 +137,22 @@ export function ScoreAnalyticsProvider({
 
   // Step 2: Only run main query after estimate succeeds
   // This applies to both single-score and two-score modes now
-  const queryResult = useScoreAnalyticsQuery(params, {
-    enabled: !canEstimate || estimateQuery.isSuccess,
-  });
+  // Pass estimate results to avoid duplicate preflight query
+  const queryResult = useScoreAnalyticsQuery(
+    {
+      ...params,
+      estimateResults: estimateQuery.data
+        ? {
+            score1Count: estimateQuery.data.score1Count,
+            score2Count: estimateQuery.data.score2Count,
+            estimatedMatchedCount: estimateQuery.data.estimatedMatchedCount,
+          }
+        : undefined,
+    },
+    {
+      enabled: !canEstimate || estimateQuery.isSuccess,
+    },
+  );
 
   // Determine color scheme based on mode
   const colors = useMemo(() => {

--- a/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.ts
+++ b/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.ts
@@ -47,6 +47,12 @@ export interface ScoreAnalyticsQueryParams {
   interval: IntervalConfig;
   objectType?: ObjectType;
   nBins?: number; // Default: 10
+  // Optional: Pass estimate results to avoid duplicate preflight query
+  estimateResults?: {
+    score1Count: number;
+    score2Count: number;
+    estimatedMatchedCount: number;
+  };
 }
 
 /**
@@ -207,6 +213,7 @@ export function useScoreAnalyticsQuery(
     interval,
     objectType,
     nBins = 10,
+    estimateResults,
   } = params;
 
   // Determine mode: "single" when only score1 selected, "two" when score2 explicitly provided
@@ -227,6 +234,7 @@ export function useScoreAnalyticsQuery(
       toTimestamp,
       interval,
       objectType,
+      estimateResults, // Pass estimate results to avoid duplicate preflight query
     },
     {
       enabled: (options?.enabled ?? true) && !!(projectId && score1),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor score analytics to eliminate duplicate preflight queries by passing estimate results from client to server.
> 
>   - **Behavior**:
>     - Passes `estimateResults` from `ScoreAnalyticsProvider` to `useScoreAnalyticsQuery` to avoid duplicate preflight queries.
>     - In `scoreAnalyticsRouter`, uses `estimateResults` if available, otherwise runs `buildEstimateQuery`.
>   - **Components**:
>     - `ScoreAnalyticsProvider`: Modifies `useScoreAnalyticsQuery` call to include `estimateResults`.
>   - **Hooks**:
>     - `useScoreAnalyticsQuery`: Accepts `estimateResults` in `params` to prevent duplicate queries.
>   - **Server**:
>     - `scoreAnalyticsRouter`: Checks for `estimateResults` in input to skip redundant preflight queries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0601a6e3ff82652aa79031d1361b1c7d1acd8d13. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->