### PR TITLE
chore: add event deletion in case event inserts are enabled

### DIFF
--- a/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
+++ b/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
@@ -1,4 +1,5 @@
 import {
+  deleteEventsOlderThanDays,
   deleteObservationsOlderThanDays,
   deleteScoresOlderThanDays,
   deleteTracesOlderThanDays,
@@ -78,6 +79,9 @@ export const handleDataRetentionProcessingJob = async (job: Job) => {
     deleteTracesOlderThanDays(projectId, cutoffDate),
     deleteObservationsOlderThanDays(projectId, cutoffDate),
     deleteScoresOlderThanDays(projectId, cutoffDate),
+    env.LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE === "true"
+      ? deleteEventsOlderThanDays(projectId, cutoffDate)
+      : Promise.resolve(),
   ]);
   logger.info(
     `[Data Retention] Deleted ClickHouse and S3 data older than ${retention} days for project ${projectId}`,

--- a/worker/src/features/traces/processClickhouseTraceDelete.ts
+++ b/worker/src/features/traces/processClickhouseTraceDelete.ts
@@ -1,4 +1,5 @@
 import {
+  deleteEventsByTraceIds,
   deleteObservationsByTraceIds,
   deleteScoresByTraceIds,
   deleteTraces,
@@ -159,6 +160,9 @@ export const processClickhouseTraceDelete = async (
       deleteTraces(projectId, traceIds),
       deleteObservationsByTraceIds(projectId, traceIds),
       deleteScoresByTraceIds(projectId, traceIds),
+      env.LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE === "true"
+        ? deleteEventsByTraceIds(projectId, traceIds)
+        : Promise.resolve(),
     ]);
   } catch (e) {
     logger.error(

--- a/worker/src/queues/projectDelete.ts
+++ b/worker/src/queues/projectDelete.ts
@@ -1,5 +1,6 @@
 import { Job, Processor } from "bullmq";
 import {
+  deleteEventsByProjectId,
   deleteObservationsByProjectId,
   deleteScoresByProjectId,
   deleteTracesByProjectId,
@@ -92,6 +93,9 @@ export const projectDeleteProcessor: Processor = async (
     deleteTracesByProjectId(projectId),
     deleteObservationsByProjectId(projectId),
     deleteScoresByProjectId(projectId),
+    env.LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE === "true"
+      ? deleteEventsByProjectId(projectId)
+      : Promise.resolve(),
   ]);
 
   // Trigger async delete of dataset run items


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add event deletion functions for trace IDs, project IDs, and data retention, with conditional execution based on environment variables.
> 
>   - **Functions Added**:
>     - `deleteEventsByTraceIds(projectId, traceIds)` in `events.ts` to delete events by trace IDs.
>     - `deleteEventsByProjectId(projectId)` in `events.ts` to delete all events for a project.
>     - `deleteEventsOlderThanDays(projectId, beforeDate)` in `events.ts` to delete events older than a cutoff date.
>   - **Integration**:
>     - In `handleDataRetentionProcessingJob.ts`, added `deleteEventsOlderThanDays()` to data retention job if `LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE` is "true".
>     - In `processClickhouseTraceDelete.ts`, added `deleteEventsByTraceIds()` to trace deletion process if `LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE` is "true".
>     - In `projectDelete.ts`, added `deleteEventsByProjectId()` to project deletion process if `LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE` is "true".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5100b3472a2fcea449066e052c94be40d0c0aff5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->