### PR TITLE
chore: whitelist "dataset_run_item-create" event type

### DIFF
--- a/packages/shared/src/server/clickhouse/schemaUtils.ts
+++ b/packages/shared/src/server/clickhouse/schemaUtils.ts
@@ -39,6 +39,7 @@ export const getClickhouseEntityType = (
       return "score";
     case eventTypes.DATASET_RUN_ITEM_CREATE:
     // Replay compatibility: s3-ingestion-event-replay.ts reconstructs event types from S3 paths containing entity types
+    // eslint-disable-next-line no-fallthrough
     case "dataset_run_item-create":
       return "dataset_run_item";
     case eventTypes.SDK_LOG:

--- a/packages/shared/src/server/clickhouse/schemaUtils.ts
+++ b/packages/shared/src/server/clickhouse/schemaUtils.ts
@@ -38,6 +38,8 @@ export const getClickhouseEntityType = (
     case eventTypes.SCORE_CREATE:
       return "score";
     case eventTypes.DATASET_RUN_ITEM_CREATE:
+    // Replay compatibility: s3-ingestion-event-replay.ts reconstructs event types from S3 paths containing entity types
+    case "dataset_run_item-create":
       return "dataset_run_item";
     case eventTypes.SDK_LOG:
       return "sdk_log";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add case for `"dataset_run_item-create"` in `getClickhouseEntityType()` for S3 replay compatibility.
> 
>   - **Behavior**:
>     - Add case for `"dataset_run_item-create"` in `getClickhouseEntityType()` in `schemaUtils.ts` for replay compatibility with S3 paths.
>     - Ensures `"dataset_run_item-create"` returns `"dataset_run_item"` entity type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0283da4dc78c5b5bbf4beb7e369a7c4161b396d8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->