### PR TITLE
feat: add model name filter for observation widgets

### DIFF
--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -423,6 +423,23 @@ export function WidgetForm({
     },
   );
 
+  const generationsFilterOptions = api.generations.filterOptions.useQuery(
+    {
+      projectId,
+    },
+    {
+      trpc: {
+        context: {
+          skipBatch: true,
+        },
+      },
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: Infinity,
+    },
+  );
+
   const environmentFilterOptions =
     api.projects.environmentFilterOptions.useQuery(
       {
@@ -447,6 +464,7 @@ export function WidgetForm({
     })) || [];
   const nameOptions = traceFilterOptions.data?.name || [];
   const tagsOptions = traceFilterOptions.data?.tags || [];
+  const modelOptions = generationsFilterOptions.data?.model || [];
 
   // Filter columns for PopoverFilterBuilder
   const filterColumns: ColumnDefinition[] = [
@@ -514,6 +532,15 @@ export function WidgetForm({
       internal: "internalValue",
     },
   ];
+  if (selectedView === "observations") {
+    filterColumns.push({
+      name: "Model",
+      id: "providedModelName",
+      type: "stringOptions",
+      options: modelOptions,
+      internal: "internalValue",
+    });
+  }
   if (selectedView === "scores-categorical") {
     filterColumns.push({
       name: "Score String Value",
@@ -1368,6 +1395,7 @@ export function WidgetForm({
                       "environment",
                       "traceName",
                       "tags",
+                      "providedModelName",
                     ]}
                   />
                 </div>


### PR DESCRIPTION
## What does this PR do?

This PR implements the "provided model name" filter for observation metrics within custom dashboards. It adds a "Model" filter option to the widget form when the "observations" view is selected, allowing users to filter their observation data by the model name used.

Fixes # LFE-8027

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [ ] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my PR needs changes to the documentation
- [ ] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [ ] I haven't added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-8027](https://linear.app/langfuse/issue/LFE-8027/model-filter-on-observation-metrics)

<a href="https://cursor.com/background-agent?bcId=bc-389d6033-c9f3-4061-aa56-a0778ca64480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-389d6033-c9f3-4061-aa56-a0778ca64480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a "Model" filter option to `WidgetForm` for "observations" view, enabling filtering by model name.
> 
>   - **Behavior**:
>     - Adds "Model" filter option to `WidgetForm` for "observations" view, allowing filtering by model name.
>     - Uses `generationsFilterOptions` to fetch model options.
>   - **Code Changes**:
>     - Updates `filterColumns` in `WidgetForm.tsx` to include "Model" filter when `selectedView` is "observations".
>     - Adds `modelOptions` derived from `generationsFilterOptions.data?.model`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0fad52c77234173ac647475a20e1f98a420fd03f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->