### PR TITLE
fix(CI): only release tagged versions as docker images on hub

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -705,7 +705,7 @@ jobs:
   push-docker-image:
     needs: all-ci-passed
     # if something inside all-ci-passed was skipped, but everything that ran passed, we still want to deploy
-    if: always() && needs.all-ci-passed.outputs.success == 'true' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    if: always() && needs.all-ci-passed.outputs.success == 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     environment: "protected branches"
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify CI/CD workflow to release Docker images only on tag pushes, not on main branch pushes.
> 
>   - **CI/CD Workflow**:
>     - In `.github/workflows/pipeline.yml`, modify `push-docker-image` job condition to only release Docker images on tag pushes.
>     - Remove condition allowing Docker image release on `main` branch pushes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 514b71fcf6a878de59ab7c1bd5c2e5396f17cd6c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->