### PR TITLE
chore: increase event backfill dual write timeout to 10min

### DIFF
--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -85,7 +85,7 @@ export const handleEventPropagationJob = async (
         FROM system.parts
         WHERE table = 'observations_batch_staging'
           AND active = 1
-          AND toDateTime(partition) < now() - INTERVAL 6 MINUTE
+          AND toDateTime(partition) < now() - INTERVAL 10 MINUTE
           ${lastProcessedPartition ? `AND partition > {lastProcessedPartition: String}` : ""}
         ORDER BY partition ASC
       `,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase partition processing timeout in `handleEventPropagationJob` to 10 minutes.
> 
>   - **Behavior**:
>     - Increase timeout for processing partitions in `handleEventPropagationJob` from 6 minutes to 10 minutes.
>     - Affects query filtering in `handleEventPropagationJob` to select partitions older than 10 minutes instead of 6.
>   - **Misc**:
>     - Adjusts `request_timeout` in `commandClickhouse` to 10 minutes to match the new interval.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 484e3897655155e9556653c4b788107117ccebe8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->