### PR TITLE
fix(data-table): center the no results correctly

### DIFF
--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -598,8 +598,8 @@ function TableBodyComponent<TData>({
         ))
       ) : (
         <TableRow className="hover:bg-transparent">
-          <TableCell colSpan={columns.length} className="h-24">
-            <div className="pointer-events-none absolute left-[50%] flex -translate-y-1/2 items-center justify-center">
+          <TableCell colSpan={columns.length} className="h-24 text-center">
+            <div className="pointer-events-none flex h-full items-center justify-center">
               No results.{" "}
               {help && (
                 <DocPopup description={help.description} href={help.href} />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjusts CSS in `data-table.tsx` to center 'No results' message in `TableBodyComponent`.
> 
>   - **UI Fix**:
>     - Adjusts CSS in `data-table.tsx` to center 'No results' message vertically and horizontally in `TableBodyComponent` when no data is present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1c2faac5dac995f6d8b6d9b8e6f223b2c04c400e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->