### PR TITLE
fix: revert "fix: reverting get rid of extra IN clauses along trace and score deletion paths "

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1229,14 +1229,7 @@ export const deleteObservationsByTraceIds = async (
   const query = `
     DELETE FROM observations
     WHERE project_id = {projectId: String}
-    AND trace_id IN ({traceIds: Array(String)})
-    AND (project_id, type, start_time, id) IN
-    (
-      SELECT project_id, type, start_time, id
-      FROM observations
-      WHERE project_id = {projectId: String}
-      AND trace_id IN ({traceIds: Array(String)})
-    );
+    AND trace_id IN ({traceIds: Array(String)});
   `;
   await commandClickhouse({
     query: query,

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1182,13 +1182,7 @@ export const deleteScoresByTraceIds = async (
   const query = `
     DELETE FROM scores
     WHERE project_id = {projectId: String}
-    AND trace_id IN ({traceIds: Array(String)})
-    AND (project_id, timestamp, name) IN (
-      SELECT project_id, timestamp, name
-      FROM scores
-      WHERE project_id = {projectId: String}
-      AND trace_id IN ({traceIds: Array(String)})
-    );
+    AND trace_id IN ({traceIds: Array(String)});
   `;
   await commandClickhouse({
     query: query,

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -883,16 +883,7 @@ export const deleteTraces = async (projectId: string, traceIds: string[]) => {
       const query = `
         DELETE FROM traces
         WHERE project_id = {projectId: String}
-        AND id IN ({traceIds: Array(String)})
-        AND (project_id, timestamp, id) IN  (
-	        SELECT
-	          project_id,
-	          timestamp,
-	          id
-	        FROM traces
-	        WHERE project_id = {projectId: String}
-	        AND id IN ({traceIds: Array(String)})
-        );
+        AND id IN ({traceIds: Array(String)});
       `;
       await commandClickhouse({
         query: query,


### PR DESCRIPTION
Reverts langfuse/langfuse#11242

Seems to make no real the difference to performance. Reverting my canry-revert to at least get https://github.com/langfuse/langfuse/issues/11101 fixed.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts additional IN clauses in SQL DELETE queries in `observations.ts`, `scores.ts`, and `traces.ts` to fix issue #11101 due to no performance gain.
> 
>   - **Behavior**:
>     - Reverts additional IN clauses in SQL DELETE queries in `deleteObservationsByTraceIds()` in `observations.ts`, `deleteScoresByTraceIds()` in `scores.ts`, and `deleteTraces()` in `traces.ts`.
>     - The revert aims to fix issue #11101 as the previous change did not improve performance.
>   - **Misc**:
>     - No changes to functionality beyond reverting to previous query structure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e6eb436545b072d957aaf9a49e2d90439c8b38f6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->