### PR TITLE
fix(trace): add beta toggle instead of tab

### DIFF
--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -35,6 +35,7 @@ import { PeekViewTraceDetail } from "@/src/components/table/peek/peek-trace-deta
 import { usePeekNavigation } from "@/src/components/table/peek/hooks/usePeekNavigation";
 import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
 import { LazyTraceRow } from "@/src/components/session/TraceRow";
+import { useParsedTrace } from "@/src/hooks/useParsedTrace";
 
 // some projects have thousands of users in a session, paginate to avoid rendering all at once
 const INITIAL_USERS_DISPLAY_COUNT = 10;
@@ -470,6 +471,15 @@ export const SessionIO = ({
       refetchOnMount: false,
     },
   );
+
+  // Parse trace data in Web Worker (non-blocking)
+  const { parsedInput, parsedOutput, isParsing } = useParsedTrace({
+    traceId,
+    input: trace.data?.input,
+    output: trace.data?.output,
+    metadata: undefined,
+  });
+
   return (
     <div className="flex w-full flex-col gap-2 overflow-hidden p-0">
       {!trace.data ? (
@@ -482,6 +492,9 @@ export const SessionIO = ({
           key={traceId}
           input={trace.data.input}
           output={trace.data.output}
+          parsedInput={parsedInput}
+          parsedOutput={parsedOutput}
+          isParsing={isParsing}
           hideIfNull
           projectId={projectId}
           traceId={traceId}

--- a/web/src/components/trace2/TracePreview.tsx
+++ b/web/src/components/trace2/TracePreview.tsx
@@ -34,12 +34,14 @@ import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 import { ItemBadge } from "@/src/components/ItemBadge";
 import Link from "next/link";
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
+import { Switch } from "@/src/components/ui/switch";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useRouter } from "next/router";
 import { CopyIdsPopover } from "@/src/components/trace2/components/_shared/CopyIdsPopover";
 import { useJsonExpansion } from "@/src/components/trace2/contexts/JsonExpansionContext";
 import { TraceLogView } from "@/src/components/trace2/components/TraceLogView/TraceLogView";
 import { useParsedTrace } from "@/src/hooks/useParsedTrace";
+import { useJsonBetaToggle } from "@/src/components/trace2/hooks/useJsonBetaToggle";
 import { TraceDataProvider } from "@/src/components/trace2/contexts/TraceDataContext";
 import { ViewPreferencesProvider } from "@/src/components/trace2/contexts/ViewPreferencesContext";
 import {
@@ -95,6 +97,13 @@ export const TracePreview = ({
   const [currentView, setCurrentView] = useLocalStorage<
     "pretty" | "json" | "json-beta"
   >("jsonViewPreference", "pretty");
+  const {
+    jsonBetaEnabled,
+    selectedViewTab,
+    handleViewTabChange,
+    handleBetaToggle,
+  } = useJsonBetaToggle(currentView, setCurrentView);
+
   const [isPrettyViewAvailable, setIsPrettyViewAvailable] = useState(false);
   const isAuthenticatedAndProjectMember = useIsAuthenticatedAndProjectMember(
     trace.projectId,
@@ -363,59 +372,79 @@ export const TracePreview = ({
                   <TabsBarTrigger value="scores">Scores</TabsBarTrigger>
                 )}
                 {selectedTab.includes("preview") && isPrettyViewAvailable && (
-                  <Tabs
-                    className="ml-auto mr-1 h-fit px-2 py-0.5"
-                    value={currentView}
-                    onValueChange={(value) => {
-                      capture("trace_detail:io_mode_switch", { view: value });
-                      setCurrentView(value as "pretty" | "json" | "json-beta");
-                    }}
-                  >
-                    <TabsList className="h-fit py-0.5">
-                      <TabsTrigger
-                        value="pretty"
-                        className="h-fit px-1 text-xs"
-                      >
-                        Formatted
-                      </TabsTrigger>
-                      <TabsTrigger value="json" className="h-fit px-1 text-xs">
-                        JSON
-                      </TabsTrigger>
-                      <TabsTrigger
-                        value="json-beta"
-                        className="h-fit px-1 text-xs"
-                      >
-                        JSON Beta
-                      </TabsTrigger>
-                    </TabsList>
-                  </Tabs>
+                  <>
+                    <Tabs
+                      className="ml-auto h-fit px-2 py-0.5"
+                      value={selectedViewTab}
+                      onValueChange={(value) => {
+                        capture("trace_detail:io_mode_switch", { view: value });
+                        handleViewTabChange(value);
+                      }}
+                    >
+                      <TabsList className="h-fit py-0.5">
+                        <TabsTrigger
+                          value="pretty"
+                          className="h-fit px-1 text-xs"
+                        >
+                          Formatted
+                        </TabsTrigger>
+                        <TabsTrigger
+                          value="json"
+                          className="h-fit px-1 text-xs"
+                        >
+                          JSON
+                        </TabsTrigger>
+                      </TabsList>
+                    </Tabs>
+                    {selectedViewTab === "json" && (
+                      <div className="mr-1 flex items-center gap-1.5">
+                        <Switch
+                          size="sm"
+                          checked={jsonBetaEnabled}
+                          onCheckedChange={handleBetaToggle}
+                        />
+                        <span className="text-xs text-muted-foreground">
+                          Beta
+                        </span>
+                      </div>
+                    )}
+                  </>
                 )}
                 {selectedTab === "log" && (
-                  <Tabs
-                    className="ml-auto mr-1 h-fit px-2 py-0.5"
-                    value={currentView}
-                    onValueChange={(value) => {
-                      setCurrentView(value as "pretty" | "json" | "json-beta");
-                    }}
-                  >
-                    <TabsList className="h-fit py-0.5">
-                      <TabsTrigger
-                        value="pretty"
-                        className="h-fit px-1 text-xs"
-                      >
-                        Formatted
-                      </TabsTrigger>
-                      <TabsTrigger value="json" className="h-fit px-1 text-xs">
-                        JSON
-                      </TabsTrigger>
-                      <TabsTrigger
-                        value="json-beta"
-                        className="h-fit px-1 text-xs"
-                      >
-                        JSON Beta
-                      </TabsTrigger>
-                    </TabsList>
-                  </Tabs>
+                  <>
+                    <Tabs
+                      className="ml-auto h-fit px-2 py-0.5"
+                      value={selectedViewTab}
+                      onValueChange={handleViewTabChange}
+                    >
+                      <TabsList className="h-fit py-0.5">
+                        <TabsTrigger
+                          value="pretty"
+                          className="h-fit px-1 text-xs"
+                        >
+                          Formatted
+                        </TabsTrigger>
+                        <TabsTrigger
+                          value="json"
+                          className="h-fit px-1 text-xs"
+                        >
+                          JSON
+                        </TabsTrigger>
+                      </TabsList>
+                    </Tabs>
+                    {selectedViewTab === "json" && (
+                      <div className="mr-1 flex items-center gap-1.5">
+                        <Switch
+                          size="sm"
+                          checked={jsonBetaEnabled}
+                          onCheckedChange={handleBetaToggle}
+                        />
+                        <span className="text-xs text-muted-foreground">
+                          Beta
+                        </span>
+                      </div>
+                    )}
+                  </>
                 )}
               </TabsBarList>
             </TooltipProvider>

--- a/web/src/components/trace2/components/IOPreview/components/ViewModeToggle.tsx
+++ b/web/src/components/trace2/components/IOPreview/components/ViewModeToggle.tsx
@@ -1,4 +1,6 @@
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
+import { Switch } from "@/src/components/ui/switch";
+import { useJsonBetaToggle } from "@/src/components/trace2/hooks/useJsonBetaToggle";
 
 export type ViewMode = "pretty" | "json" | "json-beta";
 
@@ -13,13 +15,20 @@ export function ViewModeToggle({
   onViewChange,
   compensateScrollRef,
 }: ViewModeToggleProps) {
+  const {
+    jsonBetaEnabled,
+    selectedViewTab,
+    handleViewTabChange,
+    handleBetaToggle,
+  } = useJsonBetaToggle(selectedView, onViewChange);
+
   return (
-    <div className="flex w-full flex-row justify-start">
+    <div className="flex w-full flex-row items-center justify-start gap-1.5">
       <Tabs
         ref={compensateScrollRef}
         className="h-fit py-0.5"
-        value={selectedView}
-        onValueChange={(value) => onViewChange(value as ViewMode)}
+        value={selectedViewTab}
+        onValueChange={handleViewTabChange}
       >
         <TabsList className="h-fit p-0.5">
           <TabsTrigger value="pretty" className="h-fit px-1 text-xs">
@@ -28,11 +37,18 @@ export function ViewModeToggle({
           <TabsTrigger value="json" className="h-fit px-1 text-xs">
             JSON
           </TabsTrigger>
-          <TabsTrigger value="json-beta" className="h-fit px-1 text-xs">
-            JSON Beta
-          </TabsTrigger>
         </TabsList>
       </Tabs>
+      {selectedViewTab === "json" && (
+        <div className="flex items-center gap-1.5">
+          <Switch
+            size="sm"
+            checked={jsonBetaEnabled}
+            onCheckedChange={handleBetaToggle}
+          />
+          <span className="text-xs text-muted-foreground">Beta</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
+++ b/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
@@ -12,6 +12,7 @@ import {
   TabsBarTrigger,
 } from "@/src/components/ui/tabs-bar";
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
+import { Switch } from "@/src/components/ui/switch";
 import { useCallback, useMemo, useState } from "react";
 import { type SelectionData } from "@/src/features/comments/contexts/InlineCommentSelectionContext";
 import { api } from "@/src/utils/api";
@@ -87,10 +88,37 @@ export function TraceDetailView({
   }, []);
 
   // Get jsonViewPreference directly from ViewPreferencesContext for "json-beta" support
-  const { jsonViewPreference, setJsonViewPreference } = useViewPreferences();
+  const {
+    jsonViewPreference,
+    setJsonViewPreference,
+    jsonBetaEnabled,
+    setJsonBetaEnabled,
+  } = useViewPreferences();
 
   // Map jsonViewPreference to currentView format expected by child components
   const currentView = jsonViewPreference;
+
+  const selectedViewTab =
+    jsonViewPreference === "pretty" ? "pretty" : ("json" as const);
+
+  const handleViewTabChange = useCallback(
+    (tab: string) => {
+      if (tab === "pretty") {
+        setJsonViewPreference("pretty");
+      } else {
+        setJsonViewPreference(jsonBetaEnabled ? "json-beta" : "json");
+      }
+    },
+    [jsonBetaEnabled, setJsonViewPreference],
+  );
+
+  const handleBetaToggle = useCallback(
+    (enabled: boolean) => {
+      setJsonBetaEnabled(enabled);
+      setJsonViewPreference(enabled ? "json-beta" : "json");
+    },
+    [setJsonBetaEnabled, setJsonViewPreference],
+  );
 
   // Context hooks
   const { comments } = useTraceData();
@@ -193,98 +221,80 @@ export function TraceDetailView({
               <TabsBarTrigger value="scores">Scores</TabsBarTrigger>
             )}
 
-            {/* View toggle (Formatted/JSON/JSON Beta) - show for preview and log tabs when pretty view available */}
+            {/* View toggle (Formatted/JSON) - show for preview and log tabs when pretty view available */}
             {/* JSON views are disabled for virtualized log view (large traces) */}
             {(selectedTab === "log" ||
               (selectedTab === "preview" && isPrettyViewAvailable)) && (
-              <Tabs
-                className="ml-auto mr-1 h-fit px-2 py-0.5"
-                value={
-                  selectedTab === "log" && isLogViewVirtualized
-                    ? "pretty"
-                    : currentView
-                }
-                onValueChange={(value) => {
-                  // Don't allow JSON views for virtualized log view
-                  if (
-                    selectedTab === "log" &&
-                    isLogViewVirtualized &&
-                    (value === "json" || value === "json-beta")
-                  ) {
-                    return;
+              <>
+                <Tabs
+                  className="ml-auto h-fit px-2 py-0.5"
+                  value={
+                    selectedTab === "log" && isLogViewVirtualized
+                      ? "pretty"
+                      : selectedViewTab
                   }
-                  setJsonViewPreference(
-                    value as "pretty" | "json" | "json-beta",
-                  );
-                }}
-              >
-                <TabsList className="h-fit py-0.5">
-                  <TabsTrigger value="pretty" className="h-fit px-1 text-xs">
-                    Formatted
-                  </TabsTrigger>
-                  {selectedTab === "log" && isLogViewVirtualized ? (
-                    <HoverCard openDelay={200}>
-                      <HoverCardTrigger asChild>
-                        <TabsTrigger
-                          value="json"
-                          className="h-fit px-1 text-xs"
-                          disabled
-                        >
-                          JSON
-                        </TabsTrigger>
-                      </HoverCardTrigger>
-                      <HoverCardContent
-                        align="end"
-                        className="w-64 text-sm"
-                        sideOffset={8}
-                      >
-                        <p className="font-medium">JSON view unavailable</p>
-                        <p className="mt-1 text-muted-foreground">
-                          Disabled for traces with{" "}
-                          {TRACE_VIEW_CONFIG.logView.virtualizationThreshold}+
-                          observations to maintain performance.
-                        </p>
-                      </HoverCardContent>
-                    </HoverCard>
-                  ) : (
-                    <TabsTrigger value="json" className="h-fit px-1 text-xs">
-                      JSON
+                  onValueChange={(value) => {
+                    // Don't allow JSON views for virtualized log view
+                    if (
+                      selectedTab === "log" &&
+                      isLogViewVirtualized &&
+                      value === "json"
+                    ) {
+                      return;
+                    }
+                    handleViewTabChange(value);
+                  }}
+                >
+                  <TabsList className="h-fit py-0.5">
+                    <TabsTrigger value="pretty" className="h-fit px-1 text-xs">
+                      Formatted
                     </TabsTrigger>
-                  )}
-                  {selectedTab === "log" && isLogViewVirtualized ? (
-                    <HoverCard openDelay={200}>
-                      <HoverCardTrigger asChild>
-                        <TabsTrigger
-                          value="json-beta"
-                          className="h-fit px-1 text-xs"
-                          disabled
+                    {selectedTab === "log" && isLogViewVirtualized ? (
+                      <HoverCard openDelay={200}>
+                        <HoverCardTrigger asChild>
+                          <TabsTrigger
+                            value="json"
+                            className="h-fit px-1 text-xs"
+                            disabled
+                          >
+                            JSON
+                          </TabsTrigger>
+                        </HoverCardTrigger>
+                        <HoverCardContent
+                          align="end"
+                          className="w-64 text-sm"
+                          sideOffset={8}
                         >
-                          JSON Beta
-                        </TabsTrigger>
-                      </HoverCardTrigger>
-                      <HoverCardContent
-                        align="end"
-                        className="w-64 text-sm"
-                        sideOffset={8}
-                      >
-                        <p className="font-medium">JSON Beta unavailable</p>
-                        <p className="mt-1 text-muted-foreground">
-                          Disabled for traces with{" "}
-                          {TRACE_VIEW_CONFIG.logView.virtualizationThreshold}+
-                          observations to maintain performance.
-                        </p>
-                      </HoverCardContent>
-                    </HoverCard>
-                  ) : (
-                    <TabsTrigger
-                      value="json-beta"
-                      className="h-fit px-1 text-xs"
-                    >
-                      JSON Beta
-                    </TabsTrigger>
+                          <p className="font-medium">JSON view unavailable</p>
+                          <p className="mt-1 text-muted-foreground">
+                            Disabled for traces with{" "}
+                            {TRACE_VIEW_CONFIG.logView.virtualizationThreshold}+
+                            observations to maintain performance.
+                          </p>
+                        </HoverCardContent>
+                      </HoverCard>
+                    ) : (
+                      <TabsTrigger value="json" className="h-fit px-1 text-xs">
+                        JSON
+                      </TabsTrigger>
+                    )}
+                  </TabsList>
+                </Tabs>
+                {/* Beta toggle - only show when JSON is selected and not in virtualized log view */}
+                {selectedViewTab === "json" &&
+                  !(selectedTab === "log" && isLogViewVirtualized) && (
+                    <div className="mr-1 flex items-center gap-1.5">
+                      <Switch
+                        size="sm"
+                        checked={jsonBetaEnabled}
+                        onCheckedChange={handleBetaToggle}
+                      />
+                      <span className="text-xs text-muted-foreground">
+                        Beta
+                      </span>
+                    </div>
                   )}
-                </TabsList>
-              </Tabs>
+              </>
             )}
           </TabsBarList>
         </TooltipProvider>

--- a/web/src/components/trace2/contexts/ViewPreferencesContext.tsx
+++ b/web/src/components/trace2/contexts/ViewPreferencesContext.tsx
@@ -50,6 +50,9 @@ interface ViewPreferencesContextValue {
   /** JSON view preference (pretty/formatted or raw JSON) */
   jsonViewPreference: JsonViewPreference;
   setJsonViewPreference: (value: JsonViewPreference) => void;
+  /** Whether JSON Beta (advanced viewer) is enabled */
+  jsonBetaEnabled: boolean;
+  setJsonBetaEnabled: (value: boolean) => void;
 }
 
 const ViewPreferencesContext =
@@ -107,6 +110,17 @@ export function ViewPreferencesProvider({
     useLocalStorage<LogViewTreeStyle>("logViewTreeStyle", "flat");
   const [jsonViewPreference, setJsonViewPreference] =
     useLocalStorage<JsonViewPreference>("jsonViewPreference", "pretty");
+  const [jsonBetaEnabled, setJsonBetaEnabled] = useLocalStorage<boolean>(
+    "jsonBetaEnabled",
+    () => {
+      // Initialize from existing preference (migration for users who had json-beta selected)
+      if (typeof window !== "undefined") {
+        const existing = localStorage.getItem("jsonViewPreference");
+        return existing === '"json-beta"';
+      }
+      return false;
+    },
+  );
 
   const value = useMemo<ViewPreferencesContextValue>(
     () => ({
@@ -131,6 +145,8 @@ export function ViewPreferencesProvider({
       setLogViewTreeStyle,
       jsonViewPreference,
       setJsonViewPreference,
+      jsonBetaEnabled,
+      setJsonBetaEnabled,
     }),
     [
       showDuration,
@@ -154,6 +170,8 @@ export function ViewPreferencesProvider({
       setLogViewTreeStyle,
       jsonViewPreference,
       setJsonViewPreference,
+      jsonBetaEnabled,
+      setJsonBetaEnabled,
     ],
   );
 

--- a/web/src/components/trace2/contexts/ViewPreferencesContext.tsx
+++ b/web/src/components/trace2/contexts/ViewPreferencesContext.tsx
@@ -110,16 +110,12 @@ export function ViewPreferencesProvider({
     useLocalStorage<LogViewTreeStyle>("logViewTreeStyle", "flat");
   const [jsonViewPreference, setJsonViewPreference] =
     useLocalStorage<JsonViewPreference>("jsonViewPreference", "pretty");
+  // Migration: default to true if user had json-beta selected previously
+  // TODO: Remove migration logic after 2025-01-26 (2 weeks) when user settings are migrated
   const [jsonBetaEnabled, setJsonBetaEnabled] = useLocalStorage<boolean>(
     "jsonBetaEnabled",
-    () => {
-      // Initialize from existing preference (migration for users who had json-beta selected)
-      if (typeof window !== "undefined") {
-        const existing = localStorage.getItem("jsonViewPreference");
-        return existing === '"json-beta"';
-      }
-      return false;
-    },
+    typeof window !== "undefined" &&
+      localStorage.getItem("jsonViewPreference") === '"json-beta"',
   );
 
   const value = useMemo<ViewPreferencesContextValue>(

--- a/web/src/components/trace2/hooks/useJsonBetaToggle.ts
+++ b/web/src/components/trace2/hooks/useJsonBetaToggle.ts
@@ -14,16 +14,12 @@ export function useJsonBetaToggle(
   currentView: ViewMode,
   setCurrentView: (view: ViewMode) => void,
 ) {
+  // Migration: default to true if user had json-beta selected previously
+  // TODO: Remove migration logic after 2025-01-26 (2 weeks) when user settings are migrated
   const [jsonBetaEnabled, setJsonBetaEnabled] = useLocalStorage<boolean>(
     "jsonBetaEnabled",
-    () => {
-      // Initialize from existing preference (migration for users who had json-beta selected)
-      if (typeof window !== "undefined") {
-        const existing = localStorage.getItem("jsonViewPreference");
-        return existing === '"json-beta"';
-      }
-      return false;
-    },
+    typeof window !== "undefined" &&
+      localStorage.getItem("jsonViewPreference") === '"json-beta"',
   );
 
   // Derive UI tab selection (2 tabs: pretty or json)

--- a/web/src/components/trace2/hooks/useJsonBetaToggle.ts
+++ b/web/src/components/trace2/hooks/useJsonBetaToggle.ts
@@ -1,0 +1,53 @@
+import useLocalStorage from "@/src/components/useLocalStorage";
+
+type ViewMode = "pretty" | "json" | "json-beta";
+
+/**
+ * Hook for managing JSON Beta toggle state alongside view preference.
+ * Used by components that manage view state via localStorage directly
+ * (TracePreview, ObservationPreview, ViewModeToggle).
+ *
+ * For context-based components (TraceDetailView, ObservationDetailView),
+ * use useViewPreferences() instead.
+ */
+export function useJsonBetaToggle(
+  currentView: ViewMode,
+  setCurrentView: (view: ViewMode) => void,
+) {
+  const [jsonBetaEnabled, setJsonBetaEnabled] = useLocalStorage<boolean>(
+    "jsonBetaEnabled",
+    () => {
+      // Initialize from existing preference (migration for users who had json-beta selected)
+      if (typeof window !== "undefined") {
+        const existing = localStorage.getItem("jsonViewPreference");
+        return existing === '"json-beta"';
+      }
+      return false;
+    },
+  );
+
+  // Derive UI tab selection (2 tabs: pretty or json)
+  const selectedViewTab =
+    currentView === "pretty" ? ("pretty" as const) : ("json" as const);
+
+  const handleViewTabChange = (tab: string) => {
+    if (tab === "pretty") {
+      setCurrentView("pretty");
+    } else {
+      // When switching to JSON, use beta preference
+      setCurrentView(jsonBetaEnabled ? "json-beta" : "json");
+    }
+  };
+
+  const handleBetaToggle = (enabled: boolean) => {
+    setJsonBetaEnabled(enabled);
+    setCurrentView(enabled ? "json-beta" : "json");
+  };
+
+  return {
+    jsonBetaEnabled,
+    selectedViewTab,
+    handleViewTabChange,
+    handleBetaToggle,
+  };
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replaces JSON Beta tab with a toggle switch across components, adding a new hook and updating view preferences context.
> 
>   - **Behavior**:
>     - Replaces JSON Beta tab with a toggle switch in `ObservationPreview`, `TracePreview`, `TraceDetailView`, `ObservationDetailView`, and `ViewModeToggle`.
>     - JSON Beta toggle only appears when JSON view is selected.
>     - Disables JSON view in virtualized log view in `TraceDetailView`.
>   - **Hooks**:
>     - Adds `useJsonBetaToggle` hook to manage JSON Beta toggle state and view preference.
>   - **Context**:
>     - Updates `ViewPreferencesContext` to include `jsonBetaEnabled` state and migration logic for `json-beta` preference.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9ba55a500e9346f94137c40b5de6d6c59ea2a805. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->