### PR TITLE
chore: bump lodash to 4.17.21

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -110,7 +110,7 @@
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
-    "@types/lodash": "^4.17.10",
+    "@types/lodash": "^4.17.21",
     "@types/node": "^24.3.0",
     "@types/nodemailer": "^7.0.4",
     "@types/pg": "^8.11.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,8 +293,8 @@ importers:
         specifier: workspace:*
         version: link:../config-typescript
       '@types/lodash':
-        specifier: ^4.17.10
-        version: 4.17.10
+        specifier: ^4.17.21
+        version: 4.17.21
       '@types/node':
         specifier: ^24.3.0
         version: 24.3.0
@@ -834,8 +834,8 @@ importers:
         specifier: ^29.5.12
         version: 29.5.12
       '@types/lodash':
-        specifier: ^4.17.10
-        version: 4.17.10
+        specifier: ^4.17.21
+        version: 4.17.21
       '@types/node':
         specifier: 24.3.0
         version: 24.3.0
@@ -1033,8 +1033,8 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       '@types/lodash':
-        specifier: ^4.17.10
-        version: 4.17.10
+        specifier: ^4.17.21
+        version: 4.17.21
       '@types/node':
         specifier: ^24.3.0
         version: 24.3.0
@@ -6288,8 +6288,8 @@ packages:
   '@types/katex@0.16.7':
     resolution: {integrity: sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==}
 
-  '@types/lodash@4.17.10':
-    resolution: {integrity: sha512-YpS0zzoduEhuOWjAotS6A5AVCva7X4lVlYLF0FYHAY9sdraBfnatttHItlWeZdGhuEkf+OzMNg2ZYAx8t+52uQ==}
+  '@types/lodash@4.17.21':
+    resolution: {integrity: sha512-FOvQ0YPD5NOfPgMzJihoT+Za5pdkDJWcbpuj1DjaKZIr/gxodQjY/uWEFlTNqW2ugXHUiL8lRQgw63dzKHZdeQ==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -21123,7 +21123,7 @@ snapshots:
 
   '@types/katex@0.16.7': {}
 
-  '@types/lodash@4.17.10': {}
+  '@types/lodash@4.17.21': {}
 
   '@types/mdast@4.0.4':
     dependencies:

--- a/web/package.json
+++ b/web/package.json
@@ -186,7 +186,7 @@
     "@types/dompurify": "^3.0.5",
     "@types/eslint": "^9.6.1",
     "@types/jest": "^29.5.12",
-    "@types/lodash": "^4.17.10",
+    "@types/lodash": "^4.17.21",
     "@types/node": "24.3.0",
     "@types/react": "19.2.3",
     "@types/react-dom": "19.2.3",

--- a/worker/package.json
+++ b/worker/package.json
@@ -67,7 +67,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.6",
     "@types/express-serve-static-core": "^5.1.0",
-    "@types/lodash": "^4.17.10",
+    "@types/lodash": "^4.17.21",
     "@types/node": "^24.3.0",
     "@types/pg": "^8.11.10",
     "@types/uuid": "^9.0.8",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `@types/lodash` to `^4.17.21` in `packages/shared`, `web`, and `worker` `package.json` files.
> 
>   - **Dependencies**:
>     - Bump `@types/lodash` from `^4.17.10` to `^4.17.21` in `packages/shared/package.json`, `web/package.json`, and `worker/package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 36db81cc49fdb33e501a17a58b82e9e714c35af7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->