### PR TITLE
chore(ui): show 1pass modal only for sign-up/sign-in input fields

### DIFF
--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -3,12 +3,15 @@ import * as React from "react";
 import { cn } from "@/src/utils/tailwind";
 
 export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  allowPasswordManager?: boolean;
+}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, type, allowPasswordManager = false, ...props }, ref) => {
     return (
       <input
+        {...(!allowPasswordManager && { "data-1p-ignore": true })}
         type={type}
         className={cn(
           "flex h-8 w-full min-w-14 rounded-md border border-input bg-background px-2 py-1 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50",

--- a/web/src/features/auth-credentials/components/ResetPasswordPage.tsx
+++ b/web/src/features/auth-credentials/components/ResetPasswordPage.tsx
@@ -149,6 +149,8 @@ export function ResetPasswordPage({
                           <Input
                             placeholder="jsdoe@example.com"
                             disabled={session.status === "authenticated"}
+                            allowPasswordManager
+                            autoComplete="email"
                             {...field}
                           />
                           {emailVerified.verified && (
@@ -171,7 +173,10 @@ export function ResetPasswordPage({
                         <FormItem>
                           <FormLabel>New Password</FormLabel>
                           <FormControl>
-                            <PasswordInput {...field} />
+                            <PasswordInput
+                              autoComplete="new-password"
+                              {...field}
+                            />
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -184,7 +189,10 @@ export function ResetPasswordPage({
                         <FormItem>
                           <FormLabel>Confirm New Password</FormLabel>
                           <FormControl>
-                            <PasswordInput {...field} />
+                            <PasswordInput
+                              autoComplete="new-password"
+                              {...field}
+                            />
                           </FormControl>
                           <FormMessage />
                         </FormItem>

--- a/web/src/pages/auth/enterprise-sso-required.tsx
+++ b/web/src/pages/auth/enterprise-sso-required.tsx
@@ -165,6 +165,7 @@ export default function EnterpriseSsoRequiredPage() {
                     <FormControl>
                       <Input
                         placeholder="jsdoe@example.com"
+                        allowPasswordManager
                         autoComplete="email"
                         {...field}
                       />

--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -750,7 +750,12 @@ export default function SignIn({
                         <FormItem>
                           <FormLabel>Email</FormLabel>
                           <FormControl>
-                            <Input placeholder="jsdoe@example.com" {...field} />
+                            <Input
+                              placeholder="jsdoe@example.com"
+                              allowPasswordManager
+                              autoComplete="email"
+                              {...field}
+                            />
                           </FormControl>
                           <FormMessage />
                         </FormItem>

--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -246,7 +246,12 @@ export default function SignIn({
                   <FormItem>
                     <FormLabel>Email</FormLabel>
                     <FormControl>
-                      <Input placeholder="jsdoe@example.com" {...field} />
+                      <Input
+                        placeholder="jsdoe@example.com"
+                        allowPasswordManager
+                        autoComplete="email"
+                        {...field}
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `allowPasswordManager` prop to control 1Password modal visibility for email fields in authentication pages.
> 
>   - **Behavior**:
>     - Adds `allowPasswordManager` prop to `Input` component in `input.tsx` to control 1Password modal visibility.
>     - Sets `allowPasswordManager` to `true` for email fields in `ResetPasswordPage.tsx`, `enterprise-sso-required.tsx`, `sign-in.tsx`, and `sign-up.tsx`.
>     - Adds `autoComplete` attributes to email and password fields in `ResetPasswordPage.tsx` to enhance form autofill.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9a7dce9a2181bfc937b1073f703d07249758910c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->