### PR TITLE
fix: deleteEventsByTraceIds should respect global deletion timeout

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -1681,6 +1681,9 @@ export const deleteEventsByTraceIds = async (
   await commandClickhouse({
     query,
     params: { projectId, traceIds },
+    clickhouseConfigs: {
+      request_timeout: env.LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS,
+    },
     tags: {
       feature: "tracing",
       type: "events",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `deleteEventsByTraceIds` in `events.ts` now respects global deletion timeout using `env.LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS`.
> 
>   - **Behavior**:
>     - `deleteEventsByTraceIds` in `events.ts` now respects global deletion timeout by using `env.LANGFUSE_CLICKHOUSE_DELETION_TIMEOUT_MS` for `request_timeout` in `clickhouseConfigs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a6bbbce9901c643dc8fdd76d744266b0158f315b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->