### PR TITLE
feat(trace): add input and output fields to trace definitions

### DIFF
--- a/packages/shared/src/server/tableMappings/mapTracesTable.ts
+++ b/packages/shared/src/server/tableMappings/mapTracesTable.ts
@@ -90,6 +90,20 @@ export const tracesTableUiColumnDefinitions: UiColumnMappings = [
     queryPrefix: "t",
   },
   {
+    uiTableName: "Input",
+    uiTableId: "input",
+    clickhouseTableName: "traces",
+    clickhouseSelect: "input",
+    queryPrefix: "t",
+  },
+  {
+    uiTableName: "Output",
+    uiTableId: "output",
+    clickhouseTableName: "traces",
+    clickhouseSelect: "output",
+    queryPrefix: "t",
+  },
+  {
     uiTableName: "Warning Level Count",
     uiTableId: "warningCount",
     clickhouseTableName: "observations",

--- a/packages/shared/src/tableDefinitions/tracesTable.ts
+++ b/packages/shared/src/tableDefinitions/tracesTable.ts
@@ -88,6 +88,20 @@ export const tracesOnlyCols: ColumnDefinition[] = [
     internal: 't."tags"',
     options: [], // to be filled in at runtime
   },
+  {
+    name: "Input",
+    id: "input",
+    type: "string",
+    internal: "t.input",
+    nullable: true,
+  },
+  {
+    name: "Output",
+    id: "output",
+    type: "string",
+    internal: "t.output",
+    nullable: true,
+  },
 ];
 export const tracesTableCols: ColumnDefinition[] = [
   ...tracesOnlyCols,

--- a/worker/src/__tests__/inMemoryFilterService.test.ts
+++ b/worker/src/__tests__/inMemoryFilterService.test.ts
@@ -31,6 +31,8 @@ describe("InMemoryFilterService", () => {
     cost: 0.0025,
     latency: 1500,
     tokenCount: 250,
+    input: "What is the capital of France?",
+    output: "The capital of France is Paris.",
   };
 
   // Simple field mapper for testing
@@ -69,6 +71,10 @@ describe("InMemoryFilterService", () => {
         return data.latency;
       case "tokenCount":
         return data.tokenCount;
+      case "input":
+        return data.input;
+      case "output":
+        return data.output;
       default:
         return undefined;
     }
@@ -1150,6 +1156,221 @@ describe("InMemoryFilterService", () => {
               type: "unsupportedType" as any,
               operator: "=",
               value: "test",
+            },
+          ],
+          fieldMapper,
+        ),
+      ).toBe(false);
+    });
+
+    test("evaluates input field filters correctly", () => {
+      // Input contains
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          mockData,
+          [
+            {
+              column: "input",
+              type: "string",
+              operator: "contains",
+              value: "capital",
+            },
+          ],
+          fieldMapper,
+        ),
+      ).toBe(true);
+
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          mockData,
+          [
+            {
+              column: "input",
+              type: "string",
+              operator: "contains",
+              value: "weather",
+            },
+          ],
+          fieldMapper,
+        ),
+      ).toBe(false);
+
+      // Input starts with
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          mockData,
+          [
+            {
+              column: "input",
+              type: "string",
+              operator: "starts with",
+              value: "What is",
+            },
+          ],
+          fieldMapper,
+        ),
+      ).toBe(true);
+
+      // Input does not contain
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          mockData,
+          [
+            {
+              column: "input",
+              type: "string",
+              operator: "does not contain",
+              value: "error",
+            },
+          ],
+          fieldMapper,
+        ),
+      ).toBe(true);
+
+      // Test with null input
+      const dataWithNullInput = { ...mockData, input: null };
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          dataWithNullInput,
+          [
+            {
+              column: "input",
+              type: "string",
+              operator: "contains",
+              value: "test",
+            },
+          ],
+          fieldMapper,
+        ),
+      ).toBe(false);
+    });
+
+    test("evaluates output field filters correctly", () => {
+      // Output contains
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          mockData,
+          [
+            {
+              column: "output",
+              type: "string",
+              operator: "contains",
+              value: "Paris",
+            },
+          ],
+          fieldMapper,
+        ),
+      ).toBe(true);
+
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          mockData,
+          [
+            {
+              column: "output",
+              type: "string",
+              operator: "contains",
+              value: "London",
+            },
+          ],
+          fieldMapper,
+        ),
+      ).toBe(false);
+
+      // Output ends with
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          mockData,
+          [
+            {
+              column: "output",
+              type: "string",
+              operator: "ends with",
+              value: "Paris.",
+            },
+          ],
+          fieldMapper,
+        ),
+      ).toBe(true);
+
+      // Output does not contain
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          mockData,
+          [
+            {
+              column: "output",
+              type: "string",
+              operator: "does not contain",
+              value: "error",
+            },
+          ],
+          fieldMapper,
+        ),
+      ).toBe(true);
+    });
+
+    test("evaluates combined input/output filters with other fields", () => {
+      // Input contains AND environment is production
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          mockData,
+          [
+            {
+              column: "input",
+              type: "string",
+              operator: "contains",
+              value: "capital",
+            },
+            {
+              column: "environment",
+              type: "string",
+              operator: "=",
+              value: "production",
+            },
+          ],
+          fieldMapper,
+        ),
+      ).toBe(true);
+
+      // Input contains AND output contains
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          mockData,
+          [
+            {
+              column: "input",
+              type: "string",
+              operator: "contains",
+              value: "France",
+            },
+            {
+              column: "output",
+              type: "string",
+              operator: "contains",
+              value: "Paris",
+            },
+          ],
+          fieldMapper,
+        ),
+      ).toBe(true);
+
+      // Input contains (true) AND output contains (false) - should fail
+      expect(
+        InMemoryFilterService.evaluateFilter(
+          mockData,
+          [
+            {
+              column: "input",
+              type: "string",
+              operator: "contains",
+              value: "France",
+            },
+            {
+              column: "output",
+              type: "string",
+              operator: "contains",
+              value: "London",
             },
           ],
           fieldMapper,

--- a/worker/src/__tests__/traceFilterUtils.test.ts
+++ b/worker/src/__tests__/traceFilterUtils.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from "vitest";
+import {
+  mapTraceFilterColumn,
+  requiresDatabaseLookup,
+} from "../features/evaluation/traceFilterUtils";
+import { TraceDomain } from "@langfuse/shared";
+
+describe("traceFilterUtils", () => {
+  const mockTrace: TraceDomain = {
+    id: "trace-123",
+    name: "test-trace",
+    timestamp: new Date("2024-01-01T10:00:00Z"),
+    environment: "production",
+    tags: ["tag1", "tag2"],
+    bookmarked: true,
+    public: false,
+    release: "v1.0.0",
+    version: "v1.0",
+    input: { query: "What is the capital of France?" },
+    output: { answer: "The capital of France is Paris." },
+    metadata: { userId: "user-123" },
+    createdAt: new Date("2024-01-01T09:00:00Z"),
+    updatedAt: new Date("2024-01-01T10:00:00Z"),
+    sessionId: "session-456",
+    userId: "user-123",
+    projectId: "project-789",
+  };
+
+  describe("mapTraceFilterColumn", () => {
+    test("maps input field correctly", () => {
+      const result = mapTraceFilterColumn(mockTrace, "Input");
+      expect(result).toEqual({ query: "What is the capital of France?" });
+    });
+
+    test("maps output field correctly", () => {
+      const result = mapTraceFilterColumn(mockTrace, "Output");
+      expect(result).toEqual({ answer: "The capital of France is Paris." });
+    });
+
+    test("maps id field correctly", () => {
+      const result = mapTraceFilterColumn(mockTrace, "ID");
+      expect(result).toBe("trace-123");
+    });
+
+    test("maps name field correctly", () => {
+      const result = mapTraceFilterColumn(mockTrace, "Name");
+      expect(result).toBe("test-trace");
+    });
+
+    test("maps timestamp field correctly", () => {
+      const result = mapTraceFilterColumn(mockTrace, "Timestamp");
+      expect(result).toEqual(new Date("2024-01-01T10:00:00Z"));
+    });
+
+    test("maps environment field correctly", () => {
+      const result = mapTraceFilterColumn(mockTrace, "Environment");
+      expect(result).toBe("production");
+    });
+
+    test("maps tags field correctly", () => {
+      const result = mapTraceFilterColumn(mockTrace, "Tags");
+      expect(result).toEqual(["tag1", "tag2"]);
+    });
+
+    test("maps bookmarked field correctly", () => {
+      const result = mapTraceFilterColumn(mockTrace, "⭐️");
+      expect(result).toBe(true);
+    });
+
+    test("maps release field correctly", () => {
+      const result = mapTraceFilterColumn(mockTrace, "Release");
+      expect(result).toBe("v1.0.0");
+    });
+
+    test("maps version field correctly", () => {
+      const result = mapTraceFilterColumn(mockTrace, "Version");
+      expect(result).toBe("v1.0");
+    });
+
+    test("maps userId field correctly", () => {
+      const result = mapTraceFilterColumn(mockTrace, "User ID");
+      expect(result).toBe("user-123");
+    });
+
+    test("maps sessionId field correctly", () => {
+      const result = mapTraceFilterColumn(mockTrace, "Session ID");
+      expect(result).toBe("session-456");
+    });
+
+    test("maps metadata field correctly", () => {
+      const result = mapTraceFilterColumn(mockTrace, "Metadata");
+      expect(result).toEqual({ userId: "user-123" });
+    });
+
+    test("throws error for unhandled column", () => {
+      expect(() => mapTraceFilterColumn(mockTrace, "InvalidColumn")).toThrow(
+        "Unhandled column for trace filter: InvalidColumn",
+      );
+    });
+
+    test("handles null input/output", () => {
+      const traceWithNulls: TraceDomain = {
+        ...mockTrace,
+        input: null,
+        output: null,
+      };
+      expect(mapTraceFilterColumn(traceWithNulls, "Input")).toBeNull();
+      expect(mapTraceFilterColumn(traceWithNulls, "Output")).toBeNull();
+    });
+  });
+
+  describe("requiresDatabaseLookup", () => {
+    test("returns false for empty filter", () => {
+      expect(requiresDatabaseLookup([])).toBe(false);
+    });
+
+    test("returns false for filters on allowlisted columns only", () => {
+      expect(
+        requiresDatabaseLookup([
+          { column: "Name", type: "string", operator: "=", value: "test" },
+          {
+            column: "Environment",
+            type: "string",
+            operator: "=",
+            value: "production",
+          },
+        ]),
+      ).toBe(false);
+    });
+
+    test("returns false for input filter", () => {
+      expect(
+        requiresDatabaseLookup([
+          {
+            column: "Input",
+            type: "string",
+            operator: "contains",
+            value: "capital",
+          },
+        ]),
+      ).toBe(false);
+    });
+
+    test("returns false for output filter", () => {
+      expect(
+        requiresDatabaseLookup([
+          {
+            column: "Output",
+            type: "string",
+            operator: "contains",
+            value: "Paris",
+          },
+        ]),
+      ).toBe(false);
+    });
+
+    test("returns false for combined input/output/other allowlisted filters", () => {
+      expect(
+        requiresDatabaseLookup([
+          {
+            column: "Input",
+            type: "string",
+            operator: "contains",
+            value: "capital",
+          },
+          {
+            column: "Output",
+            type: "string",
+            operator: "contains",
+            value: "Paris",
+          },
+          {
+            column: "Environment",
+            type: "string",
+            operator: "=",
+            value: "production",
+          },
+        ]),
+      ).toBe(false);
+    });
+
+    test("returns true for filters on non-allowlisted columns", () => {
+      // Assuming "Latency" is not in the allowlist
+      expect(
+        requiresDatabaseLookup([
+          {
+            column: "Latency (s)",
+            type: "number",
+            operator: ">",
+            value: 1000,
+          },
+        ]),
+      ).toBe(true);
+    });
+
+    test("returns true when mixing allowlisted and non-allowlisted columns", () => {
+      expect(
+        requiresDatabaseLookup([
+          {
+            column: "Input",
+            type: "string",
+            operator: "contains",
+            value: "test",
+          },
+          {
+            column: "Latency (s)",
+            type: "number",
+            operator: ">",
+            value: 1000,
+          },
+        ]),
+      ).toBe(true);
+    });
+  });
+});

--- a/worker/src/features/evaluation/traceFilterUtils.ts
+++ b/worker/src/features/evaluation/traceFilterUtils.ts
@@ -14,6 +14,8 @@ const evalTraceFilterColumns = [
   "release",
   "version",
   "tags",
+  "input",
+  "output",
 ] as const;
 
 function getColumnDefinition(column: string) {
@@ -61,6 +63,10 @@ export function mapTraceFilterColumn(
       return trace.sessionId;
     case "metadata":
       return trace.metadata;
+    case "input":
+      return trace.input;
+    case "output":
+      return trace.output;
     default:
       throw new Error(`Unhandled column in trace filter mapping: ${column}`);
   }


### PR DESCRIPTION
- Added "Input" and "Output" fields to the traces table definition.
- Enhanced the InMemoryFilterService to evaluate filters for input and output fields.
- Introduced new tests for filtering based on input and output fields in the InMemoryFilterService.
- Created traceFilterUtils tests to validate mapping and database lookup requirements for input and output fields.

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # [(issue)](https://github.com/orgs/langfuse/discussions/11592)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
<img width="1331" height="792" alt="Screenshot 2026-01-18 at 1 22 18" src="https://github.com/user-attachments/assets/28847b06-eec1-46a5-a008-7bb8f89cc596" />



## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `Input` and `Output` fields to trace definitions and update filtering logic and tests to support these fields.
> 
>   - **Trace Definitions**:
>     - Added `Input` and `Output` fields to `tracesTable` in `tracesTable.ts`.
>   - **Filtering Logic**:
>     - Updated `InMemoryFilterService` to handle `input` and `output` fields in `inMemoryFilterService.test.ts`.
>     - Enhanced `traceFilterUtils.ts` to map and evaluate `input` and `output` fields.
>   - **Testing**:
>     - Added tests for `input` and `output` field filtering in `inMemoryFilterService.test.ts`.
>     - Created `traceFilterUtils.test.ts` to validate `mapTraceFilterColumn` and `requiresDatabaseLookup` functions for `input` and `output` fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e23920d2fe84ce18474fedd8b8a5e030c3ff9332. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->