### PR TITLE
fix(prompts): draft button overlap

### DIFF
--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -320,7 +320,9 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
                 </TabsList>
               ) : null}
               {hadDraft && (
-                <p className="-mt-2 mb-1 text-right text-xs text-muted-foreground">
+                <p
+                  className={`mb-1 text-right text-xs text-muted-foreground ${initialPrompt ? "-mt-2" : "mt-1"}`}
+                >
                   Draft restored.{" "}
                   <button
                     type="button"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes draft button overlap in `NewPromptForm` by adjusting margin-top conditionally based on `initialPrompt`.
> 
>   - **UI Fix**:
>     - Adjusts margin-top for draft restored message in `NewPromptForm` component to prevent button overlap.
>     - Uses conditional className to set `-mt-2` if `initialPrompt` exists, otherwise `mt-1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f00a88ae864f6147b36031b65a4b3f55d4cf6d3a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->