### PR TITLE
fix(redis): enable dual stack DNS resolving

### DIFF
--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -6,6 +6,7 @@ import { logger } from "../logger";
 const defaultRedisOptions: Partial<RedisOptions> = {
   enableReadyCheck: true,
   maxRetriesPerRequest: null,
+  // enable dual stack DNS resolution
   family: 0,
   enableAutoPipelining: env.REDIS_ENABLE_AUTO_PIPELINING === "true",
   keyPrefix: env.REDIS_KEY_PREFIX ?? undefined,

--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -6,6 +6,7 @@ import { logger } from "../logger";
 const defaultRedisOptions: Partial<RedisOptions> = {
   enableReadyCheck: true,
   maxRetriesPerRequest: null,
+  family: 0,
   enableAutoPipelining: env.REDIS_ENABLE_AUTO_PIPELINING === "true",
   keyPrefix: env.REDIS_KEY_PREFIX ?? undefined,
 };


### PR DESCRIPTION
This issue is found on AWS EKS IPv6 only cluster related to ioredis. Langfuse web or worker component cannot resolve IPv6 redis host.

See https://github.com/langfuse/langfuse-k8s/issues/282 for user-side discussions.

## What does this PR do?

Fixes [bug: web and worker cannot resolve redis host on AWS EKS IPv6 only cluster](https://github.com/langfuse/langfuse-k8s/issues/282)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable dual-stack DNS resolution for Redis in IPv6-only AWS EKS clusters by setting `family: 0` in `redis.ts`.
> 
>   - **Behavior**:
>     - Sets `family: 0` in `defaultRedisOptions` in `redis.ts` to enable dual-stack DNS resolution for Redis connections.
>   - **Context**:
>     - Fixes issue where Langfuse web and worker components could not resolve IPv6 Redis host on AWS EKS IPv6-only cluster.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 48e6db85cd4426e086b7c277e53dd04038735441. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->