### PR TITLE
chore: lower mutation monitor safecount

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -318,7 +318,7 @@ const EnvSchema = z.object({
   LANGFUSE_DELETION_MUTATIONS_SAFE_COUNT: z.coerce
     .number()
     .positive()
-    .default(5),
+    .default(1),
 
   // Deprecated. Do not use!
   LANGFUSE_EXPERIMENT_RETURN_NEW_RESULT: z


### PR DESCRIPTION
This should prevent "resume" decisions while there is 1 or more mutations running still

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Lower `LANGFUSE_DELETION_MUTATIONS_SAFE_COUNT` default from 5 to 1 in `worker/src/env.ts` to adjust mutation monitoring sensitivity.
> 
>   - **Behavior**:
>     - Lower `LANGFUSE_DELETION_MUTATIONS_SAFE_COUNT` default from 5 to 1 in `worker/src/env.ts`.
>     - Affects mutation monitoring sensitivity for deletion operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 304cca3d6d279d5bab008760186f4e653c29f49d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->