### PR TITLE
fix(ingestion): do best-effort parsing for invalid usageDetails

### DIFF
--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -86,7 +86,7 @@ const CostDetails = z
   .nullish();
 
 const RawUsageDetails = z.record(z.string(), z.unknown()).transform((val) => {
-  if (!val) return val;
+  if (!val) return;
 
   const result: Record<string, number> = {};
 
@@ -96,7 +96,7 @@ const RawUsageDetails = z.record(z.string(), z.unknown()).transform((val) => {
     }
   }
 
-  return result;
+  return Object.keys(result).length > 0 ? result : undefined;
 });
 
 const OpenAICompletionUsageSchema = z

--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -68,13 +68,36 @@ export const usage = MixedUsage.nullish()
   .pipe(Usage.nullish());
 
 const CostDetails = z
-  .record(z.string(), z.number().nonnegative().nullish())
+  .record(z.string(), z.unknown())
+  .nullish()
+  .transform((val) => {
+    if (!val) return val;
+
+    const result: Record<string, number> = {};
+
+    for (const [key, value] of Object.entries(val)) {
+      if (typeof value === "number" && !isNaN(value) && value >= 0) {
+        result[key] = value;
+      }
+    }
+
+    return Object.keys(result).length > 0 ? result : undefined;
+  })
   .nullish();
 
-const RawUsageDetails = z.record(
-  z.string(),
-  z.number().int().nonnegative().nullish(),
-);
+const RawUsageDetails = z.record(z.string(), z.unknown()).transform((val) => {
+  if (!val) return val;
+
+  const result: Record<string, number> = {};
+
+  for (const [key, value] of Object.entries(val)) {
+    if (typeof value === "number" && Number.isInteger(value) && value >= 0) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+});
 
 const OpenAICompletionUsageSchema = z
   .object({

--- a/web/src/__tests__/async/ingestion-api.servertest.ts
+++ b/web/src/__tests__/async/ingestion-api.servertest.ts
@@ -582,7 +582,7 @@ describe("/api/public/ingestion API Endpoint", () => {
     expect(response.body.errors[0].message).toBe("Invalid request data");
   });
 
-  it("should fail for float in usageDetails", async () => {
+  it("should silently drop invalid float values in usageDetails", async () => {
     const response = await makeAPICall("POST", "/api/public/ingestion", {
       batch: [
         {
@@ -598,18 +598,17 @@ describe("/api/public/ingestion API Endpoint", () => {
             input: { text: "input" },
             output: { text: "output" },
             usageDetails: {
-              key: 0.1,
+              key: 0.1, // invalid float - should be silently dropped
             },
           },
         },
       ],
     });
 
+    // Event should succeed, invalid usageDetails values are silently dropped
     expect(response.status).toBe(207);
-    expect("errors" in response.body).toBe(true);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(response.body.errors.length).toBe(1);
-    expect(response.body.errors[0].message).toBe("Invalid request data");
+    expect(response.body.successes.length).toBe(1);
+    expect(response.body.errors.length).toBe(0);
   });
 
   it.each([


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `usageDetails` parsing in `types.ts` to drop invalid values and update test case in `ingestion-api.servertest.ts` accordingly.
> 
>   - **Behavior**:
>     - `CostDetails` and `RawUsageDetails` in `types.ts` now transform records to drop invalid values (non-integers or negative numbers) and return `undefined` if no valid entries remain.
>     - Updates test in `ingestion-api.servertest.ts` to expect successful processing when `usageDetails` contains invalid float values, which are now silently dropped.
>   - **Tests**:
>     - Modifies test case in `ingestion-api.servertest.ts` to check that invalid float values in `usageDetails` are dropped without causing errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bf1891f7fb82b72747b40c78c109f7dee7f44b83. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->