### PR TITLE
fix(tools): parse thinking block from anthropic models

### DIFF
--- a/packages/shared/src/server/ingestion/extractToolsBackend.ts
+++ b/packages/shared/src/server/ingestion/extractToolsBackend.ts
@@ -218,7 +218,7 @@ function extractToolCallsFromRawOutput(
     }
   }
 
-  // Anthropic tool_use in content array: {content: [{type: "tool_use", ...}]}
+  // Anthropic tool_use in content array: {content: [{type: "tool_use", ...}, {type: "thinking", ...}, {type: "text", ...}]}
   if (Array.isArray(obj.content)) {
     for (const part of obj.content) {
       if (
@@ -234,6 +234,7 @@ function extractToolCallsFromRawOutput(
           type: "tool_use",
         });
       }
+      // Skip thinking and text blocks - they don't contain tool calls
     }
   }
 
@@ -261,7 +262,7 @@ function extractToolCallsFromMessage(
     }
   }
 
-  // Anthropic content array
+  // Anthropic content array: [{type: "tool_use", ...}, {type: "thinking", ...}, {type: "text", ...}]
   if (Array.isArray(msg.content)) {
     for (const part of msg.content) {
       if (
@@ -277,6 +278,7 @@ function extractToolCallsFromMessage(
           type: "tool_use",
         });
       }
+      // Skip thinking and text blocks - they don't contain tool calls
     }
   }
 }

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -55,6 +55,10 @@ const AnthropicMessageContentWithToolUse = z.union([
     name: z.string(),
     input: z.unknown(),
   }),
+  z.object({
+    type: z.literal("thinking"),
+    thinking: z.string(),
+  }),
 ]);
 
 const GoogleAIStudioMessageContentWithToolUse = z.object({

--- a/packages/shared/src/utils/chatml/helpers.ts
+++ b/packages/shared/src/utils/chatml/helpers.ts
@@ -97,3 +97,43 @@ export function getNestedProperty(
   }
   return current;
 }
+
+/**
+ * Extract text content from Anthropic content array.
+ * Skips `thinking` blocks and concatenates all `text` blocks.
+ * Handles arrays like: [{type: "thinking", thinking: "..."}, {type: "text", text: "..."}, {type: "text", text: "..."}]
+ *
+ * @param content - Anthropic content array or string
+ * @returns Extracted text string, or empty string if no text blocks found
+ */
+export function extractTextFromAnthropicContent(content: unknown): string {
+  // If content is already a string, return it
+  if (typeof content === "string") {
+    return content;
+  }
+
+  // If content is not an array, return empty string
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  const textParts: string[] = [];
+
+  for (const part of content) {
+    if (!part || typeof part !== "object") continue;
+
+    const p = part as Record<string, unknown>;
+
+    // Skip thinking blocks
+    if (p.type === "thinking") {
+      continue;
+    }
+
+    // Extract text from text blocks
+    if (p.type === "text" && typeof p.text === "string") {
+      textParts.push(p.text);
+    }
+  }
+
+  return textParts.join("");
+}


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #11109 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes parsing of Anthropic content by skipping 'thinking' blocks and concatenating 'text' blocks across multiple functions.
> 
>   - **Behavior**:
>     - `extractToolCallsFromRawOutput()` and `extractToolCallsFromMessage()` in `extractToolsBackend.ts` now skip 'thinking' and 'text' blocks in Anthropic content arrays.
>     - `extractTextFromAnthropicContent()` in `helpers.ts` added to extract text from Anthropic content, skipping 'thinking' blocks.
>     - `contentToString()` in `playgroundConverter.ts` updated to use `extractTextFromAnthropicContent()` for Anthropic content.
>   - **Schemas**:
>     - `AnthropicMessageContentWithToolUse` in `types.ts` updated to include 'thinking' type.
>   - **Misc**:
>     - Comments updated in `extractToolsBackend.ts` to reflect changes in handling Anthropic content.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 22c69699a47b7870a8ba108f1f5254f92ab1b2b0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->