### PR TITLE
chore(test): skip performance tests in trace2 components

### DIFF
--- a/web/src/components/trace2/components/_shared/tree-flattening.clienttest.ts
+++ b/web/src/components/trace2/components/_shared/tree-flattening.clienttest.ts
@@ -495,7 +495,7 @@ describe("flattenTree", () => {
     });
   });
 
-  describe("Performance Tests", () => {
+  describe.skip("Performance Tests", () => {
     // Helper to generate tree structures at scale
     const generateTree = (
       count: number,

--- a/web/src/components/trace2/contexts/json-expansion-utils.clienttest.ts
+++ b/web/src/components/trace2/contexts/json-expansion-utils.clienttest.ts
@@ -202,7 +202,7 @@ describe("json-expansion-utils", () => {
     });
   });
 
-  describe("Performance Tests", () => {
+  describe.skip("Performance Tests", () => {
     // Helper to generate random 8-char hex ID
     const generateHexId = (): string => {
       return Math.random().toString(16).slice(2, 10).padEnd(8, "0");

--- a/web/src/components/trace2/lib/tree-building.clienttest.ts
+++ b/web/src/components/trace2/lib/tree-building.clienttest.ts
@@ -651,7 +651,7 @@ describe("buildTraceUiData", () => {
     });
   });
 
-  describe("Performance Tests", () => {
+  describe.skip("Performance Tests", () => {
     // Helper to generate observations at scale
     const generateObservations = (
       count: number,


### PR DESCRIPTION
## Summary
- Skip performance test suites in trace2 components that test large-scale data handling (1k-5M observations/nodes)
- These tests are time-consuming and should be run manually when needed rather than in CI

## Files Updated
- `tree-building.clienttest.ts`: Skip performance tests for 1k-1M observations
- `tree-flattening.clienttest.ts`: Skip performance tests for 1k-1M nodes  
- `json-expansion-utils.clienttest.ts`: Skip performance tests for 1k-5M scale

## Test plan
- [x] Verified tests are skipped with `.skip` modifier
- [x] No functional code changes, only test configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Skips performance tests in trace2 components for large-scale data handling in CI.
> 
>   - **Behavior**:
>     - Skips performance tests in `tree-building.clienttest.ts`, `tree-flattening.clienttest.ts`, and `json-expansion-utils.clienttest.ts` using `.skip`.
>     - Affects tests handling 1k-5M observations/nodes, intended for manual execution.
>   - **Test Plan**:
>     - Verified tests are skipped with `.skip` modifier.
>     - No functional code changes, only test configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a95a6eb5814ef49337ec3616f0d3eb0c8d505e41. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->