### PR TITLE
fix(json-path): return all results from array slice syntax

### DIFF
--- a/packages/shared/src/features/batchAction/applyFieldMapping.ts
+++ b/packages/shared/src/features/batchAction/applyFieldMapping.ts
@@ -39,7 +39,10 @@ export function evaluateJsonPath(data: unknown, jsonPath: string): unknown {
   try {
     const parsed = typeof data === "string" ? JSON.parse(data) : data;
     const results = JSONPath({ path: jsonPath, json: parsed });
-    return results?.[0];
+
+    if (!results) return;
+
+    return results.length > 1 ? results : results[0];
   } catch {
     return undefined;
   }

--- a/worker/src/__tests__/applyFieldMapping.test.ts
+++ b/worker/src/__tests__/applyFieldMapping.test.ts
@@ -26,7 +26,7 @@ describe("applyFieldMapping", () => {
     metadata: {
       user_id: "user-123",
       session_id: "session-456",
-      tags: ["math", "simple"],
+      tags: ["math", "simple", "hello"],
     },
   };
 
@@ -125,6 +125,9 @@ describe("applyFieldMapping", () => {
       expect(evaluateJsonPath(sampleObservation.metadata, "$.tags[1]")).toBe(
         "simple",
       );
+      expect(
+        evaluateJsonPath(sampleObservation.metadata, "$.tags[1:]"),
+      ).toEqual(["simple", "hello"]);
     });
   });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `evaluateJsonPath` to return all results for array slice syntax and add corresponding test case.
> 
>   - **Behavior**:
>     - Modify `evaluateJsonPath` in `applyFieldMapping.ts` to return all results for array slice syntax, not just the first result.
>     - Handles cases where `results` is undefined or has multiple elements.
>   - **Tests**:
>     - Add test case in `applyFieldMapping.test.ts` to verify array slice syntax returns all elements (e.g., `$.tags[1:]` returns `["simple", "hello"]`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a5f6e5cba16e9c44440d0eb28525954ff0097e59. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->