### PR TITLE
feat(otel): support mapping of custom trace_id for litellm

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -194,7 +194,12 @@ export class OtelIngestionProcessor {
               const scopeAttributes = this.extractScopeAttributes(scopeSpan);
               for (const span of scopeSpan?.spans ?? []) {
                 const spanAttributes = this.extractSpanAttributes(span);
-                const traceId = this.parseId(span.traceId);
+                // For LiteLLM spans, use langfuse.trace.id from attributes if provided
+                const isLiteLLMSpan = scopeSpan?.scope?.name === "litellm";
+                const traceId =
+                  isLiteLLMSpan && spanAttributes["langfuse.trace.id"]
+                    ? (spanAttributes["langfuse.trace.id"] as string)
+                    : this.parseId(span.traceId);
                 const spanId = this.parseId(span.spanId);
                 const parentSpanId = span?.parentSpanId
                   ? this.parseId(span.parentSpanId)
@@ -629,7 +634,12 @@ export class OtelIngestionProcessor {
     const events: IngestionEventType[] = [];
     const attributes = this.extractSpanAttributes(span);
 
-    const traceId = this.parseId(span.traceId?.data ?? span.traceId);
+    // For LiteLLM spans, use langfuse.trace.id from attributes if provided
+    const isLiteLLMSpan = scopeSpan?.scope?.name === "litellm";
+    const traceId =
+      isLiteLLMSpan && attributes["langfuse.trace.id"]
+        ? (attributes["langfuse.trace.id"] as string)
+        : this.parseId(span.traceId?.data ?? span.traceId);
     const parentObservationId = span?.parentSpanId
       ? this.parseId(span.parentSpanId?.data ?? span.parentSpanId)
       : null;


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for custom trace IDs in LiteLLM spans by using `langfuse.trace.id` if available in `OtelIngestionProcessor`.
> 
>   - **Behavior**:
>     - In `OtelIngestionProcessor`, for LiteLLM spans, use `langfuse.trace.id` from attributes if available, otherwise use `span.traceId`.
>     - Affects `processToEvent()` and `processSpan()` methods.
>   - **Misc**:
>     - Adds comments to clarify the use of `langfuse.trace.id` for LiteLLM spans.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4e25f8eb05716b972b9b1cadf295f8a7cde2d8ba. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->