### PR TITLE
fix(dataset-items): update metadata filter to be case-insensitive

### DIFF
--- a/packages/shared/src/server/repositories/dataset-items.ts
+++ b/packages/shared/src/server/repositories/dataset-items.ts
@@ -1435,7 +1435,9 @@ export async function getDatasetItemsByLatest<
       // STATEFUL: Use raw SQL if search or metadata filters are present
       const hasSearch = props.searchQuery && props.searchQuery !== "";
       const hasMetadataFilter = props.filterState.some(
-        (f) => f.column === "metadata" && f.type === "stringObject",
+        (f) =>
+          (f.column === "metadata" || f.column === "Metadata") &&
+          f.type === "stringObject",
       );
 
       if (hasSearch || hasMetadataFilter) {
@@ -1527,7 +1529,9 @@ export async function getDatasetItemsCountByLatest(props: {
       // STATEFUL: Use raw SQL if search or metadata filters are present
       const hasSearch = props.searchQuery && props.searchQuery !== "";
       const hasMetadataFilter = props.filterState.some(
-        (f) => f.column === "metadata" && f.type === "stringObject",
+        (f) =>
+          (f.column === "metadata" || f.column === "Metadata") &&
+          f.type === "stringObject",
       );
 
       if (hasSearch || hasMetadataFilter) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make metadata filters case-insensitive in `getDatasetItemsByLatest` and `getDatasetItemsCountByLatest`.
> 
>   - **Behavior**:
>     - Update metadata filter in `getDatasetItemsByLatest` and `getDatasetItemsCountByLatest` to be case-insensitive by checking both `metadata` and `Metadata` columns.
>   - **Functions**:
>     - Modify `getDatasetItemsByLatest` to handle case-insensitive metadata filters.
>     - Modify `getDatasetItemsCountByLatest` to handle case-insensitive metadata filters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fc3af8213fcd039085f1605e4f581b9a51ac0271. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->