### PR TITLE
chore(scores): converter Date fallbacks

### DIFF
--- a/packages/shared/src/server/repositories/scores_converters.ts
+++ b/packages/shared/src/server/repositories/scores_converters.ts
@@ -37,12 +37,12 @@ export const convertClickhouseScoreToDomain = <ExcludeMetadata extends boolean>(
     dataType: record.data_type as ScoreDataType,
     queueId: record.queue_id ?? null,
     executionTraceId: record.execution_trace_id ?? null,
-    createdAt: parseClickhouseUTCDateTimeFormat(
-      record.created_at ?? new Date(),
-    ),
-    updatedAt: parseClickhouseUTCDateTimeFormat(
-      record.updated_at ?? new Date(),
-    ),
+    createdAt: record.created_at
+      ? parseClickhouseUTCDateTimeFormat(record.created_at)
+      : new Date(),
+    updatedAt: record.updated_at
+      ? parseClickhouseUTCDateTimeFormat(record.updated_at)
+      : new Date(),
     metadata: (includeMetadataPayload
       ? (parseMetadataCHRecordToDomain(record.metadata ?? {}) ?? {})
       : {}) as ExcludeMetadata extends true


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default date handling in `convertClickhouseScoreToDomain` to use `new Date()` directly if `created_at` or `updated_at` is null.
> 
>   - **Behavior**:
>     - In `convertClickhouseScoreToDomain` in `scores_converters.ts`, changed default date handling for `createdAt` and `updatedAt`.
>     - If `record.created_at` or `record.updated_at` is null, directly use `new Date()` instead of parsing it.
>   - **Misc**:
>     - No changes to other functions or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 743d02af901fd0e9b0fd774efb337cf55b958dde. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->