### PR TITLE
fix(public traces): adjust shared trace header controls

### DIFF
--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -13,6 +13,7 @@ import { cn } from "@/src/utils/tailwind";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { type ParsedUrlQuery } from "querystring";
+import { type ReactNode } from "react";
 
 type TabDefinition = {
   value: string;
@@ -43,6 +44,10 @@ export type PageHeaderProps = {
   container?: boolean;
   tabsProps?: PageTabsProps;
   className?: string;
+  showSidebarTrigger?: boolean;
+  leadingControl?: ReactNode;
+  titleBadges?: ReactNode;
+  breadcrumbBadges?: ReactNode;
 };
 
 const PageHeader = ({
@@ -56,6 +61,10 @@ const PageHeader = ({
   tabsProps,
   container = false,
   className,
+  showSidebarTrigger = true,
+  leadingControl,
+  titleBadges,
+  breadcrumbBadges,
 }: PageHeaderProps) => {
   const router = useRouter();
   return (
@@ -75,11 +84,20 @@ const PageHeader = ({
               container && "lg:container",
             )}
           >
-            <SidebarTrigger />
+            {showSidebarTrigger ? (
+              <SidebarTrigger />
+            ) : (
+              leadingControl && (
+                <div className="flex items-center">{leadingControl}</div>
+              )
+            )}
             <div>
               <EnvLabel />
             </div>
-            <BreadcrumbComponent items={breadcrumb} />
+            <div className="flex items-center gap-2">
+              <BreadcrumbComponent items={breadcrumb} />
+              {breadcrumbBadges}
+            </div>
           </div>
         </div>
 
@@ -148,6 +166,11 @@ const PageHeader = ({
                     )}
                   </h2>
                 </div>
+                {titleBadges && (
+                  <div className="ml-1 flex items-center gap-1">
+                    {titleBadges}
+                  </div>
+                )}
               </div>
               {actionButtonsLeft && (
                 <div className="flex flex-wrap items-center gap-1 self-center">

--- a/web/src/components/trace2/TracePage.tsx
+++ b/web/src/components/trace2/TracePage.tsx
@@ -8,6 +8,12 @@ import { ErrorPage } from "@/src/components/error-page";
 import { DeleteTraceButton } from "@/src/components/deleteButton";
 import Page from "@/src/components/layouts/page";
 import { Trace } from "@/src/components/trace2/Trace";
+import { useSession } from "next-auth/react";
+import { useIsAuthenticatedAndProjectMember } from "@/src/features/auth/hooks";
+import { Button } from "@/src/components/ui/button";
+import Link from "next/link";
+import { stripBasePath } from "@/src/utils/redirect";
+import { Badge } from "@/src/components/ui/badge";
 
 export function TracePage({
   traceId,
@@ -17,12 +23,14 @@ export function TracePage({
   timestamp?: Date;
 }) {
   const router = useRouter();
+  const session = useSession();
+  const routeProjectId = (router.query.projectId as string) ?? "";
 
   const trace = api.traces.byIdWithObservationsAndScores.useQuery(
     {
       traceId,
       timestamp,
-      projectId: router.query.projectId as string,
+      projectId: routeProjectId,
     },
     {
       retry(failureCount, error) {
@@ -34,6 +42,11 @@ export function TracePage({
         return failureCount < 3;
       },
     },
+  );
+
+  const projectIdForAccessCheck = trace.data?.projectId ?? routeProjectId;
+  const hasProjectAccess = useIsAuthenticatedAndProjectMember(
+    projectIdForAccessCheck,
   );
 
   const [selectedTab, setSelectedTab] = useQueryParam(
@@ -58,6 +71,42 @@ export function TracePage({
 
   if (!trace.data) return <div className="p-3">Loading...</div>;
 
+  const isSharedTrace = trace.data.public;
+  const showPublicIndicators = isSharedTrace && !hasProjectAccess;
+  const encodedTargetPath = encodeURIComponent(
+    stripBasePath(router.asPath || "/"),
+  );
+  const leadingControl = showPublicIndicators ? (
+    session.status === "authenticated" ? (
+      <Button
+        asChild
+        size="sm"
+        variant="outline"
+        title="Back to Langfuse"
+        className="px-3"
+      >
+        <Link href="/">Langfuse</Link>
+      </Button>
+    ) : (
+      <Button
+        asChild
+        size="sm"
+        variant="default"
+        title="Sign in to Langfuse"
+        className="px-3"
+      >
+        <Link href={`/auth/sign-in?targetPath=${encodedTargetPath}`}>
+          Sign in
+        </Link>
+      </Button>
+    )
+  ) : undefined;
+  const sharedBadge = showPublicIndicators ? (
+    <Badge variant="outline" className="text-xs font-medium">
+      Public
+    </Badge>
+  ) : undefined;
+
   return (
     <Page
       headerProps={{
@@ -71,6 +120,9 @@ export function TracePage({
             href: `/project/${router.query.projectId as string}/traces`,
           },
         ],
+        showSidebarTrigger: !showPublicIndicators,
+        leadingControl,
+        breadcrumbBadges: sharedBadge,
         actionButtonsLeft: (
           <div className="ml-1 flex items-center gap-1">
             <div className="flex items-center gap-0">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `PageHeader` and `TracePage` to support shared trace UI adjustments based on user authentication and trace sharing status.
> 
>   - **Behavior**:
>     - `PageHeader` in `page-header.tsx` now supports `showSidebarTrigger`, `leadingControl`, `titleBadges`, and `breadcrumbBadges` props for enhanced UI control.
>     - `TracePage` in `TracePage.tsx` uses `showSidebarTrigger`, `leadingControl`, and `breadcrumbBadges` to adjust UI for shared traces.
>   - **UI Components**:
>     - `leadingControl` in `PageHeader` can display a button for navigation or sign-in based on `showPublicIndicators`.
>     - `breadcrumbBadges` in `PageHeader` can display a "Public" badge for shared traces without project access.
>   - **Logic**:
>     - `TracePage` checks `isSharedTrace` and `hasProjectAccess` to determine `showPublicIndicators` and adjust UI accordingly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 208126f9a1ab79c6f5f01eba978c4f1dd11d0a7d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->