### PR TITLE
fix: don't expose traces view via API endpoint

### DIFF
--- a/web/src/__tests__/async/metrics-v2-api.servertest.ts
+++ b/web/src/__tests__/async/metrics-v2-api.servertest.ts
@@ -334,7 +334,7 @@ describe("/api/public/v2/metrics API Endpoint", () => {
   });
 
   maybe("Validation - View Support", () => {
-    it("should support traces view", async () => {
+    it("should reject traces view with 400 error - traces not supported in v2 API", async () => {
       const query = {
         view: "traces",
         metrics: [{ measure: "count", aggregation: "count" }],
@@ -342,14 +342,21 @@ describe("/api/public/v2/metrics API Endpoint", () => {
         toTimestamp: new Date().toISOString(),
       };
 
-      const response = await makeZodVerifiedAPICall(
-        GetMetricsV1Response,
+      const response = await makeAPICall(
         "GET",
         `/api/public/v2/metrics?query=${encodeURIComponent(JSON.stringify(query))}`,
       );
 
-      expect(response.status).toBe(200);
-      expect(response.body.data).toBeDefined();
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe("Invalid request data");
+      expect(response.body.error).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: ["query", "view"],
+            message: expect.stringContaining("observations"),
+          }),
+        ]),
+      );
     });
 
     it("should support scores-numeric view", async () => {
@@ -946,288 +953,5 @@ describe("/api/public/v2/metrics API Endpoint", () => {
         expect(foundRow).toBeDefined();
       },
     );
-  });
-
-  maybe("Traces View - V2 Events Table", () => {
-    let testTraceId: string;
-    let traceEventIds: string[];
-    let traceScoreId: string;
-    const nowMs = Date.now();
-    const now = nowMs * 1000; // microseconds
-
-    beforeAll(async () => {
-      if (!hasEvents) return;
-
-      testTraceId = randomUUID();
-      traceEventIds = [randomUUID(), randomUUID()];
-      traceScoreId = randomUUID();
-
-      // Create multiple observations with different tags to test aggregation
-      const traceEvents = [
-        createEvent({
-          id: traceEventIds[0],
-          span_id: traceEventIds[0],
-          trace_id: testTraceId,
-          project_id: projectId,
-          trace_name: "test-trace-v2",
-          type: "GENERATION",
-          name: "observation-1",
-          start_time: now,
-          end_time: now + 1000000, // +1 second
-          user_id: "trace-user-v2",
-          session_id: "trace-session-v2",
-          tags: ["api", "prod"],
-          release: "v2.1.0",
-          version: "1.0",
-          environment: "production",
-          usage_details: { input: 100, output: 50, total: 150 },
-          total_cost: 0.01,
-        }),
-        createEvent({
-          id: traceEventIds[1],
-          span_id: traceEventIds[1],
-          trace_id: testTraceId,
-          project_id: projectId,
-          trace_name: "test-trace-v2",
-          type: "SPAN",
-          name: "observation-2",
-          start_time: now + 500000, // +0.5 seconds
-          end_time: now + 2000000, // +2 seconds
-          user_id: "trace-user-v2",
-          session_id: "trace-session-v2",
-          tags: ["api", "v2"],
-          release: "v2.1.0",
-          usage_details: { input: 200, output: 100, total: 300 },
-          total_cost: 0.02,
-        }),
-      ];
-
-      await createEventsCh(traceEvents);
-
-      // Create a trace-level score
-      await createScoresCh([
-        {
-          id: traceScoreId,
-          trace_id: testTraceId,
-          project_id: projectId,
-          name: "trace-quality",
-          value: 0.95,
-          data_type: "NUMERIC",
-          source: "API",
-          timestamp: now,
-          environment: "production",
-          metadata: { quality: "high" },
-          is_deleted: 0,
-          created_at: now,
-          updated_at: now,
-          event_ts: now,
-        },
-      ]);
-
-      // Wait for ClickHouse to process events and scores
-      await waitForExpect(
-        async () => {
-          const eventsResult = await queryClickhouse<{ count: string }>({
-            query: `SELECT count() as count FROM events WHERE project_id = {projectId: String} AND span_id IN ({ids: Array(String)})`,
-            params: { projectId, ids: traceEventIds },
-          });
-          expect(Number(eventsResult[0]?.count)).toBeGreaterThanOrEqual(
-            traceEventIds.length,
-          );
-        },
-        5000,
-        10,
-      );
-      await waitForExpect(
-        async () => {
-          const scoresResult = await queryClickhouse<{ count: string }>({
-            query: `SELECT count() as count FROM scores WHERE project_id = {projectId: String} AND id IN ({ids: Array(String)})`,
-            params: { projectId, ids: [traceScoreId] },
-          });
-          expect(Number(scoresResult[0]?.count)).toBeGreaterThanOrEqual(1);
-        },
-        5000,
-        10,
-      );
-    });
-
-    it.each([
-      ["name", "test-trace-v2"],
-      ["userId", "trace-user-v2"],
-      ["sessionId", "trace-session-v2"],
-      ["release", "v2.1.0"],
-      ["version", "1.0"],
-      ["environment", "production"],
-    ])("should support %s dimension", async (dimension, expectedValue) => {
-      const query = {
-        view: "traces",
-        dimensions: [{ field: dimension }],
-        metrics: [{ measure: "count", aggregation: "count" }],
-        fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
-        toTimestamp: new Date().toISOString(),
-      };
-
-      const response = await makeZodVerifiedAPICall(
-        GetMetricsV1Response,
-        "GET",
-        `/api/public/v2/metrics?query=${encodeURIComponent(JSON.stringify(query))}`,
-      );
-
-      expect(response.status).toBe(200);
-      expect(response.body.data).toBeDefined();
-
-      const row = response.body.data.find(
-        (r: any) => r[dimension] === expectedValue,
-      );
-      expect(row).toBeDefined();
-      expect(row?.count_count).toBeGreaterThan(0);
-    });
-
-    it("should aggregate tags from all observations in trace", async () => {
-      const query = {
-        view: "traces",
-        dimensions: [{ field: "tags" }],
-        metrics: [{ measure: "count", aggregation: "count" }],
-        fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
-        toTimestamp: new Date().toISOString(),
-      };
-
-      const response = await makeZodVerifiedAPICall(
-        GetMetricsV1Response,
-        "GET",
-        `/api/public/v2/metrics?query=${encodeURIComponent(JSON.stringify(query))}`,
-      );
-
-      expect(response.status).toBe(200);
-      expect(response.body.data).toBeDefined();
-
-      // Tags should be union of all tags from observations: ["api", "prod", "v2"]
-      const traceRow = response.body.data.find(
-        (r: any) => Array.isArray(r.tags) && r.tags.includes("api"),
-      );
-      expect(traceRow).toBeDefined();
-      expect(traceRow?.tags).toContain("api");
-      // Should contain tags from both observations (deduped)
-      expect(traceRow?.tags.length).toBeGreaterThanOrEqual(2);
-    });
-
-    it.each([
-      ["count", "count"],
-      ["observationsCount", "sum"],
-      ["scoresCount", "sum"],
-      ["totalTokens", "sum"],
-      ["totalCost", "sum"],
-      ["latency", "avg"],
-    ])("should support %s measure", async (measure, aggregation) => {
-      const query = {
-        view: "traces",
-        metrics: [{ measure, aggregation }],
-        fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
-        toTimestamp: new Date().toISOString(),
-      };
-
-      const response = await makeZodVerifiedAPICall(
-        GetMetricsV1Response,
-        "GET",
-        `/api/public/v2/metrics?query=${encodeURIComponent(JSON.stringify(query))}`,
-      );
-
-      expect(response.status).toBe(200);
-      expect(response.body.data).toBeDefined();
-      expect(response.body.data.length).toBeGreaterThan(0);
-
-      const metricKey = `${aggregation}_${measure}`;
-      expect(response.body.data[0]).toHaveProperty(metricKey);
-    });
-
-    it("should convert latency from microseconds to milliseconds", async () => {
-      const query = {
-        view: "traces",
-        dimensions: [{ field: "name" }],
-        metrics: [{ measure: "latency", aggregation: "avg" }],
-        filters: [
-          {
-            column: "name",
-            operator: "=",
-            value: "test-trace-v2",
-            type: "string",
-          },
-        ],
-        fromTimestamp: new Date(nowMs - 86400000).toISOString(),
-        toTimestamp: new Date(nowMs + 1000).toISOString(),
-      };
-
-      const response = await makeZodVerifiedAPICall(
-        GetMetricsV1Response,
-        "GET",
-        `/api/public/v2/metrics?query=${encodeURIComponent(JSON.stringify(query))}`,
-      );
-
-      expect(response.status).toBe(200);
-      expect(response.body.data).toBeDefined();
-
-      const traceData = response.body.data.find(
-        (r: any) => r.name === "test-trace-v2",
-      );
-      expect(traceData).toBeDefined();
-
-      // Latency should be in milliseconds (2 seconds based on test data)
-      const avgLatency = traceData?.avg_latency as number;
-      expect(avgLatency).toBeGreaterThan(1000); // At least 1 second
-      expect(avgLatency).toBeLessThan(3000); // Less than 3 seconds
-    });
-
-    it("should count trace-level scores only (not observation-level)", async () => {
-      const query = {
-        view: "traces",
-        metrics: [{ measure: "scoresCount", aggregation: "sum" }],
-        fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
-        toTimestamp: new Date().toISOString(),
-      };
-
-      const response = await makeZodVerifiedAPICall(
-        GetMetricsV1Response,
-        "GET",
-        `/api/public/v2/metrics?query=${encodeURIComponent(JSON.stringify(query))}`,
-      );
-
-      expect(response.status).toBe(200);
-      expect(response.body.data).toBeDefined();
-
-      // Should have trace-level scores counted
-      const totalScores = response.body.data[0]?.sum_scoresCount;
-      expect(totalScores).toBeGreaterThan(0);
-    });
-
-    it("should support multiple dimensions and metrics together", async () => {
-      const query = {
-        view: "traces",
-        dimensions: [{ field: "environment" }, { field: "release" }],
-        metrics: [
-          { measure: "count", aggregation: "count" },
-          { measure: "totalCost", aggregation: "sum" },
-          { measure: "observationsCount", aggregation: "sum" },
-        ],
-        fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
-        toTimestamp: new Date().toISOString(),
-      };
-
-      const response = await makeZodVerifiedAPICall(
-        GetMetricsV1Response,
-        "GET",
-        `/api/public/v2/metrics?query=${encodeURIComponent(JSON.stringify(query))}`,
-      );
-
-      expect(response.status).toBe(200);
-      expect(response.body.data).toBeDefined();
-
-      const prodRow = response.body.data.find(
-        (r: any) => r.environment === "production" && r.release === "v2.1.0",
-      );
-      expect(prodRow).toBeDefined();
-      expect(prodRow?.count_count).toBeGreaterThan(0);
-      expect(prodRow?.sum_totalCost).toBeGreaterThan(0);
-      expect(prodRow?.sum_observationsCount).toBeGreaterThanOrEqual(2);
-    });
   });
 });

--- a/web/src/features/public-api/types/metrics.ts
+++ b/web/src/features/public-api/types/metrics.ts
@@ -6,7 +6,13 @@ import {
 } from "@langfuse/shared";
 import { stringDateTime } from "@langfuse/shared/src/server";
 import { z } from "zod/v4";
-import { dimension, granularities, metric, views } from "@/src/features/query";
+import {
+  dimension,
+  granularities,
+  metric,
+  views,
+  viewsV2,
+} from "@/src/features/query";
 
 /**
  * Query Object Structure
@@ -80,6 +86,66 @@ export const GetMetricsV1Response = z.object({
   data: z.array(z.record(z.string(), z.unknown())),
   // meta: paginationMetaResponseZod,
 });
+
+/**
+ * V2 Query Object Structure - excludes "traces" view
+ */
+export const MetricsQueryObjectV2 = z
+  .object({
+    view: viewsV2,
+    dimensions: z.array(dimension).optional().default([]),
+    metrics: z.array(metric),
+    filters: z.array(singleFilter).optional().default([]),
+    timeDimension: z
+      .object({
+        granularity: granularities,
+      })
+      .nullable()
+      .optional()
+      .default(null),
+    fromTimestamp: z.string().datetime({ offset: true }),
+    toTimestamp: z.string().datetime({ offset: true }),
+    orderBy: z
+      .array(
+        z.object({
+          field: z.string(),
+          direction: z.enum(["asc", "desc"]),
+        }),
+      )
+      .nullable()
+      .optional()
+      .default(null),
+    config: z
+      .object({
+        bins: z.number().int().min(1).max(100).optional(),
+        row_limit: z.number().int().positive().lte(1000).optional(),
+      })
+      .optional(),
+  })
+  .refine(
+    (query) =>
+      new Date(query.fromTimestamp).getTime() <
+      new Date(query.toTimestamp).getTime(),
+    {
+      message: "fromTimestamp must be before toTimestamp",
+    },
+  );
+
+// GET /api/public/v2/metrics
+export const GetMetricsV2Query = z.object({
+  query: z
+    .string()
+    .transform((str) => {
+      try {
+        return JSON.parse(str);
+      } catch (_e) {
+        throw new InvalidRequestError("Invalid JSON in query parameter");
+      }
+    })
+    .pipe(MetricsQueryObjectV2),
+});
+
+export const GetMetricsV2Response = GetMetricsV1Response;
 
 // Get /metrics/daily
 export const GetMetricsDailyV1Query = z.object({

--- a/web/src/features/query/types.ts
+++ b/web/src/features/query/types.ts
@@ -59,6 +59,13 @@ export const views = z.enum([
   // "users",
 ]);
 
+// V2 views - excludes "traces" which is not supported in v2 API
+export const viewsV2 = z.enum([
+  "observations",
+  "scores-numeric",
+  "scores-categorical",
+]);
+
 export const viewVersions = z.enum(["v1", "v2"]);
 export type ViewVersion = z.infer<typeof viewVersions>;
 

--- a/web/src/pages/api/public/v2/metrics.ts
+++ b/web/src/pages/api/public/v2/metrics.ts
@@ -2,8 +2,8 @@ import { withMiddlewares } from "@/src/features/public-api/server/withMiddleware
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import { logger } from "@langfuse/shared/src/server";
 import {
-  GetMetricsV1Query,
-  GetMetricsV1Response,
+  GetMetricsV2Query,
+  GetMetricsV2Response,
 } from "@/src/features/public-api/types/metrics";
 import { executeQuery } from "@/src/features/query/server/queryExecutor";
 
@@ -11,8 +11,8 @@ export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "Get Metrics V2",
     rateLimitResource: "public-api-metrics", // Same rate limit as v1
-    querySchema: GetMetricsV1Query,
-    responseSchema: GetMetricsV1Response,
+    querySchema: GetMetricsV2Query,
+    responseSchema: GetMetricsV2Response,
     fn: async ({ query, auth }) => {
       try {
         const queryParams = query.query;
@@ -28,6 +28,7 @@ export default withMiddlewares({
           auth.scope.projectId,
           queryParams,
           "v2",
+          true /* always enable single-level SELECT optimization for public API v2 */,
         );
 
         return { data: result };


### PR DESCRIPTION
So, while we can support traces view on top of `events` we decided to limit it to backwards compatibility uses for now. All dimensions that used to be exclusive to traces are available on observations now. And, unlike `traces` view we can apply single-level select optimization when running against `observations`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR removes the 'traces' view from the v2 API, updates tests, and optimizes query execution for supported views.
> 
>   - **Behavior**:
>     - Removes support for `traces` view in v2 API, returning a 400 error if requested (`metrics-v2-api.servertest.ts`).
>     - Supports `observations`, `scores-numeric`, and `scores-categorical` views in v2 API (`metrics.ts`, `types.ts`).
>     - Enables single-level SELECT optimization for v2 API queries (`metrics.ts`).
>   - **Tests**:
>     - Updates test `Validation - View Support` to expect 400 error for `traces` view (`metrics-v2-api.servertest.ts`).
>     - Removes extensive traces view tests from `metrics-v2-api.servertest.ts`.
>   - **Types**:
>     - Adds `viewsV2` excluding `traces` to `types.ts`.
>     - Defines `MetricsQueryObjectV2` in `metrics.ts` excluding `traces` view.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 20faf816261a502d65607c338c575f5d7b500ada. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->