### PR TITLE
fix(app): fix scrolling behavior in chrome v144 and later

### DIFF
--- a/web/src/components/editor/CodeMirrorEditor.tsx
+++ b/web/src/components/editor/CodeMirrorEditor.tsx
@@ -211,11 +211,6 @@ export function CodeMirrorEditor({
           "&.cm-focused": {
             outline: "none",
           },
-          // Override global overscroll-behavior-y: none to allow scroll propagation
-          // to parent. Required for Chrome 144+ (see globals.css).
-          ".cm-scroller": {
-            overscrollBehavior: "auto",
-          },
         }),
         // Hide gutter when lineNumbers is false
         // Fix missing gutter border
@@ -254,9 +249,7 @@ export function CodeMirrorEditor({
       }}
       onBlur={onBlur}
       className={cn(
-        // overscroll-y-auto overrides global overscroll-behavior-y: none to allow
-        // scroll propagation to parent. Required for Chrome 144+ (see globals.css).
-        "overflow-hidden overflow-y-auto overscroll-y-auto rounded-md border text-xs",
+        "overflow-hidden overflow-y-auto rounded-md border text-xs",
         className,
       )}
       editable={editable}

--- a/web/src/components/layouts/app-layout/components/ResizableContent.tsx
+++ b/web/src/components/layouts/app-layout/components/ResizableContent.tsx
@@ -59,9 +59,7 @@ export function ResizableContent({ children }: PropsWithChildren) {
   if (!isDesktop) {
     return (
       <>
-        <main className="h-full flex-1" style={{ overscrollBehaviorY: "none" }}>
-          {children}
-        </main>
+        <main className="h-full flex-1">{children}</main>
 
         <Drawer open={open} onOpenChange={setOpen} forceDirection="bottom">
           <DrawerContent
@@ -92,10 +90,7 @@ export function ResizableContent({ children }: PropsWithChildren) {
   return (
     <ResizablePanelGroup direction="horizontal" className="flex h-full w-full">
       <ResizablePanel ref={mainPanelRef} defaultSize={100} minSize={30}>
-        <main
-          className="relative h-full w-full overflow-scroll"
-          style={{ overscrollBehaviorY: "none" }}
-        >
+        <main className="relative h-full w-full overflow-scroll">
           {children}
         </main>
       </ResizablePanel>

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -186,6 +186,11 @@
 @layer base {
   * {
     @apply border-border;
+  }
+
+  html,
+  body {
+    /* Prevent pull-to-refresh and rubber-banding on the page level only */
     overscroll-behavior-y: none;
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes scrolling behavior in Chrome v144+ by removing unnecessary overscroll CSS properties in `CodeMirrorEditor.tsx`, `ResizableContent.tsx`, and `globals.css`.
> 
>   - **Behavior**:
>     - Removes `overscrollBehavior: auto` from `.cm-scroller` in `CodeMirrorEditor.tsx`.
>     - Removes `overscrollBehaviorY: none` from `main` elements in `ResizableContent.tsx`.
>     - Ensures `overscroll-behavior-y: none` is applied only at the page level in `globals.css`.
>   - **Misc**:
>     - Removes redundant `overscroll-y-auto` class from `CodeMirrorEditor.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ed3009a4c6494bf3061ad77d3377762479db25a5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->