### PR TITLE
perf: enable block columns on mergetree tables for more efficient deletes

### DIFF
--- a/packages/shared/clickhouse/migrations/clustered/0031_enable_block_columns.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0031_enable_block_columns.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE traces ON CLUSTER default RESET SETTING enable_block_number_column, enable_block_offset_column;
+ALTER TABLE observations ON CLUSTER default RESET SETTING enable_block_number_column, enable_block_offset_column;
+ALTER TABLE scores ON CLUSTER default RESET SETTING enable_block_number_column, enable_block_offset_column;
+ALTER TABLE dataset_run_items_rmt ON CLUSTER default RESET SETTING enable_block_number_column, enable_block_offset_column;

--- a/packages/shared/clickhouse/migrations/clustered/0031_enable_block_columns.down.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0031_enable_block_columns.down.sql
@@ -2,3 +2,4 @@ ALTER TABLE traces ON CLUSTER default RESET SETTING enable_block_number_column, 
 ALTER TABLE observations ON CLUSTER default RESET SETTING enable_block_number_column, enable_block_offset_column;
 ALTER TABLE scores ON CLUSTER default RESET SETTING enable_block_number_column, enable_block_offset_column;
 ALTER TABLE dataset_run_items_rmt ON CLUSTER default RESET SETTING enable_block_number_column, enable_block_offset_column;
+ALTER TABLE blob_storage_file_log ON CLUSTER default RESET SETTING enable_block_number_column, enable_block_offset_column;

--- a/packages/shared/clickhouse/migrations/clustered/0031_enable_block_columns.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0031_enable_block_columns.up.sql
@@ -2,3 +2,4 @@ ALTER TABLE traces ON CLUSTER default MODIFY SETTING enable_block_number_column 
 ALTER TABLE observations ON CLUSTER default MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;
 ALTER TABLE scores ON CLUSTER default MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;
 ALTER TABLE dataset_run_items_rmt ON CLUSTER default MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;
+ALTER TABLE blob_storage_file_log ON CLUSTER default MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;

--- a/packages/shared/clickhouse/migrations/clustered/0031_enable_block_columns.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0031_enable_block_columns.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE traces ON CLUSTER default MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;
+ALTER TABLE observations ON CLUSTER default MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;
+ALTER TABLE scores ON CLUSTER default MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;
+ALTER TABLE dataset_run_items_rmt ON CLUSTER default MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;

--- a/packages/shared/clickhouse/migrations/unclustered/0031_enable_block_columns.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0031_enable_block_columns.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE traces RESET SETTING enable_block_number_column, enable_block_offset_column;
+ALTER TABLE observations RESET SETTING enable_block_number_column, enable_block_offset_column;
+ALTER TABLE scores RESET SETTING enable_block_number_column, enable_block_offset_column;
+ALTER TABLE dataset_run_items_rmt RESET SETTING enable_block_number_column, enable_block_offset_column;

--- a/packages/shared/clickhouse/migrations/unclustered/0031_enable_block_columns.down.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0031_enable_block_columns.down.sql
@@ -2,3 +2,4 @@ ALTER TABLE traces RESET SETTING enable_block_number_column, enable_block_offset
 ALTER TABLE observations RESET SETTING enable_block_number_column, enable_block_offset_column;
 ALTER TABLE scores RESET SETTING enable_block_number_column, enable_block_offset_column;
 ALTER TABLE dataset_run_items_rmt RESET SETTING enable_block_number_column, enable_block_offset_column;
+ALTER TABLE blob_storage_file_log RESET SETTING enable_block_number_column, enable_block_offset_column;

--- a/packages/shared/clickhouse/migrations/unclustered/0031_enable_block_columns.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0031_enable_block_columns.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE traces MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;
+ALTER TABLE observations MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;
+ALTER TABLE scores MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;
+ALTER TABLE dataset_run_items_rmt MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;

--- a/packages/shared/clickhouse/migrations/unclustered/0031_enable_block_columns.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0031_enable_block_columns.up.sql
@@ -2,3 +2,4 @@ ALTER TABLE traces MODIFY SETTING enable_block_number_column = 1, enable_block_o
 ALTER TABLE observations MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;
 ALTER TABLE scores MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;
 ALTER TABLE dataset_run_items_rmt MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;
+ALTER TABLE blob_storage_file_log MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add ClickHouse migration scripts to enable block columns for efficient deletes on specific tables.
> 
>   - **Migrations**:
>     - Add `0031_enable_block_columns.up.sql` and `0031_enable_block_columns.down.sql` for both clustered and unclustered migrations.
>     - Enable `enable_block_number_column` and `enable_block_offset_column` for `traces`, `observations`, `scores`, `dataset_run_items_rmt`, and `blob_storage_file_log` tables.
>     - Reset these settings in the corresponding down migration scripts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d7d1258ed6bcff14acdf01a08b3866784e0d41f5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->