### PR TITLE
fix(seeder): add default value for scores

### DIFF
--- a/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
+++ b/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
@@ -254,7 +254,8 @@ export class ClickHouseQueryBuilder {
         timestamp AS updated_at,
         timestamp AS event_ts,
         0 AS is_deleted,
-        NULL AS execution_trace_id
+        NULL AS execution_trace_id,
+        '' AS long_string_value
       FROM numbers(${totalScores});
     `;
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds default value for `long_string_value` in `buildBulkScoresInsert()` to prevent null entries in `scores` table.
> 
>   - **Behavior**:
>     - Adds default value `''` for `long_string_value` in `buildBulkScoresInsert()` in `clickhouse-builder.ts` to prevent null entries in the `scores` table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f4b8d3fb81d3ccb8526e8f59f4251216a1bf7af7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->