### PR TITLE
feat(corrections): add global toggle for showing corrections in session and IOPreview components

### DIFF
--- a/web/src/components/session/TraceRow.tsx
+++ b/web/src/components/session/TraceRow.tsx
@@ -35,11 +35,13 @@ const TraceRow = React.memo(
     projectId,
     openPeek,
     traceCommentCounts,
+    showCorrections,
   }: {
     trace: RouterOutputs["sessions"]["byIdWithScores"]["traces"][number];
     projectId: string;
     openPeek: (id: string, row: any) => void;
     traceCommentCounts: Map<string, number> | undefined;
+    showCorrections: boolean;
   }) => {
     return (
       <Card className="border-border shadow-none">
@@ -49,6 +51,7 @@ const TraceRow = React.memo(
               traceId={trace.id}
               projectId={projectId}
               timestamp={new Date(trace.timestamp)}
+              showCorrections={showCorrections}
             />
           </div>
           <div className="hidden bg-border md:block"></div>
@@ -165,10 +168,11 @@ export const LazyTraceRow = React.forwardRef<
     openPeek: (id: string, row: any) => void;
     index: number;
     traceCommentCounts: Map<string, number> | undefined;
+    showCorrections: boolean;
     onLoad?: (index: number) => void;
   }
 >((props, measureRef) => {
-  const { index, onLoad: onLoad, ...cardProps } = props;
+  const { index, onLoad: onLoad, showCorrections, ...cardProps } = props;
   const [shouldLoad, setShouldLoad] = useState(false);
   const internalRef = useRef<HTMLDivElement>(null);
 
@@ -196,7 +200,11 @@ export const LazyTraceRow = React.forwardRef<
 
   return (
     <div ref={combinedRef} className="pb-3">
-      {shouldLoad ? <TraceRow {...cardProps} /> : <TraceSkeleton />}
+      {shouldLoad ? (
+        <TraceRow showCorrections={showCorrections} {...cardProps} />
+      ) : (
+        <TraceSkeleton />
+      )}
     </div>
   );
 });

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -36,6 +36,8 @@ import { usePeekNavigation } from "@/src/components/table/peek/hooks/usePeekNavi
 import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
 import { LazyTraceRow } from "@/src/components/session/TraceRow";
 import { useParsedTrace } from "@/src/hooks/useParsedTrace";
+import useLocalStorage from "@/src/components/useLocalStorage";
+import { Switch } from "@/src/components/ui/switch";
 
 // some projects have thousands of users in a session, paginate to avoid rendering all at once
 const INITIAL_USERS_DISPLAY_COUNT = 10;
@@ -169,6 +171,11 @@ export const SessionPage: React.FC<{
         return failureCount < 3;
       },
     },
+  );
+
+  const [showCorrections, setShowCorrections] = useLocalStorage(
+    "showCorrections",
+    false,
   );
 
   const sessionComments = api.comments.getByObjectId.useQuery({
@@ -369,6 +376,16 @@ export const SessionPage: React.FC<{
                 variant="outline"
               />
             </div>
+            <div className="flex items-center">
+              <Switch
+                checked={showCorrections}
+                onCheckedChange={setShowCorrections}
+                className="scale-75"
+              />
+              <span className="text-xs text-muted-foreground">
+                Show corrections
+              </span>
+            </div>
           </>
         ),
       }}
@@ -419,6 +436,7 @@ export const SessionPage: React.FC<{
                     openPeek={openPeek}
                     traceCommentCounts={traceCommentCounts.data}
                     index={virtualItem.index}
+                    showCorrections={showCorrections}
                     onLoad={() => {
                       // Force virtualizer to remeasure this specific item
                       virtualizer.measureElement(
@@ -454,10 +472,12 @@ export const SessionIO = ({
   traceId,
   projectId,
   timestamp,
+  showCorrections,
 }: {
   traceId: string;
   projectId: string;
   timestamp: Date;
+  showCorrections: boolean;
 }) => {
   const trace = api.traces.byId.useQuery(
     { traceId, projectId, timestamp },
@@ -499,6 +519,7 @@ export const SessionIO = ({
           projectId={projectId}
           traceId={traceId}
           environment={trace.data.environment}
+          showCorrections={showCorrections}
         />
       ) : (
         <div className="p-2 text-xs text-muted-foreground">

--- a/web/src/components/trace2/components/IOPreview/IOPreview.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreview.tsx
@@ -61,6 +61,7 @@ export interface IOPreviewProps extends ExpansionStateProps {
   projectId: string;
   traceId: string;
   environment?: string;
+  showCorrections?: boolean;
 }
 
 /**
@@ -106,6 +107,7 @@ export function IOPreview({
   projectId,
   traceId,
   environment = "default",
+  showCorrections = true,
 }: IOPreviewProps) {
   const capture = usePostHogClientCapture();
   const [dismissedTraceViewNotifications, setDismissedTraceViewNotifications] =
@@ -158,6 +160,7 @@ export function IOPreview({
     projectId,
     traceId,
     environment,
+    showCorrections,
   };
 
   // Only show empty state popup for traces (not observations) when there's no input/output
@@ -215,6 +218,7 @@ export function IOPreview({
           projectId={projectId}
           traceId={traceId}
           environment={environment}
+          showCorrections={showCorrections}
         />
       ) : selectedView === "json" ? (
         <IOPreviewJSONSimple {...sharedProps} />

--- a/web/src/components/trace2/components/IOPreview/IOPreviewJSON.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreviewJSON.tsx
@@ -52,6 +52,7 @@ export interface IOPreviewJSONProps extends ExpansionStateProps {
   projectId: string;
   traceId: string;
   environment?: string;
+  showCorrections?: boolean;
 }
 
 /**
@@ -84,6 +85,7 @@ function IOPreviewJSONInner({
   projectId,
   traceId,
   environment = "default",
+  showCorrections = true,
 }: IOPreviewJSONProps) {
   const selectionContext = useInlineCommentSelectionOptional();
 
@@ -428,14 +430,16 @@ function IOPreviewJSONInner({
         ) : (
           viewerContent
         )}
-        <CorrectedOutputField
-          actualOutput={parsedOutput}
-          existingCorrection={outputCorrection}
-          observationId={observationId}
-          projectId={projectId}
-          traceId={traceId}
-          environment={environment}
-        />
+        {showCorrections && (
+          <CorrectedOutputField
+            actualOutput={parsedOutput}
+            existingCorrection={outputCorrection}
+            observationId={observationId}
+            projectId={projectId}
+            traceId={traceId}
+            environment={environment}
+          />
+        )}
       </div>
     </div>
   );

--- a/web/src/components/trace2/components/IOPreview/IOPreviewJSONSimple.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreviewJSONSimple.tsx
@@ -24,6 +24,7 @@ export interface IOPreviewJSONSimpleProps extends ExpansionStateProps {
   projectId: string;
   traceId: string;
   environment?: string;
+  showCorrections?: boolean;
 }
 
 /**
@@ -57,6 +58,7 @@ export function IOPreviewJSONSimple({
   projectId,
   traceId,
   environment = "default",
+  showCorrections = true,
 }: IOPreviewJSONSimpleProps) {
   // Parse data if not pre-parsed
   // IMPORTANT: Don't parse while isParsing=true to avoid double-parsing with different object references
@@ -107,14 +109,16 @@ export function IOPreviewJSONSimple({
           onExternalExpansionChange={onOutputExpansionChange}
         />
       )}
-      <CorrectedOutputField
-        actualOutput={effectiveOutput}
-        existingCorrection={outputCorrection}
-        observationId={observationId}
-        projectId={projectId}
-        traceId={traceId}
-        environment={environment}
-      />
+      {showCorrections && (
+        <CorrectedOutputField
+          actualOutput={effectiveOutput}
+          existingCorrection={outputCorrection}
+          observationId={observationId}
+          projectId={projectId}
+          traceId={traceId}
+          environment={environment}
+        />
+      )}
       {showMetadata && (
         <PrettyJsonView
           title="Metadata"

--- a/web/src/components/trace2/components/IOPreview/IOPreviewPretty.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreviewPretty.tsx
@@ -3,7 +3,6 @@ import { type Prisma, type ScoreDomain, deepParseJson } from "@langfuse/shared";
 import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
 import { MARKDOWN_RENDER_CHARACTER_LIMIT } from "@/src/utils/constants";
 import { type MediaReturnType } from "@/src/features/media/validation";
-
 import { useChatMLParser } from "./hooks/useChatMLParser";
 import { ChatMessageList } from "./components/ChatMessageList";
 import { SectionToolDefinitions } from "./components/SectionToolDefinitions";
@@ -98,6 +97,7 @@ export interface IOPreviewPrettyProps extends ExpansionStateProps {
   projectId: string;
   traceId: string;
   environment?: string;
+  showCorrections?: boolean;
 }
 
 /**
@@ -136,6 +136,7 @@ export function IOPreviewPretty({
   projectId,
   traceId,
   environment = "default",
+  showCorrections = true,
 }: IOPreviewPrettyProps) {
   // Use pre-parsed data if available (from useParsedObservation hook),
   // otherwise parse with size/depth limits to prevent UI freeze
@@ -255,19 +256,7 @@ export function IOPreviewPretty({
             messageToToolCallNumbers={messageToToolCallNumbers}
             inputMessageCount={inputMessageCount}
           />
-          <CorrectedOutputField
-            actualOutput={parsedOutput}
-            existingCorrection={outputCorrection}
-            observationId={observationId}
-            projectId={projectId}
-            traceId={traceId}
-            environment={environment}
-          />
-        </div>
-      ) : (
-        <>
-          <JsonInputOutputView {...jsonViewProps} />
-          <div className="[&_.io-message-content]:px-2 [&_.io-message-header]:px-2">
+          {showCorrections && (
             <CorrectedOutputField
               actualOutput={parsedOutput}
               existingCorrection={outputCorrection}
@@ -276,6 +265,22 @@ export function IOPreviewPretty({
               traceId={traceId}
               environment={environment}
             />
+          )}
+        </div>
+      ) : (
+        <>
+          <JsonInputOutputView {...jsonViewProps} />
+          <div className="[&_.io-message-content]:px-2 [&_.io-message-header]:px-2">
+            {showCorrections && (
+              <CorrectedOutputField
+                actualOutput={parsedOutput}
+                existingCorrection={outputCorrection}
+                observationId={observationId}
+                projectId={projectId}
+                traceId={traceId}
+                environment={environment}
+              />
+            )}
           </div>
         </>
       )}

--- a/web/src/components/trace2/components/IOPreview/components/CorrectedOutputField.tsx
+++ b/web/src/components/trace2/components/IOPreview/components/CorrectedOutputField.tsx
@@ -131,7 +131,7 @@ export function CorrectedOutputField({
             onClick={handleEdit}
             disabled={!hasAccess}
             className={cn(
-              "w-full cursor-pointer rounded-md border px-3 py-8 text-center text-sm text-muted-foreground transition-colors hover:bg-muted/50",
+              "w-full cursor-pointer rounded-md border px-3 py-4 text-center text-xs text-muted-foreground transition-colors hover:bg-muted/50",
             )}
           >
             Click to add corrected output

--- a/web/src/features/annotation-queues/components/processors/SessionAnnotationProcessor.tsx
+++ b/web/src/features/annotation-queues/components/processors/SessionAnnotationProcessor.tsx
@@ -126,6 +126,7 @@ export const SessionAnnotationProcessor: React.FC<
                   traceId={trace.id}
                   projectId={projectId}
                   timestamp={trace.timestamp}
+                  showCorrections
                 />
               </Card>
             ))}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add global toggle for showing corrections in `Session` and `IOPreview` components, controlled via local storage.
> 
>   - **Behavior**:
>     - Adds `showCorrections` toggle in `SessionPage` and `SessionAnnotationProcessor` to control visibility of corrections.
>     - `showCorrections` state stored in local storage using `useLocalStorage` hook.
>     - `Switch` component added to `SessionPage` for user to toggle corrections visibility.
>   - **Components**:
>     - `TraceRow`, `LazyTraceRow`, `SessionIO`, `IOPreview`, `IOPreviewJSON`, `IOPreviewJSONSimple`, and `IOPreviewPretty` updated to accept `showCorrections` prop.
>     - `CorrectedOutputField` rendering is conditional on `showCorrections` prop in `IOPreview` components.
>   - **Misc**:
>     - Adjusted `CorrectedOutputField` styling in `CorrectedOutputField.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 125ab69c137492ae6b93de24b55e9ad2f7978ffe. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->