### PR TITLE
chore: move from privateViews to versioned viewDeclarations to simplify simultaneous access

### DIFF
--- a/web/src/features/query/server/queryExecutor.ts
+++ b/web/src/features/query/server/queryExecutor.ts
@@ -1,20 +1,23 @@
 import { queryClickhouse, measureAndReturn } from "@langfuse/shared/src/server";
 import { QueryBuilder } from "@/src/features/query/server/queryBuilder";
-import { type QueryType } from "@/src/features/query/types";
+import { type QueryType, type ViewVersion } from "@/src/features/query/types";
 
 /**
  * Execute a query using the QueryBuilder.
  *
  * @param projectId - The project ID
  * @param query - The query configuration as defined in QueryType
+ * @param version - The view version to use (v1 or v2), defaults to v1
  * @returns The query result data
  */
 export async function executeQuery(
   projectId: string,
   query: QueryType,
+  version: ViewVersion = "v1",
 ): Promise<Array<Record<string, unknown>>> {
   const { query: compiledQuery, parameters } = await new QueryBuilder(
     query.chartConfig,
+    version,
   ).build(query, projectId);
 
   // Check if the query contains trace table references

--- a/web/src/features/query/types.ts
+++ b/web/src/features/query/types.ts
@@ -57,7 +57,8 @@ export const views = z.enum([
   // "users",
 ]);
 
-export const privateViews = views.or(z.literal("events-observations"));
+export const viewVersions = z.enum(["v1", "v2"]);
+export type ViewVersion = z.infer<typeof viewVersions>;
 
 export const dimension = z.object({
   field: z.string(),
@@ -95,7 +96,7 @@ export type QueryType = z.infer<typeof query>;
 
 export const query = z
   .object({
-    view: privateViews,
+    view: views,
     dimensions: z.array(dimension),
     metrics: z.array(metric),
     filters: z.array(singleFilter),

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -630,7 +630,7 @@ export function WidgetForm({
 
   // Get available metrics for the selected view
   const availableMetrics = useMemo(() => {
-    const viewDeclaration = viewDeclarations[selectedView];
+    const viewDeclaration = viewDeclarations.v1[selectedView];
 
     // For pivot tables, only show measures that still have available aggregations
     if (selectedChartType === "PIVOT_TABLE") {
@@ -697,7 +697,7 @@ export function WidgetForm({
   // Get available metrics for a specific metric index in pivot tables
   const getAvailableMetrics = (metricIndex: number) => {
     if (selectedChartType === "PIVOT_TABLE") {
-      const viewDeclaration = viewDeclarations[selectedView];
+      const viewDeclaration = viewDeclarations.v1[selectedView];
       return Object.entries(viewDeclaration.measures)
         .filter(([measureKey]) => {
           // For count, there's only one aggregation option
@@ -734,7 +734,7 @@ export function WidgetForm({
 
   // Get available dimensions for the selected view
   const availableDimensions = useMemo(() => {
-    const viewDeclaration = viewDeclarations[selectedView];
+    const viewDeclaration = viewDeclarations.v1[selectedView];
     return Object.entries(viewDeclaration.dimensions)
       .map(([key]) => ({
         value: key,
@@ -1075,7 +1075,7 @@ export function WidgetForm({
                   onValueChange={(value) => {
                     if (value !== selectedView) {
                       const newView = value as z.infer<typeof views>;
-                      const newViewDeclaration = viewDeclarations[newView];
+                      const newViewDeclaration = viewDeclarations.v1[newView];
 
                       // Reset regular chart fields
                       setSelectedMeasure("count");
@@ -1137,7 +1137,7 @@ export function WidgetForm({
                         key={view}
                         value={view}
                         label={startCase(view)}
-                        description={viewDeclarations[view].description}
+                        description={viewDeclarations.v1[view].description}
                       />
                     ))}
                   </SelectContent>
@@ -1222,7 +1222,7 @@ export function WidgetForm({
                                   <SelectContent>
                                     {metricsForIndex.map((metric) => {
                                       const meta =
-                                        viewDeclarations[selectedView]
+                                        viewDeclarations.v1[selectedView]
                                           ?.measures?.[metric.value];
                                       return (
                                         <WidgetPropertySelectItem
@@ -1306,7 +1306,7 @@ export function WidgetForm({
                       <SelectContent>
                         {availableMetrics.map((metric) => {
                           const meta =
-                            viewDeclarations[selectedView]?.measures?.[
+                            viewDeclarations.v1[selectedView]?.measures?.[
                               metric.value
                             ];
                           return (
@@ -1392,7 +1392,7 @@ export function WidgetForm({
                         <SelectItem value="none">None</SelectItem>
                         {availableDimensions.map((dimension) => {
                           const meta =
-                            viewDeclarations[selectedView]?.dimensions?.[
+                            viewDeclarations.v1[selectedView]?.dimensions?.[
                               dimension.value
                             ];
                           return (
@@ -1467,7 +1467,7 @@ export function WidgetForm({
                                 )
                                 .map((dimension) => {
                                   const meta =
-                                    viewDeclarations[selectedView]
+                                    viewDeclarations.v1[selectedView]
                                       ?.dimensions?.[dimension.value];
                                   return (
                                     <WidgetPropertySelectItem

--- a/web/src/pages/api/public/v2/metrics.ts
+++ b/web/src/pages/api/public/v2/metrics.ts
@@ -6,7 +6,6 @@ import {
   GetMetricsV2Response,
 } from "@/src/features/public-api/types/metrics";
 import { executeQuery } from "@/src/features/query/server/queryExecutor";
-import { type QueryType } from "@/src/features/query/types";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
@@ -18,22 +17,18 @@ export default withMiddlewares({
       try {
         const queryParams = query.query;
 
-        // Map observations view to events-observations internally
-        let resolvedQuery: QueryType = queryParams;
-        if (queryParams.view === "observations") {
-          resolvedQuery = {
-            ...queryParams,
-            view: "events-observations", // Always use events table
-          };
-        }
-
         logger.info("Received v2 metrics query", {
-          query: resolvedQuery,
+          query: queryParams,
           version: "v2",
           projectId: auth.scope.projectId,
         });
 
-        const result = await executeQuery(auth.scope.projectId, resolvedQuery);
+        // Explicitly use v2 (events table)
+        const result = await executeQuery(
+          auth.scope.projectId,
+          queryParams,
+          "v2",
+        );
 
         return { data: result };
       } catch (error) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces versioning for view declarations, updates query handling to support multiple versions, and modifies API and UI components to utilize versioned views.
> 
>   - **Behavior**:
>     - Introduces versioning for view declarations in `dataModel.ts` using `VersionedViewDeclarations` type.
>     - Adds `getViewDeclaration()` function to fetch view based on version.
>     - Updates `executeQuery()` in `queryExecutor.ts` to accept a `version` parameter, defaulting to `v1`.
>   - **QueryBuilder**:
>     - Updates constructor in `queryBuilder.ts` to accept a `version` parameter, defaulting to `v1`.
>     - Replaces direct access to `viewDeclarations` with `getViewDeclaration()`.
>   - **WidgetForm**:
>     - Updates `WidgetForm.tsx` to use `viewDeclarations.v1` for accessing view declarations.
>   - **API**:
>     - Updates `metrics.ts` to explicitly use version `v2` for metrics queries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c837a0f26dad8b427b165b6439ab5401bd58e2b9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->