### PR TITLE
chore(dataset-versioning): swap pk from id -> sys_id

### DIFF
--- a/packages/shared/prisma/migrations/20251202171742_dataset_items_swap_pk/migration.sql
+++ b/packages/shared/prisma/migrations/20251202171742_dataset_items_swap_pk/migration.sql
@@ -7,8 +7,12 @@
 BEGIN;
 
 -- 1. Drop pk constraint that prevents appending
-ALTER TABLE "dataset_items" DROP CONSTRAINT "dataset_items_pkey",
- -- 2. Enforce Physical Identity
+ALTER TABLE "dataset_items" 
+DROP CONSTRAINT "dataset_items_pkey";
+
+-- 2. Add new PK (drop the unique constraint first to avoid duplicate)
+ALTER TABLE "dataset_items"
+DROP CONSTRAINT "dataset_items_sys_id_project_id_key",
 ADD CONSTRAINT "dataset_items_pkey" PRIMARY KEY ("sys_id", "project_id");
 
 COMMIT;

--- a/packages/shared/prisma/migrations/20251202171742_dataset_items_swap_pk/migration.sql
+++ b/packages/shared/prisma/migrations/20251202171742_dataset_items_swap_pk/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - The primary key for the `dataset_items` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+BEGIN;
+
+-- 1. Drop pk constraint that prevents appending
+ALTER TABLE "dataset_items" DROP CONSTRAINT "dataset_items_pkey",
+ -- 2. Enforce Physical Identity
+ADD CONSTRAINT "dataset_items_pkey" PRIMARY KEY ("sys_id", "project_id");
+
+COMMIT;

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -633,7 +633,7 @@ model DatasetItem {
   isDeleted           Boolean           @default(false) @map("is_deleted")
   datasetRunItems     DatasetRunItems[]
 
-  @@id([id, projectId])
+  @@id([sysId, projectId])
   @@index([sourceTraceId], type: Hash)
   @@index([sourceObservationId], type: Hash)
   @@index([datasetId], type: Hash)


### PR DESCRIPTION
⚠️ Do not merge this PR before fk constraint has been lifted: [chore(dataset-run-items): remove foreign key relation to DatasetItem](https://github.com/langfuse/langfuse/pull/10776)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Change primary key of `dataset_items` table from `id` to `sys_id` and `project_id`.
> 
>   - **Database Migration**:
>     - In `migration.sql`, drop primary key constraint `dataset_items_pkey` from `dataset_items` table.
>     - Add new primary key constraint on `sys_id` and `project_id`.
>   - **Schema Update**:
>     - In `schema.prisma`, change primary key of `DatasetItem` model from `id` to `sysId` and `projectId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 46b1b26d58fd1a53a8e9fc5f0902f9069875ccf6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->