### PR TITLE
perf(models-table): lazy load lastUsed column

### DIFF
--- a/web/src/features/models/validation.ts
+++ b/web/src/features/models/validation.ts
@@ -56,7 +56,6 @@ export const GetModelResultSchema = z.object({
   ]),
   tokenizerId: TokenizerSchema,
   pricingTiers: z.array(PricingTierSchema),
-  lastUsed: z.date().nullish(),
 });
 
 export type GetModelResult = z.infer<typeof GetModelResultSchema>;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize `lastUsed` column in models table by implementing lazy loading and adding a new query for fetching data.
> 
>   - **Behavior**:
>     - Lazy load `lastUsed` column in `ModelTable` in `models.tsx` using `api.models.lastUsedByModelIds` query.
>     - Display skeleton loader in `lastUsed` column while data is being fetched.
>   - **API**:
>     - Add `lastUsedByModelIds` query in `models.ts` to fetch `lastUsed` data for specific model IDs.
>   - **Schema**:
>     - Remove `lastUsed` from `ModelTableRow` in `models.tsx` and `GetModelResultSchema` in `validation.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 916e30c34a4dc3e4d281d4ce7e0cca1bfced00fc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->