### PR TITLE
chore: an attempt to stabilize a flaky test

### DIFF
--- a/web/src/__tests__/async/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/async/observations-api-v2.servertest.ts
@@ -375,7 +375,7 @@ describe("/api/public/v2/observations API Endpoint", () => {
       const userIdFilterResponse = await makeZodVerifiedAPICall(
         GetObservationsV2Response,
         "GET",
-        `/api/public/v2/observations?traceId=${traceId}&fields=basic&filter=${encodeURIComponent(userIdFilterParam)}`,
+        `/api/public/v2/observations?traceId=${traceId}&fields=basic&filter=${encodeURIComponent(userIdFilterParam)}&limit=1000`,
       );
 
       expect(userIdFilterResponse.status).toBe(200);
@@ -429,7 +429,6 @@ describe("/api/public/v2/observations API Endpoint", () => {
       }
 
       await createEventsCh(observations);
-      await new Promise((resolve) => setTimeout(resolve, 100));
 
       // Fetch with limit=2 (should have cursor since we have 3 observations)
       const response = await makeZodVerifiedAPICall(
@@ -468,7 +467,6 @@ describe("/api/public/v2/observations API Endpoint", () => {
       }
 
       await createEventsCh(observations);
-      await new Promise((resolve) => setTimeout(resolve, 100));
 
       // Fetch with limit=5 (should not have cursor since we only have 2)
       const response = await makeZodVerifiedAPICall(
@@ -506,7 +504,6 @@ describe("/api/public/v2/observations API Endpoint", () => {
       }
 
       await createEventsCh(observations);
-      await new Promise((resolve) => setTimeout(resolve, 100));
 
       // Fetch first page with limit=2
       const page1 = await makeZodVerifiedAPICall(
@@ -598,7 +595,6 @@ describe("/api/public/v2/observations API Endpoint", () => {
       });
 
       await createEventsCh([obs1, obs2, obs3]);
-      await new Promise((resolve) => setTimeout(resolve, 100));
 
       // Fetch first page
       const page1 = await makeZodVerifiedAPICall(
@@ -658,7 +654,6 @@ describe("/api/public/v2/observations API Endpoint", () => {
       }
 
       await createEventsCh(observations);
-      await new Promise((resolve) => setTimeout(resolve, 100));
 
       // Fetch first page with type filter
       const page1 = await makeZodVerifiedAPICall(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Stabilize flaky test in `observations-api-v2.servertest.ts` by adding a limit to API calls and removing unnecessary delays.
> 
>   - **Test Stabilization**:
>     - Add `limit=1000` to API call in `observations-api-v2.servertest.ts` to ensure sufficient data is fetched for tests.
>     - Remove `setTimeout` delays after `createEventsCh()` calls in `observations-api-v2.servertest.ts` to reduce flakiness.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fbd0b41be79d191a2ff8498649eb0c98e5c3d9b0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->