### PR TITLE
feat(comments): allow text referencing comments on prompts

### DIFF
--- a/packages/shared/src/features/comments/types.ts
+++ b/packages/shared/src/features/comments/types.ts
@@ -9,7 +9,12 @@ export const COMMENT_OBJECT_TYPES = [
   "PROMPT",
 ] as const;
 
-export const COMMENT_DATA_FIELDS = ["input", "output", "metadata"] as const;
+export const OBSERVATION_DATA_FIELDS = ["input", "output", "metadata"] as const;
+export const PROMPT_DATA_FIELDS = ["prompt", "config"] as const;
+export const COMMENT_DATA_FIELDS = [
+  ...OBSERVATION_DATA_FIELDS,
+  ...PROMPT_DATA_FIELDS,
+] as const;
 
 // JSON Path validation
 // TODO: simplify
@@ -68,6 +73,20 @@ export const CreateCommentData = z
       return true;
     },
     { message: "Each rangeStart must be less than corresponding rangeEnd" },
+  )
+  .refine(
+    (data) => {
+      if (!data.dataField) return true; // General comment, always valid
+
+      if (data.objectType === "PROMPT") {
+        return PROMPT_DATA_FIELDS.includes(data.dataField as any);
+      }
+      if (data.objectType === "TRACE" || data.objectType === "OBSERVATION") {
+        return OBSERVATION_DATA_FIELDS.includes(data.dataField as any);
+      }
+      return data.dataField === null; // SESSION doesn't support inline comments
+    },
+    { message: "Invalid dataField for objectType" },
   );
 
 export const DeleteCommentData = z.object({

--- a/web/src/components/ui/AdvancedJsonViewer/utils/commentRanges.ts
+++ b/web/src/components/ui/AdvancedJsonViewer/utils/commentRanges.ts
@@ -15,12 +15,14 @@ export type CommentRange = {
 };
 
 /**
- * Type for comment ranges organized by field (input/output/metadata)
+ * Type for comment ranges organized by field (input/output/metadata/prompt/config)
  */
 export type CommentedPathsByField = {
   input?: Map<string, CommentRange[]>;
   output?: Map<string, CommentRange[]>;
   metadata?: Map<string, CommentRange[]>;
+  prompt?: Map<string, CommentRange[]>;
+  config?: Map<string, CommentRange[]>;
 };
 
 /**
@@ -35,7 +37,9 @@ export function getCommentCountForSection(
   if (
     sectionKey !== "input" &&
     sectionKey !== "output" &&
-    sectionKey !== "metadata"
+    sectionKey !== "metadata" &&
+    sectionKey !== "prompt" &&
+    sectionKey !== "config"
   ) {
     return 0;
   }
@@ -58,7 +62,9 @@ export function getCommentRangesForRow(
   if (
     sectionKey !== "input" &&
     sectionKey !== "output" &&
-    sectionKey !== "metadata"
+    sectionKey !== "metadata" &&
+    sectionKey !== "prompt" &&
+    sectionKey !== "config"
   ) {
     return undefined;
   }

--- a/web/src/features/comments/CommentList.tsx
+++ b/web/src/features/comments/CommentList.tsx
@@ -57,6 +57,8 @@ const IO_FIELD_COLORS = {
   input: { light: "rgb(249, 252, 255)", dark: "rgb(15, 23, 42)" },
   output: { light: "rgb(248, 253, 250)", dark: "rgb(20, 30, 41)" },
   metadata: { light: "rgb(253, 251, 254)", dark: "rgb(30, 20, 40)" },
+  prompt: { light: "rgb(255, 251, 235)", dark: "rgb(45, 35, 15)" }, // Amber
+  config: { light: "rgb(240, 253, 244)", dark: "rgb(20, 40, 30)" }, // Green
 } as const;
 
 /**

--- a/web/src/features/comments/components/CommentableJsonView.tsx
+++ b/web/src/features/comments/components/CommentableJsonView.tsx
@@ -9,7 +9,7 @@ import { useTextSelection } from "../hooks/useTextSelection";
 
 interface CommentableJsonViewProps {
   children: ReactNode;
-  dataField?: "input" | "output" | "metadata"; // Optional - auto-detected from [data-section-key] in DOM if not provided
+  dataField?: "input" | "output" | "metadata" | "prompt" | "config"; // Optional - auto-detected from [data-section-key] in DOM if not provided
   enabled?: boolean;
   className?: string;
 }

--- a/web/src/features/comments/contexts/InlineCommentSelectionContext.tsx
+++ b/web/src/features/comments/contexts/InlineCommentSelectionContext.tsx
@@ -7,7 +7,7 @@ import {
 } from "react";
 
 export interface SelectionData {
-  dataField: "input" | "output" | "metadata";
+  dataField: "input" | "output" | "metadata" | "prompt" | "config";
   path: string[];
   rangeStart: number[];
   rangeEnd: number[];

--- a/web/src/features/comments/hooks/useCommentedPaths.ts
+++ b/web/src/features/comments/hooks/useCommentedPaths.ts
@@ -25,6 +25,8 @@ export function useCommentedPaths(
     const inputMap = new Map<string, Array<CommentRange>>();
     const outputMap = new Map<string, Array<CommentRange>>();
     const metadataMap = new Map<string, Array<CommentRange>>();
+    const promptMap = new Map<string, Array<CommentRange>>();
+    const configMap = new Map<string, Array<CommentRange>>();
 
     for (const comment of comments) {
       // Only process comments with position data (inline comments)
@@ -52,6 +54,8 @@ export function useCommentedPaths(
           if (comment.dataField === "input") targetMap = inputMap;
           else if (comment.dataField === "output") targetMap = outputMap;
           else if (comment.dataField === "metadata") targetMap = metadataMap;
+          else if (comment.dataField === "prompt") targetMap = promptMap;
+          else if (comment.dataField === "config") targetMap = configMap;
           else return;
 
           const existing = targetMap.get(jsonPath) || [];
@@ -64,6 +68,8 @@ export function useCommentedPaths(
       input: inputMap.size > 0 ? inputMap : undefined,
       output: outputMap.size > 0 ? outputMap : undefined,
       metadata: metadataMap.size > 0 ? metadataMap : undefined,
+      prompt: promptMap.size > 0 ? promptMap : undefined,
+      config: configMap.size > 0 ? configMap : undefined,
     };
   }, [comments]);
 }

--- a/web/src/features/comments/hooks/useTextSelection.ts
+++ b/web/src/features/comments/hooks/useTextSelection.ts
@@ -4,23 +4,29 @@ import { selectionToPath } from "../lib/selectionToPath";
 
 interface UseTextSelectionOptions {
   containerRef: React.RefObject<HTMLElement | null>;
-  dataField?: "input" | "output" | "metadata"; // Optional - auto-detected from [data-section-key] if not provided
+  dataField?: "input" | "output" | "metadata" | "prompt" | "config"; // Optional - auto-detected from [data-section-key] if not provided
   enabled?: boolean;
 }
 
 /**
- * Finds the section key (input/output/metadata) from the DOM by looking for
+ * Finds the section key (input/output/metadata/prompt/config) from the DOM by looking for
  * the closest ancestor with [data-section-key] attribute.
  */
 function detectSectionFromDOM(
   node: Node,
-): "input" | "output" | "metadata" | null {
+): "input" | "output" | "metadata" | "prompt" | "config" | null {
   let current: Node | null = node;
   while (current && current !== document.body) {
     if (current instanceof HTMLElement && current.dataset.sectionKey) {
       const key = current.dataset.sectionKey;
-      if (key === "input" || key === "output" || key === "metadata") {
-        return key;
+      if (
+        key === "input" ||
+        key === "output" ||
+        key === "metadata" ||
+        key === "prompt" ||
+        key === "config"
+      ) {
+        return key as "input" | "output" | "metadata" | "prompt" | "config";
       }
     }
     current = current.parentNode;

--- a/web/src/features/comments/lib/selectionToPath.ts
+++ b/web/src/features/comments/lib/selectionToPath.ts
@@ -6,7 +6,7 @@
  */
 
 interface SelectionPathResult {
-  dataField: "input" | "output" | "metadata";
+  dataField: "input" | "output" | "metadata" | "prompt" | "config";
   path: string[];
   rangeStart: number[];
   rangeEnd: number[];
@@ -16,7 +16,7 @@ interface SelectionPathResult {
 export function selectionToPath(
   selection: Selection,
   containerElement: HTMLElement,
-  dataField: "input" | "output" | "metadata",
+  dataField: "input" | "output" | "metadata" | "prompt" | "config",
 ): SelectionPathResult | null {
   if (selection.rangeCount === 0 || selection.isCollapsed) {
     return null;

--- a/web/src/features/prompts/components/PromptContentViewer.tsx
+++ b/web/src/features/prompts/components/PromptContentViewer.tsx
@@ -1,0 +1,120 @@
+import { useCallback } from "react";
+import { PromptType } from "@langfuse/shared";
+import { type z } from "zod/v4";
+import { ChatMlArraySchema } from "@/src/components/schemas/ChatMlSchema";
+import { OpenAiMessageView } from "@/src/components/trace2/components/IOPreview/components/ChatMessageList";
+import { CodeView } from "@/src/components/ui/CodeJsonViewer";
+import { AdvancedJsonViewer } from "@/src/components/ui/AdvancedJsonViewer/AdvancedJsonViewer";
+import { api } from "@/src/utils/api";
+import { useCommentedPaths } from "@/src/features/comments/hooks/useCommentedPaths";
+import {
+  InlineCommentSelectionProvider,
+  useInlineCommentSelectionOptional,
+} from "@/src/features/comments/contexts/InlineCommentSelectionContext";
+import { CommentableJsonView } from "@/src/features/comments/components/CommentableJsonView";
+import { InlineCommentBubble } from "@/src/features/comments/components/InlineCommentBubble";
+import { type SelectionData } from "@/src/features/comments/contexts/InlineCommentSelectionContext";
+
+interface PromptContentViewerProps {
+  promptId: string;
+  projectId: string;
+  prompt: unknown;
+  promptType: PromptType;
+  enableInlineComments?: boolean;
+  onAddInlineComment?: (selection: SelectionData) => void;
+}
+
+function PromptContentViewerInner({
+  promptId,
+  projectId,
+  prompt,
+  promptType,
+  enableInlineComments = false,
+  onAddInlineComment,
+}: PromptContentViewerProps) {
+  const selectionContext = useInlineCommentSelectionOptional();
+
+  const handleAddComment = useCallback(() => {
+    if (selectionContext?.selection && onAddInlineComment) {
+      onAddInlineComment(selectionContext.selection);
+    }
+  }, [selectionContext?.selection, onAddInlineComment]);
+
+  // Fetch existing comments
+  const comments = api.comments.getByObjectId.useQuery({
+    projectId,
+    objectId: promptId,
+    objectType: "PROMPT",
+  });
+
+  // Build commented paths map
+  const commentedPathsByField = useCommentedPaths(comments.data);
+
+  // Parse chat messages if chat type
+  let chatMessages: z.infer<typeof ChatMlArraySchema> | null = null;
+  try {
+    chatMessages = ChatMlArraySchema.parse(prompt);
+  } catch (error) {
+    if (promptType === PromptType.Chat) {
+      console.warn("Could not parse chat prompt", error);
+    }
+  }
+
+  // Render based on prompt type
+  return (
+    <div className="flex flex-col gap-2">
+      {/* Inline comment bubble - shows when text is selected */}
+      {enableInlineComments && (
+        <InlineCommentBubble onAddComment={handleAddComment} />
+      )}
+
+      {/* Prompt section */}
+      <CommentableJsonView enabled={enableInlineComments}>
+        {promptType === PromptType.Chat && chatMessages ? (
+          <OpenAiMessageView
+            messages={chatMessages}
+            shouldRenderMarkdown={true}
+            currentView="pretty"
+            messageToToolCallNumbers={new Map()}
+            collapseLongHistory={false}
+            projectIdForPromptButtons={projectId}
+            enableInlineComments={enableInlineComments}
+            sectionKey="prompt"
+            commentedPathsByField={commentedPathsByField}
+          />
+        ) : typeof prompt === "string" ? (
+          <CodeView
+            content={prompt}
+            originalContent={prompt}
+            title="Text Prompt"
+            enableInlineComments={enableInlineComments}
+            sectionKey="prompt"
+            commentedRanges={commentedPathsByField?.prompt?.get("$")}
+          />
+        ) : (
+          <AdvancedJsonViewer
+            data={prompt}
+            field="prompt"
+            title="Prompt"
+            commentedPathsByField={commentedPathsByField}
+          />
+        )}
+      </CommentableJsonView>
+    </div>
+  );
+}
+
+/**
+ * PromptContentViewer - Wrapper that conditionally adds InlineCommentSelectionProvider.
+ */
+export function PromptContentViewer(props: PromptContentViewerProps) {
+  // Wrap with selection provider if inline comments are enabled
+  if (props.enableInlineComments) {
+    return (
+      <InlineCommentSelectionProvider>
+        <PromptContentViewerInner {...props} />
+      </InlineCommentSelectionProvider>
+    );
+  }
+  return <PromptContentViewerInner {...props} />;
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> This PR adds inline comment support for prompts, enabling users to comment on specific text ranges within prompts and configurations, with UI and backend enhancements to manage and display these comments.
> 
>   - **Behavior**:
>     - Adds inline comment support for `PROMPT` and `CONFIG` fields in `types.ts`.
>     - Updates `CreateCommentData` schema to validate `PROMPT` and `CONFIG` fields.
>     - Implements comment highlighting in `ChatMessage.tsx` and `CodeJsonViewer.tsx`.
>   - **UI Components**:
>     - Adds `PromptContentViewer` to render prompts with inline comment capabilities.
>     - Updates `ChatMessageList.tsx` and `CommentableJsonView.tsx` to support comment rendering.
>     - Enhances `CommentList.tsx` to display comment metadata and reactions.
>   - **Utilities**:
>     - Modifies `useCommentedPaths` and `useTextSelection` hooks to handle new fields.
>     - Updates `selectionToPath.ts` to convert text selections to JSON paths for comments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 944bc9e2fd19beb16632a8c4865e171bbad53449. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->