### PR TITLE
feat(api): GET /scores support for filtering by traceId, datasetRunId

### DIFF
--- a/fern/apis/server/definition/score-v2.yml
+++ b/fern/apis/server/definition/score-v2.yml
@@ -53,6 +53,12 @@ service:
           sessionId:
             type: optional<string>
             docs: Retrieve only scores with a specific sessionId.
+          datasetRunId:
+            type: optional<string>
+            docs: Retrieve only scores with a specific datasetRunId.
+          traceId:
+            type: optional<string>
+            docs: Retrieve only scores with a specific traceId.
           queueId:
             type: optional<string>
             docs: Retrieve only scores with a specific annotation queueId.

--- a/packages/shared/src/features/scores/interfaces/api/v2/endpoints.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v2/endpoints.ts
@@ -10,6 +10,8 @@ export const GetScoreResponseV2 = APIScoreSchemaV2;
 // GET /scores v2
 export const GetScoresQueryV2 = GetScoresQuery.extend({
   sessionId: z.string().nullish(),
+  traceId: z.string().nullish(),
+  datasetRunId: z.string().nullish(),
 });
 export const GetScoreResponseDataV2 = z.intersection(
   APIScoreSchemaV2,

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -4412,6 +4412,20 @@ paths:
           schema:
             type: string
             nullable: true
+        - name: datasetRunId
+          in: query
+          description: Retrieve only scores with a specific datasetRunId.
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: traceId
+          in: query
+          description: Retrieve only scores with a specific traceId.
+          required: false
+          schema:
+            type: string
+            nullable: true
         - name: queueId
           in: query
           description: Retrieve only scores with a specific annotation queueId.
@@ -7763,6 +7777,8 @@ components:
         - image/svg+xml
         - image/tiff
         - image/bmp
+        - image/avif
+        - image/heic
         - audio/mpeg
         - audio/mp3
         - audio/wav
@@ -7771,19 +7787,42 @@ components:
         - audio/aac
         - audio/mp4
         - audio/flac
+        - audio/opus
+        - audio/webm
         - video/mp4
         - video/webm
+        - video/ogg
+        - video/mpeg
+        - video/quicktime
+        - video/x-msvideo
+        - video/x-matroska
         - text/plain
         - text/html
         - text/css
         - text/csv
+        - text/markdown
+        - text/x-python
+        - application/javascript
+        - text/x-typescript
+        - application/x-yaml
         - application/pdf
         - application/msword
         - application/vnd.ms-excel
+        - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
         - application/zip
         - application/json
         - application/xml
         - application/octet-stream
+        - >-
+          application/vnd.openxmlformats-officedocument.wordprocessingml.document
+        - >-
+          application/vnd.openxmlformats-officedocument.presentationml.presentation
+        - application/rtf
+        - application/x-ndjson
+        - application/vnd.apache.parquet
+        - application/gzip
+        - application/x-tar
+        - application/x-7z-compressed
       description: The MIME type of the media record
     MetricsResponse:
       title: MetricsResponse

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -3039,7 +3039,7 @@
           "request": {
             "description": "Get a list of scores (supports both trace and session scores)",
             "url": {
-              "raw": "{{baseUrl}}/api/public/v2/scores?page=&limit=&userId=&name=&fromTimestamp=&toTimestamp=&environment=&source=&operator=&value=&scoreIds=&configId=&sessionId=&queueId=&dataType=&traceTags=",
+              "raw": "{{baseUrl}}/api/public/v2/scores?page=&limit=&userId=&name=&fromTimestamp=&toTimestamp=&environment=&source=&operator=&value=&scoreIds=&configId=&sessionId=&datasetRunId=&traceId=&queueId=&dataType=&traceTags=",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -3114,6 +3114,16 @@
                   "key": "sessionId",
                   "value": "",
                   "description": "Retrieve only scores with a specific sessionId."
+                },
+                {
+                  "key": "datasetRunId",
+                  "value": "",
+                  "description": "Retrieve only scores with a specific datasetRunId."
+                },
+                {
+                  "key": "traceId",
+                  "value": "",
+                  "description": "Retrieve only scores with a specific traceId."
                 },
                 {
                   "key": "queueId",

--- a/web/src/__tests__/async/scores-api-v1.servertest.ts
+++ b/web/src/__tests__/async/scores-api-v1.servertest.ts
@@ -414,6 +414,7 @@ describe("/api/public/scores API Endpoint", () => {
       const traceId_3 = v4();
       const generationId = v4();
       const sessionId = v4();
+      const datasetRunId = v4();
       const scoreId_1 = v4();
       const scoreId_2 = v4();
       const scoreId_3 = v4();
@@ -1043,6 +1044,36 @@ describe("/api/public/scores API Endpoint", () => {
           await makeAPICall(
             "GET",
             `/api/public/scores?sessionId=${sessionId}`,
+            undefined,
+            authentication,
+          );
+        } catch (error) {
+          expect((error as Error).message).toContain(
+            "API call did not return 200, returned status 400",
+          );
+        }
+      });
+
+      it("should reject dataset run ID filtering", async () => {
+        try {
+          await makeAPICall(
+            "GET",
+            `/api/public/scores?datasetRunId=${datasetRunId}`,
+            undefined,
+            authentication,
+          );
+        } catch (error) {
+          expect((error as Error).message).toContain(
+            "API call did not return 200, returned status 400",
+          );
+        }
+      });
+
+      it("should reject trace ID filtering", async () => {
+        try {
+          await makeAPICall(
+            "GET",
+            `/api/public/scores?traceId=${traceId}`,
             undefined,
             authentication,
           );

--- a/web/src/__tests__/async/scores-api-v2.servertest.ts
+++ b/web/src/__tests__/async/scores-api-v2.servertest.ts
@@ -898,6 +898,78 @@ describe("/api/public/v2/scores API Endpoint", () => {
           ]),
         );
       });
+
+      it("should filter scores by dataset run ID", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponseV2,
+          "GET",
+          `/api/public/v2/scores?datasetRunId=${runId}`,
+          undefined,
+          authentication,
+        );
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({
+          page: 1,
+          limit: 50,
+          totalItems: 2,
+          totalPages: 1,
+        });
+        expect(getScore.body.data).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: scoreId_8,
+              datasetRunId: runId,
+              name: scoreName,
+              value: 100.5,
+            }),
+            expect.objectContaining({
+              id: scoreId_9,
+              datasetRunId: runId,
+              name: scoreName,
+              value: 100.5,
+            }),
+          ]),
+        );
+      });
+
+      it("should filter scores by trace ID", async () => {
+        const getScore = await makeZodVerifiedAPICall(
+          GetScoresResponseV2,
+          "GET",
+          `/api/public/v2/scores?traceId=${traceId}`,
+          undefined,
+          authentication,
+        );
+        expect(getScore.status).toBe(200);
+        expect(getScore.body.meta).toMatchObject({
+          page: 1,
+          limit: 50,
+          totalItems: 3,
+          totalPages: 1,
+        });
+        expect(getScore.body.data).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: scoreId_1,
+              traceId: traceId,
+              name: scoreName,
+              value: 10.5,
+            }),
+            expect.objectContaining({
+              id: scoreId_2,
+              traceId: traceId,
+              name: scoreName,
+              value: 50.5,
+            }),
+            expect.objectContaining({
+              id: scoreId_3,
+              traceId: traceId,
+              name: scoreName,
+              value: 100.8,
+            }),
+          ]),
+        );
+      });
     });
   });
 });

--- a/web/src/features/public-api/server/scores.ts
+++ b/web/src/features/public-api/server/scores.ts
@@ -21,6 +21,7 @@ export type ScoreQueryType = {
   scoreId?: string;
   configId?: string;
   sessionId?: string;
+  datasetRunId?: string;
   queueId?: string;
   traceTags?: string | string[];
   operator?: string;
@@ -292,6 +293,13 @@ const secureScoreFilterOptions = [
   {
     id: "sessionId",
     clickhouseSelect: "session_id",
+    clickhouseTable: "scores",
+    filterType: "StringFilter",
+    clickhousePrefix: "s",
+  },
+  {
+    id: "datasetRunId",
+    clickhouseSelect: "dataset_run_id",
     clickhouseTable: "scores",
     filterType: "StringFilter",
     clickhousePrefix: "s",

--- a/web/src/pages/api/public/v2/scores/index.ts
+++ b/web/src/pages/api/public/v2/scores/index.ts
@@ -21,6 +21,8 @@ export default withMiddlewares({
         name: query.name ?? undefined,
         configId: query.configId ?? undefined,
         sessionId: query.sessionId ?? undefined,
+        traceId: query.traceId ?? undefined,
+        datasetRunId: query.datasetRunId ?? undefined,
         queueId: query.queueId ?? undefined,
         traceTags: query.traceTags ?? undefined,
         dataType: query.dataType ?? undefined,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for filtering scores by `traceId` and `datasetRunId` in the GET /scores API endpoint, with updated schema, server logic, and tests.
> 
>   - **API Changes**:
>     - Add `traceId` and `datasetRunId` as optional query parameters in `score-v2.yml` and `endpoints.ts`.
>     - Update `openapi.yml` and `collection.json` to include new query parameters.
>   - **Server Logic**:
>     - Update `ScoreQueryType` in `scores.ts` to include `traceId` and `datasetRunId`.
>     - Modify `_handleGenerateScoresForPublicApi` and `_handleGetScoresCountForPublicApi` to handle new filters.
>     - Add `datasetRunId` and `traceId` to `secureScoreFilterOptions` in `scores.ts`.
>   - **Testing**:
>     - Add test cases in `scores-api-v2.servertest.ts` to verify filtering by `traceId` and `datasetRunId`.
>     - Ensure `scores-api-v1.servertest.ts` rejects filtering by `traceId` and `datasetRunId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 24bb7cd37effeb36131492268a34f42f568a10d1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->