### PR TITLE
fix(ui): enable text selection in formatted view value column

### DIFF
--- a/web/src/components/table/ValueCell.tsx
+++ b/web/src/components/table/ValueCell.tsx
@@ -277,7 +277,7 @@ export const ValueCell = memo(
 
     return (
       <div className={`${MONO_TEXT_CLASSES} group relative max-w-full`}>
-        {content}
+        <span className="cursor-text">{content}</span>
         {needsTruncation && !row.original.hasChildren && (
           <div
             className="inline cursor-pointer opacity-50"
@@ -296,7 +296,7 @@ export const ValueCell = memo(
         <Button
           variant="ghost"
           size="icon"
-          className="absolute right-0 top-1/2 h-5 w-5 -translate-y-1/2 border bg-background/80 p-0.5 opacity-0 shadow-sm transition-opacity duration-200 hover:bg-background group-hover:opacity-100"
+          className="absolute right-0 top-0 h-5 w-5 border bg-background/80 p-0.5 opacity-0 shadow-sm transition-opacity duration-200 hover:bg-background group-hover:opacity-100"
           onClick={handleCopy}
           title="Copy value"
           aria-label="Copy cell value"

--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -648,23 +648,7 @@ function JsonPrettyTable({
                   : undefined
               }
               data-observation-id={row.id}
-              onClick={() =>
-                handleRowExpansion(
-                  row,
-                  onLazyLoadChildren,
-                  expandedCells,
-                  toggleCellExpansion,
-                )
-              }
               className={cn(
-                row.original.hasChildren ||
-                  (!row.original.hasChildren &&
-                    row.original.type !== "array" &&
-                    row.original.type !== "object" &&
-                    getValueStringLength(row.original.value) >
-                      MAX_CELL_DISPLAY_CHARS)
-                  ? "cursor-pointer"
-                  : "",
                 row.original.level === 0 && stickyTopLevelKey
                   ? "sticky z-10 bg-background shadow-sm"
                   : "",

--- a/web/src/hooks/useClickWithoutSelection.ts
+++ b/web/src/hooks/useClickWithoutSelection.ts
@@ -1,0 +1,119 @@
+import { useRef, useCallback, type MouseEvent } from "react";
+
+interface UseClickWithoutSelectionOptions {
+  /**
+   * Callback to execute when a click is detected (not a text selection drag)
+   */
+  onClick: (event: MouseEvent) => void;
+
+  /**
+   * Distance threshold in pixels to distinguish click from drag
+   * @default 5
+   */
+  dragThreshold?: number;
+
+  /**
+   * Whether the hook is enabled
+   * @default true
+   */
+  enabled?: boolean;
+}
+
+interface UseClickWithoutSelectionReturn {
+  /**
+   * Props to spread onto the element
+   */
+  props: {
+    onMouseDown: (e: MouseEvent) => void;
+    onClick: (e: MouseEvent) => void;
+  };
+}
+
+/**
+ * Hook to distinguish between clicks and text selection drags.
+ * Returns props to spread onto an element that should be clickable
+ * but also allow text selection within it.
+ *
+ * Uses two detection mechanisms:
+ * 1. Position-based: Tracks mouse movement between mousedown and click
+ * 2. Selection API: Checks if text was selected within the element
+ *
+ * @example
+ * ```tsx
+ * const { props } = useClickWithoutSelection({
+ *   onClick: () => handleExpand(),
+ * });
+ *
+ * return <div {...props}>Clickable content with selectable text</div>
+ * ```
+ */
+export function useClickWithoutSelection({
+  onClick,
+  dragThreshold = 5,
+  enabled = true,
+}: UseClickWithoutSelectionOptions): UseClickWithoutSelectionReturn {
+  const mouseDownPosRef = useRef<{ x: number; y: number } | null>(null);
+
+  const handleMouseDown = useCallback(
+    (e: MouseEvent) => {
+      if (!enabled) return;
+
+      // Only track left mouse button
+      if (e.button === 0) {
+        mouseDownPosRef.current = { x: e.clientX, y: e.clientY };
+      }
+    },
+    [enabled],
+  );
+
+  const handleClick = useCallback(
+    (e: MouseEvent) => {
+      if (!enabled) {
+        onClick(e);
+        return;
+      }
+
+      // Check 1: Position-based drag detection
+      let wasDrag = false;
+      if (mouseDownPosRef.current) {
+        const dx = e.clientX - mouseDownPosRef.current.x;
+        const dy = e.clientY - mouseDownPosRef.current.y;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        wasDrag = distance > dragThreshold;
+        mouseDownPosRef.current = null;
+      }
+
+      if (wasDrag) {
+        return; // Mouse moved significantly - was a selection drag
+      }
+
+      // Check 2: Selection API detection
+      const selection = window.getSelection();
+      if (selection && selection.toString().length > 0) {
+        try {
+          const range = selection.getRangeAt(0);
+          const targetElement = e.currentTarget as HTMLElement;
+
+          // Only ignore click if selection is within this element
+          if (targetElement.contains(range.commonAncestorContainer)) {
+            return; // User just selected text in this element
+          }
+        } catch {
+          // getRangeAt can throw if no range exists
+          // Fall through to onClick
+        }
+      }
+
+      // Passed all checks - this was a genuine click
+      onClick(e);
+    },
+    [enabled, onClick, dragThreshold],
+  );
+
+  return {
+    props: {
+      onMouseDown: handleMouseDown,
+      onClick: handleClick,
+    },
+  };
+}


### PR DESCRIPTION
## Description

Fixes text selection issue in the formatted view where selecting text in the value column was not possible. When users tried to select text, the mouseup event would trigger the row's onClick handler, causing the cell to expand/collapse and clearing the text selection.

## Changes

- Removed onClick handler from TableRow in PrettyJsonView component
- Removed cursor-pointer styling that indicated row-level clickability
- All expand/collapse functionality is still available through explicit controls:
  - Chevron button for rows with nested children
  - ...expand text for long text values

## Testing

Tested on trace: https://us.cloud.langfuse.com/project/cm3dxty9i00od7oppziofvd96/traces/b8335173-7fd1-48f7-b4cd-ab3127cc203f

- ✅ Text selection works in value column
- ✅ Copy works after selection
- ✅ Expand/collapse via explicit controls still works
- ✅ Nested row expansion via chevron still works

Fixes LFE-7803


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes text selection in `PrettyJsonView` by removing `onClick` from `TableRow` and adding `useClickWithoutSelection` hook.
> 
>   - **Behavior**:
>     - Fixes text selection in the value column of `PrettyJsonView` by removing `onClick` from `TableRow`.
>     - Introduces `useClickWithoutSelection` hook to differentiate between clicks and text selection.
>   - **Components**:
>     - `PrettyJsonView`: Removes `onClick` from `TableRow` and uses `useClickWithoutSelection` for row expansion.
>     - `ValueCell`: Changes `content` to be wrapped in a `span` with `cursor-text` class.
>   - **New Hook**:
>     - `useClickWithoutSelection`: Added to handle click vs. text selection logic, using position-based and selection API checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1e957f7ef2d5baa32539471b4a567946bab88411. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->