### PR TITLE
style: update styles for TableLink, IOTableCell and Sidebar components

### DIFF
--- a/web/src/components/table/table-link.tsx
+++ b/web/src/components/table/table-link.tsx
@@ -28,7 +28,7 @@ export default function TableLink({
   return (
     <Link
       className={cn(
-        "inline-block max-w-full overflow-hidden text-ellipsis text-nowrap rounded bg-primary-accent/20 px-2 py-0.5 text-xs font-semibold text-accent-dark-blue shadow-sm hover:bg-accent-light-blue/45",
+        "inline-block max-w-full overflow-hidden text-ellipsis text-nowrap rounded px-2 py-0.5 text-xs font-semibold text-accent-dark-blue hover:text-primary-accent/60",
         className,
       )}
       href={path}

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -304,14 +304,22 @@ export function CodeView(props: {
 }
 
 export const JsonSkeleton = ({
-  className,
   numRows = 10,
+  borderless = false,
+  className,
 }: {
   numRows?: number;
+  borderless?: boolean;
   className?: string;
 }) => {
   return (
-    <div className={cn("w-[400px] rounded-md border", className)}>
+    <div
+      className={cn(
+        "w-[400px] rounded-md",
+        borderless ? "" : "border",
+        className,
+      )}
+    >
       <div className="flex flex-col gap-1">
         {[...Array<number>(numRows)].map((_, i) => (
           <Skeleton

--- a/web/src/components/ui/IOTableCell.tsx
+++ b/web/src/components/ui/IOTableCell.tsx
@@ -84,7 +84,12 @@ export const IOTableCell = ({
   enableExpandOnHover?: boolean;
 }) => {
   if (isLoading) {
-    return <JsonSkeleton className="h-full w-full overflow-hidden px-2 py-1" />;
+    return (
+      <JsonSkeleton
+        borderless
+        className="h-full w-full overflow-hidden px-2 py-1"
+      />
+    );
   }
 
   if (!enableExpandOnHover) {

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -440,7 +440,7 @@ const SidebarGroup = React.forwardRef<
       ref={ref}
       data-sidebar="group"
       className={cn(
-        "relative flex w-full min-w-0 flex-col px-1 py-1 first:pt-0",
+        "relative flex w-full min-w-0 flex-col py-1 first:pt-0",
         "group-data-[collapsible=icon]:p-2 group-data-[collapsible=icon]:first:pt-2",
         className,
       )}
@@ -539,7 +539,7 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = "SidebarMenuItem";
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden group-data-[collapsible=icon]:rounded-sm p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update styles for `TableLink`, `IOTableCell`, and `Sidebar` components to improve UI consistency.
> 
>   - **TableLink**:
>     - Updated CSS classes to remove `bg-primary-accent/20` and `shadow-sm` and add `hover:text-primary-accent/60`.
>   - **IOTableCell**:
>     - Added `borderless` prop to `JsonSkeleton` in `IOTableCell`.
>   - **Sidebar**:
>     - Removed `px-1` from `SidebarGroup`.
>     - Updated `sidebarMenuButtonVariants` to include `group-data-[collapsible=icon]:rounded-sm`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8c293b731ed394c227a36ee004aec784da9dcf29. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->