### PR TITLE
chore: revert cookie workaround after auth misconfiguration

### DIFF
--- a/web/src/pages/api/auth/[...nextauth].ts
+++ b/web/src/pages/api/auth/[...nextauth].ts
@@ -49,13 +49,5 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   res.setHeader("Pragma", "no-cache");
   res.setHeader("Expires", "0");
 
-  // Clean up the cookie from incident: https://status.langfuse.com/incident/770854
-  if (env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
-    res.setHeader(
-      "Set-Cookie",
-      `__Secure-next-auth.session-token.${env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Lax; Max-Age=0`,
-    );
-  }
-
   return await NextAuth(req, res, authOptions);
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reverts cookie cleanup workaround in `auth` function in `[...nextauth].ts` after resolving a past misconfiguration incident.
> 
>   - **Behavior**:
>     - Removes cookie cleanup workaround in `auth` function in `[...nextauth].ts` related to a past misconfiguration incident.
>     - No longer sets `__Secure-next-auth.session-token` cookie to expire immediately.
>   - **Misc**:
>     - References to the incident in comments are removed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ecf46bcb571f3d50e0919a0ae55295e2a720a7a7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->