### PR TITLE
fix(model-prices): add apac identifier for bedrock hosted anthropic models

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1004,9 +1004,9 @@
   {
     "id": "clxt0n0m60000pumz1j5b7zsf",
     "model_name": "claude-3-5-sonnet-20240620",
-    "match_pattern": "(?i)^(claude-3-5-sonnet-20240620|(eu\\.|us\\.)?anthropic\\.claude-3-5-sonnet-20240620-v1:0|claude-3-5-sonnet@20240620)$",
+    "match_pattern": "(?i)^(claude-3-5-sonnet-20240620|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20240620-v1:0|claude-3-5-sonnet@20240620)$",
     "created_at": "2024-06-25T11:47:24.475Z",
-    "updated_at": "2025-07-16T14:56:27.501Z",
+    "updated_at": "2025-11-18T00:00:00.000Z",
     "prices": {
       "input": 3e-6,
       "input_tokens": 3e-6,
@@ -1148,9 +1148,9 @@
   {
     "id": "cm2krz1uf000208jjg5653iud",
     "model_name": "claude-3.5-sonnet-20241022",
-    "match_pattern": "(?i)^(claude-3-5-sonnet-20241022|(eu\\.|us\\.)?anthropic\\.claude-3-5-sonnet-20241022-v2:0|claude-3-5-sonnet-V2@20241022)$",
+    "match_pattern": "(?i)^(claude-3-5-sonnet-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20241022-v2:0|claude-3-5-sonnet-V2@20241022)$",
     "created_at": "2024-10-22T18:48:01.676Z",
-    "updated_at": "2025-07-16T14:56:27.501Z",
+    "updated_at": "2025-11-18T00:00:00.000Z",
     "prices": {
       "input": 3e-6,
       "input_tokens": 3e-6,
@@ -1186,9 +1186,9 @@
   {
     "id": "cm34aq60d000207ml0j1h31ar",
     "model_name": "claude-3-5-haiku-20241022",
-    "match_pattern": "(?i)^(claude-3-5-haiku-20241022|(eu\\.|us\\.)?anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
+    "match_pattern": "(?i)^(claude-3-5-haiku-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
     "created_at": "2024-11-05T10:30:50.566Z",
-    "updated_at": "2025-07-16T14:56:27.501Z",
+    "updated_at": "2025-11-18T00:00:00.000Z",
     "prices": {
       "input": 0.8e-6,
       "input_tokens": 0.8e-6,
@@ -1446,9 +1446,9 @@
   {
     "id": "cm7ka7561000108js3t9tb3at",
     "model_name": "claude-3.7-sonnet-20250219",
-    "match_pattern": "(?i)^(claude-3.7-sonnet-20250219|(eu\\.|us\\.)?anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
+    "match_pattern": "(?i)^(claude-3.7-sonnet-20250219|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
     "created_at": "2025-02-25T09:35:39.000Z",
-    "updated_at": "2025-07-16T14:51:47.025Z",
+    "updated_at": "2025-11-18T00:00:00.000Z",
     "prices": {
       "input": 3e-6,
       "input_tokens": 3e-6,
@@ -1736,9 +1736,9 @@
   {
     "id": "c5qmrqolku82tra3vgdixmys",
     "model_name": "claude-sonnet-4-5-20250929",
-    "match_pattern": "(?i)^(claude-sonnet-4-5-20250929|(eu\\.|us\\.)?anthropic\\.claude-sonnet-4-5-20250929-v1:0|claude-sonnet-4-5-V1@20250929|claude-sonnet-4-5@20250929)$",
+    "match_pattern": "(?i)^(claude-sonnet-4-5-20250929|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-sonnet-4-5-20250929-v1:0|claude-sonnet-4-5-V1@20250929|claude-sonnet-4-5@20250929)$",
     "created_at": "2025-09-29T00:00:00.000Z",
-    "updated_at": "2025-09-29T00:00:00.000Z",
+    "updated_at": "2025-11-18T00:00:00.000Z",
     "prices": {
       "input": 3e-6,
       "input_tokens": 3e-6,
@@ -1755,9 +1755,9 @@
   {
     "id": "cmazmkzlm00000djp1e1qe4k4",
     "model_name": "claude-sonnet-4-20250514",
-    "match_pattern": "(?i)^(claude-sonnet-4-20250514|(eu\\.|us\\.)?anthropic\\.claude-sonnet-4-20250514-v1:0|claude-sonnet-4-V1@20250514|claude-sonnet-4@20250514)$",
+    "match_pattern": "(?i)^(claude-sonnet-4-20250514|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-sonnet-4-20250514-v1:0|claude-sonnet-4-V1@20250514|claude-sonnet-4@20250514)$",
     "created_at": "2025-05-22T17:09:02.131Z",
-    "updated_at": "2025-07-16T14:56:27.501Z",
+    "updated_at": "2025-11-18T00:00:00.000Z",
     "prices": {
       "input": 3e-6,
       "input_tokens": 3e-6,
@@ -1793,9 +1793,9 @@
   {
     "id": "cmazmlm2p00020djpa9s64jw5",
     "model_name": "claude-opus-4-20250514",
-    "match_pattern": "(?i)^(claude-opus-4-20250514|(eu\\.|us\\.)?anthropic\\.claude-opus-4-20250514-v1:0|claude-opus-4@20250514)$",
+    "match_pattern": "(?i)^(claude-opus-4-20250514|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4-20250514-v1:0|claude-opus-4@20250514)$",
     "created_at": "2025-05-22T17:09:02.131Z",
-    "updated_at": "2025-07-16T14:56:27.501Z",
+    "updated_at": "2025-11-18T00:00:00.000Z",
     "prices": {
       "input": 15e-6,
       "input_tokens": 15e-6,
@@ -1922,9 +1922,9 @@
   {
     "id": "cmdysde5w0000rkmzbc1g5au3",
     "model_name": "claude-opus-4-1-20250805",
-    "match_pattern": "(?i)^(claude-opus-4-1-20250805|(eu\\.|us\\.)?anthropic\\.claude-opus-4-1-20250805-v1:0|claude-opus-4-1@20250805)$",
+    "match_pattern": "(?i)^(claude-opus-4-1-20250805|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4-1-20250805-v1:0|claude-opus-4-1@20250805)$",
     "created_at": "2025-08-05T15:00:00.000Z",
-    "updated_at": "2025-08-05T15:00:00.000Z",
+    "updated_at": "2025-11-18T00:00:00.000Z",
     "prices": {
       "input": 15e-6,
       "input_tokens": 15e-6,
@@ -2126,9 +2126,9 @@
   {
     "id": "cmgt5gnkv000104jx171tbq4e",
     "model_name": "claude-haiku-4-5-20251001",
-    "match_pattern": "(?i)^(claude-haiku-4-5-20251001|(eu\\.|us\\.)?anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
+    "match_pattern": "(?i)^(claude-haiku-4-5-20251001|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
     "created_at": "2025-10-16T08:20:44.558Z",
-    "updated_at": "2025-10-16T08:20:44.558Z",
+    "updated_at": "2025-11-18T00:00:00.000Z",
     "prices": {
       "input": 1e-6,
       "input_tokens": 1e-6,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `apac` identifier to `match_pattern` for several models in `default-model-prices.json` to support regional differentiation.
> 
>   - **Behavior**:
>     - Updated `match_pattern` to include `apac` identifier for models in `default-model-prices.json`.
>     - Affects models: `claude-3-5-sonnet-20240620`, `claude-3.5-sonnet-20241022`, `claude-3-5-haiku-20241022`, `claude-3.7-sonnet-20250219`, `claude-sonnet-4-5-20250929`, `claude-sonnet-4-20250514`, `claude-opus-4-20250514`, `claude-opus-4-1-20250805`, `claude-haiku-4-5-20251001`.
>   - **Metadata**:
>     - Updated `updated_at` timestamps to `2025-11-18T00:00:00.000Z` for affected models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 65e62e4f07fc1e1159c8889a44975b3d7886e8ba. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->