### PR TITLE
chore: move clickhouse logs to warning and recreate connections on inserts

### DIFF
--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -107,6 +107,9 @@ export class ClickHouseClientManager {
           idle_socket_ttl: env.CLICKHOUSE_KEEP_ALIVE_IDLE_SOCKET_TTL,
         },
         max_open_connections: env.CLICKHOUSE_MAX_OPEN_CONNECTIONS,
+        log: {
+          level: 3, // WARN
+        },
         clickhouse_settings: {
           // Overwrite async insert settings to tune throughput
           ...(env.CLICKHOUSE_ASYNC_INSERT_MAX_DATA_SIZE

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -461,7 +461,14 @@ export class ClickhouseWriter {
   }): Promise<void> {
     const startTime = Date.now();
 
-    await (ClickhouseWriter.client ?? clickhouseClient())
+    await (
+      ClickhouseWriter.client ??
+      clickhouseClient({
+        keep_alive: {
+          enabled: false,
+        },
+      })
+    )
       .insert({
         table: params.table,
         format: "JSONEachRow",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Set ClickHouse client log level to WARN and disable keep-alive for connections during inserts in `ClickhouseWriter`.
> 
>   - **Logging**:
>     - Set ClickHouse client log level to WARN in `client.ts`.
>   - **Connection Handling**:
>     - Disable keep-alive for connections in `ClickhouseWriter.writeToClickhouse()` in `index.ts` to recreate connections on inserts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e84e5fcae5131f9c1885fac4f95902e8a0bbe43b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->