### PR TITLE
fix(security): encrypt blob storage secretAccessKey in public API

### DIFF
--- a/packages/shared/prisma/migrations/20260106120000_add_encrypt_blob_storage_secrets_background_migration/migration.sql
+++ b/packages/shared/prisma/migrations/20260106120000_add_encrypt_blob_storage_secrets_background_migration/migration.sql
@@ -1,0 +1,2 @@
+INSERT INTO background_migrations (id, name, script, args)
+VALUES ('01a0c890-2094-8e2f-c773-cf4d14638fa4', '20260106_encrypt_blob_storage_secrets', 'encryptBlobStorageSecrets', '{}');

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -13,6 +13,7 @@ import {
   UnauthorizedError,
   ForbiddenError,
 } from "@langfuse/shared";
+import { encrypt } from "@langfuse/shared/encryption";
 
 export default withMiddlewares({
   GET: handleGetBlobStorageIntegrations,
@@ -151,7 +152,9 @@ async function handleUpsertBlobStorageIntegration(
     endpoint: validatedData.endpoint || null,
     region: validatedData.region,
     accessKeyId: validatedData.accessKeyId || null,
-    secretAccessKey: validatedData.secretAccessKey || null,
+    secretAccessKey: validatedData.secretAccessKey
+      ? encrypt(validatedData.secretAccessKey)
+      : null,
     prefix: validatedData.prefix,
     exportFrequency: validatedData.exportFrequency,
     enabled: validatedData.enabled,

--- a/worker/src/backgroundMigrations/encryptBlobStorageSecrets.ts
+++ b/worker/src/backgroundMigrations/encryptBlobStorageSecrets.ts
@@ -1,0 +1,154 @@
+import { IBackgroundMigration } from "./IBackgroundMigration";
+import { logger } from "@langfuse/shared/src/server";
+import { prisma } from "@langfuse/shared/src/db";
+import { encrypt, decrypt } from "@langfuse/shared/encryption";
+
+/**
+ * Background migration to encrypt previously stored unencrypted secretAccessKey values
+ * in the blob_storage_integrations table.
+ *
+ * Background:
+ * - The public API endpoint previously stored secretAccessKey without encryption
+ * - The tRPC endpoint correctly encrypted secrets
+ * - This migration encrypts any unencrypted secrets
+ *
+ * Detection:
+ * - Encrypted format: `<iv_hex>:<encrypted_hex>:<authTag_hex>` (contains colons)
+ * - Unencrypted: Cloud provider secrets (AWS/Azure/GCP) never contain colons
+ * - We try to decrypt; if it fails with "Invalid or corrupted cipher format", it's unencrypted
+ *
+ * This migration is idempotent and can be safely re-run if interrupted.
+ */
+export default class EncryptBlobStorageSecrets implements IBackgroundMigration {
+  private isAborted = false;
+
+  async validate(
+    _args: Record<string, unknown>,
+  ): Promise<{ valid: boolean; invalidReason: string | undefined }> {
+    // No special prerequisites - encryption key is validated at decrypt/encrypt time
+    return { valid: true, invalidReason: undefined };
+  }
+
+  async run(_args: Record<string, unknown>): Promise<void> {
+    const startTime = Date.now();
+    logger.info(
+      "[Background Migration] Starting blob storage secrets encryption migration",
+    );
+
+    try {
+      // Fetch all integrations with non-null secretAccessKey
+      const integrations = await prisma.blobStorageIntegration.findMany({
+        where: { secretAccessKey: { not: null } },
+        select: { projectId: true, secretAccessKey: true },
+      });
+
+      const total = integrations.length;
+      if (total === 0) {
+        logger.info(
+          "[Background Migration] No integrations to check, migration complete",
+        );
+        return;
+      }
+      logger.info(
+        `[Background Migration] Found ${total} blob storage integrations to check`,
+      );
+
+      let encrypted = 0;
+      let alreadyEncrypted = 0;
+      let errors = 0;
+
+      for (const integration of integrations) {
+        // Check for abort signal
+        if (this.isAborted) {
+          logger.info(
+            `[Background Migration] Migration aborted after processing ${encrypted + alreadyEncrypted} integrations`,
+          );
+          return;
+        }
+
+        if (!integration.secretAccessKey) {
+          continue;
+        }
+
+        try {
+          // Try to decrypt - if it succeeds, already encrypted
+          decrypt(integration.secretAccessKey);
+          alreadyEncrypted++;
+          logger.debug(
+            `[Background Migration] Integration ${integration.projectId} already encrypted, skipping`,
+          );
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            error.message === "Invalid or corrupted cipher format"
+          ) {
+            // Unencrypted - needs encryption
+            try {
+              const encryptedValue = encrypt(integration.secretAccessKey);
+              await prisma.blobStorageIntegration.update({
+                where: { projectId: integration.projectId },
+                data: { secretAccessKey: encryptedValue },
+              });
+              encrypted++;
+              logger.info(
+                `[Background Migration] Encrypted secretAccessKey for project ${integration.projectId}`,
+              );
+            } catch (encryptError) {
+              errors++;
+              logger.error(
+                `[Background Migration] Failed to encrypt secret for ${integration.projectId}: ${encryptError}`,
+                { error: encryptError },
+              );
+            }
+          } else {
+            // Different error (wrong key, corrupted data) - log and skip
+            errors++;
+            logger.error(
+              `[Background Migration] Unexpected decryption error for ${integration.projectId}: ${error}`,
+              { error },
+            );
+          }
+        }
+      }
+
+      const duration = Date.now() - startTime;
+      logger.info(
+        `[Background Migration] Blob storage secrets encryption completed in ${duration}ms: ` +
+          `${encrypted} encrypted, ${alreadyEncrypted} already encrypted, ${errors} errors`,
+      );
+    } catch (error) {
+      logger.error(
+        "[Background Migration] Blob storage secrets encryption failed",
+        { error },
+      );
+      throw error;
+    }
+  }
+
+  async abort(): Promise<void> {
+    logger.info(
+      "[Background Migration] Aborting EncryptBlobStorageSecrets migration",
+    );
+    this.isAborted = true;
+  }
+}
+
+async function main() {
+  const migration = new EncryptBlobStorageSecrets();
+  await migration.validate({});
+  await migration.run({});
+}
+
+if (require.main === module) {
+  main()
+    .then(() => {
+      process.exit(0);
+    })
+    .catch((error) => {
+      logger.error(
+        `[Background Migration] Migration execution failed: ${error}`,
+        error,
+      );
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary

Fixes a security vulnerability where the public API endpoint for blob storage integrations stored `secretAccessKey` in plaintext, while the tRPC endpoint correctly encrypted it.

- **Encrypt secretAccessKey** in public API endpoint before storing in database
- **Add background migration** to encrypt existing unencrypted secrets
- **Add test** verifying encryption works correctly

## Background Migration

The migration (`encryptBlobStorageSecrets`) detects unencrypted values by attempting to decrypt them:
- If decryption succeeds → already encrypted, skip
- If "Invalid or corrupted cipher format" → unencrypted, encrypt it

This detection is reliable because cloud provider secrets (AWS/Azure/GCP/MinIO) never contain colons, which are required in the encrypted format (`iv:encrypted:authTag`).

The migration is idempotent and can be safely re-run if interrupted.

## Test plan

- [ ] Verify new integrations created via public API have encrypted `secretAccessKey`
- [ ] Verify existing encrypted integrations (via tRPC) still work
- [ ] Run background migration and verify unencrypted secrets are encrypted
- [ ] Verify blob storage exports still work after migration

Closes INT-372

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Encrypt `secretAccessKey` in public API for blob storage integrations and add a background migration to secure existing secrets.
> 
>   - **Behavior**:
>     - Encrypt `secretAccessKey` in `handleUpsertBlobStorageIntegration` in `index.ts` before storing in the database.
>     - Add background migration `EncryptBlobStorageSecrets` in `encryptBlobStorageSecrets.ts` to encrypt existing unencrypted secrets.
>   - **Migration**:
>     - `encryptBlobStorageSecrets` detects unencrypted secrets by attempting decryption; if it fails with "Invalid or corrupted cipher format", it encrypts the secret.
>     - Migration is idempotent and can be re-run safely.
>   - **Tests**:
>     - Add test in `blob-storage-integration-api.servertest.ts` to verify `secretAccessKey` is encrypted in the database and can be decrypted back to the original value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 63f295549cdfc5b2bbb6ce9be82f8796e0501daf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->