### PR TITLE
fix(app-router-routes): explicitly return nextRequest

### DIFF
--- a/web/src/app/api/billing/stripe-webhook/route.ts
+++ b/web/src/app/api/billing/stripe-webhook/route.ts
@@ -1,5 +1,8 @@
 import { stripeWebhookHandler } from "@/src/ee/features/billing/server/stripeWebhookHandler";
+import { type NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
 
-export const POST = stripeWebhookHandler;
+export async function POST(req: NextRequest) {
+  return stripeWebhookHandler(req);
+}

--- a/web/src/app/api/chatCompletion/route.ts
+++ b/web/src/app/api/chatCompletion/route.ts
@@ -1,6 +1,9 @@
 import chatCompletionHandler from "@/src/features/playground/server/chatCompletionHandler";
+import { type NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 120;
 
-export const POST = chatCompletionHandler;
+export async function POST(req: NextRequest) {
+  return chatCompletionHandler(req);
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Explicitly return handler functions with `NextRequest` in `POST` functions of `stripe-webhook/route.ts` and `chatCompletion/route.ts`.
> 
>   - **Behavior**:
>     - Modify `POST` function in `stripe-webhook/route.ts` to explicitly return `stripeWebhookHandler(req)` with `req` as `NextRequest`.
>     - Modify `POST` function in `chatCompletion/route.ts` to explicitly return `chatCompletionHandler(req)` with `req` as `NextRequest`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d614074d2e1179632b03a24969c52774a62923b8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->