### PR TITLE
fix(playground): empty values on playground jump for microsoft semant…

### DIFF
--- a/packages/shared/src/utils/chatml/adapters/index.ts
+++ b/packages/shared/src/utils/chatml/adapters/index.ts
@@ -4,6 +4,7 @@ import { aisdkAdapter } from "./aisdk";
 import { openAIAdapter } from "./openai";
 import { geminiAdapter } from "./gemini";
 import { microsoftAgentAdapter } from "./microsoft-agent";
+import { semanticKernelAdapter } from "./semantic-kernel";
 import { pydanticAIAdapter } from "./pydantic-ai";
 import { genericAdapter } from "./generic";
 
@@ -15,6 +16,7 @@ const adapters: ProviderAdapter[] = [
   microsoftAgentAdapter, // Microsoft Agent Framework
   pydanticAIAdapter, // Pydantic AI framework
   // Add more adapters here as needed
+  semanticKernelAdapter, // Microsoft Semantic Kernel - detects by scope.name prefix
   genericAdapter, // Always last (fallback)
 ];
 
@@ -43,5 +45,6 @@ export { aisdkAdapter } from "./aisdk";
 export { openAIAdapter } from "./openai";
 export { geminiAdapter } from "./gemini";
 export { microsoftAgentAdapter } from "./microsoft-agent";
+export { semanticKernelAdapter } from "./semantic-kernel";
 export { pydanticAIAdapter } from "./pydantic-ai";
 export { genericAdapter } from "./generic";

--- a/packages/shared/src/utils/chatml/adapters/langgraph.ts
+++ b/packages/shared/src/utils/chatml/adapters/langgraph.ts
@@ -275,9 +275,9 @@ export const langgraphAdapter: ProviderAdapter = {
     // EXPLICIT: Framework hint
     if (ctx.framework === "langgraph") return true;
 
-    // REJECTIONS: Reject AI SDK v5 and OpenAI Agents SDK formats
+    // REJECTIONS: Reject AI SDK v5, OpenAI Agents SDK, and Semantic Kernel formats
     if (meta && typeof meta === "object") {
-      // Check scope.name for AI SDK or OpenAI Agents
+      // Check scope.name for AI SDK, OpenAI Agents, or Semantic Kernel
       if ("scope" in meta && typeof meta.scope === "object") {
         const scope = meta.scope as Record<string, unknown>;
 
@@ -289,6 +289,13 @@ export const langgraphAdapter: ProviderAdapter = {
           scope.name === "openinference.instrumentation.openai_agents" ||
           (typeof scope.name === "string" &&
             scope.name.includes("openai_agents"))
+        ) {
+          return false;
+        }
+
+        if (
+          typeof scope.name === "string" &&
+          scope.name.startsWith("Microsoft.SemanticKernel")
         ) {
           return false;
         }

--- a/packages/shared/src/utils/chatml/adapters/openai.ts
+++ b/packages/shared/src/utils/chatml/adapters/openai.ts
@@ -309,7 +309,7 @@ export const openAIAdapter: ProviderAdapter = {
   detect(ctx: NormalizerContext): boolean {
     const meta = parseMetadata(ctx.metadata);
 
-    // REJECTIONS: Explicit rejection of LangGraph/LangChain formats
+    // REJECTIONS: Explicit rejection of LangGraph/LangChain/Semantic Kernel formats
     if (meta && typeof meta === "object") {
       // LangGraph
       if (
@@ -320,6 +320,17 @@ export const openAIAdapter: ProviderAdapter = {
         (Array.isArray(meta.tags) && meta.tags.includes("langgraph"))
       ) {
         return false;
+      }
+
+      // Semantic Kernel (scope.name starts with Microsoft.SemanticKernel)
+      if ("scope" in meta && typeof meta.scope === "object") {
+        const scope = meta.scope as Record<string, unknown>;
+        if (
+          typeof scope.name === "string" &&
+          scope.name.startsWith("Microsoft.SemanticKernel")
+        ) {
+          return false;
+        }
       }
 
       // LangChain (type without role)

--- a/packages/shared/src/utils/chatml/adapters/semantic-kernel.ts
+++ b/packages/shared/src/utils/chatml/adapters/semantic-kernel.ts
@@ -1,0 +1,158 @@
+import type { NormalizerContext, ProviderAdapter } from "../types";
+import { parseMetadata, getNestedProperty, removeNullFields } from "../helpers";
+
+/**
+ * Semantic Kernel Adapter
+ *
+ * Microsoft Semantic Kernel wraps message content in `gen_ai.event.content` as a JSON string.
+ * Detection is based on scope.name starting with "Microsoft.SemanticKernel".
+ *
+ * Input format:
+ * [{
+ *   "role": "system",
+ *   "gen_ai.event.content": "{\"role\":\"system\",\"content\":\"...\",\"tool_calls\":[]}",
+ *   "gen_ai.system": "openai"
+ * }]
+ *
+ * Output format:
+ * {
+ *   "gen_ai.event.content": "{\"index\":0,\"message\":{\"role\":\"Assistant\",\"content\":\"...\"},\"finish_reason\":\"Stop\"}"
+ * }
+ */
+
+/**
+ * Parse gen_ai.event.content JSON string and extract normalized message
+ */
+function parseEventContent(content: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(content);
+    if (!parsed || typeof parsed !== "object") return null;
+
+    // Handle output format with nested message: {index, message: {...}, finish_reason}
+    if ("message" in parsed && typeof parsed.message === "object") {
+      return parsed.message as Record<string, unknown>;
+    }
+
+    // Handle input format: {role, content, tool_calls, name}
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Normalize role casing: "Assistant" -> "assistant"
+ */
+function normalizeRole(role: unknown): string {
+  if (typeof role !== "string") return "assistant";
+  return role.toLowerCase();
+}
+
+/**
+ * Normalize a single Semantic Kernel message
+ */
+function normalizeMessage(msg: unknown): Record<string, unknown> {
+  if (!msg || typeof msg !== "object") return {};
+
+  const message = msg as Record<string, unknown>;
+
+  // If has gen_ai.event.content, parse and extract
+  if (typeof message["gen_ai.event.content"] === "string") {
+    const inner = parseEventContent(message["gen_ai.event.content"]);
+    if (inner) {
+      const normalized: Record<string, unknown> = {
+        role: normalizeRole(inner.role),
+      };
+
+      // Extract content
+      if (inner.content !== null && inner.content !== undefined) {
+        normalized.content = inner.content;
+      }
+
+      // Extract tool_calls if present and non-empty
+      if (Array.isArray(inner.tool_calls) && inner.tool_calls.length > 0) {
+        normalized.tool_calls = inner.tool_calls;
+      }
+
+      // Extract name if present
+      if (inner.name !== null && inner.name !== undefined) {
+        normalized.name = inner.name;
+      }
+
+      return removeNullFields(normalized);
+    }
+  }
+
+  // Fallback: return as-is without OTel fields
+  const {
+    "gen_ai.event.content": _content,
+    "gen_ai.system": _system,
+    ...rest
+  } = message;
+  return removeNullFields(rest);
+}
+
+function normalizeMessages(data: unknown[]): unknown[] {
+  return data.map(normalizeMessage);
+}
+
+function preprocessData(data: unknown, _ctx: NormalizerContext): unknown {
+  if (!data) return data;
+
+  // Array of messages (input format)
+  if (Array.isArray(data)) {
+    return normalizeMessages(data);
+  }
+
+  // Single object with gen_ai.event.content (output format)
+  if (typeof data === "object" && "gen_ai.event.content" in data) {
+    const normalized = normalizeMessage(data);
+    // Wrap single message in array for consistency
+    return [normalized];
+  }
+
+  // Object with messages key
+  if (typeof data === "object" && "messages" in data) {
+    const obj = data as Record<string, unknown>;
+    return {
+      ...obj,
+      messages: Array.isArray(obj.messages)
+        ? normalizeMessages(obj.messages)
+        : obj.messages,
+    };
+  }
+
+  // Single message object with role
+  if (typeof data === "object" && "role" in data) {
+    return normalizeMessage(data);
+  }
+
+  return data;
+}
+
+export const semanticKernelAdapter: ProviderAdapter = {
+  id: "semantic-kernel",
+
+  detect(ctx: NormalizerContext): boolean {
+    // Explicit framework override
+    if (ctx.framework === "semantic-kernel") return true;
+
+    // Detect by scope name (Microsoft.SemanticKernel.Diagnostics)
+    // gen_ai.event.content is Semantic Kernel-specific, so we require scope name
+    const meta = parseMetadata(ctx.metadata);
+    const scopeName = getNestedProperty(meta, "scope", "name");
+
+    return (
+      typeof scopeName === "string" &&
+      scopeName.startsWith("Microsoft.SemanticKernel")
+    );
+  },
+
+  preprocess(
+    data: unknown,
+    _kind: "input" | "output",
+    ctx: NormalizerContext,
+  ): unknown {
+    return preprocessData(data, ctx);
+  },
+};

--- a/packages/shared/src/utils/chatml/index.ts
+++ b/packages/shared/src/utils/chatml/index.ts
@@ -16,5 +16,6 @@ export {
   geminiAdapter,
   microsoftAgentAdapter,
   pydanticAIAdapter,
+  semanticKernelAdapter,
   genericAdapter,
 } from "./adapters";

--- a/web/src/utils/chatml/adapters/index.ts
+++ b/web/src/utils/chatml/adapters/index.ts
@@ -7,6 +7,7 @@ export {
   geminiAdapter,
   microsoftAgentAdapter,
   pydanticAIAdapter,
+  semanticKernelAdapter,
   genericAdapter,
   normalizeInput,
   normalizeOutput,

--- a/web/src/utils/chatml/jumptoplayground.clienttest.ts
+++ b/web/src/utils/chatml/jumptoplayground.clienttest.ts
@@ -936,10 +936,14 @@ describe("Playground Jump Full Pipeline", () => {
       .data!.map(convertChatMlToPlayground)
       .filter((m) => m)[0]!;
     expect(inputMsg).toBeDefined();
-    expect(inputMsg.role).toBe("user");
-    expect(inputMsg.content).toBe("What is the weather?");
-    // Ensure gen_ai.event.content was unwrapped, not passed through
-    expect(inputMsg).not.toHaveProperty("gen_ai.event.content");
+    if ("role" in inputMsg) {
+      expect(inputMsg.role).toBe("user");
+      expect(inputMsg.content).toBe("What is the weather?");
+      // Ensure gen_ai.event.content was unwrapped, not passed through
+      expect(inputMsg).not.toHaveProperty("gen_ai.event.content");
+    } else {
+      throw new Error("Expected message with role property");
+    }
 
     // Output: single object with nested message structure
     const output = {
@@ -953,10 +957,14 @@ describe("Playground Jump Full Pipeline", () => {
       .data!.map(convertChatMlToPlayground)
       .filter((m) => m)[0];
     expect(outputMsg).toBeDefined();
-    expect(outputMsg.role).toBe("assistant");
-    expect(outputMsg.content).toBe("The answer is positive.");
-    // Ensure gen_ai.event.content was unwrapped, not passed through
-    expect(outputMsg).not.toHaveProperty("gen_ai.event.content");
+    if (outputMsg && "role" in outputMsg) {
+      expect(outputMsg.role).toBe("assistant");
+      expect(outputMsg.content).toBe("The answer is positive.");
+      // Ensure gen_ai.event.content was unwrapped, not passed through
+      expect(outputMsg).not.toHaveProperty("gen_ai.event.content");
+    } else {
+      throw new Error("Expected message with role property");
+    }
   });
 
   it("should respect includeOutput flag when jumping to playground, default to no output added", () => {

--- a/web/src/utils/chatml/jumptoplayground.clienttest.ts
+++ b/web/src/utils/chatml/jumptoplayground.clienttest.ts
@@ -934,7 +934,7 @@ describe("Playground Jump Full Pipeline", () => {
 
     const inputMsg = inputResult
       .data!.map(convertChatMlToPlayground)
-      .filter((m) => m)[0];
+      .filter((m) => m)[0]!;
     expect(inputMsg).toBeDefined();
     expect(inputMsg.role).toBe("user");
     expect(inputMsg.content).toBe("What is the weather?");

--- a/worker/src/__tests__/chatml/adapters/semantic-kernel.test.ts
+++ b/worker/src/__tests__/chatml/adapters/semantic-kernel.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from "vitest";
+import {
+  semanticKernelAdapter,
+  selectAdapter,
+  SimpleChatMlArraySchema,
+  type NormalizerContext,
+} from "@langfuse/shared";
+
+const skMetadata = {
+  scope: { name: "Microsoft.SemanticKernel.Diagnostics", version: "" },
+};
+
+// Test helpers
+function normalizeInput(input: unknown, ctx: NormalizerContext = {}) {
+  const adapter = selectAdapter({
+    ...ctx,
+    metadata: ctx.metadata ?? input,
+    data: input,
+  });
+  const preprocessed = adapter.preprocess(input, "input", ctx);
+  return SimpleChatMlArraySchema.safeParse(preprocessed);
+}
+
+function normalizeOutput(output: unknown, ctx: NormalizerContext = {}) {
+  const adapter = selectAdapter({
+    ...ctx,
+    metadata: ctx.metadata ?? output,
+    data: output,
+  });
+  const preprocessed = adapter.preprocess(output, "output", ctx);
+  return SimpleChatMlArraySchema.safeParse(preprocessed);
+}
+
+describe("Semantic Kernel Adapter", () => {
+  describe("detection", () => {
+    it("should detect Semantic Kernel by scope name", () => {
+      const ctx: NormalizerContext = {
+        metadata: {
+          scope: {
+            name: "Microsoft.SemanticKernel.Diagnostics",
+            version: "",
+          },
+        },
+      };
+
+      expect(semanticKernelAdapter.detect(ctx)).toBe(true);
+    });
+
+    it("should detect by framework override", () => {
+      expect(
+        semanticKernelAdapter.detect({ framework: "semantic-kernel" }),
+      ).toBe(true);
+    });
+
+    it("should not detect messages with gen_ai.event.content but no scope name", () => {
+      // Detection requires scope.name, not just structural pattern
+      const input = [
+        {
+          role: "system",
+          "gen_ai.event.content":
+            '{"role":"system","name":null,"content":"Today is 2025-12-12T00:00:00.","tool_calls":[]}',
+          "gen_ai.system": "openai",
+        },
+      ];
+
+      expect(semanticKernelAdapter.detect({ data: input })).toBe(false);
+    });
+
+    it("should detect with scope name and gen_ai.event.content", () => {
+      expect(
+        semanticKernelAdapter.detect({
+          metadata: skMetadata,
+          data: [{ role: "user", "gen_ai.event.content": '{"content":"Hi"}' }],
+        }),
+      ).toBe(true);
+    });
+
+    it("should not detect standard OpenAI format", () => {
+      expect(
+        semanticKernelAdapter.detect({
+          data: { role: "user", content: "Hello" },
+        }),
+      ).toBe(false);
+    });
+
+    it("should not detect MS Agent Framework format with parts", () => {
+      expect(
+        semanticKernelAdapter.detect({
+          data: [
+            {
+              role: "user",
+              parts: [{ type: "text", content: "Hello" }],
+            },
+          ],
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("normalization", () => {
+    it("should extract content from gen_ai.event.content in input messages", () => {
+      // Real format from Semantic Kernel traces (pg.json)
+      const metadata = {
+        attributes: {
+          "gen_ai.operation.name": "chat.completions",
+          "gen_ai.system": "openai",
+          "gen_ai.request.model": "o4-mini",
+        },
+        scope: {
+          name: "Microsoft.SemanticKernel.Diagnostics",
+          version: "",
+          attributes: {},
+        },
+      };
+
+      const input = [
+        {
+          role: "system",
+          "gen_ai.event.content":
+            '{"role":"system","name":null,"content":"Today is 2025-12-12T00:00:00.","tool_calls":[]}',
+          "gen_ai.system": "openai",
+        },
+        {
+          role: "user",
+          "gen_ai.event.content":
+            '{"role":"user","name":null,"content":"What is the weather in Portland?","tool_calls":[]}',
+          "gen_ai.system": "openai",
+        },
+      ];
+
+      const result = normalizeInput(input, { metadata });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(2);
+
+      expect(result.data?.[0].content).toBe("Today is 2025-12-12T00:00:00.");
+      expect(result.data?.[0].role).toBe("system");
+
+      expect(result.data?.[1].content).toBe("What is the weather in Portland?");
+      expect(result.data?.[1].role).toBe("user");
+    });
+
+    it("should extract content from gen_ai.event.content output format with nested message", () => {
+      // Semantic Kernel output format wraps content in a message object
+      // Real format from pg.json line 73
+      const output = {
+        "gen_ai.event.content":
+          '{"index":0,"message":{"role":"Assistant","name":null,"content":"Based on the analysis, the answer is positive.","tool_calls":[]},"tool_calls":[],"finish_reason":"Stop"}',
+      };
+
+      const result = normalizeOutput(output, { metadata: skMetadata });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(1);
+
+      expect(result.data?.[0].content).toBe(
+        "Based on the analysis, the answer is positive.",
+      );
+      // Role should be normalized to lowercase
+      expect(result.data?.[0].role).toBe("assistant");
+    });
+
+    it("should extract tool_calls from gen_ai.event.content", () => {
+      const input = [
+        {
+          role: "assistant",
+          "gen_ai.event.content":
+            '{"role":"assistant","name":null,"content":"","tool_calls":[{"id":"call_abc123","type":"function","function":{"name":"get_weather","arguments":"{\\"location\\":\\"Portland\\"}"}}]}',
+          "gen_ai.system": "openai",
+        },
+      ];
+
+      const result = normalizeInput(input, { metadata: skMetadata });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.[0].tool_calls).toBeDefined();
+      expect(result.data?.[0].tool_calls).toHaveLength(1);
+      expect(result.data?.[0].tool_calls?.[0].id).toBe("call_abc123");
+      expect(result.data?.[0].tool_calls?.[0].function?.name).toBe(
+        "get_weather",
+      );
+    });
+
+    it("should strip gen_ai.* fields from output", () => {
+      const input = [
+        {
+          role: "user",
+          "gen_ai.event.content":
+            '{"role":"user","content":"Hello","tool_calls":[]}',
+          "gen_ai.system": "openai",
+        },
+      ];
+
+      const result = normalizeInput(input, { metadata: skMetadata });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.[0]).not.toHaveProperty("gen_ai.event.content");
+      expect(result.data?.[0]).not.toHaveProperty("gen_ai.system");
+    });
+
+    it("should handle messages without gen_ai.event.content gracefully", () => {
+      // If a message doesn't have gen_ai.event.content, pass through cleaned
+      const input = [
+        {
+          role: "user",
+          content: "Regular message without OTel wrapping",
+        },
+      ];
+
+      const result = normalizeInput(input, { framework: "semantic-kernel" });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.[0].content).toBe(
+        "Regular message without OTel wrapping",
+      );
+      expect(result.data?.[0].role).toBe("user");
+    });
+  });
+});


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `semanticKernelAdapter` to handle Microsoft Semantic Kernel format, update existing adapters for detection, and add tests for validation.
> 
>   - **Adapters**:
>     - Add `semanticKernelAdapter` in `adapters/index.ts` and `semantic-kernel.ts` to handle Microsoft Semantic Kernel format.
>     - Update `langgraphAdapter` and `openAIAdapter` to reject Semantic Kernel format based on `scope.name`.
>   - **Detection and Normalization**:
>     - `semanticKernelAdapter` detects by `scope.name` starting with `Microsoft.SemanticKernel` and normalizes messages by parsing `gen_ai.event.content`.
>     - Normalize role casing and extract `tool_calls` and `name` if present.
>   - **Tests**:
>     - Add tests in `jumptoplayground.clienttest.ts` and `semantic-kernel.test.ts` to verify detection and normalization of Semantic Kernel input and output formats.
>     - Ensure `gen_ai.event.content` is correctly unwrapped and not passed through.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d667d1e70f7b212a8a8f3b10ef2a33f85641e303. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->