### PR TITLE
chore(dataset): display comprehensive error message if item IO exceeds size limit

### DIFF
--- a/web/src/features/datasets/components/NewDatasetItemForm.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemForm.tsx
@@ -214,7 +214,15 @@ export const NewDatasetItemForm = (props: {
   const createManyDatasetItemsMutation =
     api.datasets.createManyDatasetItems.useMutation({
       onSuccess: () => utils.datasets.invalidate(),
-      onError: (error) => setFormError(error.message),
+      onError: (error) => {
+        if (error.message.includes("Body exc")) {
+          setFormError(
+            "Data exceeds maximum size (4.5MB). Please attempt to create dataset item via CSV upload or programmatically.",
+          );
+        } else {
+          setFormError(error.message);
+        }
+      },
     });
 
   function onSubmit(values: z.infer<typeof formSchema>) {

--- a/web/src/features/datasets/components/NewDatasetItemForm.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemForm.tsx
@@ -217,7 +217,7 @@ export const NewDatasetItemForm = (props: {
       onError: (error) => {
         if (error.message.includes("Body exc")) {
           setFormError(
-            "Data exceeds maximum size (4.5MB). Please attempt to create dataset item via CSV upload or programmatically.",
+            "Data exceeds maximum size (4.5MB). Please attempt to create dataset item programmatically.",
           );
         } else {
           setFormError(error.message);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves error messaging in `NewDatasetItemForm` for data exceeding 4.5MB size limit.
> 
>   - **Behavior**:
>     - In `NewDatasetItemForm`, updates `onError` in `createManyDatasetItemsMutation` to display a specific error message when data exceeds 4.5MB.
>     - Default error message is shown for other errors.
>   - **Misc**:
>     - No changes to existing functionality or other parts of the code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9f540b55a59207c920ae993287ef906bbe836df6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->