### PR TITLE
fix(trace): advanced json viewer improvements

### DIFF
--- a/web/src/components/trace2/components/IOPreview/IOPreview.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreview.tsx
@@ -45,6 +45,9 @@ export interface IOPreviewProps extends ExpansionStateProps {
   hideInput?: boolean;
   currentView?: ViewMode;
   setIsPrettyViewAvailable?: (value: boolean) => void;
+  // Whether to show metadata section in pretty view (default: false)
+  // JSON view always shows metadata
+  showMetadata?: boolean;
 }
 
 /**
@@ -80,6 +83,7 @@ export function IOPreview({
   onInputExpansionChange,
   onOutputExpansionChange,
   setIsPrettyViewAvailable,
+  showMetadata = false,
 }: IOPreviewProps) {
   const capture = usePostHogClientCapture();
   const [dismissedTraceViewNotifications, setDismissedTraceViewNotifications] =
@@ -158,49 +162,55 @@ export function IOPreview({
       {selectedView === "json" ? (
         <IOPreviewJSON {...sharedProps} />
       ) : (
-        <IOPreviewPretty {...sharedProps} observationName={observationName} />
+        <IOPreviewPretty
+          {...sharedProps}
+          observationName={observationName}
+          showMetadata={showMetadata}
+        />
       )}
 
       {showEmptyState && (
-        <div className="relative mx-2 flex flex-col items-start gap-2 rounded-lg border border-dashed p-4">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="absolute right-1.5 top-1.5 h-5 w-5 p-0"
-            onClick={() => {
-              capture("notification:dismiss_notification", {
-                notification_id: EMPTY_IO_ALERT_ID,
-              });
-              setDismissedTraceViewNotifications((prev) =>
-                prev.includes(EMPTY_IO_ALERT_ID)
-                  ? prev
-                  : [...prev, EMPTY_IO_ALERT_ID],
-              );
-            }}
-            title="Dismiss"
-          >
-            <X className="h-3.5 w-3.5" />
-          </Button>
-          <div className="flex w-full flex-row items-center gap-2 pr-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-accent">
-              <BookOpen className="h-4 w-4 text-muted-foreground" />
+        <div className="py-2">
+          <div className="relative mx-2 flex flex-col items-start gap-2 rounded-lg border border-dashed p-4">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="absolute right-1.5 top-1.5 h-5 w-5 p-0"
+              onClick={() => {
+                capture("notification:dismiss_notification", {
+                  notification_id: EMPTY_IO_ALERT_ID,
+                });
+                setDismissedTraceViewNotifications((prev) =>
+                  prev.includes(EMPTY_IO_ALERT_ID)
+                    ? prev
+                    : [...prev, EMPTY_IO_ALERT_ID],
+                );
+              }}
+              title="Dismiss"
+            >
+              <X className="h-3.5 w-3.5" />
+            </Button>
+            <div className="flex w-full flex-row items-center gap-2 pr-6">
+              <div className="flex h-8 w-8 items-center justify-center rounded-full bg-accent">
+                <BookOpen className="h-4 w-4 text-muted-foreground" />
+              </div>
+              <h3 className="text-sm font-semibold">
+                Looks like this trace didn&apos;t receive an input or output.
+              </h3>
             </div>
-            <h3 className="text-sm font-semibold">
-              Looks like this trace didn&apos;t receive an input or output.
-            </h3>
+            <p className="max-w-sm text-sm text-muted-foreground">
+              Add it in your code to make debugging a lot easier.
+            </p>
+            <ActionButton
+              variant="outline"
+              size="sm"
+              href="https://langfuse.com/faq/all/empty-trace-input-and-output"
+              trackingEventName="notification:click_link"
+              trackingProps={{ notification_id: EMPTY_IO_ALERT_ID }}
+            >
+              View Documentation
+            </ActionButton>
           </div>
-          <p className="max-w-sm text-sm text-muted-foreground">
-            Add it in your code to make debugging a lot easier.
-          </p>
-          <ActionButton
-            variant="outline"
-            size="sm"
-            href="https://langfuse.com/faq/all/empty-trace-input-and-output"
-            trackingEventName="notification:click_link"
-            trackingProps={{ notification_id: EMPTY_IO_ALERT_ID }}
-          >
-            View Documentation
-          </ActionButton>
         </div>
       )}
     </>

--- a/web/src/components/trace2/components/IOPreview/IOPreviewJSON.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreviewJSON.tsx
@@ -65,11 +65,11 @@ export function IOPreviewJSON({
   const showMetadata = !(hideIfNull && !parsedMetadata && !metadata);
 
   // Accordion state: only one section can be expanded at a time
-  // Default to first visible section
-  const defaultExpanded = showInput
-    ? "input"
-    : showOutput
-      ? "output"
+  // Default to output first (as it's crucial for generations), then input
+  const defaultExpanded = showOutput
+    ? "output"
+    : showInput
+      ? "input"
       : showMetadata
         ? "metadata"
         : null;
@@ -78,17 +78,18 @@ export function IOPreviewJSON({
   >(defaultExpanded);
 
   // Ensure expandedSection is always valid (if current is hidden, switch to first visible)
+  // Priority: output > input > metadata
   useEffect(() => {
-    if (expandedSection === "input" && !showInput) {
-      setExpandedSection(
-        showOutput ? "output" : showMetadata ? "metadata" : null,
-      );
-    } else if (expandedSection === "output" && !showOutput) {
+    if (expandedSection === "output" && !showOutput) {
       setExpandedSection(
         showInput ? "input" : showMetadata ? "metadata" : null,
       );
+    } else if (expandedSection === "input" && !showInput) {
+      setExpandedSection(
+        showOutput ? "output" : showMetadata ? "metadata" : null,
+      );
     } else if (expandedSection === "metadata" && !showMetadata) {
-      setExpandedSection(showInput ? "input" : showOutput ? "output" : null);
+      setExpandedSection(showOutput ? "output" : showInput ? "input" : null);
     }
   }, [showInput, showOutput, showMetadata, expandedSection]);
 

--- a/web/src/components/trace2/components/IOPreview/IOPreviewJSON.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreviewJSON.tsx
@@ -55,11 +55,6 @@ export function IOPreviewJSON({
   const outputBgColor = isDark ? "rgb(20, 30, 41)" : "rgb(248, 253, 250)"; // Dark blue-gray vs light green
   const metadataBgColor = isDark ? "rgb(30, 20, 40)" : "rgb(253, 251, 254)"; // Dark purple vs light purple
 
-  // Height constants for accordion layout
-  // AdvancedJsonSection header has minHeight: 38px
-  const HEADER_HEIGHT = 38; // px
-  const BODY_MAX_HEIGHT = `calc(100% - ${HEADER_HEIGHT}px)`;
-
   const showInput = !hideInput && !(hideIfNull && !parsedInput && !input);
   const showOutput = !hideOutput && !(hideIfNull && !parsedOutput && !output);
   const showMetadata = !(hideIfNull && !parsedMetadata && !metadata);
@@ -94,7 +89,7 @@ export function IOPreviewJSON({
   }, [showInput, showOutput, showMetadata, expandedSection]);
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex min-h-0 flex-1 flex-col">
       {showInput && (
         <AdvancedJsonSection
           title="Input"
@@ -109,7 +104,6 @@ export function IOPreviewJSON({
           media={media?.filter((m) => m.field === "input")}
           enableSearch={true}
           searchPlaceholder="Search input"
-          maxHeight={BODY_MAX_HEIGHT}
           hideIfNull={hideIfNull}
           truncateStringsAt={100}
           enableCopy={true}
@@ -132,7 +126,6 @@ export function IOPreviewJSON({
           media={media?.filter((m) => m.field === "output")}
           enableSearch={true}
           searchPlaceholder="Search output"
-          maxHeight={BODY_MAX_HEIGHT}
           hideIfNull={hideIfNull}
           truncateStringsAt={100}
           enableCopy={true}
@@ -157,7 +150,6 @@ export function IOPreviewJSON({
           media={media?.filter((m) => m.field === "metadata")}
           enableSearch={true}
           searchPlaceholder="Search metadata"
-          maxHeight={BODY_MAX_HEIGHT}
           hideIfNull={hideIfNull}
           truncateStringsAt={100}
           enableCopy={true}

--- a/web/src/components/trace2/components/IOPreview/IOPreviewPretty.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreviewPretty.tsx
@@ -155,8 +155,6 @@ export function IOPreviewPretty({
 
   // Determine if markdown is safe to render (content size check)
   const shouldRenderMarkdown = useMemo(() => {
-    const startTime = performance.now();
-
     // Fast byte estimation without expensive JSON.stringify
     // Estimate: count string lengths + rough object overhead
     const estimateSize = (obj: unknown): number => {

--- a/web/src/components/trace2/components/IOPreview/IOPreviewPretty.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreviewPretty.tsx
@@ -90,6 +90,8 @@ export interface IOPreviewPrettyProps extends ExpansionStateProps {
   media?: MediaReturnType[];
   hideOutput?: boolean;
   hideInput?: boolean;
+  // Whether to show metadata section (default: false)
+  showMetadata?: boolean;
 }
 
 /**
@@ -122,6 +124,7 @@ export function IOPreviewPretty({
   outputExpansionState,
   onInputExpansionChange,
   onOutputExpansionChange,
+  showMetadata = false,
 }: IOPreviewPrettyProps) {
   // Use pre-parsed data if available (from useParsedObservation hook),
   // otherwise parse with size/depth limits to prevent UI freeze
@@ -213,6 +216,9 @@ export function IOPreviewPretty({
     onOutputExpansionChange,
   };
 
+  // Determine if metadata should be shown
+  const shouldShowMetadata = showMetadata && parsedMetadata;
+
   return (
     <>
       <SectionToolDefinitions
@@ -235,6 +241,20 @@ export function IOPreviewPretty({
         </div>
       ) : (
         <JsonInputOutputView {...jsonViewProps} />
+      )}
+
+      {/* Metadata Section */}
+      {shouldShowMetadata && (
+        <div className="[&_.io-message-content]:px-2 [&_.io-message-header]:px-2">
+          <PrettyJsonView
+            title="Metadata"
+            json={parsedMetadata}
+            isLoading={isLoading}
+            isParsing={isParsing}
+            media={media?.filter((m) => m.field === "metadata") ?? []}
+            currentView="pretty"
+          />
+        </div>
       )}
     </>
   );

--- a/web/src/components/trace2/components/IOPreview/IOPreviewPretty.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreviewPretty.tsx
@@ -46,7 +46,7 @@ function JsonInputOutputView({
   const showOutput = !hideOutput && !(hideIfNull && !parsedOutput);
 
   return (
-    <div className="[&_.io-message-content]:px-2 [&_.io-message-header]:px-2">
+    <div className="min-h-0 flex-1 overflow-auto [&_.io-message-content]:px-2 [&_.io-message-header]:px-2">
       {showInput && (
         <PrettyJsonView
           title="Input"
@@ -217,10 +217,10 @@ export function IOPreviewPretty({
   };
 
   // Determine if metadata should be shown
-  const shouldShowMetadata = showMetadata && parsedMetadata;
+  const shouldShowMetadata = showMetadata && parsedMetadata !== undefined;
 
   return (
-    <>
+    <div className="min-h-0 flex-1 overflow-auto">
       <SectionToolDefinitions
         tools={allTools}
         toolCallCounts={toolCallCounts}
@@ -256,6 +256,6 @@ export function IOPreviewPretty({
           />
         </div>
       )}
-    </>
+    </div>
   );
 }

--- a/web/src/components/trace2/components/IOPreview/IOPreviewPretty.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreviewPretty.tsx
@@ -46,7 +46,7 @@ function JsonInputOutputView({
   const showOutput = !hideOutput && !(hideIfNull && !parsedOutput);
 
   return (
-    <div className="min-h-0 flex-1 overflow-auto [&_.io-message-content]:px-2 [&_.io-message-header]:px-2">
+    <div className="min-h-0 flex-1 [&_.io-message-content]:px-2 [&_.io-message-header]:px-2">
       {showInput && (
         <PrettyJsonView
           title="Input"
@@ -220,7 +220,7 @@ export function IOPreviewPretty({
   const shouldShowMetadata = showMetadata && parsedMetadata !== undefined;
 
   return (
-    <div className="min-h-0 flex-1 overflow-auto">
+    <div className="min-h-0 flex-1">
       <SectionToolDefinitions
         tools={allTools}
         toolCallCounts={toolCallCounts}

--- a/web/src/components/trace2/components/IOPreview/IOPreviewPretty.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreviewPretty.tsx
@@ -188,20 +188,6 @@ export function IOPreviewPretty({
 
     const shouldRender = totalSize <= MARKDOWN_RENDER_CHARACTER_LIMIT;
 
-    const elapsed = performance.now() - startTime;
-
-    // Performance logging
-    console.log(
-      `[IOPreviewPretty] shouldRenderMarkdown check:`,
-      `\n  - Input size: ${(inputSize / 1024).toFixed(2)}KB`,
-      `\n  - Output size: ${(outputSize / 1024).toFixed(2)}KB`,
-      `\n  - Messages size: ${(messagesSize / 1024).toFixed(2)}KB`,
-      `\n  - Total size: ${(totalSize / 1024).toFixed(2)}KB`,
-      `\n  - Limit: ${(MARKDOWN_RENDER_CHARACTER_LIMIT / 1024).toFixed(2)}KB`,
-      `\n  - Decision: ${shouldRender ? "RENDER MARKDOWN" : "SKIP MARKDOWN"}`,
-      `\n  - Time taken: ${elapsed.toFixed(2)}ms`,
-    );
-
     return shouldRender;
   }, [parsedInput, parsedOutput, allMessages]);
 

--- a/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
@@ -313,7 +313,11 @@ export function ObservationDetailView({
           value="preview"
           className="mt-0 flex max-h-full min-h-0 w-full flex-1"
         >
-          <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden">
+          <div
+            className={`flex min-h-0 w-full flex-1 flex-col ${
+              currentView === "pretty" ? "overflow-auto" : "overflow-hidden"
+            }`}
+          >
             <IOPreview
               key={observation.id}
               observationName={observation.name ?? undefined}

--- a/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
@@ -334,6 +334,7 @@ export function ObservationDetailView({
               onOutputExpansionChange={(exp) =>
                 setFieldExpansion("output", exp)
               }
+              showMetadata
             />
           </div>
         </TabsBarContent>

--- a/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
@@ -313,7 +313,7 @@ export function ObservationDetailView({
           value="preview"
           className="mt-0 flex max-h-full min-h-0 w-full flex-1"
         >
-          <div className="flex w-full flex-col gap-2 overflow-y-auto">
+          <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden">
             <IOPreview
               key={observation.id}
               observationName={observation.name ?? undefined}

--- a/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
+++ b/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
@@ -210,12 +210,20 @@ export function TraceDetailView({
           value="preview"
           className="mt-0 flex max-h-full min-h-0 w-full flex-1"
         >
-          <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden">
-            {/* Tags Section */}
-            <div className="flex-shrink-0 px-2 pt-2 text-sm font-medium">
+          <div
+            className={`flex min-h-0 w-full flex-1 flex-col ${
+              currentView === "pretty" ? "overflow-auto" : "overflow-hidden"
+            }`}
+          >
+            {/* Tags Section - scrolls with content in pretty view, fixed in JSON view */}
+            <div
+              className={`px-2 pt-2 text-sm font-medium ${currentView === "json" ? "flex-shrink-0" : ""}`}
+            >
               Tags
             </div>
-            <div className="flex flex-shrink-0 flex-wrap gap-x-1 gap-y-1 px-2 pb-2">
+            <div
+              className={`flex flex-wrap gap-x-1 gap-y-1 px-2 pb-2 ${currentView === "json" ? "flex-shrink-0" : ""}`}
+            >
               <TagList selectedTags={trace.tags} isLoading={false} />
             </div>
 

--- a/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
+++ b/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
@@ -210,10 +210,12 @@ export function TraceDetailView({
           value="preview"
           className="mt-0 flex max-h-full min-h-0 w-full flex-1"
         >
-          <div className="flex w-full flex-col gap-2 overflow-y-auto">
+          <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden">
             {/* Tags Section */}
-            <div className="px-2 text-sm font-medium">Tags</div>
-            <div className="flex flex-wrap gap-x-1 gap-y-1 px-2">
+            <div className="flex-shrink-0 px-2 pt-2 text-sm font-medium">
+              Tags
+            </div>
+            <div className="flex flex-shrink-0 flex-wrap gap-x-1 gap-y-1 px-2 pb-2">
               <TagList selectedTags={trace.tags} isLoading={false} />
             </div>
 

--- a/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
+++ b/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
@@ -219,7 +219,7 @@ export function TraceDetailView({
               <TagList selectedTags={trace.tags} isLoading={false} />
             </div>
 
-            {/* I/O Preview (includes metadata in JSON view) */}
+            {/* I/O Preview (includes metadata in both views) */}
             <IOPreview
               key={trace.id + "-io"}
               input={trace.input ?? undefined}
@@ -238,6 +238,7 @@ export function TraceDetailView({
               onOutputExpansionChange={(exp) =>
                 setFieldExpansion("output", exp)
               }
+              showMetadata
             />
           </div>
         </TabsBarContent>

--- a/web/src/components/ui/AdvancedJsonSection/AdvancedJsonSection.tsx
+++ b/web/src/components/ui/AdvancedJsonSection/AdvancedJsonSection.tsx
@@ -47,9 +47,6 @@ export interface AdvancedJsonSectionProps {
   /** Callback when section collapse state changes */
   onToggleCollapse?: () => void;
 
-  /** Max height for the JSON viewer */
-  maxHeight?: string;
-
   /** Background color for the JSON viewer body */
   backgroundColor?: string;
 
@@ -94,7 +91,6 @@ export function AdvancedJsonSection({
   parsedData,
   collapsed: controlledCollapsed,
   onToggleCollapse,
-  maxHeight = "500px",
   backgroundColor,
   headerBackgroundColor,
   className,

--- a/web/src/components/ui/AdvancedJsonSection/AdvancedJsonSection.tsx
+++ b/web/src/components/ui/AdvancedJsonSection/AdvancedJsonSection.tsx
@@ -13,7 +13,6 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from "react";
 import {
   ChevronDown,
-  ChevronRight,
   ChevronUp,
   WrapText,
   Minus,
@@ -281,11 +280,6 @@ export function AdvancedJsonSection({
         <AdvancedJsonSectionHeader
           title={
             <div className="flex items-center gap-2">
-              {sectionCollapsed ? (
-                <ChevronRight className="h-4 w-4" />
-              ) : (
-                <ChevronDown className="h-4 w-4" />
-              )}
               <span>{title}</span>
               <span className="text-xs font-normal text-muted-foreground">
                 {totalRowCount} rows{isVirtualized ? " (virtualized)" : ""}
@@ -295,6 +289,7 @@ export function AdvancedJsonSection({
           handleOnCopy={handleCopy}
           backgroundColor={headerBackgroundColor}
           onToggleCollapse={handleToggleSectionCollapse}
+          sectionCollapsed={sectionCollapsed}
           controlButtons={
             <>
               {/* Search */}

--- a/web/src/components/ui/AdvancedJsonSection/AdvancedJsonSection.tsx
+++ b/web/src/components/ui/AdvancedJsonSection/AdvancedJsonSection.tsx
@@ -281,19 +281,11 @@ export function AdvancedJsonSection({
         <AdvancedJsonSectionHeader
           title={
             <div className="flex items-center gap-2">
-              <button
-                onClick={handleToggleSectionCollapse}
-                className="inline-flex items-center justify-center rounded-sm p-0.5 transition-colors hover:bg-accent"
-                aria-label={
-                  sectionCollapsed ? "Expand section" : "Collapse section"
-                }
-              >
-                {sectionCollapsed ? (
-                  <ChevronRight className="h-4 w-4" />
-                ) : (
-                  <ChevronDown className="h-4 w-4" />
-                )}
-              </button>
+              {sectionCollapsed ? (
+                <ChevronRight className="h-4 w-4" />
+              ) : (
+                <ChevronDown className="h-4 w-4" />
+              )}
               <span>{title}</span>
               <span className="text-xs font-normal text-muted-foreground">
                 {totalRowCount} rows{isVirtualized ? " (virtualized)" : ""}
@@ -302,6 +294,7 @@ export function AdvancedJsonSection({
           }
           handleOnCopy={handleCopy}
           backgroundColor={headerBackgroundColor}
+          onToggleCollapse={handleToggleSectionCollapse}
           controlButtons={
             <>
               {/* Search */}

--- a/web/src/components/ui/AdvancedJsonSection/AdvancedJsonSection.tsx
+++ b/web/src/components/ui/AdvancedJsonSection/AdvancedJsonSection.tsx
@@ -264,7 +264,7 @@ export function AdvancedJsonSection({
 
   return (
     <div
-      className={`border-b border-t ${className || ""}`}
+      className={`flex flex-col border-b border-t ${sectionCollapsed ? "" : "min-h-0 overflow-hidden"} ${className || ""}`}
       style={{
         backgroundColor: headerBackgroundColor || backgroundColor,
       }}
@@ -406,12 +406,9 @@ export function AdvancedJsonSection({
       {!sectionCollapsed && (
         <div
           ref={scrollContainerRef}
+          className="min-h-0 flex-1 overflow-auto"
           style={{
-            minHeight: "100px",
-            maxHeight: maxHeight,
-            overflow: "auto", // Single scroll container for both X and Y
             backgroundColor: headerBackgroundColor || backgroundColor,
-            height: "100%",
           }}
         >
           {!hasData ? (

--- a/web/src/components/ui/AdvancedJsonSection/AdvancedJsonSectionHeader.tsx
+++ b/web/src/components/ui/AdvancedJsonSection/AdvancedJsonSectionHeader.tsx
@@ -27,6 +27,9 @@ export interface AdvancedJsonSectionHeaderProps {
 
   /** Background color for the header */
   backgroundColor?: string;
+
+  /** Callback when header title area is clicked (for expand/collapse) */
+  onToggleCollapse?: () => void;
 }
 
 export function AdvancedJsonSectionHeader({
@@ -35,6 +38,7 @@ export function AdvancedJsonSectionHeader({
   handleOnCopy,
   controlButtons,
   backgroundColor,
+  onToggleCollapse,
 }: AdvancedJsonSectionHeaderProps) {
   const [isCopied, setIsCopied] = useState(false);
 
@@ -43,7 +47,18 @@ export function AdvancedJsonSectionHeader({
       className="io-message-header flex flex-row items-center justify-between px-1 py-1 text-sm font-medium capitalize transition-colors group-hover:bg-muted/80"
       style={{ backgroundColor }}
     >
-      <div className="flex items-center gap-2">
+      <div
+        className="flex flex-1 cursor-pointer items-center gap-2"
+        onClick={onToggleCollapse}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggleCollapse?.();
+          }
+        }}
+      >
         {titleIcon}
         {title}
       </div>

--- a/web/src/components/ui/AdvancedJsonSection/AdvancedJsonSectionHeader.tsx
+++ b/web/src/components/ui/AdvancedJsonSection/AdvancedJsonSectionHeader.tsx
@@ -10,7 +10,7 @@
 
 import { useState } from "react";
 import { Button } from "@/src/components/ui/button";
-import { Check, Copy } from "lucide-react";
+import { Check, ChevronDown, ChevronRight, Copy } from "lucide-react";
 
 export interface AdvancedJsonSectionHeaderProps {
   /** Section title (can be string or React node for custom rendering) */
@@ -30,6 +30,9 @@ export interface AdvancedJsonSectionHeaderProps {
 
   /** Callback when header title area is clicked (for expand/collapse) */
   onToggleCollapse?: () => void;
+
+  /** Whether the section is currently collapsed */
+  sectionCollapsed?: boolean;
 }
 
 export function AdvancedJsonSectionHeader({
@@ -39,6 +42,7 @@ export function AdvancedJsonSectionHeader({
   controlButtons,
   backgroundColor,
   onToggleCollapse,
+  sectionCollapsed,
 }: AdvancedJsonSectionHeaderProps) {
   const [isCopied, setIsCopied] = useState(false);
 
@@ -59,6 +63,24 @@ export function AdvancedJsonSectionHeader({
           }
         }}
       >
+        {onToggleCollapse && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleCollapse();
+            }}
+            className="inline-flex items-center justify-center rounded-sm p-0.5 transition-colors hover:bg-accent"
+            aria-label={
+              sectionCollapsed ? "Expand section" : "Collapse section"
+            }
+          >
+            {sectionCollapsed ? (
+              <ChevronRight className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
+          </button>
+        )}
         {titleIcon}
         {title}
       </div>

--- a/web/src/components/ui/AdvancedJsonViewer/AdvancedJsonViewer.tsx
+++ b/web/src/components/ui/AdvancedJsonViewer/AdvancedJsonViewer.tsx
@@ -44,7 +44,7 @@ export function AdvancedJsonViewer({
   matchCounts,
   showLineNumbers = false,
   enableCopy = true,
-  stringWrapMode = "truncate",
+  stringWrapMode = "wrap",
   onStringWrapModeChange: _onStringWrapModeChange,
   truncateStringsAt = 100,
   className,

--- a/web/src/components/ui/AdvancedJsonViewer/SimpleJsonViewer.tsx
+++ b/web/src/components/ui/AdvancedJsonViewer/SimpleJsonViewer.tsx
@@ -42,7 +42,7 @@ export const SimpleJsonViewer = memo(function SimpleJsonViewer({
   matchCounts,
   showLineNumbers = false,
   enableCopy = false,
-  stringWrapMode = "truncate",
+  stringWrapMode = "wrap",
   truncateStringsAt = null,
   onToggleExpansion,
   className,

--- a/web/src/components/ui/AdvancedJsonViewer/VirtualizedJsonViewer.tsx
+++ b/web/src/components/ui/AdvancedJsonViewer/VirtualizedJsonViewer.tsx
@@ -42,7 +42,7 @@ export const VirtualizedJsonViewer = memo(function VirtualizedJsonViewer({
   matchCounts,
   showLineNumbers = false,
   enableCopy = false,
-  stringWrapMode = "truncate",
+  stringWrapMode = "wrap",
   truncateStringsAt = null,
   onToggleExpansion,
   className,

--- a/web/src/components/ui/AdvancedJsonViewer/components/JsonRowFixed.tsx
+++ b/web/src/components/ui/AdvancedJsonViewer/components/JsonRowFixed.tsx
@@ -32,7 +32,7 @@ export function JsonRowFixed({
   searchMatch,
   isCurrentMatch = false,
   onToggleExpansion,
-  stringWrapMode = "truncate",
+  stringWrapMode = "wrap",
   className,
   isToggling = false,
 }: JsonRowFixedProps) {

--- a/web/src/components/ui/AdvancedJsonViewer/components/JsonRowScrollable.tsx
+++ b/web/src/components/ui/AdvancedJsonViewer/components/JsonRowScrollable.tsx
@@ -26,7 +26,7 @@ export interface JsonRowScrollableProps {
 export function JsonRowScrollable({
   row,
   theme,
-  stringWrapMode = "truncate",
+  stringWrapMode = "wrap",
   truncateStringsAt = null,
   matchCount,
   currentMatchIndexInRow,

--- a/web/src/components/ui/AdvancedJsonViewer/components/JsonValue.tsx
+++ b/web/src/components/ui/AdvancedJsonViewer/components/JsonValue.tsx
@@ -16,7 +16,7 @@ export function JsonValue({
   theme,
   isExpandable = false,
   childCount: _childCount,
-  stringWrapMode = "truncate",
+  stringWrapMode = "wrap",
   truncateStringsAt = null,
   highlightStart,
   highlightEnd,

--- a/web/src/components/ui/AdvancedJsonViewer/hooks/useJsonTheme.ts
+++ b/web/src/components/ui/AdvancedJsonViewer/hooks/useJsonTheme.ts
@@ -11,12 +11,13 @@ import { type JSONTheme, type PartialJSONTheme } from "../types";
 
 /**
  * Default light theme
+ * Colors inspired by GitHub's syntax highlighting
  */
 const defaultLightTheme: JSONTheme = {
   background: "hsl(var(--background))",
   foreground: "hsl(var(--foreground))",
-  keyColor: "hsl(var(--foreground))",
-  stringColor: "hsl(var(--foreground))",
+  keyColor: "#0550ae", // Blue for keys (GitHub property color)
+  stringColor: "#0a3069", // Dark blue for strings (GitHub string color)
   numberColor: "#0550ae", // Blue for numbers
   booleanColor: "#0550ae", // Blue for booleans
   nullColor: "hsl(var(--muted-foreground))",
@@ -35,11 +36,14 @@ const defaultLightTheme: JSONTheme = {
 
 /**
  * Default dark theme
+ * Colors inspired by GitHub's dark mode syntax highlighting
  */
 const defaultDarkTheme: JSONTheme = {
   ...defaultLightTheme,
-  numberColor: "#539bf5", // Lighter blue for dark mode
-  booleanColor: "#539bf5",
+  keyColor: "#79c0ff", // Light blue for keys (GitHub dark property color)
+  stringColor: "#a5d6ff", // Lighter blue for strings (GitHub dark string color)
+  numberColor: "#79c0ff", // Light blue for numbers
+  booleanColor: "#79c0ff", // Light blue for booleans
   searchMatchBackground: "rgba(255, 255, 0, 0.2)",
   searchCurrentBackground: "rgba(255, 255, 0, 0.35)",
 };

--- a/web/src/components/ui/AdvancedJsonViewer/hooks/useJsonViewPreferences.ts
+++ b/web/src/components/ui/AdvancedJsonViewer/hooks/useJsonViewPreferences.ts
@@ -14,7 +14,7 @@ export interface JsonViewPreferences {
 }
 
 const DEFAULT_PREFERENCES: JsonViewPreferences = {
-  stringWrapMode: "truncate",
+  stringWrapMode: "wrap",
 };
 
 /**

--- a/web/src/hooks/useParsedTrace.ts
+++ b/web/src/hooks/useParsedTrace.ts
@@ -116,8 +116,6 @@ async function parseTraceData(
   return new Promise<ParsedData>((resolve, reject) => {
     const parseId = `${Date.now()}-${Math.random()}`;
 
-    console.log(`[useParsedTrace] Starting background parse ${parseId}`);
-
     pendingCallbacks.set(parseId, (result) => {
       pendingCallbacks.delete(parseId);
 
@@ -126,10 +124,6 @@ async function parseTraceData(
         reject(new Error(result.error));
         return;
       }
-
-      console.log(
-        `[useParsedTrace] Parse completed in ${result.parseTime?.toFixed(2)}ms`,
-      );
 
       resolve({
         input: result.parsedInput,


### PR DESCRIPTION
## What does this PR do?

This PR addresses feedback on the `AdvancedJSONViewer` by reintroducing syntax highlighting and setting the output section as default visible in the `IOPreviewJSON`.

Fixes #LFE-8106

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [ ] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my PR needs changes to the documentation
- [x] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [ ] I haven't added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-8106](https://linear.app/langfuse/issue/LFE-8106/advanced-json-viewer-improvements)

<a href="https://cursor.com/background-agent?bcId=bc-05b9b38a-74d5-4b28-85d5-2a3571111bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-05b9b38a-74d5-4b28-85d5-2a3571111bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `AdvancedJsonViewer` with syntax highlighting and default output visibility, improving user experience and addressing feedback.
> 
>   - **Behavior**:
>     - Reintroduces syntax highlighting in `AdvancedJsonViewer`.
>     - Sets output section as default visible in `IOPreviewJSON`.
>     - Adds user preference for section expansion in `IOPreviewJSON`.
>   - **Components**:
>     - Updates `IOPreview` to include `showMetadata` prop for both JSON and pretty views.
>     - Modifies `IOPreviewJSON` to handle user preferences for section visibility and content.
>     - Enhances `IOPreviewPretty` to include metadata section.
>   - **UI Enhancements**:
>     - Changes default `stringWrapMode` to `wrap` in `AdvancedJsonViewer` and related components.
>     - Updates theme colors in `useJsonTheme` for better syntax highlighting.
>   - **Misc**:
>     - Fixes layout and overflow issues in `AdvancedJsonSection` and `AdvancedJsonSectionHeader`.
>     - Improves search and navigation in `AdvancedJsonViewer`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9e605b7d2406750fa98593b039201bc505a4e1de. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->