### PR TITLE
chore(api): update trace colulmn handling on observation API on top of events

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -33,7 +33,6 @@ import {
 } from "../queries/clickhouse-sql/query-fragments";
 import { clickhouseSearchCondition } from "../queries/clickhouse-sql/search";
 import {
-  eventsTableLegacyTraceUiColumnDefinitions,
   eventsTableNativeUiColumnDefinitions,
   eventsTableUiColumnDefinitions,
 } from "../tableMappings/mapEventsTable";
@@ -339,20 +338,9 @@ async function getObservationsFromEventsTableInternal<T>(
   );
 
   // Query optimization: joining traces onto observations is expensive.
-  // Hence, only join if the UI table contains filters on traces.
-  const traceTableFilter = filter.filter((f) =>
-    eventsTableLegacyTraceUiColumnDefinitions.some(
-      (c) => c.uiTableId === f.column || c.uiTableName === f.column,
-    ),
-  );
-  const orderByTraces = orderBy
-    ? eventsTableLegacyTraceUiColumnDefinitions.some(
-        (c) =>
-          c.uiTableId === orderBy.column || c.uiTableName === orderBy.column,
-      )
-    : undefined;
-  const needsTraceJoin =
-    traceTableFilter.length > 0 || orderByTraces || search.query;
+  // Only join if search query requires it.
+  // TODO further optimize by checking if specific trace fields are filtered on.
+  const needsTraceJoin = search.query;
 
   const chOrderBy = orderByToClickhouseSql(
     [orderBy ?? null],
@@ -707,10 +695,7 @@ type PublicApiObservationsQuery = {
 
 function buildObservationsQueryBase(
   opts: PublicApiObservationsQuery,
-  eventsTableUiColumnDefinitions: UiColumnMappings = [
-    ...eventsTableLegacyTraceUiColumnDefinitions,
-    ...eventsTableNativeUiColumnDefinitions,
-  ],
+  columnDefinitions: UiColumnMappings = eventsTableNativeUiColumnDefinitions,
 ): EventsQueryBuilder {
   const { projectId, advancedFilters, ...filterParams } = opts;
 
@@ -719,7 +704,7 @@ function buildObservationsQueryBase(
     { ...filterParams, projectId },
     PUBLIC_API_EVENTS_COLUMN_MAPPING,
     advancedFilters,
-    eventsTableUiColumnDefinitions,
+    columnDefinitions,
   );
 
   // Determine if we need to join traces (check both simple params and advanced filters)
@@ -910,10 +895,10 @@ export const getObservationsV2FromEventsTableForPublicApi = async (
   const { projectId } = opts;
 
   // Build query with filters and common CTEs
-  let queryBuilder = buildObservationsQueryBase(opts, [
-    ...eventsTableLegacyTraceUiColumnDefinitions,
-    ...eventsTableNativeUiColumnDefinitions,
-  ]);
+  let queryBuilder = buildObservationsQueryBase(
+    opts,
+    eventsTableNativeUiColumnDefinitions,
+  );
 
   // Determine which field groups to include
   // If fields are not specified (null), include "default" groups: core + basic

--- a/packages/shared/src/server/tableMappings/mapEventsTable.ts
+++ b/packages/shared/src/server/tableMappings/mapEventsTable.ts
@@ -3,36 +3,6 @@
 
 import { UiColumnMappings } from "../../tableDefinitions";
 
-// TODO
-// Leaving these here for temporary compatibility with legacy traces UI (this may require fixing search condition)
-// user_id should be moved to the main list, and the rest removed.
-export const eventsTableLegacyTraceUiColumnDefinitions: UiColumnMappings = [
-  {
-    uiTableName: "Trace Tags",
-    uiTableId: "traceTags",
-    clickhouseTableName: "traces",
-    clickhouseSelect: "t.tags",
-  },
-  {
-    uiTableName: "User ID",
-    uiTableId: "userId",
-    clickhouseTableName: "traces",
-    clickhouseSelect: 't."user_id"',
-  },
-  {
-    uiTableName: "Trace Name",
-    uiTableId: "traceName",
-    clickhouseTableName: "traces",
-    clickhouseSelect: 't."name"',
-  },
-  {
-    uiTableName: "Trace Environment",
-    uiTableId: "traceEnvironment",
-    clickhouseTableName: "traces",
-    clickhouseSelect: 't."environment"',
-  },
-];
-
 export const eventsTableNativeUiColumnDefinitions: UiColumnMappings = [
   {
     uiTableName: "Environment",
@@ -221,10 +191,39 @@ export const eventsTableNativeUiColumnDefinitions: UiColumnMappings = [
     clickhouseTableName: "events",
     clickhouseSelect: 'e."session_id"',
   },
+  {
+    uiTableName: "Trace Name",
+    uiTableId: "traceName",
+    clickhouseTableName: "events",
+    clickhouseSelect: 'e."trace_name"',
+  },
+  {
+    uiTableName: "User ID",
+    uiTableId: "userId",
+    clickhouseTableName: "events",
+    clickhouseSelect: 'e."user_id"',
+  },
+  {
+    uiTableName: "Trace Tags",
+    uiTableId: "traceTags",
+    clickhouseTableName: "events",
+    clickhouseSelect: 'e."tags"',
+  },
+  {
+    uiTableName: "Tags",
+    uiTableId: "tags",
+    clickhouseTableName: "events",
+    clickhouseSelect: 'e."tags"',
+  },
+  {
+    uiTableName: "Trace Environment",
+    uiTableId: "traceEnvironment",
+    clickhouseTableName: "events",
+    clickhouseSelect: 'e."environment"',
+  },
 ];
 
 export const eventsTableUiColumnDefinitions: UiColumnMappings = [
-  ...eventsTableLegacyTraceUiColumnDefinitions,
   ...eventsTableNativeUiColumnDefinitions,
   // Scores column duplicated to allow renaming column name. Will be removed once session storage cache is outdated
   // Column names are cached in user sessions - changing them breaks existing filters

--- a/web/src/__tests__/async/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/async/observations-api-v2.servertest.ts
@@ -290,11 +290,11 @@ describe("/api/public/v2/observations API Endpoint", () => {
         10,
       );
 
-      // Focus on testing columns that require joins to other tables
-      // (columns from traces table: userId, traceName, sessionId, traceTags, traceEnvironment)
+      // Focus on testing filter columns that may have complex handling
+      // (trace-level fields now read directly from events table: userId, traceName, sessionId, traceTags, traceEnvironment)
       // and score-related columns that may require special handling
       const filterTestCases = [
-        // Trace table columns (require join)
+        // Trace-level fields (now read directly from events table)
         {
           description: "trace field: userId",
           filter: [
@@ -397,7 +397,8 @@ describe("/api/public/v2/observations API Endpoint", () => {
       );
 
       expect(userIdFilterResponse.status).toBe(200);
-      expect(userIdFilterResponse.body.data.length).toEqual(2);
+      // Only observation1 has user_id: "test-user-123"
+      expect(userIdFilterResponse.body.data.length).toEqual(1);
       const userFilteredObs = userIdFilterResponse.body.data.find(
         (obs: any) => obs.id === observationId1,
       );

--- a/web/src/__tests__/async/observations-api.servertest.ts
+++ b/web/src/__tests__/async/observations-api.servertest.ts
@@ -40,6 +40,7 @@ type ObservationData = {
 const createObservationData = (
   useEventsTable: boolean,
   data: ObservationData,
+  trace?: ReturnType<typeof createTrace>,
 ) => {
   const id = data.id ?? randomUUID();
 
@@ -67,6 +68,9 @@ const createObservationData = (
       provided_cost_details: data.provided_cost_details,
       usage_details: data.provided_usage_details,
       cost_details: data.provided_cost_details,
+      // Propagate trace-level fields to events
+      user_id: trace?.user_id ?? null,
+      tags: trace?.tags ?? [],
     });
   } else {
     // For observations table: milliseconds, simpler structure
@@ -98,7 +102,7 @@ const createAndInsertObservations = async (
   await createTracesCh([trace]);
 
   const data = observations.map((obs) =>
-    createObservationData(useEventsTable, obs),
+    createObservationData(useEventsTable, obs, trace),
   );
 
   if (useEventsTable) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updated observation API to handle trace columns directly from events table, removing legacy trace definitions and optimizing query logic.
> 
>   - **Behavior**:
>     - Removed `eventsTableLegacyTraceUiColumnDefinitions` from `events.ts` and `mapEventsTable.ts`.
>     - Updated `getObservationsFromEventsTableInternal()` in `events.ts` to optimize trace joins by relying on search queries.
>     - Modified `buildObservationsQueryBase()` in `events.ts` to use `eventsTableNativeUiColumnDefinitions`.
>   - **Tests**:
>     - Updated `observations-api-v2.servertest.ts` to reflect changes in trace field handling, ensuring trace-level fields are read directly from the events table.
>     - Adjusted test cases in `observations-api.servertest.ts` to verify behavior with both events and observations tables.
>   - **Misc**:
>     - Added trace-level fields to `eventsTableNativeUiColumnDefinitions` in `mapEventsTable.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 19d111f0245a1318fb210361e4cfedb5f4c6c9f2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->