### PR TITLE
perf: use uploadStream for Readable uploads to azure blob storage

### DIFF
--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -198,36 +198,24 @@ class AzureBlobStorageService implements StorageService {
   }
 
   public async uploadFile(params: UploadFile): Promise<void> {
-    const { fileName, data } = params;
+    const { fileName, fileType, data, partSize } = params;
     try {
       await this.createContainerIfNotExists();
 
       const blockBlobClient = this.client.getBlockBlobClient(fileName);
 
       if (typeof data === "string") {
-        await blockBlobClient.upload(data, data.length);
+        await blockBlobClient.upload(data, data.length, {
+          blobHTTPHeaders: { blobContentType: fileType },
+        });
       } else if (data instanceof Readable) {
-        const blockIds = [];
-        for await (const chunk of data) {
-          // Azure requires block IDs to be base64 strings of the same length
-          // Use a fixed format with padded index to ensure consistent length
-          const blockIdStr: string = `block-${blockIds.length.toString().padStart(10, "0")}`;
-          const blockId = Buffer.from(blockIdStr).toString("base64");
+        // bufferSize controls the block size (default 8MB supports ~800GB files)
+        const bufferSize = partSize ?? 8 * 1024 * 1024; // Default 8MB per block
+        const maxConcurrency = 5; // Default value
 
-          const bufferChunk = Buffer.isBuffer(chunk)
-            ? chunk
-            : Buffer.from(chunk);
-
-          await blockBlobClient.stageBlock(
-            blockId,
-            bufferChunk,
-            bufferChunk.length,
-          );
-          blockIds.push(blockId);
-        }
-        if (blockIds.length > 0) {
-          await blockBlobClient.commitBlockList(blockIds);
-        }
+        await blockBlobClient.uploadStream(data, bufferSize, maxConcurrency, {
+          blobHTTPHeaders: { blobContentType: fileType },
+        });
       } else {
         throw new Error("Unsupported data type. Must be Readable or string.");
       }

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -25,7 +25,7 @@ import { encrypt } from "@langfuse/shared/encryption";
 // with multipart uploads. These tests use MinIO explicitly or are skipped.
 // Unfortunately, this is necessary as we don't have a good way to skip empty file uploads
 // and at least azurite doesn't handle them gracefully.
-const maybeIt = env.LANGFUSE_USE_AZURE_BLOB === "true" ? it.skip : it;
+const maybeIt = env.LANGFUSE_USE_AZURE_BLOB === "true" ? it : it;
 
 describe("BlobStorageIntegrationProcessingJob", () => {
   let storageService: StorageService;

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -25,7 +25,7 @@ import { encrypt } from "@langfuse/shared/encryption";
 // with multipart uploads. These tests use MinIO explicitly or are skipped.
 // Unfortunately, this is necessary as we don't have a good way to skip empty file uploads
 // and at least azurite doesn't handle them gracefully.
-const maybeIt = env.LANGFUSE_USE_AZURE_BLOB === "true" ? it : it;
+const maybeIt = env.LANGFUSE_USE_AZURE_BLOB === "true" ? it.skip : it;
 
 describe("BlobStorageIntegrationProcessingJob", () => {
   let storageService: StorageService;

--- a/worker/src/__tests__/storageservice.test.ts
+++ b/worker/src/__tests__/storageservice.test.ts
@@ -6,6 +6,8 @@ import {
   StorageServiceFactory,
 } from "@langfuse/shared/src/server";
 
+const { Readable } = require('stream');
+
 describe("StorageService", () => {
   let storageService: StorageService;
   let storageServiceWithExternalEndpoint: StorageService;
@@ -98,6 +100,31 @@ describe("StorageService", () => {
     const files = await storageService.listFiles("");
     const fileNames = files.map((f) => f.file);
     expect(fileNames).not.toContain(fileName1);
+  });
+
+  test("uploadFile should successfully process a Readable entity", async () => {
+    // Setup
+    const fileName = `${randomUUID()}.txt`;
+    const fileType = "text/plain";
+    const data = "Hello, world!";
+    const expiresInSeconds = 3600;
+
+    // Upload a file
+    await storageService.uploadFile({
+      fileName,
+      fileType,
+      data:  Readable.from(data),
+    });
+
+    // When
+    const signedUrl = await storageService.getSignedUrl(
+      fileName,
+      expiresInSeconds,
+    );
+
+    // Then
+    expect(signedUrl).toContain(env.LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT);
+    expect(signedUrl).not.toContain("external-endpoint.example.com");
   });
 
   test("getSignedUrl should return URL with internal endpoint when no external endpoint is configured", async () => {

--- a/worker/src/__tests__/storageservice.test.ts
+++ b/worker/src/__tests__/storageservice.test.ts
@@ -6,7 +6,7 @@ import {
   StorageServiceFactory,
 } from "@langfuse/shared/src/server";
 
-const { Readable } = require('stream');
+const { Readable } = require("stream");
 
 describe("StorageService", () => {
   let storageService: StorageService;
@@ -113,7 +113,7 @@ describe("StorageService", () => {
     await storageService.uploadFile({
       fileName,
       fileType,
-      data:  Readable.from(data),
+      data: Readable.from(data),
     });
 
     // When


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimizes Azure Blob Storage uploads by using `uploadStream` for `Readable` data, improving performance and simplifying code.
> 
>   - **Behavior**:
>     - `uploadFile` in `StorageService.ts` now uses `uploadStream` for `Readable` data, with default `bufferSize` of 8MB and `maxConcurrency` of 5.
>     - Removes manual block staging and committing for `Readable` uploads.
>   - **Tests**:
>     - Adds test in `storageservice.test.ts` to verify `uploadFile` processes `Readable` data correctly.
>     - Ensures signed URLs do not contain external endpoints unless configured.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2317e02bb51750d77179c91157c371a1b8a1a7ac. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->