### PR TITLE
feat(model-prices): add gpt-5.2

### DIFF
--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -311,6 +311,7 @@ export const openAIModels = [
   "gpt-4.1-mini-2025-04-14",
   "gpt-4.1-nano",
   "gpt-4.1-nano-2025-04-14",
+  "gpt-5.2-2025-12-11",
   "gpt-5.1",
   "gpt-5.1-2025-11-13",
   "gpt-5",
@@ -353,6 +354,7 @@ export const openAIModels = [
 type OpenAIReasoningMap = Record<OpenAIModel, boolean>;
 export const openAIModelToReasoning: OpenAIReasoningMap = {
   // reasoning models
+  "gpt-5.2-2025-12-11": true,
   "gpt-5.1": true,
   "gpt-5.1-2025-11-13": true,
   "gpt-5": true,

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -3357,5 +3357,65 @@
         }
       }
     ]
+  },
+  {
+    "id": "cmj2n4f2a000304kz49g4c43u",
+    "modelName": "gpt-5.2",
+    "matchPattern": "(?i)^(gpt-5.2)$",
+    "createdAt": "2025-12-12T09:00:06.513Z",
+    "updatedAt": "2025-12-12T09:00:06.513Z",
+    "tokenizerConfig": {
+      "tokensPerName": 1,
+      "tokenizerModel": "gpt-4",
+      "tokensPerMessage": 3
+    },
+    "tokenizerId": "openai",
+    "pricingTiers": [
+      {
+        "id": "cmj2n4f2a000304kz49g4c43u_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 1.75e-6,
+          "input_cached_tokens": 0.175e-6,
+          "input_cache_read": 0.175e-6,
+          "output": 14e-6,
+          "output_reasoning_tokens": 14e-6,
+          "output_reasoning": 14e-6
+        }
+      }
+    ]
+  },
+  {
+    "id": "cmj2muxg6000104kzd2tc8953",
+    "modelName": "gpt-5.2-2025-12-11",
+    "matchPattern": "(?i)^(gpt-5.2-2025-12-11)$",
+    "createdAt": "2025-12-12T09:00:06.513Z",
+    "updatedAt": "2025-12-12T09:00:06.513Z",
+    "tokenizerConfig": {
+      "tokensPerName": 1,
+      "tokenizerModel": "gpt-4",
+      "tokensPerMessage": 3
+    },
+    "tokenizerId": "openai",
+    "pricingTiers": [
+      {
+        "id": "cmj2muxg6000104kzd2tc8953_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 1.75e-6,
+          "input_cached_tokens": 0.175e-6,
+          "input_cache_read": 0.175e-6,
+          "output": 14e-6,
+          "output_reasoning_tokens": 14e-6,
+          "output_reasoning": 14e-6
+        }
+      }
+    ]
   }
 ]

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -3417,5 +3417,61 @@
         }
       }
     ]
+  },
+  {
+    "id": "cmj2n6pkq000404kz2s0b6if7",
+    "modelName": "gpt-5.2-pro",
+    "matchPattern": "(?i)^(gpt-5.2-pro)$",
+    "createdAt": "2025-12-12T09:00:06.513Z",
+    "updatedAt": "2025-12-12T09:00:06.513Z",
+    "tokenizerConfig": {
+      "tokensPerName": 1,
+      "tokenizerModel": "gpt-4",
+      "tokensPerMessage": 3
+    },
+    "tokenizerId": "openai",
+    "pricingTiers": [
+      {
+        "id": "cmj2n6pkq000404kz2s0b6if7_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 21e-6,
+          "output": 168e-6,
+          "output_reasoning_tokens": 168e-6,
+          "output_reasoning": 168e-6
+        }
+      }
+    ]
+  },
+  {
+    "id": "cmj2n70oe000504kz21b76mes",
+    "modelName": "gpt-5.2-pro-2025-12-11",
+    "matchPattern": "(?i)^(gpt-5.2-pro-2025-12-11)$",
+    "createdAt": "2025-12-12T09:00:06.513Z",
+    "updatedAt": "2025-12-12T09:00:06.513Z",
+    "tokenizerConfig": {
+      "tokensPerName": 1,
+      "tokenizerModel": "gpt-4",
+      "tokensPerMessage": 3
+    },
+    "tokenizerId": "openai",
+    "pricingTiers": [
+      {
+        "id": "cmj2n70oe000504kz21b76mes_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 21e-6,
+          "output": 168e-6,
+          "output_reasoning_tokens": 168e-6,
+          "output_reasoning": 168e-6
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `gpt-5.2` model to OpenAI models and update pricing in `default-model-prices.json`.
> 
>   - **Models**:
>     - Add `gpt-5.2`, `gpt-5.2-2025-12-11`, `gpt-5.2-pro`, and `gpt-5.2-pro-2025-12-11` to `openAIModels` in `types.ts`.
>     - Mark `gpt-5.2-2025-12-11` as a reasoning model in `openAIModelToReasoning`.
>   - **Pricing**:
>     - Add pricing details for `gpt-5.2`, `gpt-5.2-2025-12-11`, `gpt-5.2-pro`, and `gpt-5.2-pro-2025-12-11` in `default-model-prices.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cc3e536506a5c602289c24e2c4f4a683a118f23a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->