### PR TITLE
fix(prompts): save editor state to sessionStorage and restore on remount

### DIFF
--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -226,27 +226,6 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
         onSubmit={form.handleSubmit(onSubmit)}
         className="flex flex-col gap-6"
       >
-        {hadDraft && (
-          <div className="flex items-center justify-between rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-200">
-            <span>Draft restored from previous session.</span>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                clearDraft();
-                form.reset(defaultValues);
-                setInitialMessages(
-                  initialPrompt?.type === PromptType.Chat
-                    ? initialPrompt.prompt
-                    : [],
-                );
-              }}
-            >
-              Discard draft
-            </Button>
-          </div>
-        )}
         {/* Prompt name field - text vs. chat only for new prompts */}
         {!initialPrompt ? (
           <FormField
@@ -340,6 +319,26 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
                   </TabsTrigger>
                 </TabsList>
               ) : null}
+              {hadDraft && (
+                <p className="-mt-2 mb-1 text-right text-xs text-muted-foreground">
+                  Draft restored.{" "}
+                  <button
+                    type="button"
+                    className="underline hover:text-foreground"
+                    onClick={() => {
+                      clearDraft();
+                      form.reset(defaultValues);
+                      setInitialMessages(
+                        initialPrompt?.type === PromptType.Chat
+                          ? initialPrompt.prompt
+                          : [],
+                      );
+                    }}
+                  >
+                    Discard
+                  </button>
+                </p>
+              )}
               <TabsContent value={PromptType.Text}>
                 <FormField
                   control={form.control}

--- a/web/src/hooks/useFormPersistence.ts
+++ b/web/src/hooks/useFormPersistence.ts
@@ -1,0 +1,95 @@
+import { useEffect, useRef, useCallback, useState } from "react";
+import { type UseFormReturn } from "react-hook-form";
+import { useDebounce } from "./useDebounce";
+
+const getStorageKey = (projectId: string, formId: string) =>
+  `langfuse:form-draft:${projectId}:${formId}`;
+
+export interface UseFormPersistenceOptions<T extends Record<string, unknown>> {
+  formId: string;
+  projectId: string;
+  form: UseFormReturn<T>;
+  debounceMs?: number;
+  enabled?: boolean;
+  onDraftRestored?: (draft: Partial<T>) => void;
+}
+
+export interface UseFormPersistenceReturn {
+  hadDraft: boolean;
+  hasDraft: boolean;
+  clearDraft: () => void;
+}
+
+export function useFormPersistence<T extends Record<string, unknown>>({
+  formId,
+  projectId,
+  form,
+  debounceMs = 350,
+  enabled = true,
+  onDraftRestored,
+}: UseFormPersistenceOptions<T>): UseFormPersistenceReturn {
+  const storageKey = getStorageKey(projectId, formId);
+  const [hadDraft, setHadDraft] = useState(false);
+  const [hasDraft, setHasDraft] = useState(false);
+  const isInitialized = useRef(false);
+  const lastSaved = useRef<string | null>(null);
+  const onDraftRestoredRef = useRef(onDraftRestored);
+  onDraftRestoredRef.current = onDraftRestored;
+
+  // Restore on mount (once)
+  useEffect(() => {
+    if (!enabled || isInitialized.current) return;
+    isInitialized.current = true;
+
+    try {
+      const saved = sessionStorage.getItem(storageKey);
+      if (saved) {
+        const draft = JSON.parse(saved) as Partial<T>;
+        const current = form.getValues();
+        form.reset({ ...current, ...draft } as T, {
+          keepDirty: true,
+          keepTouched: true,
+        });
+        setHadDraft(true);
+        setHasDraft(true);
+        onDraftRestoredRef.current?.(draft);
+      }
+    } catch {
+      sessionStorage.removeItem(storageKey);
+    }
+  }, [enabled, storageKey, form]);
+
+  // Save on change (debounced)
+  const saveDraft = useDebounce(
+    (values: T) => {
+      const serialized = JSON.stringify(values);
+      if (serialized === lastSaved.current) return;
+      try {
+        sessionStorage.setItem(storageKey, serialized);
+        lastSaved.current = serialized;
+        setHasDraft(true);
+      } catch {
+        /* storage full - ignore */
+      }
+    },
+    debounceMs,
+    false,
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+    const sub = form.watch((values) => {
+      if (form.formState.isDirty) saveDraft(values as T);
+    });
+    return () => sub.unsubscribe();
+  }, [form, enabled, saveDraft]);
+
+  const clearDraft = useCallback(() => {
+    sessionStorage.removeItem(storageKey);
+    lastSaved.current = null;
+    setHasDraft(false);
+    setHadDraft(false);
+  }, [storageKey]);
+
+  return { hadDraft, hasDraft, clearDraft };
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `useFormPersistence` hook to persist form state in `sessionStorage` and integrate it into `NewPromptForm` to prevent data loss.
> 
>   - **Behavior**:
>     - Introduces `useFormPersistence` hook in `useFormPersistence.ts` to persist form state in `sessionStorage`.
>     - Integrates `useFormPersistence` in `NewPromptForm` to restore drafts and save form state changes.
>     - Adds draft restoration message and discard option in `NewPromptForm`.
>   - **Functions**:
>     - `useFormPersistence` handles draft restoration on mount and saves changes with debouncing.
>     - Provides `clearDraft` function to remove saved drafts.
>   - **Misc**:
>     - Adds `useRef` to prevent multiple initializations in `NewPromptForm`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a87f8999c998852b2be2d07889f61cfbb11877fa. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->