### PR TITLE
fix(ui): remove borders from IO in table

### DIFF
--- a/web/src/components/table/data-table-row-height-switch.tsx
+++ b/web/src/components/table/data-table-row-height-switch.tsx
@@ -19,7 +19,7 @@ const heightOptions = [
 ] as const;
 
 const defaultHeights: Record<RowHeight, string> = {
-  s: "h-6",
+  s: "h-7", // after removing the container around IO, we want the row height a bit more than 6
   m: "h-24",
   l: "h-64",
 };

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -555,7 +555,7 @@ function TableBodyComponent<TData>({
                 <TableCell
                   key={cell.id}
                   className={cn(
-                    "overflow-hidden border-b p-1 text-xs first:pl-2",
+                    "overflow-hidden border-b px-1 text-xs first:pl-2",
                     isSmallRowHeight && "whitespace-nowrap",
                     getPinningClasses(cell.column),
                   )}

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -1332,7 +1332,10 @@ const GenerationsDynamicCell = ({
     <MemoizedIOTableCell
       isLoading={observation.isPending}
       data={data}
-      className={cn(col === "output" && "bg-accent-light-green")}
+      className={cn(
+        col === "output" && "bg-accent-light-green",
+        col === "input" && "bg-muted/50",
+      )}
       singleLine={singleLine}
     />
   );

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -1314,7 +1314,10 @@ const TracesDynamicCell = ({
     <MemoizedIOTableCell
       isLoading={trace.isPending}
       data={data}
-      className={cn(col === "output" && "bg-accent-light-green")}
+      className={cn(
+        col === "output" && "bg-accent-light-green",
+        col === "input" && "bg-muted/50",
+      )}
       singleLine={singleLine}
     />
   );

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -35,6 +35,7 @@ export function JSONView(props: {
   collapseStringsAfterLength?: number | null;
   media?: MediaReturnType[];
   scrollable?: boolean;
+  borderless?: boolean;
   projectIdForPromptButtons?: string;
   controlButtons?: React.ReactNode;
   externalJsonCollapsed?: boolean;
@@ -86,14 +87,15 @@ export function JSONView(props: {
     <>
       <div
         className={cn(
-          "io-message-content flex gap-2 whitespace-pre-wrap break-words p-2 text-xs",
+          "io-message-content flex gap-2 whitespace-pre-wrap break-words text-xs",
+          props.borderless ? "" : "p-2",
           props.title === "assistant" || props.title === "Output"
             ? "bg-accent-light-green dark:border-accent-dark-green"
             : "",
           props.title === "system" || props.title === "Input"
             ? "bg-primary-foreground"
             : "",
-          props.scrollable ? "" : "rounded-sm border",
+          props.scrollable || props.borderless ? "" : "rounded-sm border",
           props.codeClassName,
         )}
       >

--- a/web/src/components/ui/IOTableCell.tsx
+++ b/web/src/components/ui/IOTableCell.tsx
@@ -32,7 +32,7 @@ const IOTableCellContent = ({
   return singleLine ? (
     <div
       className={cn(
-        "h-full w-full self-stretch overflow-hidden overflow-y-auto truncate rounded-sm border px-2 py-0.5",
+        "h-full w-full self-stretch overflow-hidden overflow-y-auto truncate px-2 py-1",
         className,
       )}
     >
@@ -48,9 +48,10 @@ const IOTableCellContent = ({
             `...[truncated ${stringifiedJson.length - IO_TABLE_CHAR_LIMIT} characters]`,
           true, // greedy mode for double-escaped Unicode (e.g., \\uXXXX)
         )}
-        className={cn("h-full w-full self-stretch rounded-sm", className)}
+        className={cn("h-full w-full self-stretch", className)}
         codeClassName="py-1 px-2 min-h-0 h-full overflow-y-auto"
         collapseStringsAfterLength={null} // in table, show full strings as row height is fixed
+        borderless
       />
       <div className="text-xs text-muted-foreground">
         Content was truncated.
@@ -61,9 +62,10 @@ const IOTableCellContent = ({
       json={
         stringifiedJson ? decodeUnicodeEscapesOnly(stringifiedJson, true) : data
       }
-      className={cn("h-full w-full self-stretch rounded-sm", className)}
+      className={cn("h-full w-full self-stretch", className)}
       codeClassName="py-1 px-2 min-h-0 h-full overflow-y-auto"
       collapseStringsAfterLength={null} // in table, show full strings as row height is fixed
+      borderless
     />
   );
 };

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -89,7 +89,7 @@ const TableCell = React.forwardRef<
   <td
     ref={ref}
     className={cn(
-      "p-4 align-middle [&:has([role=checkbox])]:pr-0",
+      "h-full px-2 py-0 align-top [&:has([role=checkbox])]:pr-0",
       "border-b [:last-child_>_&]:border-b-0",
       className,
     )}


### PR DESCRIPTION
before:
<img width="1281" height="267" alt="2025-12-05_14 33 32-Google Chrome@2x" src="https://github.com/user-attachments/assets/575a8581-655c-49d7-8394-82dbe8ccd007" />


after:
<img width="1201" height="102" alt="2025-12-05_14 33 59-Google Chrome@2x" src="https://github.com/user-attachments/assets/f1c2d6fe-5b72-4f9c-8bfe-1c6d887aa1f1" />

before:
<img width="1497" height="532" alt="2025-12-05_14 35 03-Google Chrome@2x" src="https://github.com/user-attachments/assets/83e9c295-6d2b-4bb1-9055-53d206d60f59" />


after:

<img width="1341" height="394" alt="2025-12-05_14 35 27-Google Chrome@2x" src="https://github.com/user-attachments/assets/b81ffc25-3df7-4b0f-82c6-7172db30b637" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove borders from IO in tables and adjust row heights and component styles for a cleaner UI.
> 
>   - **UI Changes**:
>     - Remove borders from IO in tables by adjusting CSS classes in `data-table.tsx`, `IOTableCell.tsx`, and `CodeJsonViewer.tsx`.
>     - Update `TableCell` class in `table.tsx` to remove padding and align top.
>   - **Component Adjustments**:
>     - Add `borderless` prop to `JSONView` in `CodeJsonViewer.tsx` to control border rendering.
>     - Modify `IOTableCellContent` in `IOTableCell.tsx` to use `borderless` JSON view.
>     - Adjust `GenerationsDynamicCell` and `TracesDynamicCell` in `observations.tsx` and `traces.tsx` to apply new background styles.
>   - **Row Height**:
>     - Change default small row height from `h-6` to `h-7` in `data-table-row-height-switch.tsx` to accommodate new layout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 34c0487aab147ef73e69bebecc859ae6c49a3945. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->