### PR TITLE
chore: link to v2 endpoints from v1

### DIFF
--- a/fern/apis/server/definition/metrics.yml
+++ b/fern/apis/server/definition/metrics.yml
@@ -9,7 +9,9 @@ service:
     metrics:
       docs: |
         Get metrics from the Langfuse project using a query object.
-        
+
+        Consider using the [v2 metrics endpoint](/api-reference/metrics-v2/metrics) for better performance.
+
         For more details, see the [Metrics API documentation](https://langfuse.com/docs/metrics/features/metrics-api).
       method: GET
       path: /metrics

--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -16,7 +16,10 @@ service:
           docs: The unique langfuse identifier of an observation, can be an event, span or generation
       response: commons.ObservationsView
     getMany:
-      docs: Get a list of observations
+      docs: |
+        Get a list of observations.
+
+        Consider using the [v2 observations endpoint](/api-reference/observations-v2/getMany) for cursor-based pagination and field selection.
       method: GET
       path: /observations
       request:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -2262,6 +2262,10 @@ paths:
         Get metrics from the Langfuse project using a query object.
 
 
+        Consider using the [v2 metrics
+        endpoint](/api-reference/metrics-v2/metrics) for better performance.
+
+
         For more details, see the [Metrics API
         documentation](https://langfuse.com/docs/metrics/features/metrics-api).
       operationId: metrics_metrics
@@ -2962,7 +2966,13 @@ paths:
         - BasicAuth: []
   /api/public/observations:
     get:
-      description: Get a list of observations
+      description: >-
+        Get a list of observations.
+
+
+        Consider using the [v2 observations
+        endpoint](/api-reference/observations-v2/getMany) for cursor-based
+        pagination and field selection.
       operationId: observations_getMany
       tags:
         - Observations
@@ -9459,6 +9469,19 @@ components:
             $ref: '#/components/schemas/Project'
       required:
         - data
+    Organization:
+      title: Organization
+      type: object
+      properties:
+        id:
+          type: string
+          description: The unique identifier of the organization
+        name:
+          type: string
+          description: The name of the organization
+      required:
+        - id
+        - name
     Project:
       title: Project
       type: object
@@ -9467,6 +9490,9 @@ components:
           type: string
         name:
           type: string
+        organization:
+          $ref: '#/components/schemas/Organization'
+          description: The organization this project belongs to
         metadata:
           type: object
           additionalProperties: true
@@ -9480,6 +9506,7 @@ components:
       required:
         - id
         - name
+        - organization
         - metadata
     ProjectDeletionResponse:
       title: ProjectDeletionResponse

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -1580,7 +1580,7 @@
           "_type": "endpoint",
           "name": "Metrics",
           "request": {
-            "description": "Get metrics from the Langfuse project using a query object.\n\nFor more details, see the [Metrics API documentation](https://langfuse.com/docs/metrics/features/metrics-api).",
+            "description": "Get metrics from the Langfuse project using a query object.\n\nConsider using the [v2 metrics endpoint](/api-reference/metrics-v2/metrics) for better performance.\n\nFor more details, see the [Metrics API documentation](https://langfuse.com/docs/metrics/features/metrics-api).",
             "url": {
               "raw": "{{baseUrl}}/api/public/metrics?query=",
               "host": [
@@ -1899,7 +1899,7 @@
           "_type": "endpoint",
           "name": "Get Many",
           "request": {
-            "description": "Get a list of observations",
+            "description": "Get a list of observations.\n\nConsider using the [v2 observations endpoint](/api-reference/observations-v2/getMany) for cursor-based pagination and field selection.",
             "url": {
               "raw": "{{baseUrl}}/api/public/observations?page=&limit=&name=&userId=&type=&traceId=&level=&parentObservationId=&environment=&fromStartTime=&toStartTime=&version=&filter=",
               "host": [


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added links to v2 endpoints in v1 documentation to guide users towards improved performance and features.
> 
>   - **Documentation Updates**:
>     - Added links to v2 endpoints in `metrics.yml` and `observations.yml` for better performance and features.
>     - Updated `openapi.yml` and `collection.json` to include v2 endpoint links for `metrics` and `observations`.
>   - **Purpose**:
>     - Encourage users to use v2 endpoints for improved performance and additional features like cursor-based pagination and field selection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1aa427e447aa5acf22411158501d0349f7d20c3d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->