### PR TITLE
fix(otel-pydantic-ai): parse cached token counts for pydantic AI logfire

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1942,10 +1942,10 @@ export class OtelIngestionProcessor {
       const inputTokens = attributes["gen_ai.usage.input_tokens"];
       const outputTokens = attributes["gen_ai.usage.output_tokens"];
       const cacheReadTokens =
-        attributes["gen_ai.usage.cache_read_tokens"] ||
+        attributes["gen_ai.usage.cache_read_tokens"] ??
         attributes["gen_ai.usage.details.cache_read_input_tokens"];
       const cacheWriteTokens =
-        attributes["gen_ai.usage.cache_write_tokens"] ||
+        attributes["gen_ai.usage.cache_write_tokens"] ??
         attributes["gen_ai.usage.details.cache_creation_input_tokens"];
 
       return {

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1938,6 +1938,24 @@ export class OtelIngestionProcessor {
       }
     }
 
+    if (instrumentationScopeName === "pydantic-ai") {
+      const inputTokens = attributes["gen_ai.usage.input_tokens"];
+      const outputTokens = attributes["gen_ai.usage.output_tokens"];
+      const cacheReadTokens =
+        attributes["gen_ai.usage.cache_read_tokens"] ||
+        attributes["gen_ai.usage.details.cache_read_input_tokens"];
+      const cacheWriteTokens =
+        attributes["gen_ai.usage.cache_write_tokens"] ||
+        attributes["gen_ai.usage.details.cache_creation_input_tokens"];
+
+      return {
+        input: inputTokens,
+        output: outputTokens,
+        input_cache_read: cacheReadTokens,
+        input_cache_creation: cacheWriteTokens,
+      };
+    }
+
     const usageDetails = Object.keys(attributes).filter(
       (key) =>
         (key.startsWith("gen_ai.usage.") && key !== "gen_ai.usage.cost") ||


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds parsing for specific token attributes in `OtelIngestionProcessor` for `pydantic-ai` scope.
> 
>   - **Behavior**:
>     - Adds handling for `pydantic-ai` instrumentation scope in `OtelIngestionProcessor`.
>     - Parses `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.usage.cache_read_tokens`, and `gen_ai.usage.cache_write_tokens` attributes.
>     - Uses fallback attributes `gen_ai.usage.details.cache_read_input_tokens` and `gen_ai.usage.details.cache_creation_input_tokens` if primary attributes are missing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ed9ac49f63d021b3ffe97382e00bc873be32fec0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->