### PR TITLE
chore(annotation-queue-ui): simplify button labels

### DIFF
--- a/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
@@ -257,9 +257,7 @@ export const AnnotationQueueItemPage: React.FC<{
               className={`px-4 ${!relevantItem ? "w-full" : ""}`}
               variant="outline"
             >
-              {relevantItem?.status === AnnotationQueueStatus.PENDING
-                ? "Skip"
-                : "Next"}
+              Next
               <ArrowRight className="ml-1 h-4 w-4" />
             </Button>
           )}
@@ -273,9 +271,7 @@ export const AnnotationQueueItemPage: React.FC<{
                   completeMutation.isPending || !hasAccess || objectData.isError
                 }
               >
-                {isSingleItem || progressIndex + 1 === totalItems
-                  ? "Complete"
-                  : "Complete + Next"}
+                Mark Completed
               </Button>
             ) : (
               <div className="text-dark-gree inline-flex h-9 w-full items-center justify-center rounded-md border border-dark-green bg-light-green px-8 text-sm font-medium">

--- a/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
@@ -243,8 +243,7 @@ export const AnnotationQueueItemPage: React.FC<{
               size="lg"
               className="px-4"
             >
-              <ArrowLeft className="mr-1 h-4 w-4" />
-              Back
+              <ArrowLeft className="h-4 w-4" />
             </Button>
           </div>
         )}
@@ -257,8 +256,7 @@ export const AnnotationQueueItemPage: React.FC<{
               className={`px-4 ${!relevantItem ? "w-full" : ""}`}
               variant="outline"
             >
-              Next
-              <ArrowRight className="ml-1 h-4 w-4" />
+              <ArrowRight className="h-4 w-4" />
             </Button>
           )}
           {!!relevantItem &&


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Simplified button labels in `AnnotationQueueItemPage.tsx` by removing text from navigation buttons and updating completion button text.
> 
>   - **UI Changes**:
>     - Simplified button labels in `AnnotationQueueItemPage.tsx` by removing text from navigation buttons.
>     - "Back" button now only shows `ArrowLeft` icon.
>     - "Skip"/"Next" button now only shows `ArrowRight` icon.
>     - "Complete"/"Complete + Next" button text changed to "Mark Completed".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f2867c6a2b7ced30a727b7ddb7292ad4b3b20d0e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->