### PR TITLE
chore: increase trace upsert delay to 30s

### DIFF
--- a/packages/shared/src/server/redis/traceUpsert.ts
+++ b/packages/shared/src/server/redis/traceUpsert.ts
@@ -77,7 +77,7 @@ export class TraceUpsertQueue {
             removeOnComplete: 100,
             removeOnFail: 100_000,
             attempts: env.LANGFUSE_TRACE_UPSERT_QUEUE_ATTEMPTS,
-            delay: 15_000, // 15 seconds
+            delay: 30_000, // 30 seconds
             backoff: {
               type: "exponential",
               delay: 5000,

--- a/worker/src/__tests__/redisConsumer.test.ts
+++ b/worker/src/__tests__/redisConsumer.test.ts
@@ -40,10 +40,10 @@ describe.sequential("handle redis events", () => {
         expect(jobState).toEqual("completed");
       },
       {
-        timeout: 20_000,
+        timeout: 35_000,
       },
     );
-  }, 20_000);
+  }, 35_000);
 
   test("handle no matching queue worker", async () => {
     // IngestionQueue worker vs TraceUpsert producer


### PR DESCRIPTION
## What

Increase consistency on eval create decisions by using a longer trace upsert delay.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Increase trace upsert delay to 30 seconds and update test timeouts accordingly.
> 
>   - **Behavior**:
>     - Increase `delay` from 15,000 ms to 30,000 ms in `TraceUpsertQueue` in `traceUpsert.ts`.
>     - Update test timeout from 20,000 ms to 35,000 ms in `redisConsumer.test.ts` to accommodate the increased delay.
>   - **Tests**:
>     - Adjust `timeout` and test duration in `redisConsumer.test.ts` to match the new delay settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2adff5b0992d34397c1b819530002740af31fde2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->