### PR TITLE
fix(api): fix score API environment filtering for session scores

### DIFF
--- a/web/src/pages/api/public/scores/index.ts
+++ b/web/src/pages/api/public/scores/index.ts
@@ -66,7 +66,6 @@ export default withMiddlewares({
         fromTimestamp: query.fromTimestamp ?? undefined,
         toTimestamp: query.toTimestamp ?? undefined,
         environment: query.environment ?? undefined,
-        traceEnvironment: query.environment ?? undefined,
         source: query.source ?? undefined,
         value: query.value ?? undefined,
         operator: query.operator ?? undefined,

--- a/web/src/pages/api/public/v2/scores/index.ts
+++ b/web/src/pages/api/public/v2/scores/index.ts
@@ -51,7 +51,6 @@ export default withMiddlewares({
         fromTimestamp: query.fromTimestamp ?? undefined,
         toTimestamp: query.toTimestamp ?? undefined,
         environment: query.environment ?? undefined,
-        traceEnvironment: query.environment ?? undefined,
         source: query.source ?? undefined,
         value: query.value ?? undefined,
         operator: query.operator ?? undefined,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix environment filtering for session scores in the score API by applying environment filters to traces when trace filters are present, and update tests to verify the behavior.
> 
>   - **Behavior**:
>     - Fix environment filtering for session scores in `scores.ts` by applying environment filter to traces when trace filters are present.
>     - Remove `traceEnvironment` from query parameters in `index.ts` for v1 and v2 API endpoints.
>   - **Tests**:
>     - Add tests in `scores-api-v2.servertest.ts` to verify environment filtering for session scores, including cases with default environments and combined trace filters.
>   - **Misc**:
>     - Update `ScoreQueryType` in `scores.ts` to include `environment` as a filter option.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9a88db3710c8957df686f20acf8d8fc88e3648b6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->