### PR TITLE
fix(playground): enable parsing for double stringified msg array

### DIFF
--- a/packages/shared/src/utils/chatml/adapters/generic.ts
+++ b/packages/shared/src/utils/chatml/adapters/generic.ts
@@ -117,11 +117,23 @@ function preprocessData(data: unknown): unknown {
   // Object with messages key
   if (typeof data === "object" && "messages" in data) {
     const obj = data as Record<string, unknown>;
+    let messages = obj.messages;
+
+    // Handle double-stringified messages: { messages: "[{...}]" }
+    // ClickHouse can store the array as a string due to double-stringification
+    if (typeof messages === "string") {
+      try {
+        messages = JSON.parse(messages);
+      } catch {
+        // Keep as string if parse fails
+      }
+    }
+
     return {
       ...obj,
-      messages: Array.isArray(obj.messages)
-        ? obj.messages.map(normalizeGoogleMessage)
-        : obj.messages,
+      messages: Array.isArray(messages)
+        ? messages.map(normalizeGoogleMessage)
+        : messages,
     };
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `preprocessData` now parses double-stringified message arrays, with tests added to verify this behavior.
> 
>   - **Behavior**:
>     - `preprocessData` in `generic.ts` now handles double-stringified message arrays by attempting to parse them into arrays.
>     - If parsing fails, the message remains a string.
>   - **Tests**:
>     - Added test case in `jumptoplayground.clienttest.ts` to verify handling of double-stringified message arrays.
>     - Ensures that the parsed messages are correctly converted to playground format and contain all expected messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7c39da7b9dfe0098db9f5956f7feaac423f43e88. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->