### PR TITLE
chore(dataset-item-events): rename createdAt and deletedAt to validFrom and validTo in schema

### DIFF
--- a/packages/shared/prisma/generated/types.ts
+++ b/packages/shared/prisma/generated/types.ts
@@ -441,8 +441,8 @@ export type DatasetItemEvent = {
   metadata: unknown | null;
   source_trace_id: string | null;
   source_observation_id: string | null;
-  created_at: Timestamp | null;
-  deleted_at: Timestamp | null;
+  valid_from: Timestamp | null;
+  valid_to: Timestamp | null;
 };
 export type DatasetRunItems = {
   id: string;

--- a/packages/shared/prisma/migrations/20251127135052_dataset_item_events_rename_columns/migration.sql
+++ b/packages/shared/prisma/migrations/20251127135052_dataset_item_events_rename_columns/migration.sql
@@ -1,0 +1,11 @@
+-- DropIndex
+DROP INDEX "public"."dataset_item_events_project_id_dataset_id_item_id_created_at_id";
+
+-- AlterTable
+ALTER TABLE "dataset_item_events" DROP COLUMN "created_at",
+DROP COLUMN "deleted_at",
+ADD COLUMN     "valid_from" TIMESTAMP(3),
+ADD COLUMN     "valid_to" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "dataset_item_events_project_id_dataset_id_item_id_valid_to_idx" ON "dataset_item_events"("project_id", "dataset_id", "item_id", "valid_to");

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -650,10 +650,10 @@ model DatasetItemEvent {
   metadata            Json?
   sourceTraceId       String?        @map("source_trace_id")
   sourceObservationId String?        @map("source_observation_id")
-  createdAt           DateTime?      @map("created_at")
-  deletedAt           DateTime?      @map("deleted_at")
+  validFrom           DateTime?      @map("valid_from")
+  validTo             DateTime?      @map("valid_to")
 
-  @@index([projectId, datasetId, itemId, createdAt])
+  @@index([projectId, datasetId, itemId, validTo])
   @@map("dataset_item_events")
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename `createdAt` and `deletedAt` to `validFrom` and `validTo` in `DatasetItemEvent` schema, types, and database migration.
> 
>   - **Schema Changes**:
>     - Rename `createdAt` to `validFrom` and `deletedAt` to `validTo` in `DatasetItemEvent` model in `schema.prisma`.
>     - Update index in `schema.prisma` to use `validTo` instead of `createdAt`.
>   - **Generated Types**:
>     - Rename `created_at` to `valid_from` and `deleted_at` to `valid_to` in `DatasetItemEvent` type in `types.ts`.
>   - **Database Migration**:
>     - Drop `created_at` and `deleted_at` columns, add `valid_from` and `valid_to` columns in `migration.sql`.
>     - Update index in `migration.sql` to use `valid_to`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bae2f8ab8de2f985661a8603a53f717efd15327a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->