### PR TITLE
chore: extend invalid observation logging errors

### DIFF
--- a/worker/src/queues/otelIngestionQueue.ts
+++ b/worker/src/queues/otelIngestionQueue.ts
@@ -170,7 +170,7 @@ export const otelIngestionQueueProcessor: Processor = async (
       .map((o) => ingestionSchema.safeParse(o))
       .flatMap((o) => {
         if (!o.success) {
-          logger.warn(`Failed to parse otel observation: ${o.error}`, o.error);
+          logger.warn(`Failed to parse otel observation for project ${projectId} in ${fileKey}: ${o.error}`, o.error);
           return [];
         }
         return [o.data];

--- a/worker/src/queues/otelIngestionQueue.ts
+++ b/worker/src/queues/otelIngestionQueue.ts
@@ -170,7 +170,10 @@ export const otelIngestionQueueProcessor: Processor = async (
       .map((o) => ingestionSchema.safeParse(o))
       .flatMap((o) => {
         if (!o.success) {
-          logger.warn(`Failed to parse otel observation for project ${projectId} in ${fileKey}: ${o.error}`, o.error);
+          logger.warn(
+            `Failed to parse otel observation for project ${projectId} in ${fileKey}: ${o.error}`,
+            o.error,
+          );
           return [];
         }
         return [o.data];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Extend logging in `otelIngestionQueueProcessor` to include `projectId` and `fileKey` for failed otel observation parsing.
> 
>   - **Logging**:
>     - Extend logging in `otelIngestionQueueProcessor` to include `projectId` and `fileKey` when parsing otel observations fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5f535f8cebc6467c93b5bb54806dc7a82b6b9085. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->