### PR TITLE
chore: update haiku model pricing

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -3126,9 +3126,9 @@
   {
     "id": "cmgt5gnkv000104jx171tbq4e",
     "modelName": "claude-haiku-4-5-20251001",
-    "matchPattern": "(?i)^(claude-haiku-4-5-20251001|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
+    "matchPattern": "(?i)^(claude-haiku-4-5-20251001|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001|claude-haiku-4-5@20251001)$",
     "createdAt": "2025-10-16T08:20:44.558Z",
-    "updatedAt": "2025-11-18T00:00:00.000Z",
+    "updatedAt": "2025-12-10T00:00:00.000Z",
     "tokenizerId": "claude",
     "pricingTiers": [
       {


### PR DESCRIPTION
## What does this PR do?

Add a new model alias for Pricing calculation for Haiku-4-5. This version of the alias was present for sonnet-4-5 but missing for 4-5.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ✓] Chore (refactoring code, technical debt, workflow improvements)

## Mandatory Tasks

- [ ✓] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add new alias to `matchPattern` for `claude-haiku-4-5-20251001` in `default-model-prices.json`.
> 
>   - **Behavior**:
>     - Added new alias `claude-haiku-4-5@20251001` to `matchPattern` for `claude-haiku-4-5-20251001` in `default-model-prices.json`.
>     - Updated `updatedAt` timestamp to `2025-12-10T00:00:00.000Z` for the same entry.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 00a95b9083900685216a9f50bec4f3109098400a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->