### PR TITLE
chore: add events table to the mutation monitor

### DIFF
--- a/worker/src/features/mutation-monitoring/mutationMonitor.ts
+++ b/worker/src/features/mutation-monitoring/mutationMonitor.ts
@@ -41,18 +41,12 @@ export class MutationMonitor {
   private static timeoutId: NodeJS.Timeout | null = null;
   private static pausedQueues: Set<QueueName> = new Set();
   private static isRunning = false;
-  private static readonly TABLES_TO_MONITOR = [
-    "traces",
-    "observations",
-    "scores",
-    "dataset_run_items_rmt",
-  ];
 
   // Mapping of which ClickHouse tables each deletion queue affects
   private static readonly QUEUE_TABLE_MAPPING: Partial<
     Record<QueueName, string[]>
   > = {
-    [QueueName.TraceDelete]: ["traces", "observations", "scores"],
+    [QueueName.TraceDelete]: ["traces", "observations", "scores", "events"],
     [QueueName.ScoreDelete]: ["scores"],
     [QueueName.DatasetDelete]: ["dataset_run_items_rmt"],
     [QueueName.ProjectDelete]: [
@@ -60,14 +54,25 @@ export class MutationMonitor {
       "observations",
       "scores",
       "dataset_run_items_rmt",
+      "events",
     ],
     [QueueName.DataRetentionProcessingQueue]: [
       "traces",
       "observations",
       "scores",
+      "events",
     ],
-    [QueueName.BatchActionQueue]: ["traces", "observations", "scores"],
+    [QueueName.BatchActionQueue]: [
+      "traces",
+      "observations",
+      "scores",
+      "events",
+    ],
   };
+
+  private static readonly TABLES_TO_MONITOR = Array.from(
+    new Set(Object.values(this.QUEUE_TABLE_MAPPING).flat()).values(),
+  );
 
   /**
    * Start the mutation monitoring service


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds 'events' table to mutation monitoring in `mutationMonitor.ts`, affecting queue pause/resume logic.
> 
>   - **Behavior**:
>     - Adds `events` table to `QUEUE_TABLE_MAPPING` in `mutationMonitor.ts`, affecting `TraceDelete`, `ProjectDelete`, `DataRetentionProcessingQueue`, and `BatchActionQueue`.
>     - Updates `TABLES_TO_MONITOR` to include `events` table in `mutationMonitor.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 42deb7268dfe77e5b4f33404cc0b937949b020d3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->