### PR TITLE
fix(storage): add max file limit to GCS and Azure listFiles

### DIFF
--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -329,7 +329,7 @@ class AzureBlobStorageService implements StorageService {
     try {
       await this.createContainerIfNotExists();
 
-      const result = await this.client.listBlobsFlat({ prefix });
+      const result = this.client.listBlobsFlat({ prefix });
       const files = [];
       for await (const blob of result) {
         if (blob.name.startsWith(prefix)) {
@@ -337,6 +337,9 @@ class AzureBlobStorageService implements StorageService {
             file: blob.name,
             createdAt: blob?.properties?.createdOn ?? new Date(),
           });
+          if (files.length >= env.LANGFUSE_S3_LIST_MAX_KEYS) {
+            break;
+          }
         }
       }
       return files;
@@ -823,7 +826,10 @@ class GoogleCloudStorageService implements StorageService {
     prefix: string,
   ): Promise<{ file: string; createdAt: Date }[]> {
     try {
-      const [files] = await this.bucket.getFiles({ prefix });
+      const [files] = await this.bucket.getFiles({
+        prefix,
+        maxResults: env.LANGFUSE_S3_LIST_MAX_KEYS,
+      });
 
       return files.map((file) => ({
         file: file.name,


### PR DESCRIPTION
Apply the same LANGFUSE_S3_LIST_MAX_KEYS limit (default: 200) to Google Cloud Storage and Azure Blob Storage listFiles methods for consistency with S3 implementation. This prevents potential resource exhaustion when listing large numbers of files.

Contributes to #11394
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `LANGFUSE_S3_LIST_MAX_KEYS` limit to `listFiles()` in Azure and Google Cloud Storage for consistency with S3.
> 
>   - **Behavior**:
>     - Adds `LANGFUSE_S3_LIST_MAX_KEYS` limit to `listFiles()` in `AzureBlobStorageService` and `GoogleCloudStorageService` for consistency with S3.
>     - Limits the number of files returned to prevent resource exhaustion.
>   - **Misc**:
>     - Contributes to issue #11394.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c66dd1557d0b0787fcf495e2a73fa0565ee2fcb7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->