### PR TITLE
chore: ch drop script should run without .env as well

### DIFF
--- a/packages/shared/clickhouse/scripts/drop.sh
+++ b/packages/shared/clickhouse/scripts/drop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Load environment variables
-source ../../.env
+[ -f ../../.env ] && source ../../.env
 
 # Check if golang-migrate is installed
 if ! command -v migrate &> /dev/null


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `drop.sh` now runs without `.env` by conditionally sourcing it if present.
> 
>   - **Behavior**:
>     - Modify `drop.sh` to conditionally source `.env` only if it exists, allowing the script to run without it.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f88221e5f228a50190ee7f2ecddaa8bf48b37d5b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->