### PR TITLE
fix: tags and release should now be defined on event-traces aggregation

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -218,9 +218,8 @@ const EVENTS_AGGREGATION_FIELDS = {
   default_count: "countIf(level = 'DEFAULT') as default_count",
   debug_count: "countIf(level = 'DEBUG') as debug_count",
 
-  // Legacy fields for backward compatibility
-  tags: "array() AS tags",
-  release: "'' AS release",
+  tags: "argMaxIf(tags, event_ts, notEmpty(tags)) AS tags",
+  release: "argMaxIf(release, event_ts, release <> '') AS release",
 } as const;
 
 /**


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates `tags` and `release` aggregation in `event-query-builder.ts` to use `argMaxIf` for accurate non-empty value selection.
> 
>   - **Behavior**:
>     - Updates `tags` and `release` fields in `EVENTS_AGGREGATION_FIELDS` in `event-query-builder.ts` to use `argMaxIf` for selecting the most recent non-empty values.
>     - Ensures accurate aggregation of `tags` and `release` in event-traces.
>   - **Misc**:
>     - Removes legacy default values for `tags` and `release`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cce3ac96460ca9ff1911315d6aca8738f42e2634. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->