### PR TITLE
chore(dataset-versioning): make sys_id required and create unique idx

### DIFF
--- a/packages/shared/prisma/generated/types.ts
+++ b/packages/shared/prisma/generated/types.ts
@@ -429,7 +429,7 @@ export type DatasetItem = {
   dataset_id: string;
   created_at: Generated<Timestamp>;
   updated_at: Generated<Timestamp>;
-  sys_id: Generated<string | null>;
+  sys_id: Generated<string>;
   valid_from: Generated<Timestamp>;
   is_deleted: Generated<boolean>;
 };

--- a/packages/shared/prisma/migrations/20251204153406_dataset_items_make_sys_id_required/migration.sql
+++ b/packages/shared/prisma/migrations/20251204153406_dataset_items_make_sys_id_required/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `sys_id` on table `dataset_items` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "dataset_items" ALTER COLUMN "sys_id" SET NOT NULL;

--- a/packages/shared/prisma/migrations/20251204154135_dataset_items_add_unique_constraint_sys_id_projet_id/migration.sql
+++ b/packages/shared/prisma/migrations/20251204154135_dataset_items_add_unique_constraint_sys_id_projet_id/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[sys_id,project_id]` on the table `dataset_items` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX CONCURRENTLY "dataset_items_sys_id_project_id_key" ON "dataset_items"("sys_id", "project_id");
+

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -628,7 +628,7 @@ model DatasetItem {
   createdAt           DateTime          @default(now()) @map("created_at")
   updatedAt           DateTime          @default(now()) @updatedAt @map("updated_at")
   // dataset version cols
-  sysId               String?           @default(dbgenerated()) @map("sys_id")
+  sysId               String            @default(dbgenerated()) @map("sys_id")
   validFrom           DateTime          @default(now()) @map("valid_from")
   isDeleted           Boolean           @default(false) @map("is_deleted")
   datasetRunItems     DatasetRunItems[]

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -634,6 +634,7 @@ model DatasetItem {
   datasetRunItems     DatasetRunItems[]
 
   @@id([id, projectId])
+  @@unique([sysId, projectId])
   @@index([sourceTraceId], type: Hash)
   @@index([sourceObservationId], type: Hash)
   @@index([datasetId], type: Hash)


### PR DESCRIPTION
⚠️ Only merge once https://github.com/langfuse/langfuse/pull/10921 has been applied. 

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make `sys_id` required and add unique constraint on `[sys_id, project_id]` in `DatasetItem`.
> 
>   - **Behavior**:
>     - `sys_id` in `DatasetItem` is now required in `types.ts` and `schema.prisma`.
>     - Adds unique constraint on `[sys_id, project_id]` in `schema.prisma`.
>   - **Migrations**:
>     - New migration `20251204153406_dataset_items_make_sys_id_required` to set `sys_id` as NOT NULL.
>     - New migration `20251204154135_dataset_items_add_unique_constraint_sys_id_projet_id` to add unique index on `[sys_id, project_id]`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 085b44343a8bcba76ae484b15584ba7702c42a44. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->