### PR TITLE
Langfuse tokenizer deactivation

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -399,6 +399,12 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(2),
+
+  // Tokenizer configuration
+  // Set to "false" to disable Langfuse's built-in tokenizer for token counting.
+  // This is useful when your LLM provider or SDK (e.g., LiteLLM) already provides
+  // accurate token counts via the API, and you want to avoid double-counting.
+  LANGFUSE_TOKENIZER_ENABLED: z.enum(["true", "false"]).default("true"),
 });
 
 export const env: z.infer<typeof EnvSchema> =

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -53,6 +53,7 @@ import {
 
 import { tokenCountAsync } from "../../features/tokenisation/async-usage";
 import { tokenCount } from "../../features/tokenisation/usage";
+import { env } from "../../env";
 import { ClickhouseWriter, TableName } from "../ClickhouseWriter";
 import {
   convertJsonSchemaToRecord,
@@ -1229,6 +1230,8 @@ export class IngestionService {
 
     if (
       // Manual tokenisation when no user provided usage and generation has not status ERROR
+      // Can be disabled globally via LANGFUSE_TOKENIZER_ENABLED=false
+      env.LANGFUSE_TOKENIZER_ENABLED === "true" &&
       model &&
       Object.keys(providedUsageDetails).length === 0 &&
       observationRecord.level !== ObservationLevel.ERROR


### PR DESCRIPTION
## What does this PR do?

This PR introduces the `LANGFUSE_TOKENIZER_ENABLED` environment variable, allowing users to globally disable Langfuse's built-in tokenizer. This prevents double-counting of tokens when usage details are already provided by the LLM provider or SDK (e.g., LiteLLM), ensuring accurate token reporting.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- [x] I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- [x] I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

---
<a href="https://cursor.com/background-agent?bcId=bc-8de97c1a-910c-4590-96c6-0f0cbbab0e67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8de97c1a-910c-4590-96c6-0f0cbbab0e67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

