### PR TITLE
fix(ui): version number spacing

### DIFF
--- a/web/src/components/VersionLabel.tsx
+++ b/web/src/components/VersionLabel.tsx
@@ -86,7 +86,7 @@ export const VersionLabel = ({ className }: { className?: string }) => {
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" size="xs" className={cn("text-xs", className)}>
           {VERSION}
-          {selfHostedPlanLabel ? ` ${selfHostedPlanLabel.short}` : null}
+          {selfHostedPlanLabel ? <> {selfHostedPlanLabel.short}</> : null}
           {showBackgroundMigrationStatus && (
             <StatusBadge
               type={backgroundMigrationStatus.data?.status.toLowerCase()}

--- a/web/src/components/VersionLabel.tsx
+++ b/web/src/components/VersionLabel.tsx
@@ -84,7 +84,11 @@ export const VersionLabel = ({ className }: { className?: string }) => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="xs" className={cn("text-xs", className)}>
+        <Button
+          variant="ghost"
+          size="xs"
+          className={cn("text-[0.625rem]", className)}
+        >
           {VERSION}
           {selfHostedPlanLabel ? <> {selfHostedPlanLabel.short}</> : null}
           {showBackgroundMigrationStatus && (

--- a/web/src/components/VersionLabel.tsx
+++ b/web/src/components/VersionLabel.tsx
@@ -87,7 +87,7 @@ export const VersionLabel = ({ className }: { className?: string }) => {
         <Button
           variant="ghost"
           size="xs"
-          className={cn("text-[0.625rem]", className)}
+          className={cn("mt-[0.1px] text-[0.625rem]", className)}
         >
           {VERSION}
           {selfHostedPlanLabel ? <> {selfHostedPlanLabel.short}</> : null}


### PR DESCRIPTION
## What does this PR do?

Fixes the visual bug where the Langfuse version number and plan label were displayed without a space (e.g., "v3.133.0OSS"). The change ensures proper spacing by using a React fragment with an explicit space character in `VersionLabel.tsx`.

Fixes # LFE-7801

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-7801](https://linear.app/langfuse/issue/LFE-7801/bug-version-number-shown-without-spacing-in-the-ui)

<a href="https://cursor.com/background-agent?bcId=bc-770786cd-77f1-43ce-806f-19d2ba3e8507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-770786cd-77f1-43ce-806f-19d2ba3e8507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes spacing issue in `VersionLabel.tsx` by adding a React fragment with a space between version number and plan label.
> 
>   - **UI Fix**:
>     - In `VersionLabel.tsx`, adds a React fragment with a space between `VERSION` and `selfHostedPlanLabel.short` to fix spacing issue in version number display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 299be7f5b4376854f906f22480bb508955ce295d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->