### PR TITLE
fix(auth): assign default org/project memberships for SSO users with existing accounts

### DIFF
--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -511,6 +511,16 @@ const extendedPrismaAdapter: Adapter = {
     }
 
     await prismaAdapter.linkAccount(data);
+
+    // Assign default memberships for existing users logging in via SSO
+    // This is idempotent - won't duplicate or overwrite existing memberships
+    const user = await prisma.user.findUnique({
+      where: { id: data.userId },
+      select: { id: true, email: true },
+    });
+    if (user) {
+      await createProjectMembershipsOnSignup(user);
+    }
   },
 
   // Make email-OTP login that is used for password reset safer


### PR DESCRIPTION
When users log in via SSO (e.g., Keycloak) with allowDangerousEmailAccountLinking enabled, existing users were not being assigned to the default org/project because createProjectMembershipsOnSignup was only called from createUser, not linkAccount.

This fix:
- Changes all prisma.create() calls to prisma.upsert() with update: {} to make the function idempotent and preserve existing roles
- Calls createProjectMembershipsOnSignup from linkAccount so SSO users with pre-existing accounts get default memberships assigned

Fixes #10907

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes default org/project membership assignment for SSO users with existing accounts by using `prisma.upsert()` and calling `createProjectMembershipsOnSignup()` from `linkAccount`.
> 
>   - **Behavior**:
>     - Calls to `prisma.create()` in `createProjectMembershipsOnSignup.ts` replaced with `prisma.upsert()` to preserve existing roles.
>     - `createProjectMembershipsOnSignup()` now called from `linkAccount` in `auth.ts` to assign default memberships to SSO users with existing accounts.
>   - **Fixes**:
>     - Resolves issue #10907 where SSO users with existing accounts were not assigned default org/project memberships.
>   - **Misc**:
>     - Minor comments and logging adjustments in `createProjectMembershipsOnSignup.ts` and `auth.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5fe321b993dda7bed63aea2f0a16633ef6b44a0c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->