### PR TITLE
fix(llm-connections): validate provider names cannot contain colons

### DIFF
--- a/web/src/features/llm-api-key/types.ts
+++ b/web/src/features/llm-api-key/types.ts
@@ -7,7 +7,10 @@ import {
 
 export const LlmApiKeySchema = z.object({
   projectId: z.string(),
-  provider: z.string().min(1),
+  provider: z
+    .string()
+    .min(1)
+    .regex(/^[^:]+$/, "Provider name cannot contain colons"),
   adapter: z.enum(LLMAdapter),
   baseURL: z.string().url().optional(),
   withDefaultModels: z.boolean().optional(),

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -49,7 +49,11 @@ const createFormSchema = (mode: "create" | "update") =>
       secretKey: z.string().optional(),
       provider: z
         .string()
-        .min(1, "Please add a provider name that identifies this connection."),
+        .min(1, "Please add a provider name that identifies this connection.")
+        .regex(
+          /^[^:]+$/,
+          "Provider name cannot contain colons. Use a format like 'OpenRouter_Mistral' instead.",
+        ),
       adapter: z.nativeEnum(LLMAdapter),
       baseURL: z.union([z.literal(""), z.url()]),
       withDefaultModels: z.boolean(),
@@ -561,7 +565,8 @@ export function CreateLLMApiKeyForm({
               <FormItem>
                 <FormLabel>Provider name</FormLabel>
                 <FormDescription>
-                  Key to identify the connection within Langfuse.
+                  Key to identify the connection within Langfuse. Cannot contain
+                  colons.
                 </FormDescription>
                 <FormControl>
                   <Input


### PR DESCRIPTION
## Summary

- Add validation to prevent colons in LLM connection provider names
- Provider names like `"OpenRouter: Mistral"` break the Playground model selector due to delimiter parsing issues
- Validation added both client-side (form) and server-side (tRPC schema)

## Root Cause

The system combines provider and model as `"Provider: model"` and parses using `indexOf(": ")`. If a provider contains colons, parsing fails silently - the model dropdown appears to work but selections revert to defaults.

## Changes

| File | Change |
|------|--------|
| `web/src/features/llm-api-key/types.ts` | Add regex validation `/^[^:]+$/` to `LlmApiKeySchema.provider` |
| `web/src/features/public-api/components/CreateLLMApiKeyForm.tsx` | Add regex validation + update helper text |

## Test plan

- [ ] Attempt to create LLM connection with provider name containing `:`
- [ ] Verify validation error appears immediately
- [ ] Verify valid names (e.g., `OpenRouter_Mistral`) work correctly
- [ ] Test model selection in Playground works with valid provider names

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add validation to prevent colons in LLM connection provider names in `types.ts` and `CreateLLMApiKeyForm.tsx`.
> 
>   - **Validation**:
>     - Add regex validation `/^[^:]+$/` to `provider` in `LlmApiKeySchema` in `types.ts`.
>     - Add regex validation to `provider` in `createFormSchema` in `CreateLLMApiKeyForm.tsx`.
>   - **Behavior**:
>     - Prevents provider names with colons, which caused parsing issues in the model selector.
>     - Updates helper text in `CreateLLMApiKeyForm.tsx` to reflect new validation rule.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7f4e3cd0ebe10aca04e97e94e623c263f33ec3c8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->