### PR TITLE
fix(trace-preview): optimistically populate annotation scores in trace tree

### DIFF
--- a/web/src/components/trace2/Trace.tsx
+++ b/web/src/components/trace2/Trace.tsx
@@ -68,7 +68,7 @@ export function Trace({
       <TraceDataProvider
         trace={trace}
         observations={observations}
-        scores={scores}
+        serverScores={scores}
         comments={commentsMap}
       >
         <TraceGraphDataProvider

--- a/web/src/components/trace2/TracePreview.tsx
+++ b/web/src/components/trace2/TracePreview.tsx
@@ -460,7 +460,7 @@ export const TracePreview = ({
             <TraceDataProvider
               trace={trace}
               observations={observations}
-              scores={scores}
+              serverScores={scores}
               comments={commentCounts ?? new Map()}
             >
               <ViewPreferencesProvider>

--- a/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
@@ -77,7 +77,7 @@ export function ObservationDetailView({
   const [isJSONBetaVirtualized, setIsJSONBetaVirtualized] = useState(false);
 
   // Get comments, scores, and expansion state from contexts
-  const { comments, scores } = useTraceData();
+  const { comments, serverScores: scores } = useTraceData();
   const { expansionState, setFieldExpansion } = useJsonExpansion();
   const observationScores = useMemo(
     () => scores.filter((s) => s.observationId === observation.id),

--- a/web/src/components/trace2/components/SpanContent.tsx
+++ b/web/src/components/trace2/components/SpanContent.tsx
@@ -48,7 +48,7 @@ export function SpanContent({
   onHover,
   className,
 }: SpanContentProps) {
-  const { scores } = useTraceData();
+  const { mergedScores } = useTraceData();
   const {
     showDuration,
     showCostTokens,
@@ -81,8 +81,8 @@ export function SpanContent({
   // Filter scores for this node
   const nodeScores =
     node.type === "TRACE"
-      ? scores.filter((s) => s.observationId === null)
-      : scores.filter((s) => s.observationId === node.id);
+      ? mergedScores.filter((s) => s.observationId === null)
+      : mergedScores.filter((s) => s.observationId === node.id);
 
   return (
     <button

--- a/web/src/components/trace2/components/TraceTimeline/index.tsx
+++ b/web/src/components/trace2/components/TraceTimeline/index.tsx
@@ -15,7 +15,7 @@ import { TimelineScale } from "./TimelineScale";
 import { TimelineRow } from "./TimelineRow";
 
 export function TraceTimeline() {
-  const { tree, scores, comments } = useTraceData();
+  const { tree, serverScores: scores, comments } = useTraceData();
   const { collapsedNodes, toggleCollapsed, selectedNodeId, setSelectedNodeId } =
     useSelection();
   const {

--- a/web/src/components/trace2/components/_layout/TracePanelDetail.tsx
+++ b/web/src/components/trace2/components/_layout/TracePanelDetail.tsx
@@ -23,7 +23,7 @@ import { useMemo } from "react";
 
 export function TracePanelDetail() {
   const { selectedNodeId } = useSelection();
-  const { trace, nodeMap, observations, scores } = useTraceData();
+  const { trace, nodeMap, observations, serverScores: scores } = useTraceData();
 
   // Memoize to prevent recreation when deps haven't changed
   const content = useMemo(() => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renames `scores` to `serverScores`, introduces `mergedScores` for optimistic caching, and updates components to use these in `TraceDataContext`.
> 
>   - **Behavior**:
>     - Rename `scores` to `serverScores` in `Trace.tsx`, `TracePreview.tsx`, `ObservationDetailView.tsx`, `SpanContent.tsx`, `TraceTimeline/index.tsx`, and `TracePanelDetail.tsx`.
>     - Introduce `mergedScores` in `TraceDataContext.tsx` using `useMergedScores` for optimistic score caching.
>     - Replace `scores` with `mergedScores` in `SpanContent.tsx` for node score filtering.
>   - **Contexts**:
>     - Update `TraceDataContext` to provide both `serverScores` and `mergedScores`.
>     - Modify `TraceDataProvider` to compute `mergedScores` and pass them to the context.
>   - **Components**:
>     - Update `TraceDataProvider` usage in `Trace.tsx`, `TracePreview.tsx`, `ObservationDetailView.tsx`, `SpanContent.tsx`, `TraceTimeline/index.tsx`, and `TracePanelDetail.tsx` to use `serverScores` and `mergedScores`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c63ffa2cae4959bb1f5e8462804d486030510d27. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->