### PR TITLE
fix: make BatchProjectCleaner start conditional for events table

### DIFF
--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -549,6 +549,13 @@ export const batchProjectCleaners: BatchProjectCleaner[] = [];
 
 if (env.LANGFUSE_BATCH_PROJECT_CLEANER_ENABLED === "true") {
   for (const table of BATCH_DELETION_TABLES) {
+    // Only start the events table cleaner if the events table experiment is enabled
+    if (
+      table === "events" &&
+      env.LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE !== "true"
+    ) {
+      continue;
+    }
     const cleaner = new BatchProjectCleaner(table);
     batchProjectCleaners.push(cleaner);
     cleaner.start();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Conditionally start `BatchProjectCleaner` for `events` table based on `LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE` environment variable in `app.ts`.
> 
>   - **Behavior**:
>     - In `app.ts`, `BatchProjectCleaner` for `events` table only starts if `LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE` is `true`.
>   - **Environment Variables**:
>     - Adds condition to check `LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE` for `events` table cleaner.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b4a131008a54d109721c2e81e735f0070b0ea363. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->