### PR TITLE
fix: vertically align comment icons in AnnotationForm component t

### DIFF
--- a/web/src/features/scores/components/AnnotationForm.tsx
+++ b/web/src/features/scores/components/AnnotationForm.tsx
@@ -635,7 +635,7 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
                                 type="button"
                                 size="xs"
                                 title="Add or view score comment"
-                                className="h-full items-start px-0 pl-1 disabled:text-primary/50 disabled:opacity-100"
+                                className="h-full px-0 pl-1 disabled:text-primary/50 disabled:opacity-100"
                                 disabled={
                                   isScoreUnsaved(score.id) ||
                                   (config.isArchived && !score.comment)


### PR DESCRIPTION
## What does this PR do?

Removed the items-start class from the AnnotationForm component, so that the comment icons are vertically aligned with the rest of the row contents. 

Fixes # (issue)

<img width="775" height="387" alt="image" src="https://github.com/user-attachments/assets/ad73ea7f-a593-4230-b90f-436bfe3d4564" />

<img width="769" height="254" alt="image" src="https://github.com/user-attachments/assets/63db43f6-346c-4bef-8b22-4cd80a0c16db" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `items-start` class from `Button` in `InnerAnnotationForm` to align comment icons vertically in `AnnotationForm.tsx`.
> 
>   - **UI Fix**:
>     - Remove `items-start` class from `Button` in `InnerAnnotationForm` in `AnnotationForm.tsx` to vertically align comment icons with row contents.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5dd93c6e7b49495a7fa91d347a23c9930228c0ee. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->