### PR TITLE
fix(ui): trace preview empty state popup layout and visibility

### DIFF
--- a/web/src/components/trace2/components/IOPreview/IOPreview.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreview.tsx
@@ -134,9 +134,14 @@ export function IOPreview({
     onOutputExpansionChange,
   };
 
+  // Only show empty state popup for traces (not observations) when there's no input/output
+  // Check both parsed and raw props since not all callers provide parsedInput/parsedOutput
+  const hasInput = input !== null && input !== undefined;
+  const hasOutput = output !== null && output !== undefined;
   const showEmptyState =
-    (parsedInput === null || parsedInput === undefined) &&
-    (parsedOutput === null || parsedOutput === undefined) &&
+    !hasInput &&
+    !hasOutput &&
+    !observationName && // Only show for traces, not observations
     !isLoading &&
     !hideIfNull &&
     !dismissedTraceViewNotifications.includes(EMPTY_IO_ALERT_ID);

--- a/web/src/components/trace2/components/IOPreview/IOPreviewPretty.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreviewPretty.tsx
@@ -46,7 +46,7 @@ function JsonInputOutputView({
   const showOutput = !hideOutput && !(hideIfNull && !parsedOutput);
 
   return (
-    <div className="min-h-0 flex-1 [&_.io-message-content]:px-2 [&_.io-message-header]:px-2">
+    <div className="[&_.io-message-content]:px-2 [&_.io-message-header]:px-2">
       {showInput && (
         <PrettyJsonView
           title="Input"
@@ -220,7 +220,7 @@ export function IOPreviewPretty({
   const shouldShowMetadata = showMetadata && parsedMetadata !== undefined;
 
   return (
-    <div className="min-h-0 flex-1">
+    <div>
       <SectionToolDefinitions
         tools={allTools}
         toolCallCounts={toolCallCounts}


### PR DESCRIPTION
## What does this PR do?

Fixes # (issue)

2 issues with empty trace input/output popup:
1. when metadata is long, the popup would overlap with metadata in the formatted trace peek view:
<img width="1566" height="1846" alt="image" src="https://github.com/user-attachments/assets/f69fe453-d050-4a55-b70d-4df92c54ccaa" />
This is fixed by removing 

- `min-h-0 flex-1` from IOPreviewPretty's outer container
- `min-h-0 flex-1` from JsonInputOutputView's container 

2. the popup would also show on the observation view in the annotation queue:
<img width="3328" height="1128" alt="CleanShot 2025-12-17 at 11 25 15@2x" src="https://github.com/user-attachments/assets/59329760-da52-46a8-a91d-ae653ba4541c" />
This is fixed by also checking that the IOPreview is being used to render a trace (and not an observation)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes layout and context issues with trace input/output popup in `IOPreview.tsx` and `IOPreviewPretty.tsx`.
> 
>   - **Behavior**:
>     - Fixes layout issue in `IOPreviewPretty.tsx` by removing `min-h-0 flex-1` from outer container to prevent overlap with metadata.
>     - Prevents empty trace popup from showing in observation view by checking `observationName` in `IOPreview.tsx`.
>   - **UI Components**:
>     - Adjusts `JsonInputOutputView` and `IOPreviewPretty` containers to remove `min-h-0 flex-1` class for better layout handling.
>     - Adds logic in `IOPreview` to ensure empty state popup only shows for traces, not observations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2ebc5eb18eef4b419ecb79bdadc0628df9358878. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->