### PR TITLE
fix(traces-table-ui): do not revert optimistic update to stars toggle

### DIFF
--- a/web/src/components/star-toggle.tsx
+++ b/web/src/components/star-toggle.tsx
@@ -95,7 +95,6 @@ export function StarTraceToggle({
     },
     onSettled: () => {
       setIsLoading(false);
-      void utils.traces.all.invalidate();
     },
   });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove cache invalidation in `StarTraceToggle` to prevent reverting optimistic updates to star toggle.
> 
>   - **Behavior**:
>     - Removed cache invalidation in `onSettled` of `mutBookmarkTrace` in `StarTraceToggle` to prevent reverting optimistic updates.
>   - **Components**:
>     - Affects `StarTraceToggle` in `star-toggle.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4004fcacfa2def35887f5d4e103789ca83dc9367. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->