### PR TITLE
fix(api): prevent v2/metrics from accepting hight cardinality dimensions

### DIFF
--- a/web/src/features/query/types.ts
+++ b/web/src/features/query/types.ts
@@ -21,6 +21,7 @@ export const viewDeclaration = z.object({
       type: z.string().optional(),
       unit: z.string().optional(),
       aggregationFunction: z.string().optional(),
+      highCardinality: z.boolean().optional(),
     }),
   ),
   measures: z.record(

--- a/web/src/pages/api/public/v2/metrics.ts
+++ b/web/src/pages/api/public/v2/metrics.ts
@@ -6,8 +6,35 @@ import {
   GetMetricsV2Response,
 } from "@/src/features/public-api/types/metrics";
 import { executeQuery } from "@/src/features/query/server/queryExecutor";
+import { getViewDeclaration } from "@/src/features/query/dataModel";
+import { InvalidRequestError } from "@langfuse/shared";
 
 const DEFAULT_ROW_LIMIT = 100;
+
+/**
+ * Validates that no high cardinality dimensions are used in the query.
+ * High cardinality dimensions (id, traceId, userId, sessionId, etc.) are not
+ * supported in the v2 metrics API as they can cause performance issues.
+ */
+function validateNoHighCardinalityDimensions(queryParams: {
+  view: string;
+  dimensions?: Array<{ field: string }>;
+}): void {
+  if (!queryParams.dimensions || queryParams.dimensions.length === 0) {
+    return;
+  }
+
+  const view = getViewDeclaration(queryParams.view as any, "v2");
+
+  for (const dimension of queryParams.dimensions) {
+    const dim = view.dimensions[dimension.field];
+    if (dim?.highCardinality) {
+      throw new InvalidRequestError(
+        `Dimension '${dimension.field}' has high cardinality and is not supported in v2 metrics API. Use filters instead.`,
+      );
+    }
+  }
+}
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
@@ -25,6 +52,9 @@ export default withMiddlewares({
             row_limit: query.query.config?.row_limit ?? DEFAULT_ROW_LIMIT,
           },
         };
+
+        // Validate no high cardinality dimensions are used
+        validateNoHighCardinalityDimensions(queryParams);
 
         logger.info("Received v2 metrics query", {
           query: queryParams,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevent high cardinality dimensions in v2 metrics API by adding validation and updating data models.
> 
>   - **Behavior**:
>     - Adds `validateNoHighCardinalityDimensions()` in `metrics.ts` to reject high cardinality dimensions in v2 metrics API.
>     - Updates `eventsTracesView`, `scoresV2BaseDimensions`, and `eventsObservationsView` in `dataModel.ts` to mark dimensions like `id`, `traceId`, `userId`, `sessionId`, etc., as `highCardinality`.
>   - **Tests**:
>     - Adds tests in `metrics-v2-api.servertest.ts` to verify rejection of high cardinality dimensions and acceptance in filters.
>     - Removes tests for unsupported dimensions in v2 metrics API.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bf4bd27095f42aae5e78555128c5f3a64576e193. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->