### PR TITLE
fix: add search for prompt version dropdown

### DIFF
--- a/web/src/features/experiments/components/steps/PromptModelStep.tsx
+++ b/web/src/features/experiments/components/steps/PromptModelStep.tsx
@@ -186,6 +186,10 @@ export const PromptModelStep: React.FC<PromptModelStepProps> = ({
                   align="start"
                 >
                   <InputCommand>
+                    <InputCommandInput
+                      placeholder="Search versions..."
+                      className="h-9"
+                    />
                     <InputCommandList>
                       <InputCommandEmpty>No version found.</InputCommandEmpty>
                       <InputCommandGroup className="overflow-y-auto">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds search input for prompt version dropdown in `PromptModelStep` to enable version searching.
> 
>   - **Behavior**:
>     - Adds `InputCommandInput` with placeholder "Search versions..." to the prompt version dropdown in `PromptModelStep` to enable searching through prompt versions.
>   - **UI Components**:
>     - Modifies `PromptModelStep.tsx` to include a search input for prompt versions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4af5b45a86129c848b8889162f18cd741b8e8ccd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->