### PR TITLE
fix(ui): height of peek view aligns

### DIFF
--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -108,7 +108,7 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
         side="right"
         className="flex max-h-full min-h-0 min-w-[60vw] flex-col gap-0 overflow-hidden p-0"
       >
-        <SheetHeader className="flex min-h-12 flex-row flex-nowrap items-center justify-between bg-header px-2">
+        <SheetHeader className="flex min-h-11 flex-row flex-nowrap items-center justify-between bg-header px-2">
           <SheetTitle className="!mt-0 ml-2 flex min-w-0 flex-row items-center gap-2">
             <ItemBadge type={peekView.itemType} showLabel />
             <span

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -108,7 +108,7 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
         side="right"
         className="flex max-h-full min-h-0 min-w-[60vw] flex-col gap-0 overflow-hidden p-0"
       >
-        <SheetHeader className="flex min-h-11 flex-row flex-nowrap items-center justify-between bg-header px-2">
+        <SheetHeader className="flex min-h-11 flex-row flex-nowrap items-center justify-between bg-header px-2 py-1">
           <SheetTitle className="!mt-0 ml-2 flex min-w-0 flex-row items-center gap-2">
             <ItemBadge type={peekView.itemType} showLabel />
             <span


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adjusts `SheetHeader` height in `TablePeekViewComponent` for better alignment in `peek.tsx`.
> 
>   - **UI Adjustment**:
>     - In `TablePeekViewComponent` in `peek.tsx`, change `SheetHeader` class from `min-h-12` to `min-h-11` and add `py-1` for better alignment of peek view height.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8cf9faf47f72c2c958d5e8ccadb78e8298d56382. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->