### PR TITLE
fix(auth): prevent SSO domain enumeration via /api/auth/providers

### DIFF
--- a/web/src/pages/api/auth/providers.ts
+++ b/web/src/pages/api/auth/providers.ts
@@ -1,0 +1,17 @@
+/**
+ * Override NextAuth's default /api/auth/providers endpoint to prevent
+ * exposure of SSO domain information.
+ *
+ * Background: NextAuth exposes provider IDs like "acme.com.okta" which
+ * reveals customer domains. Langfuse doesn't use this endpoint - the
+ * sign-in page uses getServerSideProps and /api/auth/check-sso instead.
+ */
+
+import { type NextApiRequest, type NextApiResponse } from "next";
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  // Return 404 to prevent enumeration of SSO domains
+  return res.status(404).json({
+    error: "This endpoint is not available",
+  });
+}


### PR DESCRIPTION
NextAuth's built-in /api/auth/providers endpoint exposes all configured SSO providers with their IDs. Since provider IDs are constructed as "domain.provider" (e.g. "acme.com.okta"), this leaked customer domains and their identity provider types.

This fix creates a custom handler at /api/auth/providers that returns 404, overriding NextAuth's default behavior. Next.js routing gives specific routes priority over catch-all routes like [...nextauth].ts.

Langfuse's sign-in flow doesn't use this endpoint - it uses getServerSideProps and /api/auth/check-sso instead, so this change has no impact on functionality.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Overrides NextAuth's `/api/auth/providers` endpoint to return 404, preventing SSO domain enumeration without affecting Langfuse's sign-in flow.
> 
>   - **Security Fix**:
>     - Overrides NextAuth's `/api/auth/providers` endpoint in `providers.ts` to return 404, preventing SSO domain enumeration.
>     - Custom handler in `providers.ts` returns a JSON error message.
>   - **Routing**:
>     - Next.js routing prioritizes this specific route over catch-all routes, ensuring the override is effective.
>   - **Impact**:
>     - No impact on Langfuse's sign-in flow, which uses `getServerSideProps` and `/api/auth/check-sso` instead.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1c3710dd62ceffe907861966269fa08d440670f7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->