### PR TITLE
fix(trace): show prompt badge on observations again

### DIFF
--- a/web/src/components/trace2/ObservationPreview.tsx
+++ b/web/src/components/trace2/ObservationPreview.tsx
@@ -44,6 +44,7 @@ import { useRouter } from "next/router";
 import { CopyIdsPopover } from "@/src/components/trace2/components/_shared/CopyIdsPopover";
 import { useJsonExpansion } from "@/src/components/trace2/contexts/JsonExpansionContext";
 import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
+import { PromptBadge } from "@/src/components/trace2/components/_shared/PromptBadge";
 
 export const ObservationPreview = ({
   observations,
@@ -525,29 +526,5 @@ export const ObservationPreview = ({
         </TabsBar>
       </div>
     </div>
-  );
-};
-
-const PromptBadge = (props: { promptId: string; projectId: string }) => {
-  const prompt = api.prompts.byId.useQuery({
-    id: props.promptId,
-    projectId: props.projectId,
-  });
-
-  if (prompt.isLoading || !prompt.data) return null;
-  return (
-    <Link
-      href={`/project/${props.projectId}/prompts/${encodeURIComponent(prompt.data.name)}?version=${prompt.data.version}`}
-      className="inline-flex"
-    >
-      <Badge variant="tertiary">
-        <span className="truncate">
-          Prompt: {prompt.data.name}
-          {" - v"}
-          {prompt.data.version}
-        </span>
-        <ExternalLinkIcon className="ml-1 h-3 w-3" />
-      </Badge>
-    </Link>
   );
 };

--- a/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
@@ -59,6 +59,7 @@ import { AnnotateDrawer } from "@/src/features/scores/components/AnnotateDrawer"
 import { CreateNewAnnotationQueueItem } from "@/src/features/annotation-queues/components/CreateNewAnnotationQueueItem";
 import { CommentDrawerButton } from "@/src/features/comments/CommentDrawerButton";
 import { JumpToPlaygroundButton } from "@/src/features/playground/page/components/JumpToPlaygroundButton";
+import { PromptBadge } from "@/src/components/trace2/components/_shared/PromptBadge";
 import { useTraceData } from "@/src/components/trace2/contexts/TraceDataContext";
 
 export interface ObservationDetailViewProps {
@@ -258,6 +259,12 @@ export function ObservationDetailView({
             />
             <LevelBadge level={observation.level} />
             <StatusMessageBadge statusMessage={observation.statusMessage} />
+            {observation.promptId && (
+              <PromptBadge
+                promptId={observation.promptId}
+                projectId={projectId}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/web/src/components/trace2/components/_shared/PromptBadge.tsx
+++ b/web/src/components/trace2/components/_shared/PromptBadge.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import { ExternalLinkIcon } from "lucide-react";
+import { Badge } from "@/src/components/ui/badge";
+import { api } from "@/src/utils/api";
+
+export const PromptBadge = (props: { promptId: string; projectId: string }) => {
+  const prompt = api.prompts.byId.useQuery({
+    id: props.promptId,
+    projectId: props.projectId,
+  });
+
+  if (prompt.isLoading || !prompt.data) return null;
+
+  return (
+    <Link
+      href={`/project/${props.projectId}/prompts/${encodeURIComponent(prompt.data.name)}?version=${prompt.data.version}`}
+      className="inline-flex"
+    >
+      <Badge variant="tertiary">
+        <span className="truncate">
+          Prompt: {prompt.data.name}
+          {" - v"}
+          {prompt.data.version}
+        </span>
+        <ExternalLinkIcon className="ml-1 h-3 w-3" />
+      </Badge>
+    </Link>
+  );
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reintroduces `PromptBadge` in `ObservationPreview` and `ObservationDetailView` to display prompt information when available.
> 
>   - **Behavior**:
>     - Reintroduces `PromptBadge` in `ObservationPreview` and `ObservationDetailView` to display prompt information when `promptId` is available.
>   - **Components**:
>     - Moves `PromptBadge` to `components/_shared/PromptBadge.tsx` for shared use.
>     - Removes inline `PromptBadge` definition from `ObservationPreview.tsx`.
>   - **Imports**:
>     - Adds `PromptBadge` import to `ObservationPreview.tsx` and `ObservationDetailView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for dfa9301531d70cecbc5372652b4b36222ec81703. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->