### PR TITLE
fix(playground): allow saving new prompts after editing in playground

### DIFF
--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -207,7 +207,7 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
     formId,
     projectId: projectId ?? "",
     form,
-    enabled: Boolean(projectId),
+    enabled: Boolean(projectId) && !shouldLoadPlaygroundCache,
     onDraftRestored: (draft) => {
       // Restore chat messages if present
       if (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `usePlaygroundCache` for synchronous cache reading and update `NewPromptForm` to conditionally enable form persistence based on cache loading.
> 
>   - **Behavior**:
>     - Refactor `usePlaygroundCache` in `usePlaygroundCache.ts` to read cache synchronously and handle cache key changes with `useEffect`.
>     - Update `NewPromptForm` in `index.tsx` to conditionally enable form persistence based on `shouldLoadPlaygroundCache`.
>   - **Functions**:
>     - Add `readCache` function in `usePlaygroundCache.ts` for synchronous cache reading.
>     - Modify `setPlaygroundCache` in `usePlaygroundCache.ts` to use `cacheKey` directly.
>   - **Misc**:
>     - Change `enabled` condition in `useFormPersistence` in `index.tsx` to include `!shouldLoadPlaygroundCache`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6c5631562bafaec41b502d0c56cfd5a4c9e1a7cd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->