### PR TITLE
chore: avoid default clickhouse exception handling for backfill script

### DIFF
--- a/worker/src/backgroundMigrations/backfillEventsHistoric.ts
+++ b/worker/src/backgroundMigrations/backfillEventsHistoric.ts
@@ -572,15 +572,15 @@ export default class BackfillEventsHistoric implements IBackgroundMigration {
 
     // Apply memory-reducing settings on retries
     const retrySettings =
-      retryCount > 0
+      retryCount > 1
         ? {
-            max_block_size: "4096",
+            max_threads: 1,
+            max_insert_threads: "1",
+            max_block_size: "2048",
           }
-        : retryCount > 1
+        : retryCount > 0
           ? {
-              max_threads: 1,
-              max_insert_threads: "1",
-              max_block_size: "2048",
+              max_block_size: "4096",
             }
           : {};
 

--- a/worker/src/backgroundMigrations/backfillEventsHistoric.ts
+++ b/worker/src/backgroundMigrations/backfillEventsHistoric.ts
@@ -430,18 +430,26 @@ export default class BackfillEventsHistoric implements IBackgroundMigration {
   // Recovery Logic
   // ============================================================================
 
-  private async recoverInProgressTodos(state: MigrationState): Promise<void> {
+  /**
+   * Recovers in-progress todos from a previous run.
+   * Returns an array of todos that are still running and should be added to the query manager.
+   */
+  private async recoverInProgressTodos(
+    state: MigrationState,
+  ): Promise<ChunkTodo[]> {
     const inProgress = state.todos.filter(
       (t) => t.status === "in_progress" && t.queryId,
     );
 
     if (inProgress.length === 0) {
-      return;
+      return [];
     }
 
     logger.info(
       `[Backfill Events] Recovering ${inProgress.length} in-progress chunks`,
     );
+
+    const stillRunning: ChunkTodo[] = [];
 
     for (const todo of inProgress) {
       const status = await pollQueryStatus(todo.queryId!);
@@ -459,21 +467,23 @@ export default class BackfillEventsHistoric implements IBackgroundMigration {
         logger.warn(
           `[Backfill Events] Recovered chunk ${todo.id} as failed, will retry: ${error}`,
         );
+      } else if (status === "running") {
+        // Query is still running on ClickHouse - track it in the manager
+        logger.info(
+          `[Backfill Events] Recovered chunk ${todo.id} as still running (query ${todo.queryId}), will continue tracking`,
+        );
+        stillRunning.push(todo);
       } else {
-        // not_found or running
-        if (status === "not_found") {
-          // Query never started or was lost
-          todo.status = "pending";
-          logger.warn(
-            `[Backfill Events] Recovered chunk ${todo.id} as not_found, resetting to pending`,
-          );
-        }
-        // If still running, we leave it as in_progress but clear queryId
-        // so it doesn't interfere with new queries
+        // not_found - query was lost
+        todo.status = "pending";
+        logger.warn(
+          `[Backfill Events] Recovered chunk ${todo.id} as not_found, resetting to pending`,
+        );
       }
     }
 
     await this.updateState(state);
+    return stillRunning;
   }
 
   // ============================================================================
@@ -759,7 +769,8 @@ export default class BackfillEventsHistoric implements IBackgroundMigration {
     }
 
     // Phase 2: Recover any in-progress queries from previous run
-    await this.recoverInProgressTodos(state);
+    // Returns queries that are still running on ClickHouse so we can track them
+    const stillRunningTodos = await this.recoverInProgressTodos(state);
 
     // Phase 2.5: Reset failed chunks to pending if --retry-failed flag is set
     if (migrationArgs.retryFailed) {
@@ -887,8 +898,18 @@ export default class BackfillEventsHistoric implements IBackgroundMigration {
     // Start polling and initial scheduling
     manager.startPolling(config.pollIntervalMs!, onComplete, scheduleNext);
 
-    // Schedule initial batch up to concurrency limit
-    for (let i = 0; i < config.concurrency!; i++) {
+    // Add recovered still-running queries to the manager so they count against concurrency
+    // This prevents scheduling new queries on top of already-running ones after a restart
+    for (const todo of stillRunningTodos) {
+      manager.addQuery(todo, todo.queryId!);
+      logger.info(
+        `[Backfill Events] Added recovered running query ${todo.queryId} for chunk ${todo.id} to manager`,
+      );
+    }
+
+    // Schedule initial batch up to concurrency limit (minus already-running recovered queries)
+    const slotsAvailable = config.concurrency! - stillRunningTodos.length;
+    for (let i = 0; i < slotsAvailable; i++) {
       await scheduleNext();
     }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance backfill script to handle ClickHouse exceptions explicitly and improve recovery logic for in-progress tasks.
> 
>   - **Behavior**:
>     - Changes `getQueryError()` to select `exception as exception_message` instead of `exception`.
>     - Updates `recoverInProgressTodos()` to return an array of still-running `ChunkTodo` items.
>     - Adjusts retry settings in `fireQuery()` to apply `max_threads` and `max_insert_threads` for retries > 1.
>   - **Recovery Logic**:
>     - `recoverInProgressTodos()` now tracks still-running queries and returns them for further management.
>     - Adds still-running queries to `ConcurrentQueryManager` to prevent over-scheduling.
>   - **Misc**:
>     - Updates logging in `fireQuery()` to reflect new retry settings.
>     - Adjusts initial scheduling to account for already-running queries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 31479a67a3aeb68756cd8f7f2d7d0d2dfbfe27da. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->