### PR TITLE
fix(api): stricter delete API limits on cloud

### DIFF
--- a/packages/shared/src/interfaces/rate-limits.ts
+++ b/packages/shared/src/interfaces/rate-limits.ts
@@ -9,6 +9,7 @@ export const RateLimitResource = z.enum([
   "prompts",
   "legacy-ingestion",
   "datasets",
+  "trace-delete",
 ]);
 
 // result of the rate limit check.

--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -264,6 +264,12 @@ const getPlanBasedRateLimitConfig = (
             points: 10,
             durationInSec: 86400, // 10 requests per day
           };
+        case "trace-delete":
+          return {
+            resource: "trace-delete",
+            points: 50,
+            durationInSec: 86400, // 50 requests per day
+          };
         default:
           const exhaustiveCheck: never = resource;
           throw new Error(`Unhandled resource case: ${exhaustiveCheck}`);
@@ -320,6 +326,12 @@ const getPlanBasedRateLimitConfig = (
             points: 200, // temporary: using pro limit
             durationInSec: 86400, // 200 requests per day
           };
+        case "trace-delete":
+          return {
+            resource: "trace-delete",
+            points: 200,
+            durationInSec: 86400, // 200 requests per day
+          };
         default:
           const exhaustiveCheck: never = resource;
           throw new Error(`Unhandled resource case: ${exhaustiveCheck}`);
@@ -369,6 +381,12 @@ const getPlanBasedRateLimitConfig = (
             resource: "public-api-daily-metrics-legacy",
             points: 200,
             durationInSec: 86400, // 200 requests per day
+          };
+        case "trace-delete":
+          return {
+            resource: "trace-delete",
+            points: 1000,
+            durationInSec: 86400, // 1000 requests per day
           };
         default:
           const exhaustiveCheck: never = resource;

--- a/web/src/features/public-api/types/traces.ts
+++ b/web/src/features/public-api/types/traces.ts
@@ -144,7 +144,10 @@ export const DeleteTraceV1Response = z
 // DELETE /api/public/traces
 export const DeleteTracesV1Body = z
   .object({
-    traceIds: z.array(z.string()).min(1, "At least 1 traceId is required."),
+    traceIds: z
+      .array(z.string())
+      .min(1, "At least 1 traceId is required.")
+      .max(1000, "Cannot specify more than 1000 traces in a single request."),
   })
   .strict();
 export const DeleteTracesV1Response = z

--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -147,6 +147,7 @@ export default withMiddlewares({
     name: "Delete Single Trace",
     querySchema: DeleteTraceV1Query,
     responseSchema: DeleteTraceV1Response,
+    rateLimitResource: "trace-delete",
     fn: async ({ query, auth }) => {
       const { traceId } = query;
 

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -145,6 +145,7 @@ export default withMiddlewares({
     name: "Delete Multiple Traces",
     bodySchema: DeleteTracesV1Body,
     responseSchema: DeleteTracesV1Response,
+    rateLimitResource: "trace-delete",
     fn: async ({ body, auth }) => {
       const { traceIds } = body;
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces stricter limits on trace deletion API, including rate limiting, maximum traces per request.
> 
>   - **Behavior**:
>     - Adds `trace-delete` to `RateLimitResource` in `rate-limits.ts`.
>     - Limits trace deletion requests to 1000 traces per request in `DeleteTracesV1Body`.
>     - Adds rate limiting for `trace-delete` in `RateLimitService.ts` with different limits for various plans.
>   - **API Changes**:
>     - Adds `rateLimitResource: "trace-delete"` to DELETE routes in `[traceId].ts` and `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ce57f1718cd8f06f6154cf33fd6c81ea77846145. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->