### PR TITLE
fix: LANGFUSE_TRACE_DELETE_SKIP_PROJECT_IDS  should be checked on boths sides of the deletion processig queue.

### DIFF
--- a/packages/shared/src/server/traceDeletionProcessor.ts
+++ b/packages/shared/src/server/traceDeletionProcessor.ts
@@ -9,6 +9,48 @@ export interface TraceDeletionProcessorOptions {
   delayMs?: number; // Default from LANGFUSE_TRACE_DELETE_DELAY_MS env var
 }
 
+export async function shouldSkipTraceDeletionFor(
+  projectId: string,
+  traceIds: string[],
+): Promise<boolean> {
+  // Check if project is in skip list
+  if (env.LANGFUSE_TRACE_DELETE_SKIP_PROJECT_IDS.includes(projectId)) {
+    logger.info(
+      `Skipping trace deletion for project ${projectId} (in skip list). No pending deletions created, no queue job added.`,
+      {
+        projectId,
+        traceIds,
+        traceCount: traceIds.length,
+        skipReason: "LANGFUSE_TRACE_DELETE_SKIP_PROJECT_IDS",
+      },
+    );
+
+    return true;
+  }
+
+  // Check if project still exists (might have been deleted)
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: { id: true },
+  });
+
+  if (!project) {
+    logger.info(
+      `Skipping trace deletion for project ${projectId} (project no longer exists). No pending deletions created, no queue job added.`,
+      {
+        projectId,
+        traceIds,
+        traceCount: traceIds.length,
+        skipReason: "PROJECT_NOT_FOUND",
+      },
+    );
+
+    return true;
+  }
+
+  return false;
+}
+
 /**
  * Efficient trace deletion processor that batches deletions for better performance.
  *
@@ -45,39 +87,8 @@ export async function traceDeletionProcessor(
     },
   );
 
-  // Check if project is in skip list
-  if (env.LANGFUSE_TRACE_DELETE_SKIP_PROJECT_IDS.includes(projectId)) {
-    logger.info(
-      `Skipping trace deletion for project ${projectId} (in skip list). No pending deletions created, no queue job added.`,
-      {
-        projectId,
-        traceIds,
-        traceCount: traceIds.length,
-        skipReason: "LANGFUSE_TRACE_DELETE_SKIP_PROJECT_IDS",
-      },
-    );
-
+  if (await shouldSkipTraceDeletionFor(projectId, traceIds)) {
     return; // Early return - don't create pending_deletions or queue job
-  }
-
-  // Check if project still exists (might have been deleted)
-  const project = await prisma.project.findUnique({
-    where: { id: projectId },
-    select: { id: true },
-  });
-
-  if (!project) {
-    logger.info(
-      `Skipping trace deletion for project ${projectId} (project no longer exists). No pending deletions created, no queue job added.`,
-      {
-        projectId,
-        traceIds,
-        traceCount: traceIds.length,
-        skipReason: "PROJECT_NOT_FOUND",
-      },
-    );
-
-    return; // Early return - project deletion handles cleanup separately
   }
 
   try {

--- a/worker/src/queues/traceDelete.ts
+++ b/worker/src/queues/traceDelete.ts
@@ -3,6 +3,7 @@ import {
   getCurrentSpan,
   logger,
   QueueName,
+  shouldSkipTraceDeletionFor,
   TQueueJobTypes,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
@@ -90,6 +91,10 @@ export const traceDeleteProcessor: Processor = async (
   }
 
   try {
+    if (await shouldSkipTraceDeletionFor(projectId, traceIdsToDelete)) {
+      return;
+    }
+
     // Delete from both Postgres and ClickHouse
     await Promise.all([
       processPostgresTraceDelete(projectId, traceIdsToDelete),


### PR DESCRIPTION
Follow up to https://github.com/langfuse/langfuse/pull/10760
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Centralizes trace deletion skipping logic with `shouldSkipTraceDeletionFor` function, applied in both `traceDeletionProcessor` and `traceDeleteProcessor`.
> 
>   - **Behavior**:
>     - Introduces `shouldSkipTraceDeletionFor` function in `traceDeletionProcessor.ts` to check if trace deletion should be skipped based on `LANGFUSE_TRACE_DELETE_SKIP_PROJECT_IDS` and project existence.
>     - Applies `shouldSkipTraceDeletionFor` in `traceDeletionProcessor` and `traceDeleteProcessor` to ensure consistent skipping logic.
>   - **Functions**:
>     - Refactors `traceDeletionProcessor` in `traceDeletionProcessor.ts` to use `shouldSkipTraceDeletionFor` for early return if deletion should be skipped.
>     - Updates `traceDeleteProcessor` in `traceDelete.ts` to use `shouldSkipTraceDeletionFor` before processing deletions.
>   - **Logging**:
>     - Adds detailed logging in `shouldSkipTraceDeletionFor` for skip reasons, including project not found and skip list inclusion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 09896d0b80c62879ccd421725d827fa164a31bf1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->