### PR TITLE
fix(tables): small row height spacing equalized

### DIFF
--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -567,14 +567,13 @@ function TableBodyComponent<TData>({
                   <div
                     className={cn(
                       "flex",
-                      "items-start",
-                      isSmallRowHeight && "items-center",
+                      isSmallRowHeight ? "items-center" : "items-start",
                       !isSmallRowHeight && "py-1",
                       rowheighttw,
                     )}
                   >
                     {isStringCell && isSmallRowHeight ? (
-                      <div className="min-w-0 truncate">
+                      <div className="min-w-0 truncate leading-none">
                         {flexRender(
                           cell.column.columnDef.cell,
                           cell.getContext(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjusts alignment and spacing for small row heights in `TableBodyComponent` in `data-table.tsx`.
> 
>   - **Behavior**:
>     - Adjusts alignment in `TableBodyComponent` in `data-table.tsx` for small row heights using a ternary operator for `items-center` vs `items-start`.
>     - Adds `leading-none` class to string cells with small row height for consistent spacing.
>   - **Misc**:
>     - Minor refactor of class assignment logic in `TableBodyComponent`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6cf48aa12125a0afc70a56e623587d109e12c3a1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->