### PR TITLE
Revert "chore: read from versioned implementation"

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -276,7 +276,7 @@ const EnvSchema = z.object({
     .default("false"),
   LANGFUSE_DATASET_SERVICE_READ_FROM_VERSIONED_IMPLEMENTATION: z
     .enum(["true", "false"])
-    .default("true"),
+    .default("false"),
 });
 
 export const env: z.infer<typeof EnvSchema> =


### PR DESCRIPTION
Reverts langfuse/langfuse#11056
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts default value of `LANGFUSE_DATASET_SERVICE_READ_FROM_VERSIONED_IMPLEMENTATION` to `false` in `env.ts`.
> 
>   - **Behavior**:
>     - Reverts default value of `LANGFUSE_DATASET_SERVICE_READ_FROM_VERSIONED_IMPLEMENTATION` from `true` to `false` in `env.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a459c4b1245d885b418e1d3066f6bfaacac32973. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->