### PR TITLE
fix(otel-ingestion-ai-sdk): parse usage from both ai.usage and providerMetadata

### DIFF
--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -5029,7 +5029,120 @@ describe("OTel Resource Span Mapping", () => {
     });
   });
 
-  describe("Vercel AI SDK Bedrock Provider Cache Tokens", () => {
+  describe("Vercel AI SDK Usage details", () => {
+    it("should extract usage details from both provider metadata and 'ai.usage'", async () => {
+      const traceId = "abcdef1234567890abcdef1234567890";
+      const spanId = "1234567890abcdef";
+
+      const vercelAIAnthropicSpan = {
+        resource: {
+          attributes: [
+            {
+              key: "service.name",
+              value: { stringValue: "test-service" },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: {
+              name: "ai", // Vercel AI SDK scope
+              version: "4.0.0",
+            },
+            spans: [
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from(spanId, "hex"),
+                name: "bedrock-generation",
+                kind: 1,
+                startTimeUnixNano: {
+                  low: 1000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                endTimeUnixNano: {
+                  low: 2000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                attributes: [
+                  {
+                    key: "gen_ai.usage.input_tokens",
+                    value: {
+                      intValue: { low: 18495, high: 0, unsigned: false },
+                    },
+                  },
+                  {
+                    key: "gen_ai.usage.output_tokens",
+                    value: { intValue: { low: 445, high: 0, unsigned: false } },
+                  },
+                  {
+                    key: "ai.usage.cachedInputTokens",
+                    value: { stringValue: "16399" },
+                  },
+                  {
+                    key: "ai.response.providerMetadata",
+                    value: {
+                      stringValue: JSON.stringify({
+                        anthropic: {
+                          usage: {
+                            input_tokens: 7,
+                            cache_creation_input_tokens: 2089,
+                            cache_read_input_tokens: 16399,
+                            cache_creation: {
+                              ephemeral_5m_input_tokens: 2089,
+                              ephemeral_1h_input_tokens: 0,
+                            },
+                            output_tokens: 445,
+                            service_tier: "standard",
+                          },
+                          cacheCreationInputTokens: 2089,
+                          stopSequence: null,
+                          container: null,
+                          contextManagement: null,
+                        },
+                      }),
+                    },
+                  },
+                ],
+                status: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const events = await convertOtelSpanToIngestionEvent(
+        vercelAIAnthropicSpan,
+        new Set(),
+      );
+
+      const observationEvent = events.find(
+        (e) => e.type === "generation-create" || e.type === "span-create",
+      );
+
+      console.log(JSON.stringify(observationEvent, null, 2));
+
+      expect(observationEvent).toBeDefined();
+
+      // Verify basic token usage
+      expect(observationEvent?.body.usageDetails.input).toBe(7);
+      expect(observationEvent?.body.usageDetails.output).toBe(445);
+
+      // Verify cache tokens are extracted
+      expect(observationEvent?.body.usageDetails.input_cached_tokens).toBe(
+        16399,
+      );
+      expect(
+        observationEvent?.body.usageDetails.input_cache_read,
+      ).toBeUndefined(); // no double accounting
+      expect(observationEvent?.body.usageDetails.input_cache_creation).toBe(
+        2089,
+      );
+      expect(
+        observationEvent?.body.usageDetails.input_cache_write,
+      ).toBeUndefined(); // no double accounting
+    });
     it("should extract all Bedrock cache token types from Vercel AI SDK provider metadata", async () => {
       const traceId = "abcdef1234567890abcdef1234567890";
       const spanId = "1234567890abcdef";

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -5121,8 +5121,6 @@ describe("OTel Resource Span Mapping", () => {
         (e) => e.type === "generation-create" || e.type === "span-create",
       );
 
-      console.log(JSON.stringify(observationEvent, null, 2));
-
       expect(observationEvent).toBeDefined();
 
       // Verify basic token usage


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances `OtelIngestionProcessor` to extract usage details from both `ai.usage` and `providerMetadata`, with updated tests to verify behavior.
> 
>   - **Behavior**:
>     - `OtelIngestionProcessor` now extracts usage details from both `ai.usage` and `providerMetadata`.
>     - Handles `openai`, `anthropic`, and `bedrock` provider metadata for token usage.
>     - Ensures no double accounting of cache tokens.
>   - **Tests**:
>     - Adds test in `otelMapping.servertest.ts` to verify extraction of usage details from `providerMetadata` and `ai.usage`.
>     - Verifies handling of `bedrock` cache token types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2bcfab78e48e2d14f616d2247c6dbf82454ef3a8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->