### PR TITLE
chore: another attempt to stabilize a flaky test

### DIFF
--- a/web/src/__tests__/async/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/async/observations-api-v2.servertest.ts
@@ -272,6 +272,8 @@ describe("/api/public/v2/observations API Endpoint", () => {
 
       await createEventsCh([observation1, observation2]);
 
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
       // Focus on testing columns that require joins to other tables
       // (columns from traces table: userId, traceName, sessionId, traceTags, traceEnvironment)
       // and score-related columns that may require special handling
@@ -375,10 +377,11 @@ describe("/api/public/v2/observations API Endpoint", () => {
       const userIdFilterResponse = await makeZodVerifiedAPICall(
         GetObservationsV2Response,
         "GET",
-        `/api/public/v2/observations?traceId=${traceId}&fields=basic&filter=${encodeURIComponent(userIdFilterParam)}&limit=1000`,
+        `/api/public/v2/observations?traceId=${traceId}&fields=basic&filter=${encodeURIComponent(userIdFilterParam)}`,
       );
 
       expect(userIdFilterResponse.status).toBe(200);
+      expect(userIdFilterResponse.body.data.length).toEqual(2);
       const userFilteredObs = userIdFilterResponse.body.data.find(
         (obs: any) => obs.id === observationId1,
       );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a delay and an assertion to stabilize a flaky test in `observations-api-v2.servertest.ts`.
> 
>   - **Stabilization**:
>     - Adds a 50ms delay using `setTimeout` in `observations-api-v2.servertest.ts` to ensure data consistency before assertions.
>     - Adds an assertion to check `userIdFilterResponse.body.data.length` equals 2 in `observations-api-v2.servertest.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 989bd6cd442ccf8466c934f3b78b03d0cccbbd01. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->