### PR TITLE
perf: increase http send and receive timeouts for clickhouse queries for batch exports

### DIFF
--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -310,6 +310,10 @@ function handleExceptionRow<T>(parsedRow: T): T {
   ) {
     const potentialException = (parsedRow as { exception: string }).exception;
     if (potentialException.match(/^Code: (\d+)/)) {
+      logger.error(
+        `[clickhouse] Exception row detected: ${potentialException}`,
+        parsedRow,
+      );
       throw new Error(potentialException);
     }
   }

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -121,6 +121,12 @@ export const getDatabaseReadStreamPaginated = async ({
 
   const clickhouseConfigs = {
     request_timeout: 180_000,
+    clickhouse_settings: {
+      // Increase HTTP timeouts to prevent Code 209 errors during slow blob storage uploads
+      // See: https://github.com/ClickHouse/ClickHouse/issues/64731
+      http_send_timeout: 300,
+      http_receive_timeout: 300,
+    },
   };
 
   switch (tableName) {
@@ -384,9 +390,7 @@ export const getDatabaseReadStreamPaginated = async ({
                 (min, t) => (!min || t.timestamp < min ? t.timestamp : min),
                 undefined as Date | undefined,
               ),
-              {
-                request_timeout: 180_000,
-              },
+              clickhouseConfigs,
             ),
           ]);
 
@@ -699,6 +703,12 @@ export const getTraceIdentifierStream = async (props: {
 
   const clickhouseConfigs = {
     request_timeout: 180_000,
+    clickhouse_settings: {
+      // Increase HTTP timeouts to prevent Code 209 errors during slow blob storage uploads
+      // See: https://github.com/ClickHouse/ClickHouse/issues/64731
+      http_send_timeout: 300,
+      http_receive_timeout: 300,
+    },
   };
 
   return new DatabaseReadStream<TraceIdentifiers>(

--- a/worker/src/features/database-read-stream/observation-stream.ts
+++ b/worker/src/features/database-read-stream/observation-stream.ts
@@ -97,6 +97,10 @@ export const getObservationStream = async (props: {
     request_timeout: 180_000, // 3 minutes
     clickhouse_settings: {
       join_algorithm: "partial_merge" as const,
+      // Increase HTTP timeouts to prevent Code 209 errors during slow blob storage uploads
+      // See: https://github.com/ClickHouse/ClickHouse/issues/64731
+      http_send_timeout: 300,
+      http_receive_timeout: 300,
     },
   };
 

--- a/worker/src/features/database-read-stream/trace-stream.ts
+++ b/worker/src/features/database-read-stream/trace-stream.ts
@@ -46,6 +46,10 @@ export const getTraceStream = async (props: {
     request_timeout: 180_000,
     clickhouse_settings: {
       join_algorithm: "partial_merge" as const,
+      // Increase HTTP timeouts to prevent Code 209 errors during slow blob storage uploads
+      // See: https://github.com/ClickHouse/ClickHouse/issues/64731
+      http_send_timeout: 300,
+      http_receive_timeout: 300,
     },
   };
 


### PR DESCRIPTION
LFE-4995
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase HTTP send and receive timeouts for ClickHouse queries to 300 seconds to prevent errors during slow blob storage uploads, and add logging for exception rows.
> 
>   - **Timeouts**:
>     - Increase `http_send_timeout` and `http_receive_timeout` to 300 seconds in `getDatabaseReadStreamPaginated`, `getTraceIdentifierStream`, `getObservationStream`, and `getTraceStream`.
>     - Aimed to prevent Code 209 errors during slow blob storage uploads.
>   - **Logging**:
>     - Add error logging for exception rows in `handleExceptionRow()` in `clickhouse.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bb716bae2b339fd1dacb1f3ad95729716086138b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->