### PR TITLE
fix(otel-ai-sdk): avoid duplicate generations

### DIFF
--- a/packages/shared/src/server/otel/ObservationTypeMapper.ts
+++ b/packages/shared/src/server/otel/ObservationTypeMapper.ts
@@ -271,11 +271,12 @@ export class ObservationTypeMapperRegistry {
 
         // Only handle generation and embedding operations
         const generationEmbeddingPrefixes = [
-          "ai.generateText",
-          "ai.streamText",
-          "ai.generateObject",
-          "ai.streamObject",
-          "ai.embed",
+          "ai.generateText.doGenerate",
+          "ai.streamText.doStream",
+          "ai.generateObject.doGenerate",
+          "ai.streamObject.doStream",
+          "ai.embedMany.doEmbed",
+          "ai.embed.doEmbed",
         ];
 
         const isGenerationOrEmbedding = matchesVercelAiSdkOperation(

--- a/packages/shared/src/server/otel/ObservationTypeMapper.ts
+++ b/packages/shared/src/server/otel/ObservationTypeMapper.ts
@@ -290,18 +290,16 @@ export class ObservationTypeMapperRegistry {
         // IMPORTANT: prefixes inversely ordered by length to avoid false matches
         // AI SDK may append function ID after operation name (e.g., "ai.embed my-function")
         const prefixMappings: Array<[string[], LangfuseObservationType]> = [
-          [["ai.generateText.doGenerate"], "GENERATION"],
-          [["ai.generateText"], "GENERATION"],
-          [["ai.streamText.doStream"], "GENERATION"],
-          [["ai.streamText"], "GENERATION"],
-          [["ai.generateObject.doGenerate"], "GENERATION"],
-          [["ai.generateObject"], "GENERATION"],
-          [["ai.streamObject.doStream"], "GENERATION"],
-          [["ai.streamObject"], "GENERATION"],
-          [["ai.embed.doEmbed"], "EMBEDDING"],
-          [["ai.embedMany.doEmbed"], "EMBEDDING"],
-          [["ai.embedMany"], "EMBEDDING"],
-          [["ai.embed"], "EMBEDDING"],
+          [
+            [
+              "ai.generateText.doGenerate",
+              "ai.streamText.doStream",
+              "ai.generateObject.doGenerate",
+              "ai.streamObject.doStream",
+            ],
+            "GENERATION",
+          ],
+          [["ai.embedMany.doEmbed", "ai.embed.doEmbed"], "EMBEDDING"],
         ];
 
         for (const [prefixes, type] of prefixMappings) {
@@ -340,11 +338,12 @@ export class ObservationTypeMapperRegistry {
         // technically, not required here because the generation-like mapper has higher priority
         // but to keep them interchangeable, we reject them here
         const generationEmbeddingPrefixes = [
-          "ai.generateText",
-          "ai.streamText",
-          "ai.generateObject",
-          "ai.streamObject",
-          "ai.embed",
+          "ai.generateText.doGenerate",
+          "ai.streamText.doStream",
+          "ai.generateObject.doGenerate",
+          "ai.streamObject.doStream",
+          "ai.embedMany.doEmbed",
+          "ai.embed.doEmbed",
         ];
 
         const isGenerationOrEmbedding = matchesVercelAiSdkOperation(

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -1073,7 +1073,8 @@ describe("OTel Resource Span Mapping", () => {
                   {
                     key: "operation.name",
                     value: {
-                      stringValue: "ai.embed generate-document-embedding",
+                      stringValue:
+                        "ai.embed.doEmbed generate-document-embedding",
                     },
                   },
                   {
@@ -1270,19 +1271,13 @@ describe("OTel Resource Span Mapping", () => {
     );
 
     it.each([
-      ["ai.generateText", "generation-create"],
       ["ai.generateText.doGenerate", "generation-create"],
-      ["ai.streamText", "generation-create"],
       ["ai.streamText.doStream", "generation-create"],
       ["ai.generateObject", "generation-create"],
       ["ai.generateObject.doGenerate", "generation-create"],
-      ["ai.streamObject", "generation-create"],
       ["ai.streamObject.doStream", "generation-create"],
-      ["ai.embed", "embedding-create"],
       ["ai.embed.doEmbed", "embedding-create"],
-      ["ai.embedMany", "embedding-create"],
       ["ai.embedMany.doEmbed", "embedding-create"],
-      ["ai.embed generate-document-embedding", "embedding-create"],
       ["ai.embed.doEmbed generate-document-embedding", "embedding-create"],
       ["ai.toolCall", "tool-create"],
     ])(

--- a/web/src/components/trace/IOPreview.tsx
+++ b/web/src/components/trace/IOPreview.tsx
@@ -124,14 +124,9 @@ export const IOPreview: React.FC<{
       const message = messages[i];
       const isOutputMessage = i >= inputMessageCount; // Only output messages get numbered
 
-      const toolCallList =
-        message.tool_calls && Array.isArray(message.tool_calls)
-          ? message.tool_calls
-          : message.json?.tool_calls && Array.isArray(message.json.tool_calls)
-            ? message.json.tool_calls
-            : undefined;
+      const toolCallList = parseToolCallsFromMessage(message);
 
-      if (toolCallList) {
+      if (toolCallList.length > 0) {
         const messageToolNumbers: number[] = [];
 
         for (const toolCall of toolCallList) {
@@ -561,18 +556,17 @@ export const OpenAiMessageView: React.FC<{
                                     ) : undefined
                                   }
                                 />
-                                {message.tool_calls &&
-                                  Array.isArray(message.tool_calls) &&
-                                  message.tool_calls.length > 0 && (
-                                    <div className="mt-2">
-                                      <ToolCallInvocationsView
-                                        message={message}
-                                        toolCallNumbers={messageToToolCallNumbers?.get(
-                                          originalIndex,
-                                        )}
-                                      />
-                                    </div>
-                                  )}
+                                {parseToolCallsFromMessage(message).length >
+                                  0 && (
+                                  <div className="mt-2">
+                                    <ToolCallInvocationsView
+                                      message={message}
+                                      toolCallNumbers={messageToToolCallNumbers?.get(
+                                        originalIndex,
+                                      )}
+                                    />
+                                  </div>
+                                )}
                               </div>
                               <div
                                 style={{
@@ -604,18 +598,17 @@ export const OpenAiMessageView: React.FC<{
                                     ) : undefined
                                   }
                                 />
-                                {message.tool_calls &&
-                                  Array.isArray(message.tool_calls) &&
-                                  message.tool_calls.length > 0 && (
-                                    <div className="mt-2">
-                                      <ToolCallInvocationsView
-                                        message={message}
-                                        toolCallNumbers={messageToToolCallNumbers?.get(
-                                          originalIndex,
-                                        )}
-                                      />
-                                    </div>
-                                  )}
+                                {parseToolCallsFromMessage(message).length >
+                                  0 && (
+                                  <div className="mt-2">
+                                    <ToolCallInvocationsView
+                                      message={message}
+                                      toolCallNumbers={messageToToolCallNumbers?.get(
+                                        originalIndex,
+                                      )}
+                                    />
+                                  </div>
+                                )}
                               </div>
                             </>
                           )}
@@ -641,9 +634,7 @@ export const OpenAiMessageView: React.FC<{
                             }
                           />
                         ) : !shouldRenderContent(message) &&
-                          message.tool_calls &&
-                          Array.isArray(message.tool_calls) &&
-                          message.tool_calls.length > 0 ? (
+                          parseToolCallsFromMessage(message).length > 0 ? (
                           // No content but has tool_calls - show tool invocations
                           <div>
                             <MarkdownJsonViewHeader
@@ -728,3 +719,13 @@ export const OpenAiMessageView: React.FC<{
     </div>
   );
 };
+
+function parseToolCallsFromMessage(
+  message: ReturnType<typeof combineInputOutputMessages>[0],
+) {
+  return message.tool_calls && Array.isArray(message.tool_calls)
+    ? message.tool_calls
+    : message.json?.tool_calls && Array.isArray(message.json?.tool_calls)
+      ? message.json.tool_calls
+      : [];
+}

--- a/web/src/components/trace/ToolCallDefinitionCard.tsx
+++ b/web/src/components/trace/ToolCallDefinitionCard.tsx
@@ -79,7 +79,7 @@ export function ToolCallDefinitionCard({
                   className={cn(
                     "text-xs font-medium",
                     isCalled &&
-                      "border-transparent bg-light-green text-dark-green hover:bg-light-green",
+                      "select-none border-transparent bg-light-green text-dark-green hover:bg-light-green",
                   )}
                 >
                   {statusText}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Consolidates prefix mappings and improves tool call parsing to avoid duplicate generations in AI SDK.
> 
>   - **Behavior**:
>     - Consolidates prefix mappings in `ObservationTypeMapper.ts` to avoid duplicate generation entries.
>     - Updates `generationEmbeddingPrefixes` to use specific `.doGenerate` and `.doStream` suffixes.
>   - **Functions**:
>     - Introduces `parseToolCallsFromMessage()` in `IOPreview.tsx` to handle tool call parsing from both `message.tool_calls` and `message.json.tool_calls`.
>   - **UI Components**:
>     - Updates `ToolCallDefinitionCard.tsx` to include `select-none` class for called tools' badges.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7fee7d9e1c42923a04f3ae07c02b5480de31baf6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->