### PR TITLE
fix: reverting get rid of extra IN clauses along trace and score deletion paths 

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1111,7 +1111,14 @@ export const deleteObservationsByTraceIds = async (
   const query = `
     DELETE FROM observations
     WHERE project_id = {projectId: String}
-    AND trace_id IN ({traceIds: Array(String)});
+    AND trace_id IN ({traceIds: Array(String)})
+    AND (project_id, type, start_time, id) IN
+    (
+      SELECT project_id, type, start_time, id
+      FROM observations
+      WHERE project_id = {projectId: String}
+      AND trace_id IN ({traceIds: Array(String)})
+    );
   `;
   await commandClickhouse({
     query: query,

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1125,7 +1125,13 @@ export const deleteScoresByTraceIds = async (
   const query = `
     DELETE FROM scores
     WHERE project_id = {projectId: String}
-    AND trace_id IN ({traceIds: Array(String)});
+    AND trace_id IN ({traceIds: Array(String)})
+    AND (project_id, timestamp, name) IN (
+      SELECT project_id, timestamp, name
+      FROM scores
+      WHERE project_id = {projectId: String}
+      AND trace_id IN ({traceIds: Array(String)})
+    );
   `;
   await commandClickhouse({
     query: query,

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -883,7 +883,16 @@ export const deleteTraces = async (projectId: string, traceIds: string[]) => {
       const query = `
         DELETE FROM traces
         WHERE project_id = {projectId: String}
-        AND id IN ({traceIds: Array(String)});
+        AND id IN ({traceIds: Array(String)})
+        AND (project_id, timestamp, id) IN  (
+	        SELECT
+	          project_id,
+	          timestamp,
+	          id
+	        FROM traces
+	        WHERE project_id = {projectId: String}
+	        AND id IN ({traceIds: Array(String)})
+        );
       `;
       await commandClickhouse({
         query: query,


### PR DESCRIPTION
Reverts langfuse/langfuse#11126
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts extra IN clauses in SQL DELETE queries in `observations.ts`, `scores.ts`, and `traces.ts`, simplifying the deletion logic.
> 
>   - **Reversion**:
>     - Reverts changes in `observations.ts`, `scores.ts`, and `traces.ts` to remove extra IN clauses in SQL DELETE queries.
>   - **Behavior**:
>     - Simplifies `deleteObservationsByTraceIds()` in `observations.ts` by removing subquery conditions.
>     - Simplifies `deleteScoresByTraceIds()` in `scores.ts` by removing subquery conditions.
>     - Simplifies `deleteTraces()` in `traces.ts` by removing subquery conditions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1964f18e40270209714aa0b5b52961c61ec4e2c1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->