### PR TITLE
fix(dataset-compare): diff label colors are inverted for cost and latency

### DIFF
--- a/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
+++ b/web/src/features/datasets/components/DatasetAggregateTableCell.tsx
@@ -207,6 +207,7 @@ const DatasetAggregateCellContent = ({
               (latencyDiff ? (
                 <DiffLabel
                   diff={latencyDiff}
+                  preferNegativeDiff={true}
                   formatValue={(value) => formatIntervalSeconds(value)}
                   className="ml-1"
                 />
@@ -222,6 +223,7 @@ const DatasetAggregateCellContent = ({
               (totalCostDiff ? (
                 <DiffLabel
                   diff={totalCostDiff}
+                  preferNegativeDiff={true}
                   formatValue={(value) => usdFormatter(value, 2, 4)}
                   className="ml-1"
                 />

--- a/web/src/features/datasets/components/DiffLabel.tsx
+++ b/web/src/features/datasets/components/DiffLabel.tsx
@@ -5,6 +5,13 @@ import {
 } from "@/src/features/datasets/lib/calculateBaselineDiff";
 import { cn } from "@/src/utils/tailwind";
 
+const getVariant = (direction: "+" | "-", preferNegativeDirection: boolean) => {
+  if (preferNegativeDirection) {
+    return direction === "-" ? "success" : "error";
+  }
+  return direction === "+" ? "success" : "error";
+};
+
 /**
  * Displays a diff value with color coding
  * Used for scores, latency, and cost diffs in compare view
@@ -13,16 +20,18 @@ export function DiffLabel({
   diff,
   formatValue,
   className,
+  preferNegativeDiff = false,
 }: {
   diff: NumericDiff | CategoricalDiff;
   formatValue: (value: number) => string;
   className?: string;
+  preferNegativeDiff?: boolean;
 }) {
   if (diff.type === "NUMERIC") {
     return (
       <Badge
         size="sm"
-        variant={diff.direction === "+" ? "success" : "error"}
+        variant={getVariant(diff.direction, preferNegativeDiff)}
         className={cn("font-semibold", className)}
       >
         {diff.direction}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes inverted diff label colors for cost and latency by adding a `preferNegativeDiff` flag to `DiffLabel` in `DatasetAggregateTableCell.tsx`.
> 
>   - **Behavior**:
>     - Fixes inverted diff label colors for cost and latency in `DatasetAggregateTableCell.tsx` by setting `preferNegativeDiff` to `true` in `DiffLabel`.
>   - **Functions**:
>     - Adds `preferNegativeDiff` parameter to `DiffLabel` in `DiffLabel.tsx` to control color logic for negative differences.
>     - Introduces `getVariant()` function in `DiffLabel.tsx` to determine badge variant based on `preferNegativeDiff` flag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ad1574a590f8753d9e9b6d77f3210d1f3cd5a288. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->