### PR TITLE
Revert "fix(ui): remove 2nd scrollbar"

### DIFF
--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -437,7 +437,7 @@ export function ResizableContent({ children }: PropsWithChildren) {
     <ResizablePanelGroup direction="horizontal" className="flex h-full w-full">
       <ResizablePanel ref={mainPanelRef} defaultSize={100} minSize={30}>
         <main
-          className="relative h-full w-full"
+          className="relative h-full w-full overflow-scroll"
           style={{ overscrollBehaviorY: "none" }}
         >
           {children}


### PR DESCRIPTION
Reverts langfuse/langfuse#10399
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts previous change in `ResizableContent` in `layout.tsx` to restore the `overflow-scroll` class, reintroducing the second scrollbar.
> 
>   - **Behavior**:
>     - Reverts previous change in `ResizableContent` in `layout.tsx` to restore the `overflow-scroll` class to the `main` element, reintroducing the second scrollbar.
>   - **Misc**:
>     - Reverts langfuse/langfuse#10399.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d737a902077f1a946bdf76d249c741c06d058e4d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->