### PR TITLE
fix(filter): cost steps default to decimals

### DIFF
--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -816,7 +816,7 @@ export function NumericFacet({
             <Slider
               min={min}
               max={max}
-              step={1}
+              step={max - min <= 1000 ? 0.01 : 1}
               value={localValue}
               onValueChange={handleSliderChange}
             />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjusts `Slider` step in `NumericFacet` to `0.01` for ranges less than or equal to 1000, enhancing precision.
> 
>   - **Behavior**:
>     - Adjusts `Slider` step in `NumericFacet` to `0.01` if `max - min <= 1000`, otherwise keeps it as `1`.
>   - **Components**:
>     - Affects `NumericFacet` in `data-table-controls.tsx` by changing the slider precision for small ranges.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 97aaf367053a3523e1dc44beebcf10583acce45f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->