### PR TITLE
fix(tracing): show input / output label on trace correctly if not ChatML

### DIFF
--- a/web/src/components/trace2/components/IOPreview/IOPreview.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreview.tsx
@@ -164,6 +164,7 @@ export function IOPreview({
     toolCallCounts,
     messageToToolCallNumbers,
     toolNameToDefinitionNumber,
+    inputMessageCount,
   } = useChatMLParser(input, output, metadata, observationName);
 
   // Notify parent about pretty view availability
@@ -251,6 +252,7 @@ export function IOPreview({
               media={media ?? []}
               currentView={selectedView}
               messageToToolCallNumbers={messageToToolCallNumbers}
+              inputMessageCount={inputMessageCount}
             />
           </div>
         ) : (

--- a/web/src/components/trace2/components/IOPreview/components/ChatMessage.tsx
+++ b/web/src/components/trace2/components/IOPreview/components/ChatMessage.tsx
@@ -30,6 +30,7 @@ export interface ChatMessageProps {
   currentView: ViewMode;
   toolCallNumbers?: number[];
   projectIdForPromptButtons?: string;
+  isOutputMessage?: boolean;
 }
 
 /**
@@ -47,6 +48,7 @@ export function ChatMessage({
   currentView,
   toolCallNumbers,
   projectIdForPromptButtons,
+  isOutputMessage,
 }: ChatMessageProps) {
   const [showTableView, setShowTableView] = useState(false);
 
@@ -101,7 +103,7 @@ export function ChatMessage({
     return (
       <div className={cn("transition-colors hover:bg-muted")}>
         <PrettyJsonView
-          title={title || "Output"}
+          title={title || (isOutputMessage ? "Output" : "Input")}
           json={message.json}
           projectIdForPromptButtons={projectIdForPromptButtons}
           currentView={currentView}
@@ -199,7 +201,7 @@ export function ChatMessage({
     return (
       <div className={cn("transition-colors hover:bg-muted")}>
         <PrettyJsonView
-          title={title || "Message"}
+          title={title || (isOutputMessage ? "Output" : "Input")}
           json={message}
           projectIdForPromptButtons={projectIdForPromptButtons}
           currentView={currentView}

--- a/web/src/components/trace2/components/IOPreview/components/ChatMessageList.tsx
+++ b/web/src/components/trace2/components/IOPreview/components/ChatMessageList.tsx
@@ -18,6 +18,7 @@ export interface ChatMessageListProps {
   messageToToolCallNumbers: Map<number, number[]>;
   collapseLongHistory?: boolean;
   projectIdForPromptButtons?: string;
+  inputMessageCount?: number;
 }
 
 /**
@@ -38,6 +39,7 @@ export function ChatMessageList({
   messageToToolCallNumbers,
   collapseLongHistory = true,
   projectIdForPromptButtons,
+  inputMessageCount,
 }: ChatMessageListProps) {
   // Filter messages to only those with renderable content
   const messagesToRender = useMemo(
@@ -74,6 +76,7 @@ export function ChatMessageList({
                   currentView={currentView}
                   toolCallNumbers={messageToToolCallNumbers.get(originalIndex)}
                   projectIdForPromptButtons={projectIdForPromptButtons}
+                  isOutputMessage={originalIndex >= (inputMessageCount ?? 0)}
                 />
                 {/* Show collapse/expand button after first message */}
                 {isCollapsed !== null && originalIndex === 0 && (

--- a/web/src/components/trace2/components/IOPreview/hooks/useChatMLParser.ts
+++ b/web/src/components/trace2/components/IOPreview/hooks/useChatMLParser.ts
@@ -29,6 +29,7 @@ export interface ChatMLParserResult {
   toolCallCounts: Map<string, number>;
   messageToToolCallNumbers: Map<number, number[]>;
   toolNameToDefinitionNumber: Map<string, number>;
+  inputMessageCount: number;
 }
 
 /**
@@ -156,6 +157,7 @@ export function useChatMLParser(
       toolCallCounts,
       messageToToolCallNumbers,
       toolNameToDefinitionNumber,
+      inputMessageCount,
     };
   }, [parsedInput, parsedOutput, parsedMetadata, observationName]);
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes input/output labeling in trace components by using `inputMessageCount` from `useChatMLParser`.
> 
>   - **Behavior**:
>     - Corrects input/output labeling in `ChatMessage` and `ChatMessageList` by using `inputMessageCount` to determine if a message is an output.
>     - Updates `useChatMLParser` to return `inputMessageCount`.
>   - **Components**:
>     - Adds `inputMessageCount` prop to `ChatMessageList` and `ChatMessage`.
>     - Modifies `ChatMessage` to use `isOutputMessage` for title determination.
>   - **Hooks**:
>     - `useChatMLParser` now calculates and returns `inputMessageCount` to differentiate input and output messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bc1118696303bc41b9e77df36261cd9bedf14e27. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->