### PR TITLE
fix(dataset-compare): invert diff badge colors for cost and latency

### DIFF
--- a/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
+++ b/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
@@ -209,6 +209,7 @@ const DatasetAggregateCellContent = ({
                   diff={latencyDiff}
                   formatValue={(value) => formatIntervalSeconds(value)}
                   className="ml-1"
+                  invertColors={true}
                 />
               ) : (
                 <Badge variant="tertiary" size="sm" className="font-normal">
@@ -224,6 +225,7 @@ const DatasetAggregateCellContent = ({
                   diff={totalCostDiff}
                   formatValue={(value) => usdFormatter(value, 2, 4)}
                   className="ml-1"
+                  invertColors={true}
                 />
               ) : (
                 <Badge variant="tertiary" size="sm" className="font-normal">

--- a/web/src/features/datasets/components/DiffLabel.tsx
+++ b/web/src/features/datasets/components/DiffLabel.tsx
@@ -13,16 +13,26 @@ export function DiffLabel({
   diff,
   formatValue,
   className,
+  invertColors,
 }: {
   diff: NumericDiff | CategoricalDiff;
   formatValue: (value: number) => string;
   className?: string;
+  invertColors?: boolean;
 }) {
   if (diff.type === "NUMERIC") {
+    let variant: "success" | "error";
+    if (invertColors) {
+      // Lower is better (cost/latency)
+      variant = diff.direction === "+" ? "error" : "success";
+    } else {
+      // Higher is better (scores)
+      variant = diff.direction === "+" ? "success" : "error";
+    }
     return (
       <Badge
         size="sm"
-        variant={diff.direction === "+" ? "success" : "error"}
+        variant={variant}
         className={cn("font-semibold", className)}
       >
         {diff.direction}


### PR DESCRIPTION
## What does this PR do?

PR #10155 added a diff view for dataset comparisons, but a lower cost and lower latency (both "good") show up with a red color. It's more intuitive for the user if **direction (to determine badge colors) for latency and cost are inverted from the direction of scores** (higher score = better).

See picture of the change (higher score = green, lower cost or latency = green):
<img width="824" height="351" alt="image" src="https://github.com/user-attachments/assets/97356ef8-3e07-4c41-9d70-26f6cb25660a" />

Fixes [#10627](https://github.com/langfuse/langfuse/issues/10627)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Inverts color logic for cost and latency diffs in dataset comparison to show lower values as green, fixing issue #10627.
> 
>   - **Behavior**:
>     - In `DatasetAggregateTableCell.tsx`, `invertColors` set to `true` for `DiffLabel` components handling `latencyDiff` and `totalCostDiff`.
>     - In `DiffLabel.tsx`, added `invertColors` prop to invert color logic for numeric diffs, making lower values green for cost and latency.
>   - **Misc**:
>     - Fixes issue #10627 where lower cost and latency were incorrectly shown as red.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 29d9f2f68345d6798db1d3f79dd386de70ec03da. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->