### PR TITLE
feat(api): allow selective expansion of metadata on observations-v2 endpoints

### DIFF
--- a/fern/apis/server/definition/observations-v2.yml
+++ b/fern/apis/server/definition/observations-v2.yml
@@ -20,7 +20,7 @@ service:
         - `basic` - name, level, statusMessage, version, environment, bookmarked, public, userId, sessionId
         - `time` - completionStartTime, createdAt, updatedAt
         - `io` - input, output
-        - `metadata` - metadata
+        - `metadata` - metadata (truncated to 200 chars by default, use `expandMetadata` to get full values)
         - `model` - providedModelName, internalModelId, modelParameters
         - `usage` - usageDetails, costDetails, totalCost
         - `prompt` - promptId, promptName, promptVersion
@@ -43,6 +43,13 @@ service:
               Available groups: core, basic, time, io, metadata, model, usage, prompt, metrics.
               If not specified, `core` and `basic` field groups are returned.
               Example: "basic,usage,model"
+          expandMetadata:
+            type: optional<string>
+            docs: |
+              Comma-separated list of metadata keys to return non-truncated.
+              By default, metadata values over 200 characters are truncated.
+              Use this parameter to retrieve full values for specific keys.
+              Example: "key1,key2"
           limit:
             type: optional<integer>
             docs: Number of items to return per page. Maximum 1000, default 50.

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -2582,7 +2582,8 @@ paths:
 
         - `io` - input, output
 
-        - `metadata` - metadata
+        - `metadata` - metadata (truncated to 200 chars by default, use
+        `expandMetadata` to get full values)
 
         - `model` - providedModelName, internalModelId, modelParameters
 
@@ -2618,6 +2619,17 @@ paths:
             If not specified, `core` and `basic` field groups are returned.
 
             Example: "basic,usage,model"
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: expandMetadata
+          in: query
+          description: |-
+            Comma-separated list of metadata keys to return non-truncated.
+            By default, metadata values over 200 characters are truncated.
+            Use this parameter to retrieve full values for specific keys.
+            Example: "key1,key2"
           required: false
           schema:
             type: string

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -1758,9 +1758,9 @@
           "_type": "endpoint",
           "name": "Get Many",
           "request": {
-            "description": "Get a list of observations with cursor-based pagination and flexible field selection.\n\n## Cursor-based Pagination\nThis endpoint uses cursor-based pagination for efficient traversal of large datasets.\nThe cursor is returned in the response metadata and should be passed in subsequent requests\nto retrieve the next page of results.\n\n## Field Selection\nUse the `fields` parameter to control which observation fields are returned:\n- `core` - Always included: id, traceId, startTime, endTime, projectId, parentObservationId, type\n- `basic` - name, level, statusMessage, version, environment, bookmarked, public, userId, sessionId\n- `time` - completionStartTime, createdAt, updatedAt\n- `io` - input, output\n- `metadata` - metadata\n- `model` - providedModelName, internalModelId, modelParameters\n- `usage` - usageDetails, costDetails, totalCost\n- `prompt` - promptId, promptName, promptVersion\n- `metrics` - latency, timeToFirstToken\n\nIf not specified, `core` and `basic` field groups are returned.\n\n## Filters\nMultiple filtering options are available via query parameters or the structured `filter` parameter.\nWhen using the `filter` parameter, it takes precedence over individual query parameter filters.",
+            "description": "Get a list of observations with cursor-based pagination and flexible field selection.\n\n## Cursor-based Pagination\nThis endpoint uses cursor-based pagination for efficient traversal of large datasets.\nThe cursor is returned in the response metadata and should be passed in subsequent requests\nto retrieve the next page of results.\n\n## Field Selection\nUse the `fields` parameter to control which observation fields are returned:\n- `core` - Always included: id, traceId, startTime, endTime, projectId, parentObservationId, type\n- `basic` - name, level, statusMessage, version, environment, bookmarked, public, userId, sessionId\n- `time` - completionStartTime, createdAt, updatedAt\n- `io` - input, output\n- `metadata` - metadata (truncated to 200 chars by default, use `expandMetadata` to get full values)\n- `model` - providedModelName, internalModelId, modelParameters\n- `usage` - usageDetails, costDetails, totalCost\n- `prompt` - promptId, promptName, promptVersion\n- `metrics` - latency, timeToFirstToken\n\nIf not specified, `core` and `basic` field groups are returned.\n\n## Filters\nMultiple filtering options are available via query parameters or the structured `filter` parameter.\nWhen using the `filter` parameter, it takes precedence over individual query parameter filters.",
             "url": {
-              "raw": "{{baseUrl}}/api/public/v2/observations?fields=&limit=&cursor=&parseIoAsJson=&name=&userId=&type=&traceId=&level=&parentObservationId=&environment=&fromStartTime=&toStartTime=&version=&filter=",
+              "raw": "{{baseUrl}}/api/public/v2/observations?fields=&expandMetadata=&limit=&cursor=&parseIoAsJson=&name=&userId=&type=&traceId=&level=&parentObservationId=&environment=&fromStartTime=&toStartTime=&version=&filter=",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1775,6 +1775,11 @@
                   "key": "fields",
                   "value": "",
                   "description": "Comma-separated list of field groups to include in the response.\nAvailable groups: core, basic, time, io, metadata, model, usage, prompt, metrics.\nIf not specified, `core` and `basic` field groups are returned.\nExample: \"basic,usage,model\""
+                },
+                {
+                  "key": "expandMetadata",
+                  "value": "",
+                  "description": "Comma-separated list of metadata keys to return non-truncated.\nBy default, metadata values over 200 characters are truncated.\nUse this parameter to retrieve full values for specific keys.\nExample: \"key1,key2\""
                 },
                 {
                   "key": "limit",

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -284,6 +284,7 @@ export const encodeCursor = (
 // GET /v2/observations
 export const GetObservationsV2Query = z.object({
   // Field groups parameter (optional - defaults to all groups)
+  // Comma-separated list of field groups: fields=basic,metadata,io
   fields: z
     .string()
     .nullish()
@@ -292,11 +293,25 @@ export const GetObservationsV2Query = z.object({
       return v
         .split(",")
         .map((f) => f.trim())
-        .filter((f) =>
+        .filter((f): f is ObservationFieldGroup =>
           OBSERVATION_FIELD_GROUPS.includes(f as ObservationFieldGroup),
         );
     })
     .pipe(z.array(z.enum(OBSERVATION_FIELD_GROUPS)).nullable()),
+  // Metadata expansion keys (optional)
+  // Comma-separated list of metadata keys to return non-truncated: expandMetadata=transcript,steps
+  expandMetadata: z
+    .string()
+    .nullish()
+    .transform((v) => {
+      if (!v) return null;
+      const keys = v
+        .split(",")
+        .map((k) => k.trim())
+        .filter((k) => k.length > 0);
+      return keys.length > 0 ? keys : null;
+    })
+    .pipe(z.array(z.string()).nullable()),
   // Pagination
   limit: z.coerce.number().nonnegative().lte(1000).default(50),
   cursor: EncodedObservationsCursorV2.optional(),

--- a/web/src/pages/api/public/v2/observations/index.ts
+++ b/web/src/pages/api/public/v2/observations/index.ts
@@ -23,6 +23,10 @@ export default withMiddlewares({
         );
       }
 
+      // Extract field groups and metadata expansion keys
+      const fieldGroups = query.fields ?? undefined;
+      const expandMetadataKeys = query.expandMetadata ?? undefined;
+
       const filterProps = {
         projectId: auth.scope.projectId,
         page: 0, // v2 doesn't use page-based pagination
@@ -40,7 +44,8 @@ export default withMiddlewares({
         advancedFilters: query.filter,
         parseIoAsJson: query.parseIoAsJson ?? false,
         cursor: query.cursor ?? undefined,
-        fields: query.fields ?? undefined,
+        fields: fieldGroups,
+        expandMetadataKeys,
       };
 
       // Fetch observations from events table with field groups applied at query time


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add selective metadata expansion to observations-v2 API with new `expandMetadata` parameter and update backend logic and tests accordingly.
> 
>   - **API Changes**:
>     - Add `expandMetadata` query parameter to `observations-v2.yml` and `openapi.yml` for selective metadata expansion.
>     - Update `GetObservationsV2Query` in `observations.ts` to handle `expandMetadata` as a comma-separated list of keys.
>   - **Backend Logic**:
>     - Modify `event-query-builder.ts` to support metadata expansion by adding `selectMetadataExpanded()` method.
>     - Update `getObservationsV2FromEventsTableForPublicApi` in `events.ts` to handle expanded metadata keys.
>   - **Testing**:
>     - Add tests in `observations-api-v2.servertest.ts` to verify selective metadata expansion, handling of non-existent keys, and default truncation behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6fc3883226c42c0811c5e004286cf922649ae557. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->