### PR TITLE
chore: add detailed logging for QueryBuilderError on invalid filter columns

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/factory.ts
@@ -140,9 +140,15 @@ const matchAndVerifyTracesUiColumn = (
   );
 
   if (!uiTable) {
-    throw new QueryBuilderError(
-      `Column ${filter.column} does not match a UI / CH table mapping.`,
-    );
+    const errorMessage = `Column ${filter.column} does not match a UI / CH table mapping.`;
+    logger.error(errorMessage, {
+      filterColumn: filter.column,
+      filterType: filter.type,
+      availableColumns: uiTableDefinitions.map(
+        (col) => col.uiTableId ?? col.uiTableName,
+      ),
+    });
+    throw new QueryBuilderError(errorMessage);
   }
 
   if (!isValidTableName(uiTable.clickhouseTableName)) {


### PR DESCRIPTION
## Summary
- Adds enhanced error logging when a filter column doesn't match any UI/CH table mapping in `QueryBuilderError`
- The log now includes the invalid column name, filter type, and all available columns for the target table
- Helps diagnose issues where filters from one table are accidentally sent to a different table's endpoint (e.g., `score_categories` filter sent to the scores endpoint)

## Context
When investigating a `QueryBuilderError` in production, the error logs only showed `{"cause":{"name":"QueryBuilderError"}}` without the actual error message. This change ensures the full context is logged before throwing the error.

Example new log output:
```json
{
  "level": "error",
  "message": "Column score_categories does not match a UI / CH table mapping.",
  "filterColumn": "score_categories",
  "filterType": "categoryOptions",
  "availableColumns": ["id", "timestamp", "environment", "traceId", ...]
}
```

## Test plan
- [ ] Verify build succeeds (`pnpm --filter=@langfuse/shared run build`)
- [ ] Manually test by sending an invalid filter column to an endpoint and checking logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)