### PR TITLE
fix: link to v2 endpoints from v1

### DIFF
--- a/fern/apis/server/definition/metrics.yml
+++ b/fern/apis/server/definition/metrics.yml
@@ -10,7 +10,7 @@ service:
       docs: |
         Get metrics from the Langfuse project using a query object.
 
-        Consider using the [v2 metrics endpoint](/api-reference/metrics-v2/metrics) for better performance.
+        Consider using the [v2 metrics endpoint](/api-reference#tag/metricsv2/GET/api/public/v2/metrics) for better performance.
 
         For more details, see the [Metrics API documentation](https://langfuse.com/docs/metrics/features/metrics-api).
       method: GET

--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -19,7 +19,7 @@ service:
       docs: |
         Get a list of observations.
 
-        Consider using the [v2 observations endpoint](/api-reference/observations-v2/getMany) for cursor-based pagination and field selection.
+        Consider using the [v2 observations endpoint](/api-reference#tag/observationsv2/GET/api/public/v2/observations) for cursor-based pagination and field selection.
       method: GET
       path: /observations
       request:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -2263,7 +2263,8 @@ paths:
 
 
         Consider using the [v2 metrics
-        endpoint](/api-reference/metrics-v2/metrics) for better performance.
+        endpoint](/api-reference#tag/metricsv2/GET/api/public/v2/metrics) for
+        better performance.
 
 
         For more details, see the [Metrics API
@@ -2971,8 +2972,8 @@ paths:
 
 
         Consider using the [v2 observations
-        endpoint](/api-reference/observations-v2/getMany) for cursor-based
-        pagination and field selection.
+        endpoint](/api-reference#tag/observationsv2/GET/api/public/v2/observations)
+        for cursor-based pagination and field selection.
       operationId: observations_getMany
       tags:
         - Observations

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -1580,7 +1580,7 @@
           "_type": "endpoint",
           "name": "Metrics",
           "request": {
-            "description": "Get metrics from the Langfuse project using a query object.\n\nConsider using the [v2 metrics endpoint](/api-reference/metrics-v2/metrics) for better performance.\n\nFor more details, see the [Metrics API documentation](https://langfuse.com/docs/metrics/features/metrics-api).",
+            "description": "Get metrics from the Langfuse project using a query object.\n\nConsider using the [v2 metrics endpoint](/api-reference#tag/metricsv2/GET/api/public/v2/metrics) for better performance.\n\nFor more details, see the [Metrics API documentation](https://langfuse.com/docs/metrics/features/metrics-api).",
             "url": {
               "raw": "{{baseUrl}}/api/public/metrics?query=",
               "host": [
@@ -1899,7 +1899,7 @@
           "_type": "endpoint",
           "name": "Get Many",
           "request": {
-            "description": "Get a list of observations.\n\nConsider using the [v2 observations endpoint](/api-reference/observations-v2/getMany) for cursor-based pagination and field selection.",
+            "description": "Get a list of observations.\n\nConsider using the [v2 observations endpoint](/api-reference#tag/observationsv2/GET/api/public/v2/observations) for cursor-based pagination and field selection.",
             "url": {
               "raw": "{{baseUrl}}/api/public/observations?page=&limit=&name=&userId=&type=&traceId=&level=&parentObservationId=&environment=&fromStartTime=&toStartTime=&version=&filter=",
               "host": [


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update links to v2 metrics and observations endpoints in API documentation for improved performance and pagination.
> 
>   - **Documentation Updates**:
>     - Updated link to v2 metrics endpoint in `metrics.yml` and `openapi.yml` for better performance.
>     - Updated link to v2 observations endpoint in `observations.yml` and `openapi.yml` for cursor-based pagination and field selection.
>     - Updated link to v2 metrics endpoint in `collection.json` for better performance.
>     - Updated link to v2 observations endpoint in `collection.json` for cursor-based pagination and field selection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 89445707fb73c3d1b881a20091a4f32478c51691. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->