### PR TITLE
chore: add pricing tier columns in seeder script

### DIFF
--- a/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
+++ b/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
@@ -194,7 +194,7 @@ export class ClickHouseQueryBuilder {
         start_time AS updated_at,
         start_time AS event_ts,
         0 AS is_deleted,
-        '' as usage_pricing_tier_id,
+        '' AS usage_pricing_tier_id,
         '' as usage_pricing_tier_name
       FROM numbers(${totalObservations});
     `;

--- a/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
+++ b/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
@@ -195,7 +195,7 @@ export class ClickHouseQueryBuilder {
         start_time AS event_ts,
         0 AS is_deleted,
         '' AS usage_pricing_tier_id,
-        '' as usage_pricing_tier_name
+        '' AS usage_pricing_tier_name
       FROM numbers(${totalObservations});
     `;
   }

--- a/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
+++ b/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
@@ -193,7 +193,9 @@ export class ClickHouseQueryBuilder {
         start_time AS created_at,
         start_time AS updated_at,
         start_time AS event_ts,
-        0 AS is_deleted
+        0 AS is_deleted,
+        '' as usage_pricing_tier_id,
+        '' as usage_pricing_tier_name
       FROM numbers(${totalObservations});
     `;
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `usage_pricing_tier_id` and `usage_pricing_tier_name` columns to `buildBulkObservationsInsert` in `clickhouse-builder.ts`.
> 
>   - **Behavior**:
>     - Adds `usage_pricing_tier_id` and `usage_pricing_tier_name` columns to the `buildBulkObservationsInsert` function in `clickhouse-builder.ts`.
>     - Both columns are initialized with empty strings in the SQL query.
>   - **Purpose**:
>     - Prepares for future support of pricing tier data in observation records.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ed44d0544b0b45e073d1d621167398466b269314. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->