### PR TITLE
fix(comments): dont expose inline data path on public api yet

### DIFF
--- a/fern/apis/server/definition/comments.yml
+++ b/fern/apis/server/definition/comments.yml
@@ -62,18 +62,6 @@ types:
       authorUserId:
         type: optional<string>
         docs: The id of the user who created the comment.
-      dataField:
-        type: optional<string>
-        docs: For inline comments on IO, specifies which field (input, output, or metadata). Must be set together with path, rangeStart, and rangeEnd.
-      path:
-        type: optional<list<string>>
-        docs: JSON Path expressions specifying comment location within the dataField. Must have same length as rangeStart and rangeEnd.
-      rangeStart:
-        type: optional<list<integer>>
-        docs: Start character offsets (inclusive, UTF-16 code units) for each path entry.
-      rangeEnd:
-        type: optional<list<integer>>
-        docs: End character offsets (exclusive, UTF-16 code units) for each path entry.
   CreateCommentResponse:
     properties:
       id:

--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -377,18 +377,6 @@ types:
       objectId: string
       content: string
       authorUserId: optional<string>
-      dataField:
-        type: optional<string>
-        docs: For inline comments, the IO field (input, output, metadata)
-      path:
-        type: optional<list<string>>
-        docs: JSON Path expressions for comment location
-      rangeStart:
-        type: optional<list<integer>>
-        docs: Start character offsets (inclusive, UTF-16)
-      rangeEnd:
-        type: optional<list<integer>>
-        docs: End character offsets (exclusive, UTF-16)
 
   Dataset:
     properties:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -6362,36 +6362,6 @@ components:
           type: string
           nullable: true
           description: The id of the user who created the comment.
-        dataField:
-          type: string
-          nullable: true
-          description: >-
-            For inline comments on IO, specifies which field (input, output, or
-            metadata). Must be set together with path, rangeStart, and rangeEnd.
-        path:
-          type: array
-          items:
-            type: string
-          nullable: true
-          description: >-
-            JSON Path expressions specifying comment location within the
-            dataField. Must have same length as rangeStart and rangeEnd.
-        rangeStart:
-          type: array
-          items:
-            type: integer
-          nullable: true
-          description: >-
-            Start character offsets (inclusive, UTF-16 code units) for each path
-            entry.
-        rangeEnd:
-          type: array
-          items:
-            type: integer
-          nullable: true
-          description: >-
-            End character offsets (exclusive, UTF-16 code units) for each path
-            entry.
       required:
         - projectId
         - objectType
@@ -7185,28 +7155,6 @@ components:
         authorUserId:
           type: string
           nullable: true
-        dataField:
-          type: string
-          nullable: true
-          description: For inline comments, the IO field (input, output, metadata)
-        path:
-          type: array
-          items:
-            type: string
-          nullable: true
-          description: JSON Path expressions for comment location
-        rangeStart:
-          type: array
-          items:
-            type: integer
-          nullable: true
-          description: Start character offsets (inclusive, UTF-16)
-        rangeEnd:
-          type: array
-          items:
-            type: integer
-          nullable: true
-          description: End character offsets (exclusive, UTF-16)
       required:
         - id
         - projectId

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -570,7 +570,7 @@
             "auth": null,
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"projectId\": \"example\",\n    \"objectType\": \"example\",\n    \"objectId\": \"example\",\n    \"content\": \"example\",\n    \"authorUserId\": \"example\",\n    \"dataField\": \"example\",\n    \"path\": [\n        \"example\"\n    ],\n    \"rangeStart\": [\n        0\n    ],\n    \"rangeEnd\": [\n        0\n    ]\n}",
+              "raw": "{\n    \"projectId\": \"example\",\n    \"objectType\": \"example\",\n    \"objectId\": \"example\",\n    \"content\": \"example\",\n    \"authorUserId\": \"example\"\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/web/src/features/public-api/types/comments.ts
+++ b/web/src/features/public-api/types/comments.ts
@@ -3,7 +3,6 @@ import {
   CreateCommentData,
   paginationMetaResponseZod,
   publicApiPaginationZod,
-  COMMENT_DATA_FIELDS,
 } from "@langfuse/shared";
 import { z } from "zod/v4";
 
@@ -21,10 +20,6 @@ const APIComment = z
     objectId: z.string(),
     content: z.string().min(1).max(5000),
     authorUserId: z.string().nullish(),
-    dataField: z.enum(COMMENT_DATA_FIELDS).nullish(),
-    path: z.array(z.string()).nullish(),
-    rangeStart: z.array(z.number()).nullish(),
-    rangeEnd: z.array(z.number()).nullish(),
   })
   .strict();
 
@@ -33,10 +28,17 @@ const APIComment = z
  */
 
 // POST /comments
-// Note: Public API does not process mentions
-export const PostCommentsV1Body = CreateCommentData.extend({
-  authorUserId: z.string().nullish(),
-}).strict();
+// Note: Public API does not process mentions or inline comment positioning
+export const PostCommentsV1Body = CreateCommentData.omit({
+  dataField: true,
+  path: true,
+  rangeStart: true,
+  rangeEnd: true,
+})
+  .extend({
+    authorUserId: z.string().nullish(),
+  })
+  .strict();
 export const PostCommentsV1Response = z.object({ id: z.string() }).strict();
 
 // GET /comments

--- a/web/src/pages/api/public/comments/[commentId].ts
+++ b/web/src/pages/api/public/comments/[commentId].ts
@@ -1,10 +1,7 @@
 import { prisma } from "@langfuse/shared/src/db";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
-import {
-  LangfuseNotFoundError,
-  type COMMENT_DATA_FIELDS,
-} from "@langfuse/shared";
+import { LangfuseNotFoundError } from "@langfuse/shared";
 import {
   GetCommentV1Query,
   GetCommentV1Response,
@@ -31,13 +28,10 @@ export default withMiddlewares({
         );
       }
 
-      // cast dataField to expected enum type, Prisma just returns string | null
-      return {
-        ...comment,
-        dataField: comment.dataField as
-          | (typeof COMMENT_DATA_FIELDS)[number]
-          | null,
-      };
+      // Exclude inline positioning fields from public API
+      const { dataField, path, rangeStart, rangeEnd, ...publicComment } =
+        comment;
+      return publicComment;
     },
   }),
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> This PR removes inline comment positioning fields from the public API to prevent exposure of sensitive data.
> 
>   - **Behavior**:
>     - Removed `dataField`, `path`, `rangeStart`, and `rangeEnd` from public API comment responses in `comments.yml`, `commons.yml`, and `openapi.yml`.
>     - Updated `PostCommentsV1Body` in `comments.ts` to omit inline positioning fields.
>     - Modified `GetCommentV1Response` and `GetCommentsV1Response` in `comments.ts` to exclude inline positioning fields.
>   - **API Endpoints**:
>     - Updated `GET /comments/:commentId` in `[commentId].ts` to exclude inline positioning fields from response.
>     - Updated `POST /comments` and `GET /comments` in `index.ts` to exclude inline positioning fields from request and response.
>   - **Misc**:
>     - Updated `collection.json` to remove inline positioning fields from example request body.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 56ce5bc6065f226d31ba8be8c4e398dec94ebc04. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->