### PR TITLE
chore(dataset-versioning): remove 'ACTIVE' status filter from dataset item count queries

### DIFF
--- a/packages/shared/src/server/repositories/dataset-items.ts
+++ b/packages/shared/src/server/repositories/dataset-items.ts
@@ -1160,7 +1160,6 @@ function buildDatasetItemsLatestCountGroupedQuery(
       COUNT(*) as count
     FROM latest_items di
     WHERE di.is_deleted = false
-      AND di.status = 'ACTIVE'
     GROUP BY di.dataset_id
   `;
 }
@@ -1368,7 +1367,7 @@ export async function getDatasetItemById<
 
       const statusFilter =
         status === "ACTIVE"
-          ? Prisma.sql`AND status = ${DatasetStatus.ACTIVE}`
+          ? Prisma.sql`AND status = ${DatasetStatus.ACTIVE}::"DatasetStatus"`
           : Prisma.empty;
 
       const result = await prisma.$queryRaw<DatasetItem[]>(

--- a/packages/shared/src/server/repositories/dataset-items.ts
+++ b/packages/shared/src/server/repositories/dataset-items.ts
@@ -1358,8 +1358,8 @@ export async function getDatasetItemById<
     [Implementation.VERSIONED]: async () => {
       // Get latest version using raw SQL with subquery to filter after ordering
       const selectFields = includeIO
-        ? 'id, project_id AS "projectId", dataset_id AS "datasetId", input, expected_output AS "expectedOutput", metadata, source_trace_id AS "sourceTraceId", source_observation_id AS "sourceObservationId", status, created_at AS "createdAt", updated_at AS "updatedAt"'
-        : 'id, project_id AS "projectId", dataset_id AS "datasetId", source_trace_id AS "sourceTraceId", source_observation_id AS "sourceObservationId", status, created_at AS "createdAt", updated_at AS "updatedAt"';
+        ? 'id, project_id AS "projectId", dataset_id AS "datasetId", input, expected_output AS "expectedOutput", metadata, source_trace_id AS "sourceTraceId", source_observation_id AS "sourceObservationId", status, created_at AS "createdAt", updated_at AS "updatedAt, valid_from AS "validFrom"'
+        : 'id, project_id AS "projectId", dataset_id AS "datasetId", source_trace_id AS "sourceTraceId", source_observation_id AS "sourceObservationId", status, created_at AS "createdAt", updated_at AS "updatedAt, valid_from AS "validFrom"';
 
       const datasetFilter = props.datasetId
         ? Prisma.sql`AND dataset_id = ${props.datasetId}`

--- a/packages/shared/src/server/repositories/dataset-items.ts
+++ b/packages/shared/src/server/repositories/dataset-items.ts
@@ -1367,7 +1367,7 @@ export async function getDatasetItemById<
 
       const statusFilter =
         status === "ACTIVE"
-          ? Prisma.sql`AND status = ${DatasetStatus.ACTIVE}::"DatasetStatus"`
+          ? Prisma.sql`AND status = 'ACTIVE'::"DatasetStatus"`
           : Prisma.empty;
 
       const result = await prisma.$queryRaw<DatasetItem[]>(

--- a/web/src/pages/api/public/datasets/[name]/index.ts
+++ b/web/src/pages/api/public/datasets/[name]/index.ts
@@ -44,6 +44,7 @@ export default withMiddlewares({
         projectId: auth.scope.projectId,
         filterState: createDatasetItemFilterState({
           datasetIds: [dataset.id],
+          status: "ACTIVE",
         }),
         includeDatasetName: true,
       });

--- a/web/src/pages/api/public/datasets/[name]/index.ts
+++ b/web/src/pages/api/public/datasets/[name]/index.ts
@@ -44,7 +44,6 @@ export default withMiddlewares({
         projectId: auth.scope.projectId,
         filterState: createDatasetItemFilterState({
           datasetIds: [dataset.id],
-          status: "ACTIVE",
         }),
         includeDatasetName: true,
       });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Removes 'ACTIVE' status filter from dataset item count queries and updates SQL syntax for status filtering in `getDatasetItemById`.
> 
>   - **Behavior**:
>     - Removes 'ACTIVE' status filter from `buildDatasetItemsLatestCountGroupedQuery` in `dataset-items.ts`.
>     - Modifies SQL query in `getDatasetItemById` to use `'ACTIVE'::"DatasetStatus"` for status filtering.
>   - **Misc**:
>     - Adds `valid_from` field to SQL select in `getDatasetItemById` for both cases of `includeIO`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a98d35a4cc10b90306ab0ff84bd0361bed2e89f1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->