### PR TITLE
chore: stringify metadata in backfill

### DIFF
--- a/worker/src/backgroundMigrations/backfillEventsHistoric.ts
+++ b/worker/src/backgroundMigrations/backfillEventsHistoric.ts
@@ -529,7 +529,7 @@ export default class BackfillEventsHistoric implements IBackgroundMigration {
         o.cost_details,
         coalesce(o.input, '') AS input,
         coalesce(o.output, '') AS output,
-        metadata::JSON AS metadata,
+        toJsonString(o.metadata) AS metadata,
         mapKeys(o.metadata) AS metadata_names,
         mapValues(o.metadata) AS metadata_raw_values,
         multiIf(mapContains(o.metadata, 'resourceAttributes'), 'otel-backfill', 'ingestion-api-backfill') AS source,

--- a/worker/src/backgroundMigrations/backfillEventsHistoric.ts
+++ b/worker/src/backgroundMigrations/backfillEventsHistoric.ts
@@ -529,7 +529,7 @@ export default class BackfillEventsHistoric implements IBackgroundMigration {
         o.cost_details,
         coalesce(o.input, '') AS input,
         coalesce(o.output, '') AS output,
-        toJsonString(o.metadata) AS metadata,
+        toJSONString(o.metadata) AS metadata,
         mapKeys(o.metadata) AS metadata_names,
         mapValues(o.metadata) AS metadata_raw_values,
         multiIf(mapContains(o.metadata, 'resourceAttributes'), 'otel-backfill', 'ingestion-api-backfill') AS source,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change metadata handling in `BackfillEventsHistoric` to use `toJSONString` for stringifying metadata in SQL queries.
> 
>   - **Behavior**:
>     - Modify `buildQuery` in `BackfillEventsHistoric` to use `toJSONString(o.metadata)` instead of `metadata::JSON` for metadata handling.
>   - **Misc**:
>     - No other changes or new features introduced.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9f1543dfe6d013f60f977a307c38a28fe537bed9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->