### PR TITLE
feat(metrics): export bullmq stats in prometheus format

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -80,7 +80,7 @@
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "bcryptjs": "^2.4.3",
-    "bullmq": "^5.34.10",
+    "bullmq": "^5.65.0",
     "date-fns": "^3.3.1",
     "dd-trace": "^5.65.0",
     "decimal.js": "^10.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,8 +205,8 @@ importers:
         specifier: ^2.4.3
         version: 2.4.3
       bullmq:
-        specifier: ^5.34.10
-        version: 5.34.10
+        specifier: ^5.65.0
+        version: 5.65.0
       date-fns:
         specifier: ^3.3.1
         version: 3.6.0
@@ -345,7 +345,7 @@ importers:
         version: 0.0.4
       '@appsignal/opentelemetry-instrumentation-bullmq':
         specifier: ^0.7.3
-        version: 0.7.3(bullmq@5.34.10)
+        version: 0.7.3(bullmq@5.65.0)
       '@baselime/trpc-opentelemetry-middleware':
         specifier: ^0.1.2
         version: 0.1.2(@opentelemetry/api@1.9.0)(@trpc/server@11.4.4(typescript@5.9.2))
@@ -578,8 +578,8 @@ importers:
         specifier: ^2.4.3
         version: 2.4.3
       bullmq:
-        specifier: ^5.34.10
-        version: 5.34.10
+        specifier: ^5.65.0
+        version: 5.65.0
       chroma-js:
         specifier: ^3.1.2
         version: 3.1.2
@@ -2914,6 +2914,9 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@ioredis/commands@1.4.0':
+    resolution: {integrity: sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==}
 
   '@ioredis/commands@1.4.0':
     resolution: {integrity: sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==}
@@ -6966,6 +6969,9 @@ packages:
   bullmq@5.34.10:
     resolution: {integrity: sha512-ia6EzpQm1ZPq6GUBSLyfvzJrhdBTd1f3Gn2g9pFtLX4hBOob6QHmcmBzGgPlSCyr/i2Qfe4OdjS21bRd02srbw==}
 
+  bullmq@5.65.0:
+    resolution: {integrity: sha512-fyOcyf2ad4zrNmE18vdF/ie7DrW0TwhLt5e0DkqDxbRpDNiUdYqgp2QZJW2ntnUN08T2mDMC4deUUhF2UOAmeQ==}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -9214,6 +9220,10 @@ packages:
   interpret@1.4.0:
     resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
     engines: {node: '>= 0.10'}
+
+  ioredis@5.8.2:
+    resolution: {integrity: sha512-C6uC+kleiIMmjViJINWk80sOQw5lEzse1ZmvD+S/s8p8CWapftSaC+kocGTx6xrbrJ4WmYQGC08ffHLr6ToR6Q==}
+    engines: {node: '>=12.22.0'}
 
   ioredis@5.8.2:
     resolution: {integrity: sha512-C6uC+kleiIMmjViJINWk80sOQw5lEzse1ZmvD+S/s8p8CWapftSaC+kocGTx6xrbrJ4WmYQGC08ffHLr6ToR6Q==}
@@ -13808,6 +13818,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@appsignal/opentelemetry-instrumentation-bullmq@0.7.3(bullmq@5.65.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.27.0
+      flat: 5.0.2
+    optionalDependencies:
+      bullmq: 5.65.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
@@ -17000,6 +17021,8 @@ snapshots:
   '@inquirer/type@3.0.8(@types/node@24.10.1)':
     optionalDependencies:
       '@types/node': 24.10.1
+
+  '@ioredis/commands@1.4.0': {}
 
   '@ioredis/commands@1.4.0': {}
 
@@ -21295,7 +21318,7 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.7.2
+      semver: 7.7.3
       ts-api-utils: 1.3.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
@@ -21325,7 +21348,7 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.7.1
+      semver: 7.7.3
       ts-api-utils: 1.3.0(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
@@ -21342,7 +21365,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.2)
       eslint: 8.57.0
       eslint-scope: 5.1.1
-      semver: 7.7.2
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -22271,6 +22294,18 @@ snapshots:
       semver: 7.6.3
       tslib: 2.6.3
       uuid: 9.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  bullmq@5.65.0:
+    dependencies:
+      cron-parser: 4.9.0
+      ioredis: 5.8.2
+      msgpackr: 1.11.2
+      node-abort-controller: 3.1.1
+      semver: 7.7.3
+      tslib: 2.8.1
+      uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25047,6 +25082,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ioredis@5.8.2:
+    dependencies:
+      '@ioredis/commands': 1.4.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ip-address@10.0.1: {}
 
   ip-address@9.0.5:
@@ -25703,7 +25752,7 @@ snapshots:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.7.2
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 

--- a/web/package.json
+++ b/web/package.json
@@ -102,7 +102,7 @@
     "@uiw/react-codemirror": "^4.24.1",
     "ai": "^3.4.9",
     "bcryptjs": "^2.4.3",
-    "bullmq": "^5.34.10",
+    "bullmq": "^5.65.0",
     "chroma-js": "^3.1.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/web/src/__tests__/admin-bullmq-metrics.servertest.ts
+++ b/web/src/__tests__/admin-bullmq-metrics.servertest.ts
@@ -1,0 +1,106 @@
+/** @jest-environment node */
+
+import { createMocks } from "node-mocks-http";
+import handler from "@/src/pages/api/admin/bullmq/metrics";
+import { type NextApiRequest, type NextApiResponse } from "next";
+import {
+  IngestionQueue,
+  TraceUpsertQueue,
+  OtelIngestionQueue,
+  getQueue,
+  logger,
+} from "@langfuse/shared/src/server";
+
+type QueueMock = {
+  exportPrometheusMetrics: jest.Mock<Promise<string | undefined>, []>;
+};
+
+const buildQueue = (metric?: string): QueueMock => ({
+  exportPrometheusMetrics: jest.fn().mockResolvedValue(metric),
+});
+
+jest.mock("@langfuse/shared/src/server", () => {
+  const QueueName = {
+    IngestionQueue: "ingestion-queue",
+    TraceUpsert: "trace-upsert",
+    OtelIngestionQueue: "otel-ingestion-queue",
+    BatchExport: "batch-export-queue",
+  } as const;
+
+  return {
+    __esModule: true,
+    QueueName,
+    logger: { error: jest.fn() },
+    IngestionQueue: { getInstance: jest.fn() },
+    TraceUpsertQueue: { getInstance: jest.fn() },
+    OtelIngestionQueue: { getInstance: jest.fn() },
+    getQueue: jest.fn(),
+  };
+});
+
+describe("/api/admin/bullmq/metrics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns aggregated metrics while filtering undefined values", async () => {
+    (IngestionQueue.getInstance as jest.Mock).mockReturnValue(
+      buildQueue("ingestion metrics"),
+    );
+    (TraceUpsertQueue.getInstance as jest.Mock).mockReturnValue(
+      buildQueue(undefined),
+    );
+    (OtelIngestionQueue.getInstance as jest.Mock).mockReturnValue(
+      buildQueue("otel metrics"),
+    );
+    (getQueue as jest.Mock).mockReturnValue(buildQueue("batch metrics"));
+
+    const { req, res } = createMocks({ method: "GET" });
+
+    await handler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse,
+    );
+
+    expect(res._getStatusCode()).toBe(200);
+    const body = res._getData();
+    expect(body).toBe("ingestion metrics\notel metrics\nbatch metrics");
+    const headers = res._getHeaders();
+    expect(headers["content-type"]).toBe("text/plain");
+    expect(headers["content-length"]).toBe(
+      Buffer.byteLength(body, "utf-8").toString(),
+    );
+  });
+
+  it("rejects non-GET requests", async () => {
+    const { req, res } = createMocks({ method: "POST" });
+
+    await handler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse,
+    );
+
+    expect(res._getStatusCode()).toBe(405);
+    expect(res._getJSONData()).toEqual({ error: "Method Not Allowed" });
+  });
+
+  it("logs and returns 500 when queue resolution fails", async () => {
+    (IngestionQueue.getInstance as jest.Mock).mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    const { req, res } = createMocks({ method: "GET" });
+
+    await handler(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse,
+    );
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getJSONData()).toEqual({ error: "Internal Server Error" });
+    expect((logger.error as jest.Mock).mock.calls[0][0]).toBe(
+      "Error fetching BullMQ metrics",
+    );
+    expect((logger.error as jest.Mock).mock.calls[0][1]).toBeInstanceOf(Error);
+  });
+});

--- a/web/src/pages/api/admin/bullmq/metrics/index.ts
+++ b/web/src/pages/api/admin/bullmq/metrics/index.ts
@@ -1,0 +1,68 @@
+import { type NextApiRequest, type NextApiResponse } from "next";
+
+import {
+  logger,
+  QueueName,
+  getQueue,
+  IngestionQueue,
+  TraceUpsertQueue,
+  OtelIngestionQueue,
+} from "@langfuse/shared/src/server";
+import { AdminApiAuthService } from "@/src/ee/features/admin-api/server/adminApiAuth";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (
+    !AdminApiAuthService.handleAdminAuth(req, res, {
+      isAllowedOnLangfuseCloud: true,
+    })
+  ) {
+    return;
+  }
+
+  try {
+    // allow only GET requests
+    if (req.method !== "GET") {
+      res.status(405).json({ error: "Method Not Allowed" });
+      return;
+    }
+
+    const queues: string[] = Object.values(QueueName);
+
+    const metrics = await Promise.all(
+      queues.map(async (queueName) => {
+        let queue;
+        if (queueName.startsWith(QueueName.IngestionQueue)) {
+          queue = IngestionQueue.getInstance({ shardName: queueName });
+        } else if (queueName.startsWith(QueueName.TraceUpsert)) {
+          queue = TraceUpsertQueue.getInstance({ shardName: queueName });
+        } else if (queueName.startsWith(QueueName.OtelIngestionQueue)) {
+          queue = OtelIngestionQueue.getInstance({ shardName: queueName });
+        } else {
+          queue = getQueue(
+            queueName as Exclude<
+              QueueName,
+              | QueueName.IngestionQueue
+              | QueueName.TraceUpsert
+              | QueueName.OtelIngestionQueue
+            >,
+          );
+        }
+        return queue?.exportPrometheusMetrics();
+      }),
+    );
+    const result = metrics
+      .filter((chunk): chunk is string => typeof chunk === "string")
+      .join("\n");
+    res.writeHead(200, {
+      "Content-Type": "text/plain",
+      "Content-Length": Buffer.byteLength(result),
+    });
+    res.end(result);
+  } catch (error) {
+    logger.error("Error fetching BullMQ metrics", error);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Export BullMQ metrics in prometheus format for easier monitoring.
This required an update of BullMQ and ioredis to latest versions.

## Type of change

- [X] New feature (non-breaking change which adds functionality)


## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add API endpoint to export BullMQ metrics in Prometheus format, with tests and updated dependencies.
> 
>   - **New Feature**:
>     - Export BullMQ metrics in Prometheus format via new API endpoint in `web/src/pages/api/admin/bullmq/metrics/index.ts`.
>     - Handles GET requests to fetch metrics, returns 405 for other methods.
>     - Logs errors and returns 500 if queue resolution fails.
>   - **Testing**:
>     - Adds `web/src/__tests__/admin-bullmq-metrics.servertest.ts` to test new API endpoint.
>     - Tests for correct status codes, response content, and error logging.
>   - **Dependencies**:
>     - Update `bullmq` to `^5.65.0` and `ioredis` to `^5.8.2` in `packages/shared/package.json` and `web/package.json`.
>   - **Misc**:
>     - Change Docker commands from `docker` to `podman` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b4cdc6336c2a1ef82fb557a4357935b8f1940046. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->