### PR TITLE
fix(datasets): set default order condition to show most recent datasets first

### DIFF
--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -152,7 +152,7 @@ const generateDatasetQuery = ({
 
   // Common ORDER BY and LIMIT clauses
   const orderAndLimit = Prisma.sql`
-   ${orderCondition.sql ? Prisma.sql`ORDER BY datasets.sort_priority, ${Prisma.raw(orderCondition.sql.replace(/ORDER BY /i, ""))}` : Prisma.empty}
+   ${orderCondition.sql ? Prisma.sql`ORDER BY d.sort_priority, ${Prisma.raw(orderCondition.sql.replace(/ORDER BY /i, ""))}` : Prisma.empty}
    LIMIT ${limit} OFFSET ${page * limit}`;
 
   if (pathPrefix) {
@@ -346,6 +346,7 @@ export const datasetRouter = createTRPCRouter({
             pathFilter, // SQL WHERE clause: filters DB to only datasets in current folder, derived from prefix.
             pathPrefix: input.pathPrefix, // Raw folder path: used for segment splitting & folder detection logic
             searchFilter,
+            orderCondition: Prisma.sql`ORDER BY d.created_at DESC`,
           }),
         ),
         // datasetCount


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default dataset order to show most recent first by ordering by `created_at` in descending order in `dataset-router.ts`.
> 
>   - **Behavior**:
>     - Default order condition in `generateDatasetQuery` in `dataset-router.ts` changed to order datasets by `created_at` in descending order.
>     - Affects dataset listing queries to show most recent datasets first.
>   - **Code**:
>     - Modified `orderCondition` in `generateDatasetQuery` to `ORDER BY d.created_at DESC`.
>     - Adjusted SQL query logic to reflect new default ordering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e60a1934ccf637c1a24de4d65f259e5492a1d2eb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->