### PR TITLE
fix(trace): make the new JSON view beta

### DIFF
--- a/web/src/components/trace2/ObservationPreview.tsx
+++ b/web/src/components/trace2/ObservationPreview.tsx
@@ -73,10 +73,9 @@ export const ObservationPreview = ({
     "view",
     withDefault(StringParam, "preview"),
   );
-  const [currentView, setCurrentView] = useLocalStorage<"pretty" | "json">(
-    "jsonViewPreference",
-    "pretty",
-  );
+  const [currentView, setCurrentView] = useLocalStorage<
+    "pretty" | "json" | "json-beta"
+  >("jsonViewPreference", "pretty");
   const capture = usePostHogClientCapture();
   const [isPrettyViewAvailable, setIsPrettyViewAvailable] = useState(false);
 
@@ -426,7 +425,7 @@ export const ObservationPreview = ({
                   value={currentView}
                   onValueChange={(value) => {
                     capture("trace_detail:io_mode_switch", { view: value });
-                    setCurrentView(value as "pretty" | "json");
+                    setCurrentView(value as "pretty" | "json" | "json-beta");
                   }}
                 >
                   <TabsList className="h-fit py-0.5">
@@ -435,6 +434,12 @@ export const ObservationPreview = ({
                     </TabsTrigger>
                     <TabsTrigger value="json" className="h-fit px-1 text-xs">
                       JSON
+                    </TabsTrigger>
+                    <TabsTrigger
+                      value="json-beta"
+                      className="h-fit px-1 text-xs"
+                    >
+                      JSON Beta
                     </TabsTrigger>
                   </TabsList>
                 </Tabs>
@@ -445,7 +450,11 @@ export const ObservationPreview = ({
             value="preview"
             className="mt-0 flex max-h-full min-h-0 w-full flex-1 pr-2"
           >
-            <div className="mb-2 flex max-h-full min-h-0 w-full flex-col gap-2 overflow-y-auto">
+            <div
+              className={`mb-2 flex max-h-full min-h-0 w-full flex-col gap-2 overflow-y-auto ${
+                currentView === "json-beta" ? "" : "pb-4"
+              }`}
+            >
               <div>
                 <IOPreview
                   key={preloadedObservation.id + "-input"}
@@ -477,7 +486,9 @@ export const ObservationPreview = ({
                     key={preloadedObservation.id + "-status"}
                     title="Status Message"
                     json={preloadedObservation.statusMessage}
-                    currentView={currentView}
+                    currentView={
+                      currentView === "json-beta" ? "pretty" : currentView
+                    }
                   />
                 )}
               </div>
@@ -490,7 +501,9 @@ export const ObservationPreview = ({
                     media={observationMedia.data?.filter(
                       (m) => m.field === "metadata",
                     )}
-                    currentView={currentView}
+                    currentView={
+                      currentView === "json-beta" ? "pretty" : currentView
+                    }
                     externalExpansionState={expansionState.metadata}
                     onExternalExpansionChange={(expansion) =>
                       setFieldExpansion("metadata", expansion)

--- a/web/src/components/trace2/TracePreview.tsx
+++ b/web/src/components/trace2/TracePreview.tsx
@@ -88,10 +88,9 @@ export const TracePreview = ({
     "view",
     withDefault(StringParam, "preview"),
   );
-  const [currentView, setCurrentView] = useLocalStorage<"pretty" | "json">(
-    "jsonViewPreference",
-    "pretty",
-  );
+  const [currentView, setCurrentView] = useLocalStorage<
+    "pretty" | "json" | "json-beta"
+  >("jsonViewPreference", "pretty");
   const [isPrettyViewAvailable, setIsPrettyViewAvailable] = useState(false);
   const isAuthenticatedAndProjectMember = useIsAuthenticatedAndProjectMember(
     trace.projectId,
@@ -350,7 +349,7 @@ export const TracePreview = ({
                     value={currentView}
                     onValueChange={(value) => {
                       capture("trace_detail:io_mode_switch", { view: value });
-                      setCurrentView(value as "pretty" | "json");
+                      setCurrentView(value as "pretty" | "json" | "json-beta");
                     }}
                   >
                     <TabsList className="h-fit py-0.5">
@@ -362,6 +361,12 @@ export const TracePreview = ({
                       </TabsTrigger>
                       <TabsTrigger value="json" className="h-fit px-1 text-xs">
                         JSON
+                      </TabsTrigger>
+                      <TabsTrigger
+                        value="json-beta"
+                        className="h-fit px-1 text-xs"
+                      >
+                        JSON Beta
                       </TabsTrigger>
                     </TabsList>
                   </Tabs>
@@ -371,7 +376,7 @@ export const TracePreview = ({
                     className="ml-auto mr-1 h-fit px-2 py-0.5"
                     value={currentView}
                     onValueChange={(value) => {
-                      setCurrentView(value as "pretty" | "json");
+                      setCurrentView(value as "pretty" | "json" | "json-beta");
                     }}
                   >
                     <TabsList className="h-fit py-0.5">
@@ -383,6 +388,12 @@ export const TracePreview = ({
                       </TabsTrigger>
                       <TabsTrigger value="json" className="h-fit px-1 text-xs">
                         JSON
+                      </TabsTrigger>
+                      <TabsTrigger
+                        value="json-beta"
+                        className="h-fit px-1 text-xs"
+                      >
+                        JSON Beta
                       </TabsTrigger>
                     </TabsList>
                   </Tabs>
@@ -395,7 +406,11 @@ export const TracePreview = ({
             value="preview"
             className="mt-0 flex max-h-full min-h-0 w-full flex-1 pr-2"
           >
-            <div className="mb-2 flex max-h-full min-h-0 w-full flex-col gap-2 overflow-y-auto">
+            <div
+              className={`mb-2 flex max-h-full min-h-0 w-full flex-col gap-2 overflow-y-auto ${
+                currentView === "json-beta" ? "" : "pb-4"
+              }`}
+            >
               <IOPreview
                 key={trace.id + "-io"}
                 input={trace.input ?? undefined}
@@ -426,7 +441,9 @@ export const TracePreview = ({
                   media={
                     traceMedia.data?.filter((m) => m.field === "metadata") ?? []
                   }
-                  currentView={currentView}
+                  currentView={
+                    currentView === "json-beta" ? "pretty" : currentView
+                  }
                   externalExpansionState={expansionState.metadata}
                   onExternalExpansionChange={(expansion) =>
                     setFieldExpansion("metadata", expansion)

--- a/web/src/components/trace2/components/IOPreview/IOPreview.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreview.tsx
@@ -7,6 +7,7 @@ import { type MediaReturnType } from "@/src/features/media/validation";
 
 import { ViewModeToggle, type ViewMode } from "./components/ViewModeToggle";
 import { IOPreviewJSON } from "./IOPreviewJSON";
+import { IOPreviewJSONSimple } from "./IOPreviewJSONSimple";
 import { IOPreviewPretty } from "./IOPreviewPretty";
 import { Button } from "@/src/components/ui/button";
 import { ActionButton } from "@/src/components/ActionButton";
@@ -152,15 +153,18 @@ export function IOPreview({
 
       {/*
        * Conditional rendering based on view mode:
-       * - JSON view: IOPreviewJSON (no ChatML parsing, ~150ms faster)
+       * - JSON Beta view: IOPreviewJSON (advanced viewer with virtualization, search)
+       * - JSON view: IOPreviewJSONSimple (simple react18-json-view, no virtualization)
        * - Pretty view: IOPreviewPretty (with ChatML parsing, markdown, tools)
        *
        * Only render the active view to prevent dual DOM tree construction.
        * Trade-off: scroll/expansion state is lost when toggling views,
        * but this eliminates UI freeze with large observations.
        */}
-      {selectedView === "json" ? (
+      {selectedView === "json-beta" ? (
         <IOPreviewJSON {...sharedProps} />
+      ) : selectedView === "json" ? (
+        <IOPreviewJSONSimple {...sharedProps} />
       ) : (
         <IOPreviewPretty
           {...sharedProps}

--- a/web/src/components/trace2/components/IOPreview/IOPreviewJSONSimple.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreviewJSONSimple.tsx
@@ -1,0 +1,109 @@
+import { useMemo } from "react";
+import { type Prisma, deepParseJson } from "@langfuse/shared";
+import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
+import { type MediaReturnType } from "@/src/features/media/validation";
+import { type ExpansionStateProps } from "./IOPreview";
+
+export interface IOPreviewJSONSimpleProps extends ExpansionStateProps {
+  input?: Prisma.JsonValue;
+  output?: Prisma.JsonValue;
+  metadata?: Prisma.JsonValue;
+  // Pre-parsed data (optional, from useParsedObservation hook for performance)
+  parsedInput?: unknown;
+  parsedOutput?: unknown;
+  parsedMetadata?: unknown;
+  isLoading?: boolean;
+  isParsing?: boolean;
+  hideIfNull?: boolean;
+  media?: MediaReturnType[];
+  hideOutput?: boolean;
+  hideInput?: boolean;
+}
+
+/**
+ * IOPreviewJSONSimple - Renders input/output in legacy JSON view mode.
+ *
+ * Uses PrettyJsonView with currentView="json" which internally uses
+ * the react18-json-view library (JSONView component).
+ *
+ * This is the "stable" JSON view that was used before the AdvancedJsonViewer
+ * was introduced.
+ */
+export function IOPreviewJSONSimple({
+  input,
+  output,
+  metadata,
+  parsedInput,
+  parsedOutput,
+  parsedMetadata,
+  isLoading = false,
+  isParsing = false,
+  hideIfNull = false,
+  hideOutput = false,
+  hideInput = false,
+  media,
+  inputExpansionState,
+  outputExpansionState,
+  onInputExpansionChange,
+  onOutputExpansionChange,
+}: IOPreviewJSONSimpleProps) {
+  // Parse data if not pre-parsed
+  const effectiveInput = useMemo(
+    () => parsedInput ?? deepParseJson(input),
+    [parsedInput, input],
+  );
+  const effectiveOutput = useMemo(
+    () => parsedOutput ?? deepParseJson(output),
+    [parsedOutput, output],
+  );
+  const effectiveMetadata = useMemo(
+    () => parsedMetadata ?? deepParseJson(metadata),
+    [parsedMetadata, metadata],
+  );
+
+  const showInput = !hideInput && !(hideIfNull && !effectiveInput);
+  const showOutput = !hideOutput && !(hideIfNull && !effectiveOutput);
+  const showMetadata = !(hideIfNull && !effectiveMetadata);
+
+  return (
+    <div className="[&_.io-message-content]:px-2 [&_.io-message-header]:px-2">
+      {showInput && (
+        <PrettyJsonView
+          title="Input"
+          json={input}
+          parsedJson={effectiveInput}
+          isLoading={isLoading}
+          isParsing={isParsing}
+          media={media?.filter((m) => m.field === "input") ?? []}
+          currentView="json"
+          externalExpansionState={inputExpansionState}
+          onExternalExpansionChange={onInputExpansionChange}
+        />
+      )}
+      {showOutput && (
+        <PrettyJsonView
+          title="Output"
+          json={output}
+          parsedJson={effectiveOutput}
+          isLoading={isLoading}
+          isParsing={isParsing}
+          media={media?.filter((m) => m.field === "output") ?? []}
+          currentView="json"
+          externalExpansionState={outputExpansionState}
+          onExternalExpansionChange={onOutputExpansionChange}
+        />
+      )}
+      {showMetadata && (
+        <PrettyJsonView
+          title="Metadata"
+          json={metadata}
+          parsedJson={effectiveMetadata}
+          isLoading={isLoading}
+          isParsing={isParsing}
+          media={media?.filter((m) => m.field === "metadata") ?? []}
+          currentView="json"
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/components/trace2/components/IOPreview/components/ViewModeToggle.tsx
+++ b/web/src/components/trace2/components/IOPreview/components/ViewModeToggle.tsx
@@ -1,6 +1,6 @@
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
 
-export type ViewMode = "pretty" | "json";
+export type ViewMode = "pretty" | "json" | "json-beta";
 
 export interface ViewModeToggleProps {
   selectedView: ViewMode;
@@ -27,6 +27,9 @@ export function ViewModeToggle({
           </TabsTrigger>
           <TabsTrigger value="json" className="h-fit px-1 text-xs">
             JSON
+          </TabsTrigger>
+          <TabsTrigger value="json-beta" className="h-fit px-1 text-xs">
+            JSON Beta
           </TabsTrigger>
         </TabsList>
       </Tabs>

--- a/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
@@ -49,6 +49,7 @@ import { IOPreview } from "@/src/components/trace2/components/IOPreview/IOPrevie
 import { useJsonExpansion } from "@/src/components/trace2/contexts/JsonExpansionContext";
 import { useMedia } from "@/src/components/trace2/api/useMedia";
 import { useSelection } from "@/src/components/trace2/contexts/SelectionContext";
+import { useViewPreferences } from "@/src/components/trace2/contexts/ViewPreferencesContext";
 
 // Header action components
 import { CopyIdsPopover } from "@/src/components/trace2/components/_shared/CopyIdsPopover";
@@ -77,8 +78,6 @@ export function ObservationDetailView({
   const {
     selectedTab: globalSelectedTab,
     setSelectedTab: setGlobalSelectedTab,
-    viewPref,
-    setViewPref,
   } = useSelection();
 
   // Map global tab to observation-specific tabs (preview, scores)
@@ -90,8 +89,11 @@ export function ObservationDetailView({
     setGlobalSelectedTab(tab);
   };
 
-  // Map viewPref to currentView format expected by child components
-  const currentView = viewPref === "json" ? "json" : "pretty";
+  // Get jsonViewPreference directly from ViewPreferencesContext for "json-beta" support
+  const { jsonViewPreference, setJsonViewPreference } = useViewPreferences();
+
+  // Map jsonViewPreference to currentView format expected by child components
+  const currentView = jsonViewPreference;
 
   const [isPrettyViewAvailable, setIsPrettyViewAvailable] = useState(true);
 
@@ -287,13 +289,13 @@ export function ObservationDetailView({
           <TabsBarTrigger value="preview">Preview</TabsBarTrigger>
           <TabsBarTrigger value="scores">Scores</TabsBarTrigger>
 
-          {/* View toggle (Formatted/JSON) - show for preview tab when pretty view is available */}
+          {/* View toggle (Formatted/JSON/JSON Beta) - show for preview tab when pretty view is available */}
           {selectedTab === "preview" && isPrettyViewAvailable && (
             <Tabs
               className="ml-auto mr-1 h-fit px-2 py-0.5"
               value={currentView}
               onValueChange={(value) => {
-                setViewPref(value === "json" ? "json" : "formatted");
+                setJsonViewPreference(value as "pretty" | "json" | "json-beta");
               }}
             >
               <TabsList className="h-fit py-0.5">
@@ -302,6 +304,9 @@ export function ObservationDetailView({
                 </TabsTrigger>
                 <TabsTrigger value="json" className="h-fit px-1 text-xs">
                   JSON
+                </TabsTrigger>
+                <TabsTrigger value="json-beta" className="h-fit px-1 text-xs">
+                  JSON Beta
                 </TabsTrigger>
               </TabsList>
             </Tabs>
@@ -315,7 +320,9 @@ export function ObservationDetailView({
         >
           <div
             className={`flex min-h-0 w-full flex-1 flex-col ${
-              currentView === "pretty" ? "overflow-auto" : "overflow-hidden"
+              currentView === "json-beta"
+                ? "overflow-hidden"
+                : "overflow-auto pb-4"
             }`}
           >
             <IOPreview

--- a/web/src/components/trace2/components/TraceLogView/LogViewExpandedContent.tsx
+++ b/web/src/components/trace2/components/TraceLogView/LogViewExpandedContent.tsx
@@ -15,7 +15,7 @@ export interface LogViewExpandedContentProps {
   node: TreeNode;
   traceId: string;
   projectId: string;
-  currentView?: "pretty" | "json";
+  currentView?: "pretty" | "json" | "json-beta";
   /** Optional external expansion state for JSON tree (non-virtualized mode) */
   externalExpansionState?: Record<string, boolean> | boolean;
   /** Callback when expansion state changes (non-virtualized mode) */
@@ -83,7 +83,8 @@ export const LogViewExpandedContent = memo(function LogViewExpandedContent({
       {jsonData && !isLoading && (
         <PrettyJsonView
           json={jsonData}
-          currentView={currentView}
+          // Map "json-beta" to "pretty" for PrettyJsonView since it only supports "pretty" | "json"
+          currentView={currentView === "json-beta" ? "pretty" : currentView}
           isLoading={false}
           showNullValues={false}
           stickyTopLevelKey={false}

--- a/web/src/components/trace2/components/TraceLogView/LogViewToolbar.tsx
+++ b/web/src/components/trace2/components/TraceLogView/LogViewToolbar.tsx
@@ -53,8 +53,8 @@ export interface LogViewToolbarProps {
   onDownloadJson?: () => void;
   /** Whether download/copy uses cached I/O only (doesn't load all) */
   isDownloadCacheOnly?: boolean;
-  /** Current view type (pretty/json) */
-  currentView?: "pretty" | "json";
+  /** Current view type (pretty/json/json-beta) */
+  currentView?: "pretty" | "json" | "json-beta";
   /** Whether indent visualization is enabled */
   indentEnabled?: boolean;
   /** Whether indent toggle is disabled (tree too deep) */
@@ -128,7 +128,7 @@ export const LogViewToolbar = memo(function LogViewToolbar({
         </HoverCard>
       )}
 
-      {/* Search input or spacer (hidden in JSON view) */}
+      {/* Search input or spacer (hidden in JSON dump view) */}
       {currentView === "json" ? (
         <div className="flex-1" />
       ) : (
@@ -145,8 +145,8 @@ export const LogViewToolbar = memo(function LogViewToolbar({
 
       {/* Action buttons */}
       <div className="flex items-center gap-0.5">
-        {/* Indent Toggle - only in formatted view */}
-        {currentView === "pretty" && onToggleIndent && (
+        {/* Indent Toggle - only in table view (pretty or json-beta) */}
+        {currentView !== "json" && onToggleIndent && (
           <HoverCard openDelay={200}>
             <HoverCardTrigger asChild>
               <Button
@@ -181,8 +181,8 @@ export const LogViewToolbar = memo(function LogViewToolbar({
           </HoverCard>
         )}
 
-        {/* Milliseconds Toggle - only in formatted view */}
-        {currentView === "pretty" && onToggleMilliseconds && (
+        {/* Milliseconds Toggle - only in table view (pretty or json-beta) */}
+        {currentView !== "json" && onToggleMilliseconds && (
           <Button
             variant={showMilliseconds ? "default" : "ghost"}
             size="icon"
@@ -198,7 +198,7 @@ export const LogViewToolbar = memo(function LogViewToolbar({
         )}
 
         {/* Expand/Collapse All - show disabled with tooltip when virtualized */}
-        {currentView === "pretty" && onToggleExpandAll && (
+        {currentView !== "json" && onToggleExpandAll && (
           <Tooltip>
             <TooltipTrigger asChild>
               <span>

--- a/web/src/components/trace2/components/TraceLogView/TraceLogView.tsx
+++ b/web/src/components/trace2/components/TraceLogView/TraceLogView.tsx
@@ -56,7 +56,7 @@ import { useLogViewColumns } from "./useLogViewColumns";
 export interface TraceLogViewProps {
   traceId: string;
   projectId: string;
-  currentView?: "pretty" | "json";
+  currentView?: "pretty" | "json" | "json-beta";
 }
 
 // Import configuration constants
@@ -307,22 +307,24 @@ export const TraceLogView = ({
       )}
 
       {/* Table view mode - render as expandable table */}
-      {flatItems.length > 0 && currentView === "pretty" && (
-        <JSONTableView
-          items={flatItems}
-          columns={columns}
-          getItemKey={(item) => item.node.id}
-          expandable
-          renderExpanded={renderExpanded}
-          expandedKeys={expandedKeys}
-          onExpandedKeysChange={setExpandedKeys}
-          virtualized={isVirtualized}
-          overscan={100}
-          collapsedRowHeight={COLLAPSED_ROW_HEIGHT}
-          expandedRowHeight={EXPANDED_ROW_HEIGHT}
-          renderRowPrefix={renderRowPrefix}
-        />
-      )}
+      {/* "json-beta" uses table mode since advanced I/O viewer works in expandable rows */}
+      {flatItems.length > 0 &&
+        (currentView === "pretty" || currentView === "json-beta") && (
+          <JSONTableView
+            items={flatItems}
+            columns={columns}
+            getItemKey={(item) => item.node.id}
+            expandable
+            renderExpanded={renderExpanded}
+            expandedKeys={expandedKeys}
+            onExpandedKeysChange={setExpandedKeys}
+            virtualized={isVirtualized}
+            overscan={100}
+            collapsedRowHeight={COLLAPSED_ROW_HEIGHT}
+            expandedRowHeight={EXPANDED_ROW_HEIGHT}
+            renderRowPrefix={renderRowPrefix}
+          />
+        )}
     </div>
   );
 };

--- a/web/src/components/trace2/contexts/SelectionContext.tsx
+++ b/web/src/components/trace2/contexts/SelectionContext.tsx
@@ -95,8 +95,11 @@ export function SelectionProvider({ children }: SelectionProviderProps) {
     : DEFAULT_TAB;
 
   // Map localStorage JsonViewPreference to ViewPref format
+  // Both "json" and "json-beta" map to "json" ViewPref
   const localStorageViewPref: ViewPref =
-    jsonViewPreference === "json" ? "json" : "formatted";
+    jsonViewPreference === "json" || jsonViewPreference === "json-beta"
+      ? "json"
+      : "formatted";
 
   // View preference: URL param overrides localStorage default
   const viewPref: ViewPref = VALID_PREFS.includes(prefParam as ViewPref)

--- a/web/src/components/trace2/contexts/ViewPreferencesContext.tsx
+++ b/web/src/components/trace2/contexts/ViewPreferencesContext.tsx
@@ -21,8 +21,8 @@ export type LogViewMode = "chronological" | "tree-order";
 /** Log view tree visualization style (only applies in tree-order mode) */
 export type LogViewTreeStyle = "flat" | "indented";
 
-/** JSON view preference (formatted/pretty vs raw JSON) */
-export type JsonViewPreference = "pretty" | "json";
+/** JSON view preference (formatted/pretty vs raw JSON vs advanced JSON beta) */
+export type JsonViewPreference = "pretty" | "json" | "json-beta";
 
 interface ViewPreferencesContextValue {
   showDuration: boolean;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `json-beta` view mode to trace and observation components for advanced JSON viewing with virtualization and search.
> 
>   - **Behavior**:
>     - Adds `json-beta` view mode to `ObservationPreview`, `TracePreview`, `TraceDetailView`, `ObservationDetailView`, and `TraceLogView`.
>     - `json-beta` uses `IOPreviewJSON` for advanced viewing with virtualization and search.
>     - `json` mode now uses `IOPreviewJSONSimple` for simpler rendering.
>     - `json-beta` is mapped to `pretty` in `PrettyJsonView` where unsupported.
>   - **Components**:
>     - Updates `ViewModeToggle` to include `json-beta` option.
>     - Modifies `LogViewToolbar` to hide search in `json` mode and adjust actions for `json-beta`.
>     - Adjusts `LogViewExpandedContent` to handle `json-beta` as `pretty`.
>   - **Contexts**:
>     - Updates `ViewPreferencesContext` to include `json-beta` in `JsonViewPreference`.
>     - Modifies `SelectionContext` to map `json-beta` to `json` for `ViewPref`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bf13400ac95d62cbe53efa75247b7e0fa882b745. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->