### PR TITLE
fix(bookmark): resolve trace starring bug

### DIFF
--- a/web/src/components/star-toggle.tsx
+++ b/web/src/components/star-toggle.tsx
@@ -3,7 +3,7 @@ import { StarIcon } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import { api } from "@/src/utils/api";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
-import { type RouterOutput, type RouterInput } from "@/src/utils/types";
+import { type RouterInput } from "@/src/utils/types";
 import { useState } from "react";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { trpcErrorToast } from "@/src/utils/trpcErrorToast";


### PR DESCRIPTION
## What does this PR do?

Fixes #LFE-7947

This PR resolves a bug where starring a trace in the trace detail view required two clicks to visually update the star icon. The issue stemmed from an incorrect optimistic update implementation in the `StarTraceDetailsToggle` component.

The fix involves:
1.  Capturing the `newBookmarkState` in the `onMutate` callback.
2.  Performing an immediate optimistic update of the trace's `bookmarked` status in the cache using `setData` within `onMutate`.
3.  Removing the unreliable toggling logic from the `onSettled` callback, which now only handles invalidation.
4.  Adding proper rollback logic in `onError`.

This ensures the UI updates instantly on the first click, providing immediate visual feedback to the user.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

-   [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

-   [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
-   [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
-   [ ] I haven't commented my code, particularly in hard-to-understand areas
-   [ ] I haven't checked if my PR needs changes to the documentation
-   [ ] I haven't checked if my changes generate no new warnings (`npm run lint`)
-   [ ] I haven't added tests that prove my fix is effective or that my feature works
-   [ ] I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-7947](https://linear.app/langfuse/issue/LFE-7947/bugui-starring-a-trace-mostly-only-works-on-the-second-click)

<a href="https://cursor.com/background-agent?bcId=bc-2983843b-714c-4e90-9730-d1060dcb3ccd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2983843b-714c-4e90-9730-d1060dcb3ccd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes UI update bug in `StarTraceDetailsToggle` by improving optimistic update and error handling logic.
> 
>   - **Behavior**:
>     - Fixes bug in `StarTraceDetailsToggle` where starring required two clicks to update UI.
>     - Implements immediate optimistic update using `setData` in `onMutate`.
>     - Removes toggling logic from `onSettled`, now only handles invalidation.
>     - Adds rollback logic in `onError` to revert changes on failure.
>   - **Code Changes**:
>     - Modifies `onMutate` in `StarTraceDetailsToggle` to capture `newBookmarkState` and update cache.
>     - Updates `onError` to rollback to previous state using `prevData`.
>     - Simplifies `onSettled` to only invalidate cache.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e1997ece3b9049ea552179feeb4c14793758c41f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->