### PR TITLE
chore(dataset-items): experiment service

### DIFF
--- a/worker/src/features/experiments/experimentServiceClickhouse.ts
+++ b/worker/src/features/experiments/experimentServiceClickhouse.ts
@@ -1,5 +1,4 @@
-import { DatasetItemDomain, DatasetStatus, Prisma } from "@langfuse/shared";
-import { prisma } from "@langfuse/shared/src/db";
+import { DatasetItemDomain, Prisma } from "@langfuse/shared";
 import {
   ChatMessage,
   createDatasetItemFilterState,
@@ -349,26 +348,13 @@ async function createAllDatasetRunItemsWithConfigError(
   errorMessage: string,
 ) {
   // Fetch all dataset items
-  const datasetItems = await prisma.datasetItem.findMany({
-    where: {
-      datasetId,
-      projectId,
-      status: DatasetStatus.ACTIVE,
-    },
-    select: {
-      id: true,
-      projectId: true,
-      datasetId: true,
-      status: true,
-      input: true,
-      expectedOutput: true,
-      metadata: true,
-      sourceTraceId: true,
-      sourceObservationId: true,
-      createdAt: true,
-      updatedAt: true,
-    },
-    orderBy: [{ createdAt: "desc" }, { id: "asc" }],
+  const datasetItems = await getDatasetItemsByLatest({
+    projectId,
+    filterState: createDatasetItemFilterState({
+      datasetIds: [datasetId],
+      status: "ACTIVE",
+    }),
+    includeIO: true,
   });
 
   // Check for existing run items' dataset item ids to avoid duplicates


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactors dataset item retrieval in `experimentServiceClickhouse.ts` to use `getDatasetItemsByLatest`, centralizing logic and removing `DatasetStatus` import.
> 
>   - **Refactoring**:
>     - Replaces direct `prisma.datasetItem.findMany` call with `getDatasetItemsByLatest` in `createAllDatasetRunItemsWithConfigError()` in `experimentServiceClickhouse.ts`.
>     - Removes `DatasetStatus` import, indicating status filtering is now handled by `getDatasetItemsByLatest`.
>   - **Behavior**:
>     - Centralizes dataset item retrieval logic, potentially improving maintainability and consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 255e3907b1d74b180be1b4de9396f1ad18a41873. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->