### PR TITLE
fix(trace): convert latency from milliseconds to seconds in observati…

### DIFF
--- a/packages/shared/src/server/repositories/observations_converters.ts
+++ b/packages/shared/src/server/repositories/observations_converters.ts
@@ -249,8 +249,9 @@ export function convertObservationPartial(
     ...((record.end_time !== undefined || record.start_time !== undefined) && {
       latency:
         record.end_time && record.start_time
-          ? parseClickhouseUTCDateTimeFormat(record.end_time).getTime() -
-            parseClickhouseUTCDateTimeFormat(record.start_time).getTime()
+          ? (parseClickhouseUTCDateTimeFormat(record.end_time).getTime() -
+              parseClickhouseUTCDateTimeFormat(record.start_time).getTime()) /
+            1000
           : null,
     }),
     ...((record.completion_start_time !== undefined ||


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Convert `latency` and `timeToFirstToken` from milliseconds to seconds in `convertObservationPartial()` in `observations_converters.ts`.
> 
>   - **Behavior**:
>     - Converts `latency` and `timeToFirstToken` from milliseconds to seconds in `convertObservationPartial()` in `observations_converters.ts`.
>     - Affects calculations when both `end_time` and `start_time` or `completion_start_time` and `start_time` are defined.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c0a2a7e42468121020d70126141d7476d889dcf5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->