### PR TITLE
chore: fern API docs for public v2

### DIFF
--- a/fern/apis/server/definition/metrics-v2.yml
+++ b/fern/apis/server/definition/metrics-v2.yml
@@ -1,0 +1,178 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
+imports:
+  pagination: ./utils/pagination.yml
+  commons: ./commons.yml
+service:
+  auth: true
+  base-path: /api/public
+  endpoints:
+    metrics:
+      docs: |
+        Get metrics from the Langfuse project using a query object. V2 endpoint with optimized performance.
+
+        ## V2 Differences
+        - Supports `observations`, `scores-numeric`, and `scores-categorical` views only (traces view not supported)
+        - Direct access to tags and release fields on observations
+        - Backwards-compatible: traceName, traceRelease, traceVersion dimensions are still available on observations view
+        - High cardinality dimensions are not supported and will return a 400 error (see below)
+
+        For more details, see the [Metrics API documentation](https://langfuse.com/docs/metrics/features/metrics-api).
+
+        ## Available Views
+
+        ### observations
+        Query observation-level data (spans, generations, events).
+
+        **Dimensions:**
+        - `environment` - Deployment environment (e.g., production, staging)
+        - `type` - Type of observation (SPAN, GENERATION, EVENT)
+        - `name` - Name of the observation
+        - `level` - Logging level of the observation
+        - `version` - Version of the observation
+        - `tags` - User-defined tags
+        - `release` - Release version
+        - `traceName` - Name of the parent trace (backwards-compatible)
+        - `traceRelease` - Release version of the parent trace (backwards-compatible, maps to release)
+        - `traceVersion` - Version of the parent trace (backwards-compatible, maps to version)
+        - `providedModelName` - Name of the model used
+        - `promptName` - Name of the prompt used
+        - `promptVersion` - Version of the prompt used
+        - `startTimeMonth` - Month of start_time in YYYY-MM format
+
+        **Measures:**
+        - `count` - Total number of observations
+        - `latency` - Observation latency (milliseconds)
+        - `streamingLatency` - Generation latency from completion start to end (milliseconds)
+        - `inputTokens` - Sum of input tokens consumed
+        - `outputTokens` - Sum of output tokens produced
+        - `totalTokens` - Sum of all tokens consumed
+        - `outputTokensPerSecond` - Output tokens per second
+        - `tokensPerSecond` - Total tokens per second
+        - `inputCost` - Input cost (USD)
+        - `outputCost` - Output cost (USD)
+        - `totalCost` - Total cost (USD)
+        - `timeToFirstToken` - Time to first token (milliseconds)
+        - `countScores` - Number of scores attached to the observation
+
+        ### scores-numeric
+        Query numeric and boolean score data.
+
+        **Dimensions:**
+        - `environment` - Deployment environment
+        - `name` - Name of the score (e.g., accuracy, toxicity)
+        - `source` - Origin of the score (API, ANNOTATION, EVAL)
+        - `dataType` - Data type (NUMERIC, BOOLEAN)
+        - `configId` - Identifier of the score config
+        - `timestampMonth` - Month in YYYY-MM format
+        - `timestampDay` - Day in YYYY-MM-DD format
+        - `value` - Numeric value of the score
+        - `traceName` - Name of the parent trace
+        - `tags` - Tags
+        - `traceRelease` - Release version
+        - `traceVersion` - Version
+        - `observationName` - Name of the associated observation
+        - `observationModelName` - Model name of the associated observation
+        - `observationPromptName` - Prompt name of the associated observation
+        - `observationPromptVersion` - Prompt version of the associated observation
+
+        **Measures:**
+        - `count` - Total number of scores
+        - `value` - Score value (for aggregations)
+
+        ### scores-categorical
+        Query categorical score data. Same dimensions as scores-numeric except uses `stringValue` instead of `value`.
+
+        **Measures:**
+        - `count` - Total number of scores
+
+        ## High Cardinality Dimensions
+        The following dimensions cannot be used as grouping dimensions in v2 metrics API as they can cause performance issues.
+        Use them in filters instead.
+
+        **observations view:**
+        - `id` - Use traceId filter to narrow down results
+        - `traceId` - Use traceId filter instead
+        - `userId` - Use userId filter instead
+        - `sessionId` - Use sessionId filter instead
+        - `parentObservationId` - Use parentObservationId filter instead
+
+        **scores-numeric / scores-categorical views:**
+        - `id` - Use specific filters to narrow down results
+        - `traceId` - Use traceId filter instead
+        - `userId` - Use userId filter instead
+        - `sessionId` - Use sessionId filter instead
+        - `observationId` - Use observationId filter instead
+
+        ## Aggregations
+        Available aggregation functions: `sum`, `avg`, `count`, `max`, `min`, `p50`, `p75`, `p90`, `p95`, `p99`, `histogram`
+
+        ## Time Granularities
+        Available granularities for timeDimension: `auto`, `minute`, `hour`, `day`, `week`, `month`
+        - `auto` bins the data into approximately 50 buckets based on the time range
+      method: GET
+      path: /v2/metrics
+      request:
+        name: GetMetricsV2Request
+        query-parameters:
+          query:
+            type: string
+            docs: |
+              JSON string containing the query parameters with the following structure:
+              ```json
+              {
+                "view": string,           // Required. One of "observations", "scores-numeric", "scores-categorical"
+                "dimensions": [           // Optional. Default: []
+                  {
+                    "field": string       // Field to group by (see available dimensions above)
+                  }
+                ],
+                "metrics": [              // Required. At least one metric must be provided
+                  {
+                    "measure": string,    // What to measure (see available measures above)
+                    "aggregation": string // How to aggregate: "sum", "avg", "count", "max", "min", "p50", "p75", "p90", "p95", "p99", "histogram"
+                  }
+                ],
+                "filters": [              // Optional. Default: []
+                  {
+                    "column": string,     // Column to filter on (any dimension field)
+                    "operator": string,   // Operator based on type:
+                                          // - datetime: ">", "<", ">=", "<="
+                                          // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                          // - stringOptions: "any of", "none of"
+                                          // - arrayOptions: "any of", "none of", "all of"
+                                          // - number: "=", ">", "<", ">=", "<="
+                                          // - stringObject/numberObject: same as string/number with required "key"
+                                          // - boolean: "=", "<>"
+                                          // - null: "is null", "is not null"
+                    "value": any,         // Value to compare against
+                    "type": string,       // Data type: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+                    "key": string         // Required only for stringObject/numberObject types (e.g., metadata filtering)
+                  }
+                ],
+                "timeDimension": {        // Optional. Default: null. If provided, results will be grouped by time
+                  "granularity": string   // One of "auto", "minute", "hour", "day", "week", "month"
+                },
+                "fromTimestamp": string,  // Required. ISO datetime string for start of time range
+                "toTimestamp": string,    // Required. ISO datetime string for end of time range (must be after fromTimestamp)
+                "orderBy": [              // Optional. Default: null
+                  {
+                    "field": string,      // Field to order by (dimension or metric alias)
+                    "direction": string   // "asc" or "desc"
+                  }
+                ],
+                "config": {               // Optional. Query-specific configuration
+                  "bins": number,         // Optional. Number of bins for histogram aggregation (1-100), default: 10
+                  "row_limit": number     // Optional. Maximum number of rows to return (1-1000), default: 100
+                }
+              }
+              ```
+      response: MetricsV2Response
+types:
+  MetricsV2Response:
+    properties:
+      data:
+        type: list<map<string, unknown>>
+        docs: |
+          The metrics data. Each item in the list contains the metric values and dimensions requested in the query.
+          Format varies based on the query parameters.
+          Histograms will return an array with [lower, upper, height] tuples.

--- a/fern/apis/server/definition/observations-v2.yml
+++ b/fern/apis/server/definition/observations-v2.yml
@@ -1,0 +1,197 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
+imports:
+  commons: ./commons.yml
+service:
+  auth: true
+  base-path: /api/public
+  endpoints:
+    getMany:
+      docs: |
+        Get a list of observations with cursor-based pagination and flexible field selection.
+
+        ## Cursor-based Pagination
+        This endpoint uses cursor-based pagination for efficient traversal of large datasets.
+        The cursor is returned in the response metadata and should be passed in subsequent requests
+        to retrieve the next page of results.
+
+        ## Field Selection
+        Use the `fields` parameter to control which observation fields are returned:
+        - `core` - Always included: id, traceId, startTime, endTime, projectId, parentObservationId, type
+        - `basic` - name, level, statusMessage, version, environment, bookmarked, public, userId, sessionId
+        - `time` - completionStartTime, createdAt, updatedAt
+        - `io` - input, output
+        - `metadata` - metadata
+        - `model` - providedModelName, internalModelId, modelParameters
+        - `usage` - usageDetails, costDetails, totalCost
+        - `prompt` - promptId, promptName, promptVersion
+        - `metrics` - latency, timeToFirstToken
+
+        If not specified, `core` and `basic` field groups are returned.
+
+        ## Filters
+        Multiple filtering options are available via query parameters or the structured `filter` parameter.
+        When using the `filter` parameter, it takes precedence over individual query parameter filters.
+      method: GET
+      path: /v2/observations
+      request:
+        name: GetObservationsV2Request
+        query-parameters:
+          fields:
+            type: optional<string>
+            docs: |
+              Comma-separated list of field groups to include in the response.
+              Available groups: core, basic, time, io, metadata, model, usage, prompt, metrics.
+              If not specified, `core` and `basic` field groups are returned.
+              Example: "basic,usage,model"
+          limit:
+            type: optional<integer>
+            docs: Number of items to return per page. Maximum 1000, default 50.
+          cursor:
+            type: optional<string>
+            docs: Base64-encoded cursor for pagination. Use the cursor from the previous response to get the next page.
+          parseIoAsJson:
+            type: optional<boolean>
+            docs: |
+              Set to `true` to parse input/output fields as JSON, or `false` to return raw strings.
+              Defaults to `false` if not provided.
+          name: optional<string>
+          userId: optional<string>
+          type:
+            type: optional<string>
+            docs: Filter by observation type (e.g., "GENERATION", "SPAN", "EVENT", "AGENT", "TOOL", "CHAIN", "RETRIEVER", "EVALUATOR", "EMBEDDING", "GUARDRAIL")
+          traceId: optional<string>
+          level:
+            type: optional<commons.ObservationLevel>
+            docs: Optional filter for observations with a specific level (e.g. "DEBUG", "DEFAULT", "WARNING", "ERROR").
+          parentObservationId: optional<string>
+          environment:
+            type: optional<string>
+            allow-multiple: true
+            docs: Optional filter for observations where the environment is one of the provided values.
+          fromStartTime:
+            type: optional<datetime>
+            docs: Retrieve only observations with a start_time on or after this datetime (ISO 8601).
+          toStartTime:
+            type: optional<datetime>
+            docs: Retrieve only observations with a start_time before this datetime (ISO 8601).
+          version:
+            type: optional<string>
+            docs: Optional filter to only include observations with a certain version.
+          filter:
+            type: optional<string>
+            docs: |
+              JSON string containing an array of filter conditions. When provided, this takes precedence over query parameter filters (userId, name, type, level, environment, fromStartTime, ...).
+
+              ## Filter Structure
+              Each filter condition has the following structure:
+              ```json
+              [
+                {
+                  "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+                  "column": string,         // Required. Column to filter on (see available columns below)
+                  "operator": string,       // Required. Operator based on type:
+                                            // - datetime: ">", "<", ">=", "<="
+                                            // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                            // - stringOptions: "any of", "none of"
+                                            // - categoryOptions: "any of", "none of"
+                                            // - arrayOptions: "any of", "none of", "all of"
+                                            // - number: "=", ">", "<", ">=", "<="
+                                            // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
+                                            // - numberObject: "=", ">", "<", ">=", "<="
+                                            // - boolean: "=", "<>"
+                                            // - null: "is null", "is not null"
+                  "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
+                  "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
+                }
+              ]
+              ```
+
+              ## Available Columns
+
+              ### Core Observation Fields
+              - `id` (string) - Observation ID
+              - `type` (string) - Observation type (SPAN, GENERATION, EVENT)
+              - `name` (string) - Observation name
+              - `traceId` (string) - Associated trace ID
+              - `startTime` (datetime) - Observation start time
+              - `endTime` (datetime) - Observation end time
+              - `environment` (string) - Environment tag
+              - `level` (string) - Log level (DEBUG, DEFAULT, WARNING, ERROR)
+              - `statusMessage` (string) - Status message
+              - `version` (string) - Version tag
+              - `userId` (string) - User ID
+              - `sessionId` (string) - Session ID
+
+              ### Trace-Related Fields
+              - `traceName` (string) - Name of the parent trace
+              - `traceTags` (arrayOptions) - Tags from the parent trace
+              - `tags` (arrayOptions) - Alias for traceTags
+
+              ### Performance Metrics
+              - `latency` (number) - Latency in seconds (calculated: end_time - start_time)
+              - `timeToFirstToken` (number) - Time to first token in seconds
+              - `tokensPerSecond` (number) - Output tokens per second
+
+              ### Token Usage
+              - `inputTokens` (number) - Number of input tokens
+              - `outputTokens` (number) - Number of output tokens
+              - `totalTokens` (number) - Total tokens (alias: `tokens`)
+
+              ### Cost Metrics
+              - `inputCost` (number) - Input cost in USD
+              - `outputCost` (number) - Output cost in USD
+              - `totalCost` (number) - Total cost in USD
+
+              ### Model Information
+              - `model` (string) - Provided model name (alias: `providedModelName`)
+              - `promptName` (string) - Associated prompt name
+              - `promptVersion` (number) - Associated prompt version
+
+              ### Structured Data
+              - `metadata` (stringObject/numberObject/categoryOptions) - Metadata key-value pairs. Use `key` parameter to filter on specific metadata keys.
+
+              ## Filter Examples
+              ```json
+              [
+                {
+                  "type": "string",
+                  "column": "type",
+                  "operator": "=",
+                  "value": "GENERATION"
+                },
+                {
+                  "type": "number",
+                  "column": "latency",
+                  "operator": ">=",
+                  "value": 2.5
+                },
+                {
+                  "type": "stringObject",
+                  "column": "metadata",
+                  "key": "environment",
+                  "operator": "=",
+                  "value": "production"
+                }
+              ]
+              ```
+      response: ObservationsV2Response
+
+types:
+  ObservationsV2Response:
+    docs: |
+      Response containing observations with field-group-based filtering and cursor-based pagination.
+
+      The `data` array contains observation objects with only the requested field groups included.
+      Use the `cursor` in `meta` to retrieve the next page of results.
+    properties:
+      data:
+        type: list<map<string, unknown>>
+        docs: Array of observation objects. Fields included depend on the `fields` parameter in the request.
+      meta: ObservationsV2Meta
+
+  ObservationsV2Meta:
+    docs: Metadata for cursor-based pagination
+    properties:
+      cursor:
+        type: optional<string>
+        docs: Base64-encoded cursor to use for retrieving the next page. If not present, there are no more results.

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -1957,6 +1957,305 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/GetMediaUploadUrlRequest'
+  /api/public/v2/metrics:
+    get:
+      description: >-
+        Get metrics from the Langfuse project using a query object. V2 endpoint
+        with optimized performance.
+
+
+        ## V2 Differences
+
+        - Supports `observations`, `scores-numeric`, and `scores-categorical`
+        views only (traces view not supported)
+
+        - Direct access to tags and release fields on observations
+
+        - Backwards-compatible: traceName, traceRelease, traceVersion dimensions
+        are still available on observations view
+
+        - High cardinality dimensions are not supported and will return a 400
+        error (see below)
+
+
+        For more details, see the [Metrics API
+        documentation](https://langfuse.com/docs/metrics/features/metrics-api).
+
+
+        ## Available Views
+
+
+        ### observations
+
+        Query observation-level data (spans, generations, events).
+
+
+        **Dimensions:**
+
+        - `environment` - Deployment environment (e.g., production, staging)
+
+        - `type` - Type of observation (SPAN, GENERATION, EVENT)
+
+        - `name` - Name of the observation
+
+        - `level` - Logging level of the observation
+
+        - `version` - Version of the observation
+
+        - `tags` - User-defined tags
+
+        - `release` - Release version
+
+        - `traceName` - Name of the parent trace (backwards-compatible)
+
+        - `traceRelease` - Release version of the parent trace
+        (backwards-compatible, maps to release)
+
+        - `traceVersion` - Version of the parent trace (backwards-compatible,
+        maps to version)
+
+        - `providedModelName` - Name of the model used
+
+        - `promptName` - Name of the prompt used
+
+        - `promptVersion` - Version of the prompt used
+
+        - `startTimeMonth` - Month of start_time in YYYY-MM format
+
+
+        **Measures:**
+
+        - `count` - Total number of observations
+
+        - `latency` - Observation latency (milliseconds)
+
+        - `streamingLatency` - Generation latency from completion start to end
+        (milliseconds)
+
+        - `inputTokens` - Sum of input tokens consumed
+
+        - `outputTokens` - Sum of output tokens produced
+
+        - `totalTokens` - Sum of all tokens consumed
+
+        - `outputTokensPerSecond` - Output tokens per second
+
+        - `tokensPerSecond` - Total tokens per second
+
+        - `inputCost` - Input cost (USD)
+
+        - `outputCost` - Output cost (USD)
+
+        - `totalCost` - Total cost (USD)
+
+        - `timeToFirstToken` - Time to first token (milliseconds)
+
+        - `countScores` - Number of scores attached to the observation
+
+
+        ### scores-numeric
+
+        Query numeric and boolean score data.
+
+
+        **Dimensions:**
+
+        - `environment` - Deployment environment
+
+        - `name` - Name of the score (e.g., accuracy, toxicity)
+
+        - `source` - Origin of the score (API, ANNOTATION, EVAL)
+
+        - `dataType` - Data type (NUMERIC, BOOLEAN)
+
+        - `configId` - Identifier of the score config
+
+        - `timestampMonth` - Month in YYYY-MM format
+
+        - `timestampDay` - Day in YYYY-MM-DD format
+
+        - `value` - Numeric value of the score
+
+        - `traceName` - Name of the parent trace
+
+        - `tags` - Tags
+
+        - `traceRelease` - Release version
+
+        - `traceVersion` - Version
+
+        - `observationName` - Name of the associated observation
+
+        - `observationModelName` - Model name of the associated observation
+
+        - `observationPromptName` - Prompt name of the associated observation
+
+        - `observationPromptVersion` - Prompt version of the associated
+        observation
+
+
+        **Measures:**
+
+        - `count` - Total number of scores
+
+        - `value` - Score value (for aggregations)
+
+
+        ### scores-categorical
+
+        Query categorical score data. Same dimensions as scores-numeric except
+        uses `stringValue` instead of `value`.
+
+
+        **Measures:**
+
+        - `count` - Total number of scores
+
+
+        ## High Cardinality Dimensions
+
+        The following dimensions cannot be used as grouping dimensions in v2
+        metrics API as they can cause performance issues.
+
+        Use them in filters instead.
+
+
+        **observations view:**
+
+        - `id` - Use traceId filter to narrow down results
+
+        - `traceId` - Use traceId filter instead
+
+        - `userId` - Use userId filter instead
+
+        - `sessionId` - Use sessionId filter instead
+
+        - `parentObservationId` - Use parentObservationId filter instead
+
+
+        **scores-numeric / scores-categorical views:**
+
+        - `id` - Use specific filters to narrow down results
+
+        - `traceId` - Use traceId filter instead
+
+        - `userId` - Use userId filter instead
+
+        - `sessionId` - Use sessionId filter instead
+
+        - `observationId` - Use observationId filter instead
+
+
+        ## Aggregations
+
+        Available aggregation functions: `sum`, `avg`, `count`, `max`, `min`,
+        `p50`, `p75`, `p90`, `p95`, `p99`, `histogram`
+
+
+        ## Time Granularities
+
+        Available granularities for timeDimension: `auto`, `minute`, `hour`,
+        `day`, `week`, `month`
+
+        - `auto` bins the data into approximately 50 buckets based on the time
+        range
+      operationId: metricsV2_metrics
+      tags:
+        - MetricsV2
+      parameters:
+        - name: query
+          in: query
+          description: >-
+            JSON string containing the query parameters with the following
+            structure:
+
+            ```json
+
+            {
+              "view": string,           // Required. One of "observations", "scores-numeric", "scores-categorical"
+              "dimensions": [           // Optional. Default: []
+                {
+                  "field": string       // Field to group by (see available dimensions above)
+                }
+              ],
+              "metrics": [              // Required. At least one metric must be provided
+                {
+                  "measure": string,    // What to measure (see available measures above)
+                  "aggregation": string // How to aggregate: "sum", "avg", "count", "max", "min", "p50", "p75", "p90", "p95", "p99", "histogram"
+                }
+              ],
+              "filters": [              // Optional. Default: []
+                {
+                  "column": string,     // Column to filter on (any dimension field)
+                  "operator": string,   // Operator based on type:
+                                        // - datetime: ">", "<", ">=", "<="
+                                        // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                        // - stringOptions: "any of", "none of"
+                                        // - arrayOptions: "any of", "none of", "all of"
+                                        // - number: "=", ">", "<", ">=", "<="
+                                        // - stringObject/numberObject: same as string/number with required "key"
+                                        // - boolean: "=", "<>"
+                                        // - null: "is null", "is not null"
+                  "value": any,         // Value to compare against
+                  "type": string,       // Data type: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+                  "key": string         // Required only for stringObject/numberObject types (e.g., metadata filtering)
+                }
+              ],
+              "timeDimension": {        // Optional. Default: null. If provided, results will be grouped by time
+                "granularity": string   // One of "auto", "minute", "hour", "day", "week", "month"
+              },
+              "fromTimestamp": string,  // Required. ISO datetime string for start of time range
+              "toTimestamp": string,    // Required. ISO datetime string for end of time range (must be after fromTimestamp)
+              "orderBy": [              // Optional. Default: null
+                {
+                  "field": string,      // Field to order by (dimension or metric alias)
+                  "direction": string   // "asc" or "desc"
+                }
+              ],
+              "config": {               // Optional. Query-specific configuration
+                "bins": number,         // Optional. Number of bins for histogram aggregation (1-100), default: 10
+                "row_limit": number     // Optional. Maximum number of rows to return (1-1000), default: 100
+              }
+            }
+
+            ```
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricsV2Response'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
   /api/public/metrics:
     get:
       description: >-
@@ -2218,6 +2517,373 @@ paths:
       responses:
         '204':
           description: ''
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+  /api/public/v2/observations:
+    get:
+      description: >-
+        Get a list of observations with cursor-based pagination and flexible
+        field selection.
+
+
+        ## Cursor-based Pagination
+
+        This endpoint uses cursor-based pagination for efficient traversal of
+        large datasets.
+
+        The cursor is returned in the response metadata and should be passed in
+        subsequent requests
+
+        to retrieve the next page of results.
+
+
+        ## Field Selection
+
+        Use the `fields` parameter to control which observation fields are
+        returned:
+
+        - `core` - Always included: id, traceId, startTime, endTime, projectId,
+        parentObservationId, type
+
+        - `basic` - name, level, statusMessage, version, environment,
+        bookmarked, public, userId, sessionId
+
+        - `time` - completionStartTime, createdAt, updatedAt
+
+        - `io` - input, output
+
+        - `metadata` - metadata
+
+        - `model` - providedModelName, internalModelId, modelParameters
+
+        - `usage` - usageDetails, costDetails, totalCost
+
+        - `prompt` - promptId, promptName, promptVersion
+
+        - `metrics` - latency, timeToFirstToken
+
+
+        If not specified, `core` and `basic` field groups are returned.
+
+
+        ## Filters
+
+        Multiple filtering options are available via query parameters or the
+        structured `filter` parameter.
+
+        When using the `filter` parameter, it takes precedence over individual
+        query parameter filters.
+      operationId: observationsV2_getMany
+      tags:
+        - ObservationsV2
+      parameters:
+        - name: fields
+          in: query
+          description: >-
+            Comma-separated list of field groups to include in the response.
+
+            Available groups: core, basic, time, io, metadata, model, usage,
+            prompt, metrics.
+
+            If not specified, `core` and `basic` field groups are returned.
+
+            Example: "basic,usage,model"
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: limit
+          in: query
+          description: Number of items to return per page. Maximum 1000, default 50.
+          required: false
+          schema:
+            type: integer
+            nullable: true
+        - name: cursor
+          in: query
+          description: >-
+            Base64-encoded cursor for pagination. Use the cursor from the
+            previous response to get the next page.
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: parseIoAsJson
+          in: query
+          description: >-
+            Set to `true` to parse input/output fields as JSON, or `false` to
+            return raw strings.
+
+            Defaults to `false` if not provided.
+          required: false
+          schema:
+            type: boolean
+            nullable: true
+        - name: name
+          in: query
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: userId
+          in: query
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: type
+          in: query
+          description: >-
+            Filter by observation type (e.g., "GENERATION", "SPAN", "EVENT",
+            "AGENT", "TOOL", "CHAIN", "RETRIEVER", "EVALUATOR", "EMBEDDING",
+            "GUARDRAIL")
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: traceId
+          in: query
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: level
+          in: query
+          description: >-
+            Optional filter for observations with a specific level (e.g.
+            "DEBUG", "DEFAULT", "WARNING", "ERROR").
+          required: false
+          schema:
+            $ref: '#/components/schemas/ObservationLevel'
+            nullable: true
+        - name: parentObservationId
+          in: query
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: environment
+          in: query
+          description: >-
+            Optional filter for observations where the environment is one of the
+            provided values.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              nullable: true
+        - name: fromStartTime
+          in: query
+          description: >-
+            Retrieve only observations with a start_time on or after this
+            datetime (ISO 8601).
+          required: false
+          schema:
+            type: string
+            format: date-time
+            nullable: true
+        - name: toStartTime
+          in: query
+          description: >-
+            Retrieve only observations with a start_time before this datetime
+            (ISO 8601).
+          required: false
+          schema:
+            type: string
+            format: date-time
+            nullable: true
+        - name: version
+          in: query
+          description: Optional filter to only include observations with a certain version.
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: filter
+          in: query
+          description: >-
+            JSON string containing an array of filter conditions. When provided,
+            this takes precedence over query parameter filters (userId, name,
+            type, level, environment, fromStartTime, ...).
+
+
+            ## Filter Structure
+
+            Each filter condition has the following structure:
+
+            ```json
+
+            [
+              {
+                "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+                "column": string,         // Required. Column to filter on (see available columns below)
+                "operator": string,       // Required. Operator based on type:
+                                          // - datetime: ">", "<", ">=", "<="
+                                          // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                          // - stringOptions: "any of", "none of"
+                                          // - categoryOptions: "any of", "none of"
+                                          // - arrayOptions: "any of", "none of", "all of"
+                                          // - number: "=", ">", "<", ">=", "<="
+                                          // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
+                                          // - numberObject: "=", ">", "<", ">=", "<="
+                                          // - boolean: "=", "<>"
+                                          // - null: "is null", "is not null"
+                "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
+                "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
+              }
+            ]
+
+            ```
+
+
+            ## Available Columns
+
+
+            ### Core Observation Fields
+
+            - `id` (string) - Observation ID
+
+            - `type` (string) - Observation type (SPAN, GENERATION, EVENT)
+
+            - `name` (string) - Observation name
+
+            - `traceId` (string) - Associated trace ID
+
+            - `startTime` (datetime) - Observation start time
+
+            - `endTime` (datetime) - Observation end time
+
+            - `environment` (string) - Environment tag
+
+            - `level` (string) - Log level (DEBUG, DEFAULT, WARNING, ERROR)
+
+            - `statusMessage` (string) - Status message
+
+            - `version` (string) - Version tag
+
+            - `userId` (string) - User ID
+
+            - `sessionId` (string) - Session ID
+
+
+            ### Trace-Related Fields
+
+            - `traceName` (string) - Name of the parent trace
+
+            - `traceTags` (arrayOptions) - Tags from the parent trace
+
+            - `tags` (arrayOptions) - Alias for traceTags
+
+
+            ### Performance Metrics
+
+            - `latency` (number) - Latency in seconds (calculated: end_time -
+            start_time)
+
+            - `timeToFirstToken` (number) - Time to first token in seconds
+
+            - `tokensPerSecond` (number) - Output tokens per second
+
+
+            ### Token Usage
+
+            - `inputTokens` (number) - Number of input tokens
+
+            - `outputTokens` (number) - Number of output tokens
+
+            - `totalTokens` (number) - Total tokens (alias: `tokens`)
+
+
+            ### Cost Metrics
+
+            - `inputCost` (number) - Input cost in USD
+
+            - `outputCost` (number) - Output cost in USD
+
+            - `totalCost` (number) - Total cost in USD
+
+
+            ### Model Information
+
+            - `model` (string) - Provided model name (alias:
+            `providedModelName`)
+
+            - `promptName` (string) - Associated prompt name
+
+            - `promptVersion` (number) - Associated prompt version
+
+
+            ### Structured Data
+
+            - `metadata` (stringObject/numberObject/categoryOptions) - Metadata
+            key-value pairs. Use `key` parameter to filter on specific metadata
+            keys.
+
+
+            ## Filter Examples
+
+            ```json
+
+            [
+              {
+                "type": "string",
+                "column": "type",
+                "operator": "=",
+                "value": "GENERATION"
+              },
+              {
+                "type": "number",
+                "column": "latency",
+                "operator": ">=",
+                "value": 2.5
+              },
+              {
+                "type": "stringObject",
+                "column": "metadata",
+                "key": "environment",
+                "operator": "=",
+                "value": "production"
+              }
+            ]
+
+            ```
+          required: false
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObservationsV2Response'
         '400':
           description: ''
           content:
@@ -8292,6 +8958,24 @@ components:
         - application/x-tar
         - application/x-7z-compressed
       description: The MIME type of the media record
+    MetricsV2Response:
+      title: MetricsV2Response
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+          description: >-
+            The metrics data. Each item in the list contains the metric values
+            and dimensions requested in the query.
+
+            Format varies based on the query parameters.
+
+            Histograms will return an array with [lower, upper, height] tuples.
+      required:
+        - data
     MetricsResponse:
       title: MetricsResponse
       type: object
@@ -8424,6 +9108,43 @@ components:
       required:
         - modelName
         - matchPattern
+    ObservationsV2Response:
+      title: ObservationsV2Response
+      type: object
+      description: >-
+        Response containing observations with field-group-based filtering and
+        cursor-based pagination.
+
+
+        The `data` array contains observation objects with only the requested
+        field groups included.
+
+        Use the `cursor` in `meta` to retrieve the next page of results.
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+          description: >-
+            Array of observation objects. Fields included depend on the `fields`
+            parameter in the request.
+        meta:
+          $ref: '#/components/schemas/ObservationsV2Meta'
+      required:
+        - data
+        - meta
+    ObservationsV2Meta:
+      title: ObservationsV2Meta
+      type: object
+      description: Metadata for cursor-based pagination
+      properties:
+        cursor:
+          type: string
+          nullable: true
+          description: >-
+            Base64-encoded cursor to use for retrieving the next page. If not
+            present, there are no more results.
     Observations:
       title: Observations
       type: object

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -1535,6 +1535,45 @@
     {
       "_type": "container",
       "description": null,
+      "name": "Metrics V 2",
+      "item": [
+        {
+          "_type": "endpoint",
+          "name": "Metrics",
+          "request": {
+            "description": "Get metrics from the Langfuse project using a query object. V2 endpoint with optimized performance.\n\n## V2 Differences\n- Supports `observations`, `scores-numeric`, and `scores-categorical` views only (traces view not supported)\n- Direct access to tags and release fields on observations\n- Backwards-compatible: traceName, traceRelease, traceVersion dimensions are still available on observations view\n- High cardinality dimensions are not supported and will return a 400 error (see below)\n\nFor more details, see the [Metrics API documentation](https://langfuse.com/docs/metrics/features/metrics-api).\n\n## Available Views\n\n### observations\nQuery observation-level data (spans, generations, events).\n\n**Dimensions:**\n- `environment` - Deployment environment (e.g., production, staging)\n- `type` - Type of observation (SPAN, GENERATION, EVENT)\n- `name` - Name of the observation\n- `level` - Logging level of the observation\n- `version` - Version of the observation\n- `tags` - User-defined tags\n- `release` - Release version\n- `traceName` - Name of the parent trace (backwards-compatible)\n- `traceRelease` - Release version of the parent trace (backwards-compatible, maps to release)\n- `traceVersion` - Version of the parent trace (backwards-compatible, maps to version)\n- `providedModelName` - Name of the model used\n- `promptName` - Name of the prompt used\n- `promptVersion` - Version of the prompt used\n- `startTimeMonth` - Month of start_time in YYYY-MM format\n\n**Measures:**\n- `count` - Total number of observations\n- `latency` - Observation latency (milliseconds)\n- `streamingLatency` - Generation latency from completion start to end (milliseconds)\n- `inputTokens` - Sum of input tokens consumed\n- `outputTokens` - Sum of output tokens produced\n- `totalTokens` - Sum of all tokens consumed\n- `outputTokensPerSecond` - Output tokens per second\n- `tokensPerSecond` - Total tokens per second\n- `inputCost` - Input cost (USD)\n- `outputCost` - Output cost (USD)\n- `totalCost` - Total cost (USD)\n- `timeToFirstToken` - Time to first token (milliseconds)\n- `countScores` - Number of scores attached to the observation\n\n### scores-numeric\nQuery numeric and boolean score data.\n\n**Dimensions:**\n- `environment` - Deployment environment\n- `name` - Name of the score (e.g., accuracy, toxicity)\n- `source` - Origin of the score (API, ANNOTATION, EVAL)\n- `dataType` - Data type (NUMERIC, BOOLEAN)\n- `configId` - Identifier of the score config\n- `timestampMonth` - Month in YYYY-MM format\n- `timestampDay` - Day in YYYY-MM-DD format\n- `value` - Numeric value of the score\n- `traceName` - Name of the parent trace\n- `tags` - Tags\n- `traceRelease` - Release version\n- `traceVersion` - Version\n- `observationName` - Name of the associated observation\n- `observationModelName` - Model name of the associated observation\n- `observationPromptName` - Prompt name of the associated observation\n- `observationPromptVersion` - Prompt version of the associated observation\n\n**Measures:**\n- `count` - Total number of scores\n- `value` - Score value (for aggregations)\n\n### scores-categorical\nQuery categorical score data. Same dimensions as scores-numeric except uses `stringValue` instead of `value`.\n\n**Measures:**\n- `count` - Total number of scores\n\n## High Cardinality Dimensions\nThe following dimensions cannot be used as grouping dimensions in v2 metrics API as they can cause performance issues.\nUse them in filters instead.\n\n**observations view:**\n- `id` - Use traceId filter to narrow down results\n- `traceId` - Use traceId filter instead\n- `userId` - Use userId filter instead\n- `sessionId` - Use sessionId filter instead\n- `parentObservationId` - Use parentObservationId filter instead\n\n**scores-numeric / scores-categorical views:**\n- `id` - Use specific filters to narrow down results\n- `traceId` - Use traceId filter instead\n- `userId` - Use userId filter instead\n- `sessionId` - Use sessionId filter instead\n- `observationId` - Use observationId filter instead\n\n## Aggregations\nAvailable aggregation functions: `sum`, `avg`, `count`, `max`, `min`, `p50`, `p75`, `p90`, `p95`, `p99`, `histogram`\n\n## Time Granularities\nAvailable granularities for timeDimension: `auto`, `minute`, `hour`, `day`, `week`, `month`\n- `auto` bins the data into approximately 50 buckets based on the time range",
+            "url": {
+              "raw": "{{baseUrl}}/api/public/v2/metrics?query=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "public",
+                "v2",
+                "metrics"
+              ],
+              "query": [
+                {
+                  "key": "query",
+                  "value": "",
+                  "description": "JSON string containing the query parameters with the following structure:\n```json\n{\n  \"view\": string,           // Required. One of \"observations\", \"scores-numeric\", \"scores-categorical\"\n  \"dimensions\": [           // Optional. Default: []\n    {\n      \"field\": string       // Field to group by (see available dimensions above)\n    }\n  ],\n  \"metrics\": [              // Required. At least one metric must be provided\n    {\n      \"measure\": string,    // What to measure (see available measures above)\n      \"aggregation\": string // How to aggregate: \"sum\", \"avg\", \"count\", \"max\", \"min\", \"p50\", \"p75\", \"p90\", \"p95\", \"p99\", \"histogram\"\n    }\n  ],\n  \"filters\": [              // Optional. Default: []\n    {\n      \"column\": string,     // Column to filter on (any dimension field)\n      \"operator\": string,   // Operator based on type:\n                            // - datetime: \">\", \"<\", \">=\", \"<=\"\n                            // - string: \"=\", \"contains\", \"does not contain\", \"starts with\", \"ends with\"\n                            // - stringOptions: \"any of\", \"none of\"\n                            // - arrayOptions: \"any of\", \"none of\", \"all of\"\n                            // - number: \"=\", \">\", \"<\", \">=\", \"<=\"\n                            // - stringObject/numberObject: same as string/number with required \"key\"\n                            // - boolean: \"=\", \"<>\"\n                            // - null: \"is null\", \"is not null\"\n      \"value\": any,         // Value to compare against\n      \"type\": string,       // Data type: \"datetime\", \"string\", \"number\", \"stringOptions\", \"categoryOptions\", \"arrayOptions\", \"stringObject\", \"numberObject\", \"boolean\", \"null\"\n      \"key\": string         // Required only for stringObject/numberObject types (e.g., metadata filtering)\n    }\n  ],\n  \"timeDimension\": {        // Optional. Default: null. If provided, results will be grouped by time\n    \"granularity\": string   // One of \"auto\", \"minute\", \"hour\", \"day\", \"week\", \"month\"\n  },\n  \"fromTimestamp\": string,  // Required. ISO datetime string for start of time range\n  \"toTimestamp\": string,    // Required. ISO datetime string for end of time range (must be after fromTimestamp)\n  \"orderBy\": [              // Optional. Default: null\n    {\n      \"field\": string,      // Field to order by (dimension or metric alias)\n      \"direction\": string   // \"asc\" or \"desc\"\n    }\n  ],\n  \"config\": {               // Optional. Query-specific configuration\n    \"bins\": number,         // Optional. Number of bins for histogram aggregation (1-100), default: 10\n    \"row_limit\": number     // Optional. Maximum number of rows to return (1-1000), default: 100\n  }\n}\n```"
+                }
+              ],
+              "variable": []
+            },
+            "header": [],
+            "method": "GET",
+            "auth": null,
+            "body": null
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "_type": "container",
+      "description": null,
       "name": "Metrics",
       "item": [
         {
@@ -1703,6 +1742,115 @@
             },
             "header": [],
             "method": "DELETE",
+            "auth": null,
+            "body": null
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "_type": "container",
+      "description": null,
+      "name": "Observations V 2",
+      "item": [
+        {
+          "_type": "endpoint",
+          "name": "Get Many",
+          "request": {
+            "description": "Get a list of observations with cursor-based pagination and flexible field selection.\n\n## Cursor-based Pagination\nThis endpoint uses cursor-based pagination for efficient traversal of large datasets.\nThe cursor is returned in the response metadata and should be passed in subsequent requests\nto retrieve the next page of results.\n\n## Field Selection\nUse the `fields` parameter to control which observation fields are returned:\n- `core` - Always included: id, traceId, startTime, endTime, projectId, parentObservationId, type\n- `basic` - name, level, statusMessage, version, environment, bookmarked, public, userId, sessionId\n- `time` - completionStartTime, createdAt, updatedAt\n- `io` - input, output\n- `metadata` - metadata\n- `model` - providedModelName, internalModelId, modelParameters\n- `usage` - usageDetails, costDetails, totalCost\n- `prompt` - promptId, promptName, promptVersion\n- `metrics` - latency, timeToFirstToken\n\nIf not specified, `core` and `basic` field groups are returned.\n\n## Filters\nMultiple filtering options are available via query parameters or the structured `filter` parameter.\nWhen using the `filter` parameter, it takes precedence over individual query parameter filters.",
+            "url": {
+              "raw": "{{baseUrl}}/api/public/v2/observations?fields=&limit=&cursor=&parseIoAsJson=&name=&userId=&type=&traceId=&level=&parentObservationId=&environment=&fromStartTime=&toStartTime=&version=&filter=",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "public",
+                "v2",
+                "observations"
+              ],
+              "query": [
+                {
+                  "key": "fields",
+                  "value": "",
+                  "description": "Comma-separated list of field groups to include in the response.\nAvailable groups: core, basic, time, io, metadata, model, usage, prompt, metrics.\nIf not specified, `core` and `basic` field groups are returned.\nExample: \"basic,usage,model\""
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "Number of items to return per page. Maximum 1000, default 50."
+                },
+                {
+                  "key": "cursor",
+                  "value": "",
+                  "description": "Base64-encoded cursor for pagination. Use the cursor from the previous response to get the next page."
+                },
+                {
+                  "key": "parseIoAsJson",
+                  "value": "",
+                  "description": "Set to `true` to parse input/output fields as JSON, or `false` to return raw strings.\nDefaults to `false` if not provided."
+                },
+                {
+                  "key": "name",
+                  "value": "",
+                  "description": null
+                },
+                {
+                  "key": "userId",
+                  "value": "",
+                  "description": null
+                },
+                {
+                  "key": "type",
+                  "value": "",
+                  "description": "Filter by observation type (e.g., \"GENERATION\", \"SPAN\", \"EVENT\", \"AGENT\", \"TOOL\", \"CHAIN\", \"RETRIEVER\", \"EVALUATOR\", \"EMBEDDING\", \"GUARDRAIL\")"
+                },
+                {
+                  "key": "traceId",
+                  "value": "",
+                  "description": null
+                },
+                {
+                  "key": "level",
+                  "value": "",
+                  "description": "Optional filter for observations with a specific level (e.g. \"DEBUG\", \"DEFAULT\", \"WARNING\", \"ERROR\")."
+                },
+                {
+                  "key": "parentObservationId",
+                  "value": "",
+                  "description": null
+                },
+                {
+                  "key": "environment",
+                  "value": "",
+                  "description": "Optional filter for observations where the environment is one of the provided values."
+                },
+                {
+                  "key": "fromStartTime",
+                  "value": "",
+                  "description": "Retrieve only observations with a start_time on or after this datetime (ISO 8601)."
+                },
+                {
+                  "key": "toStartTime",
+                  "value": "",
+                  "description": "Retrieve only observations with a start_time before this datetime (ISO 8601)."
+                },
+                {
+                  "key": "version",
+                  "value": "",
+                  "description": "Optional filter to only include observations with a certain version."
+                },
+                {
+                  "key": "filter",
+                  "value": "",
+                  "description": "JSON string containing an array of filter conditions. When provided, this takes precedence over query parameter filters (userId, name, type, level, environment, fromStartTime, ...).\n\n## Filter Structure\nEach filter condition has the following structure:\n```json\n[\n  {\n    \"type\": string,           // Required. One of: \"datetime\", \"string\", \"number\", \"stringOptions\", \"categoryOptions\", \"arrayOptions\", \"stringObject\", \"numberObject\", \"boolean\", \"null\"\n    \"column\": string,         // Required. Column to filter on (see available columns below)\n    \"operator\": string,       // Required. Operator based on type:\n                              // - datetime: \">\", \"<\", \">=\", \"<=\"\n                              // - string: \"=\", \"contains\", \"does not contain\", \"starts with\", \"ends with\"\n                              // - stringOptions: \"any of\", \"none of\"\n                              // - categoryOptions: \"any of\", \"none of\"\n                              // - arrayOptions: \"any of\", \"none of\", \"all of\"\n                              // - number: \"=\", \">\", \"<\", \">=\", \"<=\"\n                              // - stringObject: \"=\", \"contains\", \"does not contain\", \"starts with\", \"ends with\"\n                              // - numberObject: \"=\", \">\", \"<\", \">=\", \"<=\"\n                              // - boolean: \"=\", \"<>\"\n                              // - null: \"is null\", \"is not null\"\n    \"value\": any,             // Required (except for null type). Value to compare against. Type depends on filter type\n    \"key\": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata\n  }\n]\n```\n\n## Available Columns\n\n### Core Observation Fields\n- `id` (string) - Observation ID\n- `type` (string) - Observation type (SPAN, GENERATION, EVENT)\n- `name` (string) - Observation name\n- `traceId` (string) - Associated trace ID\n- `startTime` (datetime) - Observation start time\n- `endTime` (datetime) - Observation end time\n- `environment` (string) - Environment tag\n- `level` (string) - Log level (DEBUG, DEFAULT, WARNING, ERROR)\n- `statusMessage` (string) - Status message\n- `version` (string) - Version tag\n- `userId` (string) - User ID\n- `sessionId` (string) - Session ID\n\n### Trace-Related Fields\n- `traceName` (string) - Name of the parent trace\n- `traceTags` (arrayOptions) - Tags from the parent trace\n- `tags` (arrayOptions) - Alias for traceTags\n\n### Performance Metrics\n- `latency` (number) - Latency in seconds (calculated: end_time - start_time)\n- `timeToFirstToken` (number) - Time to first token in seconds\n- `tokensPerSecond` (number) - Output tokens per second\n\n### Token Usage\n- `inputTokens` (number) - Number of input tokens\n- `outputTokens` (number) - Number of output tokens\n- `totalTokens` (number) - Total tokens (alias: `tokens`)\n\n### Cost Metrics\n- `inputCost` (number) - Input cost in USD\n- `outputCost` (number) - Output cost in USD\n- `totalCost` (number) - Total cost in USD\n\n### Model Information\n- `model` (string) - Provided model name (alias: `providedModelName`)\n- `promptName` (string) - Associated prompt name\n- `promptVersion` (number) - Associated prompt version\n\n### Structured Data\n- `metadata` (stringObject/numberObject/categoryOptions) - Metadata key-value pairs. Use `key` parameter to filter on specific metadata keys.\n\n## Filter Examples\n```json\n[\n  {\n    \"type\": \"string\",\n    \"column\": \"type\",\n    \"operator\": \"=\",\n    \"value\": \"GENERATION\"\n  },\n  {\n    \"type\": \"number\",\n    \"column\": \"latency\",\n    \"operator\": \">=\",\n    \"value\": 2.5\n  },\n  {\n    \"type\": \"stringObject\",\n    \"column\": \"metadata\",\n    \"key\": \"environment\",\n    \"operator\": \"=\",\n    \"value\": \"production\"\n  }\n]\n```"
+                }
+              ],
+              "variable": []
+            },
+            "header": [],
+            "method": "GET",
             "auth": null,
             "body": null
           },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds API documentation for v2 metrics and observations endpoints, updating OpenAPI and Postman collection files.
> 
>   - **API Documentation**:
>     - Adds `metrics-v2.yml` for v2 metrics API documentation, detailing endpoints, parameters, and response structures.
>     - Adds `observations-v2.yml` for v2 observations API documentation, including cursor-based pagination and field selection.
>     - Updates `openapi.yml` to include v2 metrics and observations endpoints.
>   - **Postman Collection**:
>     - Updates `collection.json` to include v2 metrics and observations endpoints with detailed descriptions and query parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cd6e9d123eccbef137d8f545045384181c840709. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->