### PR TITLE
fix: allow using commentCount filter in batch export

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -11,6 +11,7 @@ export * from "./services/PromptService/types";
 export * from "./services/traces-ui-table-service";
 export * from "./services/InMemoryFilterService";
 export * from "./services/DatasetService";
+export * from "./services/commentFilterService";
 export * from "./datasets/schemaValidation";
 export * from "./datasets/schemaTypes";
 export * from "./evalJobConfigCache";

--- a/packages/shared/src/server/services/commentFilterService.ts
+++ b/packages/shared/src/server/services/commentFilterService.ts
@@ -1,13 +1,12 @@
-import type { PrismaClient } from "@langfuse/shared/src/db";
-import { type singleFilter } from "@langfuse/shared";
+import type { PrismaClient } from "../../db";
+import { type singleFilter } from "../../interfaces/filters";
 import {
   type CommentObjectType,
   type CommentCountOperator,
   type CommentContentOperator,
   getObjectIdsByCommentCount,
   getObjectIdsByCommentContent,
-} from "@langfuse/shared/src/server";
-import { TRPCError } from "@trpc/server";
+} from "../repositories/comments";
 import type { z } from "zod/v4";
 
 /**
@@ -27,10 +26,9 @@ export function validateObjectIdCount(
 ): void {
   if (objectIds.length > COMMENT_FILTER_THRESHOLD) {
     const objectTypePlural = objectType.toLowerCase() + "s";
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message: `Comment filter matches ${objectIds.length.toLocaleString()} ${objectTypePlural} (limit: ${COMMENT_FILTER_THRESHOLD.toLocaleString()}). Please add additional filters to narrow your search.`,
-    });
+    throw new Error(
+      `Comment filter matches ${objectIds.length.toLocaleString()} ${objectTypePlural} (limit: ${COMMENT_FILTER_THRESHOLD.toLocaleString()}). Please add additional filters to narrow your search.`,
+    );
   }
 }
 

--- a/web/src/server/api/routers/generations/getAllQueries.ts
+++ b/web/src/server/api/routers/generations/getAllQueries.ts
@@ -8,7 +8,7 @@ import {
   getObservationsTableCount,
 } from "@langfuse/shared/src/server";
 import { env } from "@/src/env.mjs";
-import { applyCommentFilters } from "@/src/features/comments/server/commentFilterHelpers";
+import { applyCommentFilters } from "@langfuse/shared/src/server";
 
 const GetAllGenerationsInput = GenerationTableOptions.extend({
   ...paginationZod,

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -1,7 +1,7 @@
 import { z } from "zod/v4";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
-import { applyCommentFilters } from "@/src/features/comments/server/commentFilterHelpers";
+import { applyCommentFilters } from "@langfuse/shared/src/server";
 import {
   createTRPCRouter,
   protectedGetSessionProcedure,

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -2,7 +2,7 @@ import { z } from "zod/v4";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
-import { applyCommentFilters } from "@/src/features/comments/server/commentFilterHelpers";
+import { applyCommentFilters } from "@langfuse/shared/src/server";
 import {
   createTRPCRouter,
   protectedGetTraceProcedure,

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -9,6 +9,7 @@ import {
   createTrace,
   createTracesCh,
   createManyDatasetItems,
+  applyCommentFilters,
 } from "@langfuse/shared/src/server";
 import { BatchExportTableName, DatasetStatus } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
@@ -2080,5 +2081,183 @@ describe("batch export test suite", () => {
       description: "اختبار اللغة العربية",
     });
     expect(arabicTrace?.tags).toEqual(["عربي"]);
+  });
+
+  it("should export sessions filtered by comment count", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    // Create sessions
+    const sessionWithComments = randomUUID();
+    const sessionWithoutComments = randomUUID();
+    await prisma.traceSession.createMany({
+      data: [
+        { id: sessionWithComments, projectId },
+        { id: sessionWithoutComments, projectId },
+      ],
+    });
+
+    // Create traces for sessions
+    const traces = [
+      createTrace({
+        project_id: projectId,
+        session_id: sessionWithComments,
+        id: randomUUID(),
+      }),
+      createTrace({
+        project_id: projectId,
+        session_id: sessionWithoutComments,
+        id: randomUUID(),
+      }),
+    ];
+    await createTracesCh(traces);
+
+    // Add comment to first session only
+    await prisma.comment.create({
+      data: {
+        projectId,
+        objectId: sessionWithComments,
+        objectType: "SESSION",
+        content: "Test comment for filtering",
+      },
+    });
+
+    // Apply comment filter preprocessing (mimics what handleBatchExportJob does)
+    const { filterState: processedFilter, hasNoMatches } =
+      await applyCommentFilters({
+        filterState: [
+          {
+            type: "number",
+            operator: ">=",
+            column: "commentCount",
+            value: 1,
+          },
+        ],
+        prisma,
+        projectId,
+        objectType: "SESSION",
+      });
+
+    expect(hasNoMatches).toBe(false);
+
+    // Export with processed filter
+    const stream = await getDatabaseReadStreamPaginated({
+      projectId,
+      tableName: BatchExportTableName.Sessions,
+      cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      filter: processedFilter,
+      orderBy: { column: "createdAt", order: "DESC" },
+    });
+
+    const rows: any[] = [];
+    for await (const chunk of stream) {
+      rows.push(chunk);
+    }
+
+    // Should only return the session with comments
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(sessionWithComments);
+  });
+
+  it("should return empty results when comment filter matches nothing", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    // Create sessions without any comments
+    const sessionId = randomUUID();
+    await prisma.traceSession.create({
+      data: { id: sessionId, projectId },
+    });
+
+    const trace = createTrace({
+      project_id: projectId,
+      session_id: sessionId,
+      id: randomUUID(),
+    });
+    await createTracesCh([trace]);
+
+    // Apply comment filter preprocessing - should match nothing
+    const { filterState: processedFilter, hasNoMatches } =
+      await applyCommentFilters({
+        filterState: [
+          {
+            type: "number",
+            operator: ">=",
+            column: "commentCount",
+            value: 1,
+          },
+        ],
+        prisma,
+        projectId,
+        objectType: "SESSION",
+      });
+
+    // Should indicate no matches
+    expect(hasNoMatches).toBe(true);
+  });
+
+  it("should export traces filtered by comment count", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    // Create traces
+    const traceWithComments = randomUUID();
+    const traceWithoutComments = randomUUID();
+
+    const traces = [
+      createTrace({
+        project_id: projectId,
+        id: traceWithComments,
+        name: "trace-with-comments",
+      }),
+      createTrace({
+        project_id: projectId,
+        id: traceWithoutComments,
+        name: "trace-without-comments",
+      }),
+    ];
+    await createTracesCh(traces);
+
+    // Add comment to first trace only
+    await prisma.comment.create({
+      data: {
+        projectId,
+        objectId: traceWithComments,
+        objectType: "TRACE",
+        content: "Test comment for trace filtering",
+      },
+    });
+
+    // Apply comment filter preprocessing
+    const { filterState: processedFilter, hasNoMatches } =
+      await applyCommentFilters({
+        filterState: [
+          {
+            type: "number",
+            operator: ">=",
+            column: "commentCount",
+            value: 1,
+          },
+        ],
+        prisma,
+        projectId,
+        objectType: "TRACE",
+      });
+
+    expect(hasNoMatches).toBe(false);
+
+    // Export with processed filter
+    const stream = await getTraceStream({
+      projectId,
+      cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      filter: processedFilter,
+    });
+
+    const rows: any[] = [];
+    for await (const chunk of stream) {
+      rows.push(chunk);
+    }
+
+    // Should only return the trace with comments
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(traceWithComments);
+    expect(rows[0].name).toBe("trace-with-comments");
   });
 });


### PR DESCRIPTION
Fixes https://github.com/langfuse/langfuse/issues/11577
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable `commentCount` filter in batch export by integrating `applyCommentFilters` function, supporting `SESSION`, `TRACE`, and `OBSERVATION` types, with tests added for validation.
> 
>   - **Behavior**:
>     - Enable `commentCount` filter in batch export by integrating `applyCommentFilters` in `handleBatchExportJob`.
>     - Supports filtering for `SESSION`, `TRACE`, and `OBSERVATION` object types.
>     - If no matches are found, returns empty results.
>   - **Functionality**:
>     - Add `applyCommentFilters` function in `commentFilterService.ts` to process comment filters and return updated filter state.
>     - Handles both comment count and content filters.
>   - **Tests**:
>     - Add tests in `batchExport.test.ts` for sessions and traces filtered by comment count.
>     - Ensure correct behavior when no matches are found.
>   - **Refactoring**:
>     - Rename `commentFilterHelpers.ts` to `commentFilterService.ts` and move to `packages/shared/src/server/services/`.
>     - Update imports in `getAllQueries.ts`, `sessions.ts`, and `traces.ts` to use new path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a533c7bead9afe8d5493764db8ca7297dc45b589. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->