### PR TITLE
fix: make BatchProjectCleaner start conditional for events table

### DIFF
--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -551,14 +551,13 @@ if (env.LANGFUSE_BATCH_PROJECT_CLEANER_ENABLED === "true") {
   for (const table of BATCH_DELETION_TABLES) {
     // Only start the events table cleaner if the events table experiment is enabled
     if (
-      table === "events" &&
-      env.LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE !== "true"
+      table !== "events" ||
+      env.LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE === "true"
     ) {
-      continue;
+      const cleaner = new BatchProjectCleaner(table);
+      batchProjectCleaners.push(cleaner);
+      cleaner.start();
     }
-    const cleaner = new BatchProjectCleaner(table);
-    batchProjectCleaners.push(cleaner);
-    cleaner.start();
   }
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `worker/src/app.ts`, the `BatchProjectCleaner` for the `events` table now starts only if `LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE` is `true`.
> 
>   - **Behavior**:
>     - In `worker/src/app.ts`, the `BatchProjectCleaner` for the `events` table now starts only if `LANGFUSE_EXPERIMENT_INSERT_INTO_EVENTS_TABLE` is `true`.
>     - Previously, the cleaner would not start if the `events` table was not enabled, now it starts if the condition is met.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 947991bdd6878b6af37c703d547da18f6ccf3dae. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->