### PR TITLE
perf: add fields api for scores v2 api

### DIFF
--- a/fern/apis/server/definition/score-v2.yml
+++ b/fern/apis/server/definition/score-v2.yml
@@ -71,7 +71,7 @@ service:
             docs: Only scores linked to traces that include all of these tags will be returned.
           fields:
             type: optional<string>
-            docs: "Comma-separated list of field groups to include in the response. Available field groups: 'score' (core score fields), 'trace' (trace properties: userId, traceTags, traceEnvironment). If not specified, both 'score' and 'trace' are returned by default. Example: 'score' to exclude trace data, 'score,trace' to include both. Note: When filtering by trace properties (using userId or traceTags parameters), the 'trace' field group must be included, otherwise a 400 error will be returned."
+            docs: "Comma-separated list of field groups to include in the response. Available field groups: 'score' (core score fields), 'trace' (trace properties: userId, tags, environment). If not specified, both 'score' and 'trace' are returned by default. Example: 'score' to exclude trace data, 'score,trace' to include both. Note: When filtering by trace properties (using userId or traceTags parameters), the 'trace' field group must be included, otherwise a 400 error will be returned."
       response: GetScoresResponse
     get-by-id:
       docs: Get a score (supports both trace and session scores)

--- a/fern/apis/server/definition/score-v2.yml
+++ b/fern/apis/server/definition/score-v2.yml
@@ -69,6 +69,9 @@ service:
             type: optional<string>
             allow-multiple: true
             docs: Only scores linked to traces that include all of these tags will be returned.
+          fields:
+            type: optional<string>
+            docs: "Comma-separated list of field groups to include in the response. Available field groups: 'score' (core score fields), 'trace' (trace properties like userId, tags, environment). If not specified, both 'score' and 'trace' are returned by default. Example: 'score' to exclude trace data, 'score,trace' to include both. Note: When filtering by trace properties (userId, traceTags), the 'trace' field group must be included, otherwise a 400 error will be returned."
       response: GetScoresResponse
     get-by-id:
       docs: Get a score (supports both trace and session scores)

--- a/fern/apis/server/definition/score-v2.yml
+++ b/fern/apis/server/definition/score-v2.yml
@@ -71,7 +71,7 @@ service:
             docs: Only scores linked to traces that include all of these tags will be returned.
           fields:
             type: optional<string>
-            docs: "Comma-separated list of field groups to include in the response. Available field groups: 'score' (core score fields), 'trace' (trace properties like userId, tags, environment). If not specified, both 'score' and 'trace' are returned by default. Example: 'score' to exclude trace data, 'score,trace' to include both. Note: When filtering by trace properties (userId, traceTags), the 'trace' field group must be included, otherwise a 400 error will be returned."
+            docs: "Comma-separated list of field groups to include in the response. Available field groups: 'score' (core score fields), 'trace' (trace properties: userId, traceTags, traceEnvironment). If not specified, both 'score' and 'trace' are returned by default. Example: 'score' to exclude trace data, 'score,trace' to include both. Note: When filtering by trace properties (using userId or traceTags parameters), the 'trace' field group must be included, otherwise a 400 error will be returned."
       response: GetScoresResponse
     get-by-id:
       docs: Get a score (supports both trace and session scores)

--- a/packages/shared/src/features/scores/interfaces/api/shared.ts
+++ b/packages/shared/src/features/scores/interfaces/api/shared.ts
@@ -10,6 +10,9 @@ import {
 
 const operators = ["<", ">", "<=", ">=", "!=", "="] as const;
 
+export const SCORE_FIELD_GROUPS = ["score", "trace"] as const;
+export type ScoreFieldGroup = (typeof SCORE_FIELD_GROUPS)[number];
+
 /**
  * Endpoints
  */
@@ -41,6 +44,17 @@ export const GetScoresQuery = z.object({
       message: "Each score ID must be a string",
     })
     .nullish(),
+  fields: z
+    .string()
+    .nullish()
+    .transform((v) => {
+      if (!v) return null;
+      return v
+        .split(",")
+        .map((f) => f.trim())
+        .filter((f) => SCORE_FIELD_GROUPS.includes(f as ScoreFieldGroup));
+    })
+    .pipe(z.array(z.enum(SCORE_FIELD_GROUPS)).nullable()),
 });
 
 // POST /scores

--- a/packages/shared/src/features/scores/interfaces/api/v2/endpoints.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v2/endpoints.ts
@@ -13,8 +13,8 @@ export const GetScoresQueryV2 = GetScoresQuery.extend({
   traceId: z.string().nullish(),
   datasetRunId: z.string().nullish(),
 });
-export const GetScoreResponseDataV2 = APIScoreSchemaV2.or(
-  z.intersection(
+export const GetScoreResponseDataV2 = z
+  .intersection(
     APIScoreSchemaV2,
     z.object({
       trace: z
@@ -25,8 +25,8 @@ export const GetScoreResponseDataV2 = APIScoreSchemaV2.or(
         })
         .nullish(),
     }),
-  ),
-);
+  )
+  .or(APIScoreSchemaV2);
 
 export const GetScoresResponseV2 = z.object({
   data: z.array(GetScoreResponseDataV2),

--- a/packages/shared/src/features/scores/interfaces/api/v2/endpoints.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v2/endpoints.ts
@@ -13,17 +13,19 @@ export const GetScoresQueryV2 = GetScoresQuery.extend({
   traceId: z.string().nullish(),
   datasetRunId: z.string().nullish(),
 });
-export const GetScoreResponseDataV2 = z.intersection(
-  APIScoreSchemaV2,
-  z.object({
-    trace: z
-      .object({
-        userId: z.string().nullish(),
-        tags: z.array(z.string()).nullish(),
-        environment: z.string().nullish(),
-      })
-      .nullish(),
-  }),
+export const GetScoreResponseDataV2 = APIScoreSchemaV2.or(
+  z.intersection(
+    APIScoreSchemaV2,
+    z.object({
+      trace: z
+        .object({
+          userId: z.string().nullish(),
+          tags: z.array(z.string()).nullish(),
+          environment: z.string().nullish(),
+        })
+        .nullish(),
+    }),
+  ),
 );
 
 export const GetScoresResponseV2 = z.object({

--- a/web/src/__tests__/async/scores-api-v2.servertest.ts
+++ b/web/src/__tests__/async/scores-api-v2.servertest.ts
@@ -1269,7 +1269,7 @@ describe("/api/public/v2/scores API Endpoint", () => {
         });
       });
 
-      it("should handle fields=trace only (returns scores with trace)", async () => {
+      it("should return 400 when requesting trace field without score field", async () => {
         const { projectId, auth } = await createOrgProjectAndApiKey();
         const traceId = v4();
         const scoreId = v4();
@@ -1291,25 +1291,21 @@ describe("/api/public/v2/scores API Endpoint", () => {
         });
         await createScoresCh([score]);
 
-        const getScores = await makeZodVerifiedAPICall(
-          GetScoresResponseV2,
+        const response = await makeZodVerifiedAPICall(
+          z.object({
+            message: z.string(),
+          }),
           "GET",
           `/api/public/v2/scores?fields=trace`,
           undefined,
           auth,
+          400,
         );
 
-        expect(getScores.status).toBe(200);
-        expect(getScores.body.data).toHaveLength(1);
-        // Score is returned with trace since trace field is requested
-        expect(getScores.body.data[0]).toMatchObject({
-          id: scoreId,
-          name: "test-score",
-          value: 100,
-          trace: {
-            userId: "test-user",
-          },
-        });
+        expect(response.status).toBe(400);
+        expect(response.body.message).toContain(
+          "Scores needs to be selected always",
+        );
       });
 
       it("should handle multiple scores with fields=score", async () => {

--- a/web/src/features/public-api/server/scores.ts
+++ b/web/src/features/public-api/server/scores.ts
@@ -53,6 +53,7 @@ export type ScoreQueryType = {
   operator?: string;
   scoreIds?: string[];
   dataType?: string;
+  fields?: string[] | null;
 };
 
 /**
@@ -76,11 +77,14 @@ export const _handleGenerateScoresForPublicApi = async ({
   const appliedScoresFilter = scoresFilter.apply();
   const appliedTracesFilter = tracesFilter.apply();
 
+  // Determine if trace should be included based on fields parameter
+  const requestedFields = props.fields ?? ["score", "trace"]; // Default includes both
+  const includeTrace = requestedFields.includes("trace");
+  const needsTraceJoin = includeTrace || tracesFilter.length() > 0;
+
   const query = `
       SELECT
-          t.user_id as user_id,
-          t.tags as tags,
-          t.environment as trace_environment,
+          ${needsTraceJoin ? "t.user_id as user_id, t.tags as tags, t.environment as trace_environment," : ""}
           s.id as id,
           s.project_id as project_id,
           s.timestamp as timestamp,
@@ -104,16 +108,14 @@ export const _handleGenerateScoresForPublicApi = async ({
           s.dataset_run_id as dataset_run_id
       FROM
           scores s
-          LEFT JOIN __TRACE_TABLE__ t ON s.trace_id = t.id
-          AND s.project_id = t.project_id
+          ${needsTraceJoin ? "LEFT JOIN __TRACE_TABLE__ t ON s.trace_id = t.id AND s.project_id = t.project_id" : ""}
       WHERE
           s.project_id = {projectId: String}
           AND (
             ${scoreScope === "traces_only" ? "" : "s.trace_id IS NULL OR "}
-            (s.trace_id IS NOT NULL AND (t.id, t.project_id) IN (
+            (s.trace_id IS NOT NULL AND (${needsTraceJoin ? "t.id, t.project_id" : "s.trace_id, s.project_id"}) IN (
               SELECT
-                trace_id,
-                project_id
+                ${needsTraceJoin ? "trace_id, project_id" : "s.trace_id, s.project_id"}
               FROM
                 scores s
               WHERE
@@ -155,14 +157,15 @@ export const _handleGenerateScoresForPublicApi = async ({
         projectId: props.projectId,
         scoreScope,
         operation_name: "_handleGenerateScoresForPublicApi",
+        includeTrace: includeTrace.toString(),
       },
     },
     fn: async (input) => {
       const records = await queryClickhouse<
         ScoreRecordReadType & {
-          tags: string[];
-          user_id: string;
-          trace_environment: string;
+          tags?: string[];
+          user_id?: string;
+          trace_environment?: string;
         }
       >({
         query: query.replace("__TRACE_TABLE__", "traces"),
@@ -177,7 +180,7 @@ export const _handleGenerateScoresForPublicApi = async ({
         return {
           ...apiScore,
           trace:
-            record.trace_id !== null
+            includeTrace && record.trace_id !== null
               ? {
                   userId: record.user_id,
                   tags: record.tags,
@@ -211,22 +214,22 @@ export const _handleGetScoresCountForPublicApi = async ({
   const appliedScoresFilter = scoresFilter.apply();
   const appliedTracesFilter = tracesFilter.apply();
 
-  // for this query, we only need the traces join if we have a filter on traces
+  // Only join traces if we have trace filters (userId, traceTags, etc.)
+  const needsTraceJoin = tracesFilter.length() > 0;
+
   const query = `
       SELECT
         count() as count
       FROM
         scores s
-          LEFT JOIN __TRACE_TABLE__ t ON s.trace_id = t.id
-          AND s.project_id = t.project_id
+          ${needsTraceJoin ? "LEFT JOIN __TRACE_TABLE__ t ON s.trace_id = t.id AND s.project_id = t.project_id" : ""}
       WHERE
         s.project_id = {projectId: String}
       AND (
         ${scoreScope === "traces_only" ? "" : "s.trace_id IS NULL OR "}
-        (s.trace_id IS NOT NULL AND (t.id, t.project_id) IN (
+        (s.trace_id IS NOT NULL AND (${needsTraceJoin ? "t.id, t.project_id" : "s.trace_id, s.project_id"}) IN (
           SELECT
-            trace_id,
-            project_id
+            ${needsTraceJoin ? "trace_id, project_id" : "s.trace_id, s.project_id"}
           FROM
             scores s
           WHERE

--- a/web/src/pages/api/public/v2/scores/index.ts
+++ b/web/src/pages/api/public/v2/scores/index.ts
@@ -34,6 +34,7 @@ export default withMiddlewares({
         value: query.value ?? undefined,
         operator: query.operator ?? undefined,
         scoreIds: query.scoreIds ?? undefined,
+        fields: query.fields ?? undefined,
       };
       const scoresApiService = new ScoresApiService("v2");
       const [items, count] = await Promise.all([

--- a/web/src/pages/api/public/v2/scores/index.ts
+++ b/web/src/pages/api/public/v2/scores/index.ts
@@ -7,6 +7,7 @@ import {
   InvalidRequestError,
 } from "@langfuse/shared";
 import { ScoresApiService } from "@/src/features/public-api/server/scores-api-service";
+import { logger } from "@langfuse/shared/src/server";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
@@ -18,6 +19,10 @@ export default withMiddlewares({
       const requestedFields = query.fields ?? ["score", "trace"];
       const includesTrace = requestedFields.includes("trace");
       const hasTraceFilters = Boolean(query.userId || query.traceTags);
+
+      logger.info(
+        `fields: ${query.fields}, includesTrace: ${includesTrace}, hasTraceFilters: ${hasTraceFilters}`,
+      );
 
       if (!includesTrace && hasTraceFilters) {
         throw new InvalidRequestError(

--- a/web/src/pages/api/public/v2/scores/index.ts
+++ b/web/src/pages/api/public/v2/scores/index.ts
@@ -17,6 +17,11 @@ export default withMiddlewares({
     fn: async ({ query, auth }) => {
       // Validate that trace filters are not used when trace field is excluded
       const requestedFields = query.fields ?? ["score", "trace"];
+
+      if (!requestedFields.includes("score")) {
+        throw new InvalidRequestError("Scores needs to be selected always.");
+      }
+
       const includesTrace = requestedFields.includes("trace");
       const hasTraceFilters = Boolean(query.userId || query.traceTags);
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `fields` parameter to Scores V2 API for selective field group inclusion, with validation and tests.
> 
>   - **Behavior**:
>     - Adds `fields` parameter to `score-v2.yml` for specifying field groups ('score', 'trace') in responses.
>     - Default behavior includes both 'score' and 'trace' fields if `fields` is not specified.
>     - Returns 400 error if trace filters are used without including 'trace' in `fields`.
>   - **Validation**:
>     - Updates `GetScoresQuery` in `shared.ts` to parse and validate `fields` parameter.
>     - Adds validation in `index.ts` to ensure 'score' is always included and trace filters require 'trace'.
>   - **Implementation**:
>     - Modifies `_handleGenerateScoresForPublicApi` and `_handleGetScoresCountForPublicApi` in `scores.ts` to conditionally join trace data based on `fields`.
>     - Introduces `determineTraceJoinRequirement` function in `scores.ts` to decide trace join necessity.
>   - **Testing**:
>     - Adds tests in `scores-api-v2.servertest.ts` to verify `fields` parameter behavior, including default inclusion, exclusion, and error cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8cc9b656a643d195ceeb1e3fa3156272f8ee43b7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->