### PR TITLE
fix(otel): parse cost_details for non-Langfuse SDK spans

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -191,8 +191,6 @@ export class OtelIngestionProcessor {
             const events: any[] = [];
 
             for (const scopeSpan of resourceSpan?.scopeSpans ?? []) {
-              const isLangfuseSDKSpans =
-                scopeSpan.scope?.name?.startsWith("langfuse-sdk") ?? false;
               const scopeAttributes = this.extractScopeAttributes(scopeSpan);
               for (const span of scopeSpan?.spans ?? []) {
                 const spanAttributes = this.extractSpanAttributes(span);
@@ -907,7 +905,7 @@ export class OtelIngestionProcessor {
         attributes,
         instrumentationScopeName,
       ),
-      costDetails: this.extractCostDetails(attributes, isLangfuseSDKSpans),
+      costDetails: this.extractCostDetails(attributes),
       input,
       output,
     };

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -352,10 +352,7 @@ export class OtelIngestionProcessor {
                   providedUsageDetails: usageDetails.success
                     ? usageDetails.data
                     : undefined,
-                  providedCostDetails: this.extractCostDetails(
-                    spanAttributes,
-                    isLangfuseSDKSpans,
-                  ),
+                  providedCostDetails: this.extractCostDetails(spanAttributes),
 
                   // Properties
                   tags: this.extractTags(spanAttributes),
@@ -1997,9 +1994,8 @@ export class OtelIngestionProcessor {
 
   private extractCostDetails(
     attributes: Record<string, unknown>,
-    isLangfuseSDKSpan: boolean,
   ): Record<string, unknown> {
-    if (isLangfuseSDKSpan) {
+    if (attributes[LangfuseOtelSpanAttributes.OBSERVATION_COST_DETAILS]) {
       try {
         return JSON.parse(
           attributes[


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Removes `isLangfuseSDKSpans` check to allow parsing of `cost_details` for all spans in `OtelIngestionProcessor`.
> 
>   - **Behavior**:
>     - Removes `isLangfuseSDKSpans` check from `extractCostDetails()` calls in `OtelIngestionProcessor`.
>     - Allows parsing of `cost_details` for all spans, not just Langfuse SDK spans.
>   - **Functions**:
>     - Updates `extractCostDetails()` to no longer require `isLangfuseSDKSpans` parameter.
>   - **Misc**:
>     - Removes `isLangfuseSDKSpans` variable from `processToEvent()` and `processResourceSpan()` methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6a1355aba3b2b465dcbd094cdbfa2b29f7f3a590. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->