### PR TITLE
fix: prefer exactTimestamp from event for eval trace caching

### DIFF
--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -259,9 +259,11 @@ export const createEvalJobs = async ({
         traceId: event.traceId,
         projectId: event.projectId,
         timestamp:
-          "timestamp" in event
-            ? new Date(event.timestamp)
-            : new Date(jobTimestamp),
+          "exactTimestamp" in event && event.exactTimestamp
+            ? new Date(event.exactTimestamp)
+            : "timestamp" in event
+              ? new Date(event.timestamp)
+              : new Date(jobTimestamp),
         clickhouseFeatureTag: "eval-create",
         excludeInputOutput: true,
       });


### PR DESCRIPTION
Replaces https://github.com/langfuse/langfuse/pull/10985
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prefer `exactTimestamp` over `timestamp` for event processing in `createEvalJobs` and `getTraceById` in `evalService.ts`.
> 
>   - **Behavior**:
>     - In `createEvalJobs` and `getTraceById`, prefer `exactTimestamp` over `timestamp` for event processing.
>     - Fallback to `timestamp` or `jobTimestamp` if `exactTimestamp` is not available.
>   - **Functions**:
>     - Update `createEvalJobs` in `evalService.ts` to use `exactTimestamp` for trace data fetching and evaluation job creation.
>     - Update `getTraceById` call within `createEvalJobs` to prioritize `exactTimestamp`.
>   - **Misc**:
>     - No changes to function signatures or additional parameters added.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6c453693da2dbd5fbd25a0f33cf05fc5c8179e3f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->