### PR TITLE
fix(evals): support adding filters in llm as a judge

### DIFF
--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -277,9 +277,17 @@ export function InlineFilterBuilder({
     useState<WipFilterState>(filterState);
 
   // sync filter state, e.g. when we exclude default LF filters on score creation to reflect in UI
+  // Only sync if we don't have any WIP (invalid) filters, to avoid overwriting user's work-in-progress
   useEffect(() => {
-    _setWipFilterState(filterState);
-  }, [filterState]);
+    const hasWipFilters = wipFilterState.some(
+      (f) => !singleFilter.safeParse(f).success,
+    );
+
+    // Don't sync if we have WIP filters - user is actively editing
+    if (!hasWipFilters) {
+      _setWipFilterState(filterState);
+    }
+  }, [filterState, wipFilterState]);
 
   const setWipFilterState = (
     state: ((prev: WipFilterState) => WipFilterState) | WipFilterState,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevent overwriting WIP filters in `InlineFilterBuilder` by checking for invalid filters before syncing states.
> 
>   - **Behavior**:
>     - In `InlineFilterBuilder`, prevent syncing `wipFilterState` with `filterState` if there are invalid filters, avoiding overwriting user's WIP.
>   - **Functions**:
>     - Modify `useEffect` in `InlineFilterBuilder` to check for invalid filters using `singleFilter.safeParse()` before syncing states.
>   - **Misc**:
>     - Add `wipFilterState` dependency to `useEffect` in `InlineFilterBuilder` to ensure it checks current WIP filters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d323eae39489f49b64fe45a8d4c39a76e05a9bd4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->