### PR TITLE
feat: cursor-based sequential processing for event propagation

### DIFF
--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -510,9 +510,6 @@ export type TQueueJobTypes = {
   [QueueName.EventPropagationQueue]: {
     timestamp: Date;
     id: string;
-    payload?: {
-      partition?: string;
-    };
     name: QueueJobs.EventPropagationJob;
   };
   [QueueName.NotificationQueue]: {

--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -78,14 +78,14 @@ export const handleEventPropagationJob = async (
     );
 
     // Query for the next partition after the last processed one
-    // Filter for partitions older than 4 minutes and order by partition ASC to get the oldest first
+    // Filter for partitions older than 6 minutes and order by partition ASC to get the oldest first
     const partitions = await queryClickhouse<{ partition: string }>({
       query: `
         SELECT DISTINCT partition
         FROM system.parts
         WHERE table = 'observations_batch_staging'
           AND active = 1
-          AND toDateTime(partition) < now() - INTERVAL 4 MINUTE
+          AND toDateTime(partition) < now() - INTERVAL 6 MINUTE
           ${lastProcessedPartition ? `AND partition > {lastProcessedPartition: String}` : ""}
         ORDER BY partition ASC
       `,

--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -6,112 +6,62 @@ import {
   QueueName,
   TQueueJobTypes,
   traceException,
-  EventPropagationQueue,
-  QueueJobs,
   redis,
   recordGauge,
 } from "@langfuse/shared/src/server";
 import { Job } from "bullmq";
 import { env } from "../../env";
-import { randomUUID } from "crypto";
 
-const PARTITION_LOCK_PREFIX = "langfuse:partition-lock:event-propagation";
+const LAST_PROCESSED_PARTITION_KEY =
+  "langfuse:event-propagation:last-processed-partition";
 
 /**
- * Attempt to acquire a distributed lock for processing a specific partition.
- *
- * The lock automatically expires after the specified TTL to prevent stuck locks
- * if a worker crashes or fails to complete processing.
+ * Get the last processed partition timestamp from Redis.
+ * Returns null if no partition has been processed yet or if Redis is unavailable.
  */
-export const acquirePartitionLock = async (
-  partition: string,
-  ttlSeconds: number = 300,
-): Promise<boolean> => {
-  if (!redis) {
-    logger.warn(
-      "[DUAL WRITE] Redis not available, skipping partition lock acquisition",
-    );
-    return true; // Allow processing if Redis is unavailable
-  }
-
+export const getLastProcessedPartition = async (): Promise<string | null> => {
   try {
-    // Sanitize partition string to be Redis key friendly
-    const lockKey = `${PARTITION_LOCK_PREFIX}:${partition.replaceAll(/[^0-9_-]/g, "_")}`;
-
-    // Returns "OK" if key was set (lock acquired), null if key already exists
-    const result = await redis.set(lockKey, "true", "EX", ttlSeconds, "NX");
-    const acquired = result === "OK";
-    if (acquired) {
-      logger.debug(
-        `[DUAL WRITE] Acquired lock for partition ${partition} with TTL ${ttlSeconds}s`,
-      );
-    } else {
-      logger.debug(
-        `[DUAL WRITE] Partition ${partition} is already locked by another worker`,
-      );
-    }
-    return acquired;
+    return await redis!.get(LAST_PROCESSED_PARTITION_KEY);
   } catch (error) {
-    logger.error("[DUAL WRITE] Failed to acquire partition lock", error);
-    // On error, allow processing to avoid blocking the system
-    return true;
+    logger.error("[DUAL WRITE] Failed to get last processed partition", error);
+    return null;
   }
 };
 
 /**
- * Check if a partition lock exists without acquiring it.
- *
- * Returns true if the partition is available (not locked), false if locked.
- * Used for scheduling follow-up jobs to avoid scheduling jobs for already-locked partitions.
+ * Update the last processed partition timestamp in Redis.
+ * This is called after successfully processing a partition.
  */
-export const checkLock = async (partition: string): Promise<boolean> => {
-  if (!redis) {
-    logger.warn(
-      "[DUAL WRITE] Redis not available, assuming partition is unlocked",
-    );
-    return true; // Allow processing if Redis is unavailable
-  }
-
+export const updateLastProcessedPartition = async (
+  partition: string,
+): Promise<void> => {
   try {
-    // Sanitize partition string to be Redis key friendly (same as acquirePartitionLock)
-    const lockKey = `${PARTITION_LOCK_PREFIX}:${partition.replaceAll(/[^0-9_-]/g, "_")}`;
-
-    // Check if the lock key exists
-    const exists = await redis.exists(lockKey);
-    const isAvailable = exists === 0;
-
-    if (isAvailable) {
-      logger.debug(
-        `[DUAL WRITE] Partition ${partition} is available (not locked)`,
-      );
-    } else {
-      logger.debug(`[DUAL WRITE] Partition ${partition} is locked`);
-    }
-
-    return isAvailable;
+    await redis!.set(LAST_PROCESSED_PARTITION_KEY, partition);
+    logger.info(
+      `[DUAL WRITE] Updated last processed partition to ${partition}`,
+    );
   } catch (error) {
-    logger.error("[DUAL WRITE] Failed to check partition lock", error);
-    // On error, assume partition is available to avoid blocking the system
-    return true;
+    logger.error(
+      "[DUAL WRITE] Failed to update last processed partition",
+      error,
+    );
+    // Don't throw - allow processing to continue
   }
 };
 
 /**
  * Processes partitions from observations_batch_staging table and propagates
- * events to the events table. Supports both targeted partition processing
- * (when partition is specified in job data) and discovery mode (cron job).
+ * events to the events table. Uses cursor-based sequential processing to track
+ * the last processed partition and always processes the next partition in order.
+ * Relies on table TTL for partition cleanup instead of explicit DROP PARTITION.
  */
 export const handleEventPropagationJob = async (
   job: Job<TQueueJobTypes[QueueName.EventPropagationQueue]>,
 ) => {
-  const span = getCurrentSpan();
-  const partition = job.data.payload?.partition;
-  if (span) {
-    span.setAttribute("messaging.bullmq.job.input.jobId", job.data.id);
-    if (partition) {
-      span.setAttribute("messaging.bullmq.job.input.partition", partition);
-    }
-  }
+  getCurrentSpan()?.setAttribute(
+    "messaging.bullmq.job.input.jobId",
+    job.data.id,
+  );
 
   if (env.LANGFUSE_EXPERIMENT_EARLY_EXIT_EVENT_BATCH_JOB === "true") {
     logger.info(
@@ -121,13 +71,14 @@ export const handleEventPropagationJob = async (
   }
 
   try {
-    logger.debug("[DUAL WRITE] Starting event propagation batch processing", {
-      jobId: job.data.id,
-      partition: partition,
-    });
+    // Step 1: Get the last processed partition from Redis and find the next one to process
+    const lastProcessedPartition = await getLastProcessedPartition();
+    logger.info(
+      `[DUAL WRITE] Last processed partition: ${lastProcessedPartition ?? "none"}`,
+    );
 
-    // Step 1: Get list of partitions ordered by time, filtering for those older than 4 minutes
-    // Filter in ClickHouse for better performance - only return partitions older than 4 minutes
+    // Query for the next partition after the last processed one
+    // Filter for partitions older than 4 minutes and order by partition ASC to get the oldest first
     const partitions = await queryClickhouse<{ partition: string }>({
       query: `
         SELECT DISTINCT partition
@@ -135,15 +86,16 @@ export const handleEventPropagationJob = async (
         WHERE table = 'observations_batch_staging'
           AND active = 1
           AND toDateTime(partition) < now() - INTERVAL 4 MINUTE
-        ORDER BY partition DESC
+          ${lastProcessedPartition ? `AND partition > {lastProcessedPartition: String}` : ""}
+        ORDER BY partition ASC
       `,
+      params: lastProcessedPartition ? { lastProcessedPartition } : undefined,
       tags: {
         feature: "ingestion",
-        operation_name: "getPartitions",
+        operation_name: "getNextPartition",
       },
     });
 
-    // Record backlog metric for observability
     recordGauge(
       "langfuse.event_propagation.partition_backlog",
       partitions.length,
@@ -151,62 +103,15 @@ export const handleEventPropagationJob = async (
 
     if (partitions.length === 0) {
       logger.info(
-        `[DUAL WRITE] No partitions older than 4 minutes available for processing`,
+        `[DUAL WRITE] No partitions available for processing (last processed: ${lastProcessedPartition ?? "none"})`,
       );
       return;
     }
 
+    const partitionToProcess = partitions[0].partition;
     logger.info(
-      `[DUAL WRITE] Found ${partitions.length} partition(s) older than 4 minutes to process`,
+      `[DUAL WRITE] Processing partition ${partitionToProcess} for events table fill`,
     );
-
-    // Determine which partition to process
-    let partitionToProcess: string | null = null;
-    if (partition) {
-      // Try to acquire lock for this partition
-      const lockAcquired = await acquirePartitionLock(partition);
-      if (lockAcquired) {
-        partitionToProcess = partition;
-        logger.info(
-          `[DUAL WRITE] Processing partition ${partitionToProcess} (targeted) for events table fill`,
-        );
-      } else {
-        logger.info(
-          `[DUAL WRITE] Partition ${partition} is already locked by another worker, falling back to discovery mode`,
-        );
-      }
-    }
-
-    // If no partition was processed yet (either no partition specified or it was locked),
-    // fall back to discovery mode - process oldest partition that is unlocked
-    if (!partitionToProcess) {
-      // We sort partitions from newest to oldest and then remove elements from the back.
-      // This means that the oldest, unlocked partition will be processed.
-      // All partitions in the list are already verified to be older than 4 minutes.
-      while (partitionToProcess === null && partitions.length > 0) {
-        const internalPartition = partitions.pop()!;
-        const lockAcquired = await acquirePartitionLock(
-          internalPartition.partition,
-        );
-        if (!lockAcquired) {
-          logger.debug(
-            `[DUAL WRITE] Skipping partition ${internalPartition.partition} as it is locked by another worker`,
-          );
-          continue;
-        }
-        partitionToProcess = internalPartition.partition;
-        logger.info(
-          `[DUAL WRITE] Processing partition ${partitionToProcess} (discovery) for events table fill`,
-        );
-      }
-    }
-
-    if (!partitionToProcess) {
-      logger.info(
-        "[DUAL WRITE] No available partitions to process after checking locks, exiting",
-      );
-      return;
-    }
 
     // Step 2: Join observations_batch_staging with traces and insert into events
     // Use a time window for traces to limit the join scope
@@ -389,67 +294,9 @@ export const handleEventPropagationJob = async (
       `[DUAL WRITE] Successfully propagated observations from partition ${partitionToProcess} to events table`,
     );
 
-    // Step 3: Schedule additional jobs for remaining partitions (all are already verified to be >4 minutes old).
-    // We do this before the drop as this is a fast operation that shouldn't wait for the slow dropping call.
-    // We're only running this if there are more than one left to be processed as this means we have some catch-up to do.
-    if (partitions.length > 1) {
-      let additionalSchedules =
-        env.LANGFUSE_EVENT_PROPAGATION_WORKER_GLOBAL_CONCURRENCY;
-      const queue = EventPropagationQueue.getInstance();
-      while (queue && partitions.length > 1 && additionalSchedules > 0) {
-        const internalPartition = partitions.pop()!;
-
-        // Check if partition is locked before scheduling
-        const isUnlocked = await checkLock(internalPartition.partition);
-        if (!isUnlocked) {
-          logger.debug(
-            `[DUAL WRITE] Skipping scheduling for partition ${internalPartition.partition} as it is locked by another worker`,
-          );
-          continue;
-        }
-
-        additionalSchedules--;
-        await queue.add(
-          QueueJobs.EventPropagationJob,
-          {
-            timestamp: new Date(),
-            id: randomUUID(),
-            payload: {
-              partition: internalPartition.partition,
-            },
-          },
-          {
-            deduplication: {
-              id: `partition:${internalPartition.partition}`,
-            },
-          },
-        );
-        logger.info(
-          `[DUAL WRITE] Scheduled additional event propagation job for partition ${internalPartition.partition}. ` +
-            `Remaining partitions: ${partitions.length}`,
-        );
-      }
-    }
-
-    // Step 4: Drop the processed partition (single synchronous operation)
-    await commandClickhouse({
-      query: `
-        ALTER TABLE observations_batch_staging
-        DROP PARTITION '${partitionToProcess}'
-      `,
-      tags: {
-        feature: "ingestion",
-        partition: partitionToProcess,
-        operation_name: "dropPartition",
-      },
-      clickhouseConfigs: {
-        request_timeout: 60000 * 20, // 20 minutes timeout
-      },
-    });
-
-    logger.info(
-      `[DUAL WRITE] Successfully dropped partition ${partitionToProcess}`,
-    );
+    // Step 3: Update the last processed partition cursor in Redis
+    // This allows the next job to continue from where we left off
+    await updateLastProcessedPartition(partitionToProcess);
   } catch (error) {
     logger.error(
       "[DUAL WRITE] Failed to process event propagation batch",


### PR DESCRIPTION
## Summary
- Replace lock-based parallel partition processing with cursor-based sequential processing
- Track last processed partition in Redis cursor instead of using distributed locks
- Rely on ClickHouse table TTL (12h) for partition cleanup instead of explicit `DROP PARTITION` calls
- Enforce global concurrency of 1 in queue configuration to guarantee sequential processing

## Motivation
The immediate dropping of partitions after processing made debugging difficult when issues occurred. This change:
- Keeps data in `observations_batch_staging` for 12 hours, allowing verification of the data pipeline
- Simplifies the processing model by using a single cursor instead of distributed locks
- Reduces ClickHouse load by eliminating expensive `DROP PARTITION` operations from the application

## Changes
- `handleEventPropagationJob.ts`: Replaced lock functions with cursor tracking, removed DROP PARTITION and multi-job scheduling
- `eventPropagationQueue.ts`: Hardcoded global concurrency to 1
- `queues.ts`: Removed unused `payload.partition` from queue type
- `dev-tables.sh`: Added 12h TTL with `ttl_only_drop_parts=1` to `observations_batch_staging` table

## Test plan
- [ ] Verify Redis cursor is set after processing: `GET langfuse:event-propagation:last-processed-partition`
- [ ] Verify partitions are processed in chronological order
- [ ] Verify `observations_batch_staging` data persists (not immediately dropped)
- [ ] Verify events table receives propagated data correctly
- [ ] Monitor partition backlog metric to ensure no significant backlog builds up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replaces lock-based parallel partition processing with cursor-based sequential processing for event propagation, using Redis for tracking and ClickHouse TTL for cleanup.
> 
>   - **Behavior**:
>     - Replaces lock-based parallel partition processing with cursor-based sequential processing in `handleEventPropagationJob.ts`.
>     - Tracks last processed partition in Redis instead of using distributed locks.
>     - Relies on ClickHouse table TTL (12h) for partition cleanup instead of explicit `DROP PARTITION` calls.
>     - Enforces global concurrency of 1 in `eventPropagationQueue.ts` to guarantee sequential processing.
>   - **Code Changes**:
>     - `handleEventPropagationJob.ts`: Implements cursor tracking, removes `DROP PARTITION` and multi-job scheduling.
>     - `eventPropagationQueue.ts`: Sets global concurrency to 1.
>     - `queues.ts`: Removes unused `payload.partition` from queue type.
>     - `dev-tables.sh`: Adds 12h TTL with `ttl_only_drop_parts=1` to `observations_batch_staging` table.
>   - **Testing**:
>     - Verify Redis cursor is set after processing.
>     - Ensure partitions are processed in chronological order.
>     - Confirm `observations_batch_staging` data persists for 12 hours.
>     - Check events table receives propagated data correctly.
>     - Monitor partition backlog metric to prevent significant backlog.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5564ab2791e8c3758da23b1b97497f359423cc0c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->