### PR TITLE
fix: scores must join events on both keys

### DIFF
--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -359,6 +359,59 @@ clickhouse client \
   FROM observations o
   LEFT JOIN traces t ON o.trace_id = t.id
   WHERE (o.is_deleted = 0);
+  -- Backfill events from traces table as well
+  INSERT INTO events (project_id, trace_id, span_id, parent_span_id, start_time, name, type,
+                      environment, version, release, tags, trace_name, user_id, session_id, public, bookmarked, level,
+                      model_parameters, provided_usage_details, usage_details, provided_cost_details, cost_details,
+                      input, output,
+                      metadata, metadata_names, metadata_raw_values,
+                      source, service_name, service_version, scope_name, scope_version, telemetry_sdk_language,
+                      telemetry_sdk_name, telemetry_sdk_version, blob_storage_file_path, event_bytes,
+                      created_at, updated_at, event_ts, is_deleted)
+  SELECT t.project_id,
+         t.id,
+         t.id                                                                            AS span_id,
+         ''                                                                       AS parent_span_id,
+         t.timestamp,
+         t.name,
+         'SPAN',
+         t.environment,
+         t.version,
+         t.release as release,
+         t.tags as tags,
+         t.name as trace_name,
+         t.user_id                                                                      AS user_id,
+         t.session_id                                                                   AS session_id,
+         t.public                                                                       AS public,
+         t.bookmarked                                                                   AS bookmarked,
+         'DEFAULT'                                                                      AS level,
+         map()                                                                           AS model_parameters,
+         map(),
+         map(),
+         map(),
+         map(),
+         ifNull(t.input, '')                                                             AS input,
+         ifNull(t.output, '')                                                            AS output,
+         CAST(t.metadata, 'JSON'),
+         mapKeys(t.metadata)                                                             AS metadata_names,
+         mapValues(t.metadata)                                                           AS metadata_raw_values,
+         multiIf(mapContains(t.metadata, 'resourceAttributes'), 'otel', 'ingestion-api') AS source,
+         NULL                                                                          AS service_name,
+         NULL                                                                          AS service_version,
+         NULL                                                                          AS scope_name,
+         NULL                                                                          AS scope_version,
+         NULL                                                                          AS telemetry_sdk_language,
+         NULL                                                                          AS telemetry_sdk_name,
+         NULL                                                                          AS telemetry_sdk_version,
+         ''                                                                            AS blob_storage_file_path,
+         0                                                                             AS event_bytes,
+         t.created_at,
+         t.updated_at,
+         t.event_ts,
+         t.is_deleted
+  FROM traces t
+  WHERE (t.is_deleted = 0);
+
 EOF
 
 echo "Development tables created successfully (or already exist)."

--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -626,7 +626,7 @@ const createScoreTableRelations = (
       events: {
         name: "events",
         joinConditionSql:
-          "ON scores.observation_id = events.span_id AND scores.project_id = events.project_id",
+          "ON (scores.trace_id = events.span_id OR scores.observation_id = events.span_id) AND scores.project_id = events.project_id",
         timeDimension: "start_time",
       },
     };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix join condition in `dataModel.ts` for scores and events, and add backfill operation in `dev-tables.sh` to populate events from traces.
> 
>   - **Behavior**:
>     - Update join condition in `createScoreTableRelations` in `dataModel.ts` to join `scores` with `events` on both `trace_id` and `observation_id`.
>     - Add backfill operation in `dev-tables.sh` to insert data from `traces` into `events` table.
>   - **Scripts**:
>     - Modify `dev-tables.sh` to include a new SQL insert statement for backfilling `events` from `traces`.
>   - **Data Models**:
>     - Update `createScoreTableRelations` function in `dataModel.ts` to handle both `trace_id` and `observation_id` for `scores` and `events` join.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b7afb6994259de9646bd229bb529f94d10c36eb1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->