### PR TITLE
chore(batch-export): allow canceling jobs from ui 

### DIFF
--- a/packages/shared/src/features/batchExport/types.ts
+++ b/packages/shared/src/features/batchExport/types.ts
@@ -12,6 +12,7 @@ export enum BatchExportStatus {
   PROCESSING = "PROCESSING", // eslint-disable-line no-unused-vars
   COMPLETED = "COMPLETED", // eslint-disable-line no-unused-vars
   FAILED = "FAILED", // eslint-disable-line no-unused-vars
+  CANCELLED = "CANCELLED", // eslint-disable-line no-unused-vars
 }
 
 export enum BatchExportFileFormat {

--- a/web/src/features/batch-exports/components/BatchExportsTable.tsx
+++ b/web/src/features/batch-exports/components/BatchExportsTable.tsx
@@ -14,17 +14,45 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/src/components/ui/alert-dialog";
+import { useState } from "react";
+import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 
 export function BatchExportsTable(props: { projectId: string }) {
   const [paginationState, setPaginationState] = useQueryParams({
     pageIndex: withDefault(NumberParam, 0),
     pageSize: withDefault(NumberParam, 10),
   });
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+  const [selectedExportId, setSelectedExportId] = useState<string | null>(null);
 
   const batchExports = api.batchExport.all.useQuery({
     projectId: props.projectId,
     limit: paginationState.pageSize,
     page: paginationState.pageIndex,
+  });
+
+  const cancelBatchExport = api.batchExport.cancel.useMutation({
+    onSuccess: () => {
+      void batchExports.refetch();
+      setCancelDialogOpen(false);
+      setSelectedExportId(null);
+    },
+  });
+
+  const hasAccess = useHasProjectAccess({
+    projectId: props.projectId,
+    scope: "batchExports:create",
   });
 
   const columns = [
@@ -128,6 +156,68 @@ export function BatchExportsTable(props: { projectId: string }) {
       cell: (row) => {
         const log = row.getValue() as string | null;
         return log ?? null;
+      },
+    },
+    {
+      accessorKey: "actions",
+      id: "actions",
+      header: "Actions",
+      size: 100,
+      cell: ({ row }) => {
+        const id = row.getValue("id") as string;
+        const status = row.getValue("status") as string;
+
+        // Only show cancel button for queued or processing exports
+        if (status !== "QUEUED" && status !== "PROCESSING") {
+          return null;
+        }
+
+        return (
+          <AlertDialog
+            open={cancelDialogOpen && selectedExportId === id}
+            onOpenChange={(open) => {
+              if (!open) {
+                setCancelDialogOpen(false);
+                setSelectedExportId(null);
+              }
+            }}
+          >
+            <AlertDialogTrigger asChild>
+              <ActionButton
+                hasAccess={hasAccess}
+                size="sm"
+                onClick={() => {
+                  setSelectedExportId(id);
+                  setCancelDialogOpen(true);
+                }}
+              >
+                Cancel
+              </ActionButton>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Cancel batch export?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Are you sure you want to cancel this batch export? This action
+                  cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>No, keep it</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={() => {
+                    cancelBatchExport.mutate({
+                      projectId: props.projectId,
+                      batchExportId: id,
+                    });
+                  }}
+                >
+                  Yes, cancel export
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        );
       },
     },
   ] as LangfuseColumnDef<BatchExport>[];

--- a/web/src/features/batch-exports/server/batchExport.ts
+++ b/web/src/features/batch-exports/server/batchExport.ts
@@ -76,6 +76,25 @@ export const batchExportRouter = createTRPCRouter({
         });
       }
     }),
+  cancel: protectedProjectProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        batchExportId: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "batchExports:create",
+      });
+
+      await ctx.prisma.batchExport.update({
+        where: { id: input.batchExportId, projectId: input.projectId },
+        data: { status: BatchExportStatus.CANCELLED },
+      });
+    }),
   all: protectedProjectProcedure
     .input(
       z.object({

--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -57,6 +57,14 @@ export const handleBatchExportJob = async (
     );
   }
 
+  // Check if the batch export has been cancelled
+  if (jobDetails.status === BatchExportStatus.CANCELLED) {
+    logger.info(
+      `Batch export ${batchExportId} has been cancelled. Skipping processing.`,
+    );
+    return; // Exit early without processing
+  }
+
   // Check if the batch export is older than 30 days
   const thirtyDaysAgo = new Date();
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add cancel functionality for batch export jobs, including UI, server, and worker logic to handle `CANCELLED` status.
> 
>   - **Behavior**:
>     - Add `CANCELLED` status to `BatchExportStatus` in `types.ts`.
>     - Implement cancel functionality in `BatchExportsTable.tsx` with a cancel button for queued or processing jobs.
>     - Add `cancel` mutation in `batchExport.ts` to update job status to `CANCELLED`.
>     - Modify `handleBatchExportJob.ts` to skip processing if job status is `CANCELLED`.
>   - **UI**:
>     - Add cancel dialog in `BatchExportsTable.tsx` with confirmation prompt.
>     - Show cancel button only for jobs with `QUEUED` or `PROCESSING` status.
>   - **Server**:
>     - Add `cancel` mutation in `batchExport.ts` to update job status to `CANCELLED`.
>     - Ensure user has `batchExports:create` scope for cancel operation.
>   - **Worker**:
>     - Check for `CANCELLED` status in `handleBatchExportJob.ts` and skip processing if true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e4368c409de42fb2cf451273c3ef08cffa99dad6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->