### PR TITLE
fix(evalService): add filter for valid_to in extractVariables

### DIFF
--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -981,6 +981,7 @@ export async function extractVariablesFromTracingData({
         ) // query the internal column name raw
         .where("id", "=", datasetItemId)
         .where("project_id", "=", projectId)
+        .where("valid_to", "is", null)
         .executeTakeFirst()) as DatasetItem;
 
       // user facing errors


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a filter in `extractVariablesFromTracingData` in `evalService.ts` to exclude dataset items with non-null `valid_to`.
> 
>   - **Behavior**:
>     - Adds a filter condition in `extractVariablesFromTracingData` in `evalService.ts` to only select dataset items where `valid_to` is `null`.
>     - Ensures outdated or invalid dataset items are not processed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c8f5766729fefa09ec56542a9bd43955c9619aa7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->