### PR TITLE
chore: use AbortSignal during backfill execution to avoid Broken Pipe errors

### DIFF
--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -445,6 +445,7 @@ export async function commandClickhouse(opts: {
   clickhouseConfigs?: NodeClickHouseClientConfigOptions;
   tags?: Record<string, string>;
   clickhouseSettings?: ClickHouseSettings;
+  abortSignal?: AbortSignal;
 }): Promise<void> {
   return await instrumentAsync(
     { name: "clickhouse-command", spanKind: SpanKind.CLIENT },
@@ -461,6 +462,7 @@ export async function commandClickhouse(opts: {
         ...(opts.tags?.queryId
           ? { query_id: opts.tags.queryId as string }
           : {}),
+        ...(opts.abortSignal ? { abort_signal: opts.abortSignal } : {}),
         clickhouse_settings: {
           ...opts.clickhouseSettings,
           log_comment: JSON.stringify(opts.tags ?? {}),

--- a/worker/src/backgroundMigrations/backfillEventsHistoric.ts
+++ b/worker/src/backgroundMigrations/backfillEventsHistoric.ts
@@ -580,7 +580,7 @@ export default class BackfillEventsHistoric implements IBackgroundMigration {
 
     if (retryCount > 0) {
       logger.info(
-        `[Backfill Events] Applying retry settings for query ${queryId}: max_threads=1, max_block_size=32768 (retry ${retryCount})`,
+        `[Backfill Events] Applying retry settings for query ${queryId}: max_block_size=32768 (retry ${retryCount})`,
       );
     }
 

--- a/worker/src/backgroundMigrations/backfillEventsHistoric.ts
+++ b/worker/src/backgroundMigrations/backfillEventsHistoric.ts
@@ -576,7 +576,7 @@ export default class BackfillEventsHistoric implements IBackgroundMigration {
     const retrySettings =
       retryCount > 0
         ? {
-            max_threads: 1,
+            // max_threads: 1,
             max_block_size: "32768",
           }
         : {};
@@ -600,8 +600,8 @@ export default class BackfillEventsHistoric implements IBackgroundMigration {
         request_timeout: timeoutMs,
       },
       clickhouseSettings: {
-        send_progress_in_http_headers: 1,
-        http_headers_progress_interval_ms: "30000",
+        // send_progress_in_http_headers: 1,
+        // http_headers_progress_interval_ms: "30000",
         ...retrySettings,
       },
       abortSignal: abortController.signal,

--- a/worker/src/backgroundMigrations/backfillEventsHistoric.ts
+++ b/worker/src/backgroundMigrations/backfillEventsHistoric.ts
@@ -34,7 +34,6 @@ interface MigrationArgs {
   concurrency?: number; // Default: 4
   pollIntervalMs?: number; // Default: 30_000
   maxRetries?: number; // Default: 3
-  batchTimeoutMs?: number; // Default: 7_200_000 (2h)
   retryFailed?: boolean; // Reset failed chunks to pending
 }
 
@@ -50,7 +49,6 @@ const DEFAULT_CONFIG: MigrationState["config"] = {
   concurrency: 4,
   pollIntervalMs: 30_000,
   maxRetries: 3,
-  batchTimeoutMs: 7_200_000,
 };
 
 type OnQueryCompleteCallback = (
@@ -562,7 +560,6 @@ export default class BackfillEventsHistoric implements IBackgroundMigration {
   private async fireQuery(
     query: string,
     queryId: string,
-    timeoutMs: number,
     retryCount: number = 0,
   ): Promise<void> {
     logger.info(`[Backfill Events] Firing query ${queryId}`);
@@ -596,9 +593,9 @@ export default class BackfillEventsHistoric implements IBackgroundMigration {
         operation: "fireQuery",
         queryId,
       },
-      clickhouseConfigs: {
-        request_timeout: timeoutMs,
-      },
+      // clickhouseConfigs: {
+      //   request_timeout: timeoutMs,
+      // },
       clickhouseSettings: {
         // send_progress_in_http_headers: 1,
         // http_headers_progress_interval_ms: "30000",
@@ -732,8 +729,6 @@ export default class BackfillEventsHistoric implements IBackgroundMigration {
       pollIntervalMs:
         migrationArgs.pollIntervalMs ?? DEFAULT_CONFIG.pollIntervalMs,
       maxRetries: migrationArgs.maxRetries ?? DEFAULT_CONFIG.maxRetries,
-      batchTimeoutMs:
-        migrationArgs.batchTimeoutMs ?? DEFAULT_CONFIG.batchTimeoutMs,
     };
 
     logger.info(
@@ -817,7 +812,6 @@ export default class BackfillEventsHistoric implements IBackgroundMigration {
         await this.fireQuery(
           query,
           state.todos[todoIndex].queryId!,
-          config.batchTimeoutMs!,
           state.todos[todoIndex].retryCount || 0,
         );
         manager.addQuery(
@@ -940,7 +934,6 @@ async function main() {
       concurrency: { type: "string", short: "c", default: "4" },
       pollIntervalMs: { type: "string", short: "p", default: "30000" },
       maxRetries: { type: "string", short: "r", default: "3" },
-      batchTimeoutMs: { type: "string", short: "t", default: "7200000" },
       retryFailed: { type: "boolean", short: "f", default: false },
     },
   });
@@ -951,7 +944,6 @@ async function main() {
     concurrency: parseInt(args.values.concurrency as string, 10),
     pollIntervalMs: parseInt(args.values.pollIntervalMs as string, 10),
     maxRetries: parseInt(args.values.maxRetries as string, 10),
-    batchTimeoutMs: parseInt(args.values.batchTimeoutMs as string, 10),
     retryFailed: args.values.retryFailed as boolean,
   };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Use `AbortSignal` to handle long-running ClickHouse queries, preventing 'Broken Pipe' errors, and remove `batchTimeoutMs` from configurations.
> 
>   - **Behavior**:
>     - Add `abortSignal` to `commandClickhouse` in `clickhouse.ts` to abort HTTP connection while query continues on server.
>     - Use `AbortController` in `fireQuery()` in `backfillEventsHistoric.ts` to handle long-running queries, preventing 'Broken Pipe' errors.
>   - **Configuration**:
>     - Remove `batchTimeoutMs` from `MigrationArgs` and related configurations in `backfillEventsHistoric.ts`.
>   - **Logging**:
>     - Log expected abort errors at debug level in `fireQuery()` in `backfillEventsHistoric.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ca3bb76879bc8f4c1160baaeab483d3a626994b9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->