### PR TITLE
chore(dataset-versioning): read from versioned implementation

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -276,7 +276,7 @@ const EnvSchema = z.object({
     .default("false"),
   LANGFUSE_DATASET_SERVICE_READ_FROM_VERSIONED_IMPLEMENTATION: z
     .enum(["true", "false"])
-    .default("false"),
+    .default("true"),
 });
 
 export const env: z.infer<typeof EnvSchema> =


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default value of `LANGFUSE_DATASET_SERVICE_READ_FROM_VERSIONED_IMPLEMENTATION` to `true` in `env.ts`.
> 
>   - **Behavior**:
>     - Change default value of `LANGFUSE_DATASET_SERVICE_READ_FROM_VERSIONED_IMPLEMENTATION` to `true` in `env.ts`. This alters the default behavior to read from the versioned implementation of the dataset service.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 542b540a5c717ab2fb2e1b726231c9decfc4af81. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->