### PR TITLE
fix: support JSON paths that select sub-lists

### DIFF
--- a/packages/shared/src/features/batchAction/applyFieldMapping.ts
+++ b/packages/shared/src/features/batchAction/applyFieldMapping.ts
@@ -38,8 +38,8 @@ export function testJsonPath(props: { jsonPath: string; data: unknown }): {
 export function evaluateJsonPath(data: unknown, jsonPath: string): unknown {
   try {
     const parsed = typeof data === "string" ? JSON.parse(data) : data;
-    const results = JSONPath({ path: jsonPath, json: parsed });
-    return results?.[0];
+    const results = JSONPath({ path: jsonPath, json: parsed, wrap: false });
+    return results;
   } catch {
     return undefined;
   }

--- a/worker/src/__tests__/applyFieldMapping.test.ts
+++ b/worker/src/__tests__/applyFieldMapping.test.ts
@@ -126,6 +126,37 @@ describe("applyFieldMapping", () => {
         "simple",
       );
     });
+
+    it("should return array when using wildcard to select multiple items", () => {
+      const result = evaluateJsonPath(sampleObservation.metadata, "$.tags[*]");
+      expect(result).toEqual(["math", "simple"]);
+    });
+
+    it("should return array when selecting multiple indices", () => {
+      const result = evaluateJsonPath(
+        sampleObservation.input,
+        "$.messages[0,1].content",
+      );
+      expect(result).toEqual(["You are a helpful assistant", "What is 2+2?"]);
+    });
+
+    it("should return array when using slice notation", () => {
+      const result = evaluateJsonPath(sampleObservation.metadata, "$.tags[1:]");
+      expect(result).toEqual(["simple"]);
+    });
+
+    it("should return array with all matching items for wildcard property access", () => {
+      const result = evaluateJsonPath(
+        sampleObservation.input,
+        "$.messages[*].role",
+      );
+      expect(result).toEqual(["system", "user"]);
+    });
+
+    it("should return array when using descendant operator with multiple matches", () => {
+      const result = evaluateJsonPath(sampleObservation.input, "$..content");
+      expect(result).toEqual(["You are a helpful assistant", "What is 2+2?"]);
+    });
   });
 
   describe("applyFieldMappingConfig - full mode", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes #11574 

Fixes support for JSON paths that return sub-lists, e.g. using array slice indexes.

Previously jsonpath-plus had the default `{wrap: true}` config which wraps everything in an array, which was then manually unwrapped via `results?.[0]`. This had the effect that sometimes only the first item from an array gets returned when the whole array should be. The correct behaviour is to use `wrap: false` and return the result as is.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes JSON path evaluation to correctly return sub-lists by setting `wrap: false` in `evaluateJsonPath()` in `applyFieldMapping.ts`.
> 
>   - **Behavior**:
>     - Fixes JSON path evaluation in `evaluateJsonPath()` in `applyFieldMapping.ts` by setting `wrap: false` in `JSONPath` to correctly return sub-lists.
>   - **Tests**:
>     - Adds test cases in `applyFieldMapping.test.ts` to verify JSON path evaluations for wildcards, multiple indices, slice notation, and descendant operators.
>     - Ensures `evaluateJsonPath()` returns arrays for paths selecting multiple items.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for eea4ead71489890a4f2557c670ac1ff1c3ffaad6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->