### PR TITLE
fix(api): fix single SELECT optimization on count measures

### DIFF
--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -432,7 +432,7 @@ export const observationsView: ViewDeclarationType = {
   },
   measures: {
     count: {
-      sql: "@@AGG@@(id)",
+      sql: "@@AGG@@(1)",
       aggs: { agg: "count" },
       alias: "count",
       type: "integer",
@@ -1059,7 +1059,7 @@ export const eventsObservationsView: ViewDeclarationType = {
   },
   measures: {
     count: {
-      sql: "@@AGG@@(events_observations.span_id)",
+      sql: "@@AGG@@(1)",
       aggs: { agg: "count" },
       alias: "count",
       type: "integer",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes SQL definition for count measures to ensure correct results with sum aggregation, verified by tests in `queryBuilder.servertest.ts`.
> 
>   - **Behavior**:
>     - Fixes SQL definition for `count` measure in `observationsView` and `eventsObservationsView` in `dataModel.ts` to use `@@AGG@@(1)` instead of a column reference.
>     - Ensures correct results with sum aggregation on count measure in `queryBuilder.servertest.ts`.
>   - **Tests**:
>     - Adds test in `queryBuilder.servertest.ts` to verify correct results with sum aggregation on count measure, ensuring both optimized and non-optimized queries return the same result.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 45a60f5bc666d4acbb870c45313590dad1e5c16e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->