### PR TITLE
fix: prevent retention configuration drift when queues are backlogged

### DIFF
--- a/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
+++ b/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
@@ -19,15 +19,48 @@ export const handleDataRetentionProcessingJob = async (job: Job) => {
   if (span) {
     span.setAttribute("messaging.bullmq.job.input.jobId", job.data.id);
     span.setAttribute("messaging.bullmq.job.input.projectId", projectId);
-    span.setAttribute("messaging.bullmq.job.input.retentionId", retention);
   }
 
-  const cutoffDate = new Date(Date.now() - retention * 24 * 60 * 60 * 1000);
+  // CRITICAL FIX: Re-fetch current retention setting from database
+  // This prevents stale queued jobs from deleting data after retention is disabled
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: { retentionDays: true },
+  });
+
+  // Skip if project no longer exists, has no retention, or retention is set to 0 (indefinite)
+  if (!project || !project.retentionDays || project.retentionDays === 0) {
+    logger.info(
+      `[Data Retention] Skipping project ${projectId} - retention disabled or set to 0`,
+    );
+    return;
+  }
+
+  // Use the CURRENT retention value from database, not the queued value
+  const currentRetention = project.retentionDays;
+
+  if (span) {
+    span.setAttribute(
+      "messaging.bullmq.job.input.retentionId",
+      currentRetention,
+    );
+  }
+
+  // Log if retention value changed since job was queued
+  if (currentRetention !== retention) {
+    logger.warn(
+      `[Data Retention] Retention changed for project ${projectId}: queued=${retention} days, current=${currentRetention} days. Using current value.`,
+    );
+  }
+
+  const cutoffDate = new Date(
+    Date.now() - currentRetention * 24 * 60 * 60 * 1000,
+  );
 
   // Delete media files if bucket is configured
   if (env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET) {
     logger.info(
-      `[Data Retention] Deleting media files older than ${retention} days for project ${projectId}`,
+      `[Data Retention] Deleting media files older than ${currentRetention} days for project ${projectId}`,
     );
     const mediaFilesToDelete = await prisma.media.findMany({
       select: {
@@ -67,7 +100,7 @@ export const handleDataRetentionProcessingJob = async (job: Job) => {
 
   // Delete ClickHouse (TTL / Delete Queries)
   logger.info(
-    `[Data Retention] Deleting ClickHouse and S3 data older than ${retention} days for project ${projectId}`,
+    `[Data Retention] Deleting ClickHouse and S3 data older than ${currentRetention} days for project ${projectId}`,
   );
   await Promise.all([
     env.LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG === "true"
@@ -84,7 +117,7 @@ export const handleDataRetentionProcessingJob = async (job: Job) => {
       : Promise.resolve(),
   ]);
   logger.info(
-    `[Data Retention] Deleted ClickHouse and S3 data older than ${retention} days for project ${projectId}`,
+    `[Data Retention] Deleted ClickHouse and S3 data older than ${currentRetention} days for project ${projectId}`,
   );
 
   // Set S3 Lifecycle for deletion (Future)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes data retention job to respect current retention settings, preventing data deletion based on outdated settings.
> 
>   - **Behavior**:
>     - `handleDataRetentionProcessingJob` now re-fetches current retention settings from the database to prevent data deletion based on outdated settings.
>     - Skips deletion if retention is set to 0 or null, logging the action in `handleDataRetentionProcessingJob`.
>     - Uses current retention value if it differs from the queued value, logging a warning.
>   - **Tests**:
>     - Updated tests in `dataRetentionProcessing.test.ts` to set and reset retention settings before and after each test.
>     - Added tests for scenarios where retention changes to 0 or null after job queuing.
>     - Added test to verify current retention value is used if it differs from the queued value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cc75b564c5fd55c86612eaa0123e552a2eece1f1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->