### PR TITLE
chore: accept additional clickhouse async insert settings

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -50,6 +50,9 @@ const EnvSchema = z.object({
   CLICKHOUSE_PASSWORD: z.string(),
   CLICKHOUSE_KEEP_ALIVE_IDLE_SOCKET_TTL: z.coerce.number().int().default(9000),
   CLICKHOUSE_MAX_OPEN_CONNECTIONS: z.coerce.number().int().default(25),
+  // Optional to allow for server-setting fallbacks
+  CLICKHOUSE_ASYNC_INSERT_MAX_DATA_SIZE: z.string().optional(),
+  CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MS: z.coerce.number().int().optional(),
 
   LANGFUSE_INGESTION_QUEUE_DELAY_MS: z.coerce
     .number()

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -108,6 +108,19 @@ export class ClickHouseClientManager {
         },
         max_open_connections: env.CLICKHOUSE_MAX_OPEN_CONNECTIONS,
         clickhouse_settings: {
+          // Overwrite async insert settings to tune throughput
+          ...(env.CLICKHOUSE_ASYNC_INSERT_MAX_DATA_SIZE
+            ? {
+                async_insert_max_data_size:
+                  env.CLICKHOUSE_ASYNC_INSERT_MAX_DATA_SIZE,
+              }
+            : {}),
+          ...(env.CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MS
+            ? {
+                async_insert_busy_timeout_ms:
+                  env.CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MS,
+              }
+            : {}),
           ...cloudOptions,
           ...opts.clickhouse_settings,
           async_insert: 1,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add optional Cloudflare async insert settings to environment and update ClickHouse client to use them if provided.
> 
>   - **Environment Variables**:
>     - Add `CLICKHOUSE_ASYNC_INSERT_MAX_DATA_SIZE` and `CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MS` as optional settings in `env.ts`.
>   - **ClickHouse Client**:
>     - Update `ClickHouseClientManager` in `client.ts` to use `CLICKHOUSE_ASYNC_INSERT_MAX_DATA_SIZE` and `CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MS` if provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6aebc8e04ff34f5c363bf1ef51bb806618b00fe3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->