### PR TITLE
feat(ui): only show tags if tags exist

### DIFF
--- a/web/src/components/trace2/TracePreview.tsx
+++ b/web/src/components/trace2/TracePreview.tsx
@@ -428,10 +428,14 @@ export const TracePreview = ({
                 }
               />
 
-              <div className="px-2 text-sm font-medium">{"Tags"}</div>
-              <div className="flex flex-wrap gap-x-1 gap-y-1 px-2">
-                <TagList selectedTags={trace.tags} isLoading={false} />
-              </div>
+              {trace.tags.length > 0 && (
+                <>
+                  <div className="px-2 text-sm font-medium">{"Tags"}</div>
+                  <div className="flex flex-wrap gap-x-1 gap-y-1 px-2">
+                    <TagList selectedTags={trace.tags} isLoading={false} />
+                  </div>
+                </>
+              )}
 
               <div className="px-2">
                 <PrettyJsonView

--- a/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
+++ b/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
@@ -255,16 +255,20 @@ export function TraceDetailView({
             }`}
           >
             {/* Tags Section - scrolls with content except in JSON Beta (virtualized) */}
-            <div
-              className={`px-2 pt-2 text-sm font-medium ${currentView !== "pretty" ? "flex-shrink-0" : ""}`}
-            >
-              Tags
-            </div>
-            <div
-              className={`flex flex-wrap gap-x-1 gap-y-1 px-2 pb-2 ${currentView !== "pretty" ? "flex-shrink-0" : ""}`}
-            >
-              <TagList selectedTags={trace.tags} isLoading={false} />
-            </div>
+            {trace.tags.length > 0 && (
+              <>
+                <div
+                  className={`px-2 pt-2 text-sm font-medium ${currentView !== "pretty" ? "flex-shrink-0" : ""}`}
+                >
+                  Tags
+                </div>
+                <div
+                  className={`flex flex-wrap gap-x-1 gap-y-1 px-2 pb-2 ${currentView !== "pretty" ? "flex-shrink-0" : ""}`}
+                >
+                  <TagList selectedTags={trace.tags} isLoading={false} />
+                </div>
+              </>
+            )}
 
             {/* I/O Preview (includes metadata in both views) */}
             <IOPreview


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Conditionally render 'Tags' section in `TracePreview` and `TraceDetailView` only if tags exist.
> 
>   - **UI Behavior**:
>     - In `TracePreview` and `TraceDetailView`, the 'Tags' section is now conditionally rendered only if `trace.tags.length > 0`.
>   - **Components**:
>     - Updated `TracePreview` to wrap the 'Tags' section in a conditional block.
>     - Updated `TraceDetailView` to wrap the 'Tags' section in a conditional block.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 936b323d22039c37fb71173c7b2dee47105fe2b8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->