### PR TITLE
docs: add note on encoding of folders on prompts api

### DIFF
--- a/fern/apis/server/definition/prompt-version.yml
+++ b/fern/apis/server/definition/prompt-version.yml
@@ -15,8 +15,7 @@ service:
           type: string
           docs: |
             The name of the prompt. If the prompt is in a folder (e.g., "folder/subfolder/prompt-name"), 
-            the folder path must be URL encoded. For example, use "folder%2Fsubfolder%2Fprompt-name" instead 
-            of "folder/subfolder/prompt-name". The forward slash (/) character must be encoded as %2F.
+            the folder path must be URL encoded.
         version:
           type: integer
           docs: Version of the prompt to update

--- a/fern/apis/server/definition/prompt-version.yml
+++ b/fern/apis/server/definition/prompt-version.yml
@@ -13,7 +13,10 @@ service:
       path-parameters:
         name:
           type: string
-          docs: The name of the prompt
+          docs: |
+            The name of the prompt. If the prompt is in a folder (e.g., "folder/subfolder/prompt-name"), 
+            the folder path must be URL encoded. For example, use "folder%2Fsubfolder%2Fprompt-name" instead 
+            of "folder/subfolder/prompt-name". The forward slash (/) character must be encoded as %2F.
         version:
           type: integer
           docs: Version of the prompt to update

--- a/fern/apis/server/definition/prompts.yml
+++ b/fern/apis/server/definition/prompts.yml
@@ -15,8 +15,7 @@ service:
           type: string
           docs: |
             The name of the prompt. If the prompt is in a folder (e.g., "folder/subfolder/prompt-name"), 
-            the folder path must be URL encoded. For example, use "folder%2Fsubfolder%2Fprompt-name" instead 
-            of "folder/subfolder/prompt-name". The forward slash (/) character must be encoded as %2F.
+            the folder path must be URL encoded.
       request:
         name: GetPromptRequest
         query-parameters:

--- a/fern/apis/server/definition/prompts.yml
+++ b/fern/apis/server/definition/prompts.yml
@@ -13,7 +13,10 @@ service:
       path-parameters:
         promptName:
           type: string
-          docs: The name of the prompt
+          docs: |
+            The name of the prompt. If the prompt is in a folder (e.g., "folder/subfolder/prompt-name"), 
+            the folder path must be URL encoded. For example, use "folder%2Fsubfolder%2Fprompt-name" instead 
+            of "folder/subfolder/prompt-name". The forward slash (/) character must be encoded as %2F.
       request:
         name: GetPromptRequest
         query-parameters:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3481,7 +3481,11 @@ paths:
       parameters:
         - name: name
           in: path
-          description: The name of the prompt
+          description: >-
+            The name of the prompt. If the prompt is in a folder (e.g.,
+            "folder/subfolder/prompt-name"), 
+
+            the folder path must be URL encoded.
           required: true
           schema:
             type: string
@@ -3551,7 +3555,11 @@ paths:
       parameters:
         - name: promptName
           in: path
-          description: The name of the prompt
+          description: >-
+            The name of the prompt. If the prompt is in a folder (e.g.,
+            "folder/subfolder/prompt-name"), 
+
+            the folder path must be URL encoded.
           required: true
           schema:
             type: string

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -2480,7 +2480,7 @@
                 {
                   "key": "name",
                   "value": "",
-                  "description": "The name of the prompt"
+                  "description": "The name of the prompt. If the prompt is in a folder (e.g., \"folder/subfolder/prompt-name\"), \nthe folder path must be URL encoded."
                 },
                 {
                   "key": "version",
@@ -2544,7 +2544,7 @@
                 {
                   "key": "promptName",
                   "value": "",
-                  "description": "The name of the prompt"
+                  "description": "The name of the prompt. If the prompt is in a folder (e.g., \"folder/subfolder/prompt-name\"), \nthe folder path must be URL encoded."
                 }
               ]
             },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add documentation note specifying URL encoding requirement for folder paths in prompt names across API definitions.
> 
>   - **Documentation**:
>     - Updated `prompt-version.yml` and `prompts.yml` to specify that folder paths in prompt names must be URL encoded.
>     - Updated `openapi.yml` and `collection.json` with the same URL encoding note for prompt names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 757f51b05af055387782251641df4930e083f1ce. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->