### PR TITLE
fix(ingestion): allow environment field to be updated during trace merging

### DIFF
--- a/worker/src/__tests__/regressions/issue_10436_environment.test.ts
+++ b/worker/src/__tests__/regressions/issue_10436_environment.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Set up mocks first
+const mockClickhouseClient = {
+  query: vi.fn().mockResolvedValue({
+    json: () => Promise.resolve([]),
+    response_headers: {},
+    query_id: "mock-query-id",
+  }),
+  insert: vi.fn(),
+};
+
+vi.mock("../../env", () => ({
+  env: {
+    LANGFUSE_INGESTION_CLICKHOUSE_WRITE_BATCH_SIZE: 10,
+    LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS: 1000,
+    LANGFUSE_INGESTION_CLICKHOUSE_MAX_ATTEMPTS: 3,
+    LANGFUSE_S3_EVENT_UPLOAD_BUCKET: "test-bucket",
+    CLICKHOUSE_URL: "http://localhost:8123",
+    CLICKHOUSE_USER: "default",
+    CLICKHOUSE_PASSWORD: "",
+    DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/postgres",
+  },
+}));
+
+vi.mock("@langfuse/shared/src/server", async () => {
+  return {
+    clickhouseClient: () => mockClickhouseClient,
+    getCurrentSpan: vi.fn(),
+    recordGauge: vi.fn(),
+    recordHistogram: vi.fn(),
+    recordIncrement: vi.fn(),
+    instrumentAsync: vi.fn((_, fn) =>
+      fn({
+        setAttribute: vi.fn(),
+        setAttributes: vi.fn(),
+        addEvent: vi.fn(),
+        end: vi.fn(),
+      }),
+    ),
+    eventTypes: {
+      TRACE_CREATE: "trace-create",
+      SCORE_CREATE: "score-create",
+      EVENT_CREATE: "event-create",
+      SPAN_CREATE: "span-create",
+      SPAN_UPDATE: "span-update",
+      GENERATION_CREATE: "generation-create",
+      GENERATION_UPDATE: "generation-update",
+      OBSERVATION_CREATE: "observation-create",
+      OBSERVATION_UPDATE: "observation-update",
+    },
+    convertTraceReadToInsert: (x: any) => x,
+    convertScoreReadToInsert: (x: any) => x,
+    convertObservationReadToInsert: (x: any) => x,
+    convertTraceToStagingObservation: (x: any) => x,
+    observationRecordInsertSchema: {
+      parse: (x: any) => ({ ...x, environment: x.environment ?? "default" }),
+    },
+    scoreRecordInsertSchema: {
+      parse: (x: any) => ({ ...x, environment: x.environment ?? "default" }),
+    },
+    traceRecordInsertSchema: {
+      parse: (x: any) => ({ ...x, environment: x.environment ?? "default" }),
+    },
+    traceRecordReadSchema: { parse: (x: any) => x },
+    scoreRecordReadSchema: { parse: (x: any) => x },
+    observationRecordReadSchema: { parse: (x: any) => x },
+    traceException: vi.fn(),
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    flattenJsonToPathArrays: () => ({ names: [], values: [] }),
+    hasNoJobConfigsCache: vi.fn().mockResolvedValue(true),
+    PromptService: class {
+      constructor() {}
+      getPrompt() {
+        return Promise.resolve(null);
+      }
+    },
+    QueueJobs: { IngestionJob: "ingestion-job" },
+    TraceUpsertQueue: { getInstance: () => ({ add: vi.fn() }) },
+    validateAndInflateScore: vi.fn((x) => x),
+    findModel: vi.fn(() => ({ model: null, prices: [] })),
+  };
+});
+
+// Import after mocks
+import { IngestionService } from "../../services/IngestionService";
+import { TableName } from "../../services/ClickhouseWriter";
+import { v4 as uuidv4 } from "uuid";
+import { eventTypes } from "@langfuse/shared/src/server";
+
+const mockRedis = {
+  get: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+  scanStream: vi.fn(() => ({
+    async *[Symbol.asyncIterator]() {
+      yield [];
+    },
+  })),
+} as any;
+
+const mockPrisma = {
+  datasetRuns: { findFirst: vi.fn() },
+  datasetItem: { findFirst: vi.fn() },
+  $executeRaw: vi.fn(),
+} as any;
+
+// Mock ClickhouseWriter to capture writes
+class MockClickhouseWriter {
+  queue: any = {
+    [TableName.Traces]: [],
+    [TableName.Scores]: [],
+    [TableName.Observations]: [],
+    [TableName.ObservationsBatchStaging]: [],
+  };
+
+  addToQueue(table: any, data: any) {
+    this.queue[table].push({ data });
+  }
+}
+
+describe("Issue #10436: Environment ingestion bug", () => {
+  let ingestionService: IngestionService;
+  let mockClickhouseWriter: any;
+
+  beforeEach(() => {
+    mockClickhouseWriter = new MockClickhouseWriter();
+    ingestionService = new IngestionService(
+      mockRedis,
+      mockPrisma,
+      mockClickhouseWriter,
+      mockClickhouseClient,
+    );
+  });
+
+  it("should update environment from 'default' to 'staging' when explicitly set", async () => {
+    const traceId = uuidv4();
+    const projectId = "project-123";
+    const now = new Date();
+
+    // Event 1: Trace create with default environment
+    const traceCreate = {
+      id: uuidv4(),
+      type: eventTypes.TRACE_CREATE,
+      timestamp: now.toISOString(),
+      body: {
+        id: traceId,
+        name: "trace-1",
+        environment: "default",
+      },
+    };
+
+    // Event 2: Trace update with explicit staging environment
+    const traceUpdate = {
+      id: uuidv4(),
+      type: eventTypes.TRACE_CREATE,
+      timestamp: new Date(now.getTime() + 100).toISOString(),
+      body: {
+        id: traceId,
+        environment: "staging",
+      },
+    };
+
+    await ingestionService.mergeAndWrite(
+      "trace",
+      projectId,
+      traceId,
+      now,
+      [traceCreate, traceUpdate] as any[],
+      false,
+    );
+
+    const traces = mockClickhouseWriter.queue[TableName.Traces];
+    expect(traces).toHaveLength(1);
+
+    // After fix: environment should be updated to "staging"
+    expect(traces[0].data.environment).toBe("staging");
+  });
+
+  it("should default to 'default' environment when not specified", async () => {
+    const traceId = uuidv4();
+    const projectId = "project-123";
+    const now = new Date();
+
+    // Event without environment field
+    const traceCreate = {
+      id: uuidv4(),
+      type: eventTypes.TRACE_CREATE,
+      timestamp: now.toISOString(),
+      body: {
+        id: traceId,
+        name: "trace-without-env",
+      },
+    };
+
+    await ingestionService.mergeAndWrite(
+      "trace",
+      projectId,
+      traceId,
+      now,
+      [traceCreate] as any[],
+      false,
+    );
+
+    const traces = mockClickhouseWriter.queue[TableName.Traces];
+    expect(traces).toHaveLength(1);
+
+    // Should default to "default" when not specified
+    expect(traces[0].data.environment).toBe("default");
+  });
+
+  it("should preserve non-default environment when explicitly set from the start", async () => {
+    const traceId = uuidv4();
+    const projectId = "project-123";
+    const now = new Date();
+
+    // Event with explicit staging environment from the start
+    const traceCreate = {
+      id: uuidv4(),
+      type: eventTypes.TRACE_CREATE,
+      timestamp: now.toISOString(),
+      body: {
+        id: traceId,
+        name: "trace-staging",
+        environment: "staging",
+      },
+    };
+
+    await ingestionService.mergeAndWrite(
+      "trace",
+      projectId,
+      traceId,
+      now,
+      [traceCreate] as any[],
+      false,
+    );
+
+    const traces = mockClickhouseWriter.queue[TableName.Traces];
+    expect(traces).toHaveLength(1);
+
+    // Should preserve the explicitly set staging environment
+    expect(traces[0].data.environment).toBe("staging");
+  });
+
+  it("should preserve production environment when explicitly set", async () => {
+    const traceId = uuidv4();
+    const projectId = "project-123";
+    const now = new Date();
+
+    // Event with explicit production environment
+    const traceCreate = {
+      id: uuidv4(),
+      type: eventTypes.TRACE_CREATE,
+      timestamp: now.toISOString(),
+      body: {
+        id: traceId,
+        name: "trace-production",
+        environment: "production",
+      },
+    };
+
+    await ingestionService.mergeAndWrite(
+      "trace",
+      projectId,
+      traceId,
+      now,
+      [traceCreate] as any[],
+      false,
+    );
+
+    const traces = mockClickhouseWriter.queue[TableName.Traces];
+    expect(traces).toHaveLength(1);
+
+    // Should preserve the explicitly set production environment
+    expect(traces[0].data.environment).toBe("production");
+  });
+});

--- a/worker/src/__tests__/regressions/issue_10436_environment_integration.test.ts
+++ b/worker/src/__tests__/regressions/issue_10436_environment_integration.test.ts
@@ -1,0 +1,162 @@
+import { randomUUID } from "crypto";
+import { expect, describe, it } from "vitest";
+import {
+  createTrace,
+  createTracesCh,
+  createOrgProjectAndApiKey,
+  getTracesByIds,
+  clickhouseClient,
+} from "@langfuse/shared/src/server";
+import { IngestionService } from "../../services/IngestionService";
+import { ClickhouseWriter } from "../../services/ClickhouseWriter";
+import { redis } from "@langfuse/shared/src/server";
+import { prisma } from "@langfuse/shared/src/db";
+
+describe("Issue #10436: Environment ingestion bug (Integration with real ClickHouse)", () => {
+  it("should update environment from 'default' to 'staging' through full IngestionService", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const traceId = randomUUID();
+    const now = new Date();
+
+    // Create initial trace with default environment in ClickHouse
+    const initialTrace = createTrace({
+      id: traceId,
+      project_id: projectId,
+      environment: "default",
+      name: "initial-trace",
+      timestamp: now.getTime(),
+    });
+    await createTracesCh([initialTrace]);
+
+    // Wait for ClickHouse to process
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // Now send events through IngestionService to update to staging
+    const updateEvent = {
+      id: randomUUID(),
+      type: "trace-create" as const,
+      timestamp: new Date(now.getTime() + 1000).toISOString(),
+      body: {
+        id: traceId,
+        environment: "staging",
+        name: "updated-trace",
+      },
+    };
+
+    // Use real IngestionService with real ClickHouse
+    const ingestionService = new IngestionService(
+      redis,
+      prisma,
+      ClickhouseWriter.getInstance(),
+      clickhouseClient(),
+    );
+
+    await ingestionService.mergeAndWrite(
+      "trace",
+      projectId,
+      traceId,
+      new Date(now.getTime() + 1000),
+      [updateEvent] as any[],
+      false,
+    );
+
+    // Flush ClickHouse writer
+    await ClickhouseWriter.getInstance().shutdown();
+
+    // Wait for ClickHouse to process the write
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // Query ClickHouse to verify the environment was updated
+    const traces = await getTracesByIds([traceId], projectId);
+
+    expect(traces).toHaveLength(1);
+    // After fix: environment should be updated to "staging" (not stuck at "default")
+    expect(traces[0].environment).toBe("staging");
+  }, 30000); // 30 second timeout for async processing
+
+  it("should preserve staging environment when set from the start", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const traceId = randomUUID();
+    const now = new Date();
+
+    // Create trace with staging environment directly
+    const createEvent = {
+      id: randomUUID(),
+      type: "trace-create" as const,
+      timestamp: now.toISOString(),
+      body: {
+        id: traceId,
+        environment: "staging",
+        name: "staging-trace",
+        input: { test: "data" },
+      },
+    };
+
+    const ingestionService = new IngestionService(
+      redis,
+      prisma,
+      ClickhouseWriter.getInstance(),
+      clickhouseClient(),
+    );
+
+    await ingestionService.mergeAndWrite(
+      "trace",
+      projectId,
+      traceId,
+      now,
+      [createEvent] as any[],
+      false,
+    );
+
+    await ClickhouseWriter.getInstance().shutdown();
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    const traces = await getTracesByIds([traceId], projectId);
+
+    expect(traces).toHaveLength(1);
+    expect(traces[0].environment).toBe("staging");
+  }, 30000);
+
+  it("should default to 'default' environment when not specified", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const traceId = randomUUID();
+    const now = new Date();
+
+    // Create trace without environment field
+    const createEvent = {
+      id: randomUUID(),
+      type: "trace-create" as const,
+      timestamp: now.toISOString(),
+      body: {
+        id: traceId,
+        name: "no-env-trace",
+        input: { test: "data" },
+        // environment not specified
+      },
+    };
+
+    const ingestionService = new IngestionService(
+      redis,
+      prisma,
+      ClickhouseWriter.getInstance(),
+      clickhouseClient(),
+    );
+
+    await ingestionService.mergeAndWrite(
+      "trace",
+      projectId,
+      traceId,
+      now,
+      [createEvent] as any[],
+      false,
+    );
+
+    await ClickhouseWriter.getInstance().shutdown();
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    const traces = await getTracesByIds([traceId], projectId);
+
+    expect(traces).toHaveLength(1);
+    expect(traces[0].environment).toBe("default");
+  }, 30000);
+});

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -162,20 +162,13 @@ const immutableEntityKeys: {
   [TableName.Observations]: (keyof ObservationRecordInsertType)[];
   [TableName.DatasetRunItems]: (keyof DatasetRunItemRecordInsertType)[];
 } = {
-  [TableName.Traces]: [
-    "id",
-    "project_id",
-    "timestamp",
-    "created_at",
-    "environment",
-  ],
+  [TableName.Traces]: ["id", "project_id", "timestamp", "created_at"],
   [TableName.Scores]: [
     "id",
     "project_id",
     "timestamp",
     "trace_id",
     "created_at",
-    "environment",
   ],
   [TableName.Observations]: [
     "id",
@@ -183,7 +176,6 @@ const immutableEntityKeys: {
     "trace_id",
     "start_time",
     "created_at",
-    "environment",
   ],
   // We do not accept updates, hence this list is currently not used.
   [TableName.DatasetRunItems]: [


### PR DESCRIPTION
## Description

Fixes #10436

This PR fixes a bug where the `environment` field was always set to `default` even when explicitly specified as `staging` or other values in the Python SDK.

## Root Cause

The `environment` field was incorrectly marked as **immutable** in the `IngestionService`. This meant that once it was set (even implicitly to `default`), subsequent events couldn't update it.

## Solution

Removed `environment` from the `immutableEntityKeys` arrays for:
- Traces
- Scores  
- Observations

This allows the environment field to be updated during the merge process while still defaulting to `default` when not specified.

## Testing

Added comprehensive regression tests in `worker/src/__tests__/regressions/issue_10436_environment.test.ts`:

✅ All 4 tests passing:
1. Environment can be updated from `default` → `staging`
2. Environment defaults to `default` when not specified
3. Environment preserves `staging` when explicitly set from the start
4. Environment preserves `production` when explicitly set

## Commits

1. **test(ingestion): add regression tests for environment field updates** - Tests added (1 failing, 3 passing)
2. **fix(ingestion): remove environment from immutable keys to allow updates** - Fix applied (all 4 tests passing)

The fix is minimal and focused, changing only 10 lines to remove the immutability constraint.