### PR TITLE
chore(pricing-migration): remove 'after' statement from migration

### DIFF
--- a/packages/shared/clickhouse/migrations/clustered/0031_add_usage_pricing_tier_columns.up.sql
+++ b/packages/shared/clickhouse/migrations/clustered/0031_add_usage_pricing_tier_columns.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE observations ON CLUSTER default ADD COLUMN usage_pricing_tier_id Nullable(String) AFTER total_cost;
-ALTER TABLE observations ON CLUSTER default ADD COLUMN usage_pricing_tier_name Nullable(String) AFTER usage_pricing_tier_id;
+ALTER TABLE observations ON CLUSTER default ADD COLUMN usage_pricing_tier_id Nullable(String);
+ALTER TABLE observations ON CLUSTER default ADD COLUMN usage_pricing_tier_name Nullable(String);

--- a/packages/shared/clickhouse/migrations/unclustered/0031_add_usage_pricing_tier_columns.up.sql
+++ b/packages/shared/clickhouse/migrations/unclustered/0031_add_usage_pricing_tier_columns.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE observations ADD COLUMN usage_pricing_tier_id Nullable(String) AFTER total_cost;
-ALTER TABLE observations ADD COLUMN usage_pricing_tier_name Nullable(String) AFTER usage_pricing_tier_id;
+ALTER TABLE observations ADD COLUMN usage_pricing_tier_id Nullable(String);
+ALTER TABLE observations ADD COLUMN usage_pricing_tier_name Nullable(String);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove 'AFTER' clause from column additions in ClickHouse migration files for `observations` table.
> 
>   - **Migrations**:
>     - Remove 'AFTER' clause from `ALTER TABLE` statements in `0031_add_usage_pricing_tier_columns.up.sql` for both clustered and unclustered migrations.
>     - Affects `usage_pricing_tier_id` and `usage_pricing_tier_name` columns in `observations` table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ae42a38f46c7993189ee83998906b856e81bbae7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->