### PR TITLE
fix(dataset-schemas): allow schemas until 10k char length

### DIFF
--- a/packages/shared/src/utils/jsonSchemaValidation.ts
+++ b/packages/shared/src/utils/jsonSchemaValidation.ts
@@ -39,7 +39,7 @@ export const createAjvInstanceInternal = () => {
 export function isValidJSONSchema(schema: unknown): boolean {
   try {
     const stringified = JSON.stringify(schema);
-    if (stringified.length > 1_000) return false; // Schema too large
+    if (stringified.length > 10_000) return false; // Schema too large
 
     const ajv = createAjvInstanceInternal();
     // This will throw an error if the schema is invalid


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase max JSON schema length from 1,000 to 10,000 characters in `isValidJSONSchema()` to allow larger schemas.
> 
>   - **Behavior**:
>     - Increase max JSON schema length from 1,000 to 10,000 characters in `isValidJSONSchema()` in `jsonSchemaValidation.ts`.
>     - Allows larger schemas to be validated without returning false due to size.
>   - **Misc**:
>     - Update comment to reflect new schema size limit in `isValidJSONSchema()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 13c5cf9e7cb1640a11fb62ea3c82d019b7a8ac8b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->