### PR TITLE
feat: add extra TLS options for Redis configuration

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -22,6 +22,13 @@ const EnvSchema = z.object({
   REDIS_TLS_CA_PATH: z.string().optional(),
   REDIS_TLS_CERT_PATH: z.string().optional(),
   REDIS_TLS_KEY_PATH: z.string().optional(),
+  REDIS_TLS_SERVERNAME: z.string().optional(),
+  REDIS_TLS_REJECT_UNAUTHORIZED: z.enum(["true", "false"]).optional(),
+  REDIS_TLS_CHECK_SERVER_IDENTITY: z.enum(["true", "false"]).optional(),
+  REDIS_TLS_SECURE_PROTOCOL: z.string().optional(),
+  REDIS_TLS_CIPHERS: z.string().optional(),
+  REDIS_TLS_HONOR_CIPHER_ORDER: z.enum(["true", "false"]).optional(),
+  REDIS_TLS_KEY_PASSPHRASE: z.string().optional(),
   REDIS_ENABLE_AUTO_PIPELINING: z.enum(["true", "false"]).default("true"),
   // Redis Cluster Configuration
   REDIS_CLUSTER_ENABLED: z.enum(["true", "false"]).default("false"),

--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -72,6 +72,32 @@ const createRedisClusterInstance = (
             key: env.REDIS_TLS_KEY_PATH
               ? fs.readFileSync(env.REDIS_TLS_KEY_PATH)
               : undefined,
+            ...(env.REDIS_TLS_REJECT_UNAUTHORIZED
+              ? {
+                  rejectUnauthorized:
+                    env.REDIS_TLS_REJECT_UNAUTHORIZED !== "false",
+                }
+              : {}),
+            ...(env.REDIS_TLS_SERVERNAME
+              ? { servername: env.REDIS_TLS_SERVERNAME }
+              : {}),
+            ...(env.REDIS_TLS_CHECK_SERVER_IDENTITY === "false"
+              ? { checkServerIdentity: () => undefined }
+              : {}),
+            ...(env.REDIS_TLS_SECURE_PROTOCOL
+              ? { secureProtocol: env.REDIS_TLS_SECURE_PROTOCOL }
+              : {}),
+            ...(env.REDIS_TLS_CIPHERS
+              ? { ciphers: env.REDIS_TLS_CIPHERS }
+              : {}),
+            ...(env.REDIS_TLS_HONOR_CIPHER_ORDER
+              ? {
+                  honorCipherOrder: env.REDIS_TLS_HONOR_CIPHER_ORDER === "true",
+                }
+              : {}),
+            ...(env.REDIS_TLS_KEY_PASSPHRASE
+              ? { passphrase: env.REDIS_TLS_KEY_PASSPHRASE }
+              : {}),
           },
         }
       : {};
@@ -133,6 +159,32 @@ const createRedisSentinelInstance = (
             key: env.REDIS_TLS_KEY_PATH
               ? fs.readFileSync(env.REDIS_TLS_KEY_PATH)
               : undefined,
+            ...(env.REDIS_TLS_REJECT_UNAUTHORIZED
+              ? {
+                  rejectUnauthorized:
+                    env.REDIS_TLS_REJECT_UNAUTHORIZED !== "false",
+                }
+              : {}),
+            ...(env.REDIS_TLS_SERVERNAME
+              ? { servername: env.REDIS_TLS_SERVERNAME }
+              : {}),
+            ...(env.REDIS_TLS_CHECK_SERVER_IDENTITY === "false"
+              ? { checkServerIdentity: () => undefined }
+              : {}),
+            ...(env.REDIS_TLS_SECURE_PROTOCOL
+              ? { secureProtocol: env.REDIS_TLS_SECURE_PROTOCOL }
+              : {}),
+            ...(env.REDIS_TLS_CIPHERS
+              ? { ciphers: env.REDIS_TLS_CIPHERS }
+              : {}),
+            ...(env.REDIS_TLS_HONOR_CIPHER_ORDER
+              ? {
+                  honorCipherOrder: env.REDIS_TLS_HONOR_CIPHER_ORDER === "true",
+                }
+              : {}),
+            ...(env.REDIS_TLS_KEY_PASSPHRASE
+              ? { passphrase: env.REDIS_TLS_KEY_PASSPHRASE }
+              : {}),
           },
         }
       : {};
@@ -190,6 +242,32 @@ export const createNewRedisInstance = (
             key: env.REDIS_TLS_KEY_PATH
               ? fs.readFileSync(env.REDIS_TLS_KEY_PATH)
               : undefined,
+            ...(env.REDIS_TLS_REJECT_UNAUTHORIZED
+              ? {
+                  rejectUnauthorized:
+                    env.REDIS_TLS_REJECT_UNAUTHORIZED !== "false",
+                }
+              : {}),
+            ...(env.REDIS_TLS_SERVERNAME
+              ? { servername: env.REDIS_TLS_SERVERNAME }
+              : {}),
+            ...(env.REDIS_TLS_CHECK_SERVER_IDENTITY === "false"
+              ? { checkServerIdentity: () => undefined }
+              : {}),
+            ...(env.REDIS_TLS_SECURE_PROTOCOL
+              ? { secureProtocol: env.REDIS_TLS_SECURE_PROTOCOL }
+              : {}),
+            ...(env.REDIS_TLS_CIPHERS
+              ? { ciphers: env.REDIS_TLS_CIPHERS }
+              : {}),
+            ...(env.REDIS_TLS_HONOR_CIPHER_ORDER
+              ? {
+                  honorCipherOrder: env.REDIS_TLS_HONOR_CIPHER_ORDER === "true",
+                }
+              : {}),
+            ...(env.REDIS_TLS_KEY_PASSPHRASE
+              ? { passphrase: env.REDIS_TLS_KEY_PASSPHRASE }
+              : {}),
           },
         }
       : {};


### PR DESCRIPTION
## Summary
Adds support for additional TLS configuration options for Redis to enable proper certificate validation in enterprise environments with custom CA certificates and specific TLS requirements.

## Changes
This PR adds 7 new optional environment variables for Redis TLS configuration:

- **`REDIS_TLS_SERVERNAME`** - Server name for SNI (Server Name Indication)
- **`REDIS_TLS_REJECT_UNAUTHORIZED`** - Certificate validation control (defaults to secure)
- **`REDIS_TLS_CHECK_SERVER_IDENTITY`** - Custom server identity checking bypass
- **`REDIS_TLS_SECURE_PROTOCOL`** - TLS protocol version specification
- **`REDIS_TLS_CIPHERS`** - Cipher suite configuration
- **`REDIS_TLS_HONOR_CIPHER_ORDER`** - Cipher order preference
- **`REDIS_TLS_KEY_PASSPHRASE`** - Support for encrypted private keys

### Implementation Details
- Updated `packages/shared/src/env.ts` with new Zod schema definitions
- Updated TLS configuration in `packages/shared/src/server/redis/redis.ts` for all three Redis modes:
  - Redis Cluster
  - Redis Sentinel
  - Standard Redis
- Used spread operator pattern to conditionally add options only when environment variables are set
- Preserves Node.js TLS defaults when options are not configured

### Example Configuration
```bash
REDIS_TLS_ENABLED=true
REDIS_TLS_CA_PATH=/app/ca/cacertbundle.pem
REDIS_TLS_CERT_PATH=/app/redis-certs/tls.crt
REDIS_TLS_KEY_PATH=/app/redis-certs/tls.key
REDIS_TLS_SERVERNAME=redis.example.com
REDIS_TLS_REJECT_UNAUTHORIZED=true
```

## Benefits
✅ Solves enterprise CA certificate validation issues
✅ Eliminates need for `NODE_TLS_REJECT_UNAUTHORIZED=0` global workaround
✅ Enables proper SNI with `servername` option
✅ Maintains security compliance
✅ 100% backward compatible - all options are optional

## Risk Assessment
- **Low Risk**: All changes are backward compatible
- **Secure Defaults**: Options only applied when explicitly configured
- **No Breaking Changes**: Existing deployments continue to work unchanged

Fixes #10594

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds new optional TLS configuration options for Redis to enhance security and flexibility in enterprise environments.
> 
>   - **Behavior**:
>     - Adds 7 new optional environment variables for Redis TLS configuration: `REDIS_TLS_SERVERNAME`, `REDIS_TLS_REJECT_UNAUTHORIZED`, `REDIS_TLS_CHECK_SERVER_IDENTITY`, `REDIS_TLS_SECURE_PROTOCOL`, `REDIS_TLS_CIPHERS`, `REDIS_TLS_HONOR_CIPHER_ORDER`, `REDIS_TLS_KEY_PASSPHRASE`.
>     - Updates TLS configuration in `redis.ts` for Redis Cluster, Sentinel, and Standard modes using `buildTlsOptions()`.
>     - Uses spread operator to conditionally add TLS options when environment variables are set.
>   - **Implementation**:
>     - Updates `env.ts` with new Zod schema definitions for the added environment variables.
>     - Refactors `redis.ts` to use `buildTlsOptions()` for TLS configuration.
>   - **Benefits**:
>     - Solves enterprise CA certificate validation issues.
>     - Eliminates need for `NODE_TLS_REJECT_UNAUTHORIZED=0` workaround.
>     - Maintains security compliance and is 100% backward compatible.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 82667efa75e23203a4558cd9b02d2f5f3b91b127. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->