### PR TITLE
chore: query dataset_item_version in experiment backfill script

### DIFF
--- a/worker/src/backgroundMigrations/backfillExperimentsHistoric.ts
+++ b/worker/src/backgroundMigrations/backfillExperimentsHistoric.ts
@@ -133,6 +133,7 @@ export default class BackfillExperimentsHistoric
           dri.dataset_run_metadata,
           dri.dataset_id,
           dri.dataset_item_id,
+          dri.dataset_item_version,
           dri.dataset_item_expected_output,
           dri.dataset_item_metadata,
           dri.created_at
@@ -156,6 +157,7 @@ export default class BackfillExperimentsHistoric
           dri.dataset_run_metadata,
           dri.dataset_id,
           dri.dataset_item_id,
+          dri.dataset_item_version,
           dri.dataset_item_expected_output,
           dri.dataset_item_metadata,
           dri.created_at


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `dataset_item_version` to dataset run item queries in `BackfillExperimentsHistoric` class.
> 
>   - **Query Update**:
>     - Add `dri.dataset_item_version` to the SELECT query in `BackfillExperimentsHistoric` class in `backfillExperimentsHistoric.ts`.
>     - Affects both initial and subsequent chunk queries for dataset run items.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 020e42677e9b0a7d8710cf973ced8f1e624ed8de. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->