### PR TITLE
chore: always allow project deletes

### DIFF
--- a/worker/src/features/mutation-monitoring/mutationMonitor.ts
+++ b/worker/src/features/mutation-monitoring/mutationMonitor.ts
@@ -49,13 +49,13 @@ export class MutationMonitor {
     [QueueName.TraceDelete]: ["traces", "observations", "scores", "events"],
     [QueueName.ScoreDelete]: ["scores"],
     [QueueName.DatasetDelete]: ["dataset_run_items_rmt"],
-    [QueueName.ProjectDelete]: [
-      "traces",
-      "observations",
-      "scores",
-      "dataset_run_items_rmt",
-      "events",
-    ],
+    // [QueueName.ProjectDelete]: [
+    // "traces",
+    // "observations",
+    // "scores",
+    // "dataset_run_items_rmt",
+    // "events",
+    // ],
     [QueueName.DataRetentionProcessingQueue]: [
       "traces",
       "observations",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Comments out `ProjectDelete` queue mapping in `mutationMonitor.ts`, disabling monitoring for project deletions.
> 
>   - **Behavior**:
>     - Comments out `ProjectDelete` queue mapping in `QUEUE_TABLE_MAPPING` in `mutationMonitor.ts`, effectively disabling monitoring for project deletions.
>   - **Misc**:
>     - No other changes or additions in the code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a3d53b49ac36b80d278bf51e062c803e5eb38455. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->