### PR TITLE
fix(ui): dataset schema hovercard overflow

### DIFF
--- a/web/src/features/datasets/components/DatasetSchemaHoverCard.tsx
+++ b/web/src/features/datasets/components/DatasetSchemaHoverCard.tsx
@@ -56,7 +56,10 @@ export const DatasetSchemaHoverCard: React.FC<DatasetSchemaHoverCardProps> = ({
           {showLabel && <span>Schema enforced</span>}
         </Button>
       </HoverCardTrigger>
-      <HoverCardContent className="max-h-[600px] w-[400px] overflow-auto">
+      <HoverCardContent
+        className="max-h-[80vh] w-[400px] overflow-auto"
+        collisionPadding={20}
+      >
         <p className="text-sm font-medium">{title}</p>
         <p className="pt-2 text-sm text-muted-foreground">
           Learn more about{" "}


### PR DESCRIPTION
## What does this PR do?

This PR fixes the issue where the dataset schema hovercard overflows the screen and is not scrollable, particularly on smaller viewports. It updates the `HoverCardContent` to use `max-h-[80vh]` for a responsive maximum height and adds `collisionPadding={20}` to ensure it remains within the viewport boundaries with proper spacing, while maintaining scrollability.

Fixes #LFE-7583

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-7583](https://linear.app/langfuse/issue/LFE-7583/fix-dataset-schema-hovercard-overflows-screen-and-is-not-scrollable)

<a href="https://cursor.com/background-agent?bcId=bc-789a5429-a525-4d34-8a6f-b69d176d627b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-789a5429-a525-4d34-8a6f-b69d176d627b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes hovercard overflow by adjusting `max-h` and adding `collisionPadding` in `DatasetSchemaHoverCard`.
> 
>   - **UI Fix**:
>     - In `DatasetSchemaHoverCard`, updated `HoverCardContent` to `max-h-[80vh]` for responsive height.
>     - Added `collisionPadding={20}` to `HoverCardContent` to prevent overflow and maintain spacing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2b479a1a6ad162397458b67b12b674bb9b41bbf6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->