### PR TITLE
chore(layout): Replace error page with sentry version

### DIFF
--- a/web/src/components/error-page.tsx
+++ b/web/src/components/error-page.tsx
@@ -63,9 +63,19 @@ export const ErrorPage = ({
 export const ErrorPageWithSentry = ({
   title = "Error",
   message,
+  additionalButton,
 }: {
   title?: string;
   message: string;
+  additionalButton?:
+    | {
+        label: string;
+        href: string;
+      }
+    | {
+        label: string;
+        onClick: () => void;
+      };
 }) => {
   useEffect(() => {
     // Capture the error with Sentry
@@ -75,5 +85,11 @@ export const ErrorPageWithSentry = ({
       );
   }, [title, message]); // Empty dependency array means this effect runs once on mount
 
-  return <ErrorPage title={title} message={message} />;
+  return (
+    <ErrorPage
+      title={title}
+      message={message}
+      additionalButton={additionalButton}
+    />
+  );
 };

--- a/web/src/components/layouts/layout.tsx
+++ b/web/src/components/layouts/layout.tsx
@@ -47,7 +47,7 @@ import {
   type NavigationItem,
 } from "@/src/components/layouts/utilities/routes";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
-import { ErrorPage } from "@/src/components/error-page";
+import { ErrorPageWithSentry } from "@/src/components/error-page";
 
 const signOutUser = async () => {
   sessionStorage.clear();
@@ -318,7 +318,7 @@ export default function Layout(props: PropsWithChildren) {
     !userHasProjectAccess
   ) {
     return (
-      <ErrorPage
+      <ErrorPageWithSentry
         title="Project Not Found"
         message="The project you are trying to access does not exist or you do not have access to it."
         additionalButton={{


### PR DESCRIPTION
## What does this PR do?

This PR resolves LFE-7830 by integrating Sentry error tracking for "Project Not Found" errors. It replaces `ErrorPage` with `ErrorPageWithSentry` in `web/src/components/layouts/layout.tsx` to automatically report these access issues. Additionally, `ErrorPageWithSentry` has been enhanced to support the `additionalButton` prop, preserving the "Go to Home" navigation.

Fixes # LFE-7830

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-7830](https://linear.app/langfuse/issue/LFE-7830/choreerror-use-errorpagewithsentry-instead-of-errorpage-when-projectid)

<a href="https://cursor.com/background-agent?bcId=bc-caf07b37-19d3-473d-9045-1789e9361996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-caf07b37-19d3-473d-9045-1789e9361996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `ErrorPage` with `ErrorPageWithSentry` in `layout.tsx` to report errors to Sentry and support additional navigation.
> 
>   - **Behavior**:
>     - Replace `ErrorPage` with `ErrorPageWithSentry` in `layout.tsx` to report "Project Not Found" errors to Sentry.
>     - `ErrorPageWithSentry` in `error-page.tsx` now supports `additionalButton` prop for navigation.
>   - **Components**:
>     - `ErrorPageWithSentry` captures errors using Sentry and renders `ErrorPage` with additional button support.
>   - **Misc**:
>     - Update import in `layout.tsx` to use `ErrorPageWithSentry`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 50354940ed32c1656abef0f0fd3d9e9e36ab1463. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->