### PR TITLE
fix(trace): reduce indentation in advanced json view

### DIFF
--- a/web/src/components/ui/AdvancedJsonViewer/hooks/useJsonTheme.ts
+++ b/web/src/components/ui/AdvancedJsonViewer/hooks/useJsonTheme.ts
@@ -31,7 +31,7 @@ const defaultLightTheme: JSONTheme = {
   searchCurrentBackground: "rgba(255, 255, 0, 0.4)", // Brighter yellow
   fontSize: "0.75rem",
   lineHeight: 24,
-  indentSize: 20,
+  indentSize: 12,
 };
 
 /**


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduces `indentSize` from 20 to 12 in `defaultLightTheme` in `useJsonTheme.ts` for Advanced JSON Viewer.
> 
>   - **Behavior**:
>     - Reduces `indentSize` from 20 to 12 in `defaultLightTheme` in `useJsonTheme.ts`, affecting JSON indentation in the Advanced JSON Viewer.
>   - **Misc**:
>     - No other changes or files affected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6dd67846a06ea3acee89245caceea16853b6789c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->