### PR TITLE
chore: enable test runner sharding

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -163,12 +163,11 @@ jobs:
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
-    name: tests-web-sync (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }}, shard${{ matrix.shard }}/3)
+    name: tests-web-sync (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }})
     strategy:
       matrix:
         node-version: [24]
         postgres-version: [12, 15]
-        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v4
       - name: Install golang-migrate for Clickhouse migrations

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -204,9 +204,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-web-sync-${{ matrix.node-version }}-${{ matrix.postgres-version }}-shard${{ matrix.shard }}-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-web-sync-${{ matrix.node-version }}-${{ matrix.postgres-version }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-turbo-web-sync-${{ matrix.node-version }}-${{ matrix.postgres-version }}-shard${{ matrix.shard }}-
             ${{ runner.os }}-turbo-web-sync-${{ matrix.node-version }}-${{ matrix.postgres-version }}-
             ${{ runner.os }}-turbo-web-sync-${{ matrix.node-version }}-
             ${{ runner.os }}-turbo-
@@ -250,10 +249,10 @@ jobs:
           LANGFUSE_INIT_USER_PASSWORD: "password"
       - name: run test-sync
         working-directory: web
-        run: npx cross-env NODE_OPTIONS='--no-experimental-require-module' npx dotenv -e ../.env.test -e ../.env -- npx jest --verbose --runInBand --detectOpenHandles --selectProjects sync-server --shard=${{ matrix.shard }}/3
+        run: npx cross-env NODE_OPTIONS='--no-experimental-require-module' npx dotenv -e ../.env.test -e ../.env -- npx jest --verbose --runInBand --detectOpenHandles --selectProjects sync-server
       - name: run test-client
         working-directory: web
-        run: npx cross-env NODE_OPTIONS='--no-experimental-require-module' npx dotenv -e ../.env.test -e ../.env -- npx jest --verbose --runInBand --detectOpenHandles --selectProjects client --shard=${{ matrix.shard }}/3
+        run: npx cross-env NODE_OPTIONS='--no-experimental-require-module' npx dotenv -e ../.env.test -e ../.env -- npx jest --verbose --runInBand --detectOpenHandles --selectProjects client
 
   tests-web-async:
     timeout-minutes: 30

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -163,11 +163,13 @@ jobs:
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
-    name: tests-web-sync (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }})
+    name: tests-web-sync (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }}, shard${{ matrix.shard }}/3)
     strategy:
+      fail-fast: false
       matrix:
         node-version: [24]
         postgres-version: [12, 15]
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v4
       - name: Install golang-migrate for Clickhouse migrations
@@ -204,8 +206,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-web-sync-${{ matrix.node-version }}-${{ matrix.postgres-version }}-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-web-sync-${{ matrix.node-version }}-${{ matrix.postgres-version }}-shard${{ matrix.shard }}-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-turbo-web-sync-${{ matrix.node-version }}-${{ matrix.postgres-version }}-shard${{ matrix.shard }}-
             ${{ runner.os }}-turbo-web-sync-${{ matrix.node-version }}-${{ matrix.postgres-version }}-
             ${{ runner.os }}-turbo-web-sync-${{ matrix.node-version }}-
             ${{ runner.os }}-turbo-
@@ -248,9 +251,9 @@ jobs:
           LANGFUSE_INIT_USER_NAME: "Demo User"
           LANGFUSE_INIT_USER_PASSWORD: "password"
       - name: run test-sync
-        run: pnpm --filter=web run test-sync
+        run: pnpm --filter=web run test-sync -- --shard=${{ matrix.shard }}/3
       - name: run test-client
-        run: pnpm --filter=web run test-client
+        run: pnpm --filter=web run test-client -- --shard=${{ matrix.shard }}/3
 
   tests-web-async:
     timeout-minutes: 30
@@ -258,12 +261,14 @@ jobs:
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
-    name: tests-web-async (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }}, mode${{ matrix.deploy-mode }})
+    name: tests-web-async (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }}, mode${{ matrix.deploy-mode }}, shard${{ matrix.shard }}/3)
     strategy:
+      fail-fast: false
       matrix:
         node-version: [24]
         postgres-version: [12, 15]
         deploy-mode: ["", "-azure", "-redis-cluster"]
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v4
       - name: Install golang-migrate for Clickhouse migrations
@@ -302,8 +307,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-web-async-${{ matrix.node-version }}-${{ matrix.postgres-version }}-${{ matrix.deploy-mode }}-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-web-async-${{ matrix.node-version }}-${{ matrix.postgres-version }}-${{ matrix.deploy-mode }}-shard${{ matrix.shard }}-${{ github.sha }}
           restore-keys: |
+            ${{ runner.os }}-turbo-web-async-${{ matrix.node-version }}-${{ matrix.postgres-version }}-${{ matrix.deploy-mode }}-shard${{ matrix.shard }}-
             ${{ runner.os }}-turbo-web-async-${{ matrix.node-version }}-${{ matrix.postgres-version }}-${{ matrix.deploy-mode }}-
             ${{ runner.os }}-turbo-web-async-${{ matrix.node-version }}-${{ matrix.postgres-version }}-
             ${{ runner.os }}-turbo-
@@ -360,7 +366,7 @@ jobs:
           LANGFUSE_INIT_USER_NAME: "Demo User"
           LANGFUSE_INIT_USER_PASSWORD: "password"
       - name: run tests
-        run: pnpm --filter=web run test
+        run: pnpm --filter=web run test -- --shard=${{ matrix.shard }}/3
 
   tests-worker:
     timeout-minutes: 20

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -165,7 +165,6 @@ jobs:
     if: needs.pre-job.outputs.should_skip != 'true'
     name: tests-web-sync (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }}, shard${{ matrix.shard }}/3)
     strategy:
-      fail-fast: false
       matrix:
         node-version: [24]
         postgres-version: [12, 15]
@@ -252,10 +251,10 @@ jobs:
           LANGFUSE_INIT_USER_PASSWORD: "password"
       - name: run test-sync
         working-directory: web
-        run: cross-env NODE_OPTIONS='--no-experimental-require-module' npx dotenv -e ../.env.test -e ../.env -- jest --verbose --runInBand --detectOpenHandles --selectProjects sync-server --shard=${{ matrix.shard }}/3
+        run: npx cross-env NODE_OPTIONS='--no-experimental-require-module' npx dotenv -e ../.env.test -e ../.env -- npx jest --verbose --runInBand --detectOpenHandles --selectProjects sync-server --shard=${{ matrix.shard }}/3
       - name: run test-client
         working-directory: web
-        run: cross-env NODE_OPTIONS='--no-experimental-require-module' npx dotenv -e ../.env.test -e ../.env -- jest --verbose --runInBand --detectOpenHandles --selectProjects client --shard=${{ matrix.shard }}/3
+        run: npx cross-env NODE_OPTIONS='--no-experimental-require-module' npx dotenv -e ../.env.test -e ../.env -- npx jest --verbose --runInBand --detectOpenHandles --selectProjects client --shard=${{ matrix.shard }}/3
 
   tests-web-async:
     timeout-minutes: 30
@@ -265,7 +264,6 @@ jobs:
     if: needs.pre-job.outputs.should_skip != 'true'
     name: tests-web-async (node${{ matrix.node-version }}, pg${{ matrix.postgres-version }}, mode${{ matrix.deploy-mode }}, shard${{ matrix.shard }}/3)
     strategy:
-      fail-fast: false
       matrix:
         node-version: [24]
         postgres-version: [12, 15]
@@ -369,7 +367,7 @@ jobs:
           LANGFUSE_INIT_USER_PASSWORD: "password"
       - name: run tests
         working-directory: web
-        run: cross-env NODE_OPTIONS='--no-experimental-require-module' npx dotenv -e ../.env.test -e ../.env -- jest --verbose --runInBand --detectOpenHandles --selectProjects async-server --shard=${{ matrix.shard }}/3
+        run: npx cross-env NODE_OPTIONS='--no-experimental-require-module' npx dotenv -e ../.env.test -e ../.env -- npx jest --verbose --runInBand --detectOpenHandles --selectProjects async-server --shard=${{ matrix.shard }}/3
 
   tests-worker:
     timeout-minutes: 20

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -251,9 +251,11 @@ jobs:
           LANGFUSE_INIT_USER_NAME: "Demo User"
           LANGFUSE_INIT_USER_PASSWORD: "password"
       - name: run test-sync
-        run: pnpm --filter=web run test-sync -- --shard=${{ matrix.shard }}/3
+        working-directory: web
+        run: cross-env NODE_OPTIONS='--no-experimental-require-module' npx dotenv -e ../.env.test -e ../.env -- jest --verbose --runInBand --detectOpenHandles --selectProjects sync-server --shard=${{ matrix.shard }}/3
       - name: run test-client
-        run: pnpm --filter=web run test-client -- --shard=${{ matrix.shard }}/3
+        working-directory: web
+        run: cross-env NODE_OPTIONS='--no-experimental-require-module' npx dotenv -e ../.env.test -e ../.env -- jest --verbose --runInBand --detectOpenHandles --selectProjects client --shard=${{ matrix.shard }}/3
 
   tests-web-async:
     timeout-minutes: 30
@@ -366,7 +368,8 @@ jobs:
           LANGFUSE_INIT_USER_NAME: "Demo User"
           LANGFUSE_INIT_USER_PASSWORD: "password"
       - name: run tests
-        run: pnpm --filter=web run test -- --shard=${{ matrix.shard }}/3
+        working-directory: web
+        run: cross-env NODE_OPTIONS='--no-experimental-require-module' npx dotenv -e ../.env.test -e ../.env -- jest --verbose --runInBand --detectOpenHandles --selectProjects async-server --shard=${{ matrix.shard }}/3
 
   tests-worker:
     timeout-minutes: 20


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enable test runner sharding in `tests-web-async` by updating test commands and matrix strategy in `pipeline.yml`.
> 
>   - **Test Execution**:
>     - Update `run` commands for `test-sync` and `test-client` in `tests-web-sync` to use `npx jest` with sharding options.
>     - Modify `run` command in `tests-web-async` to include `--shard=${{ matrix.shard }}/3` for sharding.
>   - **Matrix Strategy**:
>     - Add `shard: [1, 2, 3]` to the matrix strategy in `tests-web-async`.
>   - **Caching**:
>     - Update cache keys in `tests-web-async` to include shard information.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9fc1217f89a6cc86b9fc8e3e255f042790f82893. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->