### PR TITLE
fix(datasets): implement batch processing for duplicating dataset items to handle large JSONB limits

### DIFF
--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -1284,6 +1284,7 @@ export const datasetRouter = createTRPCRouter({
           },
           orderBy: {
             createdAt: "asc",
+            // ensure consistent ordering for pagination; via bulk upload many items might have the same createdAt
             id: "asc",
           },
           take: DUPLICATE_DATASET_ITEMS_BATCH_SIZE,

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -62,6 +62,9 @@ import {
 } from "@langfuse/shared/src/server";
 import { type BulkDatasetItemValidationError } from "@langfuse/shared";
 
+// Batch size kept small (100) as items may have large input/output/metadata JSON
+const DUPLICATE_DATASET_ITEMS_BATCH_SIZE = 100;
+
 /**
  * Remove problematic C0 and C1 control characters from string values.
  * PostgreSQL TEXT columns cannot store NULL byte (\u0000) and other control characters.
@@ -1223,13 +1226,6 @@ export const datasetRouter = createTRPCRouter({
             projectId: input.projectId,
           },
         },
-        include: {
-          datasetItems: {
-            orderBy: {
-              createdAt: "asc",
-            },
-          },
-        },
       });
       if (!dataset) {
         throw new TRPCError({
@@ -1277,19 +1273,42 @@ export const datasetRouter = createTRPCRouter({
         projectId: input.projectId,
       });
 
-      await ctx.prisma.datasetItem.createMany({
-        data: dataset.datasetItems.map((item) => ({
-          // the items get new ids as they need to be unique on project level
-          input: item.input ?? undefined,
-          expectedOutput: item.expectedOutput ?? undefined,
-          metadata: item.metadata ?? undefined,
-          sourceTraceId: item.sourceTraceId,
-          sourceObservationId: item.sourceObservationId,
-          status: item.status,
-          projectId: input.projectId,
-          datasetId: newDataset.id,
-        })),
-      });
+      // Copy items in batches to avoid 256MB JSONB limit
+      let offset = 0;
+
+      while (true) {
+        const itemsBatch = await ctx.prisma.datasetItem.findMany({
+          where: {
+            datasetId: input.datasetId,
+            projectId: input.projectId,
+          },
+          orderBy: {
+            createdAt: "asc",
+            id: "asc",
+          },
+          take: DUPLICATE_DATASET_ITEMS_BATCH_SIZE,
+          skip: offset,
+        });
+
+        if (itemsBatch.length === 0) break;
+
+        await ctx.prisma.datasetItem.createMany({
+          data: itemsBatch.map((item) => ({
+            // the items get new ids as they need to be unique on project level
+            input: item.input ?? undefined,
+            expectedOutput: item.expectedOutput ?? undefined,
+            metadata: item.metadata ?? undefined,
+            sourceTraceId: item.sourceTraceId,
+            sourceObservationId: item.sourceObservationId,
+            status: item.status,
+            projectId: input.projectId,
+            datasetId: newDataset.id,
+          })),
+        });
+
+        if (itemsBatch.length < DUPLICATE_DATASET_ITEMS_BATCH_SIZE) break; // Last batch
+        offset += DUPLICATE_DATASET_ITEMS_BATCH_SIZE;
+      }
 
       await auditLog({
         session: ctx.session,

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -1282,11 +1282,11 @@ export const datasetRouter = createTRPCRouter({
             datasetId: input.datasetId,
             projectId: input.projectId,
           },
-          orderBy: {
-            createdAt: "asc",
+          orderBy: [
+            { createdAt: "asc" },
             // ensure consistent ordering for pagination; via bulk upload many items might have the same createdAt
-            id: "asc",
-          },
+            { id: "asc" },
+          ],
           take: DUPLICATE_DATASET_ITEMS_BATCH_SIZE,
           skip: offset,
         });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Implements batch processing for duplicating dataset items in `dataset-router.ts` to handle large JSONB limits by processing items in batches of 100.
> 
>   - **Behavior**:
>     - Implements batch processing in `duplicateDataset` in `dataset-router.ts` to handle large JSONB limits by processing dataset items in batches of 100.
>     - Introduces `DUPLICATE_DATASET_ITEMS_BATCH_SIZE` constant set to 100 for batch size control.
>   - **Ordering**:
>     - Adds secondary ordering by `id` in `findMany` to ensure consistent pagination when `createdAt` is the same.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c85149fb55263839d0d3b405866b36b14d5a9f64. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->