### PR TITLE
perf: make batch export part size configurable and reduce default to 10MiB

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -58,6 +58,7 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(24),
+  BATCH_EXPORT_S3_PART_SIZE_MIB: z.coerce.number().min(5).max(100).default(10),
   BATCH_ACTION_EXPORT_ROW_LIMIT: z.coerce.number().positive().default(50_000),
   LANGFUSE_MAX_HISTORIC_EVAL_CREATION_LIMIT: z.coerce
     .number()

--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -206,7 +206,7 @@ export const handleBatchExportJob = async (
       exportOptions[jobDetails.format as BatchExportFileFormat].fileType,
     data: fileStream,
     expiresInSeconds,
-    partSize: 100 * 1024 * 1024, // 100 MB for CSV
+    partSize: env.BATCH_EXPORT_S3_PART_SIZE_MIB * 1024 * 1024,
     queueSize: 4,
   });
 


### PR DESCRIPTION
Reduce default part size for batch exports from 100MiB to 10MiB to increase throughput on clickhouse and avoid connection terminations due to stale sockets.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reduce default batch export part size to 10MiB and make it configurable via `BATCH_EXPORT_S3_PART_SIZE_MIB`.
> 
>   - **Behavior**:
>     - Default batch export part size reduced from 100MiB to 10MiB in `handleBatchExportJob()` in `handleBatchExportJob.ts`.
>     - Part size is now configurable via `BATCH_EXPORT_S3_PART_SIZE_MIB` in `env.ts`, with a range of 5 to 100 MiB.
>   - **Environment**:
>     - Added `BATCH_EXPORT_S3_PART_SIZE_MIB` to `EnvSchema` in `env.ts` with a default of 10 MiB.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 050efbec07205e1fe9f08a98276323bde7c07c63. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->