### PR TITLE
fix(json-path): parse primitive strings in json root

### DIFF
--- a/packages/shared/src/features/batchAction/applyFieldMapping.ts
+++ b/packages/shared/src/features/batchAction/applyFieldMapping.ts
@@ -5,6 +5,7 @@ import type {
   SourceField,
   AddToDatasetMapping,
 } from "./addToDatasetTypes";
+import { parseJsonPrioritised } from "../../utils/json";
 
 type ObservationData = {
   input: unknown;
@@ -37,12 +38,14 @@ export function testJsonPath(props: { jsonPath: string; data: unknown }): {
  */
 export function evaluateJsonPath(data: unknown, jsonPath: string): unknown {
   try {
-    const parsed = typeof data === "string" ? JSON.parse(data) : data;
-    const results = JSONPath({ path: jsonPath, json: parsed });
+    const parsed = typeof data === "string" ? parseJsonPrioritised(data) : data;
+    const result = JSONPath({
+      path: jsonPath,
+      json: parsed as string | object,
+      wrap: false,
+    });
 
-    if (!results) return;
-
-    return results.length > 1 ? results : results[0];
+    return result;
   } catch {
     return undefined;
   }

--- a/worker/src/__tests__/applyFieldMapping.test.ts
+++ b/worker/src/__tests__/applyFieldMapping.test.ts
@@ -74,6 +74,11 @@ describe("applyFieldMapping", () => {
   });
 
   describe("evaluateJsonPath", () => {
+    it("should return the full object if on root '$' and object is string", () => {
+      const result = evaluateJsonPath("Hello", "$");
+      expect(result).toBe("Hello");
+    });
+
     it("should extract nested values using JSON path", () => {
       expect(
         evaluateJsonPath(sampleObservation.input, "$.messages[0].content"),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `evaluateJsonPath` now correctly handles primitive strings at the JSON root using `parseJsonPrioritised`, with updated tests to verify behavior.
> 
>   - **Behavior**:
>     - `evaluateJsonPath` in `applyFieldMapping.ts` now uses `parseJsonPrioritised` to handle primitive strings at the JSON root.
>     - Returns the full string if the JSON path is the root (`'$'`).
>   - **Tests**:
>     - Added test in `applyFieldMapping.test.ts` to verify `evaluateJsonPath` returns the full string for root path on primitive strings.
>     - Ensures correct handling of primitive strings and JSON objects.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3e5a5ea1321a9ce1eb05a4531598048611337a83. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->