### PR TITLE
chore(datasets): handle empty runIds in dataset queries

### DIFF
--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -542,6 +542,10 @@ const getQualifyingDatasetItems = async <T>(opts: {
   const { select, projectId, datasetId, runIds, runFilters, limit, offset } =
     opts;
 
+  if (runIds.length === 0) {
+    return [];
+  }
+
   // Build base filter (project + dataset only)
   const { datasetRunItemsFilter: baseDatasetRunItemsFilter } =
     getProjectDatasetIdDefaultFilter(projectId, datasetId);

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -1667,6 +1667,14 @@ export const datasetRouter = createTRPCRouter({
     )
     .query(async ({ input, ctx }) => {
       const { filterByRun, datasetId, projectId, runIds, limit, page } = input;
+
+      if (runIds.length === 0) {
+        return {
+          data: [],
+          totalCount: 0,
+        };
+      }
+
       // Step 1: Return dataset item ids for which the run items match the filters
       const datasetItemIds = await getDatasetItemIdsWithRunData({
         projectId: input.projectId,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Handle empty `runIds` in dataset queries by returning empty results in `dataset-run-items.ts` and `dataset-router.ts`.
> 
>   - **Behavior**:
>     - Handle empty `runIds` in `getQualifyingDatasetItems()` in `dataset-run-items.ts` by returning an empty array.
>     - Handle empty `runIds` in `datasetItemsWithRunData` in `dataset-router.ts` by returning an empty data array and `totalCount` of 0.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b3951dc9dd5abfeff2bb29f9442b91df3f8f664d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->