### PR TITLE
fix: handle malformed tool calls in chatml adapters

### DIFF
--- a/web/src/utils/chatml/adapters/langgraph.clienttest.ts
+++ b/web/src/utils/chatml/adapters/langgraph.clienttest.ts
@@ -182,6 +182,34 @@ describe("LangGraph Adapter", () => {
     expect(result.data?.[1].tools?.[0].name).toBe("Web-Search");
   });
 
+  it("should skip null entries in tool_calls arrays", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          null,
+          {
+            id: "call_valid",
+            type: "function",
+            function: {
+              name: "search_docs",
+              arguments: { topic: "Langfuse" },
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = normalizeInput(input, { framework: "langgraph" });
+    expect(result.success).toBe(true);
+
+    const toolCalls = result.data?.[0].tool_calls;
+    expect(toolCalls?.length).toBe(1);
+    expect(toolCalls?.[0].name).toBe("search_docs");
+    expect(toolCalls?.[0].arguments).toBe('{"topic":"Langfuse"}');
+  });
+
   it("should clean up additional_kwargs with null values", () => {
     const output = {
       role: "assistant",

--- a/web/src/utils/chatml/adapters/langgraph.ts
+++ b/web/src/utils/chatml/adapters/langgraph.ts
@@ -154,9 +154,12 @@ function normalizeMessage(msg: unknown): Record<string, unknown> {
   // LangGraph can have OpenAI-style nested format: {id, type, function: {name, arguments}}
   // Convert to flat format: {id, name, arguments, type}
   if (normalized.tool_calls && Array.isArray(normalized.tool_calls)) {
-    normalized.tool_calls = (
-      normalized.tool_calls as Record<string, unknown>[]
-    ).map((tc) => {
+    const sanitizedToolCalls = (normalized.tool_calls as unknown[]).filter(
+      (tc): tc is Record<string, unknown> =>
+        Boolean(tc) && typeof tc === "object",
+    );
+
+    normalized.tool_calls = sanitizedToolCalls.map((tc) => {
       // If nested format (has function.name), flatten it
       if (tc.function && typeof tc.function === "object") {
         const func = tc.function as Record<string, unknown>;

--- a/web/src/utils/chatml/adapters/openai.clienttest.ts
+++ b/web/src/utils/chatml/adapters/openai.clienttest.ts
@@ -161,6 +161,36 @@ describe("OpenAI Adapter", () => {
     expect(toolCalls?.[0].arguments).toBe('{"city":"NYC","units":"celsius"}');
   });
 
+  it("should skip null entries in tool_calls arrays", () => {
+    const input = {
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            null,
+            {
+              id: "call_valid",
+              type: "function",
+              function: {
+                name: "get_balance",
+                arguments: { account: "123" },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = normalizeInput(input, { framework: "openai" });
+    expect(result.success).toBe(true);
+
+    const toolCalls = result.data?.[0].tool_calls;
+    expect(toolCalls?.length).toBe(1);
+    expect(toolCalls?.[0].name).toBe("get_balance");
+    expect(toolCalls?.[0].arguments).toBe('{"account":"123"}');
+  });
+
   it("should handle multimodal content (array of parts)", () => {
     const input = {
       messages: [

--- a/web/src/utils/chatml/adapters/openai.ts
+++ b/web/src/utils/chatml/adapters/openai.ts
@@ -158,9 +158,7 @@ function normalizeMessage(msg: unknown): Record<string, unknown> {
   // Format: { id, type: "function", function: { name, arguments } }
   // Convert to: { id, name, arguments, type }
   if (normalized.tool_calls && Array.isArray(normalized.tool_calls)) {
-    const sanitizedToolCalls = (
-      normalized.tool_calls as unknown[]
-    ).filter(
+    const sanitizedToolCalls = (normalized.tool_calls as unknown[]).filter(
       (tc): tc is Record<string, unknown> =>
         Boolean(tc) && typeof tc === "object",
     );

--- a/web/src/utils/chatml/adapters/openai.ts
+++ b/web/src/utils/chatml/adapters/openai.ts
@@ -158,9 +158,14 @@ function normalizeMessage(msg: unknown): Record<string, unknown> {
   // Format: { id, type: "function", function: { name, arguments } }
   // Convert to: { id, name, arguments, type }
   if (normalized.tool_calls && Array.isArray(normalized.tool_calls)) {
-    normalized.tool_calls = (
-      normalized.tool_calls as Record<string, unknown>[]
-    ).map((tc) => {
+    const sanitizedToolCalls = (
+      normalized.tool_calls as unknown[]
+    ).filter(
+      (tc): tc is Record<string, unknown> =>
+        Boolean(tc) && typeof tc === "object",
+    );
+
+    normalized.tool_calls = sanitizedToolCalls.map((tc) => {
       if (tc.function && typeof tc.function === "object") {
         const func = tc.function as Record<string, unknown>;
         return {


### PR DESCRIPTION
## Summary

- guard OpenAI and LangGraph ChatML adapters against malformed tool call entries before flattening
- add regression tests for null tool_call elements so traces keep rendering even with bad history

## Root Cause
- OpenAI ChatML normalization iterated over every `tool_calls` entry and immediately dereferenced `tc.function`, so a single `null` element from LangGraph agents made the trace page throw a client-side TypeError and fail to render.
- The LangGraph adapter reused the same assumption, so malformed arrays there would crash for the same reason.

## Solution
- Filter `tool_calls` arrays down to truthy objects before flattening/stringifying in both adapters.
- Add Jest coverage that proves `null` entries are skipped and the remaining tool calls still normalize correctly.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes client-side error in ChatML adapters by filtering null `tool_calls` entries, ensuring robust processing.
> 
>   - **Behavior**:
>     - Fixes client-side TypeError in OpenAI and LangGraph ChatML adapters by filtering out null `tool_calls` entries before processing.
>     - Ensures traces render correctly even with malformed history.
>   - **Testing**:
>     - Adds regression tests in `langgraph.clienttest.ts` and `openai.clienttest.ts` to verify null `tool_calls` are skipped and remaining entries are processed correctly.
>   - **Solution**:
>     - Updates `normalizeMessage()` in `langgraph.ts` and `openai.ts` to filter `tool_calls` arrays for truthy objects before flattening.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f0608b244fe5dcb735c0c40f8a92ef4673b589fb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->