### PR TITLE
fix(events-table-ui): move trace observation table to header

### DIFF
--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -124,6 +124,7 @@ interface DataTableToolbarProps<TData, TValue> {
   viewConfig?: TableViewConfig;
   filterWithAI?: boolean;
   className?: string;
+  viewModeToggle?: React.ReactNode;
 }
 
 export function DataTableToolbar<TData, TValue>({
@@ -149,6 +150,7 @@ export function DataTableToolbar<TData, TValue>({
   orderByState,
   viewConfig,
   filterWithAI = false,
+  viewModeToggle,
 }: DataTableToolbarProps<TData, TValue>) {
   const [searchString, setSearchString] = useState(
     searchConfig?.currentQuery ?? "",
@@ -315,6 +317,7 @@ export function DataTableToolbar<TData, TValue>({
             className="my-0 max-w-full overflow-x-auto"
           />
         )}
+        {viewModeToggle}
         {refreshConfig && (
           <DataTableRefreshButton
             onRefresh={refreshConfig.onRefresh}

--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -185,6 +185,7 @@ export function DataTableToolbar<TData, TValue>({
             )}
           </Button>
         )}
+        {viewModeToggle}
         {searchConfig && (
           <div className="flex max-w-[30rem] flex-shrink-0 items-stretch md:min-w-[24rem]">
             <div
@@ -317,7 +318,6 @@ export function DataTableToolbar<TData, TValue>({
             className="my-0 max-w-full overflow-x-auto"
           />
         )}
-        {viewModeToggle}
         {refreshConfig && (
           <DataTableRefreshButton
             onRefresh={refreshConfig.onRefresh}

--- a/web/src/features/events/components/EventsViewModeToggle.tsx
+++ b/web/src/features/events/components/EventsViewModeToggle.tsx
@@ -1,0 +1,28 @@
+import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
+import { type EventsViewMode } from "@/src/features/events/hooks/useEventsViewMode";
+
+export interface EventsViewModeToggleProps {
+  viewMode: EventsViewMode;
+  onViewModeChange: (mode: EventsViewMode) => void;
+}
+
+export function EventsViewModeToggle({
+  viewMode,
+  onViewModeChange,
+}: EventsViewModeToggleProps) {
+  return (
+    <Tabs
+      value={viewMode}
+      onValueChange={(value) => onViewModeChange(value as EventsViewMode)}
+    >
+      <TabsList className="h-8 p-0.5">
+        <TabsTrigger value="trace" className="h-7 px-2 text-xs">
+          Traces
+        </TabsTrigger>
+        <TabsTrigger value="observation" className="h-7 px-2 text-xs">
+          Observations
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/web/src/features/events/config/filter-config.ts
+++ b/web/src/features/events/config/filter-config.ts
@@ -28,11 +28,6 @@ export const observationEventsFilterConfig: FilterConfig = {
 
   facets: [
     {
-      type: "boolean" as const,
-      column: "hasParentObservation",
-      label: "Has Parent Observation",
-    },
-    {
       type: "categorical" as const,
       column: "environment",
       label: getEventsColumnName("environment"),

--- a/web/src/features/events/hooks/useEventsFilterOptions.ts
+++ b/web/src/features/events/hooks/useEventsFilterOptions.ts
@@ -5,11 +5,13 @@ import { type FilterState, type TimeFilter } from "@langfuse/shared";
 type UseEventsFilterOptionsParams = {
   projectId: string;
   oldFilterState: FilterState;
+  hasParentObservation?: boolean;
 };
 
 export function useEventsFilterOptions({
   projectId,
   oldFilterState,
+  hasParentObservation,
 }: UseEventsFilterOptionsParams) {
   // Extract start time filters for filter options query
   const startTimeFilters = useMemo(() => {
@@ -26,6 +28,7 @@ export function useEventsFilterOptions({
       projectId,
       startTimeFilter:
         startTimeFilters.length > 0 ? startTimeFilters : undefined,
+      hasParentObservation,
     },
     {
       trpc: {
@@ -37,6 +40,9 @@ export function useEventsFilterOptions({
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
       staleTime: Infinity,
+      // Keep showing previous options while fetching new ones to avoid sidebar flicker
+      // TODO: maybe remove b/c unnecessary?
+      placeholderData: (prev) => prev,
     },
   );
 

--- a/web/src/features/events/hooks/useEventsViewMode.ts
+++ b/web/src/features/events/hooks/useEventsViewMode.ts
@@ -1,0 +1,39 @@
+import { useQueryParams, StringParam, withDefault } from "use-query-params";
+import { useMemo } from "react";
+import useSessionStorage from "@/src/components/useSessionStorage";
+
+export type EventsViewMode = "observation" | "trace";
+
+export interface UseEventsViewModeOutput {
+  viewMode: EventsViewMode;
+  setViewMode: (mode: EventsViewMode) => void;
+}
+
+export function useEventsViewMode(projectId: string): UseEventsViewModeOutput {
+  const defaultMode: EventsViewMode = "trace";
+
+  const [storedViewMode, setStoredViewMode] = useSessionStorage<EventsViewMode>(
+    `eventsViewMode-${projectId}`,
+    defaultMode,
+  );
+
+  const [queryParams, setQueryParams] = useQueryParams({
+    viewMode: withDefault(StringParam, storedViewMode),
+  });
+
+  return useMemo(() => {
+    const rawMode = queryParams.viewMode;
+    const viewMode: EventsViewMode =
+      rawMode === "observation" || rawMode === "trace" ? rawMode : defaultMode;
+
+    const setViewMode = (mode: EventsViewMode) => {
+      setQueryParams({ viewMode: mode });
+      setStoredViewMode(mode);
+    };
+
+    return {
+      viewMode,
+      setViewMode,
+    };
+  }, [queryParams.viewMode, setQueryParams, setStoredViewMode]);
+}

--- a/web/src/features/events/hooks/useObservationListBeta.ts
+++ b/web/src/features/events/hooks/useObservationListBeta.ts
@@ -1,35 +1,10 @@
-import { useEffect } from "react";
-import { useRouter } from "next/router";
 import useLocalStorage from "@/src/components/useLocalStorage";
 
 export function useObservationListBeta() {
-  const router = useRouter();
   const [isBetaEnabled, setIsBetaEnabled] = useLocalStorage<boolean>(
     "observationListBetaEnabled",
     false,
   );
-
-  // Clear hasParentObservation filter whenever beta is OFF
-  useEffect(() => {
-    if (isBetaEnabled || !router.isReady) return;
-    const filter = router.query.filter as string | undefined;
-    if (!filter?.includes("hasParentObservation")) return;
-
-    const cleaned = filter
-      .split(",")
-      .filter((s) => !s.startsWith("hasParentObservation"));
-    void router.replace(
-      {
-        pathname: router.pathname,
-        query: {
-          ...router.query,
-          filter: cleaned.length ? cleaned.join(",") : undefined,
-        },
-      },
-      undefined,
-      { shallow: true },
-    );
-  }, [isBetaEnabled, router.isReady]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return { isBetaEnabled, setBetaEnabled: setIsBetaEnabled };
 }

--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -111,6 +111,7 @@ export const eventsRouter = createTRPCRouter({
       zodSchema.object({
         projectId: zodSchema.string(),
         startTimeFilter: zodSchema.array(timeFilter).optional(),
+        hasParentObservation: zodSchema.boolean().optional(),
       }),
     )
     .query(async ({ input }) => {
@@ -124,6 +125,7 @@ export const eventsRouter = createTRPCRouter({
           return getEventFilterOptions({
             projectId: input.projectId,
             startTimeFilter: input.startTimeFilter,
+            hasParentObservation: input.hasParentObservation,
           });
         },
       );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a view mode toggle to the events table for switching between 'trace' and 'observation' modes, affecting data filtering and display.
> 
>   - **Behavior**:
>     - Adds `EventsViewModeToggle` component to switch between 'trace' and 'observation' modes in `EventsTable.tsx`.
>     - Integrates `viewModeToggle` into `DataTableToolbar` in `data-table-toolbar.tsx`.
>     - `useEventsViewMode` hook manages view mode state with session storage and query parameters.
>     - `hasParentObservation` filter added based on view mode in `EventsTable.tsx`.
>     - Removes `hasParentObservation` filter from sidebar in `filter-config.ts`.
>   - **Server**:
>     - Updates `eventsRouter.ts` to handle `hasParentObservation` in filter options query.
>     - Modifies `getEventFilterOptions` in `eventsService.ts` to include `hasParentObservation` in filter.
>   - **Misc**:
>     - Adjusts beta toggle behavior in `traces.tsx` to clear `viewMode` when beta is disabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 19aeef7e060f090e54842ae65340d4c1944bed56. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->