### PR TITLE
fix(datatable): allow filtering by empty string in stringOptions filter

### DIFF
--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -1190,6 +1190,10 @@ export function FilterValueCheckbox({
   // Show "All" when clicking would reverse selection (only one item selected)
   const labelText = checked && totalSelected === 1 ? "All" : "Only";
 
+  // Display placeholder for empty strings to ensure clickable area
+  const displayLabel = label === "" ? "(empty)" : label;
+  const displayTitle = label === "" ? "(empty)" : label;
+
   return (
     <div
       className={cn(
@@ -1216,8 +1220,14 @@ export function FilterValueCheckbox({
         )}
         onClick={onLabelClick}
       >
-        <span className="min-w-0 flex-1 truncate text-xs" title={label}>
-          {label}
+        <span
+          className={cn(
+            "min-w-0 flex-1 truncate text-xs",
+            label === "" && "italic text-muted-foreground",
+          )}
+          title={displayTitle}
+        >
+          {displayLabel}
         </span>
 
         {/* "Only" or "All" indicator when hovering label */}

--- a/web/src/features/filters/components/multi-select.tsx
+++ b/web/src/features/filters/components/multi-select.tsx
@@ -155,15 +155,23 @@ export function MultiSelect({
                     {selectedValues.size} selected
                   </Badge>
                 ) : (
-                  getSelectedOptions().map((option) => (
-                    <Badge
-                      variant="secondary"
-                      key={option.value}
-                      className="rounded-sm px-1 font-normal"
-                    >
-                      {option.displayValue ?? option.value}
-                    </Badge>
-                  ))
+                  getSelectedOptions().map((option) => {
+                    const displayValue =
+                      option.displayValue ??
+                      (option.value === "" ? "(empty)" : option.value);
+                    return (
+                      <Badge
+                        variant="secondary"
+                        key={option.value}
+                        className={cn(
+                          "rounded-sm px-1 font-normal",
+                          option.value === "" && "italic",
+                        )}
+                      >
+                        {displayValue}
+                      </Badge>
+                    );
+                  })
                 )}
               </div>
             </>
@@ -202,6 +210,13 @@ export function MultiSelect({
               {options.map((option) => {
                 if (option.value.length === 0) return;
                 const isSelected = selectedValues.has(option.value);
+                const displayValue =
+                  option.displayValue ??
+                  (option.value === "" ? "(empty)" : option.value);
+                const displayTitle =
+                  option.displayValue ??
+                  (option.value === "" ? "(empty)" : option.value);
+
                 const commandItem = (
                   <InputCommandItem
                     key={option.value}
@@ -226,10 +241,13 @@ export function MultiSelect({
                       <Check className={cn("h-4 w-4")} />
                     </div>
                     <div
-                      className="overflow-x-hidden text-ellipsis whitespace-nowrap"
-                      title={option.displayValue ?? option.value}
+                      className={cn(
+                        "overflow-x-hidden text-ellipsis whitespace-nowrap",
+                        option.value === "" && "italic text-muted-foreground",
+                      )}
+                      title={displayTitle}
                     >
-                      {option.displayValue ?? option.value}
+                      {displayValue}
                     </div>
                     {option.count !== undefined ? (
                       <span className="ml-auto flex h-4 w-4 items-center justify-center pl-1 font-mono text-xs">
@@ -242,7 +260,7 @@ export function MultiSelect({
                 return option.description ? (
                   <PropertyHoverCard
                     key={option.value}
-                    label={option.displayValue ?? option.value}
+                    label={displayValue}
                     description={option.description}
                   >
                     {commandItem}

--- a/web/src/features/filters/lib/filter-query-encoding-decoding.clienttest.ts
+++ b/web/src/features/filters/lib/filter-query-encoding-decoding.clienttest.ts
@@ -367,6 +367,19 @@ describe("Filter Query Encoding & Decoding (Legacy Format)", () => {
         },
       ]);
     });
+
+    it("should decode stringOptions with empty string value", () => {
+      // This URL is generated when filtering for empty trace names (clicking "Only" on empty name)
+      const result = decodeFilters("name;stringOptions;;any of;");
+      expect(result).toEqual([
+        {
+          column: "name",
+          type: "stringOptions",
+          operator: "any of",
+          value: [""],
+        },
+      ]);
+    });
   });
 
   describe("Round-trip consistency", () => {
@@ -424,6 +437,23 @@ describe("Filter Query Encoding & Decoding (Legacy Format)", () => {
       const deserialized = decodeFilters(serialized);
 
       expect(deserialized).toEqual(exclusiveFilters);
+    });
+
+    it("should maintain consistency for stringOptions with empty string value", () => {
+      // This tests filtering by empty trace names (e.g., clicking "Only" on an empty name)
+      const filterWithEmptyString: FilterState = [
+        {
+          column: "name",
+          type: "stringOptions",
+          operator: "any of",
+          value: [""],
+        },
+      ];
+
+      const serialized = encodeFilters(filterWithEmptyString);
+      const deserialized = decodeFilters(serialized);
+
+      expect(deserialized).toEqual(filterWithEmptyString);
     });
 
     it("should maintain consistency for mixed filter types", () => {

--- a/web/src/features/filters/lib/filter-query-encoding.ts
+++ b/web/src/features/filters/lib/filter-query-encoding.ts
@@ -102,7 +102,11 @@ export function decodeFiltersGeneric(query: string): FilterState {
       type === "arrayOptions" ||
       type === "categoryOptions"
     ) {
-      parsedValue = decodedValue ? decodedValue.split("|") : [];
+      parsedValue = decodedValue
+        ? decodedValue.split("|")
+        : decodedValue === ""
+          ? [""] // allow empty strings (i.e, filter for empty trace name)
+          : [decodedValue];
     } else if (type === "boolean") {
       parsedValue = decodedValue === "true";
     } else {


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where the trace filter became unresponsive when attempting to filter by trace names that were empty strings. The "Only" button for these empty string options was not clickable because the label was invisible.

To resolve this, empty string values in the filter UI (both in the sidebar and multi-select dropdown) are now displayed as `(empty)`, styled in italic with a muted foreground color. This provides a visible and clickable area, while ensuring the underlying filter logic continues to use the actual empty string value.

Fixes # LFE-8118

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [ ] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my PR needs changes to the documentation
- [ ] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [ ] I haven't added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

---
Linear Issue: [LFE-8118](https://linear.app/langfuse/issue/LFE-8118/trace-filter-view-unresponsive-unreliable-for-large-tables)

<a href="https://cursor.com/background-agent?bcId=bc-bac818cd-d493-4d88-9e3d-90d093f0d788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bac818cd-d493-4d88-9e3d-90d093f0d788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes filtering by empty strings in UI by displaying them as '(empty)', ensuring visibility and clickability, with updates to encoding/decoding logic and tests.
> 
>   - **Behavior**:
>     - Fixes issue where filtering by empty strings was unresponsive due to invisible labels.
>     - Empty strings now displayed as `(empty)` in `data-table-controls.tsx` and `multi-select.tsx`.
>     - Ensures empty string filters are visible and clickable.
>   - **Encoding/Decoding**:
>     - Updates `decodeFiltersGeneric()` in `filter-query-encoding.ts` to handle empty strings.
>     - Adds test cases for empty string handling in `filter-query-encoding-decoding.clienttest.ts`.
>   - **UI Components**:
>     - Updates `FilterValueCheckbox` in `data-table-controls.tsx` to display `(empty)` for empty string labels.
>     - Updates `MultiSelect` in `multi-select.tsx` to handle empty string options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1f912b2ac02ad24d9faf95bedd7ee031874dd5a3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->