### PR TITLE
chore: fixing flaky observations-api-v2 test. third time's a charm?

### DIFF
--- a/web/src/__tests__/async/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/async/observations-api-v2.servertest.ts
@@ -272,7 +272,7 @@ describe("/api/public/v2/observations API Endpoint", () => {
 
       await createEventsCh([observation1, observation2]);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await new Promise((resolve) => setTimeout(resolve, 150));
 
       // Focus on testing columns that require joins to other tables
       // (columns from traces table: userId, traceName, sessionId, traceTags, traceEnvironment)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase timeout in `observations-api-v2.servertest.ts` to fix flaky test issues.
> 
>   - **Test Stability**:
>     - Increase timeout in `observations-api-v2.servertest.ts` from 50ms to 150ms to address flaky test issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 83b11876d66e840a60abfacf1dd716629d32a57f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->