### PR TITLE
fix: move more logger.debug with JSON stringify under if debug

### DIFF
--- a/packages/shared/src/server/ingestion/modelMatch.ts
+++ b/packages/shared/src/server/ingestion/modelMatch.ts
@@ -32,7 +32,9 @@ export async function findModel(p: ModelMatchProps): Promise<ModelWithPrices> {
       traceScope: "model-match",
     },
     async (span) => {
-      logger.debug(`Finding model for ${JSON.stringify(p)}`);
+      if (logger.isLevelEnabled("debug")) {
+        logger.debug(`Finding model for ${JSON.stringify(p)}`);
+      }
       const cachedResult = await getModelWithPricesFromRedis(p);
       if (cachedResult) {
         span.setAttribute("model_match_source", "redis");

--- a/worker/src/features/entityChange/entityChangeWorker.ts
+++ b/worker/src/features/entityChange/entityChangeWorker.ts
@@ -12,10 +12,12 @@ export const entityChangeWorker = async (
   event: EntityChangeEventType,
 ): Promise<void> => {
   try {
-    logger.debug(
-      `Processing entity change event for entity ${event.entityType}`,
-      { event: JSON.stringify(event, null, 2) },
-    );
+    if (logger.isLevelEnabled("debug")) {
+      logger.debug(
+        `Processing entity change event for entity ${event.entityType}`,
+        { event: JSON.stringify(event, null, 2) },
+      );
+    }
 
     const span = getCurrentSpan();
 

--- a/worker/src/queues/entityChangeQueue.ts
+++ b/worker/src/queues/entityChangeQueue.ts
@@ -5,12 +5,14 @@ import { entityChangeWorker } from "../features/entityChange/entityChangeWorker"
 export const entityChangeQueueProcessor = async (
   job: Job<TQueueJobTypes[QueueName.EntityChangeQueue]>,
 ) => {
-  logger.debug(
-    `Processing entity change event for entity ${job.data.payload.entityType}, event: ${JSON.stringify(
-      job.data,
-      null,
-      2,
-    )}`,
-  );
+  if (logger.isLevelEnabled("debug")) {
+    logger.debug(
+      `Processing entity change event for entity ${job.data.payload.entityType}, event: ${JSON.stringify(
+        job.data,
+        null,
+        2,
+      )}`,
+    );
+  }
   return await entityChangeWorker(job.data.payload);
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Wrap `logger.debug` calls with debug level checks to avoid unnecessary `JSON.stringify` in `modelMatch.ts`, `entityChangeWorker.ts`, and `entityChangeQueue.ts`.
> 
>   - **Logging Optimization**:
>     - In `modelMatch.ts`, `entityChangeWorker.ts`, and `entityChangeQueue.ts`, wrap `logger.debug` calls with `if (logger.isLevelEnabled("debug"))` to avoid unnecessary `JSON.stringify` when debug logging is disabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 59fea65ce5c948336bb97940e7780aecf7606e95. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->