### PR TITLE
fix: avoid bind variable limit in trace deletion with many media items

### DIFF
--- a/worker/src/features/traces/processClickhouseTraceDelete.ts
+++ b/worker/src/features/traces/processClickhouseTraceDelete.ts
@@ -44,7 +44,6 @@ const deleteMediaItemsForTraces = async (
   const [traceMediaItems, observationMediaItems] = await Promise.all([
     prisma.traceMedia.findMany({
       select: {
-        id: true,
         mediaId: true,
       },
       where: {
@@ -56,7 +55,6 @@ const deleteMediaItemsForTraces = async (
     }),
     prisma.observationMedia.findMany({
       select: {
-        id: true,
         mediaId: true,
       },
       where: {
@@ -72,21 +70,21 @@ const deleteMediaItemsForTraces = async (
   traceMediaItems.forEach((item) => allMediaIds.add(item.mediaId));
   observationMediaItems.forEach((item) => allMediaIds.add(item.mediaId));
 
-  // Delete the junction table records in chunks
+  // Delete the junction table records by traceId (should be covered by indexes)
   await Promise.all([
     prisma.traceMedia.deleteMany({
       where: {
         projectId,
-        id: {
-          in: traceMediaItems.map((ref) => ref.id),
+        traceId: {
+          in: traceIds,
         },
       },
     }),
     prisma.observationMedia.deleteMany({
       where: {
         projectId,
-        id: {
-          in: observationMediaItems.map((ref) => ref.id),
+        traceId: {
+          in: traceIds,
         },
       },
     }),


### PR DESCRIPTION
Delete media junction records by traceId instead of by id list to avoid
database bind variable limits when processing traces with thousands of
associated media items. Addresses https://github.com/langfuse/langfuse/issues/10935
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `deleteMediaItemsForTraces` now deletes media junction records by `traceId` to avoid bind variable limits, improving efficiency for traces with many media items.
> 
>   - **Behavior**:
>     - `deleteMediaItemsForTraces` in `processClickhouseTraceDelete.ts` now deletes media junction records by `traceId` instead of `id` to avoid bind variable limits.
>     - Handles traces with thousands of media items efficiently.
>   - **Code Changes**:
>     - Removed selection of `id` in `prisma.traceMedia.findMany` and `prisma.observationMedia.findMany`.
>     - Updated `prisma.traceMedia.deleteMany` and `prisma.observationMedia.deleteMany` to use `traceId` in `where` clause.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 08c51c8d99368c27274e8b8faae981a40ea96819. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->