### PR TITLE
fix(comments): fix display order of comments

### DIFF
--- a/web/src/features/comments/CommentList.tsx
+++ b/web/src/features/comments/CommentList.tsx
@@ -324,16 +324,18 @@ export function CommentList({
   });
 
   const commentsWithFormattedTimestamp = useMemo(() => {
-    return comments.data?.map((comment) => ({
-      ...comment,
-      timestamp: getRelativeTimestampFromNow(comment.createdAt),
-      strippedLower: stripMarkdown(comment.content).toLowerCase(),
-      authorLower: (
-        comment.authorUserName ||
-        comment.authorUserId ||
-        ""
-      ).toLowerCase(),
-    }));
+    return comments.data
+      ?.map((comment) => ({
+        ...comment,
+        timestamp: getRelativeTimestampFromNow(comment.createdAt),
+        strippedLower: stripMarkdown(comment.content).toLowerCase(),
+        authorLower: (
+          comment.authorUserName ||
+          comment.authorUserId ||
+          ""
+        ).toLowerCase(),
+      }))
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
   }, [comments.data]);
 
   // stripMarkdown imported from utils


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes comment display order in `CommentList` by sorting comments chronologically using `createdAt` timestamp.
> 
>   - **Behavior**:
>     - Fixes comment display order in `CommentList` by sorting comments chronologically using `createdAt` timestamp.
>   - **Functions**:
>     - Modifies `commentsWithFormattedTimestamp` in `CommentList.tsx` to include a `.sort()` method for ordering comments by `createdAt`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b84ebbce1d9511b6eee8a8189a2828ed730f03f1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->