### PR TITLE
fix(billing): handle null values in cloudConfig stripe fields

### DIFF
--- a/packages/shared/src/interfaces/cloudConfigSchema.ts
+++ b/packages/shared/src/interfaces/cloudConfigSchema.ts
@@ -10,19 +10,18 @@ export const CloudConfigSchema = z.object({
   // need to update stripe webhook if you change this, it fetches from db via these fields
   stripe: z
     .object({
-      customerId: z.string().optional(),
-      activeSubscriptionId: z.string().optional(),
-      activeProductId: z.string().optional(),
-      activeUsageProductId: z.string().optional(),
-      subscriptionStatus: z.string().optional(), // should be one of ["active","past_due", "unpaid", "canceled", "incomplete", "incomplete_expired", "paused"]; we don't enforce to have a backwards compatibility for this field
+      customerId: z.string().nullish(),
+      activeSubscriptionId: z.string().nullish(),
+      activeProductId: z.string().nullish(),
+      activeUsageProductId: z.string().nullish(),
+      subscriptionStatus: z.string().nullish(), // should be one of ["active","past_due", "unpaid", "canceled", "incomplete", "incomplete_expired", "paused"]; we don't enforce to have a backwards compatibility for this field
     })
     .transform((data) => ({
       ...data,
       isLegacySubscription:
-        data?.activeProductId !== undefined &&
-        data?.activeUsageProductId === undefined,
+        data?.activeProductId != null && data?.activeUsageProductId == null,
     }))
-    .optional(),
+    .nullish(),
 
   // custom rate limits for an organization
   rateLimitOverrides: CloudConfigRateLimit.optional(),

--- a/web/src/ee/features/billing/server/stripeBillingService.ts
+++ b/web/src/ee/features/billing/server/stripeBillingService.ts
@@ -671,7 +671,8 @@ class BillingService {
         })();
 
         const returnUrl = `${env.NEXTAUTH_URL}/organization/${orgId}/settings/billing`;
-        const stripeCustomerId = parsedOrg.cloudConfig?.stripe?.customerId;
+        const stripeCustomerId =
+          parsedOrg.cloudConfig?.stripe?.customerId ?? undefined;
         const clientReferenceId = createStripeClientReference(orgId);
         const subscriptionMetadata: StripeSubscriptionMetadata = {
           orgId: orgId,

--- a/web/src/ee/features/billing/server/stripeWebhookHandler.ts
+++ b/web/src/ee/features/billing/server/stripeWebhookHandler.ts
@@ -573,17 +573,15 @@ async function handleSubscriptionChanged(
       after: updatedCloudConfig,
     });
   } else if (action === "deleted") {
+    // When subscription is deleted, only keep customerId and remove all other subscription fields
+    // Note: We omit fields entirely rather than setting to undefined, as undefined gets converted
+    // to null in PostgreSQL JSONB, which can cause validation issues
     const updatedCloudConfig = {
       ...parsedOrg.cloudConfig,
       stripe: {
-        ...parsedOrg.cloudConfig?.stripe,
-        ...CloudConfigSchema.shape.stripe.parse({
-          customerId: stripeCustomerId,
-          activeProductId: undefined,
-          activeSubscriptionId: undefined,
-          activeUsageProductId: undefined,
-          subscriptionStatus: undefined,
-        }),
+        customerId: stripeCustomerId,
+        // Explicitly omit activeProductId, activeSubscriptionId, activeUsageProductId, subscriptionStatus
+        // They will not be present in the saved JSON rather than being null
       },
     };
 


### PR DESCRIPTION
## Problem

Cloud usage metering was failing with "Stripe customer id not found" errors for organizations that had valid Stripe customer IDs in the database.

**Root cause**: PostgreSQL JSONB automatically converts `undefined` to `null` when storing JSON. When the Stripe webhook cleared subscription fields by setting them to `undefined`, they were stored as `null`. On subsequent reads, the Zod schema with `.optional()` rejected `null` values (only accepts `undefined` or missing fields), causing validation to fail and `cloudConfig` to be set to `null`.

## Changes

### 1. CloudConfigSchema (Defensive Fix)
- Changed all stripe fields from `.optional()` to `.nullish()`:
  - `customerId`, `activeSubscriptionId`, `activeProductId`, `activeUsageProductId`, `subscriptionStatus`
- Changed the stripe object itself to `.nullish()`
- Updated `isLegacySubscription` logic to use `!= null` instead of `!== undefined`

### 2. Stripe Webhook Handler (Preventive Fix)
- When subscription is deleted, omit fields entirely instead of setting to `undefined`
- Added documentation explaining why (prevents PostgreSQL converting to null)

### 3. stripeBillingService Type Fix
- Convert `null` to `undefined` when passing to Stripe API using nullish coalescing
- Stripe's API expects `string | undefined`, not `string | null | undefined`

## Impact

**Fixes**:
- All existing orgs with `null` values will now validate successfully
- "Stripe customer id not found" errors will stop immediately
- Cloud usage metering will work for all affected organizations

**Prevents**:
- New subscription deletions won't create `null` values
- Schema is now resilient to PostgreSQL JSONB behavior

## Testing

- Build passes
- Type checks pass
- Format checks pass

Tested with example failing cloudConfig that now validates successfully.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix handling of null values in Stripe fields within cloudConfig to prevent validation errors and ensure compatibility with PostgreSQL JSONB behavior.
> 
>   - **Behavior**:
>     - Change `CloudConfigSchema` in `cloudConfigSchema.ts` to use `.nullish()` for Stripe fields (`customerId`, `activeSubscriptionId`, `activeProductId`, `activeUsageProductId`, `subscriptionStatus`) and the stripe object itself.
>     - Update `isLegacySubscription` logic to use `!= null`.
>   - **Stripe Webhook Handler**:
>     - In `stripeWebhookHandler.ts`, omit fields instead of setting to `undefined` when a subscription is deleted.
>     - Add comments explaining the omission to prevent PostgreSQL from converting `undefined` to `null`.
>   - **Billing Service**:
>     - In `stripeBillingService.ts`, convert `null` to `undefined` using nullish coalescing when passing to Stripe API.
>     - Ensure `stripeCustomerId` is `string | undefined` as expected by Stripe API.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5a6cfc14c64c13b024c164346210c41ce6f1df8b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->