### PR TITLE
chore(ui): simplify class names in DatasetRunsTable and FolderBreadcrumbLink components

### DIFF
--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -372,7 +372,7 @@ export function DatasetRunsTable(props: {
             checked={row.getIsSelected()}
             onCheckedChange={(value) => row.toggleSelected(!!value)}
             aria-label="Select row"
-            className="mt-1 opacity-60 data-[state=checked]:mt-[5px]"
+            className="opacity-60"
           />
         );
       },

--- a/web/src/features/folders/components/FolderBreadcrumbLink.tsx
+++ b/web/src/features/folders/components/FolderBreadcrumbLink.tsx
@@ -12,12 +12,11 @@ export const FolderBreadcrumbLink = ({
     <TableLink
       path={""}
       value={name} // To satisfy table-link, fallback
-      className="flex items-center gap-2"
       icon={
-        <>
+        <div className="flex flex-row items-center gap-1">
           <Folder className="h-4 w-4" />
           {name}
-        </>
+        </div>
       }
       onClick={onClick}
       title={name || ""}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplified `className` attributes in `DatasetRunsTable.tsx` and `FolderBreadcrumbLink.tsx` components.
> 
>   - **UI Changes**:
>     - Simplified `className` in `DatasetRunsTable.tsx` by removing `mt-1` and `data-[state=checked]:mt-[5px]` from `Checkbox`.
>     - Simplified `className` in `FolderBreadcrumbLink.tsx` by removing `flex items-center gap-2` from `TableLink`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1de6842fc80de7afb765d1d463e226b41102daf5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->