### PR TITLE
chore: stringify metadata in backfill

### DIFF
--- a/worker/src/backgroundMigrations/backfillEventsHistoric.ts
+++ b/worker/src/backgroundMigrations/backfillEventsHistoric.ts
@@ -529,7 +529,7 @@ export default class BackfillEventsHistoric implements IBackgroundMigration {
         o.cost_details,
         coalesce(o.input, '') AS input,
         coalesce(o.output, '') AS output,
-        metadata::JSON AS metadata,
+        toJsonString(o.metadata) AS metadata,
         mapKeys(o.metadata) AS metadata_names,
         mapValues(o.metadata) AS metadata_raw_values,
         multiIf(mapContains(o.metadata, 'resourceAttributes'), 'otel-backfill', 'ingestion-api-backfill') AS source,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Stringify `metadata` using `toJsonString()` in `backfillEventsHistoric.ts` for backfill operations.
> 
>   - **Behavior**:
>     - Change in `backfillEventsHistoric.ts` to stringify `metadata` using `toJsonString()` instead of casting to JSON directly.
>     - Affects how `metadata` is stored in the `events` table during backfill operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 89b72b6a6484cd45b22a80a16a97a0c9df9e08a0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->