### PR TITLE
chore: make trace-delete queue configuration more lax to allow for longer waitig times

### DIFF
--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -161,6 +161,11 @@ if (env.LANGFUSE_POSTGRES_METERING_DATA_EXPORT_IS_ENABLED === "true") {
 if (env.QUEUE_CONSUMER_TRACE_DELETE_QUEUE_IS_ENABLED === "true") {
   WorkerManager.register(QueueName.TraceDelete, traceDeleteProcessor, {
     concurrency: env.LANGFUSE_TRACE_DELETE_CONCURRENCY,
+    // Same configuration as EvaluationExecution or
+    // BlobStorageIntegrationProcessingQueue queue, see detailed comment there
+    maxStalledCount: 3,
+    lockDuration: 60000, // 60 seconds
+    stalledInterval: 120000, // 120 seconds
     limiter: {
       // Process at most `max` delete jobs per 2 min
       max: env.LANGFUSE_TRACE_DELETE_CONCURRENCY,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `traceDeleteProcessor` configuration in `app.ts` to allow longer waiting times for stalled jobs.
> 
>   - **Behavior**:
>     - Update `traceDeleteProcessor` configuration in `app.ts` to allow longer waiting times for stalled jobs.
>     - Set `maxStalledCount` to 3, `lockDuration` to 60000 ms, and `stalledInterval` to 120000 ms.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8c6d34e95021e19f776be1126fd5c8e3b252c8c6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->