### PR TITLE
chore: increase timeouts for exports

### DIFF
--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -120,7 +120,7 @@ export const getDatabaseReadStreamPaginated = async ({
   };
 
   const clickhouseConfigs = {
-    request_timeout: 120_000,
+    request_timeout: 180_000,
   };
 
   switch (tableName) {
@@ -385,7 +385,7 @@ export const getDatabaseReadStreamPaginated = async ({
                 undefined as Date | undefined,
               ),
               {
-                request_timeout: 120_000,
+                request_timeout: 180_000,
               },
             ),
           ]);
@@ -698,7 +698,7 @@ export const getTraceIdentifierStream = async (props: {
   };
 
   const clickhouseConfigs = {
-    request_timeout: 120_000,
+    request_timeout: 180_000,
   };
 
   return new DatabaseReadStream<TraceIdentifiers>(

--- a/worker/src/features/database-read-stream/observation-stream.ts
+++ b/worker/src/features/database-read-stream/observation-stream.ts
@@ -89,7 +89,7 @@ export const getObservationStream = async (props: {
     rowLimit = env.BATCH_EXPORT_ROW_LIMIT,
   } = props;
   const clickhouseConfigs = {
-    request_timeout: 120_000,
+    request_timeout: 180_000, // 3 minutes
     clickhouse_settings: {
       join_algorithm: "partial_merge" as const,
     },

--- a/worker/src/features/database-read-stream/trace-stream.ts
+++ b/worker/src/features/database-read-stream/trace-stream.ts
@@ -43,7 +43,7 @@ export const getTraceStream = async (props: {
   } = props;
 
   const clickhouseConfigs = {
-    request_timeout: 120_000,
+    request_timeout: 180_000,
     clickhouse_settings: {
       join_algorithm: "partial_merge" as const,
     },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase `request_timeout` to `180_000` for database read streams in `getDatabaseReadStream.ts`, `observation-stream.ts`, and `trace-stream.ts`.
> 
>   - **Timeout Increase**:
>     - Increase `request_timeout` from `120_000` to `180_000` in `getDatabaseReadStreamPaginated` and `getTraceIdentifierStream` in `getDatabaseReadStream.ts`.
>     - Increase `request_timeout` from `120_000` to `180_000` in `getObservationStream` in `observation-stream.ts`.
>     - Increase `request_timeout` from `120_000` to `180_000` in `getTraceStream` in `trace-stream.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f2805bca57c83625f79bcff4085819e6e8f6a9cd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->