### PR TITLE
fix: parse min timestamp for blob storage export as number

### DIFF
--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -65,10 +65,10 @@ const getMinTimestampForExport = async (
         });
 
         // Extract the minimum timestamp
-        const minTimestampValue = result[0]?.min_timestamp;
         logger.info(
-          `[BLOB INTEGRATION] ClickHouse min_timestamp for project ${projectId}: ${minTimestampValue}`,
+          `[BLOB INTEGRATION] ClickHouse min_timestamp for project ${projectId}: ${result[0]?.min_timestamp}, type: ${typeof result[0]?.min_timestamp}`,
         );
+        const minTimestampValue = Number(result[0]?.min_timestamp);
 
         if (minTimestampValue && minTimestampValue > 0) {
           const date = new Date(minTimestampValue);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Parse `min_timestamp` as a number in `getMinTimestampForExport()` to ensure correct date conversion and update logging.
> 
>   - **Behavior**:
>     - Parse `min_timestamp` as a number in `getMinTimestampForExport()` in `handleBlobStorageIntegrationProjectJob.ts` to ensure correct date conversion.
>     - Log the type of `min_timestamp` for debugging purposes.
>   - **Logging**:
>     - Update log message to include the type of `min_timestamp` in `getMinTimestampForExport()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 20be71da38d5a0c6750525706754ca4a19a5b684. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->