### PR TITLE
fix: events-observations is an implementaion detail, shouldn't appear in the UI

### DIFF
--- a/web/src/features/query/dashboardUiTableToViewMapping.ts
+++ b/web/src/features/query/dashboardUiTableToViewMapping.ts
@@ -99,53 +99,6 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       viewName: "traceVersion",
     },
   ],
-  "events-observations": [
-    // Similar to observations but without trace-JOIN fields (traceName, traceRelease, traceVersion)
-    {
-      uiTableName: "Observation Name",
-      viewName: "name",
-    },
-    {
-      uiTableName: "Score Name",
-      viewName: "scoreName",
-    },
-    {
-      uiTableName: "User",
-      viewName: "userId",
-    },
-    {
-      uiTableName: "Session",
-      viewName: "sessionId",
-    },
-    {
-      uiTableName: "Metadata",
-      viewName: "metadata",
-    },
-    {
-      uiTableName: "Type",
-      viewName: "type",
-    },
-    {
-      uiTableName: "Tags",
-      viewName: "tags",
-    },
-    {
-      uiTableName: "Model",
-      viewName: "providedModelName",
-    },
-    {
-      uiTableName: "Environment",
-      viewName: "environment",
-    },
-    {
-      uiTableName: "Release",
-      viewName: "release",
-    },
-    {
-      uiTableName: "Version",
-      viewName: "version",
-    },
-  ],
   "scores-numeric": [
     {
       uiTableName: "Score Name",

--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -1,6 +1,6 @@
-import { type z } from "zod/v4";
+import type z from "zod/v4";
 import {
-  type views,
+  type privateViews,
   type ViewDeclarationType,
   type DimensionsDeclarationType,
 } from "@/src/features/query/types";
@@ -917,7 +917,7 @@ export const eventsObservationsView: ViewDeclarationType = {
 };
 
 export const viewDeclarations: Record<
-  z.infer<typeof views>,
+  z.infer<typeof privateViews>,
   ViewDeclarationType
 > = {
   traces: traceView,

--- a/web/src/features/query/server/queryBuilder.ts
+++ b/web/src/features/query/server/queryBuilder.ts
@@ -6,10 +6,10 @@ import {
 import {
   type QueryType,
   type ViewDeclarationType,
-  type views,
   query as queryModel,
   type metricAggregations,
   type granularities,
+  type privateViews,
 } from "../types";
 import { viewDeclarations } from "@/src/features/query/dataModel";
 import {
@@ -75,7 +75,7 @@ export class QueryBuilder {
   }
 
   private getViewDeclaration(
-    viewName: z.infer<typeof views>,
+    viewName: z.infer<typeof privateViews>,
   ): ViewDeclarationType {
     if (!(viewName in viewDeclarations)) {
       throw new InvalidRequestError(

--- a/web/src/features/query/types.ts
+++ b/web/src/features/query/types.ts
@@ -51,12 +51,13 @@ export const stringDateTime = z.string().datetime({ offset: true });
 export const views = z.enum([
   "traces",
   "observations",
-  "events-observations", // Events table observations (V2 API)
   "scores-numeric",
   "scores-categorical",
   // "sessions",
   // "users",
 ]);
+
+export const privateViews = views.or(z.literal("events-observations"));
 
 export const dimension = z.object({
   field: z.string(),
@@ -94,7 +95,7 @@ export type QueryType = z.infer<typeof query>;
 
 export const query = z
   .object({
-    view: views,
+    view: privateViews,
     dimensions: z.array(dimension),
     metrics: z.array(metric),
     filters: z.array(singleFilter),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> The PR hides the 'events-observations' view from the UI by changing its type to 'privateViews' and updating related mappings and type definitions.
> 
>   - **Behavior**:
>     - Removed `events-observations` from UI by changing its type to `privateViews` in `types.ts`.
>     - Deleted `events-observations` mapping in `dashboardUiTableToViewMapping.ts`.
>   - **Types**:
>     - Changed `views` to `privateViews` in `dataModel.ts` and `queryBuilder.ts`.
>     - Updated `query` type to use `privateViews` in `types.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7ec8ce5a95aa860acfe6c4bf4c1369130619563e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->