### PR TITLE
chore: remove trace queue logs

### DIFF
--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -22,12 +22,6 @@ export const evalJobTraceCreatorQueueProcessor = async (
   job: Job<TQueueJobTypes[QueueName.TraceUpsert]>,
 ) => {
   try {
-    logger.info(
-      `Executing trace-upsert jobstate: ${JSON.stringify(await job.getState())}, `,
-      {
-        ...((await job.getState()) as any),
-      },
-    );
     await createEvalJobs({
       sourceEventType: "trace-upsert",
       event: job.data.payload,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove trace queue log from `evalJobTraceCreatorQueueProcessor` in `evalQueue.ts`, eliminating job state logging for trace-upsert jobs.
> 
>   - **Logging**:
>     - Remove trace queue log in `evalJobTraceCreatorQueueProcessor` in `evalQueue.ts`. No longer logs job state when executing trace-upsert jobs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 16728cfe38b0c6afaf114573c6868e2f49f0e566. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->