### PR TITLE
chore(dataset-items): add nullable valid_to col

### DIFF
--- a/packages/shared/prisma/generated/types.ts
+++ b/packages/shared/prisma/generated/types.ts
@@ -449,6 +449,7 @@ export type DatasetItem = {
   updated_at: Generated<Timestamp>;
   sys_id: Generated<string | null>;
   valid_from: Generated<Timestamp>;
+  valid_to: Timestamp | null;
   is_deleted: Generated<boolean>;
 };
 export type DatasetItemEvent = {

--- a/packages/shared/prisma/migrations/20251215233730_dataset_items_add_valid_to/migration.sql
+++ b/packages/shared/prisma/migrations/20251215233730_dataset_items_add_valid_to/migration.sql
@@ -1,5 +1,2 @@
 -- AlterTable
-ALTER TABLE "dataset_items" ADD COLUMN     "valid_to" TIMESTAMP(3);
-
--- RenameIndex
-ALTER INDEX "dataset_item_events_project_id_dataset_id_item_id_created_at_id" RENAME TO "dataset_item_events_project_id_dataset_id_item_id_created_a_idx";
+ALTER TABLE "dataset_items" ADD COLUMN "valid_to" TIMESTAMP(3);

--- a/packages/shared/prisma/migrations/20251215233730_dataset_items_add_valid_to/migration.sql
+++ b/packages/shared/prisma/migrations/20251215233730_dataset_items_add_valid_to/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "dataset_items" ADD COLUMN     "valid_to" TIMESTAMP(3);
+
+-- RenameIndex
+ALTER INDEX "dataset_item_events_project_id_dataset_id_item_id_created_at_id" RENAME TO "dataset_item_events_project_id_dataset_id_item_id_created_a_idx";

--- a/packages/shared/prisma/migrations/20251215233903_dataset_items_add_idx_project_id_valid_to/migration.sql
+++ b/packages/shared/prisma/migrations/20251215233903_dataset_items_add_idx_project_id_valid_to/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "dataset_items_project_id_valid_to_idx" ON "dataset_items"("project_id", "valid_to");

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -631,9 +631,11 @@ model DatasetItem {
   // dataset version cols
   sysId               String?        @default(dbgenerated()) @map("sys_id")
   validFrom           DateTime       @default(now()) @map("valid_from")
+  validTo             DateTime?      @map("valid_to")
   isDeleted           Boolean        @default(false) @map("is_deleted")
 
   @@id([id, projectId, validFrom])
+  @@index([projectId, validTo])
   @@index([projectId, id, validFrom])
   @@index([sourceTraceId], type: Hash)
   @@index([sourceObservationId], type: Hash)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add nullable `valid_to` column to `DatasetItem` and update schema, types, and migrations accordingly.
> 
>   - **Schema Changes**:
>     - Add nullable `valid_to` column to `DatasetItem` in `schema.prisma`.
>     - Update `DatasetItem` type in `types.ts` to include `valid_to` as `Timestamp | null`.
>   - **Database Migrations**:
>     - Add `valid_to` column to `dataset_items` table in `20251215233730_dataset_items_add_valid_to/migration.sql`.
>     - Create index on `project_id` and `valid_to` in `dataset_items` table in `20251215233903_dataset_items_add_idx_project_id_valid_to/migration.sql`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3dbe970925a701c378ad1388e241b52af21e4f09. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->