### PR TITLE
perf: skip observation deduplication for otel projects

### DIFF
--- a/worker/src/features/database-read-stream/observation-stream.ts
+++ b/worker/src/features/database-read-stream/observation-stream.ts
@@ -16,6 +16,7 @@ import {
   enrichObservationWithModelData,
   clickhouseSearchCondition,
   convertObservation,
+  shouldSkipObservationsFinal,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { Readable } from "stream";
@@ -88,6 +89,10 @@ export const getObservationStream = async (props: {
     searchType,
     rowLimit = env.BATCH_EXPORT_ROW_LIMIT,
   } = props;
+
+  // Check if we should skip deduplication for OTEL projects
+  const skipDedup = await shouldSkipObservationsFinal(projectId);
+
   const clickhouseConfigs = {
     request_timeout: 180_000, // 3 minutes
     clickhouse_settings: {
@@ -241,7 +246,7 @@ export const getObservationStream = async (props: {
         LEFT JOIN scores_agg s ON s.trace_id = o.trace_id AND s.observation_id = o.id
       WHERE ${appliedObservationsFilter.query}
         ${search.query}
-      LIMIT 1 BY o.id, o.project_id
+      ${skipDedup ? "" : "LIMIT 1 BY o.id, o.project_id"}
       limit {rowLimit: Int64}
   `;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Skips deduplication for OTEL projects in `getObservationStream()` by conditionally modifying the SQL query.
> 
>   - **Behavior**:
>     - Skips deduplication for OTEL projects in `getObservationStream()` in `observation-stream.ts` by checking `shouldSkipObservationsFinal()`.
>     - Modifies SQL query to conditionally exclude `LIMIT 1 BY o.id, o.project_id` if deduplication is skipped.
>   - **Functions**:
>     - Adds `shouldSkipObservationsFinal` to imports in `observation-stream.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8201c652c938ac3c303b8f5faf28e09ee872eb0d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->