### PR TITLE
fix(api): make retention optional and fix metadata handling in update project

### DIFF
--- a/fern/apis/server/definition/projects.yml
+++ b/fern/apis/server/definition/projects.yml
@@ -44,8 +44,12 @@ service:
               type: optional<map<string, unknown>>
               docs: Optional metadata for the project
             retention:
-              type: integer
-              docs: Number of days to retain data. Must be 0 or at least 3 days. Requires data-retention entitlement for non-zero values. Optional.
+              type: optional<integer>
+              docs: |
+                Number of days to retain data.
+                Must be 0 or at least 3 days.
+                Requires data-retention entitlement for non-zero values.
+                Optional. Will retain existing retention setting if omitted.
       response: Project
 
     delete:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3935,13 +3935,14 @@ paths:
                   description: Optional metadata for the project
                 retention:
                   type: integer
-                  description: >-
-                    Number of days to retain data. Must be 0 or at least 3 days.
+                  nullable: true
+                  description: |-
+                    Number of days to retain data.
+                    Must be 0 or at least 3 days.
                     Requires data-retention entitlement for non-zero values.
-                    Optional.
+                    Optional. Will retain existing retention setting if omitted.
               required:
                 - name
-                - retention
     delete:
       description: >-
         Delete a project by ID (requires organization-scoped API key). Project

--- a/web/src/ee/features/admin-api/server/projects/projectById/index.ts
+++ b/web/src/ee/features/admin-api/server/projects/projectById/index.ts
@@ -77,7 +77,7 @@ export async function handleUpdateProject(
       data: {
         name,
         ...(retention !== undefined ? { retentionDays: retention } : {}),
-        metadata,
+        ...(metadata !== undefined ? metadata : {}),
       },
       select: {
         id: true,

--- a/web/src/ee/features/admin-api/server/projects/projectById/index.ts
+++ b/web/src/ee/features/admin-api/server/projects/projectById/index.ts
@@ -77,7 +77,7 @@ export async function handleUpdateProject(
       data: {
         name,
         ...(retention !== undefined ? { retentionDays: retention } : {}),
-        ...(metadata !== undefined ? metadata : {}),
+        ...(metadata !== undefined ? { metadata } : {}),
       },
       select: {
         id: true,


### PR DESCRIPTION
## Summary
- Make `retention` field optional in the update project API - omitting it now retains the existing setting instead of requiring a value
- Fix metadata handling to only spread when defined, preventing unintended null overwrites
- Update Fern API definition and regenerated OpenAPI spec

## Test plan
- [ ] Verify update project API works without providing `retention` field
- [ ] Verify existing retention settings are preserved when `retention` is omitted
- [ ] Verify metadata updates work correctly when provided
- [ ] Verify metadata is not cleared when omitted from request

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Makes `retention` optional in update project API and fixes metadata handling to prevent null overwrites.
> 
>   - **Behavior**:
>     - `retention` field in update project API is now optional; omitting it retains existing setting.
>     - Fixes metadata handling in `handleUpdateProject` in `index.ts` to prevent null overwrites.
>   - **API Definition**:
>     - Updates `projects.yml` to make `retention` an optional integer.
>     - Regenerates `openapi.yml` to reflect changes.
>   - **Misc**:
>     - Updates `handleUpdateProject` in `index.ts` to spread metadata only when defined.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5eb690853c9db29c61b23936e7a6ca21f537ff6d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->