### PR TITLE
fix(trace-tree): Dynamic row heights for virtualized trace tree

### DIFF
--- a/web/src/components/trace/SpanItem.tsx
+++ b/web/src/components/trace/SpanItem.tsx
@@ -62,7 +62,9 @@ export const SpanItem: React.FC<SpanItemProps> = ({
   return (
     <div className={cn("flex min-w-0 flex-col", className)}>
       <div className="flex min-w-0 items-center gap-2 overflow-hidden">
-        <span className="flex-shrink truncate text-xs">{node.name}</span>
+        <span className="flex-shrink truncate text-xs">
+          {node.name || `Unnamed ${node.type.toLowerCase()}`}
+        </span>
 
         <div className="flex items-center gap-x-2">
           {comments && showComments ? (


### PR DESCRIPTION
## Summary
Implements dynamic row heights for the virtualized trace tree to fix layout issues where nodes with multiple metadata elements (scores, badges, costs) were clipped due to fixed 37px row heights.

## Problem
After virtualizing the trace tree for performance with 30K+ observations, production users reported:
1. **Empty node titles** - Some nodes showed no title/name, only metadata
2. **Content clipping** - Nodes with multiple metadata lines had content cut off
3. **Layout inflexibility** - When resizing trace-tree view, nodes didn't adjust height

**Root cause:** Fixed `estimateSize: () => 37` didn't accommodate variable content heights (37-100px+)

## Solution
Uses TanStack Virtual's hybrid approach:
1. **Smart `estimateSize` callback** - Calculates better initial estimates based on visible metadata (reduces layout shift)
2. **`measureElement`** - Measures actual rendered heights for accuracy
3. **Empty name fallback** - Shows "Unnamed {type}" instead of blank

## Changes

### TraceTree.tsx
- Added `estimateSize` callback that calculates dynamic height:
  - Base: 37px
  - Metrics line: +16px (if duration/cost/tokens visible)
  - Scores: +20px per line (estimates 3 scores per line, max 3 lines)
- Added `measureElement` for post-render measurement
- Updated row rendering:
  - Added `data-index={virtualRow.index}` (required)
  - Added `ref={rowVirtualizer.measureElement}` (required)
  - Removed fixed `height` style

### SpanItem.tsx
- Added fallback for empty names: `{node.name || \`Unnamed ${node.type.toLowerCase()}\`}`

## Benefits
- ✅ All metadata visible without clipping
- ✅ No visual overlap of nodes
- ✅ Better initial estimates reduce layout shift
- ✅ Automatic adjustment for variable content (wrapping, window resize, collapse/expand)
- ✅ Improved UX with meaningful fallback for unnamed observations

## Testing
- ✅ Linter passed
- ✅ TypeScript compilation successful
- ✅ Build completed successfully
- ✅ Code formatted with Prettier

## Related
- Fixes LFE-7779
- Customer reports: 
  - https://app.plain.com/workspace/w_01JRFXKJD7T2CNACCFAH299XT1/thread/th_01KAH1JQWE4VQJQ7C92HBE0JC7/
  - https://app.plain.com/workspace/w_01JRFXKJD7T2CNACCFAH299XT1/thread/th_01KAH2QSPTPNV13HCSX0AWHRRZ/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implements dynamic row heights in `TraceTree.tsx` and adds fallback for empty node names in `SpanItem.tsx` to fix layout issues.
> 
>   - **Behavior**:
>     - Implements dynamic row heights in `TraceTree.tsx` using `estimateSize` and `measureElement` to accommodate variable content heights.
>     - Adds fallback for empty node names in `SpanItem.tsx` to display `Unnamed {type}`.
>   - **TraceTree.tsx**:
>     - Adds `estimateSize` callback to calculate row height based on visible metadata.
>     - Uses `measureElement` for accurate post-render height measurement.
>     - Removes fixed `height` style from row rendering.
>   - **SpanItem.tsx**:
>     - Updates node name rendering to use fallback for empty names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b7d3ef35a7c5988cef7fa4b3f3cd139912945aae. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->