### PR TITLE
fix: posthog init

### DIFF
--- a/web/src/features/auth/lib/createProjectMembershipsOnSignup.ts
+++ b/web/src/features/auth/lib/createProjectMembershipsOnSignup.ts
@@ -109,7 +109,11 @@ export async function createProjectMembershipsOnSignup(user: {
     if (user.email) await processMembershipInvitations(user.email, user.id);
 
     // for conversion metric tracking in posthog: did a new user sign up?
-    if (isNewUser && env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
+    if (
+      isNewUser &&
+      env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION &&
+      ["EU", "US"].includes(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION)
+    ) {
       try {
         const posthog = new ServerPosthog();
         posthog.capture({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add region-specific condition for triggering PostHog analytics in `createProjectMembershipsOnSignup`.
> 
>   - **Behavior**:
>     - In `createProjectMembershipsOnSignup`, added a condition to only trigger PostHog analytics if `env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` is "EU" or "US".
>   - **Misc**:
>     - No other changes were made to the code or functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for fc2a8f31709d59be9d427e28657aff5e204ede51. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->