### PR TITLE
fix: fixing bullmq config for BatchProjectDelete. removing accidentally commited dataModel changes.

### DIFF
--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -197,8 +197,16 @@ export const DeadLetterRetryQueueEventSchema = z.object({
   timestamp: z.date(),
 });
 
+export const BATCH_DELETION_TABLES = [
+  "traces",
+  "observations",
+  "scores",
+  "events",
+  "dataset_run_items_rmt",
+] as const;
+
 export const BatchProjectCleanerJobSchema = z.object({
-  table: z.enum(["traces", "observations", "scores", "events"]),
+  table: z.enum(BATCH_DELETION_TABLES),
 });
 export type BatchProjectCleanerJobType = z.infer<
   typeof BatchProjectCleanerJobSchema

--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -1198,28 +1198,6 @@ export const eventsObservationsView: ViewDeclarationType = {
       description: "Time to first token for the observation.",
       unit: "millisecond",
     },
-    tracesCount: {
-      sql: "uniq(events.trace_id)",
-      alias: "tracesCount",
-      type: "integer",
-      description: "Unique traces.",
-      unit: "observations",
-    },
-    uniqueUserIds: {
-      sql: "uniq(events.user_id)",
-      alias: "uniqueUserIds",
-      type: "integer",
-      description: "Count of unique userIds.",
-      unit: "users",
-    },
-    uniqueSessionIds: {
-      sql: "uniq(events.session_id)",
-      alias: "uniqueSessionIds",
-      type: "integer",
-      description: "Count of unique sessionIds.",
-      unit: "sessions",
-    },
-    // TODO trace sessions
     countScores: {
       sql: "uniq(scores.id)",
       alias: "countScores",

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -38,6 +38,7 @@ import {
   CloudFreeTierUsageThresholdQueue,
   EventPropagationQueue,
   BatchProjectCleanerQueue,
+  BATCH_DELETION_TABLES,
 } from "@langfuse/shared/src/server";
 import { env } from "./env";
 import { ingestionQueueProcessorBuilder } from "./queues/ingestionQueue";
@@ -75,7 +76,6 @@ import { otelIngestionQueueProcessor } from "./queues/otelIngestionQueue";
 import { eventPropagationProcessor } from "./queues/eventPropagationQueue";
 import { notificationQueueProcessor } from "./queues/notificationQueue";
 import { MutationMonitor } from "./features/mutation-monitoring/mutationMonitor";
-import { BATCH_DELETION_TABLES } from "./features/batch-project-cleaner";
 import { batchProjectCleanerProcessor } from "./queues/batchProjectCleanerQueue";
 
 const app = express();
@@ -549,7 +549,13 @@ if (env.LANGFUSE_BATCH_PROJECT_CLEANER_ENABLED === "true") {
   WorkerManager.register(
     QueueName.BatchProjectCleanerQueue,
     batchProjectCleanerProcessor,
-    { concurrency: 1 }, // only 1 job at a time
+    {
+      concurrency: 1, // only 1 job at a time per process.
+      limiter: {
+        max: 1,
+        duration: env.LANGFUSE_BATCH_PROJECT_CLEANER_SLEEP_ON_EMPTY_MS, // no more than 1 job at a time globally
+      },
+    },
   );
 
   // Schedule repeatable jobs for each table

--- a/worker/src/features/batch-project-cleaner/index.ts
+++ b/worker/src/features/batch-project-cleaner/index.ts
@@ -4,17 +4,10 @@ import {
   commandClickhouse,
   traceException,
   recordIncrement,
+  BATCH_DELETION_TABLES,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { env } from "../../env";
-
-export const BATCH_DELETION_TABLES = [
-  "traces",
-  "observations",
-  "scores",
-  "events",
-  "dataset_run_items_rmt",
-] as const;
 
 export type BatchDeletionTable = (typeof BATCH_DELETION_TABLES)[number];
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix BullMQ configuration for BatchProjectCleaner and remove accidental data model changes.
> 
>   - **BatchProjectCleaner Configuration**:
>     - Updated `BatchProjectCleanerJobSchema` in `queues.ts` to include `dataset_run_items_rmt` in `BATCH_DELETION_TABLES`.
>     - Adjusted `WorkerManager.register` in `app.ts` for `BatchProjectCleanerQueue` to include a global limiter.
>   - **Data Model Cleanup**:
>     - Removed `tracesCount`, `uniqueUserIds`, and `uniqueSessionIds` from `eventsObservationsView` in `dataModel.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 03e119b742cde5de02b53ede69baf7904eb85b83. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->