### PR TITLE
Fix user onboarding redirect

### DIFF
--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -181,11 +181,13 @@ export function SSOButtons({
   action = "sign in",
   lastUsedMethod,
   onProviderSelect,
+  callbackUrl,
 }: {
   authProviders: PageProps["authProviders"];
   action?: string;
   lastUsedMethod?: NextAuthProvider | null;
   onProviderSelect?: (provider: NextAuthProvider) => void;
+  callbackUrl?: string;
 }) {
   const capture = usePostHogClientCapture();
   const [providerSigningIn, setProviderSigningIn] =
@@ -204,7 +206,7 @@ export function SSOButtons({
     // Notify parent component about provider selection
     onProviderSelect?.(provider);
 
-    signIn(provider)
+    signIn(provider, callbackUrl ? { callbackUrl } : undefined)
       .then(() => {
         // do not reset loadingProvider here, as the page will reload
       })
@@ -354,7 +356,10 @@ export function SSOButtons({
               onClick={() => {
                 capture("sign_in:button_click", { provider: "keycloak" });
                 onProviderSelect?.("keycloak");
-                void signIn("keycloak");
+                void signIn(
+                  "keycloak",
+                  callbackUrl ? { callbackUrl } : undefined,
+                );
               }}
               loading={providerSigningIn === "keycloak"}
               showLastUsedBadge={
@@ -370,11 +375,15 @@ export function SSOButtons({
                 onClick={() => {
                   capture("sign_in:button_click", { provider: "workos" });
                   onProviderSelect?.("workos");
-                  void signIn("workos", undefined, {
-                    connection: (
-                      authProviders.workos as { connectionId: string }
-                    ).connectionId,
-                  });
+                  void signIn(
+                    "workos",
+                    callbackUrl ? { callbackUrl } : undefined,
+                    {
+                      connection: (
+                        authProviders.workos as { connectionId: string }
+                      ).connectionId,
+                    },
+                  );
                 }}
                 loading={providerSigningIn === "workos"}
                 showLastUsedBadge={
@@ -390,11 +399,15 @@ export function SSOButtons({
                 onClick={() => {
                   capture("sign_in:button_click", { provider: "workos" });
                   onProviderSelect?.("workos");
-                  void signIn("workos", undefined, {
-                    organization: (
-                      authProviders.workos as { organizationId: string }
-                    ).organizationId,
-                  });
+                  void signIn(
+                    "workos",
+                    callbackUrl ? { callbackUrl } : undefined,
+                    {
+                      organization: (
+                        authProviders.workos as { organizationId: string }
+                      ).organizationId,
+                    },
+                  );
                 }}
                 loading={providerSigningIn === "workos"}
                 showLastUsedBadge={
@@ -414,9 +427,13 @@ export function SSOButtons({
                   if (organization) {
                     capture("sign_in:button_click", { provider: "workos" });
                     onProviderSelect?.("workos");
-                    void signIn("workos", undefined, {
-                      organization,
-                    });
+                    void signIn(
+                      "workos",
+                      callbackUrl ? { callbackUrl } : undefined,
+                      {
+                        organization,
+                      },
+                    );
                   }
                 }}
                 loading={providerSigningIn === "workos"}
@@ -434,9 +451,13 @@ export function SSOButtons({
                   if (connection) {
                     capture("sign_in:button_click", { provider: "workos" });
                     onProviderSelect?.("workos");
-                    void signIn("workos", undefined, {
-                      connection,
-                    });
+                    void signIn(
+                      "workos",
+                      callbackUrl ? { callbackUrl } : undefined,
+                      {
+                        connection,
+                      },
+                    );
                   }
                 }}
                 loading={providerSigningIn === "workos"}

--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -127,7 +127,15 @@ export default function SignIn({
         // Store the SSO provider as the last used auth method
         setLastUsedAuthMethod(providerId as NextAuthProvider);
 
-        void signIn(providerId);
+        const ssoCallbackUrl =
+          targetPath ??
+          (isLangfuseCloud && region !== "DEV"
+            ? `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/onboarding`
+            : undefined);
+        void signIn(
+          providerId,
+          ssoCallbackUrl ? { callbackUrl: ssoCallbackUrl } : undefined,
+        );
         return; // stop further execution – page redirect expected
       }
 
@@ -297,6 +305,12 @@ export default function SignIn({
             action="sign up"
             lastUsedMethod={lastUsedAuthMethod}
             onProviderSelect={setLastUsedAuthMethod}
+            callbackUrl={
+              targetPath ??
+              (isLangfuseCloud && region !== "DEV"
+                ? `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/onboarding`
+                : undefined)
+            }
           />
           <p className="mt-10 text-center text-sm text-muted-foreground">
             Already have an account?{" "}


### PR DESCRIPTION
## What does this PR do?

Fixes #LFE-8043

This PR resolves an issue where newly signed-up users on Langfuse Cloud were not being redirected to the `/onboarding` page after completing the signup process, particularly when using SSO providers.

The `signIn()` function calls for all SSO providers in `SSOButtons` and the SSO auto-detection flow in `sign-up.tsx` have been updated to explicitly include a `callbackUrl` parameter. This ensures that new users are consistently directed to `/onboarding` to complete their initial setup. This behavior applies to Langfuse Cloud instances (non-DEV) and respects any `targetPath` query parameter if present.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-8043](https://linear.app/langfuse/issue/LFE-8043/new-users-are-not-redirected-to-onboarding)

<a href="https://cursor.com/background-agent?bcId=bc-bdad9999-7009-4ae7-8974-de38335c75c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bdad9999-7009-4ae7-8974-de38335c75c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

