### PR TITLE
fix(datasets): display trace-level cost for DRI metrics

### DIFF
--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -416,7 +416,6 @@ const getDatasetRunsTableInternal = async <T>(
       FROM dataset_run_items_deduped dri
       JOIN observations_filtered of ON dri.trace_id = of.trace_id
         AND dri.project_id = of.project_id
-      WHERE dri.observation_id IS NULL  -- Only for trace-level dataset run items
       GROUP BY dri.trace_id, dri.project_id, dri.dataset_id, dri.dataset_run_id, dri.dataset_item_id
     ),
   `;
@@ -442,8 +441,8 @@ const getDatasetRunsTableInternal = async <T>(
         AVG(CASE WHEN dri.observation_id IS NOT NULL THEN
           dateDiff('millisecond', of.start_time, of.end_time) / 1000.0
         ELSE NULL END) as obs_avg_latency,
-        AVG(CASE WHEN dri.observation_id IS NOT NULL THEN of.total_cost ELSE NULL END) as obs_avg_cost,
-        SUM(CASE WHEN dri.observation_id IS NOT NULL THEN of.total_cost ELSE NULL END) as obs_total_cost
+        AVG(CASE WHEN dri.observation_id IS NOT NULL THEN tm.total_cost ELSE NULL END) as obs_avg_cost,
+        SUM(CASE WHEN dri.observation_id IS NOT NULL THEN tm.total_cost ELSE NULL END) as obs_total_cost
 
       FROM dataset_run_items_deduped dri
       LEFT JOIN observations_filtered of ON dri.observation_id = of.id

--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -393,19 +393,31 @@ const getDatasetRunsTableInternal = async <T>(
     ),
   `;
 
+  const datasetRunItemsDedupedCte = `
+    dataset_run_items_deduped AS (
+      SELECT *
+      FROM dataset_run_items_rmt dri
+      WHERE ${baseFilter.query}
+      ORDER BY dri.created_at DESC
+      LIMIT 1 BY dri.project_id, dri.dataset_id, dri.dataset_run_id, dri.dataset_item_id
+    ),
+  `;
+
   const traceMetricsCte = `
     trace_metrics AS (
       SELECT
-        of.trace_id,
-        of.project_id,
+        dri.trace_id,
+        dri.project_id,
+        dri.dataset_id,
+        dri.dataset_run_id,
+        dri.dataset_item_id,
         dateDiff('millisecond', min(of.start_time), max(of.end_time)) as latency_ms,
         sum(of.total_cost) as total_cost
-      FROM observations_filtered of
-      JOIN dataset_run_items_rmt dri ON dri.trace_id = of.trace_id 
+      FROM dataset_run_items_deduped dri
+      JOIN observations_filtered of ON dri.trace_id = of.trace_id
         AND dri.project_id = of.project_id
-        AND dri.observation_id IS NULL  -- Only for trace-level dataset run items
-      WHERE ${baseFilter.query}
-      GROUP BY of.trace_id, of.project_id
+      WHERE dri.observation_id IS NULL  -- Only for trace-level dataset run items
+      GROUP BY dri.trace_id, dri.project_id, dri.dataset_id, dri.dataset_run_id, dri.dataset_item_id
     ),
   `;
 
@@ -420,25 +432,28 @@ const getDatasetRunsTableInternal = async <T>(
         dri.dataset_run_description as dataset_run_description,
         dri.dataset_run_metadata as dataset_run_metadata,
         count(DISTINCT dri.project_id, dri.dataset_id, dri.dataset_run_id, dri.dataset_item_id) as count_run_items,
-        
+
         -- Trace-level metrics (average across traces in this dataset run)
         AVG(CASE WHEN dri.observation_id IS NULL THEN tm.latency_ms ELSE NULL END) / 1000.0 as trace_avg_latency,
         AVG(CASE WHEN dri.observation_id IS NULL THEN tm.total_cost ELSE NULL END) as trace_avg_cost,
         SUM(CASE WHEN dri.observation_id IS NULL THEN tm.total_cost ELSE NULL END) as trace_total_cost,
-        
-        -- Observation-level metrics  
-        AVG(CASE WHEN dri.observation_id IS NOT NULL THEN 
+
+        -- Observation-level metrics
+        AVG(CASE WHEN dri.observation_id IS NOT NULL THEN
           dateDiff('millisecond', of.start_time, of.end_time) / 1000.0
         ELSE NULL END) as obs_avg_latency,
         AVG(CASE WHEN dri.observation_id IS NOT NULL THEN of.total_cost ELSE NULL END) as obs_avg_cost,
         SUM(CASE WHEN dri.observation_id IS NOT NULL THEN of.total_cost ELSE NULL END) as obs_total_cost
-        
-      FROM dataset_run_items_rmt dri
-      LEFT JOIN observations_filtered of ON dri.observation_id = of.id 
+
+      FROM dataset_run_items_deduped dri
+      LEFT JOIN observations_filtered of ON dri.observation_id = of.id
         AND dri.project_id = of.project_id
         AND dri.trace_id = of.trace_id
       LEFT JOIN trace_metrics tm ON dri.trace_id = tm.trace_id
         AND dri.project_id = tm.project_id
+        AND dri.dataset_id = tm.dataset_id
+        AND dri.dataset_run_id = tm.dataset_run_id
+        AND dri.dataset_item_id = tm.dataset_item_id
         AND dri.observation_id IS NULL
       WHERE ${baseFilter.query}
       GROUP BY dri.project_id, dri.dataset_id, dri.dataset_run_id, dri.dataset_run_name, dri.dataset_run_description, dri.dataset_run_metadata, dri.dataset_run_created_at
@@ -448,6 +463,7 @@ const getDatasetRunsTableInternal = async <T>(
   const query = `
     ${scoresCte}
     ${filteredObservationsCte}
+    ${datasetRunItemsDedupedCte}
     ${traceMetricsCte}
     ${datasetRunMetricsCte}
     SELECT ${opts.select === "count" ? "" : "DISTINCT"}

--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -453,7 +453,6 @@ const getDatasetRunsTableInternal = async <T>(
         AND dri.dataset_id = tm.dataset_id
         AND dri.dataset_run_id = tm.dataset_run_id
         AND dri.dataset_item_id = tm.dataset_item_id
-        AND dri.observation_id IS NULL
       WHERE ${baseFilter.query}
       GROUP BY dri.project_id, dri.dataset_id, dri.dataset_run_id, dri.dataset_run_name, dri.dataset_run_description, dri.dataset_run_metadata, dri.dataset_run_created_at
     )

--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -454,7 +454,7 @@ export function DatasetRunsTable(props: {
     },
     {
       accessorKey: "avgTotalCost",
-      header: "Total Cost (avg)",
+      header: "Trace Cost (avg)",
       id: "avgTotalCost",
       size: 130,
       enableHiding: true,
@@ -468,7 +468,7 @@ export function DatasetRunsTable(props: {
     },
     {
       accessorKey: "totalCost",
-      header: "Total Cost (sum)",
+      header: "Trace Cost (sum)",
       id: "totalCost",
       size: 130,
       enableHiding: true,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> This PR updates dataset run items to include trace-level cost metrics and modifies UI headers to reflect these changes.
> 
>   - **Behavior**:
>     - Removed `WHERE` clause filtering `observation_id IS NULL` in `getDatasetRunsTableInternal()` in `dataset-run-items.ts` to include trace-level cost metrics.
>     - Updated `AVG` and `SUM` calculations to use `tm.total_cost` instead of `of.total_cost` in `dataset-run-items.ts`.
>   - **UI**:
>     - Changed column headers from "Total Cost (avg)" to "Trace Cost (avg)" and "Total Cost (sum)" to "Trace Cost (sum)" in `DatasetRunsTable.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6b110231887d027020730900108a2a41ec17a2af. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->