### PR TITLE
fix: trace_name was added to events table thus events repo should use it

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -181,7 +181,7 @@ const EVENTS_AGGREGATION_FIELDS = {
   projectId: "project_id",
 
   // Aggregated fields
-  name: "argMaxIf(name, event_ts, parent_span_id = '') AS name",
+  name: "argMaxIf(trace_name, event_ts, trace_name <> '') AS name",
   timestamp: "min(start_time) as timestamp",
   environment:
     "argMaxIf(environment, event_ts, environment <> '') AS environment",

--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -118,6 +118,7 @@ const createTraceWithObservations = async (
       trace_id: trace.id,
       project_id: trace.project_id,
       name: trace.name ?? "trace",
+      trace_name: trace.name ?? "trace",
       type: "GENERATION", // Trace events are typically GENERATION type
       start_time: trace.timestamp * 1000, // Convert ms to microseconds
       end_time: null,
@@ -139,6 +140,7 @@ const createTraceWithObservations = async (
         environment: rootTraceEvent.environment,
         user_id: rootTraceEvent.user_id,
         session_id: rootTraceEvent.session_id,
+        trace_name: rootTraceEvent.name,
       }),
     );
 


### PR DESCRIPTION
`ce76ea4758b369559995306e714d7e001607df42` re-introduced `trace_name`. Let's make use of it.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update event aggregation to use `trace_name` and adjust tests to include `trace_name` in event creation.
> 
>   - **Behavior**:
>     - Update `name` field in `EVENTS_AGGREGATION_FIELDS` in `event-query-builder.ts` to use `trace_name` instead of `name`.
>     - Modify `createTraceWithObservations` in `traces-api.servertest.ts` to include `trace_name` when creating events.
>   - **Tests**:
>     - Add `trace_name` to event creation in `createTraceWithObservations` and `createObservationOrEvent` in `traces-api.servertest.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2fbbaa817e6686f31cdeba9683ba93f1ccd795aa. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->