### PR TITLE
fix(llm-completions): require user message for bedrock models

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -54,6 +54,7 @@ const PROVIDERS_WITH_REQUIRED_USER_MESSAGE = [
   LLMAdapter.VertexAI,
   LLMAdapter.GoogleAIStudio,
   LLMAdapter.Anthropic,
+  LLMAdapter.Bedrock,
 ];
 
 const transformSystemMessageToUserMessage = (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `LLMAdapter.Bedrock` to providers requiring a user message in `fetchLLMCompletion.ts`.
> 
>   - **Behavior**:
>     - Add `LLMAdapter.Bedrock` to `PROVIDERS_WITH_REQUIRED_USER_MESSAGE` in `fetchLLMCompletion.ts`.
>     - Ensures Bedrock models require at least one user message for compliance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7d577069b29e81bb81d4f8cf66b8b2740ffb48cc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->