### PR TITLE
fix(filters): date picker time adjustments don't change value

### DIFF
--- a/web/src/components/date-picker.tsx
+++ b/web/src/components/date-picker.tsx
@@ -347,10 +347,8 @@ export function TimeRangePicker({
   const onCalendarSelection = (range?: RDPDateRange) => {
     const newRange = range
       ? {
-          from: range.from
-            ? setBeginningOfDay(new Date(range.from))
-            : undefined,
-          to: range.to ? setEndOfDay(new Date(range.to)) : undefined,
+          from: range.from ? setBeginningOfDay(range.from) : undefined,
+          to: range.to ? setEndOfDay(range.to) : undefined,
         }
       : undefined;
 

--- a/web/src/components/ui/time-picker-utils.tsx
+++ b/web/src/components/ui/time-picker-utils.tsx
@@ -87,28 +87,32 @@ export function getValidArrowMinuteOrSecond(value: string, step: number) {
 }
 
 export function setMinutes(date: Date, value: string) {
+  const newDate = new Date(date);
   const minutes = getValidMinuteOrSecond(value);
-  date.setMinutes(parseInt(minutes, 10));
-  return date;
+  newDate.setMinutes(parseInt(minutes, 10));
+  return newDate;
 }
 
 export function setSeconds(date: Date, value: string) {
+  const newDate = new Date(date);
   const seconds = getValidMinuteOrSecond(value);
-  date.setSeconds(parseInt(seconds, 10));
-  return date;
+  newDate.setSeconds(parseInt(seconds, 10));
+  return newDate;
 }
 
 export function setHours(date: Date, value: string) {
+  const newDate = new Date(date);
   const hours = getValidHour(value);
-  date.setHours(parseInt(hours, 10));
-  return date;
+  newDate.setHours(parseInt(hours, 10));
+  return newDate;
 }
 
 export function set12Hours(date: Date, value: string, period: Period) {
+  const newDate = new Date(date);
   const hours = parseInt(getValid12Hour(value), 10);
   const convertedHours = convert12HourTo24Hour(hours, period);
-  date.setHours(convertedHours);
-  return date;
+  newDate.setHours(convertedHours);
+  return newDate;
 }
 
 export type TimePickerType = "minutes" | "seconds" | "hours" | "12hours";

--- a/web/src/components/ui/time-picker.tsx
+++ b/web/src/components/ui/time-picker.tsx
@@ -30,6 +30,11 @@ export function TimePicker({ date, setDate, className }: TimePickerProps) {
   const secondRef = React.useRef<HTMLInputElement>(null);
   const periodRef = React.useRef<HTMLButtonElement>(null);
 
+  // Sync period state when date prop changes externally (e.g., preset selection)
+  React.useEffect(() => {
+    setPeriod(getInitialPeriod(date));
+  }, [date]);
+
   const shortTimezone = React.useMemo(() => getShortLocalTimezone(), []);
   const timezoneDetails = React.useMemo(() => getTimezoneDetails(), []);
 

--- a/web/src/utils/dates.ts
+++ b/web/src/utils/dates.ts
@@ -21,13 +21,15 @@ export const utcDate = (localDateTime: Date) =>
   );
 
 export const setBeginningOfDay = (date: Date) => {
-  date.setHours(0, 0, 0, 0);
-  return date;
+  const newDate = new Date(date);
+  newDate.setHours(0, 0, 0, 0);
+  return newDate;
 };
 
 export const setEndOfDay = (date: Date) => {
-  date.setHours(23, 59, 59, 999);
-  return date;
+  const newDate = new Date(date);
+  newDate.setHours(23, 59, 59, 999);
+  return newDate;
 };
 
 export const intervalInSeconds = (start: Date, end: Date | null) =>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes date picker time adjustment issue by creating new date objects instead of mutating existing ones and syncing period state in `TimePicker`.
> 
>   - **Behavior**:
>     - Fixes issue where date picker time adjustments did not change the value by creating new date objects instead of mutating existing ones in `setMinutes()`, `setSeconds()`, `setHours()`, and `set12Hours()` in `time-picker-utils.tsx`.
>     - Ensures `setBeginningOfDay()` and `setEndOfDay()` in `dates.ts` return new date objects.
>     - Adds `useEffect` in `TimePicker` in `time-picker.tsx` to sync period state when date prop changes externally.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 66f29565fcd50f5131b671b048ee4e61593c4704. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->