### PR TITLE
fix(cloud): cookie set during incident was same domain, no need to set domain explicitly

### DIFF
--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -51,17 +51,9 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
 
   // Clean up the cookie from incident: https://status.langfuse.com/incident/770854
   if (env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
-    const langfuseUrls = {
-      US: "us.cloud.langfuse.com",
-      EU: "cloud.langfuse.com",
-      STAGING: "staging.langfuse.com",
-      HIPAA: "hipaa.cloud.langfuse.com",
-      DEV: "dev.langfuse.com",
-    } as const;
-
     res.setHeader(
       "Set-Cookie",
-      `__Secure-next-auth.session-token.${env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION}=; Path=/; Domain=${langfuseUrls[env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION]}; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Lax`,
+      `__Secure-next-auth.session-token.${env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Lax; Max-Age=0`,
     );
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes explicit domain setting from cookie in `auth()` in `[...nextauth].ts`, relying on default same-domain behavior.
> 
>   - **Behavior**:
>     - Removes explicit domain setting from `Set-Cookie` header in `auth()` in `[...nextauth].ts`.
>     - Cookie is now set without specifying a domain, relying on default same-domain behavior.
>   - **Misc**:
>     - Cleans up cookie handling related to incident 770854.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ef2676db0cdd1ee94fccd2c0cca61f2208e7e9d7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->