### PR TITLE
docs: prompt api folder encoding

### DIFF
--- a/fern/apis/server/definition/prompt-version.yml
+++ b/fern/apis/server/definition/prompt-version.yml
@@ -13,7 +13,10 @@ service:
       path-parameters:
         name:
           type: string
-          docs: The name of the prompt
+          docs: |
+            The name of the prompt. If the prompt is in a folder (e.g., "folder/subfolder/prompt-name"), 
+            the folder path must be URL encoded. For example, use "folder%2Fsubfolder%2Fprompt-name" instead 
+            of "folder/subfolder/prompt-name". The forward slash (/) character must be encoded as %2F.
         version:
           type: integer
           docs: Version of the prompt to update

--- a/fern/apis/server/definition/prompts.yml
+++ b/fern/apis/server/definition/prompts.yml
@@ -13,7 +13,10 @@ service:
       path-parameters:
         promptName:
           type: string
-          docs: The name of the prompt
+          docs: |
+            The name of the prompt. If the prompt is in a folder (e.g., "folder/subfolder/prompt-name"), 
+            the folder path must be URL encoded. For example, use "folder%2Fsubfolder%2Fprompt-name" instead 
+            of "folder/subfolder/prompt-name". The forward slash (/) character must be encoded as %2F.
       request:
         name: GetPromptRequest
         query-parameters:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update documentation in `prompt-version.yml` and `prompts.yml` to require URL encoding for folder paths in prompt names.
> 
>   - **Documentation**:
>     - Updated `path-parameters` documentation in `prompt-version.yml` and `prompts.yml` to specify that folder paths in prompt names must be URL encoded.
>     - Example provided for encoding: "folder/subfolder/prompt-name" should be "folder%2Fsubfolder%2Fprompt-name".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4149526f40cf618da36eb8b65b6d4f77f67d0ba9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->