### PR TITLE
perf: exclude input/output from trace by id call in evalService

### DIFF
--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -263,6 +263,7 @@ export const createEvalJobs = async ({
             ? new Date(event.timestamp)
             : new Date(jobTimestamp),
         clickhouseFeatureTag: "eval-create",
+        excludeInputOutput: true,
       });
 
       recordIncrement("langfuse.evaluation-execution.trace_cache_fetch", 1, {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize `getTraceById` in `traces.ts` by adding `excludeInputOutput` parameter to reduce database load, used in `createEvalJobs` in `evalService.ts`.
> 
>   - **Behavior**:
>     - Add `excludeInputOutput` parameter to `getTraceById` in `traces.ts` to optionally exclude input/output columns, reducing database load.
>     - Set `excludeInputOutput: true` in `createEvalJobs` in `evalService.ts` to optimize trace fetching when multiple configurations are processed.
>   - **Misc**:
>     - Add comments in `traces.ts` explaining the purpose of `excludeInputOutput` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8d686268d836023143dcda25d5ad48ba3cc08b71. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->