### PR TITLE
fix(trace): dont show empty string on only tool call + thinking strings

### DIFF
--- a/web/src/components/trace2/components/IOPreview/components/ChatMessage.tsx
+++ b/web/src/components/trace2/components/IOPreview/components/ChatMessage.tsx
@@ -186,7 +186,7 @@ export function ChatMessage({
         <div style={{ display: shouldRenderMarkdown ? "block" : "none" }}>
           <MarkdownJsonView
             title={title}
-            content={message.content || '""'}
+            content={message.content || ""}
             customCodeHeaderClassName={cn(
               message.role === "assistant" && "bg-secondary",
               message.role === "system" && "bg-primary-foreground",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes display of empty `message.content` in `ChatMessage` component by removing `""` quotes when content is empty.
> 
>   - **Behavior**:
>     - Fixes display of empty `message.content` in `ChatMessage` component by removing `""` quotes when content is empty.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 508fb869beb4386414bf1306abc6d8eb5822d8cf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->