### PR TITLE
chore: clear posthog css classes

### DIFF
--- a/web/src/components/ui/IOTableCell.tsx
+++ b/web/src/components/ui/IOTableCell.tsx
@@ -61,10 +61,7 @@ const IOTableCellContent = ({
       json={
         stringifiedJson ? decodeUnicodeEscapesOnly(stringifiedJson, true) : data
       }
-      className={cn(
-        "h-full w-full self-stretch rounded-sm",
-        className,
-      )}
+      className={cn("h-full w-full self-stretch rounded-sm", className)}
       codeClassName="py-1 px-2 min-h-0 h-full overflow-y-auto"
       collapseStringsAfterLength={null} // in table, show full strings as row height is fixed
     />

--- a/web/src/components/ui/IOTableCell.tsx
+++ b/web/src/components/ui/IOTableCell.tsx
@@ -32,7 +32,7 @@ const IOTableCellContent = ({
   return singleLine ? (
     <div
       className={cn(
-        "ph-no-capture h-full w-full self-stretch overflow-hidden overflow-y-auto truncate rounded-sm border px-2 py-0.5",
+        "h-full w-full self-stretch overflow-hidden overflow-y-auto truncate rounded-sm border px-2 py-0.5",
         className,
       )}
     >
@@ -41,7 +41,7 @@ const IOTableCellContent = ({
         : stringifiedJson}
     </div>
   ) : shouldTruncate ? (
-    <div className="ph-no-capture grid h-full grid-cols-1">
+    <div className="grid h-full grid-cols-1">
       <JSONView
         json={decodeUnicodeEscapesOnly(
           stringifiedJson.slice(0, IO_TABLE_CHAR_LIMIT) +
@@ -62,7 +62,7 @@ const IOTableCellContent = ({
         stringifiedJson ? decodeUnicodeEscapesOnly(stringifiedJson, true) : data
       }
       className={cn(
-        "ph-no-capture h-full w-full self-stretch rounded-sm",
+        "h-full w-full self-stretch rounded-sm",
         className,
       )}
       codeClassName="py-1 px-2 min-h-0 h-full overflow-y-auto"


### PR DESCRIPTION
## What does this PR do?

Removes all instances of the `ph-no-capture` class from `IOTableCell.tsx`. These classes were previously used for data redaction in PostHog session recordings and are no longer necessary.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] My changes generate no new warnings (`npm run lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked if new and existing unit tests pass locally with my changes

---
<a href="https://cursor.com/background-agent?bcId=bc-0fb931dc-637e-4564-ac89-f676399df8db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0fb931dc-637e-4564-ac89-f676399df8db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

