### PR TITLE
fix(otel-ai-sdk): handle tool calls with empty string in ai.response.text

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1211,7 +1211,8 @@ export class OtelIngestionProcessor {
               : undefined;
 
       output =
-        "ai.response.text" in attributes
+        "ai.response.text" in attributes &&
+        Boolean(attributes["ai.response.text"])
           ? attributes["ai.response.text"]
           : "ai.result.text" in attributes // Legacy support for ai SDK versions < 4.0.0
             ? attributes["ai.result.text"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes handling of `ai.response.text` in `OtelIngestionProcessor.ts` to set `output` to `undefined` if empty.
> 
>   - **Behavior**:
>     - Fixes handling of `ai.response.text` in `OtelIngestionProcessor.ts` to correctly set `output` to `undefined` if `ai.response.text` is an empty string.
>     - Ensures legacy support for `ai.result.text` remains unaffected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4dbd8c1a95c482fbb955cc5f40f7bea6112c9a08. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->