### PR TITLE
chore: add score v2 docs

### DIFF
--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -5193,6 +5193,21 @@ paths:
             items:
               type: string
               nullable: true
+        - name: fields
+          in: query
+          description: >-
+            Comma-separated list of field groups to include in the response.
+            Available field groups: 'score' (core score fields), 'trace' (trace
+            properties: userId, tags, environment). If not specified, both
+            'score' and 'trace' are returned by default. Example: 'score' to
+            exclude trace data, 'score,trace' to include both. Note: When
+            filtering by trace properties (using userId or traceTags
+            parameters), the 'trace' field group must be included, otherwise a
+            400 error will be returned.
+          required: false
+          schema:
+            type: string
+            nullable: true
       responses:
         '200':
           description: ''

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -3231,7 +3231,7 @@
           "request": {
             "description": "Get a list of scores (supports both trace and session scores)",
             "url": {
-              "raw": "{{baseUrl}}/api/public/v2/scores?page=&limit=&userId=&name=&fromTimestamp=&toTimestamp=&environment=&source=&operator=&value=&scoreIds=&configId=&sessionId=&datasetRunId=&traceId=&queueId=&dataType=&traceTags=",
+              "raw": "{{baseUrl}}/api/public/v2/scores?page=&limit=&userId=&name=&fromTimestamp=&toTimestamp=&environment=&source=&operator=&value=&scoreIds=&configId=&sessionId=&datasetRunId=&traceId=&queueId=&dataType=&traceTags=&fields=",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -3331,6 +3331,11 @@
                   "key": "traceTags",
                   "value": "",
                   "description": "Only scores linked to traces that include all of these tags will be returned."
+                },
+                {
+                  "key": "fields",
+                  "value": "",
+                  "description": "Comma-separated list of field groups to include in the response. Available field groups: 'score' (core score fields), 'trace' (trace properties: userId, tags, environment). If not specified, both 'score' and 'trace' are returned by default. Example: 'score' to exclude trace data, 'score,trace' to include both. Note: When filtering by trace properties (using userId or traceTags parameters), the 'trace' field group must be included, otherwise a 400 error will be returned."
                 }
               ],
               "variable": []


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `fields` query parameter to `Score V2` API documentation, allowing control over included field groups in responses.
> 
>   - **API Documentation**:
>     - Add `fields` query parameter to `Score V2` endpoint in `openapi.yml` and `collection.json`.
>     - `fields` allows specifying field groups: 'score' and 'trace'. Defaults to both if not specified.
>     - Excluding 'trace' when filtering by trace properties results in a 400 error.
>   - **Postman Collection**:
>     - Update `collection.json` to include `fields` parameter in `Score V2` endpoint.
>     - Description added for `fields` parameter, explaining usage and default behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4926dd6765d5a52661dbb41e00c9bc7cab4730ce. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->