### PR TITLE
fix(prompts): delete prompt API hanldes versions correctly

### DIFF
--- a/fern/apis/server/definition/prompts.yml
+++ b/fern/apis/server/definition/prompts.yml
@@ -77,7 +77,6 @@ service:
           version:
             type: optional<integer>
             docs: Optional version to filter deletion. If specified, deletes only this specific version of the prompt.
-      response: scim.EmptyResponse
 
 types:
   PromptMetaListResponse:

--- a/fern/apis/server/definition/prompts.yml
+++ b/fern/apis/server/definition/prompts.yml
@@ -61,7 +61,7 @@ service:
       response: Prompt
 
     delete:
-      docs: Delete a prompt or specific versions
+      docs: Delete prompt versions. If neither version nor label is specified, all versions of the prompt are deleted.
       method: DELETE
       path: /prompts/{promptName}
       path-parameters:
@@ -73,10 +73,10 @@ service:
         query-parameters:
           label:
             type: optional<string>
-            docs: Optional label of the prompt to delete
+            docs: Optional label to filter deletion. If specified, deletes all prompt versions that have this label.
           version:
             type: optional<integer>
-            docs: Optional version of the prompt to delete
+            docs: Optional version to filter deletion. If specified, deletes only this specific version of the prompt.
       response: scim.EmptyResponse
 
 types:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3641,12 +3641,8 @@ paths:
             type: integer
             nullable: true
       responses:
-        '200':
+        '204':
           description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EmptyResponse'
         '400':
           description: ''
           content:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3609,7 +3609,9 @@ paths:
       security:
         - BasicAuth: []
     delete:
-      description: Delete a prompt or specific versions
+      description: >-
+        Delete prompt versions. If neither version nor label is specified, all
+        versions of the prompt are deleted.
       operationId: prompts_delete
       tags:
         - Prompts
@@ -3622,14 +3624,18 @@ paths:
             type: string
         - name: label
           in: query
-          description: Optional label of the prompt to delete
+          description: >-
+            Optional label to filter deletion. If specified, deletes all prompt
+            versions that have this label.
           required: false
           schema:
             type: string
             nullable: true
         - name: version
           in: query
-          description: Optional version of the prompt to delete
+          description: >-
+            Optional version to filter deletion. If specified, deletes only this
+            specific version of the prompt.
           required: false
           schema:
             type: integer

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -2655,7 +2655,7 @@
           "_type": "endpoint",
           "name": "Delete",
           "request": {
-            "description": "Delete a prompt or specific versions",
+            "description": "Delete prompt versions. If neither version nor label is specified, all versions of the prompt are deleted.",
             "url": {
               "raw": "{{baseUrl}}/api/public/v2/prompts/:promptName?label=&version=",
               "host": [
@@ -2672,12 +2672,12 @@
                 {
                   "key": "label",
                   "value": "",
-                  "description": "Optional label of the prompt to delete"
+                  "description": "Optional label to filter deletion. If specified, deletes all prompt versions that have this label."
                 },
                 {
                   "key": "version",
                   "value": "",
-                  "description": "Optional version of the prompt to delete"
+                  "description": "Optional version to filter deletion. If specified, deletes only this specific version of the prompt."
                 }
               ],
               "variable": [

--- a/web/src/__tests__/async/prompts.v2.servertest.ts
+++ b/web/src/__tests__/async/prompts.v2.servertest.ts
@@ -3002,7 +3002,7 @@ describe("PATCH api/public/v2/prompts/[promptName]/versions/[version]", () => {
       // @ts-expect-error
       expect(res.body.message).toContain("depending on");
       // @ts-expect-error
-      expect(res.body.message).toContain(parentPrompt.id);
+      expect(res.body.message).toContain(parentName);
 
       // Verify child was NOT deleted
       const remaining = await prisma.prompt.findMany({
@@ -3132,12 +3132,12 @@ describe("PATCH api/public/v2/prompts/[promptName]/versions/[version]", () => {
       expect(res.status).toBe(400);
       // @ts-expect-error
       expect(res.body.message).toContain("depending on");
-      // @ts-expect-error - Should mention blocking parent IDs
-      expect(res.body.message).toContain(parent1.id);
+      // @ts-expect-error - Should mention blocking parent names
+      expect(res.body.message).toContain(parent1Name);
       // @ts-expect-error
-      expect(res.body.message).toContain(parent3.id);
+      expect(res.body.message).toContain(parent3Name);
       // @ts-expect-error - Should NOT mention parent2 (its dependency still satisfied)
-      expect(res.body.message).not.toContain(parent2.id);
+      expect(res.body.message).not.toContain(parent2Name);
     });
 
     it('reattaches "latest" label to highest remaining version when deleted', async () => {

--- a/web/src/__tests__/async/prompts.v2.servertest.ts
+++ b/web/src/__tests__/async/prompts.v2.servertest.ts
@@ -3010,6 +3010,135 @@ describe("PATCH api/public/v2/prompts/[promptName]/versions/[version]", () => {
       });
       expect(remaining.length).toBe(1);
     });
+
+    it("handles mixed version and label dependencies correctly", async () => {
+      const { projectId, auth } = await createOrgProjectAndApiKey();
+      const childName = "childPrompt" + uuidv4();
+      const parent1Name = "parent1" + uuidv4();
+      const parent2Name = "parent2" + uuidv4();
+      const parent3Name = "parent3" + uuidv4();
+
+      // Create child prompt with 2 versions
+      // v1: labels ["production", "latest"]
+      // v2: labels ["production"]
+      const childV1 = await prisma.prompt.create({
+        data: {
+          id: uuidv4(),
+          name: childName,
+          prompt: "child v1",
+          labels: ["production", "latest"],
+          version: 1,
+          projectId,
+          createdBy: "user",
+          config: {},
+          type: "TEXT",
+        },
+      });
+
+      await prisma.prompt.create({
+        data: {
+          id: uuidv4(),
+          name: childName,
+          prompt: "child v2",
+          labels: ["production"],
+          version: 2,
+          projectId,
+          createdBy: "user",
+          config: {},
+          type: "TEXT",
+        },
+      });
+
+      // parent1: depends on childPrompt v1 (version-based - SHOULD BLOCK)
+      const parent1 = await prisma.prompt.create({
+        data: {
+          id: uuidv4(),
+          name: parent1Name,
+          prompt: `Depends on @@@langfusePrompt:name=${childName}|version=1@@@`,
+          labels: ["production"],
+          version: 1,
+          projectId,
+          createdBy: "user",
+          config: {},
+          type: "TEXT",
+        },
+      });
+      await prisma.promptDependency.create({
+        data: {
+          parentId: parent1.id,
+          childName,
+          childVersion: 1,
+          projectId,
+        },
+      });
+
+      // parent2: depends on childPrompt|label=production (label-based - should NOT block, v2 has it)
+      const parent2 = await prisma.prompt.create({
+        data: {
+          id: uuidv4(),
+          name: parent2Name,
+          prompt: `Depends on @@@langfusePrompt:name=${childName}|label=production@@@`,
+          labels: ["production"],
+          version: 1,
+          projectId,
+          createdBy: "user",
+          config: {},
+          type: "TEXT",
+        },
+      });
+      await prisma.promptDependency.create({
+        data: {
+          parentId: parent2.id,
+          childName,
+          childLabel: "production",
+          projectId,
+        },
+      });
+
+      // parent3: depends on childPrompt|label=latest (label-based - SHOULD BLOCK, only v1 has it)
+      const parent3 = await prisma.prompt.create({
+        data: {
+          id: uuidv4(),
+          name: parent3Name,
+          prompt: `Depends on @@@langfusePrompt:name=${childName}|label=latest@@@`,
+          labels: ["production"],
+          version: 1,
+          projectId,
+          createdBy: "user",
+          config: {},
+          type: "TEXT",
+        },
+      });
+      await prisma.promptDependency.create({
+        data: {
+          parentId: parent3.id,
+          childName,
+          childLabel: "latest",
+          projectId,
+        },
+      });
+
+      // Try to delete v1 - should fail because:
+      // - parent1 depends on v1 specifically (version-based) ✓ BLOCKS
+      // - parent3 depends on "latest" label (only v1 has it) ✓ BLOCKS
+      // - parent2 depends on "production" label (v2 also has it) ✓ DOES NOT BLOCK
+      const res = await makeAPICall(
+        "DELETE",
+        `${baseURI}/${encodeURIComponent(childName)}?version=1`,
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(400);
+      // @ts-expect-error
+      expect(res.body.message).toContain("depending on");
+      // @ts-expect-error - Should mention blocking parents
+      expect(res.body.message).toContain(parent1Name);
+      // @ts-expect-error
+      expect(res.body.message).toContain(parent3Name);
+      // @ts-expect-error - Should NOT mention parent2 (its dependency still satisfied)
+      expect(res.body.message).not.toContain(parent2Name);
+    });
   });
 
   describe("Parsing prompt dependency tags", () => {

--- a/web/src/__tests__/async/prompts.v2.servertest.ts
+++ b/web/src/__tests__/async/prompts.v2.servertest.ts
@@ -3021,7 +3021,7 @@ describe("PATCH api/public/v2/prompts/[promptName]/versions/[version]", () => {
       // Create child prompt with 2 versions
       // v1: labels ["production", "latest"]
       // v2: labels ["production"]
-      const childV1 = await prisma.prompt.create({
+      await prisma.prompt.create({
         data: {
           id: uuidv4(),
           name: childName,

--- a/web/src/features/prompts/server/actions/deletePrompt.ts
+++ b/web/src/features/prompts/server/actions/deletePrompt.ts
@@ -70,11 +70,20 @@ export const deletePrompt = async (params: DeletePromptParams) => {
   });
 
   if (blockingDependents.length > 0) {
+    // we want the parent prompt names to display understandable error messages
+    const parentPrompts = await prisma.prompt.findMany({
+      where: { id: { in: blockingDependents.map((d) => d.parent_id) } },
+      select: { id: true, name: true, version: true },
+    });
+
     const dependencyMessages = blockingDependents
-      .map(
-        (d) =>
-          `Prompt ${d.parent_id} depends on ${promptName} ${d.child_version ? `v${d.child_version}` : d.child_label}`,
-      )
+      .map((d) => {
+        const parent = parentPrompts.find((p) => p.id === d.parent_id);
+        const parentInfo = parent
+          ? `${parent.name} v${parent.version}`
+          : d.parent_id;
+        return `${parentInfo} depends on ${promptName} ${d.child_version ? `v${d.child_version}` : d.child_label}`;
+      })
       .join("\n");
 
     throw new InvalidRequestError(

--- a/web/src/features/prompts/server/handlers/promptNameHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptNameHandler.ts
@@ -92,13 +92,13 @@ const deletePromptNameHandler = async (
     });
   }
 
-  // Delete prompts (pass fetched prompts to avoid duplicate query)
+  // Delete prompt versions
   await deletePrompt({
     promptName,
     projectId: authCheck.scope.projectId,
     version,
     label,
-    prompts, // Pass prompts to avoid duplicate query
+    promptVersions: prompts,
   });
 
   res.status(204).end();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix delete prompt API to correctly handle version and label dependencies, updating documentation and adding tests for verification.
> 
>   - **Behavior**:
>     - Update `delete` operation in `prompts.yml` and `openapi.yml` to clarify deletion behavior when neither version nor label is specified.
>     - Change response code from `200` to `204` for successful deletions in `openapi.yml`.
>   - **Functionality**:
>     - Modify `deletePrompt` in `deletePrompt.ts` to handle dependencies correctly, blocking deletion if other prompts depend on the version or label being deleted.
>     - Reattach "latest" label to the highest remaining version if the current "latest" version is deleted.
>   - **Tests**:
>     - Add tests in `prompts.v2.servertest.ts` to verify correct handling of mixed version and label dependencies, and reattaching "latest" label.
>     - Ensure tests cover scenarios where deletion should be blocked due to dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a4f5dac01b70fd82d692cc0ec5d137d4cc95817c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->