### PR TITLE
chore: MutationMonitor documentation comment

### DIFF
--- a/worker/src/features/mutation-monitoring/mutationMonitor.ts
+++ b/worker/src/features/mutation-monitoring/mutationMonitor.ts
@@ -20,6 +20,23 @@ interface QueueDecision {
   reason: string;
 }
 
+/**
+ * MutationMonitor pauses and resumes queue processing
+ * based on how ClickHouse mutations progress.
+ *
+ * Requires correct ClickHouse grants to work:
+ * ```
+ * GRANT SELECT(database, `table`, is_done) ON system.mutations TO <role>;
+ * ```
+ * where `role` is the role used by Langfuse to connect to ClickHouse, usually `app`.
+ *
+ * `QUEUE_TABLE_MAPPING` below shows how mutatations on various tables map to queues.
+ *
+ * - `LANGFUSE_MUTATION_MONITOR_ENABLED` must be set to `true` to enable this feature.
+ * - `LANGFUSE_MUTATION_MONITOR_CHECK_INTERVAL_MS` defines how often to check for mutations.
+ * - `LANGFUSE_DELETION_MUTATIONS_MAX_COUNT` once any table for a queue exceeds this threshold, that queue is PAUSED.
+ * `- LANGFUSE_DELETION_MUTATIONS_SAFE_COUNT` once all tables for a queue are below this threshold, that queue is RESUMED.
+ */
 export class MutationMonitor {
   private static timeoutId: NodeJS.Timeout | null = null;
   private static pausedQueues: Set<QueueName> = new Set();

--- a/worker/src/features/mutation-monitoring/mutationMonitor.ts
+++ b/worker/src/features/mutation-monitoring/mutationMonitor.ts
@@ -30,7 +30,7 @@ interface QueueDecision {
  * ```
  * where `role` is the role used by Langfuse to connect to ClickHouse, usually `app`.
  *
- * `QUEUE_TABLE_MAPPING` below shows how mutatations on various tables map to queues.
+ * `QUEUE_TABLE_MAPPING` below shows how mutations on various tables map to queues.
  *
  * - `LANGFUSE_MUTATION_MONITOR_ENABLED` must be set to `true` to enable this feature.
  * - `LANGFUSE_MUTATION_MONITOR_CHECK_INTERVAL_MS` defines how often to check for mutations.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a detailed documentation comment to `MutationMonitor` in `mutationMonitor.ts`, explaining its functionality, required ClickHouse grants, and environment variables.
> 
>   - **Documentation**:
>     - Adds a detailed comment to `MutationMonitor` in `mutationMonitor.ts`.
>     - Explains ClickHouse grants required: `GRANT SELECT(database, `table`, is_done) ON system.mutations TO <role>;`.
>     - Describes environment variables: `LANGFUSE_MUTATION_MONITOR_ENABLED`, `LANGFUSE_MUTATION_MONITOR_CHECK_INTERVAL_MS`, `LANGFUSE_DELETION_MUTATIONS_MAX_COUNT`, `LANGFUSE_DELETION_MUTATIONS_SAFE_COUNT`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 289c5241bfbbd133963fae81294f10239c30438b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->