### PR TITLE
chore(dataset-items): adjust write access patterns to write `valid_to`

### DIFF
--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -1140,6 +1140,7 @@ export const datasetRouter = createTRPCRouter({
             });
           },
           [Implementation.VERSIONED]: async () => {
+            // always creates new dataset; hence no need to invalidate old rows
             await ctx.prisma.datasetItem.createMany({
               data: preparedItems,
             });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adjust dataset item versioning to set `valid_to` on old versions during upsert and delete operations, with corresponding tests and API updates.
> 
>   - **Behavior**:
>     - `upsertDatasetItem` in `dataset-items.ts`: Sets `valid_to` on old version when upserting, then creates a new version.
>     - `deleteDatasetItem` in `dataset-items.ts`: Sets `valid_to` on old version, then creates a delete marker.
>     - `createManyDatasetItems` in `dataset-items.ts`: Sets `valid_to` for existing items when creating new versions in bulk.
>   - **Tests**:
>     - Added tests in `dataset-items-repository.servertest.ts` to verify `valid_to` is set correctly on upsert and delete operations.
>   - **API**:
>     - `dataset-router.ts`: Updated to handle new versioning logic with `valid_to` in dataset item operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a5135148d709aa419a5692ae16907b5b3e1c5113. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->