### PR TITLE
chore: block nextauth /providers endpoint

### DIFF
--- a/web/src/pages/api/auth/providers.ts
+++ b/web/src/pages/api/auth/providers.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+/**
+ * Disable the /api/auth/providers endpoint.
+ *
+ * NextAuth automatically exposes this endpoint which lists all configured
+ * authentication providers. This can be a security concern as it reveals
+ * available authentication methods to potential attackers.
+ *
+ * Since NextAuth doesn't provide a native way to disable specific endpoints,
+ * we override the route with a custom handler that returns 404.
+ */
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  return res.status(404).json({ error: "Not found" });
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Blocks `/api/auth/providers` endpoint by returning 404 to prevent exposure of authentication providers.
> 
>   - **Behavior**:
>     - Blocks `/api/auth/providers` endpoint by returning 404 in `providers.ts`.
>     - Prevents exposure of configured authentication providers, addressing a security concern.
>   - **Implementation**:
>     - Adds `providers.ts` to override default NextAuth behavior, as it doesn't natively support disabling specific endpoints.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ad83b585941ff7bb026314bafff797f65c56af50. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->