### PR TITLE
chore: reduce retries on trace upsert queue

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -77,6 +77,7 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(1),
+  LANGFUSE_TRACE_UPSERT_QUEUE_ATTEMPTS: z.coerce.number().positive().default(2),
   LANGFUSE_TRACE_DELETE_DELAY_MS: z.coerce
     .number()
     .nonnegative()

--- a/packages/shared/src/server/redis/traceUpsert.ts
+++ b/packages/shared/src/server/redis/traceUpsert.ts
@@ -76,7 +76,7 @@ export class TraceUpsertQueue {
           defaultJobOptions: {
             removeOnComplete: 100,
             removeOnFail: 100_000,
-            attempts: 5,
+            attempts: env.LANGFUSE_TRACE_UPSERT_QUEUE_ATTEMPTS,
             delay: 15_000, // 15 seconds
             backoff: {
               type: "exponential",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduces retry attempts for trace upsert queue by introducing `LANGFUSE_TRACE_UPSERT_QUEUE_ATTEMPTS` with a default of 2.
> 
>   - **Behavior**:
>     - Reduces retry attempts for trace upsert queue by introducing `LANGFUSE_TRACE_UPSERT_QUEUE_ATTEMPTS` in `env.ts` with a default of 2.
>     - Updates `TraceUpsertQueue` in `traceUpsert.ts` to use `env.LANGFUSE_TRACE_UPSERT_QUEUE_ATTEMPTS` for retry attempts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f64c81612291ed43ec22cdb9a15a3c063c519c13. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->