### PR TITLE
perf: skip observations deduplication for additional routes for otel projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,7 @@ yarn-error.log*
 /public/openapi*.yml
 
 # claude meta files
-./claude/tsc-cache/*
+.claude/tsc-cache
 
 # vscode
 node_modules


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize performance by skipping deduplication for OTel projects in `observations.ts` and `traces-ui-table-service.ts`.
> 
>   - **Behavior**:
>     - Skip deduplication for OTel projects in `getObservationsForTrace()` and `getObservationsTableInternal()` in `observations.ts`.
>     - Skip deduplication for OTel projects in `getTracesTableGeneric()` in `traces-ui-table-service.ts`.
>   - **Functions**:
>     - Add `shouldSkipObservationsFinal()` check to determine if deduplication can be skipped.
>     - Remove `ORDER BY` and `LIMIT` clauses in SQL queries when deduplication is skipped.
>   - **Misc**:
>     - Add comments explaining the rationale for skipping deduplication for OTel projects.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e903c64d5fd175263169920219c2de7bee6f0886. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->