### PR TITLE
chore: clean up error naming after eslint upgrade

### DIFF
--- a/web/src/__tests__/async/projects-api.servertest.ts
+++ b/web/src/__tests__/async/projects-api.servertest.ts
@@ -905,7 +905,7 @@ describe("Projects API", () => {
             id: deleteTestApiKeyId,
           },
         });
-      } catch (_error) {
+      } catch {
         // Ignore errors if the API key was already deleted by the test
       }
     });

--- a/web/src/__tests__/test-utils.ts
+++ b/web/src/__tests__/test-utils.ts
@@ -36,7 +36,7 @@ export const ensureTestDatabaseExists = async () => {
       stdio: "inherit",
     });
     console.log("Test database schema verified/updated");
-  } catch (_error) {
+  } catch {
     console.log("Test database not accessible, creating...");
 
     const url = new URL(env.DATABASE_URL);

--- a/web/src/components/JSONSchemaEditor.tsx
+++ b/web/src/components/JSONSchemaEditor.tsx
@@ -51,7 +51,7 @@ export const JSONSchemaEditor: React.FC<JSONSchemaEditorProps> = ({
       const parsedJson = JSON.parse(value);
       const prettified = JSON.stringify(parsedJson, null, 2);
       onChange(prettified);
-    } catch (_error) {
+    } catch {
       showErrorToast(
         "Failed to prettify JSON",
         "Please verify your input is valid JSON",

--- a/web/src/components/editor/CodeMirrorEditor.tsx
+++ b/web/src/components/editor/CodeMirrorEditor.tsx
@@ -111,7 +111,7 @@ const promptLinter = linter((view) => {
           message: "Malformed prompt dependency tag",
         });
       }
-    } catch (_error) {
+    } catch {
       diagnostics.push({
         from: match.index,
         to: match.index + match[0].length,

--- a/web/src/components/table/ValueCell.tsx
+++ b/web/src/components/table/ValueCell.tsx
@@ -177,7 +177,7 @@ export const ValueCell = memo(
         await copyTextToClipboard(copyValue);
         setShowCopySuccess(true);
         setTimeout(() => setShowCopySuccess(false), 1500);
-      } catch (_error) {
+      } catch {
         // Copy failed silently
       }
     };

--- a/web/src/components/ui/AdvancedJsonViewer/utils/jsonTypes.ts
+++ b/web/src/components/ui/AdvancedJsonViewer/utils/jsonTypes.ts
@@ -205,7 +205,7 @@ export function safeStringify(value: unknown, indent = 2): string {
       },
       indent,
     );
-  } catch (_error) {
+  } catch {
     return String(value);
   }
 }

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -71,7 +71,7 @@ const getSafeUrl = (href: string | undefined | null): string | null => {
     });
 
     return sanitized || null;
-  } catch (_error) {
+  } catch {
     return null;
   }
 };
@@ -282,7 +282,7 @@ function MarkdownRenderer({
         </MemoizedReactMarkdown>
       </div>
     );
-  } catch (_error) {
+  } catch {
     // fallback to JSON view if markdown parsing fails
 
     return (

--- a/web/src/ee/features/admin-api/server/projects/createProject.ts
+++ b/web/src/ee/features/admin-api/server/projects/createProject.ts
@@ -17,7 +17,7 @@ export async function handleCreateProject(
     // Validate project name
     try {
       projectNameSchema.parse({ name });
-    } catch (_error) {
+    } catch {
       return res.status(400).json({
         message: "Invalid project name. Should be between 3 and 60 characters.",
       });
@@ -37,7 +37,7 @@ export async function handleCreateProject(
     if (retention !== undefined) {
       try {
         projectRetentionSchema.parse({ retention });
-      } catch (_error) {
+      } catch {
         return res.status(400).json({
           message: "Invalid retention value. Must be 0 or at least 3 days.",
         });

--- a/web/src/ee/features/admin-api/server/projects/projectById/index.ts
+++ b/web/src/ee/features/admin-api/server/projects/projectById/index.ts
@@ -26,7 +26,7 @@ export async function handleUpdateProject(
     // Validate project name
     try {
       projectNameSchema.parse({ name });
-    } catch (_error) {
+    } catch {
       return res.status(400).json({
         message: "Invalid project name. Should be between 3 and 60 characters.",
       });
@@ -46,7 +46,7 @@ export async function handleUpdateProject(
     if (retention !== undefined) {
       try {
         projectRetentionSchema.parse({ retention });
-      } catch (_error) {
+      } catch {
         return res.status(400).json({
           message: "Invalid retention value. Must be 0 or at least 3 days.",
         });

--- a/web/src/features/annotation-queues/components/CreateOrEditAnnotationQueueButton.tsx
+++ b/web/src/features/annotation-queues/components/CreateOrEditAnnotationQueueButton.tsx
@@ -186,7 +186,7 @@ export const CreateOrEditAnnotationQueueButton = ({
       setIsOpen(false);
 
       // capture posthog event
-    } catch (_error) {
+    } catch {
       showErrorToast(
         "Operation failed",
         "Failed to create or update queue or assign users. Please try again.",

--- a/web/src/features/datasets/components/DatasetForm.tsx
+++ b/web/src/features/datasets/components/DatasetForm.tsx
@@ -101,7 +101,7 @@ export const jsonSchemaStringValidator = z.string().refine(
       const parsed = JSON.parse(value);
 
       return isValidJSONSchema(parsed);
-    } catch (_error) {
+    } catch {
       return false;
     }
   },
@@ -120,7 +120,7 @@ const formSchema = z.object({
         JSON.parse(value);
 
         return true;
-      } catch (_error) {
+      } catch {
         return false;
       }
     },

--- a/web/src/features/datasets/lib/csv/helpers.ts
+++ b/web/src/features/datasets/lib/csv/helpers.ts
@@ -155,7 +155,7 @@ function inferTypeFromValue(value: string): ColumnType {
     if (Array.isArray(parsed)) return "array";
     if (typeof parsed === "object") return "json";
     return typeof parsed as ColumnType;
-  } catch (_error) {
+  } catch {
     if (value.toLowerCase() === "true") return "boolean";
     if (value.toLowerCase() === "false") return "boolean";
     if (!isNaN(Number(value))) return "number";

--- a/web/src/features/datasets/utils/datasetItemUtils.ts
+++ b/web/src/features/datasets/utils/datasetItemUtils.ts
@@ -10,7 +10,7 @@ export const stringifyDatasetItemData = (data: unknown): string => {
 
   try {
     return JSON.stringify(data, null, 2);
-  } catch (_error) {
+  } catch {
     showErrorToast(
       "Failed to stringify data",
       "We are working on fixing this issue.",

--- a/web/src/features/experiments/components/RemoteExperimentTriggerModal.tsx
+++ b/web/src/features/experiments/components/RemoteExperimentTriggerModal.tsx
@@ -95,7 +95,7 @@ export const RemoteExperimentTriggerModal = ({
     if (data.payload.trim()) {
       try {
         JSON.parse(data.payload);
-      } catch (_error) {
+      } catch {
         form.setError("payload", {
           message: "Invalid JSON format",
         });

--- a/web/src/features/experiments/components/RemoteExperimentUpsertForm.tsx
+++ b/web/src/features/experiments/components/RemoteExperimentUpsertForm.tsx
@@ -113,7 +113,7 @@ export const RemoteExperimentUpsertForm = ({
     if (data.defaultPayload.trim()) {
       try {
         JSON.parse(data.defaultPayload);
-      } catch (_error) {
+      } catch {
         form.setError("defaultPayload", {
           message: "Invalid JSON format",
         });

--- a/web/src/features/onboarding/hooks/useSurveyForm.ts
+++ b/web/src/features/onboarding/hooks/useSurveyForm.ts
@@ -91,7 +91,7 @@ export function useSurveyForm() {
           response: transformedResponse,
           orgId: session?.user?.organizations?.[0]?.id,
         });
-      } catch (_error) {
+      } catch {
         // Error handling is done in the mutation callbacks
         // This catch block is for any additional error handling if needed
       }

--- a/web/src/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
+++ b/web/src/features/playground/page/components/CreateOrEditLLMSchemaDialog.tsx
@@ -140,7 +140,7 @@ export const CreateOrEditLLMSchemaDialog: React.FC<
       const parsedJson = JSON.parse(currentValue);
       const prettified = JSON.stringify(parsedJson, null, 2);
       form.setValue("schema", prettified);
-    } catch (_error) {
+    } catch {
       showErrorToast(
         "Failed to prettify JSON",
         "Please verify your input is valid JSON",

--- a/web/src/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
+++ b/web/src/features/playground/page/components/CreateOrEditLLMToolDialog.tsx
@@ -140,7 +140,7 @@ export const CreateOrEditLLMToolDialog: React.FC<CreateOrEditLLMToolDialog> = (
       const parsedJson = JSON.parse(currentValue);
       const prettified = JSON.stringify(parsedJson, null, 2);
       form.setValue("parameters", prettified);
-    } catch (_error) {
+    } catch {
       showErrorToast(
         "Failed to prettify JSON",
         "Please verify your input is valid JSON",

--- a/web/src/features/slack/components/SlackTestMessageButton.tsx
+++ b/web/src/features/slack/components/SlackTestMessageButton.tsx
@@ -75,7 +75,7 @@ export const SlackTestMessageButton: React.FC<SlackTestMessageButtonProps> = ({
         channelId: selectedChannel.id,
         channelName: selectedChannel.name,
       });
-    } catch (_error) {
+    } catch {
       // Error handling is done in the mutation
     }
   };

--- a/web/src/pages/api/public/media/index.ts
+++ b/web/src/pages/api/public/media/index.ts
@@ -193,7 +193,7 @@ export default withMiddlewares({
               mediaId,
               uploadUrl,
             };
-          } catch (_error) {
+          } catch {
             logger.error(
               `Failed to get media upload URL for trace ${traceId} and observation ${observationId}.`,
             );

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -612,7 +612,7 @@ export const scoresRouter = createTRPCRouter({
               config: config as ScoreConfigDomain,
               context: "ANNOTATION",
             });
-          } catch (_error) {
+          } catch {
             throw new TRPCError({
               code: "PRECONDITION_FAILED",
               message:

--- a/web/src/utils/date-range-utils.ts
+++ b/web/src/utils/date-range-utils.ts
@@ -638,7 +638,7 @@ export function rangeFromString<T extends string>(
         }
       }
     }
-  } catch (_error) {
+  } catch {
     // Continue to fallback
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove unused `_error` variable in `catch` blocks across multiple files after ESLint upgrade.
> 
>   - **Error Handling**:
>     - Remove unused `_error` variable in `catch` blocks across multiple files, including `projects-api.servertest.ts`, `test-utils.ts`, `JSONSchemaEditor.tsx`, `CodeMirrorEditor.tsx`, `ValueCell.tsx`, `jsonTypes.ts`, `MarkdownViewer.tsx`, `createProject.ts`, `projectById/index.ts`, `CreateOrEditAnnotationQueueButton.tsx`, `DatasetForm.tsx`, `helpers.ts`, `datasetItemUtils.ts`, `RemoteExperimentTriggerModal.tsx`, `RemoteExperimentUpsertForm.tsx`, `useSurveyForm.ts`, `CreateOrEditLLMSchemaDialog.tsx`, `CreateOrEditLLMToolDialog.tsx`, `SlackTestMessageButton.tsx`, `media/index.ts`, `scores.ts`, `date-range-utils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a8a22117fc64ff5b4612ce13a4352e6d56d83110. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->