### PR TITLE
fix: avoid potentialy expensive JSON.stringify when debug logging is disabled

### DIFF
--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -719,9 +719,11 @@ export const evaluate = async ({
     variableMapping: parsedVariableMapping,
   });
 
-  logger.debug(
-    `Evaluating job ${event.jobExecutionId} extracted variables ${JSON.stringify(mappingResult)} `,
-  );
+  if (logger.isLevelEnabled("debug")) {
+    logger.debug(
+      `Evaluating job ${event.jobExecutionId} extracted variables ${JSON.stringify(mappingResult)} `,
+    );
+  }
 
   // Get environment from trace or observation variables
   const environment = mappingResult.find((r) => r.environment)?.environment;
@@ -830,9 +832,11 @@ export const evaluate = async ({
     );
   }
 
-  logger.debug(
-    `Evaluating job ${event.jobExecutionId} Parsed LLM output ${JSON.stringify(parsedLLMOutput)}`,
-  );
+  if (logger.isLevelEnabled("debug")) {
+    logger.debug(
+      `Evaluating job ${event.jobExecutionId} Parsed LLM output ${JSON.stringify(parsedLLMOutput)}`,
+    );
+  }
 
   const baseScore = {
     id: scoreId,
@@ -1126,9 +1130,11 @@ export const parseDatabaseRowToString = (
   let jsonSelectedColumn;
 
   if (mapping.jsonSelector) {
-    logger.debug(
-      `Parsing JSON for json selector ${mapping.jsonSelector} from ${JSON.stringify(selectedColumn)}`,
-    );
+    if (logger.isLevelEnabled("debug")) {
+      logger.debug(
+        `Parsing JSON for json selector ${mapping.jsonSelector} from ${JSON.stringify(selectedColumn)}`,
+      );
+    }
 
     try {
       jsonSelectedColumn = JSONPath({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimizes debug logging in `evalService.ts` by avoiding `JSON.stringify` when debug logging is disabled.
> 
>   - **Behavior**:
>     - Avoids `JSON.stringify` in debug logs when debug level is not enabled in `evaluate()` and `parseDatabaseRowToString()` in `evalService.ts`.
>     - Checks `logger.isLevelEnabled("debug")` before logging JSON data.
>   - **Functions**:
>     - `evaluate()`: Checks debug level before logging `mappingResult` and `parsedLLMOutput`.
>     - `parseDatabaseRowToString()`: Checks debug level before logging `selectedColumn` JSON parsing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f0519fea8580e25e50e721ec1376c25d7f2777a3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->