### PR TITLE
chore: add clickhouse logger

### DIFF
--- a/packages/shared/src/server/clickhouse/clickhouse-logger.ts
+++ b/packages/shared/src/server/clickhouse/clickhouse-logger.ts
@@ -1,0 +1,66 @@
+import { ClickHouseLogLevel, Logger } from "@clickhouse/client";
+import { logger as winstonLogger } from "../logger";
+
+/**
+ * ClickHouseLogger bridges the ClickHouse client Logger interface to our Winston logger
+ * This ensures ClickHouse client logs are formatted consistently with our application logs
+ * and include OpenTelemetry trace context for correlation with spans in DataDog
+ */
+export class ClickHouseLogger implements Logger {
+  trace({ module, message, args }: LogParams): void {
+    winstonLogger.debug(`[${module}] ${message}`, args);
+  }
+
+  debug({ module, message, args }: LogParams): void {
+    winstonLogger.debug(`[${module}] ${message}`, args);
+  }
+
+  info({ module, message, args }: LogParams): void {
+    winstonLogger.info(`[${module}] ${message}`, args);
+  }
+
+  warn({ module, message, args, err }: WarnLogParams): void {
+    winstonLogger.warn(`[${module}] ${message}`, {
+      ...args,
+      ...(err ? { error: err.message, stack: err.stack } : {}),
+    });
+  }
+
+  error({ module, message, args, err }: ErrorLogParams): void {
+    winstonLogger.error(`[${module}] ${message}`, {
+      ...args,
+      error: err.message,
+      stack: err.stack,
+    });
+  }
+}
+
+// Types from @clickhouse/client documentation
+interface LogParams {
+  module: string;
+  message: string;
+  args?: Record<string, unknown>;
+}
+
+type ErrorLogParams = LogParams & { err: Error };
+type WarnLogParams = LogParams & { err?: Error };
+
+/**
+ * Map Winston log level to ClickHouse log level
+ */
+export const mapLogLevel = (level: string): ClickHouseLogLevel => {
+  switch (level.toLowerCase()) {
+    case "error":
+      return ClickHouseLogLevel.ERROR;
+    case "warn":
+      return ClickHouseLogLevel.WARN;
+    case "info":
+      return ClickHouseLogLevel.INFO;
+    case "debug":
+      return ClickHouseLogLevel.DEBUG;
+    case "trace":
+      return ClickHouseLogLevel.TRACE;
+    default:
+      return ClickHouseLogLevel.OFF;
+  }
+};

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -1,9 +1,9 @@
-import { createClient, ClickHouseLogLevel } from "@clickhouse/client";
+import { createClient } from "@clickhouse/client";
 import { env } from "../../env";
 import { NodeClickHouseClientConfigOptions } from "@clickhouse/client/dist/config";
 import { getCurrentSpan } from "../instrumentation";
 import { propagation, context } from "@opentelemetry/api";
-import { ClickHouseLogger, mapLogLevel } from "./logger";
+import { ClickHouseLogger, mapLogLevel } from "./clickhouse-logger";
 
 export type ClickhouseClientType = ReturnType<typeof createClient>;
 

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -1,8 +1,9 @@
-import { createClient } from "@clickhouse/client";
+import { createClient, ClickHouseLogLevel } from "@clickhouse/client";
 import { env } from "../../env";
 import { NodeClickHouseClientConfigOptions } from "@clickhouse/client/dist/config";
 import { getCurrentSpan } from "../instrumentation";
 import { propagation, context } from "@opentelemetry/api";
+import { ClickHouseLogger, mapLogLevel } from "./logger";
 
 export type ClickhouseClientType = ReturnType<typeof createClient>;
 
@@ -107,6 +108,10 @@ export class ClickHouseClientManager {
           idle_socket_ttl: env.CLICKHOUSE_KEEP_ALIVE_IDLE_SOCKET_TTL,
         },
         max_open_connections: env.CLICKHOUSE_MAX_OPEN_CONNECTIONS,
+        log: {
+          LoggerClass: ClickHouseLogger,
+          level: mapLogLevel(env.LANGFUSE_LOG_LEVEL ?? "info"),
+        },
         clickhouse_settings: {
           // Overwrite async insert settings to tune throughput
           ...(env.CLICKHOUSE_ASYNC_INSERT_MAX_DATA_SIZE


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `ClickHouseLogger` to bridge ClickHouse client logs to Winston logger, ensuring consistent log formatting and trace context inclusion.
> 
>   - **Logging**:
>     - Introduces `ClickHouseLogger` in `clickhouse-logger.ts` to bridge ClickHouse client logs to Winston logger.
>     - Implements log methods (`trace`, `debug`, `info`, `warn`, `error`) in `ClickHouseLogger` to format logs with module and message.
>     - Adds `mapLogLevel` function to map Winston log levels to ClickHouse log levels.
>   - **Client Configuration**:
>     - Updates `ClickHouseClientManager` in `client.ts` to use `ClickHouseLogger` for logging.
>     - Configures logging level using `mapLogLevel` based on `env.LANGFUSE_LOG_LEVEL`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e39a7a9503cff2c3f1d3cac74061adcfa5eab1c7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->