### PR TITLE
chore(annotation-queue-ui): add onOpenChange callback for smooth scrolling behavior when the dropdown opens

### DIFF
--- a/web/src/components/ui/multi-select-combobox.tsx
+++ b/web/src/components/ui/multi-select-combobox.tsx
@@ -20,6 +20,7 @@ interface MultiSelectComboboxProps<T> {
   renderSelectedItem: (item: T, onRemove: () => void) => React.ReactNode;
   getItemKey: (item: T) => string;
   disabled?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function MultiSelectCombobox<T>({
@@ -35,6 +36,7 @@ export function MultiSelectCombobox<T>({
   renderSelectedItem,
   getItemKey,
   disabled = false,
+  onOpenChange,
 }: MultiSelectComboboxProps<T>) {
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
@@ -47,6 +49,7 @@ export function MultiSelectCombobox<T>({
   const handleInputFocus = () => {
     setIsInputFocused(true);
     setShowDropdown(true);
+    onOpenChange?.(true);
   };
 
   const handleInputBlur = () => {
@@ -55,6 +58,7 @@ export function MultiSelectCombobox<T>({
     setTimeout(() => {
       if (!isInputFocused) {
         setShowDropdown(false);
+        onOpenChange?.(false);
       }
     }, 200);
   };
@@ -84,6 +88,7 @@ export function MultiSelectCombobox<T>({
       ) {
         setShowDropdown(false);
         setIsInputFocused(false);
+        onOpenChange?.(false);
       }
     };
 
@@ -93,7 +98,7 @@ export function MultiSelectCombobox<T>({
         document.removeEventListener("mousedown", handleClickOutside);
       };
     }
-  }, [showDropdown]);
+  }, [showDropdown, onOpenChange]);
 
   const handleItemToggle = (item: T) => {
     const itemKey = getItemKey(item);

--- a/web/src/features/annotation-queues/components/UserAssignmentSection.tsx
+++ b/web/src/features/annotation-queues/components/UserAssignmentSection.tsx
@@ -6,6 +6,7 @@ import { MultiSelectCombobox } from "@/src/components/ui/multi-select-combobox";
 import { useUserSearch } from "@/src/hooks/useUserSearch";
 import { useSelectedUsers } from "@/src/features/annotation-queues/hooks/useSelectedUsers";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
+import { useRef } from "react";
 
 interface UserAssignmentSectionProps {
   projectId: string;
@@ -20,6 +21,7 @@ export const UserAssignmentSection = ({
   onChange,
   queueId,
 }: UserAssignmentSectionProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
   const hasQueueAssignmentsReadAccess = useHasProjectAccess({
     projectId: projectId,
     scope: "annotationQueueAssignments:read",
@@ -87,7 +89,7 @@ export const UserAssignmentSection = ({
       queueAssignmentsQuery.data.assignments.length;
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4" ref={containerRef}>
       {/* User Selection Combobox */}
       <MultiSelectCombobox
         selectedItems={selectedUsers}
@@ -100,6 +102,16 @@ export const UserAssignmentSection = ({
         placeholder="Search users to add..."
         hasMoreResults={userSearch.hasMoreResults}
         getItemKey={(user) => user.id}
+        onOpenChange={(open) => {
+          if (open) {
+            setTimeout(() => {
+              containerRef.current?.scrollIntoView({
+                behavior: "smooth",
+                block: "center",
+              });
+            }, 100);
+          }
+        }}
         renderSelectedItem={(user, onRemove) => (
           <div className="flex flex-shrink-0 items-center gap-1 rounded-md bg-muted px-2 py-1 text-xs">
             <span className="max-w-32 truncate">{user.name || user.email}</span>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `onOpenChange` callback to `MultiSelectCombobox` for smooth scrolling in `UserAssignmentSection` when dropdown opens.
> 
>   - **Behavior**:
>     - Adds `onOpenChange` callback to `MultiSelectCombobox` to handle dropdown open/close events.
>     - Implements smooth scrolling in `UserAssignmentSection` when dropdown opens using `onOpenChange`.
>   - **Components**:
>     - Updates `MultiSelectCombobox` to call `onOpenChange` in `handleInputFocus`, `handleInputBlur`, and `handleClickOutside`.
>     - Uses `useRef` in `UserAssignmentSection` to scroll container into view on dropdown open.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f1fd8b4557678237d92cfd3a5d9f8fa405dc87a6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->