### PR TITLE
chore(worker): consolidate ClickhouseWriter drop logs into single summary

### DIFF
--- a/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
+++ b/worker/src/services/ClickhouseWriter/ClickhouseWriter.unit.test.ts
@@ -152,32 +152,6 @@ describe("ClickhouseWriter", () => {
     expect(writer["queue"][TableName.Traces]).toHaveLength(0);
   });
 
-  it("should truncate logged events after dropping", async () => {
-    const mockInsert = vi
-      .spyOn(clickhouseClientMock, "insert")
-      .mockRejectedValue(new Error("DB Error"));
-
-    const baseString =
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ";
-    const repeatCount = Math.ceil(150000);
-    const input = baseString.repeat(repeatCount);
-    writer.addToQueue(TableName.Traces, { id: "1", name: "test", input });
-
-    for (let i = 0; i < writer.maxAttempts; i++) {
-      await vi.advanceTimersByTimeAsync(writer.writeInterval);
-    }
-
-    await vi.advanceTimersByTimeAsync(writer.writeInterval);
-
-    expect(mockInsert).toHaveBeenCalledTimes(writer.maxAttempts);
-    expect(
-      logger.error.mock.calls.some((call) =>
-        call[1]?.item?.input?.includes("TRUNCATED: Field exceeded size limit"),
-      ),
-    ).toBe(true);
-    expect(writer["queue"][TableName.Traces]).toHaveLength(0);
-  });
-
   it("should shutdown gracefully", async () => {
     writer.addToQueue(TableName.Traces, { id: "1", name: "test" });
     const mockInsert = vi


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Consolidates logging of dropped records in `ClickhouseWriter` to a single summary log entry, simplifying log output.
> 
>   - **Behavior**:
>     - Consolidates logging of dropped records in `flush()` in `index.ts` to a single summary log entry.
>     - Logs the total number of dropped records instead of individual logs for each record.
>   - **Tests**:
>     - Removes test `should truncate logged events after dropping` from `ClickhouseWriter.unit.test.ts` as individual drop logs are no longer generated.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5a18c77e802f2e242b8abd4914d643b8b59e8e77. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->