### PR TITLE
fix(prompts): don't throw clientside on empty labels

### DIFF
--- a/web/src/components/layouts/status-badge.tsx
+++ b/web/src/components/layouts/status-badge.tsx
@@ -79,7 +79,7 @@ export const StatusBadge = ({
           ></span>
         </span>
       )}
-      {showText && <span>{type[0].toUpperCase() + type.slice(1)}</span>}
+      {showText && type && <span>{type[0].toUpperCase() + type.slice(1)}</span>}
       {children}
     </div>
   );

--- a/web/src/components/layouts/status-badge.tsx
+++ b/web/src/components/layouts/status-badge.tsx
@@ -32,25 +32,27 @@ export const StatusBadge = ({
   let dotPingColor = "bg-muted-foreground";
   let showDot = isLive;
 
-  if (statusCategories.active.includes(type.toLowerCase())) {
+  const normalizedType = type?.toLowerCase() ?? "";
+
+  if (statusCategories.active.includes(normalizedType)) {
     badgeColor = "bg-light-green text-dark-green";
     dotColor = "animate-ping bg-dark-green";
     dotPingColor = "bg-dark-green";
-  } else if (statusCategories.pending.includes(type.toLowerCase())) {
+  } else if (statusCategories.pending.includes(normalizedType)) {
     badgeColor = "bg-light-yellow text-dark-yellow";
     dotColor = "animate-ping bg-dark-yellow";
     dotPingColor = "bg-dark-yellow";
-  } else if (statusCategories.delayed.includes(type.toLowerCase())) {
+  } else if (statusCategories.delayed.includes(normalizedType)) {
     badgeColor = "bg-light-blue text-dark-blue";
     dotColor = "animate-ping bg-dark-blue";
     dotPingColor = "bg-dark-blue";
-  } else if (statusCategories.error.includes(type.toLowerCase())) {
+  } else if (statusCategories.error.includes(normalizedType)) {
     badgeColor = "bg-light-red text-dark-red";
     showDot = false;
-  } else if (statusCategories.completed.includes(type.toLowerCase())) {
+  } else if (statusCategories.completed.includes(normalizedType)) {
     badgeColor = "bg-light-green text-dark-green";
     showDot = false;
-  } else if (statusCategories.partial.includes(type.toLowerCase())) {
+  } else if (statusCategories.partial.includes(normalizedType)) {
     badgeColor = "bg-light-yellow text-dark-yellow";
     showDot = false;
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes client-side errors in `StatusBadge` by handling empty or undefined `type` values with `normalizedType`.
> 
>   - **Behavior**:
>     - Prevents client-side errors in `StatusBadge` by introducing `normalizedType` to handle empty or undefined `type` values.
>     - Adds a check to ensure `type` is not empty before displaying text.
>   - **Code Changes**:
>     - Introduces `normalizedType` in `StatusBadge` to safely handle `type` values.
>     - Updates conditional checks to use `normalizedType` instead of `type.toLowerCase()`.
>     - Adds `type` existence check before rendering text in `StatusBadge`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 865aaef771e8bc7d3b45735302b5e99d5c19938e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->