### PR TITLE
feat(trace): render thinking / reasoning parts in trace detail

### DIFF
--- a/packages/shared/src/utils/chatml/adapters/openai.ts
+++ b/packages/shared/src/utils/chatml/adapters/openai.ts
@@ -62,12 +62,72 @@ const OpenAIOutputSingleMessageSchema = z.looseObject({
   ),
 });
 
+/**
+ * Extract thinking content from OpenAI Responses API reasoning item
+ * Format: { type: "reasoning", content: [...], summary: [...] }
+ */
+function extractReasoningContent(item: Record<string, unknown>): {
+  thinking: Array<{ type: "thinking"; content: string; summary?: string }>;
+} | null {
+  if (item.type !== "reasoning") return null;
+
+  const contentArr = Array.isArray(item.content) ? item.content : [];
+  const summaryArr = Array.isArray(item.summary) ? item.summary : [];
+
+  // Extract text from content array (may contain {type: "text", text: "..."})
+  const contentText = contentArr
+    .map((c: unknown) => {
+      if (typeof c === "string") return c;
+      if (c && typeof c === "object" && "text" in c) {
+        return (c as { text: string }).text;
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+
+  // Extract summary text
+  const summaryText = summaryArr
+    .map((s: unknown) => {
+      if (typeof s === "string") return s;
+      if (s && typeof s === "object" && "text" in s) {
+        return (s as { text: string }).text;
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+
+  if (!contentText && !summaryText) return null;
+
+  return {
+    thinking: [
+      {
+        type: "thinking" as const,
+        content: contentText || summaryText,
+        ...(summaryText && contentText ? { summary: summaryText } : {}),
+      },
+    ],
+  };
+}
+
 function normalizeMessage(msg: unknown): Record<string, unknown> {
   if (!msg || typeof msg !== "object") return {};
 
   // we want to do type-based conversions BEFORE removeNullFields
   // because removeNullFields moves unrecognized fields to json passthrough
   let working = msg as Record<string, unknown>;
+
+  // Handle OpenAI Responses API reasoning item
+  // Format: { type: "reasoning", content: [...], summary: [...] }
+  const reasoningContent = extractReasoningContent(working);
+  if (reasoningContent) {
+    return {
+      role: "assistant",
+      content: "",
+      ...reasoningContent,
+    };
+  }
 
   // Convert direct function call message to tool_calls array format
   // Format: { type: "function_call", name: "...", arguments: {...}, call_id: "..." }

--- a/web/src/components/trace2/components/IOPreview/components/ThinkingBlock.tsx
+++ b/web/src/components/trace2/components/IOPreview/components/ThinkingBlock.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/src/utils/tailwind";
+
+interface ThinkingBlockProps {
+  content: string;
+  summary?: string;
+  defaultExpanded?: boolean;
+}
+
+export function ThinkingBlock({
+  content,
+  summary,
+  defaultExpanded = false,
+}: ThinkingBlockProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const displayContent = summary || content;
+
+  return (
+    <div className="my-2 px-1">
+      <div
+        className="flex cursor-pointer items-start gap-1 text-muted-foreground hover:text-foreground"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <ChevronRight
+          className={cn(
+            "mt-0.5 h-3 w-3 flex-shrink-0 transition-transform",
+            expanded && "rotate-90",
+          )}
+        />
+        <span className="text-xs font-medium">Thinking</span>
+        {!expanded && (
+          <span className="line-clamp-1 text-xs italic">{displayContent}</span>
+        )}
+      </div>
+
+      {expanded && (
+        <div className="ml-4 mt-1 whitespace-pre-wrap text-sm italic text-muted-foreground">
+          {content}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface RedactedThinkingBlockProps {
+  data: string;
+  defaultExpanded?: boolean;
+}
+
+// redactedThinkingBlock renders redacted thinking content if flagged by Anthropic
+export function RedactedThinkingBlock({
+  data,
+  defaultExpanded = false,
+}: RedactedThinkingBlockProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  return (
+    <div className="my-2 px-1">
+      <div
+        className="flex cursor-pointer items-start gap-1 text-muted-foreground hover:text-foreground"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <ChevronRight
+          className={cn(
+            "mt-0.5 h-3 w-3 flex-shrink-0 transition-transform",
+            expanded && "rotate-90",
+          )}
+        />
+        <span className="text-xs font-medium">Thinking (redacted)</span>
+        {!expanded && (
+          <span className="text-xs italic">[Encrypted thinking data]</span>
+        )}
+      </div>
+
+      {expanded && (
+        <div className="ml-4 mt-1 break-all rounded bg-muted/50 p-2 font-mono text-xs text-muted-foreground">
+          {data}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/trace2/components/IOPreview/components/ThinkingBlock.tsx
+++ b/web/src/components/trace2/components/IOPreview/components/ThinkingBlock.tsx
@@ -18,9 +18,11 @@ export function ThinkingBlock({
 
   return (
     <div className="my-2 px-1">
-      <div
-        className="flex cursor-pointer items-start gap-1 text-muted-foreground hover:text-foreground"
+      <button
+        type="button"
+        className="flex w-full cursor-pointer items-start gap-1 text-left text-muted-foreground hover:text-foreground"
         onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
       >
         <ChevronRight
           className={cn(
@@ -32,7 +34,7 @@ export function ThinkingBlock({
         {!expanded && (
           <span className="line-clamp-1 text-xs italic">{displayContent}</span>
         )}
-      </div>
+      </button>
 
       {expanded && (
         <div className="ml-4 mt-1 whitespace-pre-wrap text-sm italic text-muted-foreground">
@@ -57,9 +59,11 @@ export function RedactedThinkingBlock({
 
   return (
     <div className="my-2 px-1">
-      <div
-        className="flex cursor-pointer items-start gap-1 text-muted-foreground hover:text-foreground"
+      <button
+        type="button"
+        className="flex w-full cursor-pointer items-start gap-1 text-left text-muted-foreground hover:text-foreground"
         onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
       >
         <ChevronRight
           className={cn(
@@ -71,7 +75,7 @@ export function RedactedThinkingBlock({
         {!expanded && (
           <span className="text-xs italic">[Encrypted thinking data]</span>
         )}
-      </div>
+      </button>
 
       {expanded && (
         <div className="ml-4 mt-1 break-all rounded bg-muted/50 p-2 font-mono text-xs text-muted-foreground">

--- a/web/src/components/trace2/components/IOPreview/components/chat-message-utils.ts
+++ b/web/src/components/trace2/components/IOPreview/components/chat-message-utils.ts
@@ -80,3 +80,20 @@ export function parseToolCallsFromMessage(
       ? message.json.tool_calls
       : [];
 }
+
+/**
+ * Check if message has thinking content.
+ */
+export function hasThinkingContent(message: ChatMlMessage): boolean {
+  return Array.isArray(message.thinking) && message.thinking.length > 0;
+}
+
+/**
+ * Check if message has redacted thinking content.
+ */
+export function hasRedactedThinkingContent(message: ChatMlMessage): boolean {
+  return (
+    Array.isArray(message.redacted_thinking) &&
+    message.redacted_thinking.length > 0
+  );
+}

--- a/web/src/components/ui/MarkdownJsonView.tsx
+++ b/web/src/components/ui/MarkdownJsonView.tsx
@@ -88,6 +88,7 @@ export function MarkdownJsonView({
   audio,
   media,
   controlButtons,
+  afterHeader,
 }: {
   content?: unknown;
   title?: string;
@@ -97,6 +98,8 @@ export function MarkdownJsonView({
   audio?: OpenAIOutputAudioType;
   media?: MediaReturnType[];
   controlButtons?: React.ReactNode;
+  /** Content to render between header and main content (e.g., thinking blocks) */
+  afterHeader?: React.ReactNode;
 }) {
   const stringOrValidatedMarkdown = useMemo(
     () => StringOrMarkdownSchema.safeParse(content),
@@ -123,6 +126,7 @@ export function MarkdownJsonView({
           audio={audio}
           media={media}
           controlButtons={controlButtons}
+          afterHeader={afterHeader}
         />
       ) : (
         <PrettyJsonView
@@ -133,6 +137,7 @@ export function MarkdownJsonView({
           media={media}
           currentView="pretty"
           controlButtons={controlButtons}
+          afterHeader={afterHeader}
         />
       )}
     </>

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -321,6 +321,7 @@ export function MarkdownView({
   media,
   className,
   controlButtons,
+  afterHeader,
 }: {
   markdown: string | z.infer<typeof OpenAIContentSchema>;
   title?: string;
@@ -330,6 +331,8 @@ export function MarkdownView({
   media?: MediaReturnType[];
   className?: string;
   controlButtons?: React.ReactNode;
+  /** Content to render between header and main content (e.g., thinking blocks) */
+  afterHeader?: React.ReactNode;
 }) {
   const capture = usePostHogClientCapture();
   const { resolvedTheme: theme } = useTheme();
@@ -373,6 +376,7 @@ export function MarkdownView({
           <div className="border-t" />
         </>
       ) : null}
+      {afterHeader}
       <div
         className={cn(
           "io-message-content grid grid-flow-row gap-2 px-1 py-2",

--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -761,6 +761,8 @@ export function PrettyJsonView(props: {
   showNullValues?: boolean;
   stickyTopLevelKey?: boolean;
   showObservationTypeBadge?: boolean;
+  /** Content to render between header and main content (e.g., thinking blocks) */
+  afterHeader?: React.ReactNode;
 }) {
   // Use pre-parsed data if available, otherwise parse on-demand
   const parsedJson = useMemo(() => {
@@ -1352,6 +1354,7 @@ export function PrettyJsonView(props: {
           }
         />
       ) : null}
+      {props.afterHeader}
       {props.scrollable ? (
         <div
           className={cn(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for rendering thinking and redacted thinking content in trace details, including schema updates, adapter logic, and UI components.
> 
>   - **Schemas**:
>     - Add `ThinkingContentPartSchema` and `RedactedThinkingContentPartSchema` in `types.ts` for handling thinking and redacted thinking content.
>     - Update `BaseChatMlMessageSchema` and `ChatMlMessageSchema` to include `thinking` and `redacted_thinking` arrays.
>   - **Adapters**:
>     - Update `gemini.ts`, `openai.ts`, and `pydantic-ai.ts` to extract and normalize thinking and redacted thinking content.
>     - Add logic to handle `thought` flags and reasoning items in respective adapters.
>   - **UI Components**:
>     - Add `ThinkingBlock` and `RedactedThinkingBlock` components in `ThinkingBlock.tsx` for rendering thinking content.
>     - Update `ChatMessage.tsx` to render thinking blocks if present.
>     - Modify `MarkdownJsonView.tsx`, `MarkdownViewer.tsx`, and `PrettyJsonView.tsx` to support rendering thinking content after headers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 97a940022e6aaa6c38f8a69e71d2f0ef297a6aa8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->