### PR TITLE
style: display message for non-annotation scores in AnnotationDrawer

### DIFF
--- a/web/src/features/annotation-queues/components/shared/AnnotationDrawerSection.tsx
+++ b/web/src/features/annotation-queues/components/shared/AnnotationDrawerSection.tsx
@@ -29,6 +29,10 @@ export const AnnotationDrawerSection: React.FC<
 
   const isLockedByOtherUser = item.lockedByUserId !== session.data?.user?.id;
 
+  const hasNonAnnotationScores = scores.some(
+    (score) => score.source !== "ANNOTATION",
+  );
+
   return (
     <Card className="col-span-2 flex h-full flex-col overflow-y-auto p-3">
       <AnnotationForm
@@ -56,6 +60,11 @@ export const AnnotationDrawerSection: React.FC<
           ) : undefined
         }
       />
+      {hasNonAnnotationScores && (
+        <div className="mt-4 text-xs text-muted-foreground">
+          API and eval scores visible on left. Add manual annotations above.
+        </div>
+      )}
     </Card>
   );
 };

--- a/web/src/features/datasets/components/AnnotationPanel.tsx
+++ b/web/src/features/datasets/components/AnnotationPanel.tsx
@@ -12,6 +12,7 @@ import { AnnotationForm } from "@/src/features/scores/components/AnnotationForm"
 import { ChevronRight } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { decomposeAggregateScoreKey } from "@/src/features/scores/lib/aggregateScores";
 
 export const AnnotationPanel = ({ projectId }: { projectId: string }) => {
   const [hasCommentDraft, setHasCommentDraft] = useState(false);
@@ -26,6 +27,13 @@ export const AnnotationPanel = ({ projectId }: { projectId: string }) => {
     return <Skeleton className="h-full w-full" />;
   }
 
+  const hasNonAnnotationScores = Object.keys(activeCell.scoreAggregates).some(
+    (key) => {
+      const { source } = decomposeAggregateScoreKey(key);
+      return source !== "ANNOTATION";
+    },
+  );
+
   return (
     <ResizablePanelGroup
       direction="vertical"
@@ -38,38 +46,46 @@ export const AnnotationPanel = ({ projectId }: { projectId: string }) => {
         defaultSize={verticalSize}
       >
         {activeCell ? (
-          <AnnotationForm
-            key={`annotation-drawer-content-${activeCell.traceId}-${activeCell.observationId}`}
-            scoreTarget={{
-              type: "trace",
-              traceId: activeCell.traceId,
-              observationId: activeCell.observationId,
-            }}
-            serverScores={activeCell.scoreAggregates}
-            analyticsData={{
-              type: "trace",
-              source: "DatasetCompare",
-            }}
-            scoreMetadata={{
-              projectId,
-              environment: activeCell.environment,
-            }}
-            actionButtons={
-              <Button
-                variant="outline"
-                size="icon"
-                onClick={() => {
-                  if (hasCommentDraft)
-                    toast.error(
-                      "Please save or discard your comment before proceeding",
-                    );
-                  else clearActiveCell();
-                }}
-              >
-                <ChevronRight className="h-4 w-4" />
-              </Button>
-            }
-          />
+          <>
+            <AnnotationForm
+              key={`annotation-drawer-content-${activeCell.traceId}-${activeCell.observationId}`}
+              scoreTarget={{
+                type: "trace",
+                traceId: activeCell.traceId,
+                observationId: activeCell.observationId,
+              }}
+              serverScores={activeCell.scoreAggregates}
+              analyticsData={{
+                type: "trace",
+                source: "DatasetCompare",
+              }}
+              scoreMetadata={{
+                projectId,
+                environment: activeCell.environment,
+              }}
+              actionButtons={
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={() => {
+                    if (hasCommentDraft)
+                      toast.error(
+                        "Please save or discard your comment before proceeding",
+                      );
+                    else clearActiveCell();
+                  }}
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              }
+            />
+            {hasNonAnnotationScores && (
+              <div className="mt-4 text-xs text-muted-foreground">
+                API and eval scores visible on left. Add manual annotations
+                above.
+              </div>
+            )}
+          </>
         ) : (
           <Skeleton className="h-full w-full" />
         )}

--- a/web/src/features/scores/components/AnnotateDrawer.tsx
+++ b/web/src/features/scores/components/AnnotateDrawer.tsx
@@ -32,6 +32,10 @@ export function AnnotateDrawer<Target extends ScoreTarget>({
     scope: "scores:CUD",
   });
 
+  const hasNonAnnotationScores = scores.some(
+    (score) => score.source !== "ANNOTATION",
+  );
+
   return (
     <Drawer>
       <DrawerTrigger asChild>
@@ -68,6 +72,11 @@ export function AnnotateDrawer<Target extends ScoreTarget>({
           analyticsData={analyticsData}
           scoreMetadata={scoreMetadata}
         />
+        {hasNonAnnotationScores && (
+          <div className="mt-4 text-xs text-muted-foreground">
+            API and eval scores visible on left. Add manual annotations above.
+          </div>
+        )}
       </DrawerContent>
     </Drawer>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Display a message for non-annotation scores in `AnnotationDrawerSection`, `AnnotationPanel`, and `AnnotateDrawer`.
> 
>   - **Behavior**:
>     - Display message "API and eval scores visible on left. Add manual annotations above." when non-annotation scores are present in `AnnotationDrawerSection`, `AnnotationPanel`, and `AnnotateDrawer`.
>     - Checks for non-annotation scores using `scores.some(score => score.source !== "ANNOTATION")` in `AnnotationDrawerSection` and `AnnotateDrawer`, and `Object.keys(activeCell.scoreAggregates).some(...)` in `AnnotationPanel`.
>   - **Components**:
>     - `AnnotationDrawerSection`: Adds `hasNonAnnotationScores` check and conditional message rendering.
>     - `AnnotationPanel`: Adds `hasNonAnnotationScores` check and conditional message rendering.
>     - `AnnotateDrawer`: Adds `hasNonAnnotationScores` check and conditional message rendering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 04b6fa050e47fe5410ce2b4efb9c38fac2afcae2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->