### PR TITLE
feat(llm-as-a-judge): add filter sidebar to the eval table

### DIFF
--- a/web/src/features/evals/components/evaluator-detail.tsx
+++ b/web/src/features/evals/components/evaluator-detail.tsx
@@ -111,13 +111,11 @@ export const EvaluatorDetail = () => {
       }}
     >
       {existingEvaluator && (
-        <div className="grid flex-1 grid-cols-[1fr,auto] overflow-hidden contain-layout">
-          <div className="flex h-full flex-col overflow-hidden">
-            <EvalLogTable
-              projectId={projectId}
-              jobConfigurationId={existingEvaluator.id}
-            />
-          </div>
+        <div className="flex h-full flex-col overflow-hidden">
+          <EvalLogTable
+            projectId={projectId}
+            jobConfigurationId={existingEvaluator.id}
+          />
         </div>
       )}
     </Page>

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -1237,7 +1237,7 @@ export const evalRouter = createTRPCRouter({
               | "jobConfigurationId"
               | "executionTraceId"
               | "error"
-            >
+            > & { sessionId: string | null }
           >
         >(
           generateExecutionsQuery(
@@ -1250,7 +1250,8 @@ export const evalRouter = createTRPCRouter({
             je.job_template_id as "jobTemplateId",
             je.job_configuration_id as "jobConfigurationId",
             je.execution_trace_id as "executionTraceId",
-            je.error
+            je.error,
+            t.session_id as "sessionId"
             `,
             input.projectId,
             filterCondition,
@@ -1407,6 +1408,8 @@ const generateExecutionsQuery = (
   SELECT
    ${select}
    FROM job_executions je
+   LEFT JOIN traces t ON je.job_input_trace_id = t.id AND je.project_id = t.project_id
+   LEFT JOIN scores s ON je.job_output_score_id = s.id AND je.project_id = s.project_id
    WHERE je.project_id = ${projectId}
    ${filterCondition}
    AND je.status != 'CANCELLED'

--- a/web/src/features/filters/config/eval-logs-config.ts
+++ b/web/src/features/filters/config/eval-logs-config.ts
@@ -1,0 +1,43 @@
+import { evalExecutionsFilterCols } from "@/src/server/api/definitions/evalExecutionsTable";
+import type { FilterConfig } from "@/src/features/filters/lib/filter-config";
+
+export const evalLogFilterConfig: FilterConfig = {
+  tableName: "evalLogs",
+
+  columnDefinitions: evalExecutionsFilterCols,
+
+  defaultExpanded: ["status"],
+
+  defaultSidebarCollapsed: true,
+
+  facets: [
+    {
+      type: "categorical" as const,
+      column: "status",
+      label: "Status",
+    },
+    {
+      type: "string" as const,
+      column: "traceId",
+      label: "Trace ID",
+    },
+    {
+      type: "string" as const,
+      column: "sessionId",
+      label: "Session ID",
+    },
+    {
+      type: "string" as const,
+      column: "executionTraceId",
+      label: "Execution Trace ID",
+    },
+    {
+      type: "numeric" as const,
+      column: "scoreValue",
+      label: "Score Value",
+      min: 0,
+      max: 1,
+      step: 0.01,
+    },
+  ],
+};

--- a/web/src/features/filters/config/scores-config.ts
+++ b/web/src/features/filters/config/scores-config.ts
@@ -42,8 +42,9 @@ export const scoreFilterConfig: FilterConfig = {
       type: "numeric" as const,
       column: "value",
       label: "Value",
-      min: -100,
-      max: 100,
+      min: 0,
+      max: 1,
+      step: 0.01,
     },
     {
       type: "categorical" as const,
@@ -54,6 +55,11 @@ export const scoreFilterConfig: FilterConfig = {
       type: "string" as const,
       column: "traceId",
       label: "Trace ID",
+    },
+    {
+      type: "string" as const,
+      column: "sessionId",
+      label: "Session ID",
     },
     {
       type: "categorical" as const,

--- a/web/src/features/filters/lib/filter-config.ts
+++ b/web/src/features/filters/lib/filter-config.ts
@@ -20,6 +20,7 @@ interface NumericFacet {
   label: string;
   min: number;
   max: number;
+  step?: number;
   unit?: string;
 }
 

--- a/web/src/server/api/definitions/evalExecutionsTable.ts
+++ b/web/src/server/api/definitions/evalExecutionsTable.ts
@@ -10,4 +10,28 @@ export const evalExecutionsFilterCols: ColumnDefinition[] = [
       .filter((value) => value !== JobExecutionStatus.CANCELLED)
       .map((value) => ({ value })),
   },
+  {
+    name: "Trace ID",
+    id: "traceId",
+    type: "string",
+    internal: 'je."job_input_trace_id"',
+  },
+  {
+    name: "Session ID",
+    id: "sessionId",
+    type: "string",
+    internal: 't."session_id"',
+  },
+  {
+    name: "Execution Trace ID",
+    id: "executionTraceId",
+    type: "string",
+    internal: 'je."execution_trace_id"',
+  },
+  {
+    name: "Score Value",
+    id: "scoreValue",
+    type: "number",
+    internal: 's."value"',
+  },
 ];

--- a/web/src/server/api/definitions/scoresTable.ts
+++ b/web/src/server/api/definitions/scoresTable.ts
@@ -14,6 +14,12 @@ export const scoresTableCols: ColumnDefinition[] = [
     internal: 's."trace_id"',
   },
   {
+    name: "Session ID",
+    id: "sessionId",
+    type: "string",
+    internal: 's."session_id"',
+  },
+  {
     name: "Trace Name",
     id: "traceName",
     type: "stringOptions",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a filter sidebar to the evaluation table with new session linking and enhanced filtering capabilities.
> 
>   - **Behavior**:
>     - Adds a filter sidebar to `EvalLogTable` in `eval-log.tsx` using `ResizableFilterLayout` and `DataTableControlsProvider`.
>     - Introduces `sessionId` column in `EvalLogTable` and `evalRouter` to link sessions.
>   - **Filter Configurations**:
>     - Creates `evalLogFilterConfig` in `eval-logs-config.ts` with facets for `status`, `traceId`, `sessionId`, `executionTraceId`, and `scoreValue`.
>     - Updates `scoreFilterConfig` in `scores-config.ts` to include `sessionId` and adjust `value` range.
>   - **API Changes**:
>     - Modifies `getLogs` in `evalRouter` to include `sessionId` in the query and response.
>     - Joins `traces` and `scores` tables in `generateExecutionsQuery` for additional data fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e1d120ebf0addbe1aec554c1069256972cc6b568. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->