### PR TITLE
fix(trace): align media label

### DIFF
--- a/web/src/components/trace2/components/IOPreview/components/SectionMedia.tsx
+++ b/web/src/components/trace2/components/IOPreview/components/SectionMedia.tsx
@@ -16,9 +16,7 @@ export function SectionMedia({ media }: SectionMediaProps) {
 
   return (
     <>
-      <div className="mx-3 border-t px-2 py-1 text-xs text-muted-foreground">
-        Media
-      </div>
+      <div className="my-1 px-2 py-1 text-xs text-muted-foreground">Media</div>
       <div className="flex flex-wrap gap-2 p-4 pt-1">
         {media.map((m) => (
           <LangfuseMediaView

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -137,7 +137,7 @@ export function JSONView(props: {
       </div>
       {props.media && props.media.length > 0 && (
         <>
-          <div className="mx-3 border-t px-2 py-1 text-xs text-muted-foreground">
+          <div className="my-1 px-0 py-1 text-xs text-muted-foreground">
             Media
           </div>
           <div className="flex flex-wrap gap-2 p-4 pt-1">

--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -1223,7 +1223,7 @@ export function PrettyJsonView(props: {
       )}
       {props.media && props.media.length > 0 && isPrettyView && (
         <>
-          <div className="mx-3 border-t px-2 py-1 text-xs text-muted-foreground">
+          <div className="my-1 px-2 py-1 text-xs text-muted-foreground">
             Media
           </div>
           <div className="flex flex-wrap gap-2 p-4 pt-1">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjusts the styling of the 'Media' label in `SectionMedia.tsx`, `CodeJsonViewer.tsx`, and `PrettyJsonView.tsx` for improved alignment.
> 
>   - **Styling Adjustments**:
>     - In `SectionMedia.tsx`, `CodeJsonViewer.tsx`, and `PrettyJsonView.tsx`, the `Media` label's styling is adjusted.
>     - Replaces `mx-3 border-t` with `my-1` for margin adjustments.
>     - In `CodeJsonViewer.tsx`, changes `px-2` to `px-0` for padding adjustment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 309ef043392ab41b4109f60d91e3648cc5314897. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->