### PR TITLE
feat(datasets-ui): support dataset schema mapping in csv import

### DIFF
--- a/web/src/components/onboarding/DatasetItemsOnboarding.tsx
+++ b/web/src/components/onboarding/DatasetItemsOnboarding.tsx
@@ -113,7 +113,15 @@ export const DatasetItemsOnboarding = ({
               hasAccess={hasProjectAccess}
             />
           </DialogTrigger>
-          <DialogContent size="lg">
+          <DialogContent className="flex h-[80dvh] max-w-7xl flex-col overflow-hidden">
+            <DialogHeader>
+              <DialogTitle>
+                Upload CSV
+                <span className="text-lg font-normal text-muted-foreground">
+                  {csvFile ? ` - ${csvFile.name}` : ""}
+                </span>
+              </DialogTitle>
+            </DialogHeader>
             {preview ? (
               <PreviewCsvImport
                 preview={preview}

--- a/web/src/components/onboarding/DatasetItemsOnboarding.tsx
+++ b/web/src/components/onboarding/DatasetItemsOnboarding.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { type CsvPreviewResult } from "@/src/features/datasets/lib/csvHelpers";
 import { SplashScreen } from "@/src/components/ui/splash-screen";
 import { Braces, Code, ListTree, Upload } from "lucide-react";
 import DocPopup from "@/src/components/layouts/doc-popup";
@@ -11,8 +10,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/src/components/ui/dialog";
-import { UploadDatasetCsv } from "@/src/features/datasets/components/UploadDatasetCsv";
-import { PreviewCsvImport } from "@/src/features/datasets/components/PreviewCsvImport";
+import { CsvUploadDialog } from "@/src/features/datasets/components/CsvUploadDialog";
 import { NewDatasetItemForm } from "@/src/features/datasets/components/NewDatasetItemForm";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
@@ -80,8 +78,6 @@ export const DatasetItemsOnboarding = ({
   datasetId: string;
 }) => {
   const capture = usePostHogClientCapture();
-  const [preview, setPreview] = useState<CsvPreviewResult | null>(null);
-  const [csvFile, setCsvFile] = useState<File | null>(null);
   const [isUploadDialogOpen, setIsUploadDialogOpen] = useState(false);
   const [isNewItemDialogOpen, setIsNewItemDialogOpen] = useState(false);
 
@@ -96,9 +92,11 @@ export const DatasetItemsOnboarding = ({
       description="Datasets are collections of specific edge cases and underrepresented patterns used to evaluate your application."
     >
       <div className="flex flex-col gap-4">
-        <Dialog
+        <CsvUploadDialog
           open={hasProjectAccess && isUploadDialogOpen}
           onOpenChange={setIsUploadDialogOpen}
+          projectId={projectId}
+          datasetId={datasetId}
         >
           <DialogTrigger asChild disabled={!hasProjectAccess}>
             <DatasetItemEntryPointRow
@@ -113,32 +111,7 @@ export const DatasetItemsOnboarding = ({
               hasAccess={hasProjectAccess}
             />
           </DialogTrigger>
-          <DialogContent className="flex h-[80dvh] max-w-7xl flex-col overflow-hidden">
-            <DialogHeader>
-              <DialogTitle>
-                Upload CSV
-                <span className="text-lg font-normal text-muted-foreground">
-                  {csvFile ? ` - ${csvFile.name}` : ""}
-                </span>
-              </DialogTitle>
-            </DialogHeader>
-            {preview ? (
-              <PreviewCsvImport
-                preview={preview}
-                csvFile={csvFile}
-                projectId={projectId}
-                datasetId={datasetId}
-                setCsvFile={setCsvFile}
-                setPreview={setPreview}
-              />
-            ) : (
-              <UploadDatasetCsv
-                setPreview={setPreview}
-                setCsvFile={setCsvFile}
-              />
-            )}
-          </DialogContent>
-        </Dialog>
+        </CsvUploadDialog>
 
         <Dialog
           open={hasProjectAccess && isNewItemDialogOpen}

--- a/web/src/features/datasets/components/CsvColumnsCard.tsx
+++ b/web/src/features/datasets/components/CsvColumnsCard.tsx
@@ -1,0 +1,72 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/src/components/ui/card";
+import { type CsvColumnPreview } from "@/src/features/datasets/lib/csvHelpers";
+import { cn } from "@/src/utils/tailwind";
+import { useDraggable } from "@dnd-kit/core";
+import { GripVertical } from "lucide-react";
+
+function DraggableColumn({ column }: { column: CsvColumnPreview }) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: column.name,
+    data: {
+      column,
+      fromCardId: "csv-columns",
+    },
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      className={cn(
+        "group flex cursor-grab items-center gap-2 rounded-md border bg-background p-2 hover:border-primary hover:bg-accent active:cursor-grabbing",
+        isDragging && "opacity-30",
+      )}
+    >
+      <GripVertical className="h-4 w-4 shrink-0 text-muted-foreground/70 group-hover:text-primary" />
+      <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
+        <span className="truncate text-sm">{column.name}</span>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {column.inferredType}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function CsvColumnsCard({
+  columns,
+  columnCount,
+}: {
+  columns: CsvColumnPreview[];
+  columnCount: number;
+}) {
+  return (
+    <Card className="flex h-full flex-col overflow-hidden">
+      <CardHeader className="shrink-0 p-4 pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base font-semibold">CSV Columns</CardTitle>
+          <span className="rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
+            {columnCount} {columnCount === 1 ? "column" : "columns"}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="flex min-h-0 flex-1 flex-col gap-3 p-4 pt-0">
+        <div className="min-h-0 flex-1 space-y-2 overflow-y-auto">
+          {columns.map((column) => (
+            <DraggableColumn key={column.name} column={column} />
+          ))}
+        </div>
+        <div className="shrink-0 rounded-lg bg-light-blue/40 p-3 text-xs leading-relaxed text-accent-dark-blue">
+          <strong className="font-semibold">Tip:</strong> Drag columns from this
+          list to the mapping fields on the right.
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/features/datasets/components/CsvColumnsCard.tsx
+++ b/web/src/features/datasets/components/CsvColumnsCard.tsx
@@ -4,10 +4,10 @@ import {
   CardHeader,
   CardTitle,
 } from "@/src/components/ui/card";
-import { type CsvColumnPreview } from "@/src/features/datasets/lib/csvHelpers";
 import { cn } from "@/src/utils/tailwind";
 import { useDraggable } from "@dnd-kit/core";
 import { GripVertical } from "lucide-react";
+import type { CsvColumnPreview } from "@/src/features/datasets/lib/csv/types";
 
 function DraggableColumn({ column }: { column: CsvColumnPreview }) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({

--- a/web/src/features/datasets/components/CsvUploadDialog.tsx
+++ b/web/src/features/datasets/components/CsvUploadDialog.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/src/components/ui/dialog";
 import { PreviewCsvImport } from "@/src/features/datasets/components/PreviewCsvImport";
 import { UploadDatasetCsv } from "@/src/features/datasets/components/UploadDatasetCsv";
-import { CsvPreviewResult } from "@/src/features/datasets/lib/csv/types";
+import type { CsvPreviewResult } from "@/src/features/datasets/lib/csv/types";
 import {
   Tooltip,
   TooltipContent,

--- a/web/src/features/datasets/components/CsvUploadDialog.tsx
+++ b/web/src/features/datasets/components/CsvUploadDialog.tsx
@@ -5,9 +5,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/src/components/ui/dialog";
-import { type CsvPreviewResult } from "@/src/features/datasets/lib/csvHelpers";
 import { PreviewCsvImport } from "@/src/features/datasets/components/PreviewCsvImport";
 import { UploadDatasetCsv } from "@/src/features/datasets/components/UploadDatasetCsv";
+import { CsvPreviewResult } from "@/src/features/datasets/lib/csv/types";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
+import { File } from "lucide-react";
 
 type CsvUploadDialogProps = {
   open: boolean;
@@ -41,11 +47,18 @@ export function CsvUploadDialog({
       {children}
       <DialogContent className="flex h-[80dvh] max-w-7xl flex-col overflow-hidden">
         <DialogHeader>
-          <DialogTitle>
+          <DialogTitle className="flex items-center gap-2">
             Upload CSV
-            <span className="text-lg font-normal text-muted-foreground">
-              {csvFile ? ` - ${csvFile.name}` : ""}
-            </span>
+            {csvFile && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <File className="h-4 w-4 text-muted-foreground" />
+                </TooltipTrigger>
+                <TooltipContent className="max-w-[300px]">
+                  {csvFile.name}
+                </TooltipContent>
+              </Tooltip>
+            )}
           </DialogTitle>
         </DialogHeader>
         {preview ? (

--- a/web/src/features/datasets/components/CsvUploadDialog.tsx
+++ b/web/src/features/datasets/components/CsvUploadDialog.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/src/components/ui/dialog";
+import { type CsvPreviewResult } from "@/src/features/datasets/lib/csvHelpers";
+import { PreviewCsvImport } from "@/src/features/datasets/components/PreviewCsvImport";
+import { UploadDatasetCsv } from "@/src/features/datasets/components/UploadDatasetCsv";
+
+type CsvUploadDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  datasetId: string;
+  children?: React.ReactNode;
+};
+
+export function CsvUploadDialog({
+  open,
+  onOpenChange,
+  projectId,
+  datasetId,
+  children,
+}: CsvUploadDialogProps) {
+  const [preview, setPreview] = useState<CsvPreviewResult | null>(null);
+  const [csvFile, setCsvFile] = useState<File | null>(null);
+
+  const handleOpenChange = (newOpen: boolean) => {
+    onOpenChange(newOpen);
+    if (!newOpen) {
+      // Reset state when dialog closes
+      setPreview(null);
+      setCsvFile(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      {children}
+      <DialogContent className="flex h-[80dvh] max-w-7xl flex-col overflow-hidden">
+        <DialogHeader>
+          <DialogTitle>
+            Upload CSV
+            <span className="text-lg font-normal text-muted-foreground">
+              {csvFile ? ` - ${csvFile.name}` : ""}
+            </span>
+          </DialogTitle>
+        </DialogHeader>
+        {preview ? (
+          <PreviewCsvImport
+            preview={preview}
+            csvFile={csvFile}
+            projectId={projectId}
+            datasetId={datasetId}
+            setCsvFile={setCsvFile}
+            setPreview={setPreview}
+            setOpen={handleOpenChange}
+          />
+        ) : (
+          <UploadDatasetCsv setPreview={setPreview} setCsvFile={setCsvFile} />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/features/datasets/components/ImportCard.tsx
+++ b/web/src/features/datasets/components/ImportCard.tsx
@@ -18,6 +18,9 @@ type ImportCardProps = {
   id: UniqueIdentifier;
   className?: string;
   info?: string;
+  schemaKeys?: string[]; // Schema-driven mode
+  schemaKeyMapping?: Map<string, string>; // {schemaKey: csvColumn}
+  onSchemaKeyMap?: (schemaKey: string, csvColumn: string) => void;
 };
 
 function DraggableColumn({
@@ -41,8 +44,8 @@ function DraggableColumn({
       {...listeners}
       {...attributes}
       className={cn(
-        "cursor-grab rounded-md border p-2 hover:bg-accent",
-        isDragging && "opacity-50",
+        "cursor-grab rounded-md border p-2 hover:bg-accent active:cursor-grabbing",
+        isDragging && "opacity-30",
       )}
     >
       <div className="flex flex-wrap items-center justify-between space-x-1">
@@ -55,23 +58,58 @@ function DraggableColumn({
   );
 }
 
+function SchemaKeyDropZone({
+  schemaKey,
+  mappedColumn,
+  parentId,
+}: {
+  schemaKey: string;
+  mappedColumn?: string;
+  parentId: UniqueIdentifier;
+}) {
+  const dropId = `${parentId}:${schemaKey}`;
+  const { setNodeRef, isOver } = useDroppable({ id: dropId });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        "rounded-md border border-dashed p-2 text-sm",
+        isOver && "border-primary bg-accent/50",
+        mappedColumn ? "bg-accent/20" : "bg-background",
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <span className="font-medium">{schemaKey}</span>
+        {mappedColumn && (
+          <span className="text-xs text-muted-foreground">{mappedColumn}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function ImportCard({
   title,
   columns,
   id,
   className,
   info,
+  schemaKeys,
+  schemaKeyMapping,
 }: ImportCardProps) {
   const { setNodeRef, isOver } = useDroppable({
     id,
   });
+
+  const isSchemaMode = schemaKeys && schemaKeys.length > 0;
 
   return (
     <Card
       ref={setNodeRef}
       className={cn(
         "flex h-full flex-col overflow-hidden",
-        isOver && "ring-2 ring-primary",
+        !isSchemaMode && isOver && "ring-2 ring-primary",
         className,
       )}
     >
@@ -82,9 +120,36 @@ export function ImportCard({
         </CardTitle>
       </CardHeader>
       <CardContent className="min-h-0 flex-1 space-y-1 overflow-y-auto p-4 pt-2">
-        {columns.map((column) => (
-          <DraggableColumn key={column.name} column={column} parentId={id} />
-        ))}
+        {isSchemaMode ? (
+          // Schema-driven mode: show schema keys as drop zones
+          <>
+            {schemaKeys.map((schemaKey) => (
+              <SchemaKeyDropZone
+                key={schemaKey}
+                schemaKey={schemaKey}
+                mappedColumn={schemaKeyMapping?.get(schemaKey)}
+                parentId={id}
+              />
+            ))}
+          </>
+        ) : (
+          // Freeform mode: show draggable columns
+          <>
+            {columns.length === 0 && id !== "unmapped" ? (
+              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                Drag columns here
+              </div>
+            ) : (
+              columns.map((column) => (
+                <DraggableColumn
+                  key={column.name}
+                  column={column}
+                  parentId={id}
+                />
+              ))
+            )}
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/web/src/features/datasets/components/ImportCard.tsx
+++ b/web/src/features/datasets/components/ImportCard.tsx
@@ -5,10 +5,10 @@ import {
   CardHeader,
   CardTitle,
 } from "@/src/components/ui/card";
-import { type CsvColumnPreview } from "@/src/features/datasets/lib/csvHelpers";
 import { cn } from "@/src/utils/tailwind";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { type UniqueIdentifier } from "@dnd-kit/core";
+import { CsvColumnPreview } from "@/src/features/datasets/lib/csv/types";
 
 type ImportCardProps = {
   title: string;

--- a/web/src/features/datasets/components/ImportCard.tsx
+++ b/web/src/features/datasets/components/ImportCard.tsx
@@ -8,7 +8,7 @@ import {
 import { cn } from "@/src/utils/tailwind";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { type UniqueIdentifier } from "@dnd-kit/core";
-import { CsvColumnPreview } from "@/src/features/datasets/lib/csv/types";
+import type { CsvColumnPreview } from "@/src/features/datasets/lib/csv/types";
 
 type ImportCardProps = {
   title: string;

--- a/web/src/features/datasets/components/MappingCard.tsx
+++ b/web/src/features/datasets/components/MappingCard.tsx
@@ -8,8 +8,8 @@ import { cn } from "@/src/utils/tailwind";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { X } from "lucide-react";
 import {
-  CsvColumnPreview,
-  FieldMapping,
+  type CsvColumnPreview,
+  type FieldMapping,
 } from "@/src/features/datasets/lib/csv/types";
 import { isSchemaField } from "@/src/features/datasets/lib/csv/helpers";
 

--- a/web/src/features/datasets/components/MappingCard.tsx
+++ b/web/src/features/datasets/components/MappingCard.tsx
@@ -1,0 +1,258 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/src/components/ui/card";
+import { type CsvColumnPreview } from "@/src/features/datasets/lib/csvHelpers";
+import { cn } from "@/src/utils/tailwind";
+import { useDraggable, useDroppable } from "@dnd-kit/core";
+import { X } from "lucide-react";
+
+function SchemaKeyDropZone({
+  schemaKey,
+  mappedColumns,
+  parentId,
+  onRemove,
+}: {
+  schemaKey: string;
+  mappedColumns: CsvColumnPreview[];
+  parentId: string;
+  onRemove: (columnName: string) => void;
+}) {
+  const dropId = `${parentId}:${schemaKey}`;
+  const { setNodeRef, isOver } = useDroppable({ id: dropId });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        "min-h-[52px] rounded-md border border-dashed text-sm transition-colors",
+        isOver &&
+          mappedColumns.length === 0 &&
+          "border-2 border-solid border-primary bg-background",
+        mappedColumns.length > 0 &&
+          "border-solid border-accent-dark-blue bg-light-blue/40",
+      )}
+    >
+      {mappedColumns.length === 0 ? (
+        <div className="flex h-full min-h-[52px] flex-col justify-start p-2">
+          <div className="mb-1 text-sm font-medium">{schemaKey}</div>
+        </div>
+      ) : (
+        <div className="p-2">
+          <div className="mb-1 text-sm font-medium">{schemaKey}</div>
+          <div className="flex flex-wrap gap-1.5">
+            {mappedColumns.map((column) => (
+              <MappedColumnBadge
+                key={column.name}
+                column={column}
+                onRemove={onRemove}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FreeformDropZone({
+  id,
+  columns,
+  onRemove,
+}: {
+  id: string;
+  columns: CsvColumnPreview[];
+  onRemove: (columnName: string) => void;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        "min-h-[60px] rounded-md border border-dashed p-2 transition-colors",
+        isOver &&
+          columns.length === 0 &&
+          "border border-solid border-primary bg-background",
+        columns.length > 0 &&
+          "border-solid border-accent-dark-blue bg-light-blue/40",
+      )}
+    >
+      {columns.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {columns.map((column) => (
+            <MappedColumnBadge
+              key={column.name}
+              column={column}
+              onRemove={onRemove}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MappedColumnBadge({
+  column,
+  onRemove,
+}: {
+  column: CsvColumnPreview;
+  onRemove: (columnName: string) => void;
+}) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `mapped-${column.name}`,
+    data: {
+      column,
+      fromCardId: "mapped",
+    },
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        "group flex cursor-grab items-center gap-1 rounded-md bg-accent-dark-blue px-2 py-1 text-sm font-medium text-muted active:cursor-grabbing",
+        isDragging && "opacity-30",
+      )}
+      {...attributes}
+    >
+      <span {...listeners}>{column.name}</span>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onRemove(column.name);
+        }}
+        className="flex items-center rounded-sm hover:bg-accent-dark-blue/80"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}
+
+type MappingCardProps = {
+  // Schema keys
+  inputSchemaKeys?: string[];
+  expectedOutputSchemaKeys?: string[];
+
+  // Schema mappings (now supports multiple columns per key)
+  inputSchemaMapping?: Map<string, CsvColumnPreview[]>;
+  expectedOutputSchemaMapping?: Map<string, CsvColumnPreview[]>;
+
+  // Freeform columns
+  inputColumns: CsvColumnPreview[];
+  expectedColumns: CsvColumnPreview[];
+  metadataColumns: CsvColumnPreview[];
+
+  // Remove handlers
+  onRemoveInputColumn: (columnName: string) => void;
+  onRemoveExpectedColumn: (columnName: string) => void;
+  onRemoveMetadataColumn: (columnName: string) => void;
+  onRemoveInputSchemaColumn: (schemaKey: string, columnName: string) => void;
+  onRemoveExpectedSchemaColumn: (schemaKey: string, columnName: string) => void;
+};
+
+export function MappingCard({
+  inputSchemaKeys,
+  expectedOutputSchemaKeys,
+  inputSchemaMapping,
+  expectedOutputSchemaMapping,
+  inputColumns,
+  expectedColumns,
+  metadataColumns,
+  onRemoveInputColumn,
+  onRemoveExpectedColumn,
+  onRemoveMetadataColumn,
+  onRemoveInputSchemaColumn,
+  onRemoveExpectedSchemaColumn,
+}: MappingCardProps) {
+  const hasInputSchema = inputSchemaKeys && inputSchemaKeys.length > 0;
+  const hasExpectedSchema =
+    expectedOutputSchemaKeys && expectedOutputSchemaKeys.length > 0;
+
+  return (
+    <Card className="flex h-full flex-col overflow-hidden">
+      <CardHeader className="shrink-0 border-b p-3">
+        <CardTitle className="text-base font-semibold">
+          Map to Dataset Items
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="min-h-0 flex-1 space-y-4 overflow-y-auto p-3">
+        {/* INPUT SECTION */}
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold tracking-wide text-muted-foreground">
+            Input
+          </h3>
+          {hasInputSchema ? (
+            <div className="space-y-2">
+              {inputSchemaKeys.map((schemaKey) => (
+                <SchemaKeyDropZone
+                  key={schemaKey}
+                  schemaKey={schemaKey}
+                  mappedColumns={inputSchemaMapping?.get(schemaKey) ?? []}
+                  parentId="input"
+                  onRemove={(columnName) =>
+                    onRemoveInputSchemaColumn(schemaKey, columnName)
+                  }
+                />
+              ))}
+            </div>
+          ) : (
+            <FreeformDropZone
+              id="input"
+              columns={inputColumns}
+              onRemove={onRemoveInputColumn}
+            />
+          )}
+        </div>
+
+        {/* OUTPUT SECTION */}
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold tracking-wide text-muted-foreground">
+            Output
+          </h3>
+          {hasExpectedSchema ? (
+            <div className="space-y-2">
+              {expectedOutputSchemaKeys.map((schemaKey) => (
+                <SchemaKeyDropZone
+                  key={schemaKey}
+                  schemaKey={schemaKey}
+                  mappedColumns={
+                    expectedOutputSchemaMapping?.get(schemaKey) ?? []
+                  }
+                  parentId="expectedOutput"
+                  onRemove={(columnName) =>
+                    onRemoveExpectedSchemaColumn(schemaKey, columnName)
+                  }
+                />
+              ))}
+            </div>
+          ) : (
+            <FreeformDropZone
+              id="expected"
+              columns={expectedColumns}
+              onRemove={onRemoveExpectedColumn}
+            />
+          )}
+        </div>
+
+        {/* METADATA SECTION */}
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold tracking-wide text-muted-foreground">
+            Metadata
+          </h3>
+          <FreeformDropZone
+            id="metadata"
+            columns={metadataColumns}
+            onRemove={onRemoveMetadataColumn}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/features/datasets/components/MappingCard.tsx
+++ b/web/src/features/datasets/components/MappingCard.tsx
@@ -30,7 +30,7 @@ function SchemaKeyDropZone({
         "min-h-[52px] rounded-md border border-dashed text-sm transition-colors",
         isOver &&
           mappedColumns.length === 0 &&
-          "border-2 border-solid border-primary bg-background",
+          "border-solid border-primary bg-background",
         mappedColumns.length > 0 &&
           "border-solid border-accent-dark-blue bg-light-blue/40",
       )}

--- a/web/src/features/datasets/components/PreviewCsvImport.tsx
+++ b/web/src/features/datasets/components/PreviewCsvImport.tsx
@@ -25,7 +25,7 @@ import { useCsvMapping } from "@/src/features/datasets/hooks/useCsvMapping";
 import { useCsvDragAndDrop } from "@/src/features/datasets/hooks/useCsvDragAndDrop";
 import { useCsvImport } from "@/src/features/datasets/hooks/useCsvImport";
 import { createPortal } from "react-dom";
-import { CsvPreviewResult } from "@/src/features/datasets/lib/csv/types";
+import type { CsvPreviewResult } from "@/src/features/datasets/lib/csv/types";
 
 // Helper to extract schema keys from object schema
 function extractSchemaKeys(schema: unknown): string[] | null {

--- a/web/src/features/datasets/components/PreviewCsvImport.tsx
+++ b/web/src/features/datasets/components/PreviewCsvImport.tsx
@@ -3,29 +3,17 @@ import { MappingCard } from "./MappingCard";
 import {
   DndContext,
   closestCenter,
-  DragOverlay,
   MeasuringStrategy,
+  DragOverlay,
 } from "@dnd-kit/core";
-import { createPortal } from "react-dom";
-import { findDefaultColumn } from "../lib/findDefaultColumn";
-import { type DragEndEvent } from "@dnd-kit/core";
-import { useEffect, useState } from "react";
-import {
-  parseCsvClient,
-  parseColumns,
-  buildSchemaObject,
-  type CsvPreviewResult,
-} from "@/src/features/datasets/lib/csvHelpers";
+import { useState } from "react";
+import { type CsvPreviewResult } from "@/src/features/datasets/lib/csvHelpers";
 import { Button } from "@/src/components/ui/button";
-import { api, type RouterInputs } from "@/src/utils/api";
-import { showErrorToast } from "@/src/features/notifications/showErrorToast";
-import { MAX_FILE_SIZE_BYTES } from "@/src/features/datasets/components/UploadDatasetCsv";
+import { api } from "@/src/utils/api";
 import { Progress } from "@/src/components/ui/progress";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { DialogBody, DialogFooter } from "@/src/components/ui/dialog";
 import { CsvImportValidationError } from "./CsvImportValidationError";
-import { type BulkDatasetItemValidationError } from "@langfuse/shared";
-import { chunk } from "lodash";
 import { Checkbox } from "@/src/components/ui/checkbox";
 import { Label } from "@/src/components/ui/label";
 import {
@@ -34,51 +22,10 @@ import {
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
 import { InfoIcon, GripVertical } from "lucide-react";
-
-const MIN_CHUNK_SIZE = 1;
-const CHUNK_START_SIZE = 50;
-const DELAY_BETWEEN_CHUNKS = 100; // milliseconds
-
-// Max payload size is 1MB, but we must account for any trpc wrapper data and context
-const MAX_PAYLOAD_SIZE = 500 * 1024; // 500KB in bytes
-
-function getOptimalChunkSize(items: any[], startSize: number): number {
-  const getPayloadSize = (size: number) =>
-    new TextEncoder().encode(
-      JSON.stringify({
-        projectId: "test",
-        datasetId: "test",
-        items: items.slice(0, size),
-      }),
-    ).length;
-
-  // Binary search for largest chunk size under MAX_PAYLOAD_SIZE
-  let low = MIN_CHUNK_SIZE;
-  let high = startSize;
-  let best = MIN_CHUNK_SIZE;
-
-  while (low <= high) {
-    const mid = Math.floor((low + high) / 2);
-    if (getPayloadSize(mid) <= MAX_PAYLOAD_SIZE) {
-      best = mid;
-      low = mid + 1;
-    } else {
-      high = mid - 1;
-    }
-  }
-
-  return best;
-}
-
-type ImportProgress = {
-  totalItems: number;
-  processedItems: number;
-  status: "not-started" | "processing" | "complete";
-};
-
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+import { useCsvMapping } from "@/src/features/datasets/hooks/useCsvMapping";
+import { useCsvDragAndDrop } from "@/src/features/datasets/hooks/useCsvDragAndDrop";
+import { useCsvImport } from "@/src/features/datasets/hooks/useCsvImport";
+import { createPortal } from "react-dom";
 
 // Helper to extract schema keys from object schema
 function extractSchemaKeys(schema: unknown): string[] | null {
@@ -119,391 +66,81 @@ export function PreviewCsvImport({
     dataset?.expectedOutputSchema,
   );
   const isSchemaMode =
-    (inputSchemaKeys && inputSchemaKeys.length > 0) ||
-    (expectedOutputSchemaKeys && expectedOutputSchemaKeys.length > 0);
+    (!!inputSchemaKeys && inputSchemaKeys.length > 0) ||
+    (!!expectedOutputSchemaKeys && expectedOutputSchemaKeys.length > 0);
 
-  // Freeform mode state
-  const [selectedInputColumn, setSelectedInputColumn] = useState<Set<string>>(
-    new Set(),
-  );
-  const [selectedExpectedColumn, setSelectedExpectedColumn] = useState<
-    Set<string>
-  >(new Set());
-  const [selectedMetadataColumn, setSelectedMetadataColumn] = useState<
-    Set<string>
-  >(new Set());
-  const [_excludedColumns, setExcludedColumns] = useState<Set<string>>(
-    new Set(),
-  );
-
-  // Schema mode state (now supports multiple columns per schema key)
-  const [inputSchemaMapping, setInputSchemaMapping] = useState<
-    Map<string, CsvColumnPreview[]>
-  >(new Map());
-  const [expectedOutputSchemaMapping, setExpectedOutputSchemaMapping] =
-    useState<Map<string, CsvColumnPreview[]>>(new Map());
-  const [unmappedColumns, setUnmappedColumns] = useState<Set<string>>(
-    new Set(),
-  );
-
-  // Wrapping checkbox
-  const [wrapSingleColumn, setWrapSingleColumn] = useState(false);
-
-  // Drag state for overlay
-  const [activeColumn, setActiveColumn] = useState<string | null>(null);
-
-  const [progress, setProgress] = useState<ImportProgress>({
-    totalItems: 0,
-    processedItems: 0,
-    status: "not-started",
+  // Mapping state
+  const mapping = useCsvMapping({
+    preview,
+    isSchemaMode,
   });
-  const [validationErrors, setValidationErrors] = useState<
-    BulkDatasetItemValidationError[]
-  >([]);
 
-  const utils = api.useUtils();
-  const mutCreateManyDatasetItems =
-    api.datasets.createManyDatasetItems.useMutation({});
-
-  useEffect(() => {
-    if (preview && !isSchemaMode) {
-      // Freeform mode: set defaults only if no columns selected
-      if (
-        selectedInputColumn.size === 0 &&
-        selectedExpectedColumn.size === 0 &&
-        selectedMetadataColumn.size === 0
-      ) {
-        const defaultInput = findDefaultColumn(preview.columns, "Input", 0);
-        const defaultExpected = findDefaultColumn(
-          preview.columns,
-          "Expected",
-          1,
+  // Drag and drop
+  const dragAndDrop = useCsvDragAndDrop({
+    handlers: {
+      onAddToInputColumn: (columnName) => {
+        mapping.setSelectedInputColumn(
+          new Set([...mapping.selectedInputColumn, columnName]),
         );
-        const defaultMetadata = findDefaultColumn(
-          preview.columns,
-          "Metadata",
-          2,
+      },
+      onAddToExpectedColumn: (columnName) => {
+        mapping.setSelectedExpectedColumn(
+          new Set([...mapping.selectedExpectedColumn, columnName]),
         );
-
-        defaultInput && setSelectedInputColumn(new Set([defaultInput]));
-        defaultExpected &&
-          setSelectedExpectedColumn(new Set([defaultExpected]));
-        defaultMetadata &&
-          setSelectedMetadataColumn(new Set([defaultMetadata]));
-
-        const newExcluded = new Set(
-          preview.columns
-            .filter(
-              (col) =>
-                defaultInput !== col.name &&
-                defaultExpected !== col.name &&
-                defaultMetadata !== col.name,
-            )
-            .map((col) => col.name),
+      },
+      onAddToMetadataColumn: (columnName) => {
+        mapping.setSelectedMetadataColumn(
+          new Set([...mapping.selectedMetadataColumn, columnName]),
         );
-
-        setExcludedColumns(newExcluded);
-      }
-    } else if (preview && isSchemaMode) {
-      // Schema mode: initialize unmapped columns
-      if (unmappedColumns.size === 0) {
-        setUnmappedColumns(new Set(preview.columns.map((col) => col.name)));
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [preview, isSchemaMode]);
-
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
-    setActiveColumn(null);
-
-    if (!over) return;
-
-    const activeId = active.id as string;
-    const fromCardId = active.data.current?.fromCardId;
-    const column = active.data.current?.column as CsvColumnPreview;
-    const toId = over.id as string;
-
-    if (!column) return;
-
-    // Only proceed if dropping on a valid drop zone
-    const isValidDropZone =
-      toId.includes(":") || // schema key drop zones
-      toId === "input" ||
-      toId === "expected" ||
-      toId === "metadata";
-
-    if (!isValidDropZone) return;
-
-    // Helper to remove column from all mappings
-    const removeFromAllMappings = () => {
-      // Remove from input schema mapping
-      const inputMapping = new Map(inputSchemaMapping);
-      for (const [key, cols] of inputMapping.entries()) {
-        const filtered = cols.filter((c) => c.name !== column.name);
-        if (filtered.length === 0) {
-          inputMapping.delete(key);
-        } else if (filtered.length !== cols.length) {
-          inputMapping.set(key, filtered);
-        }
-      }
-      setInputSchemaMapping(inputMapping);
-
-      // Remove from expected schema mapping
-      const expectedMapping = new Map(expectedOutputSchemaMapping);
-      for (const [key, cols] of expectedMapping.entries()) {
-        const filtered = cols.filter((c) => c.name !== column.name);
-        if (filtered.length === 0) {
-          expectedMapping.delete(key);
-        } else if (filtered.length !== cols.length) {
-          expectedMapping.set(key, filtered);
-        }
-      }
-      setExpectedOutputSchemaMapping(expectedMapping);
-
-      // Remove from freeform selections
-      selectedInputColumn.delete(column.name);
-      setSelectedInputColumn(new Set(selectedInputColumn));
-      selectedExpectedColumn.delete(column.name);
-      setSelectedExpectedColumn(new Set(selectedExpectedColumn));
-      selectedMetadataColumn.delete(column.name);
-      setSelectedMetadataColumn(new Set(selectedMetadataColumn));
-    };
-
-    // Handle schema key drops (format: "input:key" or "expectedOutput:key")
-    if (toId.includes(":")) {
-      const [cardType, schemaKey] = toId.split(":");
-      if (!schemaKey) return;
-
-      // Remove from previous mappings
-      if (fromCardId === "mapped") {
-        removeFromAllMappings();
-      }
-
-      // Add to new mapping
-      if (cardType === "input") {
-        const newMapping = new Map(inputSchemaMapping);
+      },
+      onAddToInputSchemaKey: (schemaKey, column) => {
+        const newMapping = new Map(mapping.inputSchemaMapping);
         const existing = newMapping.get(schemaKey) ?? [];
         newMapping.set(schemaKey, [...existing, column]);
-        setInputSchemaMapping(newMapping);
-      } else if (cardType === "expectedOutput") {
-        const newMapping = new Map(expectedOutputSchemaMapping);
+        mapping.setInputSchemaMapping(newMapping);
+      },
+      onAddToExpectedSchemaKey: (schemaKey, column) => {
+        const newMapping = new Map(mapping.expectedOutputSchemaMapping);
         const existing = newMapping.get(schemaKey) ?? [];
         newMapping.set(schemaKey, [...existing, column]);
-        setExpectedOutputSchemaMapping(newMapping);
-      }
-      return;
-    }
+        mapping.setExpectedOutputSchemaMapping(newMapping);
+      },
+      onRemoveFromAllMappings: mapping.removeFromAllMappings,
+    },
+  });
 
-    // Handle freeform drops (input, expected, metadata)
-    if (toId === "input" || toId === "expected" || toId === "metadata") {
-      // Remove from previous mappings if exists
-      if (fromCardId === "mapped") {
-        removeFromAllMappings();
-      }
+  // Import execution
+  const csvImport = useCsvImport({
+    projectId,
+    datasetId,
+    csvFile,
+    isSchemaMode,
+    selectedInputColumn: mapping.selectedInputColumn,
+    selectedExpectedColumn: mapping.selectedExpectedColumn,
+    selectedMetadataColumn: mapping.selectedMetadataColumn,
+    inputSchemaMapping: mapping.inputSchemaMapping,
+    expectedOutputSchemaMapping: mapping.expectedOutputSchemaMapping,
+  });
 
-      // Add to new location
-      if (toId === "input") {
-        setSelectedInputColumn(new Set([...selectedInputColumn, column.name]));
-      } else if (toId === "expected") {
-        setSelectedExpectedColumn(
-          new Set([...selectedExpectedColumn, column.name]),
-        );
-      } else if (toId === "metadata") {
-        setSelectedMetadataColumn(
-          new Set([...selectedMetadataColumn, column.name]),
-        );
-      }
-    }
-  };
+  // Wrapping checkbox (only shown in freeform mode)
+  const [wrapSingleColumn, setWrapSingleColumn] = useState(false);
 
   const handleImport = async () => {
     capture("dataset_item:upload_csv_form_submit");
-    if (!csvFile) return;
-    if (csvFile.size > MAX_FILE_SIZE_BYTES) {
-      showErrorToast("File too large", "Maximum file size is 10MB");
-      return;
+    await csvImport.execute(wrapSingleColumn);
+
+    // Close dialog on success
+    if (csvImport.progress.status === "complete") {
+      setOpen?.(false);
+      setPreview(null);
     }
+  };
 
-    // Clear any previous validation errors
-    setValidationErrors([]);
-
-    let processedCount = 0;
-    let headerMap: Map<string, number>;
-
-    const items: RouterInputs["datasets"]["createManyDatasetItems"]["items"] =
-      [];
-
-    // Prepare column lists or mappings based on mode
-    // In schema mode, still use freeform columns for fields without schema
-    const input = Array.from(selectedInputColumn);
-    const expected = Array.from(selectedExpectedColumn);
-    const metadata = Array.from(selectedMetadataColumn);
-
-    const inputMapping = isSchemaMode
-      ? Object.fromEntries(
-          Array.from(inputSchemaMapping.entries()).map(([key, cols]) => [
-            key,
-            cols.map((c) => c.name),
-          ]),
-        )
-      : undefined;
-    const expectedOutputMapping = isSchemaMode
-      ? Object.fromEntries(
-          Array.from(expectedOutputSchemaMapping.entries()).map(
-            ([key, cols]) => [key, cols.map((c) => c.name)],
-          ),
-        )
-      : undefined;
-
-    try {
-      await parseCsvClient(csvFile, {
-        processor: {
-          onHeader: (headers) => {
-            headerMap = new Map(headers.map((h, i) => [h, i]));
-
-            // Validate columns exist (check both schema mappings and freeform columns)
-            const allColumns = [
-              ...Object.values(inputMapping ?? {}).flat(),
-              ...Object.values(expectedOutputMapping ?? {}).flat(),
-              ...input,
-              ...expected,
-              ...metadata,
-            ];
-            const missingColumns = allColumns.filter(
-              (col) => !headerMap.has(col),
-            );
-            if (missingColumns.length > 0) {
-              throw new Error(`Missing columns: ${missingColumns.join(", ")}`);
-            }
-          },
-          onRow: (row, _, index) => {
-            try {
-              // Process based on mode (mixed mode: some fields have schemas, some don't)
-              let itemInput: unknown;
-              let itemExpected: unknown;
-
-              if (isSchemaMode) {
-                // Input: use schema mapping if available, else freeform
-                if (inputMapping && Object.keys(inputMapping).length > 0) {
-                  itemInput = buildSchemaObject(inputMapping, row, headerMap);
-                } else {
-                  itemInput =
-                    parseColumns(input, row, headerMap, { wrapSingleColumn }) ??
-                    undefined;
-                }
-
-                // Expected output: use schema mapping if available, else freeform
-                if (
-                  expectedOutputMapping &&
-                  Object.keys(expectedOutputMapping).length > 0
-                ) {
-                  itemExpected = buildSchemaObject(
-                    expectedOutputMapping,
-                    row,
-                    headerMap,
-                  );
-                } else {
-                  itemExpected =
-                    parseColumns(expected, row, headerMap, {
-                      wrapSingleColumn,
-                    }) ?? undefined;
-                }
-              } else {
-                // Pure freeform mode
-                itemInput =
-                  parseColumns(input, row, headerMap, { wrapSingleColumn }) ??
-                  undefined;
-                itemExpected =
-                  parseColumns(expected, row, headerMap, {
-                    wrapSingleColumn,
-                  }) ?? undefined;
-              }
-
-              const itemMetadata =
-                parseColumns(metadata, row, headerMap) ?? undefined;
-
-              items.push({
-                input: JSON.stringify(itemInput),
-                expectedOutput: JSON.stringify(itemExpected),
-                metadata: JSON.stringify(itemMetadata),
-                datasetId,
-              });
-            } catch (error) {
-              throw new Error(
-                `Error processing row ${index + 1}: ${error instanceof Error ? error.message : "Unknown error"}`,
-              );
-            }
-          },
-        },
-      });
-
-      const optimalChunkSize = getOptimalChunkSize(items, CHUNK_START_SIZE);
-      const chunks = chunk(items, optimalChunkSize);
-
-      for (const [index, chunk] of chunks.entries()) {
-        const result = await mutCreateManyDatasetItems.mutateAsync({
-          projectId,
-          items: chunk,
-        });
-
-        // Check if validation failed
-        if (!result.success) {
-          // Adjust itemIndex to account for already processed chunks
-          const adjustedErrors = result.validationErrors.map((error) => ({
-            ...error,
-            itemIndex: error.itemIndex + processedCount,
-          }));
-
-          setValidationErrors(adjustedErrors);
-          setProgress?.({
-            totalItems: 0,
-            processedItems: 0,
-            status: "not-started",
-          });
-          return;
-        }
-
-        processedCount += chunk.length;
-        setProgress?.({
-          totalItems: items.length,
-          processedItems: processedCount,
-          status: "processing",
-        });
-
-        // Add delay between chunks
-        if (index < chunks.length - 1) {
-          // Skip delay after last chunk
-          await sleep(DELAY_BETWEEN_CHUNKS);
-        }
-      }
-    } catch (error) {
-      utils.datasets.invalidate();
-      setProgress?.({
-        totalItems: 0,
-        processedItems: 0,
-        status: "not-started",
-      });
-      if (error instanceof Error && processedCount === 0) {
-        showErrorToast("Failed to import all dataset items", error.message);
-      } else {
-        showErrorToast(
-          "Failed to import all dataset items",
-          `Please try again starting from row ${processedCount + 1}.`,
-        );
-      }
-      return;
-    }
-
-    utils.datasets.invalidate();
-    setOpen?.(false);
+  const handleCancel = () => {
     setPreview(null);
-
-    setProgress?.({
-      totalItems: items.length,
-      processedItems: items.length,
-      status: "complete",
-    });
+    mapping.reset();
+    setCsvFile(null);
+    csvImport.reset();
   };
 
   return (
@@ -512,8 +149,8 @@ export function PreviewCsvImport({
         <div className="flex min-h-0 w-full flex-1 flex-col gap-3 px-2 py-1">
           <DndContext
             collisionDetection={closestCenter}
-            onDragEnd={handleDragEnd}
-            onDragStart={(event) => setActiveColumn(event.active.id as string)}
+            onDragEnd={dragAndDrop.handleDragEnd}
+            onDragStart={dragAndDrop.handleDragStart}
             measuring={{
               droppable: {
                 strategy: MeasuringStrategy.Always,
@@ -528,46 +165,48 @@ export function PreviewCsvImport({
               <MappingCard
                 inputSchemaKeys={inputSchemaKeys ?? undefined}
                 expectedOutputSchemaKeys={expectedOutputSchemaKeys ?? undefined}
-                inputSchemaMapping={inputSchemaMapping}
-                expectedOutputSchemaMapping={expectedOutputSchemaMapping}
+                inputSchemaMapping={mapping.inputSchemaMapping}
+                expectedOutputSchemaMapping={
+                  mapping.expectedOutputSchemaMapping
+                }
                 inputColumns={preview.columns.filter((col) =>
-                  selectedInputColumn.has(col.name),
+                  mapping.selectedInputColumn.has(col.name),
                 )}
                 expectedColumns={preview.columns.filter((col) =>
-                  selectedExpectedColumn.has(col.name),
+                  mapping.selectedExpectedColumn.has(col.name),
                 )}
                 metadataColumns={preview.columns.filter((col) =>
-                  selectedMetadataColumn.has(col.name),
+                  mapping.selectedMetadataColumn.has(col.name),
                 )}
                 onRemoveInputColumn={(columnName) => {
-                  setSelectedInputColumn(
+                  mapping.setSelectedInputColumn(
                     new Set(
-                      [...selectedInputColumn].filter(
+                      [...mapping.selectedInputColumn].filter(
                         (col) => col !== columnName,
                       ),
                     ),
                   );
                 }}
                 onRemoveExpectedColumn={(columnName) => {
-                  setSelectedExpectedColumn(
+                  mapping.setSelectedExpectedColumn(
                     new Set(
-                      [...selectedExpectedColumn].filter(
+                      [...mapping.selectedExpectedColumn].filter(
                         (col) => col !== columnName,
                       ),
                     ),
                   );
                 }}
                 onRemoveMetadataColumn={(columnName) => {
-                  setSelectedMetadataColumn(
+                  mapping.setSelectedMetadataColumn(
                     new Set(
-                      [...selectedMetadataColumn].filter(
+                      [...mapping.selectedMetadataColumn].filter(
                         (col) => col !== columnName,
                       ),
                     ),
                   );
                 }}
                 onRemoveInputSchemaColumn={(schemaKey, columnName) => {
-                  const newMapping = new Map(inputSchemaMapping);
+                  const newMapping = new Map(mapping.inputSchemaMapping);
                   const existing = newMapping.get(schemaKey) ?? [];
                   const filtered = existing.filter(
                     (c) => c.name !== columnName,
@@ -577,10 +216,12 @@ export function PreviewCsvImport({
                   } else {
                     newMapping.set(schemaKey, filtered);
                   }
-                  setInputSchemaMapping(newMapping);
+                  mapping.setInputSchemaMapping(newMapping);
                 }}
                 onRemoveExpectedSchemaColumn={(schemaKey, columnName) => {
-                  const newMapping = new Map(expectedOutputSchemaMapping);
+                  const newMapping = new Map(
+                    mapping.expectedOutputSchemaMapping,
+                  );
                   const existing = newMapping.get(schemaKey) ?? [];
                   const filtered = existing.filter(
                     (c) => c.name !== columnName,
@@ -590,26 +231,28 @@ export function PreviewCsvImport({
                   } else {
                     newMapping.set(schemaKey, filtered);
                   }
-                  setExpectedOutputSchemaMapping(newMapping);
+                  mapping.setExpectedOutputSchemaMapping(newMapping);
                 }}
               />
             </div>
             {createPortal(
               <DragOverlay dropAnimation={null} adjustScale={false}>
-                {activeColumn ? (
-                  activeColumn.startsWith("mapped-") ? (
+                {dragAndDrop.activeColumn ? (
+                  dragAndDrop.activeColumn.startsWith("mapped-") ? (
                     <div className="cursor-grabbing rounded-md bg-accent-dark-blue px-2 py-1 text-sm font-medium text-muted-foreground shadow-xl">
-                      {activeColumn.replace("mapped-", "")}
+                      {dragAndDrop.activeColumn.replace("mapped-", "")}
                     </div>
                   ) : (
                     <div className="flex cursor-grabbing items-center gap-2 rounded-md border bg-background p-2 shadow-xl">
                       <GripVertical className="h-4 w-4 shrink-0 text-muted-foreground/70" />
                       <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
-                        <span className="truncate text-sm">{activeColumn}</span>
+                        <span className="truncate text-sm">
+                          {dragAndDrop.activeColumn}
+                        </span>
                         <span className="shrink-0 text-xs text-muted-foreground">
                           {
                             preview.columns.find(
-                              (col) => col.name === activeColumn,
+                              (col) => col.name === dragAndDrop.activeColumn,
                             )?.inferredType
                           }
                         </span>
@@ -622,72 +265,68 @@ export function PreviewCsvImport({
             )}
           </DndContext>
         </div>
-        {validationErrors.length > 0 && (
-          <CsvImportValidationError errors={validationErrors} />
+        {csvImport.validationErrors.length > 0 && (
+          <CsvImportValidationError errors={csvImport.validationErrors} />
         )}
       </DialogBody>
       <DialogFooter>
-        <div className="flex items-center gap-2">
-          <Checkbox
-            id="wrapSingleColumn"
-            checked={wrapSingleColumn}
-            onCheckedChange={(checked) => setWrapSingleColumn(checked === true)}
-          />
-          <Label
-            htmlFor="wrapSingleColumn"
-            className="cursor-pointer text-sm font-normal"
-          >
-            Force Objects
-          </Label>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <InfoIcon className="h-3.5 w-3.5 text-muted-foreground" />
-            </TooltipTrigger>
-            <TooltipContent className="max-w-[300px]">
-              When a single csv column is mapped to a dataset item field, wrap
-              its value in an object instead of using the raw value. Example:{" "}
-              {`{"columnName": "value"}`} instead of {`"value"`}
-            </TooltipContent>
-          </Tooltip>
-        </div>
-        <Button
-          variant="outline"
-          onClick={() => {
-            setPreview(null);
-            setSelectedInputColumn(new Set());
-            setSelectedExpectedColumn(new Set());
-            setSelectedMetadataColumn(new Set());
-            setExcludedColumns(new Set());
-            setInputSchemaMapping(new Map());
-            setExpectedOutputSchemaMapping(new Map());
-            setUnmappedColumns(new Set());
-            setCsvFile(null);
-            setValidationErrors([]);
-          }}
-        >
+        {!isSchemaMode && (
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="wrapSingleColumn"
+              checked={wrapSingleColumn}
+              onCheckedChange={(checked) =>
+                setWrapSingleColumn(checked === true)
+              }
+            />
+            <Label
+              htmlFor="wrapSingleColumn"
+              className="cursor-pointer text-sm font-normal"
+            >
+              Force Objects
+            </Label>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <InfoIcon className="h-3.5 w-3.5 text-muted-foreground" />
+              </TooltipTrigger>
+              <TooltipContent className="max-w-[300px]">
+                When a single csv column is mapped to a dataset item field, wrap
+                its value in an object instead of using the raw value. Example:{" "}
+                {`{"columnName": "value"}`} instead of {`"value"`}
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        )}
+        <Button variant="outline" onClick={handleCancel}>
           Cancel
         </Button>
         <Button
           disabled={
             (isSchemaMode
-              ? inputSchemaMapping.size === 0 &&
-                expectedOutputSchemaMapping.size === 0 &&
-                selectedInputColumn.size === 0 &&
-                selectedExpectedColumn.size === 0
-              : selectedInputColumn.size === 0 &&
-                selectedExpectedColumn.size === 0 &&
-                selectedMetadataColumn.size === 0) ||
-            progress.status === "processing"
+              ? mapping.inputSchemaMapping.size === 0 &&
+                mapping.expectedOutputSchemaMapping.size === 0 &&
+                mapping.selectedInputColumn.size === 0 &&
+                mapping.selectedExpectedColumn.size === 0
+              : mapping.selectedInputColumn.size === 0 &&
+                mapping.selectedExpectedColumn.size === 0 &&
+                mapping.selectedMetadataColumn.size === 0) ||
+            csvImport.progress.status === "processing"
           }
-          loading={progress.status === "processing"}
+          loading={csvImport.progress.status === "processing"}
           onClick={handleImport}
         >
-          {progress.status === "processing" ? "Importing..." : "Import"}
+          {csvImport.progress.status === "processing"
+            ? "Importing..."
+            : "Import"}
         </Button>
-        {progress.status === "processing" && (
+        {csvImport.progress.status === "processing" && (
           <div className="mt-2">
             <Progress
-              value={(progress.processedItems / progress.totalItems) * 100}
+              value={
+                (csvImport.progress.processedItems /
+                  csvImport.progress.totalItems) *
+                100
+              }
               className="w-full"
             />
           </div>

--- a/web/src/features/datasets/components/UploadDatasetCsv.tsx
+++ b/web/src/features/datasets/components/UploadDatasetCsv.tsx
@@ -7,15 +7,13 @@ import {
 } from "@/src/components/ui/card";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { z } from "zod/v4";
-import {
-  type CsvPreviewResult,
-  parseCsvClient,
-} from "@/src/features/datasets/lib/csvHelpers";
+import { parseCsvClient } from "@/src/features/datasets/lib/csv/helpers";
 import { DialogBody } from "@/src/components/ui/dialog";
 import {
   Dropzone,
   DropzoneEmptyState,
 } from "@/src/components/ui/shadcn-io/dropzone";
+import { CsvPreviewResult } from "@/src/features/datasets/lib/csv/types";
 
 export const MAX_FILE_SIZE_BYTES = 1024 * 1024 * 1 * 10; // 10MB
 const ACCEPTED_FILE_TYPES = ["text/csv"] as const;

--- a/web/src/features/datasets/components/UploadDatasetCsv.tsx
+++ b/web/src/features/datasets/components/UploadDatasetCsv.tsx
@@ -13,7 +13,7 @@ import {
   Dropzone,
   DropzoneEmptyState,
 } from "@/src/components/ui/shadcn-io/dropzone";
-import { CsvPreviewResult } from "@/src/features/datasets/lib/csv/types";
+import type { CsvPreviewResult } from "@/src/features/datasets/lib/csv/types";
 
 export const MAX_FILE_SIZE_BYTES = 1024 * 1024 * 1 * 10; // 10MB
 const ACCEPTED_FILE_TYPES = ["text/csv"] as const;

--- a/web/src/features/datasets/components/UploadDatasetCsvButton.tsx
+++ b/web/src/features/datasets/components/UploadDatasetCsvButton.tsx
@@ -42,9 +42,14 @@ export const UploadDatasetCsvButton = (props: {
           Upload CSV
         </ActionButton>
       </DialogTrigger>
-      <DialogContent className="flex h-[80dvh] max-w-[80dvw] flex-col overflow-hidden">
+      <DialogContent className="flex h-[80dvh] max-w-7xl flex-col overflow-hidden">
         <DialogHeader>
-          <DialogTitle>Upload CSV</DialogTitle>
+          <DialogTitle>
+            Upload CSV
+            <span className="text-lg font-normal text-muted-foreground">
+              {csvFile ? ` - ${csvFile.name}` : ""}
+            </span>
+          </DialogTitle>
         </DialogHeader>
         {preview ? (
           <PreviewCsvImport

--- a/web/src/features/datasets/components/UploadDatasetCsvButton.tsx
+++ b/web/src/features/datasets/components/UploadDatasetCsvButton.tsx
@@ -1,18 +1,10 @@
 import { UploadIcon } from "lucide-react";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/src/components/ui/dialog";
-import { useState } from "react";
 import { DialogTrigger } from "@radix-ui/react-dialog";
+import { useState } from "react";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { ActionButton } from "@/src/components/ActionButton";
-import { type CsvPreviewResult } from "@/src/features/datasets/lib/csvHelpers";
-import { PreviewCsvImport } from "@/src/features/datasets/components/PreviewCsvImport";
-import { UploadDatasetCsv } from "@/src/features/datasets/components/UploadDatasetCsv";
+import { CsvUploadDialog } from "@/src/features/datasets/components/CsvUploadDialog";
 
 export const UploadDatasetCsvButton = (props: {
   projectId: string;
@@ -20,8 +12,6 @@ export const UploadDatasetCsvButton = (props: {
   className?: string;
 }) => {
   const [open, setOpen] = useState(false);
-  const [preview, setPreview] = useState<CsvPreviewResult | null>(null);
-  const [csvFile, setCsvFile] = useState<File | null>(null);
   const hasAccess = useHasProjectAccess({
     projectId: props.projectId,
     scope: "datasets:CUD",
@@ -29,7 +19,12 @@ export const UploadDatasetCsvButton = (props: {
   const capture = usePostHogClientCapture();
 
   return (
-    <Dialog open={hasAccess && open} onOpenChange={setOpen}>
+    <CsvUploadDialog
+      open={hasAccess && open}
+      onOpenChange={setOpen}
+      projectId={props.projectId}
+      datasetId={props.datasetId}
+    >
       <DialogTrigger asChild className="hidden md:flex">
         <ActionButton
           variant="outline"
@@ -42,29 +37,6 @@ export const UploadDatasetCsvButton = (props: {
           Upload CSV
         </ActionButton>
       </DialogTrigger>
-      <DialogContent className="flex h-[80dvh] max-w-7xl flex-col overflow-hidden">
-        <DialogHeader>
-          <DialogTitle>
-            Upload CSV
-            <span className="text-lg font-normal text-muted-foreground">
-              {csvFile ? ` - ${csvFile.name}` : ""}
-            </span>
-          </DialogTitle>
-        </DialogHeader>
-        {preview ? (
-          <PreviewCsvImport
-            preview={preview}
-            csvFile={csvFile}
-            projectId={props.projectId}
-            datasetId={props.datasetId}
-            setCsvFile={setCsvFile}
-            setPreview={setPreview}
-            setOpen={setOpen}
-          />
-        ) : (
-          <UploadDatasetCsv setPreview={setPreview} setCsvFile={setCsvFile} />
-        )}
-      </DialogContent>
-    </Dialog>
+    </CsvUploadDialog>
   );
 };

--- a/web/src/features/datasets/hooks/useCsvDragAndDrop.ts
+++ b/web/src/features/datasets/hooks/useCsvDragAndDrop.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { type DragEndEvent } from "@dnd-kit/core";
-import { type CsvColumnPreview } from "@/src/features/datasets/lib/csvHelpers";
+import { type CsvColumnPreview } from "@/src/features/datasets/lib/csv/types";
 
 type DragHandlers = {
   onAddToInputColumn: (columnName: string) => void;

--- a/web/src/features/datasets/hooks/useCsvDragAndDrop.ts
+++ b/web/src/features/datasets/hooks/useCsvDragAndDrop.ts
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { type DragEndEvent } from "@dnd-kit/core";
+import { type CsvColumnPreview } from "@/src/features/datasets/lib/csvHelpers";
+
+type DragHandlers = {
+  onAddToInputColumn: (columnName: string) => void;
+  onAddToExpectedColumn: (columnName: string) => void;
+  onAddToMetadataColumn: (columnName: string) => void;
+  onAddToInputSchemaKey: (schemaKey: string, column: CsvColumnPreview) => void;
+  onAddToExpectedSchemaKey: (
+    schemaKey: string,
+    column: CsvColumnPreview,
+  ) => void;
+  onRemoveFromAllMappings: (columnName: string) => void;
+};
+
+export function useCsvDragAndDrop({ handlers }: { handlers: DragHandlers }) {
+  const [activeColumn, setActiveColumn] = useState<string | null>(null);
+
+  const handleDragStart = (event: { active: { id: unknown } }) => {
+    setActiveColumn(event.active.id as string);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    setActiveColumn(null);
+
+    if (!over) return;
+
+    const fromCardId = active.data.current?.fromCardId;
+    const column = active.data.current?.column as CsvColumnPreview;
+    const toId = over.id as string;
+
+    if (!column) return;
+
+    // Only proceed if dropping on a valid drop zone
+    const isValidDropZone =
+      toId.includes(":") || // schema key drop zones
+      toId === "input" ||
+      toId === "expected" ||
+      toId === "metadata";
+
+    if (!isValidDropZone) return;
+
+    // Remove from previous mappings if dragging from mapped card
+    if (fromCardId === "mapped") {
+      handlers.onRemoveFromAllMappings(column.name);
+    }
+
+    // Handle schema key drops (format: "input:key" or "expectedOutput:key")
+    if (toId.includes(":")) {
+      const [cardType, schemaKey] = toId.split(":");
+      if (!schemaKey) return;
+
+      if (cardType === "input") {
+        handlers.onAddToInputSchemaKey(schemaKey, column);
+      } else if (cardType === "expectedOutput") {
+        handlers.onAddToExpectedSchemaKey(schemaKey, column);
+      }
+      return;
+    }
+
+    // Handle freeform drops (input, expected, metadata)
+    if (toId === "input") {
+      handlers.onAddToInputColumn(column.name);
+    } else if (toId === "expected") {
+      handlers.onAddToExpectedColumn(column.name);
+    } else if (toId === "metadata") {
+      handlers.onAddToMetadataColumn(column.name);
+    }
+  };
+
+  return {
+    activeColumn,
+    handleDragStart,
+    handleDragEnd,
+  };
+}

--- a/web/src/features/datasets/hooks/useCsvImport.ts
+++ b/web/src/features/datasets/hooks/useCsvImport.ts
@@ -1,0 +1,277 @@
+import { useState } from "react";
+import { type RouterInputs, api } from "@/src/utils/api";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import { MAX_FILE_SIZE_BYTES } from "@/src/features/datasets/components/UploadDatasetCsv";
+import { type BulkDatasetItemValidationError } from "@langfuse/shared";
+import { chunk } from "lodash";
+import {
+  parseCsvClient,
+  parseColumns,
+  buildSchemaObject,
+  type CsvColumnPreview,
+} from "@/src/features/datasets/lib/csvHelpers";
+
+const MIN_CHUNK_SIZE = 1;
+const CHUNK_START_SIZE = 50;
+const DELAY_BETWEEN_CHUNKS = 100; // milliseconds
+const MAX_PAYLOAD_SIZE = 500 * 1024; // 500KB in bytes
+
+function getOptimalChunkSize(items: any[], startSize: number): number {
+  const getPayloadSize = (size: number) =>
+    new TextEncoder().encode(
+      JSON.stringify({
+        projectId: "test",
+        datasetId: "test",
+        items: items.slice(0, size),
+      }),
+    ).length;
+
+  let low = MIN_CHUNK_SIZE;
+  let high = startSize;
+  let best = MIN_CHUNK_SIZE;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    if (getPayloadSize(mid) <= MAX_PAYLOAD_SIZE) {
+      best = mid;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return best;
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+type ImportProgress = {
+  totalItems: number;
+  processedItems: number;
+  status: "not-started" | "processing" | "complete";
+};
+
+type UseCsvImportOptions = {
+  projectId: string;
+  datasetId: string;
+  csvFile: File | null;
+  isSchemaMode: boolean;
+  selectedInputColumn: Set<string>;
+  selectedExpectedColumn: Set<string>;
+  selectedMetadataColumn: Set<string>;
+  inputSchemaMapping: Map<string, CsvColumnPreview[]>;
+  expectedOutputSchemaMapping: Map<string, CsvColumnPreview[]>;
+};
+
+export function useCsvImport(options: UseCsvImportOptions) {
+  const [progress, setProgress] = useState<ImportProgress>({
+    totalItems: 0,
+    processedItems: 0,
+    status: "not-started",
+  });
+  const [validationErrors, setValidationErrors] = useState<
+    BulkDatasetItemValidationError[]
+  >([]);
+
+  const utils = api.useUtils();
+  const mutCreateManyDatasetItems =
+    api.datasets.createManyDatasetItems.useMutation({});
+
+  const execute = async (wrapSingleColumn: boolean) => {
+    const { csvFile, projectId, datasetId, isSchemaMode } = options;
+
+    if (!csvFile) return;
+    if (csvFile.size > MAX_FILE_SIZE_BYTES) {
+      showErrorToast("File too large", "Maximum file size is 10MB");
+      return;
+    }
+
+    setValidationErrors([]);
+
+    let processedCount = 0;
+    let headerMap: Map<string, number>;
+
+    const items: RouterInputs["datasets"]["createManyDatasetItems"]["items"] =
+      [];
+
+    // Prepare column lists or mappings based on mode
+    const input = Array.from(options.selectedInputColumn);
+    const expected = Array.from(options.selectedExpectedColumn);
+    const metadata = Array.from(options.selectedMetadataColumn);
+
+    const inputMapping = isSchemaMode
+      ? Object.fromEntries(
+          Array.from(options.inputSchemaMapping.entries()).map(
+            ([key, cols]) => [key, cols.map((c) => c.name)],
+          ),
+        )
+      : undefined;
+    const expectedOutputMapping = isSchemaMode
+      ? Object.fromEntries(
+          Array.from(options.expectedOutputSchemaMapping.entries()).map(
+            ([key, cols]) => [key, cols.map((c) => c.name)],
+          ),
+        )
+      : undefined;
+
+    try {
+      await parseCsvClient(csvFile, {
+        processor: {
+          onHeader: (headers) => {
+            headerMap = new Map(headers.map((h, i) => [h, i]));
+
+            // Validate columns exist
+            const allColumns = [
+              ...Object.values(inputMapping ?? {}).flat(),
+              ...Object.values(expectedOutputMapping ?? {}).flat(),
+              ...input,
+              ...expected,
+              ...metadata,
+            ];
+            const missingColumns = allColumns.filter(
+              (col) => !headerMap.has(col),
+            );
+            if (missingColumns.length > 0) {
+              throw new Error(`Missing columns: ${missingColumns.join(", ")}`);
+            }
+          },
+          onRow: (row, _, index) => {
+            try {
+              let itemInput: unknown;
+              let itemExpected: unknown;
+
+              if (isSchemaMode) {
+                // Input: use schema mapping if available, else freeform
+                if (inputMapping && Object.keys(inputMapping).length > 0) {
+                  itemInput = buildSchemaObject(inputMapping, row, headerMap);
+                } else {
+                  itemInput =
+                    parseColumns(input, row, headerMap, { wrapSingleColumn }) ??
+                    undefined;
+                }
+
+                // Expected output: use schema mapping if available, else freeform
+                if (
+                  expectedOutputMapping &&
+                  Object.keys(expectedOutputMapping).length > 0
+                ) {
+                  itemExpected = buildSchemaObject(
+                    expectedOutputMapping,
+                    row,
+                    headerMap,
+                  );
+                } else {
+                  itemExpected =
+                    parseColumns(expected, row, headerMap, {
+                      wrapSingleColumn,
+                    }) ?? undefined;
+                }
+              } else {
+                // Pure freeform mode
+                itemInput =
+                  parseColumns(input, row, headerMap, { wrapSingleColumn }) ??
+                  undefined;
+                itemExpected =
+                  parseColumns(expected, row, headerMap, {
+                    wrapSingleColumn,
+                  }) ?? undefined;
+              }
+
+              const itemMetadata =
+                parseColumns(metadata, row, headerMap) ?? undefined;
+
+              items.push({
+                input: JSON.stringify(itemInput),
+                expectedOutput: JSON.stringify(itemExpected),
+                metadata: JSON.stringify(itemMetadata),
+                datasetId,
+              });
+            } catch (error) {
+              throw new Error(
+                `Error processing row ${index + 1}: ${error instanceof Error ? error.message : "Unknown error"}`,
+              );
+            }
+          },
+        },
+      });
+
+      const optimalChunkSize = getOptimalChunkSize(items, CHUNK_START_SIZE);
+      const chunks = chunk(items, optimalChunkSize);
+
+      for (const [index, chunkItems] of chunks.entries()) {
+        const result = await mutCreateManyDatasetItems.mutateAsync({
+          projectId,
+          items: chunkItems,
+        });
+
+        if (!result.success) {
+          const adjustedErrors = result.validationErrors.map((error) => ({
+            ...error,
+            itemIndex: error.itemIndex + processedCount,
+          }));
+
+          setValidationErrors(adjustedErrors);
+          setProgress({
+            totalItems: 0,
+            processedItems: 0,
+            status: "not-started",
+          });
+          return;
+        }
+
+        processedCount += chunkItems.length;
+        setProgress({
+          totalItems: items.length,
+          processedItems: processedCount,
+          status: "processing",
+        });
+
+        if (index < chunks.length - 1) {
+          await sleep(DELAY_BETWEEN_CHUNKS);
+        }
+      }
+    } catch (error) {
+      utils.datasets.invalidate();
+      setProgress({
+        totalItems: 0,
+        processedItems: 0,
+        status: "not-started",
+      });
+      if (error instanceof Error && processedCount === 0) {
+        showErrorToast("Failed to import all dataset items", error.message);
+      } else {
+        showErrorToast(
+          "Failed to import all dataset items",
+          `Please try again starting from row ${processedCount + 1}.`,
+        );
+      }
+      return;
+    }
+
+    utils.datasets.invalidate();
+
+    setProgress({
+      totalItems: items.length,
+      processedItems: items.length,
+      status: "complete",
+    });
+  };
+
+  const reset = () => {
+    setProgress({
+      totalItems: 0,
+      processedItems: 0,
+      status: "not-started",
+    });
+    setValidationErrors([]);
+  };
+
+  return {
+    execute,
+    progress,
+    validationErrors,
+    reset,
+  };
+}

--- a/web/src/features/datasets/hooks/useCsvImport.ts
+++ b/web/src/features/datasets/hooks/useCsvImport.ts
@@ -9,9 +9,9 @@ import {
   parseColumns,
   buildSchemaObject,
 } from "@/src/features/datasets/lib/csv/helpers";
-import {
+import type {
   CsvColumnPreview,
-  type FieldMapping,
+  FieldMapping,
 } from "@/src/features/datasets/lib/csv/types";
 
 const MIN_CHUNK_SIZE = 1;

--- a/web/src/features/datasets/hooks/useCsvImport.ts
+++ b/web/src/features/datasets/hooks/useCsvImport.ts
@@ -179,7 +179,9 @@ export function useCsvImport(options: UseCsvImportOptions) {
               }
 
               const itemMetadata =
-                parseColumns(metadataColumns, row, headerMap) ?? undefined;
+                parseColumns(metadataColumns, row, headerMap, {
+                  wrapSingleColumn,
+                }) ?? undefined;
 
               items.push({
                 input: JSON.stringify(itemInput),

--- a/web/src/features/datasets/hooks/useCsvMapping.ts
+++ b/web/src/features/datasets/hooks/useCsvMapping.ts
@@ -1,167 +1,312 @@
 import { useEffect, useState } from "react";
-import { type CsvColumnPreview } from "@/src/features/datasets/lib/csvHelpers";
 import { findDefaultColumn } from "../lib/findDefaultColumn";
-
-type CsvMappingState = {
-  // Freeform mode
-  selectedInputColumn: Set<string>;
-  selectedExpectedColumn: Set<string>;
-  selectedMetadataColumn: Set<string>;
-  excludedColumns: Set<string>;
-
-  // Schema mode
-  inputSchemaMapping: Map<string, CsvColumnPreview[]>;
-  expectedOutputSchemaMapping: Map<string, CsvColumnPreview[]>;
-  unmappedColumns: Set<string>;
-};
+import {
+  CsvColumnPreview,
+  CsvMapping,
+  FieldMapping,
+  FieldMappingType,
+  FreeformField,
+  SchemaField,
+} from "@/src/features/datasets/lib/csv/types";
+import { isFreeformField } from "@/src/features/datasets/lib/csv/helpers";
 
 type CsvMappingActions = {
-  setSelectedInputColumn: (columns: Set<string>) => void;
-  setSelectedExpectedColumn: (columns: Set<string>) => void;
-  setSelectedMetadataColumn: (columns: Set<string>) => void;
-  setInputSchemaMapping: (mapping: Map<string, CsvColumnPreview[]>) => void;
-  setExpectedOutputSchemaMapping: (
-    mapping: Map<string, CsvColumnPreview[]>,
-  ) => void;
-  removeFromAllMappings: (columnName: string) => void;
+  addColumnToInput: (column: CsvColumnPreview, key?: string) => void;
+  addColumnToExpectedOutput: (column: CsvColumnPreview, key?: string) => void;
+  addColumnToMetadata: (column: CsvColumnPreview) => void;
+  removeColumnFromInput: (columnName: string, key?: string) => void;
+  removeColumnFromExpectedOutput: (columnName: string, key?: string) => void;
+  removeColumnFromMetadata: (columnName: string) => void;
+  removeColumnFromAll: (columnName: string) => void;
+  isEmpty: () => boolean;
   reset: () => void;
 };
 
-const initialState: CsvMappingState = {
-  selectedInputColumn: new Set(),
-  selectedExpectedColumn: new Set(),
-  selectedMetadataColumn: new Set(),
-  excludedColumns: new Set(),
-  inputSchemaMapping: new Map(),
-  expectedOutputSchemaMapping: new Map(),
-  unmappedColumns: new Set(),
-};
+function createFreeformField(): FreeformField {
+  return { type: FieldMappingType.FREEFORM, columns: [] };
+}
+
+function createSchemaField(keys: string[]): SchemaField {
+  return {
+    type: FieldMappingType.SCHEMA,
+    entries: keys.map((key) => ({ key, columns: [] })),
+  };
+}
 
 export function useCsvMapping({
   preview,
-  isSchemaMode,
+  inputSchemaKeys,
+  expectedOutputSchemaKeys,
 }: {
   preview: { columns: CsvColumnPreview[] } | null;
-  isSchemaMode: boolean;
-}): CsvMappingState & CsvMappingActions {
-  const [state, setState] = useState<CsvMappingState>(initialState);
+  inputSchemaKeys?: string[];
+  expectedOutputSchemaKeys?: string[];
+}): CsvMapping & CsvMappingActions {
+  const hasInputSchema = inputSchemaKeys && inputSchemaKeys.length > 0;
+  const hasExpectedSchema =
+    expectedOutputSchemaKeys && expectedOutputSchemaKeys.length > 0;
 
-  // Initialize defaults on mount
+  const [mapping, setMapping] = useState<CsvMapping>(() => ({
+    input: hasInputSchema
+      ? createSchemaField(inputSchemaKeys)
+      : createFreeformField(),
+    expectedOutput: hasExpectedSchema
+      ? createSchemaField(expectedOutputSchemaKeys)
+      : createFreeformField(),
+    metadata: [],
+  }));
+
+  // Initialize defaults for freeform mode
   useEffect(() => {
     if (!preview) return;
 
-    if (!isSchemaMode) {
-      // Freeform mode: set defaults only if no columns selected
-      if (
-        state.selectedInputColumn.size === 0 &&
-        state.selectedExpectedColumn.size === 0 &&
-        state.selectedMetadataColumn.size === 0
-      ) {
-        const defaultInput = findDefaultColumn(preview.columns, "Input", 0);
-        const defaultExpected = findDefaultColumn(
-          preview.columns,
-          "Expected",
-          1,
-        );
-        const defaultMetadata = findDefaultColumn(
-          preview.columns,
-          "Metadata",
-          2,
-        );
+    const isInitialized =
+      (isFreeformField(mapping.input) && mapping.input.columns.length > 0) ||
+      (isFreeformField(mapping.expectedOutput) &&
+        mapping.expectedOutput.columns.length > 0) ||
+      mapping.metadata.length > 0;
 
-        const newExcluded = new Set(
-          preview.columns
-            .filter(
-              (col) =>
-                defaultInput !== col.name &&
-                defaultExpected !== col.name &&
-                defaultMetadata !== col.name,
-            )
-            .map((col) => col.name),
-        );
+    if (!hasInputSchema && !hasExpectedSchema && !isInitialized) {
+      const defaultInput = findDefaultColumn(preview.columns, "Input", 0);
+      const defaultExpected = findDefaultColumn(preview.columns, "Expected", 1);
+      const defaultMetadata = findDefaultColumn(preview.columns, "Metadata", 2);
 
-        setState((prev) => ({
-          ...prev,
-          selectedInputColumn: defaultInput
-            ? new Set([defaultInput])
-            : new Set(),
-          selectedExpectedColumn: defaultExpected
-            ? new Set([defaultExpected])
-            : new Set(),
-          selectedMetadataColumn: defaultMetadata
-            ? new Set([defaultMetadata])
-            : new Set(),
-          excludedColumns: newExcluded,
-        }));
-      }
-    } else {
-      // Schema mode: initialize unmapped columns
-      if (state.unmappedColumns.size === 0) {
-        setState((prev) => ({
-          ...prev,
-          unmappedColumns: new Set(preview.columns.map((col) => col.name)),
-        }));
-      }
+      const inputColumn = defaultInput
+        ? preview.columns.find((c) => c.name === defaultInput)
+        : undefined;
+      const expectedColumn = defaultExpected
+        ? preview.columns.find((c) => c.name === defaultExpected)
+        : undefined;
+      const metadataColumn = defaultMetadata
+        ? preview.columns.find((c) => c.name === defaultMetadata)
+        : undefined;
+
+      setMapping((prev) => ({
+        input: isFreeformField(prev.input)
+          ? {
+              type: FieldMappingType.FREEFORM,
+              columns: inputColumn ? [inputColumn] : [],
+            }
+          : prev.input,
+        expectedOutput: isFreeformField(prev.expectedOutput)
+          ? {
+              type: FieldMappingType.FREEFORM,
+              columns: expectedColumn ? [expectedColumn] : [],
+            }
+          : prev.expectedOutput,
+        metadata: metadataColumn ? [metadataColumn] : [],
+      }));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [preview, isSchemaMode]);
+  }, [preview, hasInputSchema, hasExpectedSchema]);
 
-  const removeFromAllMappings = (columnName: string) => {
-    setState((prev) => {
-      // Remove from input schema mapping
-      const inputMapping = new Map(prev.inputSchemaMapping);
-      for (const [key, cols] of inputMapping.entries()) {
-        const filtered = cols.filter((c) => c.name !== columnName);
-        if (filtered.length === 0) {
-          inputMapping.delete(key);
-        } else if (filtered.length !== cols.length) {
-          inputMapping.set(key, filtered);
-        }
+  const addColumnToInput = (column: CsvColumnPreview, key?: string) => {
+    setMapping((prev) => {
+      if (isFreeformField(prev.input)) {
+        return {
+          ...prev,
+          input: {
+            type: FieldMappingType.FREEFORM,
+            columns: [...prev.input.columns, column],
+          },
+        };
+      } else if (key) {
+        return {
+          ...prev,
+          input: {
+            type: FieldMappingType.SCHEMA,
+            entries: prev.input.entries.map((entry) =>
+              entry.key === key
+                ? { ...entry, columns: [...entry.columns, column] }
+                : entry,
+            ),
+          },
+        };
       }
+      return prev;
+    });
+  };
 
-      // Remove from expected schema mapping
-      const expectedMapping = new Map(prev.expectedOutputSchemaMapping);
-      for (const [key, cols] of expectedMapping.entries()) {
-        const filtered = cols.filter((c) => c.name !== columnName);
-        if (filtered.length === 0) {
-          expectedMapping.delete(key);
-        } else if (filtered.length !== cols.length) {
-          expectedMapping.set(key, filtered);
-        }
+  const addColumnToExpectedOutput = (
+    column: CsvColumnPreview,
+    key?: string,
+  ) => {
+    setMapping((prev) => {
+      if (isFreeformField(prev.expectedOutput)) {
+        return {
+          ...prev,
+          expectedOutput: {
+            type: FieldMappingType.FREEFORM,
+            columns: [...prev.expectedOutput.columns, column],
+          },
+        };
+      } else if (key) {
+        return {
+          ...prev,
+          expectedOutput: {
+            type: FieldMappingType.SCHEMA,
+            entries: prev.expectedOutput.entries.map((entry) =>
+              entry.key === key
+                ? { ...entry, columns: [...entry.columns, column] }
+                : entry,
+            ),
+          },
+        };
       }
+      return prev;
+    });
+  };
 
-      // Remove from freeform selections
-      const newInputColumn = new Set(prev.selectedInputColumn);
-      const newExpectedColumn = new Set(prev.selectedExpectedColumn);
-      const newMetadataColumn = new Set(prev.selectedMetadataColumn);
-      newInputColumn.delete(columnName);
-      newExpectedColumn.delete(columnName);
-      newMetadataColumn.delete(columnName);
+  const addColumnToMetadata = (column: CsvColumnPreview) => {
+    setMapping((prev) => ({
+      ...prev,
+      metadata: [...prev.metadata, column],
+    }));
+  };
+
+  const removeColumnFromInput = (columnName: string, key?: string) => {
+    setMapping((prev) => {
+      if (isFreeformField(prev.input)) {
+        return {
+          ...prev,
+          input: {
+            type: FieldMappingType.FREEFORM,
+            columns: prev.input.columns.filter((c) => c.name !== columnName),
+          },
+        };
+      } else if (key) {
+        return {
+          ...prev,
+          input: {
+            type: FieldMappingType.SCHEMA,
+            entries: prev.input.entries.map((entry) =>
+              entry.key === key
+                ? {
+                    ...entry,
+                    columns: entry.columns.filter((c) => c.name !== columnName),
+                  }
+                : entry,
+            ),
+          },
+        };
+      }
+      return prev;
+    });
+  };
+
+  const removeColumnFromExpectedOutput = (columnName: string, key?: string) => {
+    setMapping((prev) => {
+      if (isFreeformField(prev.expectedOutput)) {
+        return {
+          ...prev,
+          expectedOutput: {
+            type: FieldMappingType.FREEFORM,
+            columns: prev.expectedOutput.columns.filter(
+              (c) => c.name !== columnName,
+            ),
+          },
+        };
+      } else if (key) {
+        return {
+          ...prev,
+          expectedOutput: {
+            type: FieldMappingType.SCHEMA,
+            entries: prev.expectedOutput.entries.map((entry) =>
+              entry.key === key
+                ? {
+                    ...entry,
+                    columns: entry.columns.filter((c) => c.name !== columnName),
+                  }
+                : entry,
+            ),
+          },
+        };
+      }
+      return prev;
+    });
+  };
+
+  const removeColumnFromMetadata = (columnName: string) => {
+    setMapping((prev) => ({
+      ...prev,
+      metadata: prev.metadata.filter((c) => c.name !== columnName),
+    }));
+  };
+
+  const removeColumnFromAll = (columnName: string) => {
+    setMapping((prev) => {
+      const newInput: FieldMapping = isFreeformField(prev.input)
+        ? {
+            type: FieldMappingType.FREEFORM,
+            columns: prev.input.columns.filter((c) => c.name !== columnName),
+          }
+        : {
+            type: FieldMappingType.SCHEMA,
+            entries: prev.input.entries.map((entry) => ({
+              ...entry,
+              columns: entry.columns.filter((c) => c.name !== columnName),
+            })),
+          };
+
+      const newExpectedOutput: FieldMapping = isFreeformField(
+        prev.expectedOutput,
+      )
+        ? {
+            type: FieldMappingType.FREEFORM,
+            columns: prev.expectedOutput.columns.filter(
+              (c) => c.name !== columnName,
+            ),
+          }
+        : {
+            type: FieldMappingType.SCHEMA,
+            entries: prev.expectedOutput.entries.map((entry) => ({
+              ...entry,
+              columns: entry.columns.filter((c) => c.name !== columnName),
+            })),
+          };
 
       return {
-        ...prev,
-        inputSchemaMapping: inputMapping,
-        expectedOutputSchemaMapping: expectedMapping,
-        selectedInputColumn: newInputColumn,
-        selectedExpectedColumn: newExpectedColumn,
-        selectedMetadataColumn: newMetadataColumn,
+        input: newInput,
+        expectedOutput: newExpectedOutput,
+        metadata: prev.metadata.filter((c) => c.name !== columnName),
       };
     });
   };
 
+  const isEmpty = () => {
+    const inputEmpty = isFreeformField(mapping.input)
+      ? mapping.input.columns.length === 0
+      : mapping.input.entries.every((e) => e.columns.length === 0);
+
+    const expectedOutputEmpty = isFreeformField(mapping.expectedOutput)
+      ? mapping.expectedOutput.columns.length === 0
+      : mapping.expectedOutput.entries.every((e) => e.columns.length === 0);
+
+    return inputEmpty && expectedOutputEmpty;
+  };
+
+  const reset = () => {
+    setMapping({
+      input: hasInputSchema
+        ? createSchemaField(inputSchemaKeys!)
+        : createFreeformField(),
+      expectedOutput: hasExpectedSchema
+        ? createSchemaField(expectedOutputSchemaKeys!)
+        : createFreeformField(),
+      metadata: [],
+    });
+  };
+
   return {
-    ...state,
-    setSelectedInputColumn: (columns) =>
-      setState((prev) => ({ ...prev, selectedInputColumn: columns })),
-    setSelectedExpectedColumn: (columns) =>
-      setState((prev) => ({ ...prev, selectedExpectedColumn: columns })),
-    setSelectedMetadataColumn: (columns) =>
-      setState((prev) => ({ ...prev, selectedMetadataColumn: columns })),
-    setInputSchemaMapping: (mapping) =>
-      setState((prev) => ({ ...prev, inputSchemaMapping: mapping })),
-    setExpectedOutputSchemaMapping: (mapping) =>
-      setState((prev) => ({ ...prev, expectedOutputSchemaMapping: mapping })),
-    removeFromAllMappings,
-    reset: () => setState(initialState),
+    ...mapping,
+    addColumnToInput,
+    addColumnToExpectedOutput,
+    addColumnToMetadata,
+    removeColumnFromInput,
+    removeColumnFromExpectedOutput,
+    removeColumnFromMetadata,
+    removeColumnFromAll,
+    isEmpty,
+    reset,
   };
 }

--- a/web/src/features/datasets/hooks/useCsvMapping.ts
+++ b/web/src/features/datasets/hooks/useCsvMapping.ts
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
 import { findDefaultColumn } from "../lib/findDefaultColumn";
 import {
-  CsvColumnPreview,
-  CsvMapping,
-  FieldMapping,
   FieldMappingType,
-  FreeformField,
-  SchemaField,
+  type CsvColumnPreview,
+  type CsvMapping,
+  type FieldMapping,
+  type FreeformField,
+  type SchemaField,
 } from "@/src/features/datasets/lib/csv/types";
 import { isFreeformField } from "@/src/features/datasets/lib/csv/helpers";
 

--- a/web/src/features/datasets/hooks/useCsvMapping.ts
+++ b/web/src/features/datasets/hooks/useCsvMapping.ts
@@ -1,0 +1,167 @@
+import { useEffect, useState } from "react";
+import { type CsvColumnPreview } from "@/src/features/datasets/lib/csvHelpers";
+import { findDefaultColumn } from "../lib/findDefaultColumn";
+
+type CsvMappingState = {
+  // Freeform mode
+  selectedInputColumn: Set<string>;
+  selectedExpectedColumn: Set<string>;
+  selectedMetadataColumn: Set<string>;
+  excludedColumns: Set<string>;
+
+  // Schema mode
+  inputSchemaMapping: Map<string, CsvColumnPreview[]>;
+  expectedOutputSchemaMapping: Map<string, CsvColumnPreview[]>;
+  unmappedColumns: Set<string>;
+};
+
+type CsvMappingActions = {
+  setSelectedInputColumn: (columns: Set<string>) => void;
+  setSelectedExpectedColumn: (columns: Set<string>) => void;
+  setSelectedMetadataColumn: (columns: Set<string>) => void;
+  setInputSchemaMapping: (mapping: Map<string, CsvColumnPreview[]>) => void;
+  setExpectedOutputSchemaMapping: (
+    mapping: Map<string, CsvColumnPreview[]>,
+  ) => void;
+  removeFromAllMappings: (columnName: string) => void;
+  reset: () => void;
+};
+
+const initialState: CsvMappingState = {
+  selectedInputColumn: new Set(),
+  selectedExpectedColumn: new Set(),
+  selectedMetadataColumn: new Set(),
+  excludedColumns: new Set(),
+  inputSchemaMapping: new Map(),
+  expectedOutputSchemaMapping: new Map(),
+  unmappedColumns: new Set(),
+};
+
+export function useCsvMapping({
+  preview,
+  isSchemaMode,
+}: {
+  preview: { columns: CsvColumnPreview[] } | null;
+  isSchemaMode: boolean;
+}): CsvMappingState & CsvMappingActions {
+  const [state, setState] = useState<CsvMappingState>(initialState);
+
+  // Initialize defaults on mount
+  useEffect(() => {
+    if (!preview) return;
+
+    if (!isSchemaMode) {
+      // Freeform mode: set defaults only if no columns selected
+      if (
+        state.selectedInputColumn.size === 0 &&
+        state.selectedExpectedColumn.size === 0 &&
+        state.selectedMetadataColumn.size === 0
+      ) {
+        const defaultInput = findDefaultColumn(preview.columns, "Input", 0);
+        const defaultExpected = findDefaultColumn(
+          preview.columns,
+          "Expected",
+          1,
+        );
+        const defaultMetadata = findDefaultColumn(
+          preview.columns,
+          "Metadata",
+          2,
+        );
+
+        const newExcluded = new Set(
+          preview.columns
+            .filter(
+              (col) =>
+                defaultInput !== col.name &&
+                defaultExpected !== col.name &&
+                defaultMetadata !== col.name,
+            )
+            .map((col) => col.name),
+        );
+
+        setState((prev) => ({
+          ...prev,
+          selectedInputColumn: defaultInput
+            ? new Set([defaultInput])
+            : new Set(),
+          selectedExpectedColumn: defaultExpected
+            ? new Set([defaultExpected])
+            : new Set(),
+          selectedMetadataColumn: defaultMetadata
+            ? new Set([defaultMetadata])
+            : new Set(),
+          excludedColumns: newExcluded,
+        }));
+      }
+    } else {
+      // Schema mode: initialize unmapped columns
+      if (state.unmappedColumns.size === 0) {
+        setState((prev) => ({
+          ...prev,
+          unmappedColumns: new Set(preview.columns.map((col) => col.name)),
+        }));
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [preview, isSchemaMode]);
+
+  const removeFromAllMappings = (columnName: string) => {
+    setState((prev) => {
+      // Remove from input schema mapping
+      const inputMapping = new Map(prev.inputSchemaMapping);
+      for (const [key, cols] of inputMapping.entries()) {
+        const filtered = cols.filter((c) => c.name !== columnName);
+        if (filtered.length === 0) {
+          inputMapping.delete(key);
+        } else if (filtered.length !== cols.length) {
+          inputMapping.set(key, filtered);
+        }
+      }
+
+      // Remove from expected schema mapping
+      const expectedMapping = new Map(prev.expectedOutputSchemaMapping);
+      for (const [key, cols] of expectedMapping.entries()) {
+        const filtered = cols.filter((c) => c.name !== columnName);
+        if (filtered.length === 0) {
+          expectedMapping.delete(key);
+        } else if (filtered.length !== cols.length) {
+          expectedMapping.set(key, filtered);
+        }
+      }
+
+      // Remove from freeform selections
+      const newInputColumn = new Set(prev.selectedInputColumn);
+      const newExpectedColumn = new Set(prev.selectedExpectedColumn);
+      const newMetadataColumn = new Set(prev.selectedMetadataColumn);
+      newInputColumn.delete(columnName);
+      newExpectedColumn.delete(columnName);
+      newMetadataColumn.delete(columnName);
+
+      return {
+        ...prev,
+        inputSchemaMapping: inputMapping,
+        expectedOutputSchemaMapping: expectedMapping,
+        selectedInputColumn: newInputColumn,
+        selectedExpectedColumn: newExpectedColumn,
+        selectedMetadataColumn: newMetadataColumn,
+      };
+    });
+  };
+
+  return {
+    ...state,
+    setSelectedInputColumn: (columns) =>
+      setState((prev) => ({ ...prev, selectedInputColumn: columns })),
+    setSelectedExpectedColumn: (columns) =>
+      setState((prev) => ({ ...prev, selectedExpectedColumn: columns })),
+    setSelectedMetadataColumn: (columns) =>
+      setState((prev) => ({ ...prev, selectedMetadataColumn: columns })),
+    setInputSchemaMapping: (mapping) =>
+      setState((prev) => ({ ...prev, inputSchemaMapping: mapping })),
+    setExpectedOutputSchemaMapping: (mapping) =>
+      setState((prev) => ({ ...prev, expectedOutputSchemaMapping: mapping })),
+    removeFromAllMappings,
+    reset: () => setState(initialState),
+  };
+}

--- a/web/src/features/datasets/lib/csv/helpers.ts
+++ b/web/src/features/datasets/lib/csv/helpers.ts
@@ -1,47 +1,16 @@
 import { parse } from "csv-parse";
 import { type Prisma } from "@langfuse/shared";
+import type {
+  ParseOptions,
+  CsvPreviewResult,
+  ColumnType,
+  FieldMapping,
+  FreeformField,
+  SchemaField,
+} from "./types";
 
 const MAX_PREVIEW_ROWS = 10;
 const PREVIEW_FILE_SIZE_BYTES = 1024 * 1024 * 2; // 2MB
-
-type ColumnType =
-  | "string"
-  | "number"
-  | "boolean"
-  | "null"
-  | "json"
-  | "array"
-  | "unknown"
-  | "mixed";
-
-export type CsvColumnPreview = {
-  name: string;
-  samples: string[];
-  inferredType: ColumnType;
-};
-
-// Shared types
-export type CsvPreviewResult = {
-  fileName?: string;
-  columns: CsvColumnPreview[];
-  previewRows: string[][];
-  totalColumns: number;
-};
-
-type RowProcessor = {
-  onHeader?: (headers: string[]) => void | Promise<void>;
-  onRow?: (
-    row: string[],
-    headers: string[],
-    index: number,
-  ) => void | Promise<void>;
-};
-
-type ParseOptions = {
-  isPreview?: boolean;
-  collectSamples?: boolean;
-  processor?: RowProcessor;
-};
 
 // Shared parser configuration
 const getParserConfig = (options: ParseOptions) => ({
@@ -262,4 +231,13 @@ export function buildSchemaObject(
       }
     }),
   );
+}
+
+// Type guard helpers
+export function isFreeformField(field: FieldMapping): field is FreeformField {
+  return field.type === "freeform";
+}
+
+export function isSchemaField(field: FieldMapping): field is SchemaField {
+  return field.type === "schema";
 }

--- a/web/src/features/datasets/lib/csv/types.ts
+++ b/web/src/features/datasets/lib/csv/types.ts
@@ -1,0 +1,61 @@
+export enum FieldMappingType {
+  FREEFORM = "freeform",
+  SCHEMA = "schema",
+}
+
+export type FreeformField = {
+  type: FieldMappingType.FREEFORM;
+  columns: CsvColumnPreview[];
+};
+
+export type SchemaField = {
+  type: FieldMappingType.SCHEMA;
+  entries: Array<{ key: string; columns: CsvColumnPreview[] }>;
+};
+
+export type FieldMapping = FreeformField | SchemaField;
+
+export type CsvMapping = {
+  input: FieldMapping;
+  expectedOutput: FieldMapping;
+  metadata: CsvColumnPreview[];
+};
+
+export type ColumnType =
+  | "string"
+  | "number"
+  | "boolean"
+  | "null"
+  | "json"
+  | "array"
+  | "unknown"
+  | "mixed";
+
+export type CsvColumnPreview = {
+  name: string;
+  samples: string[];
+  inferredType: ColumnType;
+};
+
+// Shared types
+export type CsvPreviewResult = {
+  fileName?: string;
+  columns: CsvColumnPreview[];
+  previewRows: string[][];
+  totalColumns: number;
+};
+
+type RowProcessor = {
+  onHeader?: (headers: string[]) => void | Promise<void>;
+  onRow?: (
+    row: string[],
+    headers: string[],
+    index: number,
+  ) => void | Promise<void>;
+};
+
+export type ParseOptions = {
+  isPreview?: boolean;
+  collectSamples?: boolean;
+  processor?: RowProcessor;
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds CSV import with schema mapping support, including UI components, hooks, and utilities for handling CSV uploads and mapping in datasets.
> 
>   - **Behavior**:
>     - Adds `CsvUploadDialog` to handle CSV uploads with schema mapping in `DatasetItemsOnboarding.tsx` and `UploadDatasetCsvButton.tsx`.
>     - Supports both freeform and schema-driven mapping modes in `PreviewCsvImport.tsx`.
>     - Implements drag-and-drop functionality for CSV columns in `CsvColumnsCard.tsx`, `ImportCard.tsx`, and `MappingCard.tsx`.
>     - Adds `useCsvMapping`, `useCsvDragAndDrop`, and `useCsvImport` hooks for managing CSV import state and operations.
>   - **Components**:
>     - Introduces `CsvColumnsCard`, `ImportCard`, and `MappingCard` for UI representation of CSV columns and mapping.
>     - Refactors `PreviewCsvImport` to integrate new mapping and import logic.
>   - **Utilities**:
>     - Refactors CSV parsing logic into `helpers.ts` and `types.ts` for better modularity.
>     - Adds functions for schema key extraction and column type inference.
>   - **Misc**:
>     - Removes unused state management from `DatasetItemsOnboarding.tsx` and `UploadDatasetCsvButton.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e59f7d545834678e8f3ada7a040f3c096180ba82. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->