### PR TITLE
fix(trace): fix bottom padding

### DIFF
--- a/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
@@ -320,9 +320,7 @@ export function ObservationDetailView({
         >
           <div
             className={`flex min-h-0 w-full flex-1 flex-col ${
-              currentView === "json-beta"
-                ? "overflow-hidden"
-                : "overflow-auto pb-4"
+              currentView === "json-beta" ? "overflow-hidden" : "overflow-auto"
             }`}
           >
             <IOPreview
@@ -347,6 +345,9 @@ export function ObservationDetailView({
               }
               showMetadata
             />
+            {currentView !== "json-beta" && (
+              <div className="h-4 w-full flex-shrink-0" />
+            )}
           </div>
         </TabsBarContent>
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes bottom padding issue for non-`json-beta` views in `ObservationDetailView.tsx`.
> 
>   - **UI Fix**:
>     - In `ObservationDetailView.tsx`, fixes bottom padding for non-`json-beta` views by adding a `<div>` with `h-4` height.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ae17c8fea5194e90ca7917414b73d3b29edc1c42. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->