### PR TITLE
fix(cloud): clear session cookie that was created during incident

### DIFF
--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -48,5 +48,22 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   );
   res.setHeader("Pragma", "no-cache");
   res.setHeader("Expires", "0");
+
+  // Clean up the cookie from incident: https://status.langfuse.com/incident/770854
+  if (env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
+    const langfuseUrls = {
+      US: "us.cloud.langfuse.com",
+      EU: "cloud.langfuse.com",
+      STAGING: "staging.langfuse.com",
+      HIPAA: "hipaa.cloud.langfuse.com",
+      DEV: "dev.langfuse.com",
+    } as const;
+
+    res.setHeader(
+      "Set-Cookie",
+      `__Secure-next-auth.session-token.${env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION}=; Path=/; Domain=${langfuseUrls[env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION]}; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax`,
+    );
+  }
+
   return await NextAuth(req, res, authOptions);
 }


### PR DESCRIPTION
https://status.langfuse.com/incident/770854

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Clear session cookie in `auth()` for specific cloud regions to address incident-related issues.
> 
>   - **Behavior**:
>     - Clears session cookie `__Secure-next-auth.session-token` for specific `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` in `auth()` in `[...nextauth].ts`.
>     - Targets incident-related cookies by setting expiration to past date.
>   - **Environment**:
>     - Uses `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` to determine domain for cookie clearing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2f713486c1dea44697665c6a719c7b7f60372027. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->