### PR TITLE
fix: fixes for delete query tracking

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -168,8 +168,6 @@ const EnvSchema = z.object({
     .default(80e6), // 80MB
   LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS: z.coerce.number().default(600_000), // 10 minutes
   LANGFUSE_CLICKHOUSE_QUERY_MAX_ATTEMPTS: z.coerce.number().default(3), // Maximum attempts for socket hang up errors
-  // Mutation monitoring for ClickHouse DELETE operations
-  LANGFUSE_MUTATION_MONITOR_ENABLED: z.enum(["true", "false"]).default("false"),
   // Async deletion tracking - uses AbortController + query_id polling for DELETE operations
   LANGFUSE_ASYNC_DELETE_TRACKING_ENABLED: z
     .enum(["true", "false"])

--- a/packages/shared/src/server/clickhouse/queryTracking.ts
+++ b/packages/shared/src/server/clickhouse/queryTracking.ts
@@ -31,28 +31,6 @@ export async function pollQueryStatus(
     operation: "pollQueryStatus",
     ...tags,
   };
-  // First check if still running in system.processes
-  const running = await queryClickhouse<{ query_id: string }>({
-    query: `
-      SELECT query_id
-      FROM clusterAllReplicas('default', 'system.processes')
-      WHERE query_id = {queryId: String}
-      LIMIT 1
-    `,
-    params: { queryId },
-    clickhouseConfigs: {
-      request_timeout: 60_000,
-    },
-    clickhouseSettings: {
-      skip_unavailable_shards: 1,
-    },
-    tags: tagsWithDefaults,
-  });
-
-  if (running.length > 0) {
-    return "running";
-  }
-
   // Check query_log for completion status
   const result = await queryClickhouse<{
     type: string;
@@ -72,10 +50,7 @@ export async function pollQueryStatus(
     clickhouseSettings: {
       skip_unavailable_shards: 1,
     },
-    tags: {
-      feature: "query-tracking",
-      operation: "pollQueryStatus-queryLog",
-    },
+    tags: tagsWithDefaults,
   });
 
   if (result.length === 0) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Removes initial running query check in `pollQueryStatus()` and `LANGFUSE_MUTATION_MONITOR_ENABLED` from `env.ts`.
> 
>   - **Behavior**:
>     - Removes initial check for running queries in `pollQueryStatus()` in `queryTracking.ts`, now relies solely on `system.query_log`.
>     - Removes `LANGFUSE_MUTATION_MONITOR_ENABLED` from `env.ts`, which was related to mutation monitoring for ClickHouse DELETE operations.
>   - **Misc**:
>     - Updates `tags` in `pollQueryStatus()` in `queryTracking.ts` to use `tagsWithDefaults` consistently.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 15336bc99ba037d85522641a338cc21872b31cf5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->