### PR TITLE
chore(score-conifgs): remove categories index from ScoreConfig table

### DIFF
--- a/packages/shared/prisma/migrations/20260113102907_score_configs_drop_categories_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20260113102907_score_configs_drop_categories_idx/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX CONCURRENTLY IF EXISTS "score_configs_categories_idx";

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -492,7 +492,6 @@ model ScoreConfig {
   @@index([dataType])
   @@index([isArchived])
   @@index([projectId])
-  @@index([categories])
   @@index([createdAt])
   @@index([updatedAt])
   @@map("score_configs")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `categories` index from `ScoreConfig` table and add migration script to drop it.
> 
>   - **Database Schema**:
>     - Removes `categories` index from `ScoreConfig` table in `schema.prisma`.
>     - Adds migration script `20260113102907_score_configs_drop_categories_idx/migration.sql` to drop `score_configs_categories_idx` index.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 33c4eca6ce918c59d4f3ddf7307057bc2aebad99. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->