### PR TITLE
fix(ui): fix CommandInput icon overlap and add bottom border variant for popovers

### DIFF
--- a/web/src/components/table/key-value-filter-builder.tsx
+++ b/web/src/components/table/key-value-filter-builder.tsx
@@ -218,7 +218,10 @@ export function KeyValueFilterBuilder(props: KeyValueFilterBuilderProps) {
                   </PopoverTrigger>
                   <PopoverContent className="w-[200px] p-0" align="start">
                     <InputCommand>
-                      <InputCommandInput placeholder="Search keys..." />
+                      <InputCommandInput
+                        placeholder="Search keys..."
+                        variant="bottom"
+                      />
                       <InputCommandList>
                         <InputCommandEmpty>No keys found.</InputCommandEmpty>
                         <InputCommandGroup>

--- a/web/src/components/ui/command.tsx
+++ b/web/src/components/ui/command.tsx
@@ -74,7 +74,7 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "flex h-8 w-full rounded-md bg-transparent px-6 py-3 text-sm outline-none placeholder:text-muted-foreground focus:outline-none focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-8 w-full rounded-md bg-transparent py-3 pl-6 pr-6 text-sm outline-none placeholder:text-muted-foreground focus:outline-none focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}

--- a/web/src/features/dashboard/components/ModelSelector.tsx
+++ b/web/src/features/dashboard/components/ModelSelector.tsx
@@ -51,7 +51,7 @@ export const ModelSelectorPopover = ({
       </PopoverTrigger>
       <PopoverContent className="w-56 p-0">
         <InputCommand>
-          <InputCommandInput placeholder="Search models..." />
+          <InputCommandInput placeholder="Search models..." variant="bottom" />
           <InputCommandEmpty>No model found.</InputCommandEmpty>
           <InputCommandGroup>
             <InputCommandItem onSelect={handleSelectAll}>

--- a/web/src/features/datasets/components/NewDatasetItemForm.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemForm.tsx
@@ -299,7 +299,10 @@ export const NewDatasetItemForm = (props: {
                     </PopoverTrigger>
                     <PopoverContent className="p-0">
                       <InputCommand>
-                        <InputCommandInput placeholder="Search datasets..." />
+                        <InputCommandInput
+                          placeholder="Search datasets..."
+                          variant="bottom"
+                        />
                         <InputCommandEmpty>
                           No datasets found.
                         </InputCommandEmpty>

--- a/web/src/features/evals/components/template-selector.tsx
+++ b/web/src/features/evals/components/template-selector.tsx
@@ -171,6 +171,7 @@ export const TemplateSelector = ({
               className="h-9"
               value={search}
               onValueChange={setSearch}
+              variant="bottom"
             />
             <div
               tabIndex={0}

--- a/web/src/features/experiments/components/steps/PromptModelStep.tsx
+++ b/web/src/features/experiments/components/steps/PromptModelStep.tsx
@@ -129,6 +129,7 @@ export const PromptModelStep: React.FC<PromptModelStepProps> = ({
                     <InputCommandInput
                       placeholder="Search prompts..."
                       className="h-9"
+                      variant="bottom"
                     />
                     <InputCommandList>
                       <InputCommandEmpty>No prompt found.</InputCommandEmpty>
@@ -299,6 +300,7 @@ export const PromptModelStep: React.FC<PromptModelStepProps> = ({
                           <InputCommandInput
                             placeholder="Search schemas..."
                             className="h-9"
+                            variant="bottom"
                           />
                           <InputCommandList>
                             <InputCommandEmpty>

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -524,7 +524,7 @@ function FilterBuilderForm({
                           <InputCommand>
                             <InputCommandInput
                               placeholder="Search for column"
-                              onFocus={(e) => (e.target.style.border = "none")}
+                              variant="bottom"
                             />
                             <InputCommandList>
                               <InputCommandEmpty>

--- a/web/src/features/filters/components/multi-select.tsx
+++ b/web/src/features/filters/components/multi-select.tsx
@@ -172,7 +172,7 @@ export function MultiSelect({
       </PopoverTrigger>
       <PopoverContent className="w-[200px] p-0" align="center">
         <InputCommand>
-          <InputCommandInput placeholder={title} />
+          <InputCommandInput placeholder={title} variant="bottom" />
           <InputCommandList>
             {/* if isCustomSelectEnabled we always show custom select hence never empty */}
             {!isCustomSelectEnabled && (

--- a/web/src/features/playground/page/components/PlaygroundTools/index.tsx
+++ b/web/src/features/playground/page/components/PlaygroundTools/index.tsx
@@ -79,7 +79,7 @@ export const PlaygroundToolsPopover = () => {
     <Command className="flex flex-col">
       <CommandInput
         placeholder="Search tools..."
-        className="h-8 border-none p-1 focus:ring-0 focus:ring-offset-0"
+        className="h-8 border-none py-1 pl-6 pr-1 focus:ring-0 focus:ring-offset-0"
       />
       <CommandList className="max-h-[300px] overflow-y-auto">
         <CommandEmpty>No tools found.</CommandEmpty>

--- a/web/src/features/playground/page/components/SaveToPromptButton.tsx
+++ b/web/src/features/playground/page/components/SaveToPromptButton.tsx
@@ -128,7 +128,10 @@ export const SaveToPromptButton: React.FC<SaveToPromptButtonProps> = ({
           </Button>
           <Divider />
           <InputCommand className="min-h-[8rem]">
-            <InputCommandInput placeholder="Search chat prompts..." />
+            <InputCommandInput
+              placeholder="Search chat prompts..."
+              variant="bottom"
+            />
             <InputCommandEmpty>
               No chat prompt found
               <DocPopup description="Prompts from the playground can only be saved to 'chat' prompts as they include multiple system/user messages." />

--- a/web/src/features/playground/page/components/StructuredOutputSchemaSection.tsx
+++ b/web/src/features/playground/page/components/StructuredOutputSchemaSection.tsx
@@ -94,7 +94,7 @@ export const StructuredOutputSchemaPopover = () => {
     <Command className="flex flex-col">
       <CommandInput
         placeholder="Search schemas..."
-        className="h-8 border-none p-1 focus:ring-0 focus:ring-offset-0"
+        className="h-8 border-none py-1 pl-6 pr-1 focus:ring-0 focus:ring-offset-0"
       />
       <CommandList className="max-h-[300px] overflow-y-auto">
         <CommandEmpty>No schemas found.</CommandEmpty>


### PR DESCRIPTION
## Description

This PR fixes the icon overlap issue in CommandInput components and adds consistent bottom-border-only styling for all popover inputs.

## Changes

- Fix icon overlap in CommandInput by changing `px-6` to `pl-6 pr-6` to ensure proper left padding for the search icon
- Add `variant='bottom'` to all InputCommandInput components rendered inside PopoverContent for consistent styling
- Update PlaygroundTools and StructuredOutputSchemaSection to maintain left padding when custom className is provided
- Ensure all popover inputs have bottom-border-only styling instead of full borders

## Testing

Tested on:
- ✅ Playground page (Tools and Schema dropdowns)
- ✅ Dashboard page (Filters and Model Selector)
- ✅ Traces page (Filter sidebar)
- ✅ Datasets page (New dataset item form)
- ✅ Evals pages (Template and evaluator selectors)
- ✅ Experiments page (Prompt and schema selectors)

## Related Issue

Fixes #10609
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix icon overlap in `CommandInput` and add consistent bottom-border styling for popover inputs across components.
> 
>   - **Behavior**:
>     - Fix icon overlap in `CommandInput` by changing `px-6` to `pl-6 pr-6` for proper padding.
>     - Add `variant='bottom'` to `InputCommandInput` in `key-value-filter-builder.tsx`, `ModelSelector.tsx`, and `NewDatasetItemForm.tsx` for consistent bottom-border styling.
>   - **Components**:
>     - Update `PlaygroundTools` and `StructuredOutputSchemaSection` to maintain left padding when custom `className` is provided.
>     - Ensure all popover inputs have bottom-border-only styling instead of full borders.
>   - **Testing**:
>     - Verified on Playground, Dashboard, Traces, Datasets, Evals, and Experiments pages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d068d694ff94c86c312f9c8f9229d229e9afe36b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->