### PR TITLE
fix: ensure correct numeric handling of usage_details values instead of concatenation

### DIFF
--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -93,6 +93,11 @@ const RawUsageDetails = z.record(z.string(), z.unknown()).transform((val) => {
   for (const [key, value] of Object.entries(val)) {
     if (typeof value === "number" && Number.isInteger(value) && value >= 0) {
       result[key] = value;
+    } else if (typeof value === "string") {
+      const parsed = parseInt(value, 10);
+      if (!isNaN(parsed) && parsed >= 0) {
+        result[key] = parsed;
+      }
     }
   }
 

--- a/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
@@ -1272,4 +1272,77 @@ describe("Token Cost Calculation", () => {
     expect(generation.usage_details.output).toBeUndefined();
     expect(generation.usage_details.total).toBeUndefined();
   });
+
+  describe("string to number conversion in getUsageUnits", () => {
+    // These tests verify that usage_details values are correctly converted to numbers
+    // even when they come in as strings (which can happen when reading from ClickHouse,
+    // as the ClickHouse JS client may return UInt64 values as strings).
+    // This prevents string concatenation bugs like "100" + "200" = "100200" instead of 300.
+
+    it("should correctly convert string usage values to numbers and compute total", async () => {
+      const generationId = uuidv4();
+
+      // Simulate usageDetails coming from ClickHouse as strings
+      const events = [
+        {
+          id: generationId,
+          startTime: new Date().toISOString(),
+          modelName,
+          // These string values simulate what ClickHouse might return for UInt64
+          providedUsageDetails: {
+            input: "100" as unknown as number,
+            output: "200" as unknown as number,
+          },
+        },
+      ];
+
+      await (mockIngestionService as any).writeEvent(events[0], "testfile.txt");
+
+      expect(mockAddToClickhouseWriter).toHaveBeenCalled();
+      const args = mockAddToClickhouseWriter.mock.calls[0];
+      const generation = args[1];
+
+      // Values should be numbers, not strings
+      expect(typeof generation.usage_details.input).toBe("number");
+      expect(typeof generation.usage_details.output).toBe("number");
+      expect(typeof generation.usage_details.total).toBe("number");
+
+      // Total should be numeric addition (300), not string concatenation ("100200")
+      expect(generation.usage_details.input).toBe(100);
+      expect(generation.usage_details.output).toBe(200);
+      expect(generation.usage_details.total).toBe(300);
+    });
+
+    it("should ignore invalid string values that cannot be converted to numbers", async () => {
+      const generationId = uuidv4();
+
+      const events = [
+        {
+          id: generationId,
+          startTime: new Date().toISOString(),
+          modelName,
+          // These string values simulate what ClickHouse might return for UInt64
+          providedUsageDetails: {
+            input: "100" as unknown as number,
+            output: "non_a_number" as unknown as number,
+          },
+        },
+      ];
+
+      await (mockIngestionService as any).writeEvent(events[0], "testfile.txt");
+
+      // Invalid values should be ignored
+      expect(mockAddToClickhouseWriter).toHaveBeenCalled();
+      const args = mockAddToClickhouseWriter.mock.calls[0];
+      console.error("***", JSON.stringify(args, null, 2));
+      const generation = args[1];
+
+      // Values should be numbers, not strings
+      expect(typeof generation.usage_details.input).toBe("number");
+      expect(typeof generation.usage_details.total).toBe("number");
+
+      expect(generation.usage_details.input).toBe(100);
+      expect(generation.usage_details.total).toBe(100);
+    });
+  });
 });

--- a/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
+++ b/worker/src/services/IngestionService/tests/calculateTokenCost.unit.test.ts
@@ -1334,7 +1334,6 @@ describe("Token Cost Calculation", () => {
       // Invalid values should be ignored
       expect(mockAddToClickhouseWriter).toHaveBeenCalled();
       const args = mockAddToClickhouseWriter.mock.calls[0];
-      console.error("***", JSON.stringify(args, null, 2));
       const generation = args[1];
 
       // Values should be numbers, not strings


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes numeric handling of `usage_details` by converting strings to numbers and summing them correctly.
> 
>   - **Behavior**:
>     - Fixes numeric handling in `RawUsageDetails` in `types.ts` to parse strings to numbers and sum them correctly.
>     - Updates `getUsageUnits` in `IngestionService/index.ts` to convert string values to numbers, preventing string concatenation.
>   - **Tests**:
>     - Adds test in `otel-api.servertest.ts` to verify correct conversion of string `usage_details` to numbers.
>     - Adds unit tests in `calculateTokenCost.unit.test.ts` to ensure string values are converted to numbers and summed correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f09984eb6460c0bc13acf3be23910f09c6dc4235. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->