### PR TITLE
feat: add update_parallel_mode CH option passthrough

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -63,6 +63,9 @@ const EnvSchema = z.object({
   CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE: z
     .enum(["alter_update", "lightweight_update", "lightweight_update_force"])
     .default("alter_update"),
+  CLICKHOUSE_UPDATE_PARALLEL_MODE: z
+    .enum(["sync", "async", "auto"])
+    .default("auto"),
 
   LANGFUSE_INGESTION_QUEUE_DELAY_MS: z.coerce
     .number()

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -124,6 +124,7 @@ export class ClickHouseClientManager {
           ...(env.CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE !== "alter_update"
             ? {
                 lightweight_delete_mode: env.CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE,
+                update_parallel_mode: env.CLICKHOUSE_UPDATE_PARALLEL_MODE,
               }
             : {}),
           ...cloudOptions,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `CLICKHOUSE_UPDATE_PARALLEL_MODE` environment variable to control update parallel mode in ClickHouse client settings.
> 
>   - **Environment**:
>     - Add `CLICKHOUSE_UPDATE_PARALLEL_MODE` to `EnvSchema` in `env.ts` with options `sync`, `async`, `auto`, defaulting to `auto`.
>   - **ClickHouse Client**:
>     - Pass `CLICKHOUSE_UPDATE_PARALLEL_MODE` to `clickhouse_settings` in `getClient()` in `client.ts` when `CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE` is not `alter_update`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2fd9445b75a7f7c21e0fcb8223004585905d5093. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->