### PR TITLE
chore: add gpt-5-codex, gpt-5.1-codex, and gpt-5.1-codex-mini model pricing

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -2183,5 +2183,68 @@
       "tokensPerMessage": 3
     },
     "tokenizer_id": "openai"
+  },
+  {
+    "id": "a7f3c8d9-1b2e-4f5a-8c9d-0e1f2a3b4c5d",
+    "model_name": "gpt-5-codex",
+    "match_pattern": "(?i)^(gpt-5-codex)$",
+    "created_at": "2025-11-13T00:00:00.000Z",
+    "updated_at": "2025-11-13T00:00:00.000Z",
+    "prices": {
+      "input": 1.25e-6,
+      "input_cached_tokens": 0.125e-6,
+      "output": 10.0e-6,
+      "input_cache_read": 0.125e-6,
+      "output_reasoning_tokens": 10e-6,
+      "output_reasoning": 10e-6
+    },
+    "tokenizer_config": {
+      "tokensPerName": 1,
+      "tokenizerModel": "gpt-4",
+      "tokensPerMessage": 3
+    },
+    "tokenizer_id": "openai"
+  },
+  {
+    "id": "b8e4d9f0-2c3f-5g6b-9d0e-1f2a3b4c5d6e",
+    "model_name": "gpt-5.1-codex",
+    "match_pattern": "(?i)^(gpt-5.1-codex)$",
+    "created_at": "2025-11-13T00:00:00.000Z",
+    "updated_at": "2025-11-13T00:00:00.000Z",
+    "prices": {
+      "input": 1.25e-6,
+      "input_cached_tokens": 0.125e-6,
+      "output": 10.0e-6,
+      "input_cache_read": 0.125e-6,
+      "output_reasoning_tokens": 10e-6,
+      "output_reasoning": 10e-6
+    },
+    "tokenizer_config": {
+      "tokensPerName": 1,
+      "tokenizerModel": "gpt-4",
+      "tokensPerMessage": 3
+    },
+    "tokenizer_id": "openai"
+  },
+  {
+    "id": "c9f5e0g1-3d4g-6h7c-0e1f-2a3b4c5d6e7f",
+    "model_name": "gpt-5.1-codex-mini",
+    "match_pattern": "(?i)^(gpt-5.1-codex-mini)$",
+    "created_at": "2025-11-13T00:00:00.000Z",
+    "updated_at": "2025-11-13T00:00:00.000Z",
+    "prices": {
+      "input": 0.25e-6,
+      "input_cached_tokens": 0.025e-6,
+      "output": 2.0e-6,
+      "input_cache_read": 0.025e-6,
+      "output_reasoning_tokens": 2e-6,
+      "output_reasoning": 2e-6
+    },
+    "tokenizer_config": {
+      "tokensPerName": 1,
+      "tokenizerModel": "gpt-4",
+      "tokensPerMessage": 3
+    },
+    "tokenizer_id": "openai"
   }
 ]


### PR DESCRIPTION
## Description

This PR adds missing Codex model pricing entries to `default-model-prices.json`:

- **gpt-5-codex**: $1.25 input, $0.125 cached input, $10.00 output
- **gpt-5.1-codex**: $1.25 input, $0.125 cached input, $10.00 output  
- **gpt-5.1-codex-mini**: $0.25 input, $0.025 cached input, $2.00 output

Pricing sourced from OpenAI official pricing page (Standard tier): https://platform.openai.com/docs/pricing

## Related Issue

Fixes #10447

## Changes

- Added three new model entries to `worker/src/constants/default-model-prices.json`
- All entries follow the same structure as other gpt-5 models
- Pricing matches OpenAI's official Standard tier pricing
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds pricing for `gpt-5-codex`, `gpt-5.1-codex`, and `gpt-5.1-codex-mini` models to `default-model-prices.json`.
> 
>   - **Pricing Updates**:
>     - Added `gpt-5-codex`, `gpt-5.1-codex`, and `gpt-5.1-codex-mini` to `default-model-prices.json`.
>     - `gpt-5-codex` and `gpt-5.1-codex`: $1.25 input, $0.125 cached input, $10.00 output.
>     - `gpt-5.1-codex-mini`: $0.25 input, $0.025 cached input, $2.00 output.
>   - **Source**:
>     - Pricing based on OpenAI's official Standard tier pricing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f2dab677e77e0683e3916b17fe996d6aed9b4c28. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->