### PR TITLE
Fix double token counting in span timeline

### DIFF
--- a/web/src/utils/usage-details.ts
+++ b/web/src/utils/usage-details.ts
@@ -1,0 +1,123 @@
+import Decimal from "decimal.js";
+
+export type UsageDetailsRecord = Record<string, number | undefined>;
+
+type DetailsInput = UsageDetailsRecord | UsageDetailsRecord[] | undefined;
+
+type PrefixSumResult = {
+  value: number;
+  hasMatches: boolean;
+};
+
+const sumByPrefix = (
+  details: UsageDetailsRecord,
+  prefix: string,
+  { excludeExactKey = false }: { excludeExactKey?: boolean } = {},
+): PrefixSumResult => {
+  const normalizedPrefix = prefix.toLowerCase();
+  let value = 0;
+  let hasMatches = false;
+
+  for (const [key, rawValue] of Object.entries(details)) {
+    if (rawValue == null) continue;
+
+    const normalizedKey = key.toLowerCase();
+    if (!normalizedKey.startsWith(normalizedPrefix)) continue;
+    if (excludeExactKey && normalizedKey === normalizedPrefix) continue;
+
+    const numericValue = Number(rawValue);
+    if (Number.isNaN(numericValue)) continue;
+
+    value += numericValue;
+    hasMatches = true;
+  }
+
+  return { value, hasMatches };
+};
+
+const getCanonicalValue = (
+  details: UsageDetailsRecord,
+  key: string,
+): number | null => {
+  const normalizedKey = key.toLowerCase();
+  for (const [entryKey, rawValue] of Object.entries(details)) {
+    if (rawValue == null) continue;
+    if (entryKey.toLowerCase() !== normalizedKey) continue;
+
+    const numericValue = Number(rawValue);
+    if (Number.isNaN(numericValue)) return null;
+    return numericValue;
+  }
+
+  return null;
+};
+
+const aggregateMetric = (
+  details: UsageDetailsRecord,
+  prefix: string,
+): number => {
+  const canonicalValue = getCanonicalValue(details, prefix);
+  const { value: breakdownValue, hasMatches } = sumByPrefix(details, prefix, {
+    excludeExactKey: true,
+  });
+
+  if (canonicalValue != null && hasMatches) {
+    return Math.max(canonicalValue, breakdownValue);
+  }
+
+  if (canonicalValue != null) {
+    return canonicalValue;
+  }
+
+  if (hasMatches) {
+    return breakdownValue;
+  }
+
+  return 0;
+};
+
+export const aggregateUsageDetails = (
+  details: DetailsInput,
+): UsageDetailsRecord => {
+  if (!details) return {};
+
+  if (!Array.isArray(details)) {
+    return details ?? {};
+  }
+
+  return details.reduce<UsageDetailsRecord>((acc, curr) => {
+    if (!curr) return acc;
+
+    for (const [key, value] of Object.entries(curr)) {
+      if (value == null) continue;
+
+      const current = acc[key] ?? 0;
+      acc[key] = new Decimal(current).plus(new Decimal(value)).toNumber();
+    }
+
+    return acc;
+  }, {});
+};
+
+export const calculateAggregatedUsage = (
+  details: DetailsInput,
+): {
+  input: number;
+  output: number;
+  total: number;
+} => {
+  const aggregatedDetails = aggregateUsageDetails(details);
+
+  const input = aggregateMetric(aggregatedDetails, "input");
+  const output = aggregateMetric(aggregatedDetails, "output");
+
+  const total =
+    getCanonicalValue(aggregatedDetails, "total") ??
+    (input || output ? input + output : 0);
+
+  return {
+    input,
+    output,
+    total,
+  };
+};


### PR DESCRIPTION
## What does this PR do?

This PR fixes a token counting bug where input/output tokens were double-counted in trace views and span timelines. The issue stemmed from summing both canonical `input`/`output` values and their detailed breakdown components (e.g., `input_tokens`), leading to inflated totals.

The solution introduces a consistent aggregation logic, applied to both frontend UI (trace breakdown tooltips) and backend ingestion, that correctly calculates usage and cost metrics. This logic prioritizes canonical values, falls back to summing breakdown components, and resolves potential double-counting by taking the maximum of the canonical value and the sum of its breakdown entries. This ensures accurate token and cost displays across the platform.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [ ] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my PR needs changes to the documentation
- [ ] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [ ] I haven't added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

---
<a href="https://cursor.com/background-agent?bcId=bc-f8ffe080-f944-496c-93cb-54887f9cb3ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f8ffe080-f944-496c-93cb-54887f9cb3ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

