### PR TITLE
fix(tables): don't top align for small rows

### DIFF
--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -569,6 +569,7 @@ function TableBodyComponent<TData>({
                       "flex",
                       "items-start",
                       isSmallRowHeight && "items-center",
+                      !isSmallRowHeight && "py-1",
                       rowheighttw,
                     )}
                   >

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -89,7 +89,7 @@ const TableCell = React.forwardRef<
   <td
     ref={ref}
     className={cn(
-      "h-full px-2 py-0 align-top [&:has([role=checkbox])]:pr-0",
+      "h-full px-2 py-0 align-middle [&:has([role=checkbox])]:pr-0",
       "border-b [:last-child_>_&]:border-b-0",
       className,
     )}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes table row alignment by adjusting CSS classes for small and regular row heights in `data-table.tsx` and `table.tsx`.
> 
>   - **Behavior**:
>     - In `data-table.tsx`, added `!isSmallRowHeight && "py-1"` to center-align small rows and add padding to others.
>     - In `table.tsx`, changed `align-top` to `align-middle` in `TableCell` to adjust vertical alignment.
>   - **Misc**:
>     - Minor CSS class adjustments for table cell alignment in `table.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fea285c13e571495bdfc0cf49ad0a6daa9a04e2c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->