### PR TITLE
perf: allow setting clickhouse lightweight delete mode (ch >25.5)

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -53,6 +53,9 @@ const EnvSchema = z.object({
   // Optional to allow for server-setting fallbacks
   CLICKHOUSE_ASYNC_INSERT_MAX_DATA_SIZE: z.string().optional(),
   CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MS: z.coerce.number().int().optional(),
+  CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE: z
+    .enum(["alter_update", "lightweight_update", "lightweight_update_force"])
+    .default("alter_update"),
 
   LANGFUSE_INGESTION_QUEUE_DELAY_MS: z.coerce
     .number()

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -121,6 +121,11 @@ export class ClickHouseClientManager {
                   env.CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MS,
               }
             : {}),
+          ...(env.CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE !== "alter_update"
+            ? {
+                lightweight_delete_mode: env.CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE,
+              }
+            : {}),
           ...cloudOptions,
           ...opts.clickhouse_settings,
           async_insert: 1,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE` to control ClickHouse delete mode for performance optimization.
> 
>   - **Environment**:
>     - Adds `CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE` to `EnvSchema` in `env.ts` with options `"alter_update"`, `"lightweight_update"`, and `"lightweight_update_force"`, defaulting to `"alter_update"`.
>   - **ClickHouse Client**:
>     - In `client.ts`, `ClickHouseClientManager` now includes `lightweight_delete_mode` in client settings if `CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE` is not `"alter_update"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d2ccd0cfa1a7a3bc7884d275c92e276c94165b0d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->