### PR TITLE
fix: get rid of extra IN clauses along trace and score deletion paths introduced in #10554

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1111,14 +1111,7 @@ export const deleteObservationsByTraceIds = async (
   const query = `
     DELETE FROM observations
     WHERE project_id = {projectId: String}
-    AND trace_id IN ({traceIds: Array(String)})
-    AND (project_id, type, start_time, id) IN
-    (
-      SELECT project_id, type, start_time, id
-      FROM observations
-      WHERE project_id = {projectId: String}
-      AND trace_id IN ({traceIds: Array(String)})
-    );
+    AND trace_id IN ({traceIds: Array(String)});
   `;
   await commandClickhouse({
     query: query,

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1125,13 +1125,7 @@ export const deleteScoresByTraceIds = async (
   const query = `
     DELETE FROM scores
     WHERE project_id = {projectId: String}
-    AND trace_id IN ({traceIds: Array(String)})
-    AND (project_id, timestamp, name) IN (
-      SELECT project_id, timestamp, name
-      FROM scores
-      WHERE project_id = {projectId: String}
-      AND trace_id IN ({traceIds: Array(String)})
-    );
+    AND trace_id IN ({traceIds: Array(String)});
   `;
   await commandClickhouse({
     query: query,

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -883,16 +883,7 @@ export const deleteTraces = async (projectId: string, traceIds: string[]) => {
       const query = `
         DELETE FROM traces
         WHERE project_id = {projectId: String}
-        AND id IN ({traceIds: Array(String)})
-        AND (project_id, timestamp, id) IN  (
-	        SELECT
-	          project_id,
-	          timestamp,
-	          id
-	        FROM traces
-	        WHERE project_id = {projectId: String}
-	        AND id IN ({traceIds: Array(String)})
-        );
+        AND id IN ({traceIds: Array(String)});
       `;
       await commandClickhouse({
         query: query,


### PR DESCRIPTION
Getting rid of extra IN clauses along trace and score deletion paths introduced in #10554. It doesn't seem to meaningfully speed up deletions while at the same time seem to cause problems once in a while. E.g. ` ALTER UPDATE/ALTER DELETE statement with subquery may be nondeterministic`

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove redundant subqueries in deletion paths for observations, scores, and traces to eliminate non-deterministic behavior.
> 
>   - **Behavior**:
>     - Removed redundant subqueries in `deleteObservationsByTraceIds()` in `observations.ts`, `deleteScoresByTraceIds()` in `scores.ts`, and `deleteTraces()` in `traces.ts`.
>     - Simplified deletion queries to only use `IN` clause for `trace_id` or `id`.
>   - **Performance**:
>     - Eliminated potential non-deterministic behavior caused by subqueries in deletion paths.
>     - No significant performance improvement observed from previous subquery usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8d1e0e512ad9c6488a3eb4c81ad46a146cee086d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->