### PR TITLE
Relax deployment.environment validation to match OTel semconv

### DIFF
--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -219,15 +219,10 @@ export const UsageDetails = z
 const INTERNAL_ENVIRONMENT_NAME_REGEX_ERROR_MESSAGE =
   "Only alphanumeric lower case characters, hyphens, and underscores are allowed";
 
-const ENVIRONMENT_NAME_REGEX_ERROR_MESSAGE =
-  INTERNAL_ENVIRONMENT_NAME_REGEX_ERROR_MESSAGE +
-  " and it must not start with 'langfuse'";
-
 const PublicEnvironmentName = z
   .string()
   .toLowerCase()
   .max(40, "Maximum length is 40 characters")
-  .regex(/^(?!langfuse)[a-z0-9-_]+$/, ENVIRONMENT_NAME_REGEX_ERROR_MESSAGE)
   .default("default");
 
 const InternalEnvironmentName = z


### PR DESCRIPTION
## Summary
- remove the regex/prefix restriction for public environments so `deployment.environment`/`deployment.environment.name` can be any string (still lowercased and max 40 chars)
- keep lowercasing but allow characters like `:` to align with OTel semantic conventions
- add OTLP trace test that accepts an environment with a colon and lowercases it

## Testing
- not run (CI)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Relax `deployment.environment` validation to allow more characters and align with OTel conventions, with added test for verification.
> 
>   - **Behavior**:
>     - Remove regex/prefix restriction for `deployment.environment` in `types.ts`, allowing any string up to 40 chars, lowercased.
>     - Allow characters like `:` in `deployment.environment` to align with OTel conventions.
>   - **Testing**:
>     - Add test in `otel-api.servertest.ts` to verify acceptance of environment values with colons and ensure they are lowercased.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3872b45698b234276a55eb701d7ddb1bcbf54d7a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->