### PR TITLE
fix(events-table): observation filter should show all events

### DIFF
--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -199,9 +199,8 @@ export default function ObservationsEventsTable({
   const { viewMode, setViewMode: setViewModeRaw } =
     useEventsViewMode(projectId);
 
-  // Convert view mode to hasParentObservation filter value
-  // trace = false (no parent), observation = true (has parent)
-  const hasParentObservation = viewMode === "observation";
+  // For filter options: trace mode filters to root items, observation mode shows all
+  const hasParentObservation = viewMode === "observation" ? undefined : false;
 
   // Wrap setViewMode to reset pagination when view mode changes
   const setViewMode = useCallback(
@@ -309,14 +308,17 @@ export default function ObservationsEventsTable({
   );
 
   // Create view mode filter (not shown in sidebar)
-  const viewModeFilter: FilterState = [
-    {
-      column: "hasParentObservation",
-      type: "boolean",
-      operator: "=",
-      value: hasParentObservation,
-    },
-  ];
+  const viewModeFilter: FilterState =
+    viewMode === "trace"
+      ? [
+          {
+            column: "hasParentObservation",
+            type: "boolean",
+            operator: "=",
+            value: false, // Only root-level items (no parent)
+          },
+        ]
+      : [];
 
   const filterState = queryFilter.filterState
     .concat(dateRangeFilter)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `ObservationsEventsTable` to show all events in observation mode by adjusting `hasParentObservation` filter logic.
> 
>   - **Behavior**:
>     - In `EventsTable.tsx`, changes `hasParentObservation` to `undefined` for observation mode, allowing all events to be shown.
>     - Updates `viewModeFilter` to apply only in trace mode, filtering to root items.
>   - **Comments**:
>     - Updates comments to clarify filter behavior for trace and observation modes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ba1ab9f0b11c8309fe93328713e10ca52ef6fea8. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->