### PR TITLE
feat(prompts): support Japanese characters in prompt variables

### DIFF
--- a/packages/shared/src/utils/stringChecks.ts
+++ b/packages/shared/src/utils/stringChecks.ts
@@ -1,11 +1,19 @@
+const JAPANESE_CHAR_RANGE = "\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF";
+
 export function getIsCharOrUnderscore(value: string): boolean {
-  const charOrUnderscore = /^[A-Za-z_]+$/;
+  const charOrUnderscore = new RegExp(
+    `^[a-zA-Z_${JAPANESE_CHAR_RANGE}]+$`,
+    "u",
+  );
 
   return charOrUnderscore.test(value);
 }
 
 // Regex for valid variable names (letters, underscores, starting with letter)
-export const VARIABLE_REGEX = /^[a-zA-Z][a-zA-Z_]*$/;
+export const VARIABLE_REGEX = new RegExp(
+  `^[a-zA-Z${JAPANESE_CHAR_RANGE}][a-zA-Z${JAPANESE_CHAR_RANGE}_]*$`,
+  "u",
+);
 
 // Regex to find variables in mustache syntax
 export const MUSTACHE_REGEX = /{{([^{}]*)}}+/g;


### PR DESCRIPTION
## What does this PR do?

This PR adds support for Japanese (Unicode) characters in prompt variables.

Previously, prompt variables were restricted to ASCII characters, which prevented users from using Japanese variable names. This change relaxes the validation/parsing logic to allow Unicode characters, enabling Japanese prompt variable names without breaking existing behavior.

Fixes https://github.com/orgs/langfuse/discussions/11468

<!--
Loom Video:
N/A (no visual UI changes)
-->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [ ] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [x] I haven't commented my code, particularly in hard-to-understand areas
- [x] I haven't checked if my PR needs changes to the documentation
- [x] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [ ] I haven't added tests that prove my fix is effective or that my feature works
- [x] I haven't checked if new and existing unit tests pass locally with my changes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Support for Japanese characters in prompt variables by updating regex patterns in `stringChecks.ts`.
> 
>   - **Behavior**:
>     - Support for Japanese characters in prompt variables by updating regex patterns in `stringChecks.ts`.
>     - `getIsCharOrUnderscore()` and `VARIABLE_REGEX` now include Japanese Unicode ranges.
>   - **Regex Changes**:
>     - `getIsCharOrUnderscore()` regex updated to include Japanese Unicode ranges.
>     - `VARIABLE_REGEX` updated to allow Japanese characters at the start and within variable names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 38055ff5c5e30aa94194df06d9aaa17416ae2b63. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->