### PR TITLE
feat: add CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MIN_MS setting

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -60,6 +60,11 @@ const EnvSchema = z.object({
   // Optional to allow for server-setting fallbacks
   CLICKHOUSE_ASYNC_INSERT_MAX_DATA_SIZE: z.string().optional(),
   CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MS: z.coerce.number().int().optional(),
+  CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MIN_MS: z.coerce
+    .number()
+    .int()
+    .min(50)
+    .optional(),
   CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE: z
     .enum(["alter_update", "lightweight_update", "lightweight_update_force"])
     .default("alter_update"),

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -126,6 +126,12 @@ export class ClickHouseClientManager {
                   env.CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MS,
               }
             : {}),
+          ...(env.CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MIN_MS
+            ? {
+                async_insert_busy_timeout_min_ms:
+                  env.CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MIN_MS,
+              }
+            : {}),
           ...(env.CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE !== "alter_update"
             ? {
                 lightweight_delete_mode: env.CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE,


### PR DESCRIPTION
Add configurable async_insert_busy_timeout_min_ms for ClickHouse client. The setting is optional and when provided must be >= 50ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MIN_MS` setting for ClickHouse client with a minimum of 50ms.
> 
>   - **Environment Variable**:
>     - Add `CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MIN_MS` to `env.ts`.
>     - Must be a number >= 50ms and is optional.
>   - **ClickHouse Client Configuration**:
>     - Use `CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MIN_MS` in `client.ts` if provided.
>     - Configures `async_insert_busy_timeout_min_ms` setting for ClickHouse client.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7ec5d4c0048cf3cbd75435d6f7b5d1d96a4568ad. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->