### PR TITLE
fix(playground): reset provider when cached unavailable

### DIFF
--- a/web/src/features/playground/page/hooks/useModelParams.ts
+++ b/web/src/features/playground/page/hooks/useModelParams.ts
@@ -112,7 +112,12 @@ export const useModelParams = (windowId?: string) => {
 
   // Set default provider and model
   useEffect(() => {
-    if (availableProviders.length > 0 && !modelParams.provider.value) {
+    if (
+      availableProviders.length > 0 &&
+      (!modelParams.provider.value ||
+        !availableProviders.includes(modelParams.provider.value))
+    ) {
+      // fall back to a valid provider whenever the cached value is missing or no longer available (e.g. after switching projects)
       if (
         persistedModelProvider &&
         availableProviders.includes(persistedModelProvider)


### PR DESCRIPTION
## Summary
- ensure playground resets provider when cached value is missing from current project
- keep "Run all" enabled for bedrock/azure custom-model setups by keeping hasAnyModelConfigured true

## Testing
- Not run (playground UI)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes provider reset in `useModelParams` when cached value is unavailable and ensures "Run all" remains enabled for certain setups.
> 
>   - **Behavior**:
>     - In `useModelParams`, reset provider if cached value is missing or unavailable in `useEffect`.
>     - Ensure "Run all" remains enabled for Bedrock/Azure custom-model setups by keeping `hasAnyModelConfigured` true.
>   - **Testing**:
>     - No tests run (playground UI).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c18f9841fddc9118c57bb2d00ef8070883c99d38. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->