### PR TITLE
fix(otel): respect Content-Type in OTLP endpoint responses

### DIFF
--- a/web/src/__tests__/async/otel-api-content-type.servertest.ts
+++ b/web/src/__tests__/async/otel-api-content-type.servertest.ts
@@ -1,0 +1,372 @@
+/**
+ * Tests for OTEL API Content-Type Specification Compliance
+ *
+ * Per the OTLP/HTTP specification (https://opentelemetry.io/docs/specs/otlp/#otlphttp-response):
+ * - Response encoding should match request encoding
+ * - Protobuf requests → application/x-protobuf response
+ * - JSON requests → application/json response
+ *
+ * These tests verify that the Langfuse OTEL endpoints correctly respect
+ * the Content-Type of incoming requests when generating responses.
+ */
+
+import { createBasicAuthHeader } from "@langfuse/shared/src/server";
+import { $root } from "@/src/pages/api/public/otel/otlp-proto/generated/root";
+import { randomBytes } from "crypto";
+
+const API_BASE_URL = "http://localhost:3000";
+const AUTH_HEADER = createBasicAuthHeader(
+  "pk-lf-1234567890",
+  "sk-lf-1234567890",
+);
+
+/**
+ * Helper to create a minimal OTEL trace payload as JSON
+ */
+function createJsonTracePayload() {
+  const traceId = randomBytes(16);
+  const spanId = randomBytes(8);
+
+  return {
+    json: {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [
+            {
+              scope: { name: "test-sdk", version: "1.0.0", attributes: [] },
+              spans: [
+                {
+                  traceId,
+                  spanId,
+                  name: "test-span",
+                  kind: 1,
+                  startTimeUnixNano: {
+                    low: 466848096,
+                    high: 406528574,
+                    unsigned: true,
+                  },
+                  endTimeUnixNano: {
+                    low: 467248096,
+                    high: 406528574,
+                    unsigned: true,
+                  },
+                  attributes: [],
+                  status: {},
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    traceId: traceId.toString("hex"),
+    spanId: spanId.toString("hex"),
+  };
+}
+
+/**
+ * Helper to create a protobuf-encoded OTEL trace request
+ */
+function createProtobufTracePayload(): Buffer {
+  const traceId = randomBytes(16);
+  const spanId = randomBytes(8);
+
+  const ExportTraceServiceRequest =
+    $root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+
+  const message = ExportTraceServiceRequest.create({
+    resourceSpans: [
+      {
+        resource: { attributes: [] },
+        scopeSpans: [
+          {
+            scope: { name: "test-sdk", version: "1.0.0" },
+            spans: [
+              {
+                traceId: new Uint8Array(traceId),
+                spanId: new Uint8Array(spanId),
+                name: "protobuf-test-span",
+                kind: 1,
+                startTimeUnixNano: BigInt("1746528574466848096"),
+                endTimeUnixNano: BigInt("1746528574467248096"),
+                attributes: [],
+                status: {},
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+
+  return Buffer.from(ExportTraceServiceRequest.encode(message).finish());
+}
+
+describe("/api/public/otel/v1/traces Content-Type Compliance", () => {
+  it("should return application/json Content-Type for JSON requests", async () => {
+    const { json } = createJsonTracePayload();
+
+    const response = await fetch(`${API_BASE_URL}/api/public/otel/v1/traces`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: AUTH_HEADER,
+      },
+      body: JSON.stringify(json),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/json");
+
+    // Verify response body is valid JSON
+    const responseBody = await response.json();
+    expect(responseBody).toBeDefined();
+    // Empty success response or partialSuccess structure
+    expect(
+      Object.keys(responseBody).length === 0 ||
+        responseBody.partialSuccess !== undefined,
+    ).toBe(true);
+  });
+
+  it("should return application/x-protobuf Content-Type for protobuf requests", async () => {
+    const protobufPayload = createProtobufTracePayload();
+
+    const response = await fetch(`${API_BASE_URL}/api/public/otel/v1/traces`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-protobuf",
+        Authorization: AUTH_HEADER,
+      },
+      body: protobufPayload,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain(
+      "application/x-protobuf",
+    );
+
+    // Verify response body is valid protobuf
+    const responseBuffer = await response.arrayBuffer();
+    const ExportTraceServiceResponse =
+      $root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+    const decoded = ExportTraceServiceResponse.decode(
+      new Uint8Array(responseBuffer),
+    );
+    expect(decoded).toBeDefined();
+  });
+
+  it("should return JSON error response for JSON requests with invalid body", async () => {
+    const response = await fetch(`${API_BASE_URL}/api/public/otel/v1/traces`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: AUTH_HEADER,
+      },
+      body: "invalid json {{{",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("content-type")).toContain("application/json");
+
+    const responseBody = await response.json();
+    expect(responseBody.error).toBeDefined();
+  });
+
+  it("should return protobuf error response for protobuf requests with invalid body", async () => {
+    const response = await fetch(`${API_BASE_URL}/api/public/otel/v1/traces`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-protobuf",
+        Authorization: AUTH_HEADER,
+      },
+      body: Buffer.from("invalid protobuf data"),
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("content-type")).toContain(
+      "application/x-protobuf",
+    );
+
+    // Verify response body is valid protobuf with error message
+    const responseBuffer = await response.arrayBuffer();
+    const ExportTraceServiceResponse =
+      $root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+    const decoded = ExportTraceServiceResponse.decode(
+      new Uint8Array(responseBuffer),
+    );
+    expect(decoded).toBeDefined();
+    expect(decoded.partialSuccess?.errorMessage).toBeDefined();
+  });
+
+  it("should return protobuf error response for auth errors on protobuf requests", async () => {
+    const protobufPayload = createProtobufTracePayload();
+
+    const response = await fetch(`${API_BASE_URL}/api/public/otel/v1/traces`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-protobuf",
+        Authorization: createBasicAuthHeader("invalid-key", "invalid-secret"),
+      },
+      body: protobufPayload,
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain(
+      "application/x-protobuf",
+    );
+
+    // Verify response body is valid protobuf
+    const responseBuffer = await response.arrayBuffer();
+    const ExportTraceServiceResponse =
+      $root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+    const decoded = ExportTraceServiceResponse.decode(
+      new Uint8Array(responseBuffer),
+    );
+    expect(decoded).toBeDefined();
+  });
+
+  it("should return JSON error response for auth errors on JSON requests", async () => {
+    const { json } = createJsonTracePayload();
+
+    const response = await fetch(`${API_BASE_URL}/api/public/otel/v1/traces`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: createBasicAuthHeader("invalid-key", "invalid-secret"),
+      },
+      body: JSON.stringify(json),
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain("application/json");
+
+    const responseBody = await response.json();
+    expect(responseBody.error).toBeDefined();
+  });
+
+  it("should handle empty resourceSpans with correct Content-Type for JSON", async () => {
+    const response = await fetch(`${API_BASE_URL}/api/public/otel/v1/traces`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: AUTH_HEADER,
+      },
+      body: JSON.stringify({ resourceSpans: [] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/json");
+  });
+
+  it("should handle empty resourceSpans with correct Content-Type for protobuf", async () => {
+    const ExportTraceServiceRequest =
+      $root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+    const message = ExportTraceServiceRequest.create({ resourceSpans: [] });
+    const protobufPayload = Buffer.from(
+      ExportTraceServiceRequest.encode(message).finish(),
+    );
+
+    const response = await fetch(`${API_BASE_URL}/api/public/otel/v1/traces`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-protobuf",
+        Authorization: AUTH_HEADER,
+      },
+      body: protobufPayload,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain(
+      "application/x-protobuf",
+    );
+  });
+});
+
+describe("/api/public/otel/v1/metrics Content-Type Compliance", () => {
+  it("should return application/json Content-Type for JSON requests", async () => {
+    const response = await fetch(`${API_BASE_URL}/api/public/otel/v1/metrics`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: AUTH_HEADER,
+      },
+      body: JSON.stringify({ resourceMetrics: [] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/json");
+  });
+
+  it("should return application/x-protobuf Content-Type for protobuf requests", async () => {
+    const ExportMetricsServiceRequest =
+      $root.opentelemetry.proto.collector.metrics.v1
+        .ExportMetricsServiceRequest;
+    const message = ExportMetricsServiceRequest.create({
+      resourceMetrics: [],
+    });
+    const protobufPayload = Buffer.from(
+      ExportMetricsServiceRequest.encode(message).finish(),
+    );
+
+    const response = await fetch(`${API_BASE_URL}/api/public/otel/v1/metrics`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-protobuf",
+        Authorization: AUTH_HEADER,
+      },
+      body: protobufPayload,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain(
+      "application/x-protobuf",
+    );
+
+    // Verify response body is valid protobuf
+    const responseBuffer = await response.arrayBuffer();
+    const ExportMetricsServiceResponse =
+      $root.opentelemetry.proto.collector.metrics.v1
+        .ExportMetricsServiceResponse;
+    const decoded = ExportMetricsServiceResponse.decode(
+      new Uint8Array(responseBuffer),
+    );
+    expect(decoded).toBeDefined();
+  });
+
+  it("should return protobuf error response for auth errors on protobuf requests", async () => {
+    const ExportMetricsServiceRequest =
+      $root.opentelemetry.proto.collector.metrics.v1
+        .ExportMetricsServiceRequest;
+    const message = ExportMetricsServiceRequest.create({
+      resourceMetrics: [],
+    });
+    const protobufPayload = Buffer.from(
+      ExportMetricsServiceRequest.encode(message).finish(),
+    );
+
+    const response = await fetch(`${API_BASE_URL}/api/public/otel/v1/metrics`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-protobuf",
+        Authorization: createBasicAuthHeader("invalid-key", "invalid-secret"),
+      },
+      body: protobufPayload,
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain(
+      "application/x-protobuf",
+    );
+
+    // Verify response body is valid protobuf
+    const responseBuffer = await response.arrayBuffer();
+    const ExportMetricsServiceResponse =
+      $root.opentelemetry.proto.collector.metrics.v1
+        .ExportMetricsServiceResponse;
+    const decoded = ExportMetricsServiceResponse.decode(
+      new Uint8Array(responseBuffer),
+    );
+    expect(decoded).toBeDefined();
+  });
+});

--- a/web/src/features/otel/otelResponse.ts
+++ b/web/src/features/otel/otelResponse.ts
@@ -1,0 +1,195 @@
+import { type NextApiResponse } from "next";
+import { $root } from "@/src/pages/api/public/otel/otlp-proto/generated/root";
+
+/**
+ * OTEL Content Types supported by the OTLP/HTTP specification.
+ * Per https://opentelemetry.io/docs/specs/otlp/#otlphttp-response:
+ * - Response encoding should match request encoding
+ * - Protobuf requests → application/x-protobuf response
+ * - JSON requests → application/json response
+ */
+export type OtelContentType = "application/json" | "application/x-protobuf";
+
+/**
+ * Determines the appropriate response Content-Type based on request Content-Type.
+ * Per OTLP spec, responses should use the same encoding as the request.
+ */
+export function getOtelContentType(
+  requestContentType: string | undefined,
+): OtelContentType {
+  if (requestContentType?.includes("application/x-protobuf")) {
+    return "application/x-protobuf";
+  }
+  return "application/json";
+}
+
+/**
+ * Sends a successful ExportTraceServiceResponse with the correct Content-Type.
+ * Per OTLP spec, success responses return ExportTraceServiceResponse with optional partialSuccess.
+ */
+export function sendOtelTraceResponse(params: {
+  res: NextApiResponse;
+  contentType: OtelContentType;
+  partialSuccess?: {
+    rejectedSpans?: number;
+    errorMessage?: string;
+  };
+}): void {
+  const { res, contentType, partialSuccess } = params;
+
+  const ExportTraceServiceResponse =
+    $root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+
+  const responseMessage = ExportTraceServiceResponse.create(
+    partialSuccess
+      ? {
+          partialSuccess: {
+            rejectedSpans: partialSuccess.rejectedSpans ?? 0,
+            errorMessage: partialSuccess.errorMessage ?? "",
+          },
+        }
+      : {},
+  );
+
+  if (contentType === "application/x-protobuf") {
+    const buffer = ExportTraceServiceResponse.encode(responseMessage).finish();
+    res.setHeader("Content-Type", "application/x-protobuf");
+    res.status(200).send(Buffer.from(buffer));
+  } else {
+    res.setHeader("Content-Type", "application/json");
+    res.status(200).json(
+      partialSuccess
+        ? {
+            partialSuccess: {
+              rejectedSpans: partialSuccess.rejectedSpans ?? 0,
+              errorMessage: partialSuccess.errorMessage ?? "",
+            },
+          }
+        : {},
+    );
+  }
+}
+
+/**
+ * Sends a successful ExportMetricsServiceResponse with the correct Content-Type.
+ * Per OTLP spec, success responses return ExportMetricsServiceResponse with optional partialSuccess.
+ */
+export function sendOtelMetricsResponse(params: {
+  res: NextApiResponse;
+  contentType: OtelContentType;
+  partialSuccess?: {
+    rejectedDataPoints?: number;
+    errorMessage?: string;
+  };
+}): void {
+  const { res, contentType, partialSuccess } = params;
+
+  const ExportMetricsServiceResponse =
+    $root.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse;
+
+  const responseMessage = ExportMetricsServiceResponse.create(
+    partialSuccess
+      ? {
+          partialSuccess: {
+            rejectedDataPoints: partialSuccess.rejectedDataPoints ?? 0,
+            errorMessage: partialSuccess.errorMessage ?? "",
+          },
+        }
+      : {},
+  );
+
+  if (contentType === "application/x-protobuf") {
+    const buffer =
+      ExportMetricsServiceResponse.encode(responseMessage).finish();
+    res.setHeader("Content-Type", "application/x-protobuf");
+    res.status(200).send(Buffer.from(buffer));
+  } else {
+    res.setHeader("Content-Type", "application/json");
+    res.status(200).json(
+      partialSuccess
+        ? {
+            partialSuccess: {
+              rejectedDataPoints: partialSuccess.rejectedDataPoints ?? 0,
+              errorMessage: partialSuccess.errorMessage ?? "",
+            },
+          }
+        : {},
+    );
+  }
+}
+
+/**
+ * Sends an error response with the correct Content-Type for traces.
+ * Error responses should also respect the request's Content-Type per OTLP spec.
+ */
+export function sendOtelTraceErrorResponse(params: {
+  res: NextApiResponse;
+  contentType: OtelContentType;
+  statusCode: number;
+  message: string;
+}): void {
+  const { res, contentType, statusCode, message } = params;
+
+  if (contentType === "application/x-protobuf") {
+    const ExportTraceServiceResponse =
+      $root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+    const errorResponse = ExportTraceServiceResponse.create({
+      partialSuccess: {
+        rejectedSpans: -1, // Indicates full rejection
+        errorMessage: message,
+      },
+    });
+    const buffer = ExportTraceServiceResponse.encode(errorResponse).finish();
+    res.setHeader("Content-Type", "application/x-protobuf");
+    res.status(statusCode).send(Buffer.from(buffer));
+  } else {
+    res.setHeader("Content-Type", "application/json");
+    res.status(statusCode).json({ error: message });
+  }
+}
+
+/**
+ * Sends an error response with the correct Content-Type for metrics.
+ * Error responses should also respect the request's Content-Type per OTLP spec.
+ */
+export function sendOtelMetricsErrorResponse(params: {
+  res: NextApiResponse;
+  contentType: OtelContentType;
+  statusCode: number;
+  message: string;
+}): void {
+  const { res, contentType, statusCode, message } = params;
+
+  if (contentType === "application/x-protobuf") {
+    const ExportMetricsServiceResponse =
+      $root.opentelemetry.proto.collector.metrics.v1
+        .ExportMetricsServiceResponse;
+    const errorResponse = ExportMetricsServiceResponse.create({
+      partialSuccess: {
+        rejectedDataPoints: -1, // Indicates full rejection
+        errorMessage: message,
+      },
+    });
+    const buffer = ExportMetricsServiceResponse.encode(errorResponse).finish();
+    res.setHeader("Content-Type", "application/x-protobuf");
+    res.status(statusCode).send(Buffer.from(buffer));
+  } else {
+    res.setHeader("Content-Type", "application/json");
+    res.status(statusCode).json({ error: message });
+  }
+}
+
+/**
+ * Sends an error response with the correct Content-Type.
+ * Error responses should also respect the request's Content-Type per OTLP spec.
+ * @deprecated Use sendOtelTraceErrorResponse or sendOtelMetricsErrorResponse instead
+ */
+export function sendOtelErrorResponse(params: {
+  res: NextApiResponse;
+  contentType: OtelContentType;
+  statusCode: number;
+  message: string;
+}): void {
+  // Default to trace error response for backward compatibility
+  return sendOtelTraceErrorResponse(params);
+}

--- a/web/src/pages/api/public/otel/v1/metrics/index.ts
+++ b/web/src/pages/api/public/otel/v1/metrics/index.ts
@@ -1,6 +1,34 @@
-import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
-import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
-import { z } from "zod/v4";
+/**
+ * OTEL Metrics Ingestion Endpoint
+ *
+ * This endpoint implements the OTLP/HTTP protocol for metrics ingestion.
+ * Per the OTLP spec (https://opentelemetry.io/docs/specs/otlp/#otlphttp-response):
+ * - Response encoding should match request encoding
+ * - Protobuf requests → application/x-protobuf response
+ * - JSON requests → application/json response
+ *
+ * Note: This is currently a stub endpoint that accepts metrics but does not process them.
+ * It returns a successful response to maintain OTEL SDK compatibility.
+ *
+ * Note: This endpoint does NOT use withMiddlewares()/createAuthedProjectAPIRoute()
+ * because those wrappers always return JSON responses regardless of request Content-Type.
+ * Instead, we handle authentication, CORS, and rate limiting directly to ensure
+ * Content-Type compliance with the OTLP specification.
+ */
+
+import { type NextApiRequest, type NextApiResponse } from "next";
+import { logger, redis } from "@langfuse/shared/src/server";
+import { ForbiddenError, UnauthorizedError } from "@langfuse/shared";
+import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
+import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
+import { prisma } from "@langfuse/shared/src/db";
+import { runMiddleware, cors } from "@/src/features/public-api/server/cors";
+import {
+  getOtelContentType,
+  sendOtelMetricsResponse,
+  sendOtelMetricsErrorResponse,
+  type OtelContentType,
+} from "@/src/features/otel/otelResponse";
 
 export const config = {
   api: {
@@ -8,12 +36,100 @@ export const config = {
   },
 };
 
-export default withMiddlewares({
-  POST: createAuthedProjectAPIRoute({
-    name: "OTel Metrics",
-    querySchema: z.any(),
-    responseSchema: z.any(),
-    rateLimitResource: "ingestion",
-    fn: async () => {},
-  }),
-});
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  // Capture Content-Type early so all responses respect it
+  const contentType: OtelContentType = getOtelContentType(
+    req.headers["content-type"],
+  );
+
+  try {
+    // CORS handling
+    await runMiddleware(req, res, cors);
+
+    // Handle preflight OPTIONS request
+    if (req.method === "OPTIONS") {
+      res.status(200).end();
+      return;
+    }
+
+    // Method check
+    if (req.method !== "POST") {
+      return sendOtelMetricsErrorResponse({
+        res,
+        contentType,
+        statusCode: 405,
+        message: "Method not allowed",
+      });
+    }
+
+    // Authentication using ApiAuthService
+    const authCheck = await new ApiAuthService(
+      prisma,
+      redis,
+    ).verifyAuthHeaderAndReturnScope(req.headers.authorization);
+
+    if (!authCheck.validKey) {
+      throw new UnauthorizedError(authCheck.error);
+    }
+
+    // Verify project-scoped access
+    if (
+      authCheck.scope.accessLevel !== "project" ||
+      !authCheck.scope.projectId
+    ) {
+      throw new ForbiddenError(
+        "Access denied: OTEL ingestion requires project-scoped API keys with BasicAuth",
+      );
+    }
+
+    // Check if ingestion is suspended due to usage threshold
+    if (authCheck.scope.isIngestionSuspended) {
+      throw new ForbiddenError(
+        "Ingestion suspended: Usage threshold exceeded. Please upgrade your plan.",
+      );
+    }
+
+    // Rate limiting
+    const rateLimitCheck =
+      await RateLimitService.getInstance().rateLimitRequest(
+        authCheck.scope,
+        "ingestion",
+      );
+
+    if (rateLimitCheck?.isRateLimited()) {
+      return rateLimitCheck.sendRestResponseIfLimited(res);
+    }
+
+    // Metrics endpoint is a stub - accept but don't process
+    // Return successful response to maintain OTEL SDK compatibility
+    return sendOtelMetricsResponse({ res, contentType });
+  } catch (error) {
+    logger.error("OTEL metrics API route error", {
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+
+    // Determine appropriate HTTP status based on error type
+    let statusCode = 500;
+    let message = "Internal server error";
+
+    if (error instanceof UnauthorizedError) {
+      statusCode = 401;
+      message = error.message || "Unauthorized";
+    } else if (error instanceof ForbiddenError) {
+      statusCode = 403;
+      message = error.message || "Forbidden";
+    } else if (error instanceof Error) {
+      message = error.message;
+    }
+
+    return sendOtelMetricsErrorResponse({
+      res,
+      contentType,
+      statusCode,
+      message,
+    });
+  }
+}

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -1,14 +1,38 @@
-import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
-import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
+/**
+ * OTEL Traces Ingestion Endpoint
+ *
+ * This endpoint implements the OTLP/HTTP protocol for trace ingestion.
+ * Per the OTLP spec (https://opentelemetry.io/docs/specs/otlp/#otlphttp-response):
+ * - Response encoding should match request encoding
+ * - Protobuf requests → application/x-protobuf response
+ * - JSON requests → application/json response
+ *
+ * Note: This endpoint does NOT use withMiddlewares()/createAuthedProjectAPIRoute()
+ * because those wrappers always return JSON responses regardless of request Content-Type.
+ * Instead, we handle authentication, CORS, and rate limiting directly to ensure
+ * Content-Type compliance with the OTLP specification.
+ */
+
+import { type NextApiRequest, type NextApiResponse } from "next";
 import {
   logger,
   OtelIngestionProcessor,
   markProjectAsOtelUser,
+  redis,
 } from "@langfuse/shared/src/server";
-import { z } from "zod/v4";
 import { $root } from "@/src/pages/api/public/otel/otlp-proto/generated/root";
 import { gunzip } from "node:zlib";
-import { ForbiddenError } from "@langfuse/shared";
+import { ForbiddenError, UnauthorizedError } from "@langfuse/shared";
+import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
+import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
+import { prisma } from "@langfuse/shared/src/db";
+import { runMiddleware, cors } from "@/src/features/public-api/server/cors";
+import {
+  getOtelContentType,
+  sendOtelTraceResponse,
+  sendOtelErrorResponse,
+  type OtelContentType,
+} from "@/src/features/otel/otelResponse";
 
 export const config = {
   api: {
@@ -16,101 +40,206 @@ export const config = {
   },
 };
 
-export default withMiddlewares({
-  POST: createAuthedProjectAPIRoute({
-    name: "OTel Traces",
-    querySchema: z.any(),
-    responseSchema: z.any(),
-    rateLimitResource: "ingestion",
-    fn: async ({ req, res, auth }) => {
-      // Check if ingestion is suspended due to usage threshold
-      if (auth.scope.isIngestionSuspended) {
-        throw new ForbiddenError(
-          "Ingestion suspended: Usage threshold exceeded. Please upgrade your plan.",
-        );
-      }
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  // Capture Content-Type early so all responses respect it
+  const contentType: OtelContentType = getOtelContentType(
+    req.headers["content-type"],
+  );
 
-      // Mark project as using OTEL API
-      await markProjectAsOtelUser(auth.scope.projectId);
+  try {
+    // CORS handling
+    await runMiddleware(req, res, cors);
 
-      let body: Buffer;
+    // Handle preflight OPTIONS request
+    if (req.method === "OPTIONS") {
+      res.status(200).end();
+      return;
+    }
+
+    // Method check
+    if (req.method !== "POST") {
+      return sendOtelErrorResponse({
+        res,
+        contentType,
+        statusCode: 405,
+        message: "Method not allowed",
+      });
+    }
+
+    // Validate Content-Type header for POST requests
+    const requestContentType = req.headers["content-type"]?.toLowerCase();
+    if (
+      !requestContentType ||
+      (!requestContentType.includes("application/json") &&
+        !requestContentType.includes("application/x-protobuf"))
+    ) {
+      logger.error(`Invalid content type: ${requestContentType}`);
+      return sendOtelErrorResponse({
+        res,
+        contentType,
+        statusCode: 400,
+        message: "Invalid content type",
+      });
+    }
+
+    // Authentication using ApiAuthService
+    const authCheck = await new ApiAuthService(
+      prisma,
+      redis,
+    ).verifyAuthHeaderAndReturnScope(req.headers.authorization);
+
+    if (!authCheck.validKey) {
+      throw new UnauthorizedError(authCheck.error);
+    }
+
+    // Verify project-scoped access
+    if (
+      authCheck.scope.accessLevel !== "project" ||
+      !authCheck.scope.projectId
+    ) {
+      throw new ForbiddenError(
+        "Access denied: OTEL ingestion requires project-scoped API keys with BasicAuth",
+      );
+    }
+
+    // Check if ingestion is suspended due to usage threshold
+    if (authCheck.scope.isIngestionSuspended) {
+      throw new ForbiddenError(
+        "Ingestion suspended: Usage threshold exceeded. Please upgrade your plan.",
+      );
+    }
+
+    // Rate limiting
+    const rateLimitCheck =
+      await RateLimitService.getInstance().rateLimitRequest(
+        authCheck.scope,
+        "ingestion",
+      );
+
+    if (rateLimitCheck?.isRateLimited()) {
+      return rateLimitCheck.sendRestResponseIfLimited(res);
+    }
+
+    // Mark project as using OTEL API
+    await markProjectAsOtelUser(authCheck.scope.projectId);
+
+    // Read request body
+    let body: Buffer;
+    try {
+      body = await new Promise((resolve, reject) => {
+        const data: Buffer[] = [];
+        req.on("data", (chunk) => data.push(chunk));
+        req.on("end", () => resolve(Buffer.concat(data)));
+        req.on("error", reject);
+      });
+    } catch (e) {
+      logger.error(`Failed to read request body`, e);
+      return sendOtelErrorResponse({
+        res,
+        contentType,
+        statusCode: 400,
+        message: "Failed to read request body",
+      });
+    }
+
+    // Handle gzip compression
+    if (req.headers["content-encoding"]?.includes("gzip")) {
       try {
         body = await new Promise((resolve, reject) => {
-          let data: any[] = [];
-          req.on("data", (chunk) => data.push(chunk));
-          req.on("end", () => resolve(Buffer.concat(data)));
-          req.on("error", reject);
+          gunzip(new Uint8Array(body), (err, result) =>
+            err ? reject(err) : resolve(result),
+          );
         });
       } catch (e) {
-        logger.error(`Failed to read request body`, e);
-        res.status(400);
-        return { error: "Failed to read request body" };
+        logger.error(`Failed to decompress request body`, e);
+        return sendOtelErrorResponse({
+          res,
+          contentType,
+          statusCode: 400,
+          message: "Failed to decompress request body",
+        });
       }
+    }
 
-      if (req.headers["content-encoding"]?.includes("gzip")) {
-        try {
-          body = await new Promise((resolve, reject) => {
-            gunzip(new Uint8Array(body), (err, result) =>
-              err ? reject(err) : resolve(result),
-            );
-          });
-        } catch (e) {
-          logger.error(`Failed to decompress request body`, e);
-          res.status(400);
-          return { error: "Failed to decompress request body" };
-        }
+    // Parse the body based on Content-Type
+    let resourceSpans: any;
+    if (requestContentType.includes("application/x-protobuf")) {
+      try {
+        const parsed =
+          $root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest.decode(
+            body,
+          );
+        resourceSpans =
+          $root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest.toObject(
+            parsed,
+          ).resourceSpans;
+      } catch (e) {
+        logger.error(`Failed to parse OTel Protobuf`, e);
+        return sendOtelErrorResponse({
+          res,
+          contentType,
+          statusCode: 400,
+          message: "Failed to parse OTel Protobuf Trace",
+        });
       }
+    } else if (requestContentType.includes("application/json")) {
+      try {
+        resourceSpans = JSON.parse(body.toString()).resourceSpans;
+      } catch (e) {
+        logger.error(`Failed to parse OTel JSON`, e);
+        return sendOtelErrorResponse({
+          res,
+          contentType,
+          statusCode: 400,
+          message: "Failed to parse OTel JSON Trace",
+        });
+      }
+    }
 
-      let resourceSpans: any;
-      const contentType = req.headers["content-type"]?.toLowerCase();
-      // Strict content-type matching does not work if something like `content-type: text/javascript; charset=utf-8` is sent.
-      if (
-        !contentType ||
-        (!contentType.includes("application/json") &&
-          !contentType.includes("application/x-protobuf"))
-      ) {
-        logger.error(`Invalid content type: ${contentType}`);
-        res.status(400);
-        return { error: "Invalid content type" };
-      }
-      if (contentType.includes("application/x-protobuf")) {
-        try {
-          const parsed =
-            $root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest.decode(
-              body,
-            );
-          resourceSpans =
-            $root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest.toObject(
-              parsed,
-            ).resourceSpans;
-        } catch (e) {
-          logger.error(`Failed to parse OTel Protobuf`, e);
-          res.status(400);
-          return { error: "Failed to parse OTel Protobuf Trace" };
-        }
-      }
-      if (contentType.includes("application/json")) {
-        try {
-          resourceSpans = JSON.parse(body.toString()).resourceSpans;
-        } catch (e) {
-          logger.error(`Failed to parse OTel JSON`, e);
-          res.status(400);
-          return { error: "Failed to parse OTel JSON Trace" };
-        }
-      }
+    // Handle empty resourceSpans
+    if (
+      !resourceSpans ||
+      (Array.isArray(resourceSpans) && resourceSpans.length === 0)
+    ) {
+      return sendOtelTraceResponse({ res, contentType });
+    }
 
-      if (!resourceSpans || resourceSpans.length === 0) {
-        return {};
-      }
+    // Process the spans
+    const processor = new OtelIngestionProcessor({
+      projectId: authCheck.scope.projectId,
+      publicKey: authCheck.scope.publicKey,
+    });
 
-      const processor = new OtelIngestionProcessor({
-        projectId: auth.scope.projectId,
-        publicKey: auth.scope.publicKey,
-      });
+    await processor.publishToOtelIngestionQueue(resourceSpans);
 
-      // At this point, we have the raw OpenTelemetry Span body. We upload the full batch to S3
-      // and the OtelIngestionProcessor logic will handle processing in the worker container.
-      return processor.publishToOtelIngestionQueue(resourceSpans);
-    },
-  }),
-});
+    return sendOtelTraceResponse({ res, contentType });
+  } catch (error) {
+    logger.error("OTEL traces API route error", {
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+
+    // Determine appropriate HTTP status based on error type
+    let statusCode = 500;
+    let message = "Internal server error";
+
+    if (error instanceof UnauthorizedError) {
+      statusCode = 401;
+      message = error.message || "Unauthorized";
+    } else if (error instanceof ForbiddenError) {
+      statusCode = 403;
+      message = error.message || "Forbidden";
+    } else if (error instanceof Error) {
+      message = error.message;
+    }
+
+    return sendOtelErrorResponse({
+      res,
+      contentType,
+      statusCode,
+      message,
+    });
+  }
+}


### PR DESCRIPTION
Per the OTLP/HTTP specification, response encoding should match request encoding. Previously, the OTEL endpoints always returned JSON responses regardless of the request's Content-Type, causing deserialization failures for clients sending protobuf requests.

Changes:
- Refactor traces and metrics endpoints to use direct handlers instead of withMiddlewares/createAuthedProjectAPIRoute wrappers
- Add otelResponse.ts utility for Content-Type aware response handling
- Return application/x-protobuf responses for protobuf requests
- Return application/json responses for JSON requests
- Add comprehensive Content-Type compliance tests

Fixes #11550

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure OTEL endpoints return responses with matching Content-Type to requests, refactor endpoints to handle responses directly, and add comprehensive tests for compliance.
> 
>   - **Behavior**:
>     - Ensure OTEL endpoints return responses with matching Content-Type to requests (`application/json` or `application/x-protobuf`).
>     - Refactor traces and metrics endpoints to handle responses directly, bypassing middleware.
>     - Add `otelResponse.ts` for Content-Type aware response handling.
>   - **Tests**:
>     - Add `otel-api-content-type.servertest.ts` to verify Content-Type compliance for traces and metrics endpoints.
>   - **Endpoints**:
>     - Update `/api/public/otel/v1/metrics/index.ts` and `/api/public/otel/v1/traces/index.ts` to handle authentication, CORS, and rate limiting directly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 352ce9ded42c8c5e097a5dd62db3060e3a1ff1bd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->