### PR TITLE
chore: limit RAM usage before forcing external group by

### DIFF
--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -207,6 +207,9 @@ export const env = createEnv({
     CLICKHOUSE_USER: z.string(),
     CLICKHOUSE_PASSWORD: z.string(),
     CLICKHOUSE_CLUSTER_ENABLED: z.enum(["true", "false"]).default("true"),
+    CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY: z.coerce
+      .number()
+      .default(32_000_000_000), // ~32GB
 
     // EE ui customization
     LANGFUSE_UI_API_HOST: z.string().optional(),
@@ -588,6 +591,8 @@ export const env = createEnv({
     CLICKHOUSE_USER: process.env.CLICKHOUSE_USER,
     CLICKHOUSE_PASSWORD: process.env.CLICKHOUSE_PASSWORD,
     CLICKHOUSE_CLUSTER_ENABLED: process.env.CLICKHOUSE_CLUSTER_ENABLED,
+    CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY:
+      process.env.CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY,
     // EE ui customization
     LANGFUSE_UI_API_HOST: process.env.LANGFUSE_UI_API_HOST,
     LANGFUSE_UI_DOCUMENTATION_HREF: process.env.LANGFUSE_UI_DOCUMENTATION_HREF,

--- a/web/src/features/query/server/queryExecutor.ts
+++ b/web/src/features/query/server/queryExecutor.ts
@@ -139,6 +139,9 @@ export async function executeQuery(
               clickhouseConfigs: {
                 clickhouse_settings: {
                   date_time_output_format: "iso",
+                  max_bytes_before_external_group_by: String(
+                    env.CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY,
+                  ),
                 },
               },
               tags: {
@@ -178,6 +181,9 @@ export async function executeQuery(
                   clickhouseConfigs: {
                     clickhouse_settings: {
                       date_time_output_format: "iso",
+                      max_bytes_before_external_group_by: String(
+                        env.CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY,
+                      ),
                     },
                   },
                   tags: input.tags,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY` environment variable to control ClickHouse's external group by threshold and apply it in query execution.
> 
>   - **Environment Variables**:
>     - Add `CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY` to `env.mjs` with a default of 32GB.
>     - Include `CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY` in `runtimeEnv` in `env.mjs`.
>   - **Query Execution**:
>     - Use `CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY` in `executeQuery()` in `queryExecutor.ts` to set `max_bytes_before_external_group_by` in ClickHouse settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fc062aa7227c70835eb375ce98588e4d122ecca8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->