### PR TITLE
feat(trace2): S5.2 ObservationDetailView with extracted badge components

### DIFF
--- a/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
@@ -1,0 +1,242 @@
+/**
+ * ObservationDetailView - Shows observation-level details when an observation is selected
+ *
+ * Responsibility:
+ * - Display observation metadata (type, timestamp, model, environment, etc.)
+ * - Show cost and token usage with tooltips
+ * - Provide tabbed interface (Preview, Scores)
+ * - Support Formatted/JSON toggle for preview content
+ *
+ * Hooks:
+ * - useLocalStorage() - for JSON view preference
+ * - useState() - for tab selection
+ *
+ * Re-renders when:
+ * - Observation prop changes (new observation selected)
+ * - Tab selection changes
+ * - View mode toggle changes
+ */
+
+import { type ObservationType } from "@langfuse/shared";
+import { type ObservationReturnTypeWithMetadata } from "@/src/server/api/routers/traces";
+import { Badge } from "@/src/components/ui/badge";
+import { ItemBadge } from "@/src/components/ItemBadge";
+import { LocalIsoDate } from "@/src/components/LocalIsoDate";
+import {
+  TabsBar,
+  TabsBarContent,
+  TabsBarList,
+  TabsBarTrigger,
+} from "@/src/components/ui/tabs-bar";
+import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
+import useLocalStorage from "@/src/components/useLocalStorage";
+import { useState } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
+
+export interface ObservationDetailViewProps {
+  observation: ObservationReturnTypeWithMetadata;
+  projectId: string;
+}
+
+export function ObservationDetailView({
+  observation,
+  projectId: _projectId,
+}: ObservationDetailViewProps) {
+  const [selectedTab, setSelectedTab] = useState<"preview" | "scores">(
+    "preview",
+  );
+  const [currentView, setCurrentView] = useLocalStorage<"pretty" | "json">(
+    "jsonViewPreference",
+    "pretty",
+  );
+
+  // Calculate latency if not provided
+  const latency =
+    observation.latency ??
+    (observation.startTime && observation.endTime
+      ? observation.endTime.getTime() - observation.startTime.getTime()
+      : null);
+
+  // Format cost and usage values
+  const totalCost = observation.totalCost;
+  const inputCost = observation.inputCost;
+  const outputCost = observation.outputCost;
+  const totalUsage = observation.totalUsage;
+  const inputUsage = observation.inputUsage;
+  const outputUsage = observation.outputUsage;
+
+  const hasCostData = totalCost !== null && totalCost !== undefined;
+  const hasUsageData = totalUsage > 0;
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* Header section */}
+      <div className="flex-shrink-0 space-y-2 border-b p-4">
+        {/* Title row */}
+        <div className="flex items-start gap-2">
+          <div className="mt-1">
+            <ItemBadge type={observation.type as ObservationType} isSmall />
+          </div>
+          <span className="min-w-0 break-all font-medium">
+            {observation.name || observation.id}
+          </span>
+        </div>
+
+        {/* Metadata badges */}
+        <div className="flex flex-col gap-2">
+          {/* Timestamp and latency */}
+          <div className="flex flex-wrap items-center gap-1">
+            <LocalIsoDate
+              date={observation.startTime}
+              accuracy="millisecond"
+              className="text-sm"
+            />
+            {latency !== null && latency !== undefined && (
+              <Badge variant="tertiary">{latency.toFixed(2)}ms</Badge>
+            )}
+          </div>
+
+          {/* Other metadata badges */}
+          <div className="flex flex-wrap items-center gap-1">
+            {observation.environment && (
+              <Badge variant="tertiary">Env: {observation.environment}</Badge>
+            )}
+            {observation.model && (
+              <Badge variant="tertiary">Model: {observation.model}</Badge>
+            )}
+            {observation.version && (
+              <Badge variant="tertiary">Version: {observation.version}</Badge>
+            )}
+            {observation.level && observation.level !== "DEFAULT" && (
+              <Badge
+                variant={
+                  observation.level === "ERROR"
+                    ? "destructive"
+                    : observation.level === "WARNING"
+                      ? "warning"
+                      : "tertiary"
+                }
+              >
+                {observation.level}
+              </Badge>
+            )}
+            {observation.statusMessage && (
+              <Badge variant="tertiary">{observation.statusMessage}</Badge>
+            )}
+          </div>
+
+          {/* Cost and token badges */}
+          {(hasCostData || hasUsageData) && (
+            <div className="flex flex-wrap items-center gap-1">
+              {hasCostData && (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <Badge variant="secondary">
+                        Cost: ${totalCost.toFixed(6)}
+                      </Badge>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <div className="space-y-1 text-xs">
+                        {inputCost !== null && inputCost !== undefined && (
+                          <div>Input: ${inputCost.toFixed(6)}</div>
+                        )}
+                        {outputCost !== null && outputCost !== undefined && (
+                          <div>Output: ${outputCost.toFixed(6)}</div>
+                        )}
+                        <div className="font-semibold">
+                          Total: ${totalCost.toFixed(6)}
+                        </div>
+                      </div>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              )}
+              {hasUsageData && (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <Badge variant="secondary">
+                        Tokens: {totalUsage.toLocaleString()}
+                      </Badge>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <div className="space-y-1 text-xs">
+                        <div>Input: {inputUsage.toLocaleString()}</div>
+                        <div>Output: {outputUsage.toLocaleString()}</div>
+                        <div className="font-semibold">
+                          Total: {totalUsage.toLocaleString()}
+                        </div>
+                      </div>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Tabs section */}
+      <TabsBar
+        value={selectedTab}
+        className="flex min-h-0 flex-1 flex-col overflow-hidden"
+        onValueChange={(value) => setSelectedTab(value as "preview" | "scores")}
+      >
+        <TabsBarList>
+          <TabsBarTrigger value="preview">Preview</TabsBarTrigger>
+          <TabsBarTrigger value="scores">Scores</TabsBarTrigger>
+
+          {/* View toggle (Formatted/JSON) - show for preview tab */}
+          {selectedTab === "preview" && (
+            <Tabs
+              className="ml-auto mr-1 h-fit px-2 py-0.5"
+              value={currentView}
+              onValueChange={(value) => {
+                setCurrentView(value as "pretty" | "json");
+              }}
+            >
+              <TabsList className="h-fit py-0.5">
+                <TabsTrigger value="pretty" className="h-fit px-1 text-xs">
+                  Formatted
+                </TabsTrigger>
+                <TabsTrigger value="json" className="h-fit px-1 text-xs">
+                  JSON
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
+          )}
+        </TabsBarList>
+
+        {/* Preview tab content - placeholder */}
+        <TabsBarContent
+          value="preview"
+          className="mt-0 flex max-h-full min-h-0 w-full flex-1"
+        >
+          <div className="flex h-full w-full items-center justify-center p-4">
+            <p className="text-sm text-muted-foreground">
+              Preview tab content (S5.1)
+            </p>
+          </div>
+        </TabsBarContent>
+
+        {/* Scores tab content - placeholder */}
+        <TabsBarContent
+          value="scores"
+          className="mt-0 flex max-h-full min-h-0 w-full flex-1"
+        >
+          <div className="flex h-full w-full items-center justify-center p-4">
+            <p className="text-sm text-muted-foreground">
+              Scores tab content (S5.5)
+            </p>
+          </div>
+        </TabsBarContent>
+      </TabsBar>
+    </div>
+  );
+}

--- a/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
@@ -87,97 +87,86 @@ export function ObservationDetailView({
           </span>
         </div>
 
-        {/* Metadata badges */}
-        <div className="flex flex-col gap-2">
-          {/* Timestamp and latency */}
-          <div className="flex flex-wrap items-center gap-1">
-            <LocalIsoDate
-              date={observation.startTime}
-              accuracy="millisecond"
-              className="text-sm"
-            />
-            {latency !== null && latency !== undefined && (
-              <Badge variant="tertiary">{latency.toFixed(2)}ms</Badge>
-            )}
-          </div>
-
-          {/* Other metadata badges */}
-          <div className="flex flex-wrap items-center gap-1">
-            {observation.environment && (
-              <Badge variant="tertiary">Env: {observation.environment}</Badge>
-            )}
-            {observation.model && (
-              <Badge variant="tertiary">Model: {observation.model}</Badge>
-            )}
-            {observation.version && (
-              <Badge variant="tertiary">Version: {observation.version}</Badge>
-            )}
-            {observation.level && observation.level !== "DEFAULT" && (
-              <Badge
-                variant={
-                  observation.level === "ERROR"
-                    ? "destructive"
-                    : observation.level === "WARNING"
-                      ? "warning"
-                      : "tertiary"
-                }
-              >
-                {observation.level}
-              </Badge>
-            )}
-            {observation.statusMessage && (
-              <Badge variant="tertiary">{observation.statusMessage}</Badge>
-            )}
-          </div>
-
-          {/* Cost and token badges */}
-          {(hasCostData || hasUsageData) && (
-            <div className="flex flex-wrap items-center gap-1">
-              {hasCostData && (
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger>
-                      <Badge variant="secondary">
-                        Cost: ${totalCost.toFixed(6)}
-                      </Badge>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <div className="space-y-1 text-xs">
-                        {inputCost !== null && inputCost !== undefined && (
-                          <div>Input: ${inputCost.toFixed(6)}</div>
-                        )}
-                        {outputCost !== null && outputCost !== undefined && (
-                          <div>Output: ${outputCost.toFixed(6)}</div>
-                        )}
-                        <div className="font-semibold">
-                          Total: ${totalCost.toFixed(6)}
-                        </div>
-                      </div>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              )}
-              {hasUsageData && (
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger>
-                      <Badge variant="secondary">
-                        Tokens: {totalUsage.toLocaleString()}
-                      </Badge>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <div className="space-y-1 text-xs">
-                        <div>Input: {inputUsage.toLocaleString()}</div>
-                        <div>Output: {outputUsage.toLocaleString()}</div>
-                        <div className="font-semibold">
-                          Total: {totalUsage.toLocaleString()}
-                        </div>
-                      </div>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              )}
-            </div>
+        {/* Metadata badges - all on one row like traces/ */}
+        <div className="flex flex-wrap items-center gap-1">
+          <LocalIsoDate
+            date={observation.startTime}
+            accuracy="millisecond"
+            className="text-sm"
+          />
+          {latency !== null && latency !== undefined && (
+            <Badge variant="tertiary">
+              Latency: {(latency / 1000).toFixed(2)}s
+            </Badge>
+          )}
+          {observation.environment && (
+            <Badge variant="tertiary">Env: {observation.environment}</Badge>
+          )}
+          {hasCostData && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger>
+                  <Badge variant="tertiary">
+                    Cost: ${totalCost.toFixed(6)}
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <div className="space-y-1 text-xs">
+                    {inputCost !== null && inputCost !== undefined && (
+                      <div>Input: ${inputCost.toFixed(6)}</div>
+                    )}
+                    {outputCost !== null && outputCost !== undefined && (
+                      <div>Output: ${outputCost.toFixed(6)}</div>
+                    )}
+                    <div className="font-semibold">
+                      Total: ${totalCost.toFixed(6)}
+                    </div>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+          {hasUsageData && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger>
+                  <Badge variant="tertiary">
+                    Tokens: {totalUsage.toLocaleString()}
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <div className="space-y-1 text-xs">
+                    <div>Input: {inputUsage.toLocaleString()}</div>
+                    <div>Output: {outputUsage.toLocaleString()}</div>
+                    <div className="font-semibold">
+                      Total: {totalUsage.toLocaleString()}
+                    </div>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+          {observation.version && (
+            <Badge variant="tertiary">Version: {observation.version}</Badge>
+          )}
+          {observation.model && (
+            <Badge variant="tertiary">{observation.model}</Badge>
+          )}
+          {observation.level && observation.level !== "DEFAULT" && (
+            <Badge
+              variant={
+                observation.level === "ERROR"
+                  ? "destructive"
+                  : observation.level === "WARNING"
+                    ? "warning"
+                    : "tertiary"
+              }
+            >
+              {observation.level}
+            </Badge>
+          )}
+          {observation.statusMessage && (
+            <Badge variant="tertiary">{observation.statusMessage}</Badge>
           )}
         </div>
       </div>

--- a/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
@@ -87,87 +87,93 @@ export function ObservationDetailView({
           </span>
         </div>
 
-        {/* Metadata badges - all on one row like traces/ */}
-        <div className="flex flex-wrap items-center gap-1">
-          <LocalIsoDate
-            date={observation.startTime}
-            accuracy="millisecond"
-            className="text-sm"
-          />
-          {latency !== null && latency !== undefined && (
-            <Badge variant="tertiary">
-              Latency: {(latency / 1000).toFixed(2)}s
-            </Badge>
-          )}
-          {observation.environment && (
-            <Badge variant="tertiary">Env: {observation.environment}</Badge>
-          )}
-          {hasCostData && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger>
-                  <Badge variant="tertiary">
-                    Cost: ${totalCost.toFixed(6)}
-                  </Badge>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <div className="space-y-1 text-xs">
-                    {inputCost !== null && inputCost !== undefined && (
-                      <div>Input: ${inputCost.toFixed(6)}</div>
-                    )}
-                    {outputCost !== null && outputCost !== undefined && (
-                      <div>Output: ${outputCost.toFixed(6)}</div>
-                    )}
-                    <div className="font-semibold">
-                      Total: ${totalCost.toFixed(6)}
+        {/* Metadata badges */}
+        <div className="flex flex-col gap-1">
+          {/* Timestamp on its own row */}
+          <div className="flex items-center">
+            <LocalIsoDate
+              date={observation.startTime}
+              accuracy="millisecond"
+              className="text-xs"
+            />
+          </div>
+          {/* Other badges on second row */}
+          <div className="flex flex-wrap items-center gap-1">
+            {latency !== null && latency !== undefined && (
+              <Badge variant="tertiary">
+                Latency: {(latency / 1000).toFixed(2)}s
+              </Badge>
+            )}
+            {observation.environment && (
+              <Badge variant="tertiary">Env: {observation.environment}</Badge>
+            )}
+            {hasCostData && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <Badge variant="tertiary">
+                      Cost: ${totalCost.toFixed(6)}
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <div className="space-y-1 text-xs">
+                      {inputCost !== null && inputCost !== undefined && (
+                        <div>Input: ${inputCost.toFixed(6)}</div>
+                      )}
+                      {outputCost !== null && outputCost !== undefined && (
+                        <div>Output: ${outputCost.toFixed(6)}</div>
+                      )}
+                      <div className="font-semibold">
+                        Total: ${totalCost.toFixed(6)}
+                      </div>
                     </div>
-                  </div>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
-          {hasUsageData && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger>
-                  <Badge variant="tertiary">
-                    Tokens: {totalUsage.toLocaleString()}
-                  </Badge>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <div className="space-y-1 text-xs">
-                    <div>Input: {inputUsage.toLocaleString()}</div>
-                    <div>Output: {outputUsage.toLocaleString()}</div>
-                    <div className="font-semibold">
-                      Total: {totalUsage.toLocaleString()}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+            {hasUsageData && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <Badge variant="tertiary">
+                      Tokens: {totalUsage.toLocaleString()}
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <div className="space-y-1 text-xs">
+                      <div>Input: {inputUsage.toLocaleString()}</div>
+                      <div>Output: {outputUsage.toLocaleString()}</div>
+                      <div className="font-semibold">
+                        Total: {totalUsage.toLocaleString()}
+                      </div>
                     </div>
-                  </div>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
-          {observation.version && (
-            <Badge variant="tertiary">Version: {observation.version}</Badge>
-          )}
-          {observation.model && (
-            <Badge variant="tertiary">{observation.model}</Badge>
-          )}
-          {observation.level && observation.level !== "DEFAULT" && (
-            <Badge
-              variant={
-                observation.level === "ERROR"
-                  ? "destructive"
-                  : observation.level === "WARNING"
-                    ? "warning"
-                    : "tertiary"
-              }
-            >
-              {observation.level}
-            </Badge>
-          )}
-          {observation.statusMessage && (
-            <Badge variant="tertiary">{observation.statusMessage}</Badge>
-          )}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+            {observation.version && (
+              <Badge variant="tertiary">Version: {observation.version}</Badge>
+            )}
+            {observation.model && (
+              <Badge variant="tertiary">{observation.model}</Badge>
+            )}
+            {observation.level && observation.level !== "DEFAULT" && (
+              <Badge
+                variant={
+                  observation.level === "ERROR"
+                    ? "destructive"
+                    : observation.level === "WARNING"
+                      ? "warning"
+                      : "tertiary"
+                }
+              >
+                {observation.level}
+              </Badge>
+            )}
+            {observation.statusMessage && (
+              <Badge variant="tertiary">{observation.statusMessage}</Badge>
+            )}
+          </div>
         </div>
       </div>
 

--- a/web/src/components/trace2/components/ObservationDetailView/ObservationMetadataBadgeModel.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationMetadataBadgeModel.tsx
@@ -1,0 +1,68 @@
+/**
+ * Model badge for ObservationDetailView
+ * Handles linked models (with external link) and unlinked models (with create form)
+ */
+
+import { Badge } from "@/src/components/ui/badge";
+import { ExternalLinkIcon, PlusCircle } from "lucide-react";
+import Link from "next/link";
+import { UpsertModelFormDrawer } from "@/src/features/models/components/UpsertModelFormDrawer";
+
+export function ModelBadge({
+  model,
+  internalModelId,
+  projectId,
+  usageDetails,
+}: {
+  model: string | null;
+  internalModelId: string | null;
+  projectId: string;
+  usageDetails: Record<string, number> | undefined;
+}) {
+  if (!model) return null;
+
+  // Linked model - show link to model settings
+  if (internalModelId) {
+    return (
+      <Badge>
+        <Link
+          href={`/project/${projectId}/settings/models/${internalModelId}`}
+          className="flex items-center"
+          title="View model details"
+        >
+          <span className="truncate">{model}</span>
+          <ExternalLinkIcon className="ml-1 h-3 w-3" />
+        </Link>
+      </Badge>
+    );
+  }
+
+  // Unlinked model - show create form drawer
+  return (
+    <UpsertModelFormDrawer
+      action="create"
+      projectId={projectId}
+      prefilledModelData={{
+        modelName: model,
+        prices:
+          usageDetails && Object.keys(usageDetails).length > 0
+            ? Object.keys(usageDetails)
+                .filter((key) => key !== "total")
+                .reduce(
+                  (acc, key) => {
+                    acc[key] = 0.000001;
+                    return acc;
+                  },
+                  {} as Record<string, number>,
+                )
+            : undefined,
+      }}
+      className="cursor-pointer"
+    >
+      <Badge variant="tertiary" className="flex items-center gap-1">
+        <span>{model}</span>
+        <PlusCircle className="h-3 w-3" />
+      </Badge>
+    </UpsertModelFormDrawer>
+  );
+}

--- a/web/src/components/trace2/components/ObservationDetailView/ObservationMetadataBadgeModelParameters.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationMetadataBadgeModelParameters.tsx
@@ -1,0 +1,50 @@
+/**
+ * Model parameters badges for ObservationDetailView
+ * Renders dynamic badges for each model parameter with truncation
+ */
+
+import { type JsonNested } from "@langfuse/shared";
+import { Badge } from "@/src/components/ui/badge";
+
+export function ModelParametersBadges({
+  modelParameters,
+}: {
+  modelParameters: JsonNested | null | undefined;
+}) {
+  // Only render if modelParameters is an object (not array, primitive, or null)
+  if (
+    !modelParameters ||
+    typeof modelParameters !== "object" ||
+    Array.isArray(modelParameters)
+  ) {
+    return null;
+  }
+
+  const entries = Object.entries(modelParameters).filter(
+    ([_, value]) => value !== null,
+  );
+
+  if (entries.length === 0) return null;
+
+  return (
+    <>
+      {entries.map(([key, value]) => {
+        const valueString =
+          Object.prototype.toString.call(value) === "[object Object]"
+            ? JSON.stringify(value)
+            : value?.toString();
+
+        return (
+          <Badge variant="tertiary" key={key} className="max-w-md">
+            <span
+              className="overflow-hidden text-ellipsis whitespace-nowrap"
+              title={valueString}
+            >
+              {key}: {valueString}
+            </span>
+          </Badge>
+        );
+      })}
+    </>
+  );
+}

--- a/web/src/components/trace2/components/ObservationDetailView/ObservationMetadataBadgesSimple.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationMetadataBadgesSimple.tsx
@@ -1,0 +1,83 @@
+/**
+ * Simple metadata badges for ObservationDetailView
+ * Each badge handles its own null checks and returns null when data is unavailable
+ */
+
+import { Badge } from "@/src/components/ui/badge";
+import { formatIntervalSeconds } from "@/src/utils/dates";
+
+export function LatencyBadge({
+  latencySeconds,
+}: {
+  latencySeconds: number | null;
+}) {
+  if (latencySeconds == null) return null;
+
+  return (
+    <Badge variant="tertiary">
+      Latency: {formatIntervalSeconds(latencySeconds)}
+    </Badge>
+  );
+}
+
+export function TimeToFirstTokenBadge({
+  timeToFirstToken,
+}: {
+  timeToFirstToken: number | null | undefined;
+}) {
+  if (timeToFirstToken == null) return null;
+
+  return (
+    <Badge variant="tertiary">
+      Time to first token: {formatIntervalSeconds(timeToFirstToken)}
+    </Badge>
+  );
+}
+
+export function EnvironmentBadge({
+  environment,
+}: {
+  environment: string | null | undefined;
+}) {
+  if (!environment) return null;
+
+  return <Badge variant="tertiary">Env: {environment}</Badge>;
+}
+
+export function VersionBadge({
+  version,
+}: {
+  version: string | null | undefined;
+}) {
+  if (!version) return null;
+
+  return <Badge variant="tertiary">Version: {version}</Badge>;
+}
+
+export function LevelBadge({ level }: { level: string | null | undefined }) {
+  if (!level || level === "DEFAULT") return null;
+
+  return (
+    <Badge
+      variant={
+        level === "ERROR"
+          ? "destructive"
+          : level === "WARNING"
+            ? "warning"
+            : "tertiary"
+      }
+    >
+      {level}
+    </Badge>
+  );
+}
+
+export function StatusMessageBadge({
+  statusMessage,
+}: {
+  statusMessage: string | null | undefined;
+}) {
+  if (!statusMessage) return null;
+
+  return <Badge variant="tertiary">{statusMessage}</Badge>;
+}

--- a/web/src/components/trace2/components/ObservationDetailView/ObservationMetadataBadgesTooltip.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationMetadataBadgesTooltip.tsx
@@ -45,12 +45,21 @@ export function UsageBadge({
   // Only show for generation-like observations
   if (!isGenerationLike(type) || !usageDetails) return null;
 
+  const tokenText = formatTokenCounts(
+    inputUsage,
+    outputUsage,
+    totalUsage,
+    true,
+  );
+  const hasText = tokenText.length > 0;
+
   return (
     <BreakdownTooltip details={usageDetails} isCost={false}>
-      <Badge variant="tertiary" className="flex items-center gap-1">
-        <span>
-          {formatTokenCounts(inputUsage, outputUsage, totalUsage, true)}
-        </span>
+      <Badge
+        variant="tertiary"
+        className={`flex items-center gap-1 ${!hasText ? "h-6 pl-2" : ""}`}
+      >
+        {hasText && <span>{tokenText}</span>}
         <InfoIcon className="h-3 w-3" />
       </Badge>
     </BreakdownTooltip>

--- a/web/src/components/trace2/components/ObservationDetailView/ObservationMetadataBadgesTooltip.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationMetadataBadgesTooltip.tsx
@@ -1,0 +1,58 @@
+/**
+ * Tooltip-based metadata badges for ObservationDetailView
+ * These badges use BreakdownTooltip to show detailed cost/usage information
+ */
+
+import { type ObservationType, isGenerationLike } from "@langfuse/shared";
+import { Badge } from "@/src/components/ui/badge";
+import { BreakdownTooltip } from "@/src/components/trace/BreakdownToolTip";
+import { usdFormatter, formatTokenCounts } from "@/src/utils/numbers";
+import { InfoIcon } from "lucide-react";
+
+export function CostBadge({
+  totalCost,
+  costDetails,
+}: {
+  totalCost: number | null;
+  costDetails: Record<string, number> | undefined;
+}) {
+  // Don't show if no cost data or cost is 0
+  if (totalCost == null || totalCost === 0 || !costDetails) return null;
+
+  return (
+    <BreakdownTooltip details={costDetails} isCost={true}>
+      <Badge variant="tertiary" className="flex items-center gap-1">
+        <span>{usdFormatter(totalCost)}</span>
+        <InfoIcon className="h-3 w-3" />
+      </Badge>
+    </BreakdownTooltip>
+  );
+}
+
+export function UsageBadge({
+  type,
+  inputUsage,
+  outputUsage,
+  totalUsage,
+  usageDetails,
+}: {
+  type: ObservationType;
+  inputUsage: number;
+  outputUsage: number;
+  totalUsage: number;
+  usageDetails: Record<string, number> | undefined;
+}) {
+  // Only show for generation-like observations
+  if (!isGenerationLike(type) || !usageDetails) return null;
+
+  return (
+    <BreakdownTooltip details={usageDetails} isCost={false}>
+      <Badge variant="tertiary" className="flex items-center gap-1">
+        <span>
+          {formatTokenCounts(inputUsage, outputUsage, totalUsage, true)}
+        </span>
+        <InfoIcon className="h-3 w-3" />
+      </Badge>
+    </BreakdownTooltip>
+  );
+}

--- a/web/src/components/trace2/components/_layout/TracePanelDetail.tsx
+++ b/web/src/components/trace2/components/_layout/TracePanelDetail.tsx
@@ -18,6 +18,7 @@
 import { useSelection } from "../../contexts/SelectionContext";
 import { useTraceData } from "../../contexts/TraceDataContext";
 import { TraceDetailView } from "../TraceDetailView/TraceDetailView";
+import { ObservationDetailView } from "../ObservationDetailView/ObservationDetailView";
 import { useMemo } from "react";
 
 export function TracePanelDetail() {
@@ -31,17 +32,26 @@ export function TracePanelDetail() {
       selectedNodeId !== null && selectedNode?.type !== "TRACE";
 
     if (isObservationSelected && selectedNode) {
-      // TODO: Replace with ObservationDetailView in Phase 3
+      // Find the full observation data from observations array
+      const observationData = observations.find(
+        (obs) => obs.id === selectedNode.id,
+      );
+
+      if (!observationData) {
+        return (
+          <div className="flex h-full w-full items-center justify-center p-4">
+            <p className="text-sm text-muted-foreground">
+              Observation not found
+            </p>
+          </div>
+        );
+      }
+
       return (
-        <div className="p-4">
-          <h2 className="text-lg font-semibold">Observation Details</h2>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Selected: {selectedNode.name} ({selectedNode.type})
-          </p>
-          <p className="mt-1 text-xs text-muted-foreground">
-            ID: {selectedNode.id}
-          </p>
-        </div>
+        <ObservationDetailView
+          observation={observationData}
+          projectId={trace.projectId}
+        />
       );
     }
 


### PR DESCRIPTION
## Summary
- Implements S5.2 - ObservationDetailView structure for trace2/ view
- Matches visual appearance to existing traces/ view (badges, tooltips, formatting)
- Extracts all metadata badges into 4 separate component files for better maintainability

## Changes
### New Files
- `ObservationMetadataBadgesSimple.tsx` - 6 simple badges (Latency, TimeToFirstToken, Environment, Version, Level, StatusMessage)
- `ObservationMetadataBadgesTooltip.tsx` - 2 tooltip badges (Cost, Usage) with BreakdownTooltip
- `ObservationMetadataBadgeModel.tsx` - Model badge with linked/unlinked variants
- `ObservationMetadataBadgeModelParameters.tsx` - Dynamic model parameters badges

### Key Improvements
- Main component reduced from ~290 to ~190 lines
- Each badge component handles its own null checks
- Cost badge only shows when cost ≠ 0
- Usage badge has proper h-6 pl-2 alignment when only info icon is shown
- Added useMemo for latency calculation

## Test plan
- [ ] Verify ObservationDetailView renders correctly in traces2/ view
- [ ] Verify badges match traces/ view visually
- [ ] Verify cost/usage tooltips show breakdown details
- [ ] Verify model badge links to settings for linked models
- [ ] Verify model badge shows create form for unlinked models

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `ObservationDetailView` with extracted badge components and update `TracePanelDetail` to use it for observation nodes.
> 
>   - **Components**:
>     - Add `ObservationDetailView` in `ObservationDetailView.tsx` to display observation details with metadata badges and tabbed interface.
>     - Extract metadata badges into separate components: `ObservationMetadataBadgesSimple.tsx`, `ObservationMetadataBadgesTooltip.tsx`, `ObservationMetadataBadgeModel.tsx`, `ObservationMetadataBadgeModelParameters.tsx`.
>   - **Behavior**:
>     - `ObservationDetailView` shows observation metadata, cost, and usage with tooltips, and supports tabbed interface (Preview, Scores) with Formatted/JSON toggle.
>     - `ModelBadge` handles linked/unlinked models with external link or create form.
>     - `CostBadge` and `UsageBadge` show tooltips with breakdown details.
>   - **Integration**:
>     - Update `TracePanelDetail.tsx` to use `ObservationDetailView` for observation nodes, falling back to `TraceDetailView` for trace nodes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 173b7d6fb7b1f885d5b5e15a25c296e56b944979. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->