### PR TITLE
chore: add env setting to limit the blob storage export for specific projects

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -150,6 +150,12 @@ const EnvSchema = z.object({
     .enum(["true", "false"])
     .default("true"),
 
+  // Comma-separated list of project IDs that should only export traces table (skip observations and scores)
+  LANGFUSE_BLOB_STORAGE_EXPORT_TRACE_ONLY_PROJECT_IDS: z
+    .string()
+    .optional()
+    .transform((s) => (s ? s.split(",").map((id) => id.trim()) : [])),
+
   // Flags to toggle queue consumers on or off.
   QUEUE_CONSUMER_CLOUD_USAGE_METERING_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -23,6 +23,7 @@ import {
 } from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
 import { randomUUID } from "crypto";
+import { env } from "../../env";
 
 const getMinTimestampForExport = async (
   projectId: string,

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -345,11 +345,26 @@ export const handleBlobStorageIntegrationProjectJob = async (
       fileType: blobStorageIntegration.fileType,
     };
 
-    await Promise.all([
-      processBlobStorageExport({ ...executionConfig, table: "traces" }),
-      processBlobStorageExport({ ...executionConfig, table: "observations" }),
-      processBlobStorageExport({ ...executionConfig, table: "scores" }),
-    ]);
+    // Check if this project should only export traces
+    const isTraceOnlyProject =
+      env.LANGFUSE_BLOB_STORAGE_EXPORT_TRACE_ONLY_PROJECT_IDS.includes(
+        projectId,
+      );
+
+    if (isTraceOnlyProject) {
+      // Only process traces table for projects in the trace-only list
+      logger.info(
+        `[BLOB INTEGRATION] Project ${projectId} is configured for trace-only export, skipping observations and scores`,
+      );
+      await processBlobStorageExport({ ...executionConfig, table: "traces" });
+    } else {
+      // Process all tables for projects not in the trace-only list
+      await Promise.all([
+        processBlobStorageExport({ ...executionConfig, table: "traces" }),
+        processBlobStorageExport({ ...executionConfig, table: "observations" }),
+        processBlobStorageExport({ ...executionConfig, table: "scores" }),
+      ]);
+    }
 
     // Determine if we've caught up with present-day data
     const caughtUp = maxTimestamp.getTime() >= uncappedMaxTimestamp.getTime();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add environment setting to limit blob storage export to traces only for specified projects.
> 
>   - **Environment**:
>     - Add `LANGFUSE_BLOB_STORAGE_EXPORT_TRACE_ONLY_PROJECT_IDS` to `env.ts` to specify projects that only export traces.
>   - **Blob Storage Export**:
>     - In `handleBlobStorageIntegrationProjectJob.ts`, check if `projectId` is in `LANGFUSE_BLOB_STORAGE_EXPORT_TRACE_ONLY_PROJECT_IDS`.
>     - If true, only export `traces` table; skip `observations` and `scores`.
>     - Log trace-only export decision and process accordingly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 32572b30914e4620ebe39a1f158a9cb9df65cdd5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->