### PR TITLE
chore: adjust flaky dataset service test

### DIFF
--- a/web/src/__tests__/async/dataset-service.servertest.ts
+++ b/web/src/__tests__/async/dataset-service.servertest.ts
@@ -1793,11 +1793,11 @@ describe("Fetch datasets for UI presentation", () => {
         const item0Run1 = result.get(itemIds[0])?.[run1Id];
         expect(item0Run1?.observation?.latency).toBeDefined();
         // Observation 1: 3500ms - 2500ms = 1000ms latency, which translates to 1 second
-        expect(item0Run1?.observation?.latency).toBe(1);
+        expect(item0Run1?.observation?.latency).toBeCloseTo(1);
 
         const item0Run2 = result.get(itemIds[0])?.[run2Id];
         expect(item0Run2?.observation?.latency).toBeDefined();
-        expect(item0Run2?.observation?.latency).toBe(1); // Same observation
+        expect(item0Run2?.observation?.latency).toBeCloseTo(1); // Same observation
 
         // Test trace-level latency (calculated from trace timestamps and observations)
         const item1Run1 = result.get(itemIds[1])?.[run1Id];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjust latency checks in `dataset-service.servertest.ts` to use `toBeCloseTo` for improved test reliability.
> 
>   - **Tests**:
>     - Change `expect(item0Run1?.observation?.latency).toBe(1)` to `expect(item0Run1?.observation?.latency).toBeCloseTo(1)` in `dataset-service.servertest.ts`.
>     - Change `expect(item0Run2?.observation?.latency).toBe(1)` to `expect(item0Run2?.observation?.latency).toBeCloseTo(1)` in `dataset-service.servertest.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 19ee2032e93d57f8dd543b03831023fd4f8d0fd1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->