### PR TITLE
fix: return empty string for correction data type

### DIFF
--- a/web/src/features/scores/lib/scoreColumns.ts
+++ b/web/src/features/scores/lib/scoreColumns.ts
@@ -128,7 +128,7 @@ export const getScoreDataTypeIcon = (dataType: ScoreDataTypeType): string => {
     case "BOOLEAN":
       return "Ⓑ";
     case "CORRECTION":
-      throw new Error("CORRECTION type not supported");
+      return "";
   }
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Return empty string for `CORRECTION` data type in `getScoreDataTypeIcon()` in `scoreColumns.ts`.
> 
>   - **Behavior**:
>     - In `getScoreDataTypeIcon()` in `scoreColumns.ts`, return an empty string for `CORRECTION` data type instead of throwing an error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for de5cee751b20e05b8ef7c13ff1093af0e052f103. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->