### PR TITLE
fix: posthog reset

### DIFF
--- a/web/src/components/layouts/app-layout/index.tsx
+++ b/web/src/components/layouts/app-layout/index.tsx
@@ -12,6 +12,8 @@
 import { type PropsWithChildren, useEffect } from "react";
 import { useRouter } from "next/router";
 import { signOut } from "next-auth/react";
+import posthog from "posthog-js";
+import { env } from "@/src/env.mjs";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { ErrorPageWithSentry } from "@/src/components/error-page";
 
@@ -127,6 +129,9 @@ export function AppLayout(props: PropsWithChildren) {
 
   const handleSignOut = async () => {
     sessionStorage.clear();
+    if (env.NEXT_PUBLIC_POSTHOG_KEY && env.NEXT_PUBLIC_POSTHOG_HOST) {
+      posthog.reset();
+    }
     await signOut({ callbackUrl: `/auth/sign-in` });
   };
 

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -204,10 +204,6 @@ function UserTracking() {
       });
     } else if (session.status === "unauthenticated") {
       lastIdentifiedUser.current = null;
-      // PostHog
-      if (env.NEXT_PUBLIC_POSTHOG_KEY && env.NEXT_PUBLIC_POSTHOG_HOST) {
-        posthog.reset();
-      }
       // Sentry
       setUser(null);
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move `posthog.reset()` to `handleSignOut` in `AppLayout` to ensure it's called only during sign-out.
> 
>   - **Behavior**:
>     - Move `posthog.reset()` from `UserTracking` in `_app.tsx` to `handleSignOut` in `AppLayout`.
>     - Ensures `posthog.reset()` is called only during sign-out, not when session is unauthenticated.
>   - **Functions**:
>     - Modify `handleSignOut` in `AppLayout` to include `posthog.reset()` if PostHog environment variables are set.
>     - Remove `posthog.reset()` from `UserTracking` in `_app.tsx` when session is unauthenticated.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 19e316b5ef8077a5f87ad2a119efaa765e265b4c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->