### PR TITLE
fix(trace): prevent visible scroll animation on initial load (S6.6)

### DIFF
--- a/web/src/components/trace2/components/_shared/VirtualizedTree.tsx
+++ b/web/src/components/trace2/components/_shared/VirtualizedTree.tsx
@@ -80,9 +80,12 @@ export function VirtualizedTree<T extends { id: string; children: T[] }>({
       );
 
       if (index !== -1) {
+        // Use behavior: "auto" for instant scroll on initial load to prevent
+        // visible scroll animation after page render. The synchronous scroll
+        // completes within useLayoutEffect, before browser paint.
         rowVirtualizer.scrollToIndex(index, {
           align: "center",
-          behavior: "smooth",
+          behavior: "auto",
         });
         hasScrolledRef.current = true;
       }


### PR DESCRIPTION
## Problem
When loading a page with `?observation=<id>` in the URL or switching between tree/timeline views, users experienced a jarring **visible animated scroll** that occurred AFTER the page had already rendered. This created a "page loads, then jumps to scroll" effect.

**Example URL:**
```
http://localhost:3000/project/.../traces2/...?observation=08f48611f156f4e0&view=timeline
```

## Root Cause
The scroll implementation used `behavior: "smooth"`, which schedules an **asynchronous animation** that runs after browser paint, even when called within `useLayoutEffect`. This caused the scroll animation to be visible to users.

## Solution

### Change 1: VirtualizedTree (Tree View)
- Changed scroll behavior from `"smooth"` to `"auto"`
- Added documentation comment explaining the choice
- Scroll now completes **synchronously** within `useLayoutEffect`, before paint

### Change 2: TraceTimeline (Timeline View)  
- **Added missing auto-scroll logic** (was completely absent before)
- Mirrors the implementation from VirtualizedTree
- Uses `behavior: "auto"` for instant scroll
- Guards prevent multiple scrolls on initial load

## Result
- ✅ Selected observation is **instantly visible and centered** when page loads
- ✅ **No visible scroll animation** on initial render
- ✅ Works for both **tree and timeline** views
- ✅ Smooth, polished user experience

## Technical Details
The key insight: `behavior: "auto"` makes the scroll **synchronous**, so it completes within the layout effect before browser paint. Users never see the scroll happen.

## Testing
- [x] Build passes with no TypeScript errors
- [ ] Manual testing needed:
  - Load URL with `?observation=<id>` → Observation instantly centered
  - Switch tree ↔ timeline views → Selected item stays centered
  - Verify no visible scroll animation on page load

## Related
- Documented in `.refactor/S6.6-scroll-timing-fix.md`
- Part of LFE-7762 refactor
- Base branch: `michael/LFE-7762`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix visible scroll animation on initial load by changing scroll behavior to 'auto' in `VirtualizedTree` and `TraceTimeline`.
> 
>   - **Behavior**:
>     - Change scroll behavior from `"smooth"` to `"auto"` in `VirtualizedTree` and `TraceTimeline` to prevent visible scroll animation.
>     - Add missing auto-scroll logic to `TraceTimeline` for URL-based navigation.
>   - **Implementation**:
>     - Use `useLayoutEffect` to ensure scroll completes synchronously before paint in both components.
>     - Guard against multiple scrolls on initial load in `TraceTimeline`.
>   - **Result**:
>     - Selected observation is instantly visible and centered on page load.
>     - No visible scroll animation on initial render for both tree and timeline views.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d2dfd150047fae627fd8ab70ca6eda81ad72f3d7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->