### PR TITLE
fix(modelMatch): move cache to separate namespace

### DIFF
--- a/packages/shared/src/server/ingestion/modelMatch.ts
+++ b/packages/shared/src/server/ingestion/modelMatch.ts
@@ -290,9 +290,9 @@ const getModelMatchKeyPrefix = () => {
   if (env.REDIS_CLUSTER_ENABLED === "true") {
     // Use hash tags for Redis cluster compatibility
     // This ensures all model cache keys are placed on the same hash slot
-    return "{model-match}";
+    return "{model-price-tiers}";
   }
-  return "model-match";
+  return "model-price-tiers";
 };
 
 export const redisModelToPrismaModel = (redisModel: Model): Model => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change Redis key prefix to `model-price-tiers` for cache key generation in `modelMatch.ts`.
> 
>   - **Behavior**:
>     - Change Redis key prefix from `model-match` to `model-price-tiers` in `getModelMatchKeyPrefix()` in `modelMatch.ts`.
>     - Ensures all model cache keys are placed on the same hash slot for Redis cluster compatibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 67d5b88e4f6ed4b8eaf44a0d9e22a73d74aab7b9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->