### PR TITLE
fix(dataset-runs): filter out any repetition modeling attempts for total cost calculation

### DIFF
--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -393,19 +393,31 @@ const getDatasetRunsTableInternal = async <T>(
     ),
   `;
 
+  const datasetRunItemsDedupedCte = `
+    dataset_run_items_deduped AS (
+      SELECT *
+      FROM dataset_run_items_rmt dri
+      WHERE ${baseFilter.query}
+      ORDER BY dri.created_at DESC
+      LIMIT 1 BY dri.project_id, dri.dataset_id, dri.dataset_run_id, dri.dataset_item_id
+    ),
+  `;
+
   const traceMetricsCte = `
     trace_metrics AS (
       SELECT
-        of.trace_id,
-        of.project_id,
+        dri.trace_id,
+        dri.project_id,
+        dri.dataset_id,
+        dri.dataset_run_id,
+        dri.dataset_item_id,
         dateDiff('millisecond', min(of.start_time), max(of.end_time)) as latency_ms,
         sum(of.total_cost) as total_cost
-      FROM observations_filtered of
-      JOIN dataset_run_items_rmt dri ON dri.trace_id = of.trace_id 
+      FROM dataset_run_items_deduped dri
+      JOIN observations_filtered of ON dri.trace_id = of.trace_id
         AND dri.project_id = of.project_id
-        AND dri.observation_id IS NULL  -- Only for trace-level dataset run items
-      WHERE ${baseFilter.query}
-      GROUP BY of.trace_id, of.project_id
+      WHERE dri.observation_id IS NULL  -- Only for trace-level dataset run items
+      GROUP BY dri.trace_id, dri.project_id, dri.dataset_id, dri.dataset_run_id, dri.dataset_item_id
     ),
   `;
 
@@ -420,25 +432,28 @@ const getDatasetRunsTableInternal = async <T>(
         dri.dataset_run_description as dataset_run_description,
         dri.dataset_run_metadata as dataset_run_metadata,
         count(DISTINCT dri.project_id, dri.dataset_id, dri.dataset_run_id, dri.dataset_item_id) as count_run_items,
-        
+
         -- Trace-level metrics (average across traces in this dataset run)
         AVG(CASE WHEN dri.observation_id IS NULL THEN tm.latency_ms ELSE NULL END) / 1000.0 as trace_avg_latency,
         AVG(CASE WHEN dri.observation_id IS NULL THEN tm.total_cost ELSE NULL END) as trace_avg_cost,
         SUM(CASE WHEN dri.observation_id IS NULL THEN tm.total_cost ELSE NULL END) as trace_total_cost,
-        
-        -- Observation-level metrics  
-        AVG(CASE WHEN dri.observation_id IS NOT NULL THEN 
+
+        -- Observation-level metrics
+        AVG(CASE WHEN dri.observation_id IS NOT NULL THEN
           dateDiff('millisecond', of.start_time, of.end_time) / 1000.0
         ELSE NULL END) as obs_avg_latency,
         AVG(CASE WHEN dri.observation_id IS NOT NULL THEN of.total_cost ELSE NULL END) as obs_avg_cost,
         SUM(CASE WHEN dri.observation_id IS NOT NULL THEN of.total_cost ELSE NULL END) as obs_total_cost
-        
-      FROM dataset_run_items_rmt dri
-      LEFT JOIN observations_filtered of ON dri.observation_id = of.id 
+
+      FROM dataset_run_items_deduped dri
+      LEFT JOIN observations_filtered of ON dri.observation_id = of.id
         AND dri.project_id = of.project_id
         AND dri.trace_id = of.trace_id
       LEFT JOIN trace_metrics tm ON dri.trace_id = tm.trace_id
         AND dri.project_id = tm.project_id
+        AND dri.dataset_id = tm.dataset_id
+        AND dri.dataset_run_id = tm.dataset_run_id
+        AND dri.dataset_item_id = tm.dataset_item_id
         AND dri.observation_id IS NULL
       WHERE ${baseFilter.query}
       GROUP BY dri.project_id, dri.dataset_id, dri.dataset_run_id, dri.dataset_run_name, dri.dataset_run_description, dri.dataset_run_metadata, dri.dataset_run_created_at
@@ -448,6 +463,7 @@ const getDatasetRunsTableInternal = async <T>(
   const query = `
     ${scoresCte}
     ${filteredObservationsCte}
+    ${datasetRunItemsDedupedCte}
     ${traceMetricsCte}
     ${datasetRunMetricsCte}
     SELECT ${opts.select === "count" ? "" : "DISTINCT"}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces deduplication in `getDatasetRunsTableInternal` to filter repeated modeling attempts for accurate total cost calculation.
> 
>   - **Behavior**:
>     - Introduces `dataset_run_items_deduped` CTE in `getDatasetRunsTableInternal` to filter out repeated modeling attempts.
>     - Modifies `traceMetricsCte` and `datasetRunMetricsCte` to use `dataset_run_items_deduped` for accurate total cost calculation.
>   - **Misc**:
>     - Adjusts SQL queries to ensure only the latest dataset run item is considered per dataset item.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d741686f715f29c88b828cf8cb233fb97dff38eb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->