### PR TITLE
fix(ingestion-ai-sdk): subtract output_reasoning_tokens from total output tokens

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1927,12 +1927,18 @@ export class OtelIngestionProcessor {
           }
         }
 
-        // Subtract cached token count from total input
+        // Subtract cached token count from total input and output
         usageDetails["input"] = Math.max(
           (usageDetails["input"] ?? 0) -
             (usageDetails["input_cached_tokens"] ?? 0) -
             (usageDetails["input_cache_creation"] ?? 0) -
             (usageDetails["input_cache_read"] ?? 0),
+          0,
+        );
+
+        usageDetails["output"] = Math.max(
+          (usageDetails["output"] ?? 0) -
+            (usageDetails["output_reasoning_tokens"] ?? 0),
           0,
         );
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes token usage calculation in `OtelIngestionProcessor` by subtracting `output_reasoning_tokens` from total output tokens.
> 
>   - **Behavior**:
>     - In `OtelIngestionProcessor`, subtracts `output_reasoning_tokens` from `output` in `usageDetails` to ensure accurate token usage reporting.
>     - This change is similar to the existing logic for subtracting cached tokens from `input`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6dac22fe880504f1cdf467a2b724e8f2a8e3833a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->