### PR TITLE
feat(trace2): add header actions (S5.6) and TraceDetailView Preview tab (S5.4a)

### DIFF
--- a/web/src/components/trace2/Trace.tsx
+++ b/web/src/components/trace2/Trace.tsx
@@ -7,6 +7,7 @@ import { TraceDataProvider } from "./contexts/TraceDataContext";
 import { ViewPreferencesProvider } from "./contexts/ViewPreferencesContext";
 import { SelectionProvider } from "./contexts/SelectionContext";
 import { SearchProvider } from "./contexts/SearchContext";
+import { JsonExpansionProvider } from "./contexts/JsonExpansionContext";
 import { TraceLayoutMobile } from "./components/_layout/TraceLayoutMobile";
 import { TraceLayoutDesktop } from "./components/_layout/TraceLayoutDesktop";
 import { TracePanelNavigation } from "./components/_layout/TracePanelNavigation";
@@ -62,7 +63,9 @@ export function Trace({ trace, observations, scores, projectId }: TraceProps) {
       >
         <SelectionProvider>
           <SearchProvider>
-            <TraceContent />
+            <JsonExpansionProvider>
+              <TraceContent />
+            </JsonExpansionProvider>
           </SearchProvider>
         </SelectionProvider>
       </TraceDataProvider>

--- a/web/src/components/trace2/Trace.tsx
+++ b/web/src/components/trace2/Trace.tsx
@@ -14,6 +14,7 @@ import { TracePanelDetail } from "./components/_layout/TracePanelDetail";
 import { TracePanelNavigationLayoutDesktop } from "./components/_layout/TracePanelNavigationLayoutDesktop";
 import { TracePanelNavigationLayoutMobile } from "./components/_layout/TracePanelNavigationLayoutMobile";
 import { useIsMobile } from "@/src/hooks/use-mobile";
+import { useTraceComments } from "./api/useTraceComments";
 
 import { useMemo } from "react";
 
@@ -35,9 +36,21 @@ export type TraceProps = {
   ) => void;
 };
 
-export function Trace({ trace, observations, scores }: TraceProps) {
-  // TODO: Build comments map (empty for now - will be populated from API in future)
-  const commentsMap = useMemo(() => new Map<string, number>(), []);
+export function Trace({ trace, observations, scores, projectId }: TraceProps) {
+  // Fetch comment counts using existing hook
+  const { observationCommentCounts, traceCommentCount } = useTraceComments({
+    projectId,
+    traceId: trace.id,
+  });
+
+  // Merge observation + trace comments into single Map for TraceDataContext
+  const commentsMap = useMemo(() => {
+    const map = new Map(observationCommentCounts);
+    if (traceCommentCount > 0) {
+      map.set(trace.id, traceCommentCount);
+    }
+    return map;
+  }, [observationCommentCounts, traceCommentCount, trace.id]);
 
   return (
     <ViewPreferencesProvider>

--- a/web/src/components/trace2/api/useMedia.ts
+++ b/web/src/components/trace2/api/useMedia.ts
@@ -1,0 +1,34 @@
+import { api } from "@/src/utils/api";
+
+export type UseMediaParams = {
+  projectId: string;
+  traceId: string;
+  observationId?: string;
+};
+
+/**
+ * Hook to fetch media attachments for a trace or observation.
+ *
+ * @param projectId - Project ID
+ * @param traceId - Trace ID (required)
+ * @param observationId - Observation ID (optional, for observation-level media)
+ */
+export function useMedia({
+  projectId,
+  traceId,
+  observationId,
+}: UseMediaParams) {
+  return api.media.getByTraceOrObservationId.useQuery(
+    {
+      projectId,
+      traceId,
+      observationId,
+    },
+    {
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      staleTime: 50 * 60 * 1000, // 50 minutes
+    },
+  );
+}

--- a/web/src/components/trace2/api/useTraceComments.ts
+++ b/web/src/components/trace2/api/useTraceComments.ts
@@ -37,11 +37,17 @@ export function useTraceComments({
     },
   );
 
+  // Extract trace comment count from the Map response
+  const traceCommentCountMap = traceCommentCounts.data
+    ? castToNumberMap(traceCommentCounts.data)
+    : undefined;
+  const traceCount = traceCommentCountMap?.get(traceId) ?? 0;
+
   return {
     observationCommentCounts: observationCommentCounts.data
       ? castToNumberMap(observationCommentCounts.data)
       : new Map<string, number>(),
-    traceCommentCount: traceCommentCounts.data ?? 0,
+    traceCommentCount: traceCount,
     isLoading:
       observationCommentCounts.isLoading || traceCommentCounts.isLoading,
   };

--- a/web/src/components/trace2/components/IOPreview/components/ChatMessage.tsx
+++ b/web/src/components/trace2/components/IOPreview/components/ChatMessage.tsx
@@ -6,7 +6,7 @@ import {
   MarkdownJsonView,
   MarkdownJsonViewHeader,
 } from "@/src/components/ui/MarkdownJsonView";
-import { ToolCallInvocationsView } from "@/src/components/trace/ToolCallInvocationsView";
+import { ToolCallInvocationsView } from "@/src/components/trace2/components/_shared/ToolCallInvocationsView";
 import { ListChevronsDownUp, ListChevronsUpDown } from "lucide-react";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
 import {

--- a/web/src/components/trace2/components/IOPreview/components/ChatMessage.tsx
+++ b/web/src/components/trace2/components/IOPreview/components/ChatMessage.tsx
@@ -6,7 +6,7 @@ import {
   MarkdownJsonView,
   MarkdownJsonViewHeader,
 } from "@/src/components/ui/MarkdownJsonView";
-import { ToolCallInvocationsView } from "@/src/components/trace2/components/_shared/ToolCallInvocationsView";
+import { ToolCallInvocationsView } from "@/src/components/trace2/components/ToolCallInvocationsView";
 import { ListChevronsDownUp, ListChevronsUpDown } from "lucide-react";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
 import {

--- a/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
@@ -17,7 +17,11 @@
  * - View mode toggle changes
  */
 
-import { type ObservationType } from "@langfuse/shared";
+import {
+  type ObservationType,
+  AnnotationQueueObjectType,
+  isGenerationLike,
+} from "@langfuse/shared";
 import { type ObservationReturnTypeWithMetadata } from "@/src/server/api/routers/traces";
 import { ItemBadge } from "@/src/components/ItemBadge";
 import { LocalIsoDate } from "@/src/components/LocalIsoDate";
@@ -46,6 +50,15 @@ import { IOPreview } from "@/src/components/trace2/components/IOPreview/IOPrevie
 import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
 import { api } from "@/src/utils/api";
 
+// Header action components
+import { CopyIdsPopover } from "@/src/components/trace2/components/_shared/CopyIdsPopover";
+import { NewDatasetItemFromExistingObject } from "@/src/features/datasets/components/NewDatasetItemFromExistingObject";
+import { AnnotateDrawer } from "@/src/features/scores/components/AnnotateDrawer";
+import { CreateNewAnnotationQueueItem } from "@/src/features/annotation-queues/components/CreateNewAnnotationQueueItem";
+import { CommentDrawerButton } from "@/src/features/comments/CommentDrawerButton";
+import { JumpToPlaygroundButton } from "@/src/features/playground/page/components/JumpToPlaygroundButton";
+import { useTraceData } from "@/src/components/trace2/contexts/TraceDataContext";
+
 export interface ObservationDetailViewProps {
   observation: ObservationReturnTypeWithMetadata;
   projectId: string;
@@ -65,6 +78,13 @@ export function ObservationDetailView({
     "pretty",
   );
   const [isPrettyViewAvailable, setIsPrettyViewAvailable] = useState(true);
+
+  // Get comments and scores from context
+  const { comments, scores } = useTraceData();
+  const observationScores = useMemo(
+    () => scores.filter((s) => s.observationId === observation.id),
+    [scores, observation.id],
+  );
 
   // Fetch observation input/output (not included in ObservationReturnTypeWithMetadata)
   const observationWithIO = api.observations.byId.useQuery(
@@ -117,14 +137,76 @@ export function ObservationDetailView({
     <div className="flex h-full flex-col overflow-hidden">
       {/* Header section */}
       <div className="flex-shrink-0 space-y-2 border-b p-4">
-        {/* Title row */}
-        <div className="flex items-start gap-2">
-          <div className="mt-1">
-            <ItemBadge type={observation.type as ObservationType} isSmall />
+        {/* Title row with actions */}
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-start gap-2">
+            <div className="mt-1">
+              <ItemBadge type={observation.type as ObservationType} isSmall />
+            </div>
+            <span className="min-w-0 break-all font-medium">
+              {observation.name || observation.id}
+            </span>
+            <CopyIdsPopover
+              idItems={[
+                { id: traceId, name: "Trace ID" },
+                { id: observation.id, name: "Observation ID" },
+              ]}
+            />
           </div>
-          <span className="min-w-0 break-all font-medium">
-            {observation.name || observation.id}
-          </span>
+          {/* Action buttons */}
+          <div className="flex flex-shrink-0 flex-wrap items-start gap-0.5">
+            {observationWithIO.data && (
+              <NewDatasetItemFromExistingObject
+                traceId={traceId}
+                observationId={observation.id}
+                projectId={projectId}
+                input={observationWithIO.data.input}
+                output={observationWithIO.data.output}
+                metadata={observationWithIO.data.metadata}
+                key={observation.id}
+                size="sm"
+              />
+            )}
+            <div className="flex items-start">
+              <AnnotateDrawer
+                key={"annotation-drawer-" + observation.id}
+                projectId={projectId}
+                scoreTarget={{
+                  type: "trace",
+                  traceId: traceId,
+                  observationId: observation.id,
+                }}
+                scores={observationScores}
+                scoreMetadata={{
+                  projectId: projectId,
+                  environment: observation.environment,
+                }}
+                size="sm"
+              />
+              <CreateNewAnnotationQueueItem
+                projectId={projectId}
+                objectId={observation.id}
+                objectType={AnnotationQueueObjectType.OBSERVATION}
+                size="sm"
+              />
+            </div>
+            {observationWithIO.data &&
+              isGenerationLike(observationWithIO.data.type) && (
+                <JumpToPlaygroundButton
+                  source="generation"
+                  generation={observationWithIO.data}
+                  analyticsEventName="trace_detail:test_in_playground_button_click"
+                  size="sm"
+                />
+              )}
+            <CommentDrawerButton
+              projectId={projectId}
+              objectId={observation.id}
+              objectType="OBSERVATION"
+              count={comments.get(observation.id)}
+              size="sm"
+            />
+          </div>
         </div>
 
         {/* Metadata badges */}

--- a/web/src/components/trace2/components/ObservationDetailView/ObservationMetadataBadgesTooltip.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationMetadataBadgesTooltip.tsx
@@ -5,7 +5,7 @@
 
 import { type ObservationType, isGenerationLike } from "@langfuse/shared";
 import { Badge } from "@/src/components/ui/badge";
-import { BreakdownTooltip } from "@/src/components/trace/BreakdownToolTip";
+import { BreakdownTooltip } from "@/src/components/trace2/components/_shared/BreakdownToolTip";
 import { usdFormatter, formatTokenCounts } from "@/src/utils/numbers";
 import { InfoIcon } from "lucide-react";
 

--- a/web/src/components/trace2/components/SpanContent.tsx
+++ b/web/src/components/trace2/components/SpanContent.tsx
@@ -24,7 +24,7 @@ import { CommentCountIcon } from "@/src/features/comments/CommentCountIcon";
 import { cn } from "@/src/utils/tailwind";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import { usdFormatter, formatTokenCounts } from "@/src/utils/numbers";
-import { heatMapTextColor } from "@/src/components/trace/lib/helpers";
+import { heatMapTextColor } from "@/src/components/trace2/lib/helpers";
 import { useViewPreferences } from "../contexts/ViewPreferencesContext";
 import { useTraceData } from "../contexts/TraceDataContext";
 import type Decimal from "decimal.js";

--- a/web/src/components/trace2/components/ToolCallInvocationsView.tsx
+++ b/web/src/components/trace2/components/ToolCallInvocationsView.tsx
@@ -1,0 +1,87 @@
+import { Wrench } from "lucide-react";
+import { cn } from "@/src/utils/tailwind";
+import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
+import type { z } from "zod/v4";
+import type { ChatMlMessageSchema } from "@/src/components/schemas/ChatMlSchema";
+
+interface ToolCallInvocationsViewProps {
+  message: z.infer<typeof ChatMlMessageSchema>;
+  toolCallNumbers?: number[];
+  className?: string;
+}
+
+export function ToolCallInvocationsView({
+  message,
+  toolCallNumbers,
+  className,
+}: ToolCallInvocationsViewProps) {
+  const toolCalls = message.tool_calls;
+
+  if (!toolCalls || !Array.isArray(toolCalls) || toolCalls.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-2", className)}>
+      {toolCalls.map((toolCall, index) => {
+        const invocationNumber = toolCallNumbers?.[index];
+        // Parse arguments if they're a JSON string
+        let parsedArguments = toolCall.arguments;
+        if (typeof toolCall.arguments === "string") {
+          try {
+            parsedArguments = JSON.parse(toolCall.arguments);
+          } catch {
+            // Keep as string if parsing fails
+            parsedArguments = toolCall.arguments;
+          }
+        }
+
+        return (
+          <div
+            key={`${toolCall.id}-${index}`}
+            className={cn(
+              "w-full border-t px-2 py-2",
+              (message.role === "assistant" ||
+                message.name === "Output" ||
+                message.name === "Model") &&
+                "bg-accent-light-green",
+            )}
+          >
+            {/* Card header */}
+            <div className="flex w-full items-center justify-between gap-2 py-1">
+              {/* Left: Tool icon + number + name */}
+              <div className="flex items-center gap-2">
+                <Wrench className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="font-mono text-xs font-medium text-foreground">
+                  {invocationNumber !== undefined && (
+                    <span className="mr-1">{invocationNumber}.</span>
+                  )}
+                  {toolCall.name}
+                </span>
+              </div>
+
+              {/* Right: Call ID if available */}
+              {toolCall.id && (
+                <span className="font-mono text-xs text-muted-foreground">
+                  {toolCall.id}
+                </span>
+              )}
+            </div>
+
+            {/* Arguments view */}
+            <div className="py-2 [&_.io-message-content]:px-0">
+              <div className="mb-1.5 text-xs font-medium text-muted-foreground">
+                Arguments
+              </div>
+              <PrettyJsonView
+                json={parsedArguments}
+                currentView="pretty"
+                codeClassName="text-xs"
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/trace2/components/TraceSearchListItem.tsx
+++ b/web/src/components/trace2/components/TraceSearchListItem.tsx
@@ -9,6 +9,7 @@ import { type TraceSearchListItem } from "../lib/types";
 import { ItemBadge } from "@/src/components/ItemBadge";
 import { SpanContent } from "./SpanContent";
 import { cn } from "@/src/utils/tailwind";
+import { useTraceData } from "../contexts/TraceDataContext";
 
 interface TraceSearchListItemProps {
   item: TraceSearchListItem;
@@ -22,6 +23,7 @@ export function TraceSearchListItem({
   onSelect,
 }: TraceSearchListItemProps) {
   const { node, parentTotalCost, parentTotalDuration } = item;
+  const { comments } = useTraceData();
 
   return (
     <div
@@ -37,6 +39,7 @@ export function TraceSearchListItem({
           node={node}
           parentTotalCost={parentTotalCost}
           parentTotalDuration={parentTotalDuration}
+          commentCount={comments.get(node.id)}
           onSelect={onSelect}
         />
       </div>

--- a/web/src/components/trace2/components/TraceTimeline/TimelineBar.tsx
+++ b/web/src/components/trace2/components/TraceTimeline/TimelineBar.tsx
@@ -10,7 +10,7 @@ import { CommentCountIcon } from "@/src/features/comments/CommentCountIcon";
 import { GroupedScoreBadges } from "@/src/components/grouped-score-badge";
 import { formatIntervalSeconds } from "@/src/utils/dates";
 import { usdFormatter } from "@/src/utils/numbers";
-import { heatMapTextColor } from "@/src/components/trace/lib/helpers";
+import { heatMapTextColor } from "@/src/components/trace2/lib/helpers";
 import { isPresent } from "@langfuse/shared";
 
 export function TimelineBar({

--- a/web/src/components/trace2/components/_shared/BreakdownToolTip.tsx
+++ b/web/src/components/trace2/components/_shared/BreakdownToolTip.tsx
@@ -1,0 +1,201 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
+import { useState } from "react";
+import Decimal from "decimal.js";
+import { getMaxDecimals } from "@/src/features/models/utils";
+
+interface Details {
+  [key: string]: number | undefined;
+}
+
+interface BreakdownTooltipProps {
+  details: Details | Details[];
+  children: React.ReactNode;
+  isCost?: boolean;
+}
+
+export const BreakdownTooltip = ({
+  details,
+  children,
+  isCost = false,
+}: BreakdownTooltipProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Aggregate details if array is provided
+  const aggregatedDetails = Array.isArray(details)
+    ? details.reduce<Details>((acc, curr) => {
+        Object.entries(curr).forEach(([key, value]) => {
+          acc[key] = new Decimal(acc[key] || 0)
+            .plus(new Decimal(value || 0))
+            .toNumber();
+        });
+        return acc;
+      }, {})
+    : details;
+
+  const formatValueWithPadding = (value: number, maxDecimals: number) => {
+    return !value
+      ? "0"
+      : isCost
+        ? `$${value.toFixed(maxDecimals)}`
+        : value.toLocaleString();
+  };
+
+  const maxDecimals = isCost
+    ? Math.max(
+        ...Object.values(aggregatedDetails).map((v) => getMaxDecimals(v)),
+      )
+    : 0;
+
+  return (
+    <TooltipProvider>
+      <Tooltip open={isOpen} onOpenChange={setIsOpen}>
+        <TooltipTrigger
+          className="flex cursor-pointer"
+          onClick={() => setIsOpen(!isOpen)}
+        >
+          {children}
+        </TooltipTrigger>
+        <TooltipContent className="w-64 p-4">
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <span className="font-semibold">
+                {isCost ? "Cost breakdown" : "Usage breakdown"}
+              </span>
+              {Array.isArray(details) && details.length > 0 && (
+                <span className="text-xs italic text-muted-foreground">
+                  Aggregate across {details.length}{" "}
+                  {details.length === 1 ? "generation" : "generations"}
+                </span>
+              )}
+            </div>
+
+            {/* Input Section */}
+            <Section
+              title={isCost ? "Input cost" : "Input usage"}
+              details={aggregatedDetails}
+              filterFn={(key) => key.includes("input")}
+              formatValue={(v) => formatValueWithPadding(v, maxDecimals)}
+            />
+
+            {/* Output Section */}
+            <Section
+              title={isCost ? "Output cost" : "Output usage"}
+              details={aggregatedDetails}
+              filterFn={(key) => key.includes("output")}
+              formatValue={(v) => formatValueWithPadding(v, maxDecimals)}
+            />
+
+            {/* Other Section */}
+            <OtherSection
+              details={aggregatedDetails}
+              isCost={isCost}
+              formatValue={(v) => formatValueWithPadding(v, maxDecimals)}
+            />
+
+            {/* Total */}
+            <div className="flex justify-between border-b-4 border-t border-double py-1">
+              <span className="text-xs font-semibold">
+                {isCost ? "Total cost" : "Total usage"}
+              </span>
+              <span className="font-mono text-xs font-semibold">
+                {formatValueWithPadding(
+                  aggregatedDetails.total ?? 0,
+                  maxDecimals,
+                )}
+              </span>
+            </div>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};
+
+interface SectionProps {
+  title: string;
+  details: Details;
+  filterFn: (key: string) => boolean;
+  formatValue: (value: number) => string;
+}
+
+const Section = ({ title, details, filterFn, formatValue }: SectionProps) => {
+  const filteredEntries = Object.entries(details)
+    .filter(([key]) => filterFn(key))
+    .sort(([, a], [, b]) => (b ?? 0) - (a ?? 0));
+
+  const sectionTotal = filteredEntries.reduce(
+    (sum, [_, value]) =>
+      new Decimal(sum).plus(new Decimal(value ?? 0)).toNumber(),
+    0,
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex justify-between border-b pb-1">
+        <span className="text-xs font-semibold">{title}</span>
+        <span className="text-right font-mono text-xs font-semibold">
+          {formatValue(sectionTotal)}
+        </span>
+      </div>
+      {filteredEntries.map(([key, value]) => (
+        <div
+          key={key}
+          className="flex justify-between text-xs text-muted-foreground"
+        >
+          <span className="mr-4">{key}</span>
+          <span className="font-mono">{formatValue(value ?? 0)}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+interface OtherSectionProps {
+  details: Details;
+  isCost: boolean;
+  formatValue: (value: number) => string;
+}
+
+const OtherSection = ({ details, isCost, formatValue }: OtherSectionProps) => {
+  const otherEntries = Object.entries(details)
+    .filter(
+      ([key]) =>
+        !key.includes("input") && !key.includes("output") && key !== "total",
+    )
+    .sort(([, a], [, b]) => (b ?? 0) - (a ?? 0));
+
+  if (otherEntries.length === 0) return null;
+
+  const otherTotal = otherEntries.reduce((acc, val) => {
+    if (typeof val[1] !== "number") return acc;
+
+    return acc + (val[1] ?? 0);
+  }, 0);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex justify-between border-b pb-2">
+        <span className="text-xs font-medium">
+          {isCost ? "Other cost" : "Other usage"}
+        </span>
+        <span className="text-right font-mono text-xs font-medium">
+          {formatValue(otherTotal)}
+        </span>
+      </div>
+      {otherEntries.map(([key, value]) => (
+        <div
+          key={key}
+          className="flex justify-between text-xs text-muted-foreground"
+        >
+          <span className="mr-4">{key}</span>
+          <span className="font-mono">{formatValue(value ?? 0)}</span>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/web/src/components/trace2/components/_shared/CopyIdsPopover.tsx
+++ b/web/src/components/trace2/components/_shared/CopyIdsPopover.tsx
@@ -1,0 +1,102 @@
+import { Button } from "@/src/components/ui/button";
+import { CopyIcon, CheckIcon } from "lucide-react";
+import { useState } from "react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/src/components/ui/popover";
+import { cn } from "@/src/utils/tailwind";
+import { copyTextToClipboard } from "@/src/utils/clipboard";
+
+interface IdItem {
+  name: string;
+  id: string;
+}
+
+export const CopyIdsPopover = ({
+  idItems,
+  className,
+}: {
+  idItems: IdItem[];
+  className?: string;
+}) => {
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const handleCopy = (textToCopy: string) => {
+    copyTextToClipboard(textToCopy);
+    setCopiedId(textToCopy);
+    setTimeout(() => setCopiedId(null), 1500);
+  };
+
+  // If only one idItem provided, use simple button with only one ID
+  if (idItems.length === 1) {
+    return (
+      <Button
+        variant="ghost"
+        title="Copy ID"
+        className={cn("h-fit p-1", className)}
+        onClick={() => handleCopy(idItems[0].id)}
+      >
+        {copiedId === idItems[0].id ? (
+          <CheckIcon className="h-3 w-3 text-muted-green" />
+        ) : (
+          <CopyIcon className="h-3 w-3" />
+        )}
+        <span className="ml-1 text-xs">ID</span>
+      </Button>
+    );
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          title="Copy ID"
+          className={cn("h-fit px-1", className)}
+        >
+          <CopyIcon className="h-3 w-3" />
+          <span className="ml-1 text-xs">ID</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="max-h-[50vh] w-auto min-w-[280px] overflow-y-auto p-1"
+        align="start"
+      >
+        <div className="flex flex-col gap-0.5">
+          {idItems.map((item) => (
+            <div
+              key={item.id}
+              className="group flex items-center justify-between gap-2 rounded-sm px-2 py-1.5 transition-colors hover:bg-muted/50"
+            >
+              <div className="flex min-w-0 flex-col gap-0.5">
+                <span className="text-xs font-medium text-muted-foreground">
+                  {item.name}
+                </span>
+                <span
+                  className="max-w-[220px] truncate font-mono text-xs"
+                  title={item.id}
+                >
+                  {item.id}
+                </span>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 shrink-0 opacity-70 transition-opacity group-hover:opacity-100"
+                onClick={() => handleCopy(item.id)}
+              >
+                {copiedId === item.id ? (
+                  <CheckIcon className="h-3 w-3 text-muted-green" />
+                ) : (
+                  <CopyIcon className="h-3 w-3" />
+                )}
+              </Button>
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/web/src/components/trace2/contexts/JsonExpansionContext.tsx
+++ b/web/src/components/trace2/contexts/JsonExpansionContext.tsx
@@ -1,0 +1,68 @@
+/**
+ * JsonExpansionContext - Persists JSON expand/collapse state across observations
+ *
+ * Purpose:
+ * - Store which JSON paths are expanded/collapsed (e.g., "response.data.items": true)
+ * - Persist state in sessionStorage (per-tab, clears on tab close)
+ * - Share expansion state between observations with similar JSON structure
+ *
+ * Usage:
+ * - Components receive externalExpansionState and onExternalExpansionChange props
+ * - When user expands a path, it persists across observation switches
+ * - Separate from TraceDataContext to avoid unnecessary re-renders
+ */
+
+import { createContext, useContext, useCallback, type ReactNode } from "react";
+import useSessionStorage from "@/src/components/useSessionStorage";
+
+type ExpandedState = Record<string, boolean> | boolean;
+
+type JsonExpansionState = {
+  input: ExpandedState;
+  output: ExpandedState;
+  metadata: ExpandedState;
+  log: ExpandedState;
+};
+
+interface JsonExpansionContextValue {
+  expansionState: JsonExpansionState;
+  setFieldExpansion: (
+    field: keyof JsonExpansionState,
+    expansion: ExpandedState,
+  ) => void;
+}
+
+const JsonExpansionContext = createContext<JsonExpansionContextValue>({
+  expansionState: { input: {}, output: {}, metadata: {}, log: {} },
+  setFieldExpansion: () => {},
+});
+
+export const useJsonExpansion = () => useContext(JsonExpansionContext);
+
+export function JsonExpansionProvider({ children }: { children: ReactNode }) {
+  const [expansionState, setExpansionState] =
+    useSessionStorage<JsonExpansionState>("trace2-jsonExpansionState", {
+      input: {},
+      output: {},
+      metadata: {},
+      log: {},
+    });
+
+  const setFieldExpansion = useCallback(
+    (field: keyof JsonExpansionState, expansion: ExpandedState) => {
+      setExpansionState((prev) => ({
+        ...prev,
+        [field]: expansion,
+      }));
+    },
+    [setExpansionState],
+  );
+
+  return (
+    <JsonExpansionContext.Provider
+      value={{ expansionState, setFieldExpansion }}
+    >
+      {children}
+    </JsonExpansionContext.Provider>
+  );
+}

--- a/web/src/components/trace2/lib/helpers.ts
+++ b/web/src/components/trace2/lib/helpers.ts
@@ -1,0 +1,466 @@
+import { type NestedObservation } from "@/src/utils/types";
+import { type TreeNode, type TraceSearchListItem } from "./types";
+import { type ObservationReturnType } from "@/src/server/api/routers/traces";
+import Decimal from "decimal.js";
+import {
+  type ObservationLevelType,
+  ObservationLevel,
+  type TraceDomain,
+} from "@langfuse/shared";
+import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
+
+export function nestObservations(
+  list: ObservationReturnType[],
+  minLevel?: ObservationLevelType,
+): {
+  nestedObservations: NestedObservation[];
+  hiddenObservationsCount: number;
+} {
+  if (list.length === 0)
+    return { nestedObservations: [], hiddenObservationsCount: 0 };
+
+  // Data prep:
+  // - Filter for observations with minimum level
+  // - Remove parentObservationId attribute from observations if the id does not exist in the list of observations
+  const mutableList = list.filter((o) =>
+    getObservationLevels(minLevel).includes(o.level),
+  );
+  const hiddenObservationsCount = list.length - mutableList.length;
+
+  // Build a Set of all observation IDs for O(1) lookup instead of O(n) find
+  const observationIds = new Set(list.map((o) => o.id));
+
+  mutableList.forEach((observation) => {
+    if (
+      observation.parentObservationId &&
+      !observationIds.has(observation.parentObservationId)
+    ) {
+      observation.parentObservationId = null;
+    }
+  });
+
+  // Step 0: Sort the list by start time to ensure observations are in right order
+  const sortedObservations = mutableList.sort(
+    (a, b) => a.startTime.getTime() - b.startTime.getTime(),
+  );
+
+  // Step 1: Create a map where the keys are object IDs, and the values are
+  // the corresponding objects with an added 'children' property.
+  const map = new Map<string, NestedObservation>();
+  for (const obj of sortedObservations) {
+    map.set(obj.id, { ...obj, children: [] });
+  }
+
+  // Step 2: Create another map for the roots of all trees.
+  const roots = new Map<string, NestedObservation>();
+
+  // Step 3: Populate the 'children' arrays and root map.
+  for (const obj of map.values()) {
+    if (obj.parentObservationId) {
+      const parent = map.get(obj.parentObservationId);
+      if (parent) {
+        parent.children.push(obj);
+      }
+    } else {
+      roots.set(obj.id, obj);
+    }
+  }
+
+  // Step 4: Sort children by start time for each parent
+  for (const obj of map.values()) {
+    obj.children.sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
+  }
+
+  // Step 5: Return the roots.
+  return {
+    nestedObservations: Array.from(roots.values()),
+    hiddenObservationsCount,
+  };
+}
+
+export function calculateDisplayTotalCost(p: {
+  allObservations: ObservationReturnType[];
+  rootObservationId?: string;
+}): Decimal | undefined {
+  // if parentObservationId is provided, only calculate cost for children of that observation
+  // need to be checked recursively for all children and children of children
+  // loop until no more children to be added
+  let observations = p.allObservations;
+
+  if (p.rootObservationId) {
+    observations = observations.filter(
+      (o) =>
+        o.parentObservationId === p.rootObservationId ||
+        o.id === p.rootObservationId,
+    );
+
+    while (true) {
+      const childrenToAdd = p.allObservations.filter(
+        (o) =>
+          o.parentObservationId &&
+          !observations.map((o2) => o2.id).includes(o.id) &&
+          observations.map((o2) => o2.id).includes(o.parentObservationId),
+      );
+      if (childrenToAdd.length === 0) break;
+      observations = [...observations, ...childrenToAdd];
+    }
+  }
+
+  const totalCost = observations.reduce<Decimal | undefined>(
+    (prev: Decimal | undefined, curr: ObservationReturnType) => {
+      // if we don't have any calculated costs, we can't do anything
+      if (!curr.totalCost && !curr.inputCost && !curr.outputCost) return prev;
+
+      // if we have either input or output cost, but not total cost, we can use that
+      if (!curr.totalCost && (curr.inputCost || curr.outputCost)) {
+        const inputCost =
+          curr.inputCost != null ? new Decimal(curr.inputCost) : new Decimal(0);
+
+        const outputCost =
+          curr.outputCost != null
+            ? new Decimal(curr.outputCost)
+            : new Decimal(0);
+
+        const combinedCost = inputCost.plus(outputCost);
+
+        return prev
+          ? prev.plus(combinedCost)
+          : combinedCost.isZero()
+            ? undefined
+            : combinedCost;
+      }
+
+      if (!curr.totalCost) return prev;
+
+      // if we have total cost, we can use that
+      return prev ? prev.plus(curr.totalCost) : new Decimal(curr.totalCost);
+    },
+    undefined,
+  );
+
+  return totalCost;
+}
+
+function getObservationLevels(minLevel: ObservationLevelType | undefined) {
+  const ascendingLevels = [
+    ObservationLevel.DEBUG,
+    ObservationLevel.DEFAULT,
+    ObservationLevel.WARNING,
+    ObservationLevel.ERROR,
+  ];
+
+  if (!minLevel) return ascendingLevels;
+
+  const minLevelIndex = ascendingLevels.indexOf(minLevel);
+
+  return ascendingLevels.slice(minLevelIndex);
+}
+
+export const heatMapTextColor = (p: {
+  min?: Decimal | number;
+  max: Decimal | number;
+  value: Decimal | number;
+}) => {
+  const { min, max, value } = p;
+  const minDecimal = min ? new Decimal(min) : new Decimal(0);
+  const maxDecimal = new Decimal(max);
+  const valueDecimal = new Decimal(value);
+
+  const cutOffs: [number, string][] = [
+    [0.75, "text-dark-red"], // 75%
+    [0.5, "text-dark-yellow"], // 50%
+  ];
+  const standardizedValueOnStartEndScale = valueDecimal
+    .sub(minDecimal)
+    .div(maxDecimal.sub(minDecimal));
+  const ratio = standardizedValueOnStartEndScale.toNumber();
+
+  // pick based on ratio if threshold is exceeded
+  for (const [threshold, color] of cutOffs) {
+    if (ratio >= threshold) {
+      return color;
+    }
+  }
+  return "";
+};
+
+// Helper function to unnest observations for cost calculation
+export const unnestObservation = (nestedObservation: NestedObservation) => {
+  const unnestedObservations = [];
+  const { children, ...observation } = nestedObservation;
+  unnestedObservations.push(observation);
+  children.forEach((child) => {
+    unnestedObservations.push(...unnestObservation(child));
+  });
+  return unnestedObservations;
+};
+
+// Transform trace + observations into unified tree structure
+// Helper function to compute and enrich tree nodes with pre-computed costs
+// This is done bottom-up: compute children first, then sum up to parent
+// Also populates the nodeMap for O(1) lookup by ID
+function enrichTreeNodeWithCosts(
+  node: TreeNode,
+  nodeMap: Map<string, TreeNode>,
+): TreeNode {
+  // First, recursively enrich all children
+  const enrichedChildren = node.children.map((child) =>
+    enrichTreeNodeWithCosts(child, nodeMap),
+  );
+
+  // Calculate this node's own cost
+  let nodeCost: Decimal | undefined;
+
+  if (node.calculatedTotalCost != null) {
+    const cost = new Decimal(node.calculatedTotalCost);
+    if (!cost.isZero()) {
+      nodeCost = cost;
+    }
+  } else if (
+    node.calculatedInputCost != null ||
+    node.calculatedOutputCost != null
+  ) {
+    const inputCost =
+      node.calculatedInputCost != null
+        ? new Decimal(node.calculatedInputCost)
+        : new Decimal(0);
+    const outputCost =
+      node.calculatedOutputCost != null
+        ? new Decimal(node.calculatedOutputCost)
+        : new Decimal(0);
+    const combinedCost = inputCost.plus(outputCost);
+    if (!combinedCost.isZero()) {
+      nodeCost = combinedCost;
+    }
+  }
+
+  // Sum up all children's total costs
+  const childrenTotalCost = enrichedChildren.reduce<Decimal | undefined>(
+    (acc, child) => {
+      if (!child.totalCost) return acc;
+      return acc ? acc.plus(child.totalCost) : child.totalCost;
+    },
+    undefined,
+  );
+
+  // Total cost = this node's cost + all children's costs
+  const totalCost =
+    nodeCost && childrenTotalCost
+      ? nodeCost.plus(childrenTotalCost)
+      : nodeCost || childrenTotalCost;
+
+  const enrichedNode = {
+    ...node,
+    children: enrichedChildren,
+    totalCost,
+  };
+
+  nodeMap.set(enrichedNode.id, enrichedNode);
+
+  return enrichedNode;
+}
+
+// This function is only used internally by buildTraceUiData
+function buildTraceTree(
+  trace: Omit<WithStringifiedMetadata<TraceDomain>, "input" | "output"> & {
+    input: string | null;
+    output: string | null;
+    latency?: number;
+  },
+  observations: ObservationReturnType[],
+  minLevel?: ObservationLevelType,
+): {
+  tree: TreeNode;
+  hiddenObservationsCount: number;
+  nodeMap: Map<string, TreeNode>;
+} {
+  // First, nest the observations as before
+  const { nestedObservations, hiddenObservationsCount } = nestObservations(
+    observations,
+    minLevel,
+  );
+
+  // Create nodeMap for O(1) lookup by ID
+  const nodeMap = new Map<string, TreeNode>();
+
+  // Convert observations to TreeNodes
+  const convertObservationToTreeNode = (obs: NestedObservation): TreeNode => ({
+    id: obs.id,
+    type: obs.type,
+    name: obs.name ?? "",
+    startTime: obs.startTime,
+    endTime: obs.endTime,
+    level: obs.level,
+    children: obs.children.map(convertObservationToTreeNode),
+    inputUsage: obs.inputUsage,
+    outputUsage: obs.outputUsage,
+    totalUsage: obs.totalUsage,
+    calculatedInputCost: obs.inputCost,
+    calculatedOutputCost: obs.outputCost,
+    calculatedTotalCost: obs.totalCost,
+    parentObservationId: obs.parentObservationId,
+    traceId: obs.traceId,
+  });
+
+  // Convert and enrich children with pre-computed costs and populate nodeMap
+  const enrichedChildren = nestedObservations
+    .map(convertObservationToTreeNode)
+    .map((node) => enrichTreeNodeWithCosts(node, nodeMap));
+
+  // Calculate total cost for trace root (sum of all top-level children)
+  const traceTotalCost = enrichedChildren.reduce<Decimal | undefined>(
+    (acc, child) => {
+      if (!child.totalCost) return acc;
+      return acc ? acc.plus(child.totalCost) : child.totalCost;
+    },
+    undefined,
+  );
+
+  // Create the root tree node (trace)
+  // Use a unique ID for the trace root to avoid conflicts with observations that might have the same ID
+  const tree: TreeNode = {
+    id: `trace-${trace.id}`,
+    type: "TRACE",
+    name: trace.name ?? "",
+    startTime: trace.timestamp,
+    endTime: null, // traces don't have explicit end times
+    children: enrichedChildren,
+    latency: trace.latency,
+    totalCost: traceTotalCost,
+  };
+
+  // Add trace root to nodeMap as well
+  nodeMap.set(tree.id, tree);
+
+  return { tree, hiddenObservationsCount, nodeMap };
+}
+
+// UI helper: build flat search items with per-node aggregated totals and root-level parent totals for heatmap scaling
+
+export function buildTraceUiData(
+  trace: Omit<WithStringifiedMetadata<TraceDomain>, "input" | "output"> & {
+    input: string | null;
+    output: string | null;
+    latency?: number;
+  },
+  observations: ObservationReturnType[],
+  minLevel?: ObservationLevelType,
+): {
+  tree: TreeNode;
+  hiddenObservationsCount: number;
+  searchItems: TraceSearchListItem[];
+  nodeMap: Map<string, TreeNode>;
+} {
+  const { tree, hiddenObservationsCount, nodeMap } = buildTraceTree(
+    trace,
+    observations,
+    minLevel,
+  );
+
+  // Calculate total cost directly from TreeNode structure
+  // This avoids unnecessary type conversions and is more straightforward
+  const calculateTreeNodeTotalCost = (node: TreeNode): Decimal | undefined => {
+    // Check if this node has cost data
+    let nodeCost: Decimal | undefined;
+
+    if (node.calculatedTotalCost != null) {
+      const cost = new Decimal(node.calculatedTotalCost);
+      if (!cost.isZero()) {
+        nodeCost = cost;
+      }
+    } else if (
+      node.calculatedInputCost != null ||
+      node.calculatedOutputCost != null
+    ) {
+      const inputCost =
+        node.calculatedInputCost != null
+          ? new Decimal(node.calculatedInputCost)
+          : new Decimal(0);
+      const outputCost =
+        node.calculatedOutputCost != null
+          ? new Decimal(node.calculatedOutputCost)
+          : new Decimal(0);
+      const combinedCost = inputCost.plus(outputCost);
+      if (!combinedCost.isZero()) {
+        nodeCost = combinedCost;
+      }
+    }
+
+    // Calculate total from all children
+    const childrenCost = node.children.reduce<Decimal | undefined>(
+      (acc, child) => {
+        const childCost = calculateTreeNodeTotalCost(child);
+        if (!childCost) return acc;
+        return acc ? acc.plus(childCost) : childCost;
+      },
+      undefined,
+    );
+
+    // Return the sum of node cost and children cost
+    if (nodeCost && childrenCost) {
+      return nodeCost.plus(childrenCost);
+    }
+    return nodeCost || childrenCost;
+  };
+
+  const rootTotalCost =
+    tree.type === "TRACE"
+      ? tree.children.reduce<Decimal | undefined>((acc, child) => {
+          const childCost = calculateTreeNodeTotalCost(child);
+          if (!childCost) return acc;
+          return acc ? acc.plus(childCost) : childCost;
+        }, undefined)
+      : calculateTreeNodeTotalCost(tree);
+  const rootDuration = tree.latency ? tree.latency * 1000 : undefined;
+
+  const out: TraceSearchListItem[] = [];
+  const visit = (node: TreeNode) => {
+    // push node; SpanItem will compute its own displayed metrics, we only need parent totals for heatmap
+    out.push({
+      node,
+      parentTotalCost: rootTotalCost,
+      parentTotalDuration: rootDuration,
+      // For TRACE nodes, observationId should be undefined (shows trace overview)
+      // For actual observations, use the node ID (which is the real observation ID)
+      observationId: node.type === "TRACE" ? undefined : node.id,
+    });
+    node.children.forEach(visit);
+  };
+  visit(tree);
+
+  return { tree, hiddenObservationsCount, searchItems: out, nodeMap };
+}
+
+/**
+ * Download trace data with optionally observations as JSON file
+ * @param trace - Trace object to download
+ * @param observations - Array of observations (can be basic or with full I/O data)
+ * @param filename - Optional custom filename (defaults to trace-{traceId}.json)
+ */
+export function downloadTraceAsJson(params: {
+  trace: {
+    id: string;
+    [key: string]: unknown;
+  };
+  observations: unknown[];
+  filename?: string;
+}) {
+  const { trace, observations, filename } = params;
+
+  const exportData = {
+    trace,
+    observations,
+  };
+
+  const jsonString = JSON.stringify(exportData, null, 2);
+  const blob = new Blob([jsonString], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename || `trace-${trace.id}.json`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary

### S5.6: Header Actions
- Add header action buttons to `ObservationDetailView` and `TraceDetailView`:
  - CopyIdsPopover for copying trace/observation IDs
  - NewDatasetItemFromExistingObject for adding to datasets
  - AnnotateDrawer + CreateNewAnnotationQueueItem for scoring
  - CommentDrawerButton with comment count indicator
  - JumpToPlaygroundButton (observations only)
- Wire up `useTraceComments` hook to populate comment counts throughout trace2
- Fix bug in `useTraceComments` returning Map instead of number for trace comment count
- Copy shared components from `trace/` to `trace2/`:
  - CopyIdsPopover, BreakdownToolTip, ToolCallInvocationsView, helpers.ts

### S5.4a: TraceDetailView Preview Tab
- Create `JsonExpansionContext` for persisting JSON expand/collapse state across observation switches (stored in sessionStorage)
- Create `useMedia` hook for reusable media fetching
- Implement TraceDetailView Preview tab with:
  - IOPreview for trace input/output
  - Tags section with TagList
  - Metadata section with PrettyJsonView
- Wire expansion state props to both TraceDetailView and ObservationDetailView
- Add JsonExpansionProvider to Trace.tsx provider hierarchy

### Files Created
- `web/src/components/trace2/contexts/JsonExpansionContext.tsx`
- `web/src/components/trace2/api/useMedia.ts`

### Files Modified
- `web/src/components/trace2/Trace.tsx` - Added JsonExpansionProvider
- `web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx` - Implemented Preview tab
- `web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx` - Added expansion state props, useMedia hook

## Test plan

### S5.6 Tests
- [ ] Open a trace in trace2 view
- [ ] Verify header action buttons appear on both trace and observation detail views
- [ ] Click Copy IDs button and verify ID is copied
- [ ] Click Add to Dataset button and verify modal opens
- [ ] Click Annotate button and verify drawer opens
- [ ] Click Add to Queue button and verify modal opens  
- [ ] Click Comments button and verify drawer opens
- [ ] Verify comment count indicator shows on items with comments
- [ ] On an observation, verify Playground button appears

### S5.4a Tests
- [ ] Select a trace (no observation selected) and verify Preview tab shows:
  - Input/Output sections with IOPreview component
  - Tags section with TagList
  - Metadata section (if metadata exists)
- [ ] Toggle Formatted/JSON view and verify content updates
- [ ] Expand/collapse JSON nodes, switch to different observation, switch back - verify expansion state persists
- [ ] Verify expansion state persists across page refresh within same browser tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add header actions, comment counts, and media fetching to trace2 views, fixing comment count bug and copying shared components.
> 
>   - **Behavior**:
>     - Add header action buttons to `ObservationDetailView` and `TraceDetailView` for copying IDs, adding to datasets, scoring, commenting, and jumping to playground.
>     - Integrate `useTraceComments` to populate comment counts in `Trace.tsx` and `TraceSearchListItem.tsx`.
>     - Fix `useTraceComments` bug returning Map instead of number for trace comment count.
>   - **Components**:
>     - Copy `CopyIdsPopover`, `BreakdownToolTip`, `ToolCallInvocationsView`, and `helpers.ts` from `trace/` to `trace2/`.
>     - Add `useMedia` hook in `useMedia.ts` for fetching media attachments.
>     - Add `JsonExpansionProvider` in `JsonExpansionContext.tsx` for JSON expand/collapse state.
>   - **UI Enhancements**:
>     - Update `ObservationDetailView.tsx` and `TraceDetailView.tsx` to include new header actions and media fetching.
>     - Enhance `SpanContent.tsx` and `TimelineBar.tsx` with comment count and cost display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9b8b7346aa465f24cc03340fc152406e63913130. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->