### PR TITLE
fix(annotation): upsert parsing

### DIFF
--- a/packages/shared/src/features/annotation/types.ts
+++ b/packages/shared/src/features/annotation/types.ts
@@ -33,7 +33,7 @@ const CreateAnnotationScoreBase = z.object({
   configId: z.string(),
   comment: StringNoHTML.nullish(),
   queueId: z.string().nullish(),
-  timestamp: z.date().optional(), // Required for ClickHouse deduplication
+  timestamp: z.coerce.date().optional(), // Required for ClickHouse deduplication - coerce handles string/number inputs
 });
 
 const UpdateAnnotationScoreBase = CreateAnnotationScoreBase.extend({

--- a/packages/shared/src/server/repositories/scores_converters.ts
+++ b/packages/shared/src/server/repositories/scores_converters.ts
@@ -37,8 +37,12 @@ export const convertClickhouseScoreToDomain = <ExcludeMetadata extends boolean>(
     dataType: record.data_type as ScoreDataType,
     queueId: record.queue_id ?? null,
     executionTraceId: record.execution_trace_id ?? null,
-    createdAt: parseClickhouseUTCDateTimeFormat(record.created_at),
-    updatedAt: parseClickhouseUTCDateTimeFormat(record.updated_at),
+    createdAt: parseClickhouseUTCDateTimeFormat(
+      record.created_at ?? new Date(),
+    ),
+    updatedAt: parseClickhouseUTCDateTimeFormat(
+      record.updated_at ?? new Date(),
+    ),
     metadata: (includeMetadataPayload
       ? (parseMetadataCHRecordToDomain(record.metadata ?? {}) ?? {})
       : {}) as ExcludeMetadata extends true

--- a/web/src/features/scores/hooks/useScoreMutations.ts
+++ b/web/src/features/scores/hooks/useScoreMutations.ts
@@ -56,7 +56,7 @@ export function useScoreMutations({
         value: variables.value ?? null,
         stringValue: variables.stringValue ?? null,
         comment: variables.comment ?? null,
-        timestamp: variables.timestamp ?? new Date(),
+        timestamp: (variables.timestamp as Date | undefined) ?? new Date(),
       });
 
       return { scoreId: variables.id! };
@@ -91,7 +91,7 @@ export function useScoreMutations({
           value: variables.value ?? null,
           stringValue: variables.stringValue ?? null,
           comment: variables.comment ?? null,
-          timestamp: variables.timestamp ?? new Date(),
+          timestamp: (variables.timestamp as Date | undefined) ?? new Date(),
         });
       } else {
         // Merge update into existing cache entry

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -543,6 +543,12 @@ export const scoresRouter = createTRPCRouter({
         data_type: input.dataType,
         string_value: input.stringValue,
         queue_id: input.queueId,
+        dataset_run_id: null,
+        execution_trace_id: null,
+        created_at: convertDateToClickhouseDateTime(score.createdAt),
+        updated_at: convertDateToClickhouseDateTime(score.updatedAt),
+        is_deleted: 0,
+        metadata: score.metadata as Record<string, string>,
       });
 
       await auditLog({
@@ -664,6 +670,12 @@ export const scoresRouter = createTRPCRouter({
           data_type: input.dataType,
           string_value: input.stringValue,
           queue_id: input.queueId,
+          dataset_run_id: null,
+          execution_trace_id: null,
+          created_at: convertDateToClickhouseDateTime(new Date()),
+          updated_at: convertDateToClickhouseDateTime(new Date()),
+          is_deleted: 0,
+          metadata: {},
         });
 
         const baseScore = {
@@ -763,6 +775,12 @@ export const scoresRouter = createTRPCRouter({
           observation_id: score.observationId,
           session_id: score.sessionId,
           environment: score.environment,
+          dataset_run_id: null,
+          execution_trace_id: null,
+          created_at: convertDateToClickhouseDateTime(score.createdAt),
+          updated_at: convertDateToClickhouseDateTime(score.updatedAt),
+          is_deleted: 0,
+          metadata: score.metadata as Record<string, string>,
         });
 
         const baseScore = {

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -543,11 +543,8 @@ export const scoresRouter = createTRPCRouter({
         data_type: input.dataType,
         string_value: input.stringValue,
         queue_id: input.queueId,
-        dataset_run_id: null,
-        execution_trace_id: null,
         created_at: convertDateToClickhouseDateTime(score.createdAt),
         updated_at: convertDateToClickhouseDateTime(score.updatedAt),
-        is_deleted: 0,
         metadata: score.metadata as Record<string, string>,
       });
 
@@ -670,11 +667,8 @@ export const scoresRouter = createTRPCRouter({
           data_type: input.dataType,
           string_value: input.stringValue,
           queue_id: input.queueId,
-          dataset_run_id: null,
-          execution_trace_id: null,
           created_at: convertDateToClickhouseDateTime(new Date()),
           updated_at: convertDateToClickhouseDateTime(new Date()),
-          is_deleted: 0,
           metadata: {},
         });
 
@@ -775,11 +769,8 @@ export const scoresRouter = createTRPCRouter({
           observation_id: score.observationId,
           session_id: score.sessionId,
           environment: score.environment,
-          dataset_run_id: null,
-          execution_trace_id: null,
           created_at: convertDateToClickhouseDateTime(score.createdAt),
           updated_at: convertDateToClickhouseDateTime(score.updatedAt),
-          is_deleted: 0,
           metadata: score.metadata as Record<string, string>,
         });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves timestamp handling by setting defaults and coercing inputs across score creation, updating, and conversion processes.
> 
>   - **Behavior**:
>     - In `types.ts`, `timestamp` in `CreateAnnotationScoreBase` now coerces string/number inputs to date.
>     - In `scores_converters.ts`, `createdAt` and `updatedAt` default to `new Date()` if missing.
>     - In `useScoreMutations.ts`, `timestamp` defaults to `new Date()` if `variables.timestamp` is undefined.
>     - In `scores.ts`, `created_at` and `updated_at` are set using `convertDateToClickhouseDateTime()` for new and updated scores.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d3ce386346a1c14d6fb528563bf69f54569e6ed6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->