### PR TITLE
feat: extend BatchProjectCleanerJob to handle dataset run items

### DIFF
--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -1198,6 +1198,28 @@ export const eventsObservationsView: ViewDeclarationType = {
       description: "Time to first token for the observation.",
       unit: "millisecond",
     },
+    tracesCount: {
+      sql: "uniq(events.trace_id)",
+      alias: "tracesCount",
+      type: "integer",
+      description: "Unique traces.",
+      unit: "observations",
+    },
+    uniqueUserIds: {
+      sql: "uniq(events.user_id)",
+      alias: "uniqueUserIds",
+      type: "integer",
+      description: "Count of unique userIds.",
+      unit: "users",
+    },
+    uniqueSessionIds: {
+      sql: "uniq(events.session_id)",
+      alias: "uniqueSessionIds",
+      type: "integer",
+      description: "Count of unique sessionIds.",
+      unit: "sessions",
+    },
+    // TODO trace sessions
     countScores: {
       sql: "uniq(scores.id)",
       alias: "countScores",

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -549,6 +549,7 @@ if (env.LANGFUSE_BATCH_PROJECT_CLEANER_ENABLED === "true") {
   WorkerManager.register(
     QueueName.BatchProjectCleanerQueue,
     batchProjectCleanerProcessor,
+    { concurrency: 1 }, // only 1 job at a time
   );
 
   // Schedule repeatable jobs for each table

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -325,10 +325,6 @@ const EnvSchema = z.object({
   LANGFUSE_BATCH_PROJECT_CLEANER_ENABLED: z
     .enum(["true", "false"])
     .default("false"),
-  LANGFUSE_BATCH_PROJECT_CLEANER_CHECK_INTERVAL_MS: z.coerce
-    .number()
-    .positive()
-    .default(60_000), // 1 minute between runs
   LANGFUSE_BATCH_PROJECT_CLEANER_SLEEP_ON_EMPTY_MS: z.coerce
     .number()
     .positive()

--- a/worker/src/features/batch-project-cleaner/index.ts
+++ b/worker/src/features/batch-project-cleaner/index.ts
@@ -13,6 +13,7 @@ export const BATCH_DELETION_TABLES = [
   "observations",
   "scores",
   "events",
+  "dataset_run_items_rmt",
 ] as const;
 
 export type BatchDeletionTable = (typeof BATCH_DELETION_TABLES)[number];

--- a/worker/src/queues/projectDelete.ts
+++ b/worker/src/queues/projectDelete.ts
@@ -99,7 +99,7 @@ export const projectDeleteProcessor: Processor = async (
   ]);
 
   // Trigger async delete of dataset run items
-  await deleteDatasetRunItemsByProjectId({ projectId });
+  await deleteDatasetRunItemsByProjectId(projectId);
 
   logger.info(`Deleting PG data for project ${projectId} in org ${orgId}`);
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Extend `BatchProjectCleanerJob` to handle dataset run items, ensuring deletion for soft-deleted projects, with updates to deletion logic and tests.
> 
>   - **Behavior**:
>     - Extend `BatchProjectCleanerJob` to handle `dataset_run_items_rmt` for soft-deleted projects in `batch-project-cleaner/index.ts`.
>     - Modify `deleteDatasetRunItemsByProjectId` to return `false` if no items exist for the project in `dataset-run-items.ts`.
>   - **Data Models**:
>     - Add `tracesCount`, `uniqueUserIds`, and `uniqueSessionIds` to `eventsObservationsView` in `dataModel.ts`.
>   - **Tests**:
>     - Add test for deleting `dataset_run_items_rmt` in `batchProjectCleaner.test.ts`.
>   - **Misc**:
>     - Register `batchProjectCleanerProcessor` with concurrency 1 in `app.ts`.
>     - Remove `LANGFUSE_BATCH_PROJECT_CLEANER_CHECK_INTERVAL_MS` from `env.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2ec57dc682474e4d4ada4c6b40bb6bdad2aba57d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->