### PR TITLE
feat(folders): add breadcrumb navigation for prompt and dataset detail pages

### DIFF
--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -61,6 +61,7 @@ import { CommentDrawerButton } from "@/src/features/comments/CommentDrawerButton
 import { Command, CommandInput } from "@/src/components/ui/command";
 import { renderRichPromptContent } from "@/src/features/prompts/components/prompt-content-utils";
 import { PromptVariableListPreview } from "@/src/features/prompts/components/PromptVariableListPreview";
+import { createBreadcrumbItems } from "@/src/features/folders/utils";
 
 const getPythonCode = (
   name: string,
@@ -275,6 +276,10 @@ export const PromptDetail = ({
       )
     : [];
 
+  const segments = promptName.split("/").filter((s) => s.trim());
+  const folderPath = segments.length > 1 ? segments.slice(0, -1).join("/") : "";
+  const breadcrumbItems = folderPath ? createBreadcrumbItems(folderPath) : [];
+
   return (
     <Page
       headerProps={{
@@ -292,6 +297,10 @@ export const PromptDetail = ({
             name: "Prompts",
             href: `/project/${projectId}/prompts/`,
           },
+          ...breadcrumbItems.map((item) => ({
+            name: item.name,
+            href: `/project/${projectId}/prompts?folder=${encodeURIComponent(item.folderPath)}`,
+          })),
         ],
         tabsProps: {
           tabs: getPromptTabs(projectId as string, promptName as string),

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
@@ -38,6 +38,7 @@ import { useEvaluatorDefaults } from "@/src/features/experiments/hooks/useEvalua
 import { useExperimentEvaluatorData } from "@/src/features/experiments/hooks/useExperimentEvaluatorData";
 import { EvaluatorForm } from "@/src/features/evals/components/evaluator-form";
 import useLocalStorage from "@/src/components/useLocalStorage";
+import { createBreadcrumbItems } from "@/src/features/folders/utils";
 
 export default function Dataset() {
   const router = useRouter();
@@ -149,6 +150,11 @@ export default function Dataset() {
     return values;
   }, []);
 
+  const datasetName = dataset.data?.name ?? "";
+  const segments = datasetName.split("/").filter((s) => s.trim());
+  const folderPath = segments.length > 1 ? segments.slice(0, -1).join("/") : "";
+  const breadcrumbItems = folderPath ? createBreadcrumbItems(folderPath) : [];
+
   return (
     <Page
       headerProps={{
@@ -156,6 +162,10 @@ export default function Dataset() {
         itemType: "DATASET",
         breadcrumb: [
           { name: "Datasets", href: `/project/${projectId}/datasets` },
+          ...breadcrumbItems.map((item) => ({
+            name: item.name,
+            href: `/project/${projectId}/datasets?folder=${encodeURIComponent(item.folderPath)}`,
+          })),
         ],
         help: dataset.data?.description
           ? {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds breadcrumb navigation to prompt and dataset detail pages, reflecting folder paths for improved navigation.
> 
>   - **Behavior**:
>     - Adds breadcrumb navigation to `PromptDetail` in `prompt-detail.tsx` and `Dataset` in `index.tsx`.
>     - Breadcrumbs reflect folder paths derived from `promptName` and `datasetName`.
>   - **Functions**:
>     - Utilizes `createBreadcrumbItems` to generate breadcrumb items from folder paths.
>   - **Misc**:
>     - Updates breadcrumb links to include folder paths in `PromptDetail` and `Dataset`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1303cb4401de38e62883d429b1104370b8f03eb7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->