### PR TITLE
perf(evaluator-cost): add filter by generation

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1768,6 +1768,7 @@ export const getCostByEvaluatorIds = async (
     FROM observations FINAL
     WHERE project_id = {projectId: String}
       AND metadata['job_configuration_id'] IN ({evaluatorIds: Array(String)})
+      AND type = 'GENERATION'
       AND start_time > today() - 7
     GROUP BY metadata['job_configuration_id']
   `;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a filter for 'GENERATION' type in `getCostByEvaluatorIds` to improve query performance in `observations.ts`.
> 
>   - **Performance Improvement**:
>     - Adds `AND type = 'GENERATION'` filter to `getCostByEvaluatorIds` query in `observations.ts` to limit data to 'GENERATION' type observations, improving query efficiency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e048c9d9cf206a3ff8270fb7b17bb7039c9edd7e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->