### PR TITLE
feat(model-prices): add gpt-5.1

### DIFF
--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -350,6 +350,8 @@ export const openAIModels = [
 type OpenAIReasoningMap = Record<OpenAIModel, boolean>;
 export const openAIModelToReasoning: OpenAIReasoningMap = {
   // reasoning models
+  "gpt-5.1": true,
+  "gpt-5.1-2025-11-13": true,
   "gpt-5": true,
   "gpt-5-2025-08-07": true,
   "gpt-5-mini": true,

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -308,6 +308,8 @@ export const openAIModels = [
   "gpt-4.1-mini-2025-04-14",
   "gpt-4.1-nano",
   "gpt-4.1-nano-2025-04-14",
+  "gpt-5.1",
+  "gpt-5.1-2025-11-13",
   "gpt-5",
   "gpt-5-2025-08-07",
   "gpt-5-mini",

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -2137,5 +2137,47 @@
     },
     "tokenizer_config": null,
     "tokenizer_id": "claude"
+  },
+  {
+    "id": "cmhymgpym000d04ih34rndvhr",
+    "model_name": "gpt-5.1",
+    "match_pattern": "(?i)^(gpt-5.1)$",
+    "created_at": "2025-11-14T08:57:23.481Z",
+    "updated_at": "2025-11-14T08:57:23.481Z",
+    "prices": {
+      "input": 1.25e-6,
+      "input_cached_tokens": 0.125e-6,
+      "output": 10.0e-6,
+      "input_cache_read": 0.125e-6,
+      "output_reasoning_tokens": 10e-6,
+      "output_reasoning": 10e-6
+    },
+    "tokenizer_config": {
+      "tokensPerName": 1,
+      "tokenizerModel": "gpt-4",
+      "tokensPerMessage": 3
+    },
+    "tokenizer_id": "openai"
+  },
+  {
+    "id": "cmhymgxiw000e04ihh9pw12ef",
+    "model_name": "gpt-5.1-2025-11-13",
+    "match_pattern": "(?i)^(gpt-5.1-2025-11-13)$",
+    "created_at": "2025-11-14T08:57:23.481Z",
+    "updated_at": "2025-11-14T08:57:23.481Z",
+    "prices": {
+      "input": 1.25e-6,
+      "input_cached_tokens": 0.125e-6,
+      "output": 10.0e-6,
+      "input_cache_read": 0.125e-6,
+      "output_reasoning_tokens": 10e-6,
+      "output_reasoning": 10e-6
+    },
+    "tokenizer_config": {
+      "tokensPerName": 1,
+      "tokenizerModel": "gpt-4",
+      "tokensPerMessage": 3
+    },
+    "tokenizer_id": "openai"
   }
 ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `gpt-5.1` and `gpt-5.1-2025-11-13` models with pricing details and reasoning capabilities.
> 
>   - **Models**:
>     - Add `gpt-5.1` and `gpt-5.1-2025-11-13` to `openAIModels` in `types.ts`.
>     - Update `openAIModelToReasoning` in `types.ts` to include `gpt-5.1` and `gpt-5.1-2025-11-13` as reasoning models.
>   - **Pricing**:
>     - Add pricing details for `gpt-5.1` and `gpt-5.1-2025-11-13` in `default-model-prices.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5da63ed39705bea48f387214a03e58e3aa8b0f84. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->