### PR TITLE
chore: adjust logger levels

### DIFF
--- a/packages/shared/src/server/clickhouse/clickhouse-logger.ts
+++ b/packages/shared/src/server/clickhouse/clickhouse-logger.ts
@@ -8,11 +8,11 @@ import { logger as winstonLogger } from "../logger";
  */
 export class ClickHouseLogger implements Logger {
   trace({ module, message, args }: LogParams): void {
-    winstonLogger.debug(`[${module}] ${message}`, args);
+    winstonLogger.info(`[${module}] ${message}`, args);
   }
 
   debug({ module, message, args }: LogParams): void {
-    winstonLogger.debug(`[${module}] ${message}`, args);
+    winstonLogger.info(`[${module}] ${message}`, args);
   }
 
   info({ module, message, args }: LogParams): void {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjust logging levels in `ClickHouseLogger` to use `info` instead of `debug` for `trace` and `debug` methods.
> 
>   - **Logging Levels**:
>     - Change `trace()` and `debug()` methods in `ClickHouseLogger` to use `winstonLogger.info()` instead of `winstonLogger.debug()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f57e7052bb733392e990cfed4053847dbc188275. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->