### PR TITLE
Langfuse PostHog user mapping

### DIFF
--- a/packages/shared/src/server/analytics-integrations/types.ts
+++ b/packages/shared/src/server/analytics-integrations/types.ts
@@ -19,6 +19,7 @@ export type AnalyticsTraceEvent = {
   langfuse_environment?: unknown;
   langfuse_event_version?: unknown;
   posthog_session_id?: unknown;
+  posthog_distinct_id?: unknown;
   mixpanel_session_id?: unknown;
 };
 
@@ -47,6 +48,7 @@ export type AnalyticsGenerationEvent = {
   langfuse_environment?: unknown;
   langfuse_event_version?: unknown;
   posthog_session_id?: unknown;
+  posthog_distinct_id?: unknown;
   mixpanel_session_id?: unknown;
 };
 
@@ -72,5 +74,6 @@ export type AnalyticsScoreEvent = {
   langfuse_score_entity_type?: unknown;
   langfuse_dataset_run_id?: unknown;
   posthog_session_id?: unknown;
+  posthog_distinct_id?: unknown;
   mixpanel_session_id?: unknown;
 };

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1812,6 +1812,7 @@ export const getGenerationsForAnalyticsIntegrations = async function* (
       t.release as trace_release,
       t.tags as trace_tags,
       t.metadata['$posthog_session_id'] as posthog_session_id,
+      t.metadata['$posthog_distinct_id'] as posthog_distinct_id,
       t.metadata['$mixpanel_session_id'] as mixpanel_session_id
     FROM observations o FINAL
     LEFT JOIN ${traceTable} t FINAL ON o.trace_id = t.id AND o.project_id = t.project_id
@@ -1875,6 +1876,7 @@ export const getGenerationsForAnalyticsIntegrations = async function* (
       langfuse_environment: record.environment,
       langfuse_event_version: "1.0.0",
       posthog_session_id: record.posthog_session_id ?? null,
+      posthog_distinct_id: record.posthog_distinct_id ?? null,
       mixpanel_session_id: record.mixpanel_session_id ?? null,
     } satisfies AnalyticsGenerationEvent;
   }

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1601,6 +1601,7 @@ export const getScoresForAnalyticsIntegrations = async function* (
       t.tags as trace_tags,
       s.metadata as metadata,
       t.metadata['$posthog_session_id'] as posthog_session_id,
+      t.metadata['$posthog_distinct_id'] as posthog_distinct_id,
       t.metadata['$mixpanel_session_id'] as mixpanel_session_id
     FROM scores s FINAL
     LEFT JOIN ${traceTable} t FINAL ON s.trace_id = t.id AND s.project_id = t.project_id
@@ -1685,6 +1686,7 @@ export const getScoresForAnalyticsIntegrations = async function* (
             : "unknown",
       langfuse_dataset_run_id: record.score_dataset_run_id,
       posthog_session_id: record.posthog_session_id ?? null,
+      posthog_distinct_id: record.posthog_distinct_id ?? null,
       mixpanel_session_id: record.mixpanel_session_id ?? null,
     } satisfies AnalyticsScoreEvent;
   }

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -1329,6 +1329,7 @@ export const getTracesForAnalyticsIntegrations = async function* (
       t.tags as tags,
       t.environment as environment,
       t.metadata['$posthog_session_id'] as posthog_session_id,
+      t.metadata['$posthog_distinct_id'] as posthog_distinct_id,
       t.metadata['$mixpanel_session_id'] as mixpanel_session_id,
       o.total_cost as total_cost,
       o.latency_milliseconds / 1000 as latency,
@@ -1385,6 +1386,7 @@ export const getTracesForAnalyticsIntegrations = async function* (
       langfuse_environment: record.environment,
       langfuse_event_version: "1.0.0",
       posthog_session_id: record.posthog_session_id ?? null,
+      posthog_distinct_id: record.posthog_distinct_id ?? null,
       mixpanel_session_id: record.mixpanel_session_id ?? null,
     } satisfies AnalyticsTraceEvent;
   }


### PR DESCRIPTION
## What does this PR do?

This PR introduces support for a custom PostHog `distinct_id` via the `$posthog_distinct_id` field in trace metadata. This allows users to specify an alternative `distinct_id` to be sent to PostHog, separate from the `userId` used within Langfuse.

This change addresses the problem where Langfuse's `userId` (e.g., email) might differ from a user's existing `distinct_id` in PostHog (e.g., internal UUID), leading to duplicate person profiles in PostHog. Users can now set `$posthog_distinct_id` in trace metadata to ensure events are correctly attributed to their existing PostHog user profiles.

Fixes # (issue) - User request for custom PostHog distinct_id mapping.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [x] I haven't commented my code, particularly in hard-to-understand areas
- [x] I haven't checked if my PR needs changes to the documentation
- [x] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [x] I haven't added tests that prove my fix is effective or that my feature works
- [x] I haven't checked if new and existing unit tests pass locally with my changes

---
<a href="https://cursor.com/background-agent?bcId=bc-96797754-03c2-4408-806e-83e7290f9870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-96797754-03c2-4408-806e-83e7290f9870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

