### PR TITLE
fix: reduce queue stalling on integration processing queues

### DIFF
--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -381,6 +381,13 @@ if (env.QUEUE_CONSUMER_POSTHOG_INTEGRATION_QUEUE_IS_ENABLED === "true") {
     postHogIntegrationProcessingProcessor,
     {
       concurrency: 1,
+      // The default lockDuration is 30s and the lockRenewTime 1/2 of that.
+      // We set it to 60s to reduce the number of lock renewals and also be less sensitive to high CPU wait times.
+      // We also update the stalledInterval check to 120s from 30s default to perform the check less frequently.
+      // Finally, we set the maxStalledCount to 3 (default 1) to perform repeated attempts on stalled jobs.
+      lockDuration: 60000, // 60 seconds
+      stalledInterval: 120000, // 120 seconds
+      maxStalledCount: 3,
       limiter: {
         // Process at most one PostHog job globally per 10s.
         max: 1,
@@ -433,6 +440,13 @@ if (env.QUEUE_CONSUMER_BLOB_STORAGE_INTEGRATION_QUEUE_IS_ENABLED === "true") {
     blobStorageIntegrationProcessingProcessor,
     {
       concurrency: 1,
+      // The default lockDuration is 30s and the lockRenewTime 1/2 of that.
+      // We set it to 60s to reduce the number of lock renewals and also be less sensitive to high CPU wait times.
+      // We also update the stalledInterval check to 120s from 30s default to perform the check less frequently.
+      // Finally, we set the maxStalledCount to 3 (default 1) to perform repeated attempts on stalled jobs.
+      lockDuration: 60000, // 60 seconds
+      stalledInterval: 120000, // 120 seconds
+      maxStalledCount: 3,
     },
   );
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updated `postHogIntegrationProcessingProcessor` and `blobStorageIntegrationProcessingProcessor` in `app.ts` to reduce queue stalling by adjusting lock durations and stalled intervals.
> 
>   - **Queue Processing**:
>     - In `app.ts`, updated `postHogIntegrationProcessingProcessor` and `blobStorageIntegrationProcessingProcessor` to reduce queue stalling.
>     - Set `lockDuration` to 60s, `stalledInterval` to 120s, and `maxStalledCount` to 3 for both processors.
>     - These changes aim to reduce lock renewals and handle high CPU wait times more effectively.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 827ea46cac6aedac382a0e6d32de52b1f74814d6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->