### PR TITLE
feat: expand mutation monitor to handle multiple queues and tables

### DIFF
--- a/worker/src/features/mutation-monitoring/mutationMonitor.ts
+++ b/worker/src/features/mutation-monitoring/mutationMonitor.ts
@@ -12,15 +12,44 @@ interface MutationCount {
   mutation_count: number;
 }
 
+type QueueAction = "pause" | "resume";
+
+interface QueueDecision {
+  queueName: QueueName;
+  action: QueueAction;
+  reason: string;
+}
+
 export class MutationMonitor {
   private static timeoutId: NodeJS.Timeout | null = null;
-  private static isPaused = false;
+  private static pausedQueues: Set<QueueName> = new Set();
   private static isRunning = false;
   private static readonly TABLES_TO_MONITOR = [
     "traces",
     "observations",
     "scores",
+    "dataset_run_items_rmt",
   ];
+
+  // Mapping of which ClickHouse tables each deletion queue affects
+  private static readonly QUEUE_TABLE_MAPPING: Partial<
+    Record<QueueName, string[]>
+  > = {
+    [QueueName.TraceDelete]: ["traces", "observations", "scores"],
+    [QueueName.ScoreDelete]: ["scores"],
+    [QueueName.DatasetDelete]: ["dataset_run_items_rmt"],
+    [QueueName.ProjectDelete]: [
+      "traces",
+      "observations",
+      "scores",
+      "dataset_run_items_rmt",
+    ],
+    [QueueName.DataRetentionProcessingQueue]: [
+      "traces",
+      "observations",
+      "scores",
+    ],
+  };
 
   /**
    * Start the mutation monitoring service
@@ -91,6 +120,74 @@ export class MutationMonitor {
   }
 
   /**
+   * Decision function - determines which queues to pause/resume
+   */
+  public static makeDecisions(
+    mutationCounts: Map<string, number>,
+    queueTableMapping: Partial<Record<QueueName, string[]>>,
+    maxThreshold: number,
+    safeThreshold: number,
+  ): QueueDecision[] {
+    const decisions: QueueDecision[] = [];
+    const decisionMap: Map<QueueName, QueueAction> = new Map();
+
+    // Find tables over MAX threshold
+    const tablesOverMax = Array.from(mutationCounts.entries())
+      .filter(([, count]) => count >= maxThreshold)
+      .map(([table]) => table);
+
+    const tableToQueuesMap: Map<string, QueueName[]> = Object.entries(
+      queueTableMapping,
+    ).reduce((map, [queue, tables]) => {
+      for (const table of tables) {
+        if (!map.has(table)) {
+          map.set(table, []);
+        }
+        map.get(table)!.push(queue as QueueName);
+      }
+      return map;
+    }, new Map());
+
+    // Decision 1: Pause queues affecting over-threshold tables
+    for (const table of tablesOverMax) {
+      const affectedQueues = tableToQueuesMap.get(table) || [];
+      for (const queue of affectedQueues) {
+        if (!decisionMap.has(queue)) {
+          decisions.push({
+            queueName: queue,
+            action: "pause",
+            reason: `${table}=${mutationCounts.get(table)}`,
+          });
+          decisionMap.set(queue, "pause");
+        }
+      }
+    }
+
+    // Decision 2: Resume queues where ALL tables are safe
+    for (const [queue, tables] of Object.entries(queueTableMapping)) {
+      const allSafe = tables.every(
+        (table) => (mutationCounts.get(table) ?? 0) < safeThreshold,
+      );
+
+      if (allSafe) {
+        if (!decisionMap.has(queue as QueueName)) {
+          decisionMap.set(queue as QueueName, "resume");
+          decisions.push({
+            queueName: queue as QueueName,
+            action: "resume",
+            reason: "",
+          });
+        } else {
+          // if there is a contradictory action, we log an error
+          logger.error(`Contradictory decisions for ${queue}`);
+        }
+      }
+    }
+
+    return decisions;
+  }
+
+  /**
    * Check ClickHouse mutations and pause/resume workers as needed
    */
   private static async checkMutations(): Promise<void> {
@@ -124,31 +221,34 @@ export class MutationMonitor {
         mutationCounts.set(result.table, result.mutation_count);
       }
 
-      // Find the maximum mutation count across all tables
-      const maxMutationCount = Math.max(...mutationCounts.values());
-      const tableWithMaxMutations = Array.from(mutationCounts.entries()).find(
-        ([, count]) => count === maxMutationCount,
-      )?.[0];
-
       logger.debug("Mutation stats", {
         mutationCounts: Object.fromEntries(mutationCounts),
-        maxMutationCount,
-        tableWithMaxMutations,
-        isPaused: this.isPaused,
+        pausedQueues: Array.from(this.pausedQueues),
         threshold: env.LANGFUSE_DELETION_MUTATIONS_MAX_COUNT,
       });
 
-      // Check if we need to pause or resume workers
-      if (maxMutationCount >= env.LANGFUSE_DELETION_MUTATIONS_MAX_COUNT) {
-        await this.pauseWorkers(
-          maxMutationCount,
-          tableWithMaxMutations,
-          mutationCounts,
-        );
-      } else if (
-        maxMutationCount < env.LANGFUSE_DELETION_MUTATIONS_SAFE_COUNT
-      ) {
-        await this.resumeWorkers(maxMutationCount, mutationCounts);
+      const decisions = this.makeDecisions(
+        mutationCounts,
+        this.QUEUE_TABLE_MAPPING,
+        env.LANGFUSE_DELETION_MUTATIONS_MAX_COUNT,
+        env.LANGFUSE_DELETION_MUTATIONS_SAFE_COUNT,
+      );
+
+      // Separate decisions by action
+      const pauseDecisions = decisions.filter((d) => d.action === "pause");
+      const resumeDecisions = decisions.filter((d) => d.action === "resume");
+
+      // Execute pause decisions
+      if (pauseDecisions.length > 0) {
+        const queuesToPause = new Set(pauseDecisions.map((d) => d.queueName));
+        const reasons = pauseDecisions.map((d) => d.reason);
+        await this.pauseWorkers(queuesToPause, mutationCounts, reasons);
+      }
+
+      // Execute resume decisions
+      if (resumeDecisions.length > 0) {
+        const queuesToResume = new Set(resumeDecisions.map((d) => d.queueName));
+        await this.resumeWorkers(queuesToResume, mutationCounts);
       }
     } catch (error) {
       logger.error("Error checking ClickHouse mutations", error);
@@ -156,86 +256,93 @@ export class MutationMonitor {
   }
 
   /**
-   * Pause TraceDelete workers to reduce mutation load on ClickHouse
+   * Pause workers (pure execution - no decision logic)
    */
   private static async pauseWorkers(
-    maxMutationCount: number,
-    tableWithMaxMutations: string | undefined,
+    queuesToPause: Set<QueueName>,
     mutationCounts: Map<string, number>,
+    offendingTables: string[],
   ): Promise<void> {
-    // Only pause if not already paused
-    if (this.isPaused) {
-      return;
-    }
-
-    try {
-      const worker = WorkerManager.getWorker(QueueName.TraceDelete);
-      if (!worker) {
-        logger.warn("TraceDelete worker not found, cannot pause");
-        return;
+    for (const queueName of queuesToPause) {
+      // Skip if already paused (optimization)
+      if (this.pausedQueues.has(queueName)) {
+        continue;
       }
 
-      await worker.pause();
-      this.isPaused = true;
+      try {
+        const worker = WorkerManager.getWorker(queueName);
+        if (!worker) {
+          logger.warn(`${queueName} worker not found, cannot pause`);
+          continue;
+        }
 
-      logger.warn("Mutation threshold exceeded, pausing TraceDelete workers", {
-        threshold: env.LANGFUSE_DELETION_MUTATIONS_MAX_COUNT,
-        maxMutationCount,
-        tableWithMaxMutations,
-        mutationCounts: Object.fromEntries(mutationCounts),
-      });
-    } catch (error) {
-      logger.error("Error pausing TraceDelete workers", error);
+        await worker.pause();
+        this.pausedQueues.add(queueName);
+
+        logger.warn(`Paused ${queueName}`, {
+          reason: `tables over threshold: ${offendingTables.join(", ")}`,
+          threshold: env.LANGFUSE_DELETION_MUTATIONS_MAX_COUNT,
+          mutationCounts: Object.fromEntries(mutationCounts),
+        });
+      } catch (error) {
+        logger.error(`Error pausing ${queueName}`, error);
+      }
     }
   }
 
   /**
-   * Resume TraceDelete workers after mutation load has decreased
+   * Resume workers (pure execution - no decision logic)
    */
   private static async resumeWorkers(
-    maxMutationCount: number,
+    queuesToResume: Set<QueueName>,
     mutationCounts: Map<string, number>,
   ): Promise<void> {
-    // Only resume if currently paused
-    if (!this.isPaused) {
-      return;
-    }
-
-    try {
-      const worker = WorkerManager.getWorker(QueueName.TraceDelete);
-      if (!worker) {
-        logger.warn("TraceDelete worker not found, cannot resume");
-        return;
+    for (const queueName of queuesToResume) {
+      // Skip if not paused (optimization)
+      if (!this.pausedQueues.has(queueName)) {
+        continue;
       }
 
-      await worker.resume();
-      this.isPaused = false;
+      try {
+        const worker = WorkerManager.getWorker(queueName);
+        if (!worker) {
+          logger.warn(`${queueName} worker not found, cannot resume`);
+          continue;
+        }
 
-      logger.info(
-        "Mutations below safe threshold, resuming TraceDelete workers",
-        {
+        await worker.resume();
+        this.pausedQueues.delete(queueName);
+
+        logger.info(`Resumed ${queueName}`, {
+          reason: "all tables below safe threshold",
           safeThreshold: env.LANGFUSE_DELETION_MUTATIONS_SAFE_COUNT,
-          maxMutationCount,
           mutationCounts: Object.fromEntries(mutationCounts),
-        },
-      );
-    } catch (error) {
-      logger.error("Error resuming TraceDelete workers", error);
+        });
+      } catch (error) {
+        logger.error(`Error resuming ${queueName}`, error);
+      }
     }
   }
 
   /**
-   * Get the current pause state (useful for testing)
+   * Get the paused queues (useful for testing)
    */
-  public static getIsPaused(): boolean {
-    return this.isPaused;
+  public static getPausedQueues(): Set<QueueName> {
+    return new Set(this.pausedQueues);
+  }
+
+  /**
+   * Check if a specific queue is paused (useful for testing)
+   */
+  public static isQueuePaused(queue: QueueName): boolean {
+    return this.pausedQueues.has(queue);
   }
 
   /**
    * Reset the state (useful for testing)
    */
   public static resetState(): void {
-    this.isPaused = false;
+    this.pausedQueues.clear();
     this.isRunning = false;
     if (this.timeoutId !== null) {
       clearTimeout(this.timeoutId);

--- a/worker/src/features/mutation-monitoring/mutationMonitor.ts
+++ b/worker/src/features/mutation-monitoring/mutationMonitor.ts
@@ -49,6 +49,7 @@ export class MutationMonitor {
       "observations",
       "scores",
     ],
+    [QueueName.BatchActionQueue]: ["traces", "observations", "scores"],
   };
 
   /**


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Expand `MutationMonitor` to manage multiple queues and tables, with new decision logic and comprehensive tests.
> 
>   - **Behavior**:
>     - `MutationMonitor` now handles multiple queues and tables, pausing/resuming based on mutation counts.
>     - Introduces `makeDecisions()` to determine queue actions based on thresholds.
>     - Updates `pauseWorkers()` and `resumeWorkers()` to handle multiple queues.
>   - **Tests**:
>     - Adds tests in `mutationMonitor.test.ts` for `makeDecisions()` covering various scenarios.
>     - Integration tests added to verify pause/resume logic with mocked ClickHouse data.
>   - **Misc**:
>     - Adds `getPausedQueues()` and `isQueuePaused()` for testing purposes.
>     - Logs contradictory decisions in `makeDecisions()` as errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d7f9951fa9d2322487f2adae9fdb6789b0a218c1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->