### PR TITLE
chore: add logging for trace-upsert

### DIFF
--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -22,7 +22,7 @@ export const evalJobTraceCreatorQueueProcessor = async (
   job: Job<TQueueJobTypes[QueueName.TraceUpsert]>,
 ) => {
   try {
-    logger.info(`Executing trace-upsert job`, job.getState(), job);
+    logger.info(`Executing trace-upsert job`, await job.getState(), job);
     await createEvalJobs({
       sourceEventType: "trace-upsert",
       event: job.data.payload,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add await to `job.getState()` in `evalJobTraceCreatorQueueProcessor` for accurate logging in `evalQueue.ts`.
> 
>   - **Logging**:
>     - In `evalQueue.ts`, updated `logger.info` in `evalJobTraceCreatorQueueProcessor` to await `job.getState()` for accurate job state logging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 27f524bb1a9e1e7f9234fc16108bdee7ae1f41cf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->