### PR TITLE
fix(trace): render thinking also on only tool calls

### DIFF
--- a/web/src/components/trace2/components/IOPreview/components/ChatMessage.tsx
+++ b/web/src/components/trace2/components/IOPreview/components/ChatMessage.tsx
@@ -130,8 +130,13 @@ export function ChatMessage({
     );
   }
 
-  // Tool-call-only message (no content)
-  if (!hasContent && toolCalls.length > 0) {
+  // Tool-call-only message (no content, no thinking)
+  if (
+    !hasContent &&
+    !hasThinkingContent(message) &&
+    !hasRedactedThinkingContent(message) &&
+    toolCalls.length > 0
+  ) {
     return (
       <div className={cn("transition-colors hover:bg-muted")}>
         <MarkdownJsonViewHeader


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modify `ChatMessage.tsx` to exclude thinking content from tool-call-only messages and add a test for thinking part extraction in `pydantic-ai.test.ts`.
> 
>   - **Behavior**:
>     - In `ChatMessage.tsx`, modify tool-call-only message rendering to exclude messages with thinking content using `hasThinkingContent()` and `hasRedactedThinkingContent()`.
>   - **Tests**:
>     - Add test case in `pydantic-ai.test.ts` to verify extraction of thinking parts from assistant messages, checking for content and tool call details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1e3a37336722b955b63bd36ed32461706cff28aa. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->