### PR TITLE
chore(public traces): Do not render sidebar for public traces when authenticated users miss project access

### DIFF
--- a/web/src/components/layouts/app-layout/index.tsx
+++ b/web/src/components/layouts/app-layout/index.tsx
@@ -79,13 +79,15 @@ export function AppLayout(props: PropsWithChildren) {
     return <LoadingLayout message={authGuard.message} />;
   }
 
-  // Project access denied - only check for authenticated users on non-publishable paths
-  // Publishable paths (traces, sessions) should be accessible without authentication
-  if (
-    session.status === "authenticated" &&
-    !isPublishable &&
-    !projectAccess.hasAccess
-  ) {
+  // Project access denied - handle based on path type
+  if (session.status === "authenticated" && !projectAccess.hasAccess) {
+    // For publishable paths (shared traces/sessions), render minimal layout without sidebar
+    // This allows authenticated users to view shared content without seeing project navigation
+    if (isPublishable) {
+      return <MinimalLayout>{props.children}</MinimalLayout>;
+    }
+
+    // For non-publishable paths, show error page
     return (
       <ErrorPageWithSentry
         title="Project Not Found"


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue (LFE-7919) where authenticated users viewing a public trace for a project they lack access to would incorrectly render the full application sidebar. This led to broken navigation links. The change ensures that in such cases, the minimal layout (without the sidebar) is displayed, aligning the experience with unauthenticated users and preventing navigation errors.

Fixes # LFE-7919

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [ ] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my PR needs changes to the documentation
- [ ] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [ ] I haven't added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-7919](https://linear.app/langfuse/issue/LFE-7919/bug-shared-trace-sidebar-links-to-project-where-user-does-not-have)

<a href="https://cursor.com/background-agent?bcId=bc-8e574d22-9a50-40e4-9f99-1531bf57b088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8e574d22-9a50-40e4-9f99-1531bf57b088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes sidebar rendering for authenticated users without project access by using `MinimalLayout` for publishable paths in `AppLayout`.
> 
>   - **Behavior**:
>     - In `AppLayout`, when authenticated users lack project access, render `MinimalLayout` for publishable paths instead of full sidebar.
>     - For non-publishable paths, show `ErrorPageWithSentry`.
>   - **Files**:
>     - Changes in `index.tsx` to handle layout rendering based on project access and path type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9f059292aab3ffc90e4bffd1332d256baf7341e2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->