### PR TITLE
fix(otel): detect vercel ai sdk embeddings

### DIFF
--- a/packages/shared/src/server/otel/ObservationTypeMapper.ts
+++ b/packages/shared/src/server/otel/ObservationTypeMapper.ts
@@ -261,6 +261,7 @@ export class ObservationTypeMapperRegistry {
       (attributes) => {
         const modelKeys = [
           LangfuseOtelSpanAttributes.OBSERVATION_MODEL,
+          "ai.model.id",
           "gen_ai.request.model",
           "gen_ai.response.model",
         ];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for detecting Vercel AI SDK embeddings in `ObservationTypeMapperRegistry` and add corresponding test case.
> 
>   - **Behavior**:
>     - Add `"ai.model.id"` to model keys in `ObservationTypeMapperRegistry` to detect Vercel AI SDK embeddings.
>     - New test case in `otelMapping.servertest.ts` to verify conversion of Vercel AI SDK embedding spans to `embedding-create` events.
>   - **Tests**:
>     - Add test in `otelMapping.servertest.ts` to ensure Vercel AI SDK embedding spans are correctly mapped to `embedding-create` events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 75ccee2ef4601c73ef5a56860bb431ddc52e031c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->