### PR TITLE
fix(playground): always show tool delete button

### DIFF
--- a/web/src/features/playground/page/components/PlaygroundTools/index.tsx
+++ b/web/src/features/playground/page/components/PlaygroundTools/index.tsx
@@ -253,7 +253,7 @@ export const PlaygroundTools = () => {
                   <div className="flex items-center gap-1">
                     <WrenchIcon className="h-4 w-4 text-muted-foreground" />
                     <h3
-                      className="max-w-[200px] truncate text-ellipsis text-sm font-medium"
+                      className="max-w-[145px] truncate text-ellipsis text-sm font-medium"
                       title={tool.name}
                     >
                       {tool.name}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjust `max-w` of tool name in `PlaygroundTools` from `200px` to `145px` for consistent display.
> 
>   - **UI Adjustment**:
>     - In `PlaygroundTools`, change `max-w` of tool name from `200px` to `145px` to ensure consistent display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4cfc196d4860eefc4e6a08580a37481979a52cc3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->