### PR TITLE
chore: add sign up event

### DIFF
--- a/web/src/features/auth/lib/createProjectMembershipsOnSignup.ts
+++ b/web/src/features/auth/lib/createProjectMembershipsOnSignup.ts
@@ -1,12 +1,19 @@
 import { env } from "@/src/env.mjs";
 import { prisma, Role } from "@langfuse/shared/src/db";
 import { logger } from "@langfuse/shared/src/server";
+import { ServerPosthog } from "@/src/features/posthog-analytics/ServerPosthog";
 
 export async function createProjectMembershipsOnSignup(user: {
   id: string;
   email: string | null;
 }) {
   try {
+    // in no case do we want to send duplicate sign up events to posthog
+    const isNewUser = !(await prisma.organizationMembership.findFirst({
+      where: { userId: user.id },
+      select: { id: true },
+    }));
+
     // Langfuse Cloud: provide view-only access to the demo project, none access to the demo org
     const demoProject =
       env.NEXT_PUBLIC_DEMO_ORG_ID && env.NEXT_PUBLIC_DEMO_PROJECT_ID
@@ -100,6 +107,26 @@ export async function createProjectMembershipsOnSignup(user: {
 
     // Invites do not work for users without emails (some future SSO users)
     if (user.email) await processMembershipInvitations(user.email, user.id);
+
+    // for conversion metric tracking in posthog: did a new user sign up?
+    if (isNewUser && env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
+      try {
+        const posthog = new ServerPosthog();
+        posthog.capture({
+          distinctId: user.id,
+          event: "memberships_created_on_signup",
+          properties: {
+            cloudRegion: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
+            hasDemoAccess: demoProject !== undefined,
+            hasDefaultOrg: defaultOrg !== undefined,
+            hasDefaultProject: defaultProject !== undefined,
+          },
+        });
+        await posthog.shutdown();
+      } catch {
+        // analytics tracking failure is not critical, just fail
+      }
+    }
   } catch (e) {
     logger.error("Error assigning project access to new user", e);
   }

--- a/web/src/features/auth/lib/createProjectMembershipsOnSignup.ts
+++ b/web/src/features/auth/lib/createProjectMembershipsOnSignup.ts
@@ -114,7 +114,7 @@ export async function createProjectMembershipsOnSignup(user: {
         const posthog = new ServerPosthog();
         posthog.capture({
           distinctId: user.id,
-          event: "memberships_created_on_signup",
+          event: "cloud_signup_complete",
           properties: {
             cloudRegion: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
             hasDemoAccess: demoProject !== undefined,

--- a/web/src/features/posthog-analytics/ServerPosthog.ts
+++ b/web/src/features/posthog-analytics/ServerPosthog.ts
@@ -1,18 +1,29 @@
 import { env } from "@/src/env.mjs";
-import { PostHog as OriginalPosthog } from "posthog-node";
+import { PostHog } from "posthog-node";
 
-// Safe as it is intended to be public
-const PUBLIC_POSTHOG_API_KEY =
-  env.NEXT_PUBLIC_POSTHOG_KEY ||
-  "phc_zkMwFajk8ehObUlMth0D7DtPItFnxETi3lmSvyQDrwB";
-const POSTHOG_HOST = env.NEXT_PUBLIC_POSTHOG_HOST || "https://eu.posthog.com";
+export class ServerPosthog {
+  private posthog: PostHog | null;
 
-export class ServerPosthog extends OriginalPosthog {
   constructor() {
-    super(PUBLIC_POSTHOG_API_KEY, {
-      host: POSTHOG_HOST,
-    });
+    if (env.NEXT_PUBLIC_POSTHOG_KEY && env.NEXT_PUBLIC_POSTHOG_HOST) {
+      this.posthog = new PostHog(env.NEXT_PUBLIC_POSTHOG_KEY, {
+        host: env.NEXT_PUBLIC_POSTHOG_HOST,
+      });
+      if (process.env.NODE_ENV === "development") this.posthog.debug();
+    } else {
+      this.posthog = null;
+    }
+  }
 
-    if (process.env.NODE_ENV === "development") this.debug();
+  capture(...args: Parameters<PostHog["capture"]>) {
+    this.posthog?.capture(...args);
+  }
+
+  async shutdown() {
+    await this.posthog?.shutdown();
+  }
+
+  async flush() {
+    await this.posthog?.flush();
   }
 }

--- a/web/src/features/posthog-analytics/ServerPosthog.ts
+++ b/web/src/features/posthog-analytics/ServerPosthog.ts
@@ -1,14 +1,24 @@
 import { env } from "@/src/env.mjs";
 import { PostHog } from "posthog-node";
 
+const FALLBACK_POSTHOG_KEY = "phc_zkMwFajk8ehObUlMth0D7DtPItFnxETi3lmSvyQDrwB";
+const FALLBACK_POSTHOG_HOST = "https://eu.posthog.com";
+
 export class ServerPosthog {
   private posthog: PostHog | null;
 
   constructor() {
-    if (env.NEXT_PUBLIC_POSTHOG_KEY && env.NEXT_PUBLIC_POSTHOG_HOST) {
-      this.posthog = new PostHog(env.NEXT_PUBLIC_POSTHOG_KEY, {
-        host: env.NEXT_PUBLIC_POSTHOG_HOST,
-      });
+    const telemetryEnabled = env.TELEMETRY_ENABLED !== "false";
+
+    const apiKey =
+      env.NEXT_PUBLIC_POSTHOG_KEY ??
+      (telemetryEnabled ? FALLBACK_POSTHOG_KEY : null);
+    const host =
+      env.NEXT_PUBLIC_POSTHOG_HOST ??
+      (telemetryEnabled ? FALLBACK_POSTHOG_HOST : null);
+
+    if (apiKey && host) {
+      this.posthog = new PostHog(apiKey, { host });
       if (process.env.NODE_ENV === "development") this.posthog.debug();
     } else {
       this.posthog = null;

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -100,6 +100,7 @@ if (
     },
     autocapture: false,
     enable_heatmaps: false,
+    persistence: "cookie",
   });
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds PostHog sign-up event tracking to `createProjectMembershipsOnSignup` and updates `ServerPosthog` for better event handling.
> 
>   - **Behavior**:
>     - Adds sign-up event tracking in `createProjectMembershipsOnSignup` to capture `cloud_signup_complete` event using `ServerPosthog`.
>     - Ensures no duplicate sign-up events are sent by checking existing organization memberships.
>   - **PostHog Integration**:
>     - Updates `ServerPosthog` class to initialize PostHog with fallback keys and hosts if telemetry is enabled.
>     - Adds `capture`, `shutdown`, and `flush` methods to `ServerPosthog` for event handling.
>   - **Misc**:
>     - Sets PostHog persistence to 'cookie' in `_app.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 699ff126e073c56114fd5297f61ff981c16d4cc6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->