### PR TITLE
fix(prompts): make docs consistent

### DIFF
--- a/web/src/components/ChatMessages/ChatMessageComponent.tsx
+++ b/web/src/components/ChatMessages/ChatMessageComponent.tsx
@@ -55,7 +55,7 @@ const getRoleNamePlaceholder = (role: string) => {
     case ChatMessageRole.Tool:
       return "a tool response message";
     case "placeholder":
-      return "placeholder name (e.g. msg_history)";
+      return "placeholder name (e.g. chat_history)";
     default:
       return `a ${role}`;
   }

--- a/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
+++ b/web/src/features/prompts/components/SetPromptVersionLabels/index.tsx
@@ -125,7 +125,7 @@ export function SetPromptVersionLabels({
           />
           <Button
             variant="outline"
-            title="Add prompt version label"
+            title="Add prompt label"
             className={cn(
               "h-6 w-6 bg-muted-gray text-primary",
               showOnlyOnHover && "opacity-0 group-hover:opacity-100",
@@ -146,7 +146,7 @@ export function SetPromptVersionLabels({
           onClick={(event) => event.stopPropagation()}
           className="flex flex-col"
         >
-          <h2 className="text-md mb-3 font-semibold">Prompt version labels</h2>
+          <h2 className="text-md mb-3 font-semibold">Prompt labels</h2>
           <h2 className="mb-3 text-xs">
             Use labels to fetch prompts via SDKs. The{" "}
             <strong>production</strong> labeled prompt will be served by


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update placeholder text and button titles for consistency in `ChatMessageComponent.tsx` and `SetPromptVersionLabels/index.tsx`.
> 
>   - **ChatMessageComponent.tsx**:
>     - Update placeholder text from `msg_history` to `chat_history` in `getRoleNamePlaceholder()`.
>   - **SetPromptVersionLabels/index.tsx**:
>     - Change button title from "Add prompt version label" to "Add prompt label".
>     - Update heading from "Prompt version labels" to "Prompt labels".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2a5ca49a9b5867e176904b8cda4743fbc943652e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->