### PR TITLE
fix(api-docs): sync Fern API types with TypeScript definitions

### DIFF
--- a/.claude/skills/backend-dev-guidelines/SKILL.md
+++ b/.claude/skills/backend-dev-guidelines/SKILL.md
@@ -50,6 +50,7 @@ Automatically activates when working on:
 - [ ] **Authentication**: Authorization via basic auth
 - [ ] **Validation**: Zod schemas for query/body/response
 - [ ] **Versioning**: Versioning in API path and Zod schemas for query/body/response
+- [ ] **Fern API Docs**: Update `fern/apis/server/definition/` to match TypeScript types
 - [ ] **Tests**: Add end-to-end test in `__tests__/async/`
 
 ### New Queue Processor Checklist (Worker)
@@ -421,6 +422,32 @@ const traces = await queryClickhouse({
   `,
   params: { projectId, startTime },
 });
+```
+
+### 9. Keep Fern API Definitions in Sync with TypeScript Types
+
+When modifying public API types in `web/src/features/public-api/types/`, the corresponding Fern API definitions in `fern/apis/server/definition/` must be updated to match.
+
+**Zod to Fern Type Mapping:**
+
+| Zod Type | Fern Type | Example |
+| -------- | --------- | ------- |
+| `.nullish()` | `optional<nullable<T>>` | `z.string().nullish()` → `optional<nullable<string>>` |
+| `.nullable()` | `nullable<T>` | `z.string().nullable()` → `nullable<string>` |
+| `.optional()` | `optional<T>` | `z.string().optional()` → `optional<string>` |
+| Always present | `T` | `z.string()` → `string` |
+
+**Source References:**
+
+Add a comment at the top of each Fern type referencing the TypeScript source file:
+
+```yaml
+# Source: web/src/features/public-api/types/traces.ts - APITrace
+Trace:
+  properties:
+    id: string
+    name:
+      type: nullable<string>
 ```
 
 ---

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -48,7 +48,7 @@
 
 ## API Documentation
 
-- Whenenver a file in `web/src/features/public-api/types` changes, the `fern/apis` definition probably needs to be adjusted, too.
-- `nullish` types should map to `<optional<nullable<T>>` in fern.
-- `nullable` types should map to `<nullableT>` in fern.
-- `optional` types should map to `<optionalT>` in fern.
+- Whenever a file in `web/src/features/public-api/types` changes, the `fern/apis` definition probably needs to be adjusted, too.
+- `nullish` types should map to `optional<nullable<T>>` in fern.
+- `nullable` types should map to `nullable<T>` in fern.
+- `optional` types should map to `optional<T>` in fern.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -45,3 +45,10 @@
 ## Seeder
 
 - make sure that for new features with data model changes, the database seeder is adjusted.
+
+## API Documentation
+
+- Whenenver a file in `web/src/features/public-api/types` changes, the `fern/apis` definition probably needs to be adjusted, too.
+- `nullish` types should map to `<optional<nullable<T>>` in fern.
+- `nullable` types should map to `<nullableT>` in fern.
+- `optional` types should map to `<optionalT>` in fern.

--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -1,5 +1,6 @@
 types:
   # Objects
+  # Source: web/src/features/public-api/types/traces.ts - APITrace, APIExtendedTrace, GetTraceV1Response
   Trace:
     properties:
       id:
@@ -9,7 +10,7 @@ types:
         type: datetime
         docs: The timestamp when the trace was created
       name:
-        type: optional<string>
+        type: nullable<string>
         docs: The name of the trace
       input:
         type: optional<unknown>
@@ -18,28 +19,28 @@ types:
         type: optional<unknown>
         docs: The output data of the trace. Can be any JSON.
       sessionId:
-        type: optional<string>
+        type: nullable<string>
         docs: The session identifier associated with the trace
       release:
-        type: optional<string>
+        type: nullable<string>
         docs: The release version of the application when the trace was created
       version:
-        type: optional<string>
+        type: nullable<string>
         docs: The version of the trace
       userId:
-        type: optional<string>
+        type: nullable<string>
         docs: The user identifier associated with the trace
       metadata:
         type: optional<unknown>
         docs: The metadata associated with the trace. Can be any JSON.
       tags:
-        type: optional<list<string>>
-        docs: The tags associated with the trace. Can be an array of strings or null.
+        type: list<string>
+        docs: The tags associated with the trace.
       public:
-        type: optional<boolean>
+        type: boolean
         docs: Public traces are accessible via url without login
       environment:
-        type: optional<string>
+        type: string
         docs: The environment from which this trace originated. Can be any lowercase alphanumeric string with hyphens and underscores that does not start with 'langfuse'.
   TraceWithDetails: # GET /traces
     extends: Trace
@@ -48,16 +49,16 @@ types:
         type: string
         docs: Path of trace in Langfuse UI
       latency:
-        type: double
+        type: optional<nullable<double>>
         docs: Latency of trace in seconds
       totalCost:
-        type: double
+        type: optional<nullable<double>>
         docs: Cost of trace in USD
       observations:
-        type: list<string>
+        type: optional<nullable<list<string>>>
         docs: List of observation ids
       scores:
-        type: list<string>
+        type: optional<nullable<list<string>>>
         docs: List of score ids
   TraceWithFullDetails: # GET traces/[traceID]
     extends: Trace
@@ -66,10 +67,10 @@ types:
         type: string
         docs: Path of trace in Langfuse UI
       latency:
-        type: double
+        type: optional<nullable<double>>
         docs: Latency of trace in seconds
       totalCost:
-        type: double
+        type: optional<nullable<double>>
         docs: Cost of trace in USD
       observations:
         type: list<ObservationsView>
@@ -77,119 +78,121 @@ types:
       scores:
         type: list<ScoreV1>
         docs: List of scores
+  # Source: web/src/features/public-api/types/sessions.ts - APISession
   Session:
     properties:
       id: string
       createdAt: datetime
       projectId: string
       environment:
-        type: optional<string>
+        type: string
         docs: The environment from which this session originated.
   SessionWithTraces:
     extends: Session
     properties:
       traces: list<Trace>
+  # Source: web/src/features/public-api/types/observations.ts - APIObservation
   Observation:
     properties:
       id:
         type: string
         docs: The unique identifier of the observation
       traceId:
-        type: optional<string>
+        type: nullable<string>
         docs: The trace ID associated with the observation
       type:
         type: string
         docs: The type of the observation
       name:
-        type: optional<string>
+        type: nullable<string>
         docs: The name of the observation
       startTime:
         type: datetime
         docs: The start time of the observation
       endTime:
-        type: optional<datetime>
+        type: nullable<datetime>
         docs: The end time of the observation.
       completionStartTime:
-        type: optional<datetime>
+        type: nullable<datetime>
         docs: The completion start time of the observation
       model:
-        type: optional<string>
+        type: nullable<string>
         docs: The model used for the observation
       modelParameters:
-        type: optional<map<string, MapValue>>
+        type: unknown
         docs: The parameters of the model used for the observation
       input:
-        type: optional<unknown>
+        type: unknown
         docs: The input data of the observation
       version:
-        type: optional<string>
+        type: nullable<string>
         docs: The version of the observation
       metadata:
-        type: optional<unknown>
+        type: unknown
         docs: Additional metadata of the observation
       output:
-        type: optional<unknown>
+        type: unknown
         docs: The output data of the observation
       usage:
-        type: optional<Usage>
+        type: Usage
         docs: (Deprecated. Use usageDetails and costDetails instead.) The usage data of the observation
       level:
         type: ObservationLevel
         docs: The level of the observation
       statusMessage:
-        type: optional<string>
+        type: nullable<string>
         docs: The status message of the observation
       parentObservationId:
-        type: optional<string>
+        type: nullable<string>
         docs: The parent observation ID
       promptId:
-        type: optional<string>
+        type: nullable<string>
         docs: The prompt ID associated with the observation
       usageDetails:
-        type: optional<map<string, integer>>
+        type: map<string, integer>
         docs: The usage details of the observation. Key is the name of the usage metric, value is the number of units consumed. The total key is the sum of all (non-total) usage metrics or the total value ingested.
       costDetails:
-        type: optional<map<string, double>>
+        type: map<string, double>
         docs: The cost details of the observation. Key is the name of the cost metric, value is the cost in USD. The total key is the sum of all (non-total) cost metrics or the total value ingested.
       environment:
-        type: optional<string>
+        type: string
         docs: The environment from which this observation originated. Can be any lowercase alphanumeric string with hyphens and underscores that does not start with 'langfuse'.
 
   ObservationsView:
     extends: Observation
     properties:
       promptName:
-        type: optional<string>
+        type: nullable<string>
         docs: The name of the prompt associated with the observation
       promptVersion:
-        type: optional<integer>
+        type: nullable<integer>
         docs: The version of the prompt associated with the observation
       modelId:
-        type: optional<string>
+        type: nullable<string>
         docs: The unique identifier of the model
       inputPrice:
-        type: optional<double>
+        type: nullable<double>
         docs: The price of the input in USD
       outputPrice:
-        type: optional<double>
+        type: nullable<double>
         docs: The price of the output in USD.
       totalPrice:
-        type: optional<double>
+        type: nullable<double>
         docs: The total price in USD.
       calculatedInputCost:
-        type: optional<double>
+        type: nullable<double>
         docs: (Deprecated. Use usageDetails and costDetails instead.) The calculated cost of the input in USD
       calculatedOutputCost:
-        type: optional<double>
+        type: nullable<double>
         docs: (Deprecated. Use usageDetails and costDetails instead.) The calculated cost of the output in USD
       calculatedTotalCost:
-        type: optional<double>
+        type: nullable<double>
         docs: (Deprecated. Use usageDetails and costDetails instead.) The calculated total cost in USD
       latency:
-        type: optional<double>
+        type: nullable<double>
         docs: The latency in seconds.
       timeToFirstToken:
-        type: optional<double>
+        type: nullable<double>
         docs: The time to the first token in seconds
 
   Usage:
@@ -197,14 +200,16 @@ types:
     properties:
       input:
         docs: Number of input units (e.g. tokens)
-        type: optional<integer>
+        type: integer
       output:
         docs: Number of output units (e.g. tokens)
-        type: optional<integer>
+        type: integer
       total:
         docs: Defaults to input+output if not set
-        type: optional<integer>
-      unit: optional<ModelUsageUnit>
+        type: integer
+      unit:
+        docs: Unit of measurement
+        type: nullable<string>
       inputCost:
         docs: USD input cost
         type: optional<double>
@@ -214,6 +219,7 @@ types:
       totalCost:
         docs: USD total cost, defaults to input+output
         type: optional<double>
+  # Source: web/src/features/public-api/types/score-configs.ts - APIScoreConfig
   ScoreConfig:
     docs: Configuration for a score
     properties:
@@ -227,40 +233,51 @@ types:
         type: boolean
         docs: Whether the score config is archived. Defaults to false
       minValue:
-        type: optional<double>
+        type: optional<nullable<double>>
         docs: Sets minimum value for numerical scores. If not set, the minimum value defaults to -∞
       maxValue:
-        type: optional<double>
+        type: optional<nullable<double>>
         docs: Sets maximum value for numerical scores. If not set, the maximum value defaults to +∞
       categories:
         type: optional<list<ConfigCategory>>
         docs: Configures custom categories for categorical scores
-      description: optional<string>
+      description:
+        type: optional<nullable<string>>
+        docs: Description of the score config
   ConfigCategory:
     properties:
       value: double
       label: string
+  # Source: packages/shared/src/features/scores/interfaces/api/v1/schemas.ts - APIScoreSchemaV1
   BaseScoreV1:
     properties:
       id: string
       traceId: string
       name: string
       source: ScoreSource
-      observationId: optional<string>
+      observationId:
+        type: optional<nullable<string>>
+        docs: The observation ID associated with the score
       timestamp: datetime
       createdAt: datetime
       updatedAt: datetime
-      authorUserId: optional<string>
-      comment: optional<string>
-      metadata: optional<unknown>
+      authorUserId:
+        type: nullable<string>
+        docs: The user ID of the author
+      comment:
+        type: nullable<string>
+        docs: Comment on the score
+      metadata:
+        type: unknown
+        docs: Metadata associated with the score
       configId:
-        type: optional<string>
+        type: nullable<string>
         docs: Reference a score config on a score. When set, config and score name must be equal and value must comply to optionally defined numerical range
       queueId:
-        type: optional<string>
+        type: nullable<string>
         docs: The annotation queue referenced by the score. Indicates if score was initially created while processing annotation queue.
       environment:
-        type: optional<string>
+        type: string
         docs: The environment from which this score originated. Can be any lowercase alphanumeric string with hyphens and underscores that does not start with 'langfuse'.
   NumericScoreV1:
     extends: BaseScoreV1
@@ -299,29 +316,44 @@ types:
         type: BooleanScoreV1
         docs: "Score with BOOLEAN data type"
 
+  # Source: packages/shared/src/features/scores/interfaces/api/v2/schemas.ts - APIScoreSchemaV2
   BaseScore:
     properties:
       id: string
-      traceId: optional<string>
-      sessionId: optional<string>
-      observationId: optional<string>
-      datasetRunId: optional<string>
+      traceId:
+        type: optional<nullable<string>>
+        docs: The trace ID associated with the score
+      sessionId:
+        type: optional<nullable<string>>
+        docs: The session ID associated with the score
+      observationId:
+        type: optional<nullable<string>>
+        docs: The observation ID associated with the score
+      datasetRunId:
+        type: optional<nullable<string>>
+        docs: The dataset run ID associated with the score
       name: string
       source: ScoreSource
       timestamp: datetime
       createdAt: datetime
       updatedAt: datetime
-      authorUserId: optional<string>
-      comment: optional<string>
-      metadata: optional<unknown>
+      authorUserId:
+        type: nullable<string>
+        docs: The user ID of the author
+      comment:
+        type: nullable<string>
+        docs: Comment on the score
+      metadata:
+        type: unknown
+        docs: Metadata associated with the score
       configId:
-        type: optional<string>
+        type: nullable<string>
         docs: Reference a score config on a score. When set, config and score name must be equal and value must comply to optionally defined numerical range
       queueId:
-        type: optional<string>
+        type: nullable<string>
         docs: The annotation queue referenced by the score. Indicates if score was initially created while processing annotation queue.
       environment:
-        type: optional<string>
+        type: string
         docs: The environment from which this score originated. Can be any lowercase alphanumeric string with hyphens and underscores that does not start with 'langfuse'.
   NumericScore:
     extends: BaseScore
@@ -367,6 +399,7 @@ types:
       - string
     docs: The value of the score. Must be passed as string for categorical scores, and numeric for boolean and numeric scores
 
+  # Source: web/src/features/public-api/types/comments.ts - APIComment
   Comment:
     properties:
       id: string
@@ -376,36 +409,55 @@ types:
       objectType: CommentObjectType
       objectId: string
       content: string
-      authorUserId: optional<string>
+      authorUserId:
+        type: optional<nullable<string>>
+        docs: The user ID of the comment author
 
+  # Source: web/src/features/public-api/types/datasets.ts - APIDataset
   Dataset:
     properties:
       id: string
       name: string
-      description: optional<string>
-      metadata: optional<unknown>
+      description:
+        type: nullable<string>
+        docs: Description of the dataset
+      metadata:
+        type: unknown
+        docs: Metadata associated with the dataset
       inputSchema:
-        type: optional<unknown>
+        type: nullable<unknown>
         docs: JSON Schema for validating dataset item inputs
       expectedOutputSchema:
-        type: optional<unknown>
+        type: nullable<unknown>
         docs: JSON Schema for validating dataset item expected outputs
       projectId: string
       createdAt: datetime
       updatedAt: datetime
+  # Source: web/src/features/public-api/types/datasets.ts - APIDatasetItem
   DatasetItem:
     properties:
       id: string
       status: DatasetStatus
-      input: optional<unknown>
-      expectedOutput: optional<unknown>
-      metadata: optional<unknown>
-      sourceTraceId: optional<string>
-      sourceObservationId: optional<string>
+      input:
+        type: unknown
+        docs: Input data for the dataset item
+      expectedOutput:
+        type: unknown
+        docs: Expected output for the dataset item
+      metadata:
+        type: unknown
+        docs: Metadata associated with the dataset item
+      sourceTraceId:
+        type: nullable<string>
+        docs: The trace ID that sourced this dataset item
+      sourceObservationId:
+        type: nullable<string>
+        docs: The observation ID that sourced this dataset item
       datasetId: string
       datasetName: string
       createdAt: datetime
       updatedAt: datetime
+  # Source: web/src/features/public-api/types/datasets.ts - APIDatasetRunItem
   DatasetRunItem:
     properties:
       id: string
@@ -413,9 +465,12 @@ types:
       datasetRunName: string
       datasetItemId: string
       traceId: string
-      observationId: optional<string>
+      observationId:
+        type: nullable<string>
+        docs: The observation ID associated with this run item
       createdAt: datetime
       updatedAt: datetime
+  # Source: web/src/features/public-api/types/datasets.ts - APIDatasetRun
   DatasetRun:
     properties:
       id:
@@ -425,10 +480,10 @@ types:
         type: string
         docs: Name of the dataset run
       description:
-        type: optional<string>
+        type: nullable<string>
         docs: Description of the run
       metadata:
-        type: optional<unknown>
+        type: unknown
         docs: Metadata of the dataset run
       datasetId:
         type: string
@@ -446,6 +501,7 @@ types:
     extends: DatasetRun
     properties:
       datasetRunItems: list<DatasetRunItem>
+  # Source: web/src/features/public-api/types/models.ts - APIModelDefinition
   Model:
     docs: |
       Model definition used for transforming usage into USD cost and/or tokenization.
@@ -467,25 +523,25 @@ types:
         type: string
       startDate:
         docs: Apply only to generations which are newer than this ISO date.
-        type: optional<datetime>
+        type: nullable<datetime>
       unit:
         docs: Unit used by this model.
-        type: optional<ModelUsageUnit>
+        type: optional<nullable<ModelUsageUnit>>
       inputPrice:
         docs: Deprecated. See 'prices' instead. Price (USD) per input unit
-        type: optional<double>
+        type: nullable<double>
       outputPrice:
         docs: Deprecated. See 'prices' instead. Price (USD) per output unit
-        type: optional<double>
+        type: nullable<double>
       totalPrice:
         docs: Deprecated. See 'prices' instead. Price (USD) per total unit. Cannot be set if input or output price is set.
-        type: optional<double>
+        type: nullable<double>
       tokenizerId:
         docs: Optional. Tokenizer to be applied to observations which match to this model. See docs for more details.
-        type: optional<string>
+        type: nullable<string>
       tokenizerConfig:
         docs: Optional. Configuration for the selected tokenizer. Needs to be JSON. See docs for more details.
-        type: optional<unknown>
+        type: unknown
       isLangfuseManaged:
         type: boolean
       createdAt:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -6445,17 +6445,12 @@ components:
           type: array
           items:
             type: string
-          nullable: true
-          description: >-
-            The tags associated with the trace. Can be an array of strings or
-            null.
+          description: The tags associated with the trace.
         public:
           type: boolean
-          nullable: true
           description: Public traces are accessible via url without login
         environment:
           type: string
-          nullable: true
           description: >-
             The environment from which this trace originated. Can be any
             lowercase alphanumeric string with hyphens and underscores that does
@@ -6463,6 +6458,9 @@ components:
       required:
         - id
         - timestamp
+        - tags
+        - public
+        - environment
     TraceWithDetails:
       title: TraceWithDetails
       type: object
@@ -6473,27 +6471,27 @@ components:
         latency:
           type: number
           format: double
+          nullable: true
           description: Latency of trace in seconds
         totalCost:
           type: number
           format: double
+          nullable: true
           description: Cost of trace in USD
         observations:
           type: array
           items:
             type: string
+          nullable: true
           description: List of observation ids
         scores:
           type: array
           items:
             type: string
+          nullable: true
           description: List of score ids
       required:
         - htmlPath
-        - latency
-        - totalCost
-        - observations
-        - scores
       allOf:
         - $ref: '#/components/schemas/Trace'
     TraceWithFullDetails:
@@ -6506,10 +6504,12 @@ components:
         latency:
           type: number
           format: double
+          nullable: true
           description: Latency of trace in seconds
         totalCost:
           type: number
           format: double
+          nullable: true
           description: Cost of trace in USD
         observations:
           type: array
@@ -6523,8 +6523,6 @@ components:
           description: List of scores
       required:
         - htmlPath
-        - latency
-        - totalCost
         - observations
         - scores
       allOf:
@@ -6542,12 +6540,12 @@ components:
           type: string
         environment:
           type: string
-          nullable: true
           description: The environment from which this session originated.
       required:
         - id
         - createdAt
         - projectId
+        - environment
     SessionWithTraces:
       title: SessionWithTraces
       type: object
@@ -6597,27 +6595,19 @@ components:
           nullable: true
           description: The model used for the observation
         modelParameters:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/MapValue'
-          nullable: true
           description: The parameters of the model used for the observation
         input:
-          nullable: true
           description: The input data of the observation
         version:
           type: string
           nullable: true
           description: The version of the observation
         metadata:
-          nullable: true
           description: Additional metadata of the observation
         output:
-          nullable: true
           description: The output data of the observation
         usage:
           $ref: '#/components/schemas/Usage'
-          nullable: true
           description: >-
             (Deprecated. Use usageDetails and costDetails instead.) The usage
             data of the observation
@@ -6640,7 +6630,6 @@ components:
           type: object
           additionalProperties:
             type: integer
-          nullable: true
           description: >-
             The usage details of the observation. Key is the name of the usage
             metric, value is the number of units consumed. The total key is the
@@ -6650,14 +6639,12 @@ components:
           additionalProperties:
             type: number
             format: double
-          nullable: true
           description: >-
             The cost details of the observation. Key is the name of the cost
             metric, value is the cost in USD. The total key is the sum of all
             (non-total) cost metrics or the total value ingested.
         environment:
           type: string
-          nullable: true
           description: >-
             The environment from which this observation originated. Can be any
             lowercase alphanumeric string with hyphens and underscores that does
@@ -6666,7 +6653,15 @@ components:
         - id
         - type
         - startTime
+        - modelParameters
+        - input
+        - metadata
+        - output
+        - usage
         - level
+        - usageDetails
+        - costDetails
+        - environment
     ObservationsView:
       title: ObservationsView
       type: object
@@ -6740,19 +6735,17 @@ components:
       properties:
         input:
           type: integer
-          nullable: true
           description: Number of input units (e.g. tokens)
         output:
           type: integer
-          nullable: true
           description: Number of output units (e.g. tokens)
         total:
           type: integer
-          nullable: true
           description: Defaults to input+output if not set
         unit:
-          $ref: '#/components/schemas/ModelUsageUnit'
+          type: string
           nullable: true
+          description: Unit of measurement
         inputCost:
           type: number
           format: double
@@ -6768,6 +6761,10 @@ components:
           format: double
           nullable: true
           description: USD total cost, defaults to input+output
+      required:
+        - input
+        - output
+        - total
     ScoreConfig:
       title: ScoreConfig
       type: object
@@ -6813,6 +6810,7 @@ components:
         description:
           type: string
           nullable: true
+          description: Description of the score config
       required:
         - id
         - name
@@ -6848,6 +6846,7 @@ components:
         observationId:
           type: string
           nullable: true
+          description: The observation ID associated with the score
         timestamp:
           type: string
           format: date-time
@@ -6860,11 +6859,13 @@ components:
         authorUserId:
           type: string
           nullable: true
+          description: The user ID of the author
         comment:
           type: string
           nullable: true
+          description: Comment on the score
         metadata:
-          nullable: true
+          description: Metadata associated with the score
         configId:
           type: string
           nullable: true
@@ -6880,7 +6881,6 @@ components:
             initially created while processing annotation queue.
         environment:
           type: string
-          nullable: true
           description: >-
             The environment from which this score originated. Can be any
             lowercase alphanumeric string with hyphens and underscores that does
@@ -6893,6 +6893,8 @@ components:
         - timestamp
         - createdAt
         - updatedAt
+        - metadata
+        - environment
     NumericScoreV1:
       title: NumericScoreV1
       type: object
@@ -6990,15 +6992,19 @@ components:
         traceId:
           type: string
           nullable: true
+          description: The trace ID associated with the score
         sessionId:
           type: string
           nullable: true
+          description: The session ID associated with the score
         observationId:
           type: string
           nullable: true
+          description: The observation ID associated with the score
         datasetRunId:
           type: string
           nullable: true
+          description: The dataset run ID associated with the score
         name:
           type: string
         source:
@@ -7015,11 +7021,13 @@ components:
         authorUserId:
           type: string
           nullable: true
+          description: The user ID of the author
         comment:
           type: string
           nullable: true
+          description: Comment on the score
         metadata:
-          nullable: true
+          description: Metadata associated with the score
         configId:
           type: string
           nullable: true
@@ -7035,7 +7043,6 @@ components:
             initially created while processing annotation queue.
         environment:
           type: string
-          nullable: true
           description: >-
             The environment from which this score originated. Can be any
             lowercase alphanumeric string with hyphens and underscores that does
@@ -7047,6 +7054,8 @@ components:
         - timestamp
         - createdAt
         - updatedAt
+        - metadata
+        - environment
     NumericScore:
       title: NumericScore
       type: object
@@ -7167,6 +7176,7 @@ components:
         authorUserId:
           type: string
           nullable: true
+          description: The user ID of the comment author
       required:
         - id
         - projectId
@@ -7186,8 +7196,9 @@ components:
         description:
           type: string
           nullable: true
+          description: Description of the dataset
         metadata:
-          nullable: true
+          description: Metadata associated with the dataset
         inputSchema:
           nullable: true
           description: JSON Schema for validating dataset item inputs
@@ -7205,6 +7216,7 @@ components:
       required:
         - id
         - name
+        - metadata
         - projectId
         - createdAt
         - updatedAt
@@ -7217,17 +7229,19 @@ components:
         status:
           $ref: '#/components/schemas/DatasetStatus'
         input:
-          nullable: true
+          description: Input data for the dataset item
         expectedOutput:
-          nullable: true
+          description: Expected output for the dataset item
         metadata:
-          nullable: true
+          description: Metadata associated with the dataset item
         sourceTraceId:
           type: string
           nullable: true
+          description: The trace ID that sourced this dataset item
         sourceObservationId:
           type: string
           nullable: true
+          description: The observation ID that sourced this dataset item
         datasetId:
           type: string
         datasetName:
@@ -7241,6 +7255,9 @@ components:
       required:
         - id
         - status
+        - input
+        - expectedOutput
+        - metadata
         - datasetId
         - datasetName
         - createdAt
@@ -7262,6 +7279,7 @@ components:
         observationId:
           type: string
           nullable: true
+          description: The observation ID associated with this run item
         createdAt:
           type: string
           format: date-time
@@ -7291,7 +7309,6 @@ components:
           nullable: true
           description: Description of the run
         metadata:
-          nullable: true
           description: Metadata of the dataset run
         datasetId:
           type: string
@@ -7310,6 +7327,7 @@ components:
       required:
         - id
         - name
+        - metadata
         - datasetId
         - datasetName
         - createdAt
@@ -7399,7 +7417,6 @@ components:
             Optional. Tokenizer to be applied to observations which match to
             this model. See docs for more details.
         tokenizerConfig:
-          nullable: true
           description: >-
             Optional. Configuration for the selected tokenizer. Needs to be
             JSON. See docs for more details.
@@ -7452,6 +7469,7 @@ components:
         - id
         - modelName
         - matchPattern
+        - tokenizerConfig
         - isLangfuseManaged
         - createdAt
         - prices


### PR DESCRIPTION
- Update fern/apis/server/definition/commons.yml to match TypeScript types
- Add source file references to each Fern type definition
- Fix nullable vs optional type mappings:
  - .nullable() → nullable<T>
  - .nullish() → optional<nullable<T>>
  - .optional() → optional<T>
  - Always present fields → T (not optional)
- Update backend-dev-guidelines skill with Fern API sync guidelines
- Add API Documentation section to REVIEW.md

Closes #11232

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Synchronize Fern API types with TypeScript definitions, update type mappings, and enhance documentation.
> 
>   - **Fern API Types**:
>     - Update `fern/apis/server/definition/commons.yml` to match TypeScript types.
>     - Add source file references to each Fern type definition.
>     - Fix type mappings: `.nullable()` to `nullable<T>`, `.nullish()` to `optional<nullable<T>>`, `.optional()` to `optional<T>`, always present fields to `T`.
>   - **Documentation**:
>     - Update backend-dev-guidelines with Fern API sync guidelines.
>     - Add API Documentation section to `REVIEW.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8fd6c8e78430997408c765ac11e1665df5045f76. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->