### PR TITLE
fix: add setup file to new traces pages folder

### DIFF
--- a/web/src/pages/project/[projectId]/traces/setup.tsx
+++ b/web/src/pages/project/[projectId]/traces/setup.tsx
@@ -1,0 +1,140 @@
+import React, { useEffect } from "react";
+import { useRouter } from "next/router";
+import { api } from "@/src/utils/api";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import ContainerPage from "@/src/components/layouts/container-page";
+import { ActionButton } from "@/src/components/ActionButton";
+import { SubHeader } from "@/src/components/layouts/header";
+import { Button } from "@/src/components/ui/button";
+import { ApiKeyRender } from "@/src/features/public-api/components/CreateApiKeyButton";
+import { type RouterOutput } from "@/src/utils/types";
+import { useState } from "react";
+
+const TracingSetup = ({
+  projectId,
+  hasTracingConfigured,
+}: {
+  projectId: string;
+  hasTracingConfigured?: boolean;
+}) => {
+  const [apiKeys, setApiKeys] = useState<
+    RouterOutput["projectApiKeys"]["create"] | null
+  >(null);
+  const utils = api.useUtils();
+  const mutCreateApiKey = api.projectApiKeys.create.useMutation({
+    onSuccess: (data) => {
+      utils.projectApiKeys.invalidate();
+      setApiKeys(data);
+    },
+  });
+
+  const createApiKey = async () => {
+    try {
+      await mutCreateApiKey.mutateAsync({ projectId });
+    } catch (error) {
+      console.error("Error creating API key:", error);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <SubHeader title="1. Get API Keys" />
+        {apiKeys ? (
+          <ApiKeyRender
+            generatedKeys={apiKeys}
+            scope={"project"}
+            className="mt-4"
+          />
+        ) : (
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-muted-foreground">
+              You need to create an API key to start tracing your application.
+              You can create more keys later in the project settings.
+            </p>
+            <div className="flex gap-2">
+              <Button
+                onClick={createApiKey}
+                loading={mutCreateApiKey.isPending}
+                className="self-start"
+              >
+                Create new API key
+              </Button>
+              <ActionButton
+                href={`/project/${projectId}/settings/api-keys`}
+                variant="secondary"
+              >
+                Manage API keys
+              </ActionButton>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div>
+        <SubHeader
+          title="2. Instrument Your Application"
+          status={hasTracingConfigured ? "active" : "pending"}
+        />
+        <p className="mb-4 text-sm text-muted-foreground">
+          Langfuse relies on OpenTelemetry to instrument your application and
+          export LLM application/agent traces to Langfuse. You can use one of
+          our SDKs or 50+ framework integrations. Please follow the quickstart
+          in the documentation to add Langfuse to your application.
+        </p>
+        <ActionButton href="https://langfuse.com/docs/observability/get-started">
+          Instrumentation Quickstart
+        </ActionButton>
+      </div>
+    </div>
+  );
+};
+
+export default function TracesSetupPage() {
+  const router = useRouter();
+  const projectId = router.query.projectId as string;
+
+  // Check if the user has tracing configured
+  const { data: hasTracingConfigured } =
+    api.traces.hasTracingConfigured.useQuery(
+      { projectId },
+      {
+        enabled: !!projectId,
+        refetchInterval: 5000,
+        trpc: {
+          context: {
+            skipBatch: true,
+          },
+        },
+      },
+    );
+
+  const capture = usePostHogClientCapture();
+  useEffect(() => {
+    if (hasTracingConfigured !== undefined) {
+      capture("onboarding:tracing_check_active", {
+        active: hasTracingConfigured,
+      });
+    }
+  }, [hasTracingConfigured, capture]);
+
+  return (
+    <ContainerPage
+      headerProps={{
+        title: "Tracing Setup",
+        help: {
+          description:
+            "Setup tracing to track and analyze your LLM calls. You can create API keys and integrate Langfuse with your application.",
+          href: "https://langfuse.com/docs/observability/overview",
+        },
+      }}
+    >
+      <div className="flex flex-col gap-4">
+        <TracingSetup
+          projectId={projectId}
+          hasTracingConfigured={hasTracingConfigured ?? false}
+        />
+      </div>
+    </ContainerPage>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Setup page was missing from the new traces page folder, which caused a "trace not found" screen to show when a new user clicked "configure tracing". 
Added the page again, which solves the issue.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `setup.tsx` to traces pages to fix 'trace not found' error and guide tracing setup.
> 
>   - **Behavior**:
>     - Adds `setup.tsx` to `web/src/pages/project/[projectId]/traces/` to resolve 'trace not found' error when configuring tracing.
>     - Implements `TracingSetup` component to manage API key creation and application instrumentation guidance.
>   - **Components**:
>     - `TracingSetup` component handles API key creation using `api.projectApiKeys.create` mutation and displays instrumentation instructions.
>     - `TracesSetupPage` component uses `useRouter` to fetch `projectId` and checks tracing configuration status with `api.traces.hasTracingConfigured` query.
>   - **Analytics**:
>     - Uses `usePostHogClientCapture` to log tracing configuration status.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 48a56faaffe8235590c90ae3cedeae1ab6aa5123. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->