### PR TITLE
test(mcp): comprehensive test coverage for MCP server (LF-1930)

### DIFF
--- a/web/src/__tests__/async/mcp-error-formatting.servertest.ts
+++ b/web/src/__tests__/async/mcp-error-formatting.servertest.ts
@@ -1,0 +1,439 @@
+/** @jest-environment node */
+
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { ZodError } from "zod/v4";
+import { z } from "zod/v4";
+import { disconnectQueues } from "@/src/__tests__/test-utils";
+import {
+  formatErrorForUser,
+  wrapErrorHandling,
+} from "@/src/features/mcp/internal/error-formatting";
+import {
+  UserInputError,
+  ApiServerError,
+} from "@/src/features/mcp/internal/errors";
+import {
+  UnauthorizedError,
+  ForbiddenError,
+  LangfuseNotFoundError,
+  InvalidRequestError,
+  BaseError,
+} from "@langfuse/shared";
+
+describe("MCP Error Formatting", () => {
+  afterAll(async () => {
+    await disconnectQueues();
+  });
+
+  describe("formatErrorForUser", () => {
+    describe("UserInputError handling", () => {
+      it("should format UserInputError as InvalidRequest", () => {
+        const error = new UserInputError("Prompt 'foo' not found");
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError).toBeInstanceOf(McpError);
+        expect(mcpError.code).toBe(ErrorCode.InvalidRequest);
+        expect(mcpError.message).toContain("Prompt 'foo' not found");
+      });
+
+      it("should preserve UserInputError message exactly", () => {
+        const error = new UserInputError(
+          "Cannot specify both label and version",
+        );
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.message).toContain(
+          "Cannot specify both label and version",
+        );
+      });
+
+      it("should handle UserInputError with special characters", () => {
+        const error = new UserInputError("Invalid name: special!@#$%^&*()");
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.message).toContain("Invalid name: special!@#$%^&*()");
+      });
+    });
+
+    describe("ApiServerError handling", () => {
+      it("should format ApiServerError as InternalError with generic message", () => {
+        const error = new ApiServerError("Database connection failed");
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError).toBeInstanceOf(McpError);
+        expect(mcpError.code).toBe(ErrorCode.InternalError);
+        // Should NOT expose internal error message
+        expect(mcpError.message).toContain(
+          "An internal server error occurred.",
+        );
+        expect(mcpError.message).not.toContain("Database");
+      });
+
+      it("should hide sensitive information in ApiServerError", () => {
+        const error = new ApiServerError(
+          "Redis connection to redis://password:secret@host:6379 failed",
+        );
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.message).not.toContain("password");
+        expect(mcpError.message).not.toContain("secret");
+        expect(mcpError.message).not.toContain("redis://");
+      });
+
+      it("should handle ApiServerError with cause", () => {
+        const cause = new Error("Network timeout");
+        const error = new ApiServerError("Service unavailable", { cause });
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.code).toBe(ErrorCode.InternalError);
+        expect(mcpError.message).not.toContain("Network timeout");
+      });
+    });
+
+    describe("ZodError handling", () => {
+      it("should format ZodError as InvalidParams", () => {
+        const schema = z.object({
+          name: z.string(),
+          version: z.number(),
+        });
+
+        let zodError: ZodError | undefined;
+        try {
+          schema.parse({ name: 123, version: "not a number" });
+        } catch (e) {
+          if (e instanceof ZodError) {
+            zodError = e;
+          }
+        }
+
+        expect(zodError).toBeDefined();
+        const mcpError = formatErrorForUser(zodError!);
+
+        expect(mcpError.code).toBe(ErrorCode.InvalidParams);
+        expect(mcpError.message).toContain("Validation failed");
+      });
+
+      it("should include field paths in validation error message", () => {
+        const schema = z.object({
+          name: z.string(),
+          config: z.object({
+            temperature: z.number().min(0).max(1),
+          }),
+        });
+
+        let zodError: ZodError | undefined;
+        try {
+          schema.parse({ name: "test", config: { temperature: 2 } });
+        } catch (e) {
+          if (e instanceof ZodError) {
+            zodError = e;
+          }
+        }
+
+        const mcpError = formatErrorForUser(zodError!);
+
+        expect(mcpError.message).toContain("config.temperature");
+      });
+
+      it("should format multiple validation errors", () => {
+        const schema = z.object({
+          name: z.string().min(1),
+          version: z.number().positive(),
+          labels: z.array(z.string()),
+        });
+
+        let zodError: ZodError | undefined;
+        try {
+          schema.parse({ name: "", version: -1, labels: "not an array" });
+        } catch (e) {
+          if (e instanceof ZodError) {
+            zodError = e;
+          }
+        }
+
+        const mcpError = formatErrorForUser(zodError!);
+
+        expect(mcpError.message).toContain("Validation failed");
+        // Should mention multiple issues
+        expect(mcpError.message.split(",").length).toBeGreaterThanOrEqual(2);
+      });
+    });
+
+    describe("Langfuse standard errors", () => {
+      it("should format UnauthorizedError with auth message", () => {
+        const error = new UnauthorizedError("Invalid API key");
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.code).toBe(ErrorCode.InvalidRequest);
+        expect(mcpError.message).toContain("Authentication failed");
+        expect(mcpError.message).toContain("API key");
+      });
+
+      it("should format ForbiddenError with permission message", () => {
+        const error = new ForbiddenError("Access denied");
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.code).toBe(ErrorCode.InvalidRequest);
+        expect(mcpError.message).toContain("forbidden");
+        expect(mcpError.message).toContain("permission");
+      });
+
+      it("should format LangfuseNotFoundError with original message", () => {
+        const error = new LangfuseNotFoundError("Prompt not found: chatbot");
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.code).toBe(ErrorCode.InvalidRequest);
+        expect(mcpError.message).toContain("Prompt not found: chatbot");
+      });
+
+      it("should format InvalidRequestError with original message", () => {
+        const error = new InvalidRequestError(
+          "Cannot delete prompt with dependencies",
+        );
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.code).toBe(ErrorCode.InvalidRequest);
+        expect(mcpError.message).toContain(
+          "Cannot delete prompt with dependencies",
+        );
+      });
+
+      it("should format BaseError as InvalidRequest", () => {
+        const error = new BaseError("Generic base error");
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.code).toBe(ErrorCode.InvalidRequest);
+        // BaseError is a base class - message handling may vary
+        expect(mcpError).toBeInstanceOf(McpError);
+      });
+    });
+
+    describe("Generic errors", () => {
+      it("should format generic Error as InternalError", () => {
+        const error = new Error("Something went wrong");
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.code).toBe(ErrorCode.InternalError);
+        expect(mcpError.message).toContain("An unexpected error occurred.");
+      });
+
+      it("should hide implementation details from generic Error", () => {
+        const error = new Error(
+          "TypeError: Cannot read property 'foo' of undefined",
+        );
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.message).not.toContain("TypeError");
+        expect(mcpError.message).not.toContain("property");
+        expect(mcpError.message).not.toContain("undefined");
+      });
+
+      it("should handle TypeError", () => {
+        const error = new TypeError("Invalid type");
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.code).toBe(ErrorCode.InternalError);
+      });
+
+      it("should handle RangeError", () => {
+        const error = new RangeError("Index out of bounds");
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.code).toBe(ErrorCode.InternalError);
+      });
+    });
+
+    describe("Unknown error types", () => {
+      it("should handle string thrown as error", () => {
+        const error = "Something went wrong";
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.code).toBe(ErrorCode.InternalError);
+        expect(mcpError.message).toContain("An unexpected error occurred.");
+      });
+
+      it("should handle number thrown as error", () => {
+        const error = 404;
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.code).toBe(ErrorCode.InternalError);
+      });
+
+      it("should handle null thrown as error", () => {
+        const error = null;
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.code).toBe(ErrorCode.InternalError);
+      });
+
+      it("should handle undefined thrown as error", () => {
+        const error = undefined;
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.code).toBe(ErrorCode.InternalError);
+      });
+
+      it("should handle object thrown as error", () => {
+        const error = { code: "ERR_CUSTOM", message: "Custom error" };
+        const mcpError = formatErrorForUser(error);
+
+        expect(mcpError.code).toBe(ErrorCode.InternalError);
+      });
+    });
+  });
+
+  describe("wrapErrorHandling", () => {
+    it("should pass through successful function result", async () => {
+      const fn = async () => ({ result: "success" });
+      const wrapped = wrapErrorHandling(fn);
+
+      const result = await wrapped();
+      expect(result).toEqual({ result: "success" });
+    });
+
+    it("should pass through function arguments", async () => {
+      const fn = async (a: number, b: string) => `${a}-${b}`;
+      const wrapped = wrapErrorHandling(fn);
+
+      const result = await wrapped(42, "test");
+      expect(result).toBe("42-test");
+    });
+
+    it("should wrap UserInputError in McpError", async () => {
+      const fn = async () => {
+        throw new UserInputError("Invalid input");
+      };
+      const wrapped = wrapErrorHandling(fn);
+
+      await expect(wrapped()).rejects.toThrow(McpError);
+      try {
+        await wrapped();
+      } catch (e) {
+        const mcpError = e as McpError;
+        expect(mcpError.code).toBe(ErrorCode.InvalidRequest);
+        expect(mcpError.message).toContain("Invalid input");
+      }
+    });
+
+    it("should wrap ApiServerError in McpError with generic message", async () => {
+      const fn = async () => {
+        throw new ApiServerError("Database crashed");
+      };
+      const wrapped = wrapErrorHandling(fn);
+
+      await expect(wrapped()).rejects.toThrow(McpError);
+      await expect(wrapped()).rejects.toMatchObject({
+        code: ErrorCode.InternalError,
+      });
+    });
+
+    it("should wrap ZodError in McpError", async () => {
+      const schema = z.object({ name: z.string() });
+      const fn = async () => {
+        schema.parse({ name: 123 });
+      };
+      const wrapped = wrapErrorHandling(fn);
+
+      await expect(wrapped()).rejects.toThrow(McpError);
+      await expect(wrapped()).rejects.toMatchObject({
+        code: ErrorCode.InvalidParams,
+      });
+    });
+
+    it("should wrap generic Error in McpError", async () => {
+      const fn = async () => {
+        throw new Error("Unexpected error");
+      };
+      const wrapped = wrapErrorHandling(fn);
+
+      await expect(wrapped()).rejects.toThrow(McpError);
+      await expect(wrapped()).rejects.toMatchObject({
+        code: ErrorCode.InternalError,
+      });
+    });
+
+    it("should handle async function that returns promise", async () => {
+      const fn = () => Promise.resolve({ data: "async result" });
+      const wrapped = wrapErrorHandling(fn);
+
+      const result = await wrapped();
+      expect(result).toEqual({ data: "async result" });
+    });
+
+    it("should handle rejected promise", async () => {
+      const fn = () => Promise.reject(new UserInputError("Async rejection"));
+      const wrapped = wrapErrorHandling(fn);
+
+      try {
+        await wrapped();
+      } catch (e) {
+        const mcpError = e as McpError;
+        expect(mcpError.code).toBe(ErrorCode.InvalidRequest);
+        expect(mcpError.message).toContain("Async rejection");
+      }
+    });
+
+    it("should preserve function return type", async () => {
+      interface PromptResult {
+        id: string;
+        name: string;
+        version: number;
+      }
+
+      const fn = async (): Promise<PromptResult> => ({
+        id: "123",
+        name: "test",
+        version: 1,
+      });
+      const wrapped = wrapErrorHandling(fn);
+
+      const result = await wrapped();
+      expect(result.id).toBe("123");
+      expect(result.name).toBe("test");
+      expect(result.version).toBe(1);
+    });
+  });
+
+  describe("Error priority and categorization", () => {
+    it("should categorize user-fixable errors as InvalidRequest", () => {
+      const userErrors = [
+        new UserInputError("Invalid input"),
+        new LangfuseNotFoundError("Not found"),
+        new InvalidRequestError("Bad request"),
+      ];
+
+      for (const error of userErrors) {
+        const mcpError = formatErrorForUser(error);
+        expect(mcpError.code).toBe(ErrorCode.InvalidRequest);
+      }
+    });
+
+    it("should categorize server errors as InternalError", () => {
+      const serverErrors = [
+        new ApiServerError("Database down"),
+        new Error("Generic error"),
+        new TypeError("Type error"),
+      ];
+
+      for (const error of serverErrors) {
+        const mcpError = formatErrorForUser(error);
+        expect(mcpError.code).toBe(ErrorCode.InternalError);
+      }
+    });
+
+    it("should categorize validation errors as InvalidParams", () => {
+      const schema = z.object({ test: z.string() });
+      let zodError: ZodError | undefined;
+      try {
+        schema.parse({ test: 123 });
+      } catch (e) {
+        if (e instanceof ZodError) {
+          zodError = e;
+        }
+      }
+
+      const mcpError = formatErrorForUser(zodError!);
+      expect(mcpError.code).toBe(ErrorCode.InvalidParams);
+    });
+  });
+});

--- a/web/src/__tests__/async/mcp-error-formatting.servertest.ts
+++ b/web/src/__tests__/async/mcp-error-formatting.servertest.ts
@@ -3,7 +3,6 @@
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { ZodError } from "zod/v4";
 import { z } from "zod/v4";
-import { disconnectQueues } from "@/src/__tests__/test-utils";
 import {
   formatErrorForUser,
   wrapErrorHandling,
@@ -21,10 +20,6 @@ import {
 } from "@langfuse/shared";
 
 describe("MCP Error Formatting", () => {
-  afterAll(async () => {
-    await disconnectQueues();
-  });
-
   describe("formatErrorForUser", () => {
     describe("UserInputError handling", () => {
       it("should format UserInputError as InvalidRequest", () => {
@@ -199,7 +194,12 @@ describe("MCP Error Formatting", () => {
       });
 
       it("should format BaseError as InvalidRequest", () => {
-        const error = new BaseError("Generic base error");
+        const error = new BaseError(
+          "Generic base error",
+          500,
+          "Generic base error",
+          true,
+        );
         const mcpError = formatErrorForUser(error);
 
         expect(mcpError.code).toBe(ErrorCode.InvalidRequest);

--- a/web/src/__tests__/async/mcp-helpers.ts
+++ b/web/src/__tests__/async/mcp-helpers.ts
@@ -1,0 +1,265 @@
+/**
+ * MCP Test Helpers
+ *
+ * Shared utilities for testing MCP server tools and resources.
+ * These helpers allow direct testing of tool handlers without HTTP overhead.
+ */
+
+import { prisma } from "@langfuse/shared/src/db";
+import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
+import type { ServerContext } from "@/src/features/mcp/types";
+
+/**
+ * Creates a complete MCP test setup including:
+ * - Organization
+ * - Project
+ * - API key
+ * - ServerContext for MCP tool handlers
+ */
+export async function createMcpTestSetup(): Promise<{
+  projectId: string;
+  orgId: string;
+  apiKeyId: string;
+  auth: string;
+  context: ServerContext;
+}> {
+  const { projectId, orgId, apiKeyId, auth } =
+    await createOrgProjectAndApiKey();
+
+  const context: ServerContext = {
+    projectId,
+    orgId,
+    apiKeyId,
+    accessLevel: "project",
+    publicKey: `pk-lf-test-${projectId}`,
+  };
+
+  return {
+    projectId,
+    orgId,
+    apiKeyId,
+    auth,
+    context,
+  };
+}
+
+/**
+ * Creates a mock ServerContext for testing.
+ * Use this when you need a context but don't want to create actual DB records.
+ */
+export function mockServerContext(
+  overrides?: Partial<ServerContext>,
+): ServerContext {
+  return {
+    projectId: overrides?.projectId ?? "test-project-id",
+    orgId: overrides?.orgId ?? "test-org-id",
+    apiKeyId: overrides?.apiKeyId ?? "test-api-key-id",
+    accessLevel: "project",
+    publicKey: overrides?.publicKey ?? "pk-lf-test",
+    ...overrides,
+  };
+}
+
+/**
+ * Verifies that a response follows the MCP content block format.
+ * MCP tools return { content: [{ type: "text", text: "..." }] }
+ */
+export function verifyMcpResponseFormat(
+  response: unknown,
+): asserts response is {
+  content: Array<{ type: "text"; text: string }>;
+} {
+  if (!response || typeof response !== "object") {
+    throw new Error("Response must be an object");
+  }
+
+  const resp = response as Record<string, unknown>;
+
+  if (!Array.isArray(resp.content)) {
+    throw new Error("Response must have 'content' array");
+  }
+
+  if (resp.content.length === 0) {
+    throw new Error("Response content array must not be empty");
+  }
+
+  for (const block of resp.content) {
+    if (typeof block !== "object" || block === null) {
+      throw new Error("Each content block must be an object");
+    }
+
+    const blockTyped = block as Record<string, unknown>;
+
+    if (blockTyped.type !== "text") {
+      throw new Error(
+        `Content block type must be 'text', got: ${blockTyped.type}`,
+      );
+    }
+
+    if (typeof blockTyped.text !== "string") {
+      throw new Error("Content block text must be a string");
+    }
+  }
+}
+
+/**
+ * Extracts the text content from an MCP tool response.
+ * Assumes the response has been validated with verifyMcpResponseFormat.
+ */
+export function extractMcpResponseText(response: {
+  content: Array<{ type: "text"; text: string }>;
+}): string {
+  return response.content.map((block) => block.text).join("");
+}
+
+/**
+ * Parses JSON from an MCP tool response text.
+ * Handles the common case where tool responses are JSON strings.
+ */
+export function parseMcpResponseJson<T = unknown>(response: {
+  content: Array<{ type: "text"; text: string }>;
+}): T {
+  const text = extractMcpResponseText(response);
+  return JSON.parse(text) as T;
+}
+
+/**
+ * Verifies that an audit log entry was created for an MCP operation.
+ * Returns the audit log entry for further assertions.
+ */
+export async function verifyAuditLog(params: {
+  projectId: string;
+  resourceType: string;
+  resourceId?: string;
+  action: "create" | "update" | "delete";
+  apiKeyId: string;
+}): Promise<{
+  id: string;
+  action: string;
+  resourceType: string;
+  resourceId: string;
+  before: unknown;
+  after: unknown;
+}> {
+  const auditLogs = await prisma.auditLog.findMany({
+    where: {
+      projectId: params.projectId,
+      resourceType: params.resourceType,
+      action: params.action,
+      apiKeyId: params.apiKeyId,
+      ...(params.resourceId && { resourceId: params.resourceId }),
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+    take: 1,
+  });
+
+  if (auditLogs.length === 0) {
+    throw new Error(
+      `No audit log found for ${params.action} ${params.resourceType} in project ${params.projectId}`,
+    );
+  }
+
+  const log = auditLogs[0];
+
+  return {
+    id: log.id,
+    action: log.action,
+    resourceType: log.resourceType,
+    resourceId: log.resourceId,
+    before: log.before,
+    after: log.after,
+  };
+}
+
+/**
+ * Creates a prompt directly in the database for testing.
+ * Similar to the helper in prompts.v2.servertest.ts.
+ */
+export async function createPromptInDb(params: {
+  name: string;
+  prompt: string | unknown; // Can be string (text) or array (chat messages)
+  projectId: string;
+  labels?: string[];
+  version?: number;
+  config?: Record<string, unknown>;
+  tags?: string[];
+  type?: "text" | "chat";
+  createdBy?: string;
+}) {
+  return await prisma.prompt.create({
+    data: {
+      name: params.name,
+      prompt: params.prompt,
+      labels: params.labels ?? [],
+      version: params.version ?? 1,
+      config: params.config ?? {},
+      tags: params.tags ?? [],
+      type: params.type ?? "text",
+      createdBy: params.createdBy ?? "test-user",
+      project: {
+        connect: { id: params.projectId },
+      },
+    },
+  });
+}
+
+/**
+ * Deletes all prompts for a specific project.
+ * Useful for cleanup in tests.
+ */
+export async function cleanupProjectPrompts(projectId: string): Promise<void> {
+  await prisma.prompt.deleteMany({
+    where: { projectId },
+  });
+}
+
+/**
+ * Helper to check if a tool has the correct MCP annotations.
+ */
+export function verifyToolAnnotations(
+  toolDefinition: { annotations?: Record<string, boolean> },
+  expectedAnnotations: {
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    expensiveHint?: boolean;
+  },
+): void {
+  const annotations = toolDefinition.annotations ?? {};
+
+  if (expectedAnnotations.readOnlyHint !== undefined) {
+    expect(annotations.readOnlyHint).toBe(expectedAnnotations.readOnlyHint);
+  }
+
+  if (expectedAnnotations.destructiveHint !== undefined) {
+    expect(annotations.destructiveHint).toBe(
+      expectedAnnotations.destructiveHint,
+    );
+  }
+
+  if (expectedAnnotations.expensiveHint !== undefined) {
+    expect(annotations.expensiveHint).toBe(expectedAnnotations.expensiveHint);
+  }
+}
+
+/**
+ * Waits for a condition to be true with timeout.
+ * Useful for async operations that need eventual consistency.
+ */
+export async function waitFor(
+  condition: () => Promise<boolean>,
+  timeoutMs: number = 5000,
+  intervalMs: number = 100,
+): Promise<void> {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeoutMs) {
+    if (await condition()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(`Condition not met within ${timeoutMs}ms`);
+}

--- a/web/src/__tests__/async/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/async/mcp-tools-read.servertest.ts
@@ -1,13 +1,8 @@
 /** @jest-environment node */
 
-import { prisma } from "@langfuse/shared/src/db";
 import { disconnectQueues } from "@/src/__tests__/test-utils";
 import { nanoid } from "ai";
-import {
-  createMcpTestSetup,
-  createPromptInDb,
-  cleanupProjectPrompts,
-} from "./mcp-helpers";
+import { createMcpTestSetup, createPromptInDb } from "./mcp-helpers";
 
 // Import MCP tool handlers directly
 import {

--- a/web/src/__tests__/async/mcp-tools-write.servertest.ts
+++ b/web/src/__tests__/async/mcp-tools-write.servertest.ts
@@ -2,7 +2,7 @@
 
 import { prisma } from "@langfuse/shared/src/db";
 import { disconnectQueues } from "@/src/__tests__/test-utils";
-import { nanoid } from "ai";
+import { nanoid } from "nanoid";
 import {
   createMcpTestSetup,
   createPromptInDb,

--- a/web/src/__tests__/async/mcp-tools-write.servertest.ts
+++ b/web/src/__tests__/async/mcp-tools-write.servertest.ts
@@ -121,7 +121,7 @@ describe("MCP Write Tools", () => {
     });
 
     it("should create text prompt with commit message", async () => {
-      const { context, projectId } = await createMcpTestSetup();
+      const { context } = await createMcpTestSetup();
       const promptName = `text-prompt-${nanoid()}`;
 
       const result = (await handleCreateTextPrompt(
@@ -195,8 +195,6 @@ describe("MCP Write Tools", () => {
     it("should use context.projectId for tenant isolation", async () => {
       const { context: context1, projectId: projectId1 } =
         await createMcpTestSetup();
-      const { context: context2, projectId: projectId2 } =
-        await createMcpTestSetup();
 
       const promptName = `isolated-${nanoid()}`;
 
@@ -214,7 +212,6 @@ describe("MCP Write Tools", () => {
         where: { id: result1.id },
       });
       expect(prompt?.projectId).toBe(projectId1);
-      expect(prompt?.projectId).not.toBe(projectId2);
     });
 
     it("should support template variables in prompt", async () => {
@@ -438,7 +435,6 @@ describe("MCP Write Tools", () => {
     it("should use context.projectId for tenant isolation", async () => {
       const { context: context1, projectId: projectId1 } =
         await createMcpTestSetup();
-      const { projectId: projectId2 } = await createMcpTestSetup();
 
       const promptName = `isolated-chat-${nanoid()}`;
 
@@ -454,7 +450,6 @@ describe("MCP Write Tools", () => {
         where: { id: result.id },
       });
       expect(prompt?.projectId).toBe(projectId1);
-      expect(prompt?.projectId).not.toBe(projectId2);
     });
 
     it("should support template variables in messages", async () => {

--- a/web/src/__tests__/async/mcp-tools-write.servertest.ts
+++ b/web/src/__tests__/async/mcp-tools-write.servertest.ts
@@ -1,0 +1,848 @@
+/** @jest-environment node */
+
+import { prisma } from "@langfuse/shared/src/db";
+import { disconnectQueues } from "@/src/__tests__/test-utils";
+import { nanoid } from "ai";
+import {
+  createMcpTestSetup,
+  createPromptInDb,
+  verifyAuditLog,
+} from "./mcp-helpers";
+
+// Import MCP tool handlers directly
+import {
+  createTextPromptTool,
+  handleCreateTextPrompt,
+} from "@/src/features/mcp/server/tools/createTextPrompt";
+import {
+  createChatPromptTool,
+  handleCreateChatPrompt,
+} from "@/src/features/mcp/server/tools/createChatPrompt";
+import {
+  updatePromptLabelsTool,
+  handleUpdatePromptLabels,
+} from "@/src/features/mcp/server/tools/updatePromptLabels";
+
+describe("MCP Write Tools", () => {
+  afterAll(async () => {
+    await disconnectQueues();
+  });
+
+  describe("createTextPrompt tool", () => {
+    it("should have destructive annotation", () => {
+      expect(createTextPromptTool.annotations?.destructive).toBe(true);
+      expect(createTextPromptTool.annotations?.readOnly).toBeUndefined();
+    });
+
+    it("should create a simple text prompt", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `text-prompt-${nanoid()}`;
+
+      const result = (await handleCreateTextPrompt(
+        {
+          name: promptName,
+          prompt: "You are a helpful assistant.",
+        },
+        context,
+      )) as {
+        id: string;
+        name: string;
+        version: number;
+        type: string;
+        labels: string[];
+        message: string;
+      };
+
+      expect(result.id).toBeDefined();
+      expect(result.name).toBe(promptName);
+      expect(result.version).toBe(1);
+      expect(result.type).toBe("text");
+      // First version automatically gets 'latest' label
+      expect(result.labels).toContain("latest");
+      expect(result.message).toContain("Successfully created");
+    });
+
+    it("should create text prompt with labels", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `text-prompt-${nanoid()}`;
+
+      const result = (await handleCreateTextPrompt(
+        {
+          name: promptName,
+          prompt: "Production prompt",
+          labels: ["production", "stable"],
+        },
+        context,
+      )) as {
+        labels: string[];
+        message: string;
+      };
+
+      expect(result.labels).toEqual(
+        expect.arrayContaining(["production", "stable"]),
+      );
+      expect(result.message).toContain("production");
+    });
+
+    it("should create text prompt with config", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `text-prompt-${nanoid()}`;
+
+      const result = (await handleCreateTextPrompt(
+        {
+          name: promptName,
+          prompt: "Test with config",
+          config: { model: "gpt-4", temperature: 0.7 },
+        },
+        context,
+      )) as {
+        config: Record<string, unknown>;
+      };
+
+      expect(result.config).toEqual({ model: "gpt-4", temperature: 0.7 });
+    });
+
+    it("should create text prompt with tags", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `text-prompt-${nanoid()}`;
+
+      const result = (await handleCreateTextPrompt(
+        {
+          name: promptName,
+          prompt: "Test with tags",
+          tags: ["experimental", "v2"],
+        },
+        context,
+      )) as {
+        tags: string[];
+      };
+
+      expect(result.tags).toEqual(["experimental", "v2"]);
+    });
+
+    it("should create text prompt with commit message", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const promptName = `text-prompt-${nanoid()}`;
+
+      const result = (await handleCreateTextPrompt(
+        {
+          name: promptName,
+          prompt: "Test with commit message",
+          commitMessage: "Initial production version",
+        },
+        context,
+      )) as {
+        id: string;
+      };
+
+      // Verify the commit message is stored
+      const prompt = await prisma.prompt.findUnique({
+        where: { id: result.id },
+      });
+      expect(prompt?.commitMessage).toBe("Initial production version");
+    });
+
+    it("should auto-increment version for same prompt name", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `text-prompt-${nanoid()}`;
+
+      // Create first version
+      const result1 = (await handleCreateTextPrompt(
+        {
+          name: promptName,
+          prompt: "Version 1",
+        },
+        context,
+      )) as { version: number };
+
+      // Create second version
+      const result2 = (await handleCreateTextPrompt(
+        {
+          name: promptName,
+          prompt: "Version 2",
+        },
+        context,
+      )) as { version: number };
+
+      expect(result1.version).toBe(1);
+      expect(result2.version).toBe(2);
+    });
+
+    it("should create audit log entry", async () => {
+      const { context, projectId, apiKeyId } = await createMcpTestSetup();
+      const promptName = `text-prompt-${nanoid()}`;
+
+      const result = (await handleCreateTextPrompt(
+        {
+          name: promptName,
+          prompt: "Audited prompt",
+        },
+        context,
+      )) as { id: string };
+
+      const auditLogEntry = await verifyAuditLog({
+        projectId,
+        resourceType: "prompt",
+        resourceId: result.id,
+        action: "create",
+        apiKeyId,
+      });
+
+      expect(auditLogEntry.after).toBeDefined();
+      expect(auditLogEntry.before).toBeNull();
+    });
+
+    it("should use context.projectId for tenant isolation", async () => {
+      const { context: context1, projectId: projectId1 } =
+        await createMcpTestSetup();
+      const { context: context2, projectId: projectId2 } =
+        await createMcpTestSetup();
+
+      const promptName = `isolated-${nanoid()}`;
+
+      // Create prompt in project 1
+      const result1 = (await handleCreateTextPrompt(
+        {
+          name: promptName,
+          prompt: "Project 1 prompt",
+        },
+        context1,
+      )) as { id: string };
+
+      // Verify it's in project 1
+      const prompt = await prisma.prompt.findUnique({
+        where: { id: result1.id },
+      });
+      expect(prompt?.projectId).toBe(projectId1);
+      expect(prompt?.projectId).not.toBe(projectId2);
+    });
+
+    it("should support template variables in prompt", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `text-prompt-${nanoid()}`;
+
+      const result = (await handleCreateTextPrompt(
+        {
+          name: promptName,
+          prompt: "Hello {{name}}, welcome to {{service}}!",
+        },
+        context,
+      )) as { id: string };
+
+      const prompt = await prisma.prompt.findUnique({
+        where: { id: result.id },
+      });
+      expect(prompt?.prompt).toBe("Hello {{name}}, welcome to {{service}}!");
+    });
+
+    it("should ignore 'latest' in user-provided labels (auto-managed)", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `text-prompt-${nanoid()}`;
+
+      // 'latest' is auto-managed, so if user provides it, it's ignored
+      // but the system will still add 'latest' automatically
+      const result = (await handleCreateTextPrompt(
+        {
+          name: promptName,
+          prompt: "Test",
+          labels: ["latest", "production"],
+        },
+        context,
+      )) as { labels: string[] };
+
+      // Should have 'latest' (auto) and 'production' (user-provided)
+      expect(result.labels).toContain("latest");
+      expect(result.labels).toContain("production");
+    });
+
+    it("should set createdBy to API", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `text-prompt-${nanoid()}`;
+
+      const result = (await handleCreateTextPrompt(
+        {
+          name: promptName,
+          prompt: "Test",
+        },
+        context,
+      )) as { createdBy: string };
+
+      expect(result.createdBy).toBe("API");
+    });
+  });
+
+  describe("createChatPrompt tool", () => {
+    it("should have destructive annotation", () => {
+      expect(createChatPromptTool.annotations?.destructive).toBe(true);
+      expect(createChatPromptTool.annotations?.readOnly).toBeUndefined();
+    });
+
+    it("should create a simple chat prompt", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `chat-prompt-${nanoid()}`;
+
+      const result = (await handleCreateChatPrompt(
+        {
+          name: promptName,
+          prompt: [
+            { role: "system", content: "You are a helpful assistant." },
+            { role: "user", content: "Help me with {{task}}" },
+          ],
+        },
+        context,
+      )) as {
+        id: string;
+        name: string;
+        version: number;
+        type: string;
+        labels: string[];
+        message: string;
+      };
+
+      expect(result.id).toBeDefined();
+      expect(result.name).toBe(promptName);
+      expect(result.version).toBe(1);
+      expect(result.type).toBe("chat");
+      // First version automatically gets 'latest' label
+      expect(result.labels).toContain("latest");
+      expect(result.message).toContain("Successfully created");
+    });
+
+    it("should create chat prompt with labels", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `chat-prompt-${nanoid()}`;
+
+      const result = (await handleCreateChatPrompt(
+        {
+          name: promptName,
+          prompt: [{ role: "system", content: "System instruction" }],
+          labels: ["production"],
+        },
+        context,
+      )) as {
+        labels: string[];
+      };
+
+      expect(result.labels).toContain("production");
+    });
+
+    it("should create chat prompt with multiple message roles", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `chat-prompt-${nanoid()}`;
+
+      const messages = [
+        { role: "system", content: "You are an expert." },
+        { role: "user", content: "What is {{topic}}?" },
+        { role: "assistant", content: "I will explain {{topic}}." },
+      ];
+
+      const result = (await handleCreateChatPrompt(
+        {
+          name: promptName,
+          prompt: messages,
+        },
+        context,
+      )) as { id: string };
+
+      const prompt = await prisma.prompt.findUnique({
+        where: { id: result.id },
+      });
+
+      expect(prompt?.prompt).toEqual(messages);
+    });
+
+    it("should create chat prompt with config", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `chat-prompt-${nanoid()}`;
+
+      const result = (await handleCreateChatPrompt(
+        {
+          name: promptName,
+          prompt: [{ role: "system", content: "Test" }],
+          config: { model: "gpt-4-turbo", maxTokens: 1000 },
+        },
+        context,
+      )) as {
+        config: Record<string, unknown>;
+      };
+
+      expect(result.config).toEqual({ model: "gpt-4-turbo", maxTokens: 1000 });
+    });
+
+    it("should create chat prompt with tags", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `chat-prompt-${nanoid()}`;
+
+      const result = (await handleCreateChatPrompt(
+        {
+          name: promptName,
+          prompt: [{ role: "system", content: "Test" }],
+          tags: ["multi-turn", "conversational"],
+        },
+        context,
+      )) as {
+        tags: string[];
+      };
+
+      expect(result.tags).toEqual(["multi-turn", "conversational"]);
+    });
+
+    it("should auto-increment version for same prompt name", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `chat-prompt-${nanoid()}`;
+
+      const result1 = (await handleCreateChatPrompt(
+        {
+          name: promptName,
+          prompt: [{ role: "system", content: "V1" }],
+        },
+        context,
+      )) as { version: number };
+
+      const result2 = (await handleCreateChatPrompt(
+        {
+          name: promptName,
+          prompt: [{ role: "system", content: "V2" }],
+        },
+        context,
+      )) as { version: number };
+
+      expect(result1.version).toBe(1);
+      expect(result2.version).toBe(2);
+    });
+
+    it("should create audit log entry", async () => {
+      const { context, projectId, apiKeyId } = await createMcpTestSetup();
+      const promptName = `chat-prompt-${nanoid()}`;
+
+      const result = (await handleCreateChatPrompt(
+        {
+          name: promptName,
+          prompt: [{ role: "system", content: "Audited" }],
+        },
+        context,
+      )) as { id: string };
+
+      const auditLogEntry = await verifyAuditLog({
+        projectId,
+        resourceType: "prompt",
+        resourceId: result.id,
+        action: "create",
+        apiKeyId,
+      });
+
+      expect(auditLogEntry.after).toBeDefined();
+      expect(auditLogEntry.before).toBeNull();
+    });
+
+    it("should use context.projectId for tenant isolation", async () => {
+      const { context: context1, projectId: projectId1 } =
+        await createMcpTestSetup();
+      const { projectId: projectId2 } = await createMcpTestSetup();
+
+      const promptName = `isolated-chat-${nanoid()}`;
+
+      const result = (await handleCreateChatPrompt(
+        {
+          name: promptName,
+          prompt: [{ role: "system", content: "Project 1" }],
+        },
+        context1,
+      )) as { id: string };
+
+      const prompt = await prisma.prompt.findUnique({
+        where: { id: result.id },
+      });
+      expect(prompt?.projectId).toBe(projectId1);
+      expect(prompt?.projectId).not.toBe(projectId2);
+    });
+
+    it("should support template variables in messages", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `chat-prompt-${nanoid()}`;
+
+      const result = (await handleCreateChatPrompt(
+        {
+          name: promptName,
+          prompt: [
+            { role: "system", content: "You are a {{domain}} expert." },
+            { role: "user", content: "Explain {{concept}} to me." },
+          ],
+        },
+        context,
+      )) as { id: string };
+
+      const prompt = await prisma.prompt.findUnique({
+        where: { id: result.id },
+      });
+
+      const messages = prompt?.prompt as Array<{
+        role: string;
+        content: string;
+      }>;
+      expect(messages[0].content).toContain("{{domain}}");
+      expect(messages[1].content).toContain("{{concept}}");
+    });
+
+    it("should allow empty message array", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `chat-prompt-${nanoid()}`;
+
+      // Empty array is allowed - flexibility for edge cases
+      const result = (await handleCreateChatPrompt(
+        {
+          name: promptName,
+          prompt: [],
+        },
+        context,
+      )) as { id: string };
+
+      const prompt = await prisma.prompt.findUnique({
+        where: { id: result.id },
+      });
+      expect(prompt?.prompt).toEqual([]);
+    });
+
+    it("should set createdBy to API", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `chat-prompt-${nanoid()}`;
+
+      const result = (await handleCreateChatPrompt(
+        {
+          name: promptName,
+          prompt: [{ role: "system", content: "Test" }],
+        },
+        context,
+      )) as { createdBy: string };
+
+      expect(result.createdBy).toBe("API");
+    });
+  });
+
+  describe("updatePromptLabels tool", () => {
+    it("should have destructive annotation", () => {
+      expect(updatePromptLabelsTool.annotations?.destructive).toBe(true);
+      expect(updatePromptLabelsTool.annotations?.readOnly).toBeUndefined();
+    });
+
+    it("should update labels for a prompt version", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const promptName = `update-labels-${nanoid()}`;
+
+      await createPromptInDb({
+        name: promptName,
+        prompt: "Test",
+        projectId,
+        labels: [],
+        version: 1,
+      });
+
+      const result = (await handleUpdatePromptLabels(
+        {
+          name: promptName,
+          version: 1,
+          newLabels: ["production"],
+        },
+        context,
+      )) as {
+        id: string;
+        name: string;
+        version: number;
+        labels: string[];
+        message: string;
+      };
+
+      expect(result.name).toBe(promptName);
+      expect(result.version).toBe(1);
+      expect(result.labels).toContain("production");
+      expect(result.message).toContain("Successfully updated");
+    });
+
+    it("should remove labels from other versions (label uniqueness)", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const promptName = `label-unique-${nanoid()}`;
+
+      // Create v1 with production label
+      await createPromptInDb({
+        name: promptName,
+        prompt: "V1",
+        projectId,
+        labels: ["production"],
+        version: 1,
+      });
+
+      // Create v2 without labels
+      await createPromptInDb({
+        name: promptName,
+        prompt: "V2",
+        projectId,
+        labels: [],
+        version: 2,
+      });
+
+      // Move production to v2
+      await handleUpdatePromptLabels(
+        {
+          name: promptName,
+          version: 2,
+          newLabels: ["production"],
+        },
+        context,
+      );
+
+      // Verify v1 no longer has production
+      const v1 = await prisma.prompt.findFirst({
+        where: { projectId, name: promptName, version: 1 },
+      });
+      expect(v1?.labels).not.toContain("production");
+
+      // Verify v2 now has production
+      const v2 = await prisma.prompt.findFirst({
+        where: { projectId, name: promptName, version: 2 },
+      });
+      expect(v2?.labels).toContain("production");
+    });
+
+    it("should allow setting multiple labels", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const promptName = `multi-labels-${nanoid()}`;
+
+      await createPromptInDb({
+        name: promptName,
+        prompt: "Test",
+        projectId,
+        labels: [],
+        version: 1,
+      });
+
+      const result = (await handleUpdatePromptLabels(
+        {
+          name: promptName,
+          version: 1,
+          newLabels: ["staging", "testing", "qa"],
+        },
+        context,
+      )) as {
+        labels: string[];
+      };
+
+      expect(result.labels).toEqual(
+        expect.arrayContaining(["staging", "testing", "qa"]),
+      );
+    });
+
+    it("should add new labels to existing labels (additive behavior)", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `add-labels-${nanoid()}`;
+
+      // Create via handler so it gets 'latest' automatically
+      const created = (await handleCreateTextPrompt(
+        {
+          name: promptName,
+          prompt: "Test",
+          labels: ["production"],
+        },
+        context,
+      )) as { version: number; labels: string[] };
+
+      expect(created.labels).toContain("production");
+      expect(created.labels).toContain("latest");
+
+      // The updatePromptLabels action ADDS labels, not replaces them
+      const result = (await handleUpdatePromptLabels(
+        {
+          name: promptName,
+          version: created.version,
+          newLabels: ["staging"],
+        },
+        context,
+      )) as {
+        labels: string[];
+        message: string;
+      };
+
+      // Should have all labels: original + new
+      expect(result.labels).toContain("latest");
+      expect(result.labels).toContain("production");
+      expect(result.labels).toContain("staging");
+    });
+
+    it("should throw error for non-existent prompt", async () => {
+      const { context } = await createMcpTestSetup();
+
+      await expect(
+        handleUpdatePromptLabels(
+          {
+            name: "non-existent",
+            version: 1,
+            newLabels: ["production"],
+          },
+          context,
+        ),
+      ).rejects.toThrow(/not found/i);
+    });
+
+    it("should throw error for non-existent version", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const promptName = `version-check-${nanoid()}`;
+
+      await createPromptInDb({
+        name: promptName,
+        prompt: "Test",
+        projectId,
+        version: 1,
+      });
+
+      await expect(
+        handleUpdatePromptLabels(
+          {
+            name: promptName,
+            version: 999,
+            newLabels: ["production"],
+          },
+          context,
+        ),
+      ).rejects.toThrow(/not found/i);
+    });
+
+    it("should create audit log entry with before and after states", async () => {
+      const { context, projectId, apiKeyId } = await createMcpTestSetup();
+      const promptName = `audit-update-${nanoid()}`;
+
+      // Create via handler to get proper structure
+      const created = (await handleCreateTextPrompt(
+        {
+          name: promptName,
+          prompt: "Test",
+          labels: ["staging"],
+        },
+        context,
+      )) as { version: number };
+
+      const result = (await handleUpdatePromptLabels(
+        {
+          name: promptName,
+          version: created.version,
+          newLabels: ["qa"],
+        },
+        context,
+      )) as { id: string };
+
+      const auditLogEntry = await verifyAuditLog({
+        projectId,
+        resourceType: "prompt",
+        resourceId: result.id,
+        action: "update",
+        apiKeyId,
+      });
+
+      expect(auditLogEntry.before).toBeDefined();
+      expect(auditLogEntry.after).toBeDefined();
+
+      // Audit log stores JSON strings - parse them
+      const beforeState =
+        typeof auditLogEntry.before === "string"
+          ? (JSON.parse(auditLogEntry.before) as Record<string, unknown>)
+          : (auditLogEntry.before as Record<string, unknown>);
+      const afterState =
+        typeof auditLogEntry.after === "string"
+          ? (JSON.parse(auditLogEntry.after) as Record<string, unknown>)
+          : (auditLogEntry.after as Record<string, unknown>);
+
+      // Verify the before and after are different and contain labels
+      expect(beforeState).toHaveProperty("labels");
+      expect(afterState).toHaveProperty("labels");
+      // Should have the new label added
+      expect(afterState.labels).toContain("qa");
+      // Should preserve original labels (additive behavior)
+      expect(afterState.labels).toContain("staging");
+    });
+
+    it("should use context.projectId for tenant isolation", async () => {
+      const { context: context1, projectId: projectId1 } =
+        await createMcpTestSetup();
+      const { context: context2 } = await createMcpTestSetup();
+
+      const promptName = `isolated-update-${nanoid()}`;
+
+      // Create prompt in project 1
+      await createPromptInDb({
+        name: promptName,
+        prompt: "Project 1",
+        projectId: projectId1,
+        version: 1,
+      });
+
+      // Project 2 should not be able to update it
+      await expect(
+        handleUpdatePromptLabels(
+          {
+            name: promptName,
+            version: 1,
+            newLabels: ["production"],
+          },
+          context2,
+        ),
+      ).rejects.toThrow(/not found/i);
+
+      // Project 1 should be able to update it
+      const result = await handleUpdatePromptLabels(
+        {
+          name: promptName,
+          version: 1,
+          newLabels: ["production"],
+        },
+        context1,
+      );
+
+      expect(result).toBeDefined();
+    });
+
+    it("should reject 'latest' label", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const promptName = `latest-reject-${nanoid()}`;
+
+      await createPromptInDb({
+        name: promptName,
+        prompt: "Test",
+        projectId,
+        version: 1,
+      });
+
+      // 'latest' is auto-managed and cannot be set manually
+      await expect(
+        handleUpdatePromptLabels(
+          {
+            name: promptName,
+            version: 1,
+            newLabels: ["latest"],
+          },
+          context,
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("should handle special characters in prompt name", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const promptName = `special!@#$-${nanoid()}`;
+
+      await createPromptInDb({
+        name: promptName,
+        prompt: "Test",
+        projectId,
+        version: 1,
+      });
+
+      const result = (await handleUpdatePromptLabels(
+        {
+          name: promptName,
+          version: 1,
+          newLabels: ["production"],
+        },
+        context,
+      )) as { name: string };
+
+      expect(result.name).toBe(promptName);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements comprehensive test coverage for the MCP server as outlined in LF-1930.

## Test Coverage

**New Test Files:**
- `mcp-helpers.ts` (266 lines) - Shared test utilities
- `mcp-tools-read.servertest.ts` (509 lines) - 22 tests for read operations
- `mcp-tools-write.servertest.ts` (848 lines) - 35 tests for write operations  
- `mcp-error-formatting.servertest.ts` (439 lines) - 35 tests for error handling

**Total: 92 tests, all passing ✅**

## What's Tested

### Read Tools
- ✅ `getPrompt`: Fetch by name/label/version, defaults, validation errors
- ✅ `listPrompts`: Filtering, pagination, tenant isolation

### Write Tools  
- ✅ `createTextPrompt`: Creation, labels, config, tags, commit messages
- ✅ `createChatPrompt`: Multi-message support, validation, tenant isolation
- ✅ `updatePromptLabels`: Label management, additive behavior, uniqueness

### Error Handling
- ✅ UserInputError → InvalidRequest
- ✅ ApiServerError → InternalError (sanitized)
- ✅ ZodError → InvalidParams
- ✅ Langfuse standard errors (UnauthorizedError, ForbiddenError, etc.)

### Cross-Cutting Concerns
- ✅ Tool annotations (readOnly, destructive hints)
- ✅ Tenant isolation (projectId filtering)
- ✅ Audit logging
- ✅ Version auto-incrementing
- ✅ Special characters handling
- ✅ Edge cases

## Quality Checks

- ✅ Linter passes (0 warnings)
- ✅ Build passes
- ✅ Prettier formatting
- ✅ All tests pass

## Notes

- Redis cleanup error after tests is expected/benign (BullMQ timing issue, doesn't affect test results)
- Tests follow existing Langfuse patterns (direct handler invocation, no HTTP overhead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds comprehensive test coverage for MCP server, including read, write, and error handling functionalities, with all tests passing.
> 
>   - **Test Coverage**:
>     - Adds `mcp-helpers.ts` for shared test utilities.
>     - Adds `mcp-tools-read.servertest.ts` with 22 tests for read operations.
>     - Adds `mcp-tools-write.servertest.ts` with 35 tests for write operations.
>     - Adds `mcp-error-formatting.servertest.ts` with 35 tests for error handling.
>   - **Read Tools**:
>     - Tests `getPrompt` for fetching by name/label/version, defaults, and validation errors.
>     - Tests `listPrompts` for filtering, pagination, and tenant isolation.
>   - **Write Tools**:
>     - Tests `createTextPrompt` for creation, labels, config, tags, and commit messages.
>     - Tests `createChatPrompt` for multi-message support, validation, and tenant isolation.
>     - Tests `updatePromptLabels` for label management, additive behavior, and uniqueness.
>   - **Error Handling**:
>     - Tests `formatErrorForUser` for various error types like `UserInputError`, `ApiServerError`, `ZodError`, and Langfuse standard errors.
>     - Tests `wrapErrorHandling` for wrapping errors in `McpError`.
>   - **Cross-Cutting Concerns**:
>     - Tests tool annotations, tenant isolation, audit logging, version auto-incrementing, special characters handling, and edge cases.
>   - **Quality Checks**:
>     - Linter passes with 0 warnings.
>     - Build and Prettier formatting pass.
>     - All tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 448cde753074be633fdec9efb562c29c390247bb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->