### PR TITLE
style(experiments-ui): enhance PromptModelStep to display truncated labels

### DIFF
--- a/web/src/features/experiments/components/steps/PromptModelStep.tsx
+++ b/web/src/features/experiments/components/steps/PromptModelStep.tsx
@@ -29,6 +29,7 @@ import { CardDescription } from "@/src/components/ui/card";
 import { cn } from "@/src/utils/tailwind";
 import { type PromptModelStepProps } from "@/src/features/experiments/types/stepProps";
 import { StepHeader } from "@/src/features/experiments/components/shared/StepHeader";
+import { TruncatedLabels } from "@/src/components/TruncatedLabels";
 
 export const PromptModelStep: React.FC<PromptModelStepProps> = ({
   projectId,
@@ -205,10 +206,21 @@ export const PromptModelStep: React.FC<PromptModelStepProps> = ({
                                 form.clearErrors("promptId");
                               }}
                             >
-                              Version {prompt.version}
+                              <div className="flex min-w-0 flex-1 items-center gap-2">
+                                <span className="shrink-0">
+                                  Version {prompt.version}
+                                </span>
+                                {prompt.labels.length > 0 && (
+                                  <TruncatedLabels
+                                    labels={prompt.labels}
+                                    maxVisibleLabels={2}
+                                    className="min-w-0"
+                                  />
+                                )}
+                              </div>
                               <CheckIcon
                                 className={cn(
-                                  "ml-auto h-4 w-4",
+                                  "ml-auto h-4 w-4 shrink-0",
                                   prompt.version === selectedPromptVersion
                                     ? "opacity-100"
                                     : "opacity-0",

--- a/web/src/features/experiments/hooks/useExperimentPromptData.ts
+++ b/web/src/features/experiments/hooks/useExperimentPromptData.ts
@@ -47,12 +47,16 @@ export function useExperimentPromptData({
   const promptsByName = useMemo(
     () =>
       promptMeta.data?.reduce<
-        Record<string, Array<{ version: number; id: string }>>
+        Record<string, Array<{ version: number; id: string; labels: string[] }>>
       >((acc, prompt) => {
         if (!acc[prompt.name]) {
           acc[prompt.name] = [];
         }
-        acc[prompt.name].push({ version: prompt.version, id: prompt.id });
+        acc[prompt.name].push({
+          version: prompt.version,
+          id: prompt.id,
+          labels: prompt.labels,
+        });
         return acc;
       }, {}),
     [promptMeta.data],

--- a/web/src/features/experiments/types/stepProps.ts
+++ b/web/src/features/experiments/types/stepProps.ts
@@ -43,7 +43,7 @@ export type PromptModelState = {
   selectedPromptVersion: number | null;
   setSelectedPromptVersion: (version: number | null) => void;
   promptsByName:
-    | Record<string, Array<{ id: string; version: number }>>
+    | Record<string, Array<{ id: string; version: number; labels: string[] }>>
     | undefined;
 };
 

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -1047,6 +1047,7 @@ export const promptRouter = createTRPCRouter({
           version: true,
           type: true,
           prompt: true,
+          labels: true,
         },
         where: {
           projectId: input.projectId,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhances `PromptModelStep` to display truncated labels for prompt versions by updating data structures and UI components.
> 
>   - **UI Enhancement**:
>     - `PromptModelStep.tsx`: Integrates `TruncatedLabels` to display truncated labels for prompt versions.
>     - Updates UI to show up to 2 labels per prompt version.
>   - **Data Structure**:
>     - `useExperimentPromptData.ts`: Adds `labels` to the `promptsByName` data structure.
>     - `stepProps.ts`: Updates `PromptModelState` to include `labels` in prompt version records.
>   - **Backend**:
>     - `promptRouter.ts`: Ensures `labels` are selected in prompt queries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b6c905eb354acb965f696dd71054dc17bec3b725. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->