### PR TITLE
fix(evals): allow creating new evaluators for haiku 4.5

### DIFF
--- a/packages/shared/src/server/llm/testModelCall.ts
+++ b/packages/shared/src/server/llm/testModelCall.ts
@@ -12,13 +12,11 @@ export const testModelCall = async ({
   provider,
   model,
   apiKey,
-  prompt,
   modelConfig,
 }: {
   provider: string;
   model: string;
   apiKey: z.infer<typeof LLMApiKeySchema>;
-  prompt?: string;
   modelConfig?: ModelConfig | null;
 }) => {
   await fetchLLMCompletion({
@@ -28,7 +26,6 @@ export const testModelCall = async ({
       {
         role: ChatMessageRole.User,
         content:
-          prompt ??
           'Extract a score (1-5) and reasoning from this text: "This is a test. It worked perfectly because it matched all passing criteria."',
         type: ChatMessageType.User,
       },

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -789,7 +789,6 @@ export const evalRouter = createTRPCRouter({
           model: modelConfig.config.model,
           apiKey: modelConfig.config.apiKey,
           modelConfig: input.modelParams,
-          prompt: input.prompt,
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : "Unknown error";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `prompt` parameter from `testModelCall` and use default prompt directly in the function.
> 
>   - **Behavior**:
>     - Remove `prompt` parameter from `testModelCall` in `testModelCall.ts` and `router.ts`.
>     - Use default prompt directly in `testModelCall` function.
>   - **Misc**:
>     - Minor refactoring in `testModelCall.ts` to simplify function call.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a3d63fb4d13eb187e93a7bcaa191b18e4b1af57c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->