### PR TITLE
fix(api): enforce row_limit on metrics endpoints

### DIFF
--- a/web/src/__tests__/queryBuilder.servertest.ts
+++ b/web/src/__tests__/queryBuilder.servertest.ts
@@ -3221,6 +3221,65 @@ describe("queryBuilder", () => {
         expect(totalCount).toBe(30); // Should match our 30 observations
       });
 
+      it("should apply row_limit to query results", async () => {
+        // Setup
+        const projectId = randomUUID();
+
+        // Create a trace with multiple observations
+        const trace = createTrace({
+          project_id: projectId,
+          name: "test-trace",
+          environment: "default",
+          timestamp: new Date().getTime(),
+        });
+
+        // Create 10 observations with different names to test row limiting
+        const observations = Array.from({ length: 10 }, (_, i) =>
+          createObservation({
+            project_id: projectId,
+            trace_id: trace.id,
+            type: "generation",
+            name: `observation-${i}`,
+            environment: "default",
+            start_time: new Date().getTime() + i * 1000,
+          }),
+        );
+
+        await createTracesCh([trace]);
+        await createObservationsCh(observations);
+
+        // Query with row_limit
+        const query: QueryType = {
+          view: "observations",
+          dimensions: [{ field: "name" }],
+          metrics: [{ measure: "count", aggregation: "count" }],
+          filters: [],
+          timeDimension: null,
+          fromTimestamp: new Date(
+            new Date().setDate(new Date().getDate() - 1),
+          ).toISOString(),
+          toTimestamp: new Date(
+            new Date().setDate(new Date().getDate() + 1),
+          ).toISOString(),
+          orderBy: [{ field: "name", direction: "asc" }],
+          chartConfig: { type: "TABLE", row_limit: 5 },
+        };
+
+        // Verify the generated SQL contains LIMIT clause
+        const queryBuilder = new QueryBuilder(query.chartConfig);
+        const { query: compiledQuery } = await queryBuilder.build(
+          query,
+          projectId,
+        );
+        expect(compiledQuery).toContain("LIMIT 5");
+
+        // Execute query and verify row limit is applied
+        const result = await executeQuery(projectId, query);
+
+        // Should return only 5 rows despite having 10 observations
+        expect(result).toHaveLength(5);
+      });
+
       it("should format startTimeMonth dimension correctly", async () => {
         // Setup
         const projectId = randomUUID();

--- a/web/src/features/query/server/queryExecutor.ts
+++ b/web/src/features/query/server/queryExecutor.ts
@@ -76,7 +76,12 @@ export async function executeQuery(
   version: ViewVersion = "v1",
   enableSingleLevelOptimization: boolean = false,
 ): Promise<Array<Record<string, unknown>>> {
-  const queryBuilder = new QueryBuilder(query.chartConfig, version);
+  // Remap config to chartConfig for public API compatibility
+  // Public API uses "config" while internal QueryType uses "chartConfig"
+  const chartConfig =
+    (query as unknown as { config?: QueryType["chartConfig"] }).config ??
+    query.chartConfig;
+  const queryBuilder = new QueryBuilder(chartConfig, version);
 
   // Build the primary query (with or without optimization based on flag)
   const { query: compiledQuery, parameters } = await queryBuilder.build(

--- a/web/src/pages/api/public/v2/metrics.ts
+++ b/web/src/pages/api/public/v2/metrics.ts
@@ -7,6 +7,8 @@ import {
 } from "@/src/features/public-api/types/metrics";
 import { executeQuery } from "@/src/features/query/server/queryExecutor";
 
+const DEFAULT_ROW_LIMIT = 100;
+
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
     name: "Get Metrics V2",
@@ -15,7 +17,14 @@ export default withMiddlewares({
     responseSchema: GetMetricsV2Response,
     fn: async ({ query, auth }) => {
       try {
-        const queryParams = query.query;
+        const queryParams = {
+          ...query.query,
+          // Apply default row_limit if not specified
+          config: {
+            ...query.query.config,
+            row_limit: query.query.config?.row_limit ?? DEFAULT_ROW_LIMIT,
+          },
+        };
 
         logger.info("Received v2 metrics query", {
           query: queryParams,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enforces a default row limit of 100 on metrics endpoints, allowing custom limits, and updates query execution to respect these limits.
> 
>   - **Behavior**:
>     - Enforces default `row_limit` of 100 in `metrics.ts` if not specified in the query.
>     - Allows custom `row_limit` in queries, overriding the default.
>   - **Query Execution**:
>     - Modifies `executeQuery` in `queryExecutor.ts` to use `chartConfig` for `row_limit`.
>     - Adds `buildLimitClause()` in `QueryBuilder` in `queryBuilder.ts` to append `LIMIT` clause to SQL queries.
>   - **Tests**:
>     - Adds tests in `metrics-v2-api.servertest.ts` to verify default and custom `row_limit` behavior.
>     - Adds test in `queryBuilder.servertest.ts` to check `LIMIT` clause in generated SQL.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d4bf478961502f56683091b8091a06fefe0a2d22. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->