### PR TITLE
fix: dev-tables.sh should use FINAL modifier to produce a correct set of rows

### DIFF
--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -357,7 +357,7 @@ clickhouse client \
          o.updated_at,
          o.event_ts,
          o.is_deleted
-  FROM observations o
+  FROM observations o FINAL
   LEFT JOIN traces t ON o.trace_id = t.id
   WHERE (o.is_deleted = 0);
   -- Backfill events from traces table as well
@@ -410,7 +410,7 @@ clickhouse client \
          t.updated_at,
          t.event_ts,
          t.is_deleted
-  FROM traces t
+  FROM traces t FINAL
   WHERE (t.is_deleted = 0);
 
 EOF


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `FINAL` modifier to SQL queries in `dev-tables.sh` to ensure correct row set by considering latest data state.
> 
>   - **Behavior**:
>     - Add `FINAL` modifier to `FROM observations o` and `FROM traces t` in `dev-tables.sh` to ensure correct row set by considering latest data state.
>   - **Misc**:
>     - No other changes or additions in the script.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8e3574d385a327db59df0abb0546a0a50a7f5713. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->