### PR TITLE
fix(annotation-queue): correctly parse IO in embeded viewers

### DIFF
--- a/web/src/components/trace2/ObservationPreview.tsx
+++ b/web/src/components/trace2/ObservationPreview.tsx
@@ -44,6 +44,7 @@ import { useRouter } from "next/router";
 import { CopyIdsPopover } from "@/src/components/trace2/components/_shared/CopyIdsPopover";
 import { useJsonExpansion } from "@/src/components/trace2/contexts/JsonExpansionContext";
 import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
+import { useParsedObservation } from "@/src/hooks/useParsedObservation";
 import { PromptBadge } from "@/src/components/trace2/components/_shared/PromptBadge";
 
 export const ObservationPreview = ({
@@ -94,17 +95,20 @@ export const ObservationPreview = ({
     (s) => s.observationId === currentObservationId,
   );
 
-  const observationWithInputAndOutput = api.observations.byId.useQuery(
-    {
-      observationId: currentObservationId,
-      startTime: currentObservation?.startTime,
-      traceId: traceId,
-      projectId: projectId,
-    },
-    {
-      staleTime: 5 * 60 * 1000, // 5 minutes - matches prefetch staleTime
-    },
-  );
+  // Fetch and parse observation input/output in background (Web Worker)
+  const {
+    observation: observationWithIO,
+    parsedInput,
+    parsedOutput,
+    parsedMetadata,
+    isLoadingObservation,
+    isWaitingForParsing,
+  } = useParsedObservation({
+    observationId: currentObservationId,
+    traceId: traceId,
+    projectId: projectId,
+    startTime: currentObservation?.startTime,
+  });
 
   const observationMedia = api.media.getByTraceOrObservationId.useQuery(
     {
@@ -154,14 +158,14 @@ export const ObservationPreview = ({
             />
           </div>
           <div className="flex h-full flex-wrap content-start items-start justify-start gap-0.5 @2xl:mr-1 @2xl:justify-end">
-            {observationWithInputAndOutput.data && (
+            {observationWithIO && (
               <NewDatasetItemFromExistingObject
                 traceId={preloadedObservation.traceId}
                 observationId={preloadedObservation.id}
                 projectId={projectId}
-                input={observationWithInputAndOutput.data.input}
-                output={observationWithInputAndOutput.data.output}
-                metadata={observationWithInputAndOutput.data.metadata}
+                input={observationWithIO.input}
+                output={observationWithIO.output}
+                metadata={observationWithIO.metadata}
                 key={preloadedObservation.id}
                 size="sm"
               />
@@ -192,11 +196,11 @@ export const ObservationPreview = ({
                     size="sm"
                   />
                 </div>
-                {observationWithInputAndOutput.data &&
-                  isGenerationLike(observationWithInputAndOutput.data.type) && (
+                {observationWithIO &&
+                  isGenerationLike(observationWithIO.type) && (
                     <JumpToPlaygroundButton
                       source="generation"
-                      generation={observationWithInputAndOutput.data}
+                      generation={observationWithIO}
                       analyticsEventName="trace_detail:test_in_playground_button_click"
                       className={cn(isTimeline ? "!hidden" : "")}
                       size="sm"
@@ -459,14 +463,14 @@ export const ObservationPreview = ({
                 <IOPreview
                   key={preloadedObservation.id + "-input"}
                   observationName={preloadedObservation.name ?? undefined}
-                  input={observationWithInputAndOutput.data?.input ?? undefined}
-                  output={
-                    observationWithInputAndOutput.data?.output ?? undefined
-                  }
-                  metadata={
-                    observationWithInputAndOutput.data?.metadata ?? undefined
-                  }
-                  isLoading={observationWithInputAndOutput.isLoading}
+                  input={observationWithIO?.input ?? undefined}
+                  output={observationWithIO?.output ?? undefined}
+                  metadata={observationWithIO?.metadata ?? undefined}
+                  parsedInput={parsedInput}
+                  parsedOutput={parsedOutput}
+                  parsedMetadata={parsedMetadata}
+                  isLoading={isLoadingObservation}
+                  isParsing={isWaitingForParsing}
                   media={observationMedia.data}
                   currentView={currentView}
                   setIsPrettyViewAvailable={setIsPrettyViewAvailable}
@@ -493,11 +497,11 @@ export const ObservationPreview = ({
                 )}
               </div>
               <div className="px-2">
-                {observationWithInputAndOutput.data?.metadata && (
+                {observationWithIO?.metadata && (
                   <PrettyJsonView
-                    key={observationWithInputAndOutput.data.id + "-metadata"}
+                    key={observationWithIO.id + "-metadata"}
                     title="Metadata"
-                    json={observationWithInputAndOutput.data.metadata}
+                    json={observationWithIO.metadata}
                     media={observationMedia.data?.filter(
                       (m) => m.field === "metadata",
                     )}

--- a/web/src/components/trace2/TracePreview.tsx
+++ b/web/src/components/trace2/TracePreview.tsx
@@ -39,6 +39,7 @@ import { useRouter } from "next/router";
 import { CopyIdsPopover } from "@/src/components/trace2/components/_shared/CopyIdsPopover";
 import { useJsonExpansion } from "@/src/components/trace2/contexts/JsonExpansionContext";
 import { TraceLogView } from "@/src/components/trace2/components/TraceLogView/TraceLogView";
+import { useParsedTrace } from "@/src/hooks/useParsedTrace";
 import { TraceDataProvider } from "@/src/components/trace2/contexts/TraceDataContext";
 import { ViewPreferencesProvider } from "@/src/components/trace2/contexts/ViewPreferencesContext";
 import {
@@ -114,6 +115,15 @@ export const TracePreview = ({
       staleTime: 50 * 60 * 1000, // 50 minutes
     },
   );
+
+  // Parse trace I/O in background (Web Worker)
+  const { parsedInput, parsedOutput, parsedMetadata, isParsing } =
+    useParsedTrace({
+      traceId: trace.id,
+      input: trace.input,
+      output: trace.output,
+      metadata: trace.metadata,
+    });
 
   const totalCost = precomputedCost;
 
@@ -415,6 +425,10 @@ export const TracePreview = ({
                 key={trace.id + "-io"}
                 input={trace.input ?? undefined}
                 output={trace.output ?? undefined}
+                parsedInput={parsedInput}
+                parsedOutput={parsedOutput}
+                parsedMetadata={parsedMetadata}
+                isParsing={isParsing}
                 media={traceMedia.data}
                 currentView={currentView}
                 setIsPrettyViewAvailable={setIsPrettyViewAvailable}

--- a/web/src/components/trace2/components/IOPreview/IOPreviewJSONSimple.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreviewJSONSimple.tsx
@@ -48,18 +48,21 @@ export function IOPreviewJSONSimple({
   onOutputExpansionChange,
 }: IOPreviewJSONSimpleProps) {
   // Parse data if not pre-parsed
-  const effectiveInput = useMemo(
-    () => parsedInput ?? deepParseJson(input),
-    [parsedInput, input],
-  );
-  const effectiveOutput = useMemo(
-    () => parsedOutput ?? deepParseJson(output),
-    [parsedOutput, output],
-  );
-  const effectiveMetadata = useMemo(
-    () => parsedMetadata ?? deepParseJson(metadata),
-    [parsedMetadata, metadata],
-  );
+  // IMPORTANT: Don't parse while isParsing=true to avoid double-parsing with different object references
+  const effectiveInput = useMemo(() => {
+    if (isParsing) return undefined; // Wait for Web Worker to finish
+    return parsedInput ?? deepParseJson(input);
+  }, [parsedInput, input, isParsing]);
+
+  const effectiveOutput = useMemo(() => {
+    if (isParsing) return undefined;
+    return parsedOutput ?? deepParseJson(output);
+  }, [parsedOutput, output, isParsing]);
+
+  const effectiveMetadata = useMemo(() => {
+    if (isParsing) return undefined;
+    return parsedMetadata ?? deepParseJson(metadata);
+  }, [parsedMetadata, metadata, isParsing]);
 
   const showInput = !hideInput && !(hideIfNull && !effectiveInput);
   const showOutput = !hideOutput && !(hideIfNull && !effectiveOutput);

--- a/web/src/components/trace2/components/IOPreview/IOPreviewPretty.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreviewPretty.tsx
@@ -128,13 +128,19 @@ export function IOPreviewPretty({
 }: IOPreviewPrettyProps) {
   // Use pre-parsed data if available (from useParsedObservation hook),
   // otherwise parse with size/depth limits to prevent UI freeze
-  const parsedInput =
-    preParsedInput ?? deepParseJson(input, { maxSize: 300_000, maxDepth: 2 });
-  const parsedOutput =
-    preParsedOutput ?? deepParseJson(output, { maxSize: 300_000, maxDepth: 2 });
-  const parsedMetadata =
-    preParsedMetadata ??
-    deepParseJson(metadata, { maxSize: 100_000, maxDepth: 2 });
+  // IMPORTANT: Don't parse while isParsing=true to avoid double-parsing with different object references
+  const parsedInput = isParsing
+    ? undefined // Wait for Web Worker to finish
+    : (preParsedInput ??
+      deepParseJson(input, { maxSize: 300_000, maxDepth: 2 }));
+  const parsedOutput = isParsing
+    ? undefined
+    : (preParsedOutput ??
+      deepParseJson(output, { maxSize: 300_000, maxDepth: 2 }));
+  const parsedMetadata = isParsing
+    ? undefined
+    : (preParsedMetadata ??
+      deepParseJson(metadata, { maxSize: 100_000, maxDepth: 2 }));
 
   // Parse ChatML format
   const {

--- a/web/src/hooks/useParsedObservation.ts
+++ b/web/src/hooks/useParsedObservation.ts
@@ -18,6 +18,28 @@ import type {
   ParseResponse,
 } from "@/src/workers/json-parser.worker";
 
+/**
+ * Threshold for using Web Worker vs sync parsing (in characters).
+ * Below this: sync parse (faster, no message-passing overhead)
+ * Above this: Web Worker (non-blocking, prevents UI freeze)
+ */
+const PARSE_IN_WEBWORKER_THRESHOLD = 100_000; // 100KB
+
+/**
+ * Estimate the size of a value in characters (for threshold check)
+ */
+function estimateSize(value: unknown): number {
+  if (value === null || value === undefined) return 0;
+  if (typeof value === "string") return value.length;
+  // For objects/arrays, estimate via JSON stringification length
+  // This is approximate but good enough for threshold decisions
+  try {
+    return JSON.stringify(value).length;
+  } catch {
+    return 0;
+  }
+}
+
 // Singleton worker instance shared across all hook calls
 let workerInstance: Worker | null = null;
 const pendingCallbacks = new Map<
@@ -72,7 +94,35 @@ interface ParsedData {
 }
 
 /**
- * Parse observation data in Web Worker (or fallback to sync)
+ * Sync parse helper - used for small payloads or when Web Worker unavailable
+ */
+async function syncParseObservationData(
+  input: unknown,
+  output: unknown,
+  metadata: unknown,
+): Promise<ParsedData> {
+  const { deepParseJsonIterative } = await import("@langfuse/shared");
+  const startTime = performance.now();
+
+  return {
+    input: deepParseJsonIterative(input, {
+      maxDepth: 50,
+      maxSize: 500_000,
+    }),
+    output: deepParseJsonIterative(output, {
+      maxDepth: 50,
+      maxSize: 500_000,
+    }),
+    metadata: deepParseJsonIterative(metadata, {
+      maxDepth: 50,
+      maxSize: 500_000,
+    }),
+    parseTime: performance.now() - startTime,
+  };
+}
+
+/**
+ * Parse observation data in Web Worker (or sync for small payloads)
  * Returns a promise that resolves with parsed data
  */
 async function parseObservationData(
@@ -80,31 +130,23 @@ async function parseObservationData(
   output: unknown,
   metadata: unknown,
 ): Promise<ParsedData> {
+  // Estimate total size to decide sync vs worker
+  const totalSize =
+    estimateSize(input) + estimateSize(output) + estimateSize(metadata);
+
+  // Small payloads: sync parse (faster, no message-passing overhead)
+  if (totalSize < PARSE_IN_WEBWORKER_THRESHOLD) {
+    return syncParseObservationData(input, output, metadata);
+  }
+
   const worker = getOrCreateWorker();
 
   // Fallback to sync parsing if no worker support
   if (!worker) {
-    const { deepParseJsonIterative } = await import("@langfuse/shared");
-    const startTime = performance.now();
-
-    return {
-      input: deepParseJsonIterative(input, {
-        maxDepth: 50,
-        maxSize: 500_000,
-      }),
-      output: deepParseJsonIterative(output, {
-        maxDepth: 50,
-        maxSize: 500_000,
-      }),
-      metadata: deepParseJsonIterative(metadata, {
-        maxDepth: 50,
-        maxSize: 500_000,
-      }),
-      parseTime: performance.now() - startTime,
-    };
+    return syncParseObservationData(input, output, metadata);
   }
 
-  // Parse in Web Worker (non-blocking)
+  // Large payloads: parse in Web Worker (non-blocking)
   return new Promise<ParsedData>((resolve, reject) => {
     const parseId = `${Date.now()}-${Math.random()}`;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance I/O data parsing in `ObservationPreview` and `TracePreview` using Web Workers for large payloads, improving UI responsiveness.
> 
>   - **Behavior**:
>     - `ObservationPreview` and `TracePreview` now use `useParsedObservation` and `useParsedTrace` hooks to parse I/O data in the background using Web Workers.
>     - Small payloads are parsed synchronously, while large payloads use Web Workers to prevent UI blocking.
>     - `IOPreviewJSONSimple` and `IOPreviewPretty` components updated to use pre-parsed data and avoid parsing during `isParsing` state.
>   - **Hooks**:
>     - `useParsedObservation` and `useParsedTrace` hooks updated to estimate data size and decide between sync and Web Worker parsing.
>     - Both hooks cache parsed data using React Query and handle parsing errors gracefully.
>   - **Misc**:
>     - Added `estimateSize` function to determine parsing method based on data size.
>     - Improved logging and error handling in Web Worker setup and parsing functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a979549c462b0d39dd5d41b58a2e48391fee0556. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->