### PR TITLE
chore: decrease data retention CH timeout

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -361,7 +361,7 @@ const EnvSchema = z.object({
   LANGFUSE_BATCH_DATA_RETENTION_CLEANER_DELETE_TIMEOUT_MS: z.coerce
     .number()
     .positive()
-    .default(10_800_000), // 3 hours for DELETE operations
+    .default(5_400_000), // 1.5 hours for DELETE operations
 
   // Media Retention Cleaner configuration (S3/PostgreSQL)
   LANGFUSE_MEDIA_RETENTION_CLEANER_ITEM_LIMIT: z.coerce


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Decrease default timeout for `LANGFUSE_BATCH_DATA_RETENTION_CLEANER_DELETE_TIMEOUT_MS` from 3 hours to 1.5 hours in `worker/src/env.ts`.
> 
>   - **Behavior**:
>     - Decrease default timeout for `LANGFUSE_BATCH_DATA_RETENTION_CLEANER_DELETE_TIMEOUT_MS` from 3 hours to 1.5 hours in `worker/src/env.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f2c15e64afe035a153d9e2ef284194ba36792812. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->