### PR TITLE
feat: environment variable to drain specific deletions for a specified project

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -82,6 +82,10 @@ const EnvSchema = z.object({
     .number()
     .nonnegative()
     .default(5_000),
+  LANGFUSE_TRACE_DELETE_SKIP_PROJECT_IDS: z
+    .string()
+    .optional()
+    .transform((s) => (s ? s.split(",").map((id) => id.trim()) : [])),
   SALT: z.string().optional(), // used by components imported by web package
   LANGFUSE_LOG_LEVEL: z
     .enum(["trace", "debug", "info", "warn", "error", "fatal"])


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `LANGFUSE_TRACE_DELETE_SKIP_PROJECT_IDS` environment variable to skip trace deletions for specified projects in `traceDeletionProcessor`.
> 
>   - **Environment Variable**:
>     - Adds `LANGFUSE_TRACE_DELETE_SKIP_PROJECT_IDS` to `env.ts` to specify project IDs to skip trace deletions.
>     - Parses as a comma-separated string and transforms into an array of trimmed strings.
>   - **Trace Deletion Logic**:
>     - In `traceDeletionProcessor` in `traceDeletionProcessor.ts`, checks if `projectId` is in `LANGFUSE_TRACE_DELETE_SKIP_PROJECT_IDS`.
>     - Logs and returns early if project is in skip list, preventing pending deletions and queue jobs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7f84e43effeafeecafb5e0767d37f9071fa43ffb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->