### PR TITLE
feat(llm-connections-api): allow setting config for Bedrock and VertexAI

### DIFF
--- a/fern/apis/server/definition/llm-connections.yml
+++ b/fern/apis/server/definition/llm-connections.yml
@@ -53,6 +53,9 @@ types:
       extraHeaderKeys:
         type: list<string>
         docs: Keys of extra headers sent with requests (values excluded for security)
+      config:
+        type: optional<map<string, unknown>>
+        docs: Adapter-specific configuration. Required for Bedrock (`{"region":"us-east-1"}`), optional for VertexAI (`{"location":"us-central1"}`), not used by other adapters.
       createdAt: datetime
       updatedAt: datetime
 
@@ -85,6 +88,13 @@ types:
       extraHeaders:
         type: optional<map<string, string>>
         docs: Extra headers to send with requests
+      config:
+        type: optional<map<string, unknown>>
+        docs: >
+          Adapter-specific configuration. Validation rules:
+          - **Bedrock**: Required. Must be `{"region": "<aws-region>"}` (e.g., `{"region":"us-east-1"}`)
+          - **VertexAI**: Optional. If provided, must be `{"location": "<gcp-location>"}` (e.g., `{"location":"us-central1"}`)
+          - **Other adapters**: Not supported. Omit this field or set to null.
 
   LlmAdapter:
     enum:

--- a/web/src/features/public-api/types/llm-connections.ts
+++ b/web/src/features/public-api/types/llm-connections.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import { paginationZod, LLMAdapter } from "@langfuse/shared";
+import { BedrockConfigSchema, VertexAIConfigSchema } from "@langfuse/shared";
 
 // Base LLM connection response schema - strict to prevent secret leakage
 export const LlmConnectionResponse = z
@@ -12,6 +13,7 @@ export const LlmConnectionResponse = z
     customModels: z.array(z.string()),
     withDefaultModels: z.boolean(),
     extraHeaderKeys: z.array(z.string()),
+    config: z.record(z.string(), z.unknown()).nullable(),
     createdAt: z.coerce.date(),
     updatedAt: z.coerce.date(),
   })
@@ -37,18 +39,66 @@ export const GetLlmConnectionsV1Response = z
   })
   .strict();
 
-// PUT /api/public/llm-connections request body (upsert)
-export const PutLlmConnectionV1Body = z
-  .object({
-    provider: z.string().min(1),
-    adapter: z.nativeEnum(LLMAdapter),
-    secretKey: z.string().min(1),
-    baseURL: z.string().url().nullable().optional(),
-    customModels: z.array(z.string().min(1)).optional(),
-    withDefaultModels: z.boolean().optional().default(true),
-    extraHeaders: z.record(z.string(), z.string()).optional(),
-  })
-  .strict();
+// Base request schema (before adapter-specific validation)
+const PutLlmConnectionV1BodyBase = z.object({
+  provider: z.string().min(1),
+  adapter: z.nativeEnum(LLMAdapter),
+  secretKey: z.string().min(1),
+  baseURL: z.string().url().nullable().optional(),
+  customModels: z.array(z.string().min(1)).optional(),
+  withDefaultModels: z.boolean().optional().default(true),
+  extraHeaders: z.record(z.string(), z.string()).optional(),
+  config: z.record(z.string(), z.unknown()).optional(),
+});
+
+// PUT /api/public/llm-connections request body (upsert) with adapter-specific validation
+export const PutLlmConnectionV1Body = PutLlmConnectionV1BodyBase.superRefine(
+  (data, ctx) => {
+    const { adapter, config } = data;
+
+    if (adapter === LLMAdapter.Bedrock) {
+      // Bedrock requires config with region
+      if (!config) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "Config is required for Bedrock adapter. Expected: { region: string }",
+          path: ["config"],
+        });
+        return;
+      }
+      const result = BedrockConfigSchema.safeParse(config);
+      if (!result.success) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Invalid Bedrock config: ${result.error.issues.map((e) => e.message).join(", ")}. Expected: { region: string }`,
+          path: ["config"],
+        });
+      }
+    } else if (adapter === LLMAdapter.VertexAI) {
+      // VertexAI config is optional, but if provided must be valid
+      if (config) {
+        const result = VertexAIConfigSchema.safeParse(config);
+        if (!result.success) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Invalid VertexAI config: ${result.error.issues.map((e) => e.message).join(", ")}. Expected: { location: string }`,
+            path: ["config"],
+          });
+        }
+      }
+    } else {
+      // Other adapters should not have config
+      if (config && Object.keys(config).length > 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Config is not supported for ${adapter} adapter. Remove the config field.`,
+          path: ["config"],
+        });
+      }
+    }
+  },
+);
 
 // PUT /api/public/llm-connections response
 export const PutLlmConnectionV1Response = LlmConnectionResponse.strict();
@@ -63,6 +113,7 @@ export function transformDbLlmConnectionToAPI(dbConnection: {
   customModels: string[];
   withDefaultModels: boolean;
   extraHeaderKeys: string[];
+  config: Record<string, unknown> | null;
   createdAt: Date;
   updatedAt: Date;
 }): z.infer<typeof LlmConnectionResponse> {
@@ -75,6 +126,7 @@ export function transformDbLlmConnectionToAPI(dbConnection: {
     customModels: dbConnection.customModels,
     withDefaultModels: dbConnection.withDefaultModels,
     extraHeaderKeys: dbConnection.extraHeaderKeys,
+    config: dbConnection.config,
     createdAt: dbConnection.createdAt,
     updatedAt: dbConnection.updatedAt,
   });

--- a/web/src/features/public-api/types/llm-connections.ts
+++ b/web/src/features/public-api/types/llm-connections.ts
@@ -1,5 +1,5 @@
 import { z } from "zod/v4";
-import { paginationZod, LLMAdapter } from "@langfuse/shared";
+import { paginationZod, LLMAdapter, type JSONValue } from "@langfuse/shared";
 import { BedrockConfigSchema, VertexAIConfigSchema } from "@langfuse/shared";
 
 // Base LLM connection response schema - strict to prevent secret leakage
@@ -48,7 +48,7 @@ const PutLlmConnectionV1BodyBase = z.object({
   customModels: z.array(z.string().min(1)).optional(),
   withDefaultModels: z.boolean().optional().default(true),
   extraHeaders: z.record(z.string(), z.string()).optional(),
-  config: z.record(z.string(), z.unknown()).optional(),
+  config: z.record(z.string(), z.string()).optional(),
 });
 
 // PUT /api/public/llm-connections request body (upsert) with adapter-specific validation
@@ -113,7 +113,7 @@ export function transformDbLlmConnectionToAPI(dbConnection: {
   customModels: string[];
   withDefaultModels: boolean;
   extraHeaderKeys: string[];
-  config: Record<string, unknown> | null;
+  config: JSONValue | null;
   createdAt: Date;
   updatedAt: Date;
 }): z.infer<typeof LlmConnectionResponse> {

--- a/web/src/pages/api/public/llm-connections/index.ts
+++ b/web/src/pages/api/public/llm-connections/index.ts
@@ -103,7 +103,7 @@ export default withMiddlewares({
         extraHeaderKeys: body.extraHeaders
           ? Object.keys(body.extraHeaders)
           : [],
-        config: body.config || null,
+        config: body.config,
       };
 
       // Perform upsert

--- a/web/src/pages/api/public/llm-connections/index.ts
+++ b/web/src/pages/api/public/llm-connections/index.ts
@@ -32,9 +32,10 @@ export default withMiddlewares({
           customModels: true,
           withDefaultModels: true,
           extraHeaderKeys: true,
+          config: true,
           createdAt: true,
           updatedAt: true,
-          // Explicitly exclude: secretKey, extraHeaders, config
+          // Explicitly exclude: secretKey, extraHeaders
         },
         where: {
           projectId: auth.scope.projectId,
@@ -102,6 +103,7 @@ export default withMiddlewares({
         extraHeaderKeys: body.extraHeaders
           ? Object.keys(body.extraHeaders)
           : [],
+        config: body.config || null,
       };
 
       // Perform upsert
@@ -127,9 +129,10 @@ export default withMiddlewares({
           customModels: true,
           withDefaultModels: true,
           extraHeaderKeys: true,
+          config: true,
           createdAt: true,
           updatedAt: true,
-          // Explicitly exclude: secretKey, extraHeaders, config
+          // Explicitly exclude: secretKey, extraHeaders
         },
       });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add adapter-specific `config` support for Bedrock and VertexAI in LLM connections API with validation and tests.
> 
>   - **Behavior**:
>     - Add `config` field to `LlmConnection` in `llm-connections.yml` for adapter-specific configurations.
>     - Bedrock requires `config` with `region`, VertexAI optionally accepts `config` with `location`.
>     - Other adapters do not support `config`.
>   - **Validation**:
>     - Add `superRefine` validation in `PutLlmConnectionV1Body` in `llm-connections.ts` for adapter-specific `config`.
>     - Validate Bedrock `config` with `BedrockConfigSchema`, VertexAI with `VertexAIConfigSchema`.
>   - **Tests**:
>     - Update `llm-connections-api.servertest.ts` to test `config` handling for Bedrock and VertexAI.
>     - Ensure `config` is null for adapters that don't use it.
>     - Add tests for invalid `config` scenarios for Bedrock and VertexAI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7fd8ec71586f7542e08a7829395bc36e777d2e6d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->