### PR TITLE
fix: update dataset name duplication logic to append "(copy)"

### DIFF
--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -1068,7 +1068,7 @@ export const datasetRouter = createTRPCRouter({
 
       // find a unique name for the new dataset
       // by appending a counter to the name in case of the name already exists
-      // e.g. "Copy of dataset" -> "Copy of dataset (1)"
+      // e.g. "dataset (copy)" -> "dataset (copy 2)"
       const existingDatasetNames = (
         await ctx.prisma.dataset.findMany({
           select: {
@@ -1077,7 +1077,7 @@ export const datasetRouter = createTRPCRouter({
           where: {
             projectId: input.projectId,
             name: {
-              startsWith: "Copy of " + dataset.name,
+              startsWith: dataset.name + " (copy",
             },
           },
         })
@@ -1085,8 +1085,8 @@ export const datasetRouter = createTRPCRouter({
       let counter: number = 0;
       const duplicateDatasetName = (pCounter: number) =>
         pCounter === 0
-          ? `Copy of ${dataset.name}`
-          : `Copy of ${dataset.name} (${counter})`;
+          ? `${dataset.name} (copy)`
+          : `${dataset.name} (copy ${counter})`;
       while (true) {
         if (!existingDatasetNames.includes(duplicateDatasetName(counter))) {
           break;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates dataset duplication logic to append "(copy)" to duplicated dataset names in `dataset-router.ts`.
> 
>   - **Behavior**:
>     - Updates dataset duplication logic in `dataset-router.ts` to append "(copy)" to duplicated dataset names instead of "Copy of".
>     - Changes name generation to "dataset (copy)" and "dataset (copy N)" for subsequent duplicates.
>   - **Logic**:
>     - Modifies `duplicateDataset` mutation to check for existing names starting with "dataset (copy".
>     - Updates `duplicateDatasetName` function to reflect new naming convention.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9035262367f8d9312f398aed65e666d5fd607ac2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->