### PR TITLE
chore: cast metadata to correct max_dynamic_paths type in dual write

### DIFF
--- a/worker/src/backgroundMigrations/backfillEventsHistoric.ts
+++ b/worker/src/backgroundMigrations/backfillEventsHistoric.ts
@@ -529,7 +529,7 @@ export default class BackfillEventsHistoric implements IBackgroundMigration {
         o.cost_details,
         coalesce(o.input, '') AS input,
         coalesce(o.output, '') AS output,
-        toJSONString(o.metadata) AS metadata,
+        CAST(o.metadata, 'JSON(max_dynamic_paths=0)') AS metadata,
         mapKeys(o.metadata) AS metadata_names,
         mapValues(o.metadata) AS metadata_raw_values,
         multiIf(mapContains(o.metadata, 'resourceAttributes'), 'otel-backfill', 'ingestion-api-backfill') AS source,

--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -331,7 +331,7 @@ export const handleEventPropagationJob = async (
           coalesce(obs.input, '') AS input,
           coalesce(obs.output, '') AS output,
           -- Merge trace and observation metadata, with observation taking precedence (first map wins)
-          CAST(mapConcat(obs.metadata, coalesce(t.metadata, map())), 'JSON') AS metadata,
+          CAST(mapConcat(obs.metadata, coalesce(t.metadata, map())), 'JSON(max_dynamic_paths=0)') AS metadata,
           mapKeys(mapConcat(obs.metadata, coalesce(t.metadata, map()))) AS metadata_names,
           mapValues(mapConcat(obs.metadata, coalesce(t.metadata, map()))) AS metadata_raw_values,
           multiIf(mapContains(obs.metadata, 'resourceAttributes'), 'otel-dual-write', 'ingestion-api-dual-write') AS source,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Cast `metadata` to `JSON(max_dynamic_paths=0)` in `backfillEventsHistoric.ts` and `handleEventPropagationJob.ts` for correct type handling.
> 
>   - **Behavior**:
>     - Cast `metadata` to `JSON(max_dynamic_paths=0)` in `backfillEventsHistoric.ts` and `handleEventPropagationJob.ts` to ensure correct type handling during dual write operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a1eed0b62ed6251f25edea2f624ba67fea8a850c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->