### PR TITLE
fix(widgets): fix Add filter button not responding in InlineFilterBuilder

### DIFF
--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -289,7 +289,16 @@ export function InlineFilterBuilder({
       const validFilters = newState.filter(
         (f) => singleFilter.safeParse(f).success,
       ) as FilterState;
-      onChange(validFilters);
+
+      // Only call onChange if valid filters actually changed to avoid
+      // triggering the useEffect sync which would discard WIP filter rows
+      const prevValidFilters = prev.filter(
+        (f) => singleFilter.safeParse(f).success,
+      ) as FilterState;
+      if (JSON.stringify(validFilters) !== JSON.stringify(prevValidFilters)) {
+        onChange(validFilters);
+      }
+
       return newState;
     });
   };


### PR DESCRIPTION
## Summary
- Fixed the "Add filter" button in widget form not responding when clicked
- The issue was caused by a race condition where the `useEffect` sync was overwriting newly added empty filter rows
- Now only calls `onChange` when valid filters have actually changed, preventing unnecessary sync triggers

## Root Cause
When clicking "Add filter":
1. A new empty filter row was added to `wipFilterState`
2. `onChange` was called with valid filters (excluding the empty row)
3. This triggered the `useEffect` that syncs `wipFilterState` with `filterState`
4. The sync immediately removed the new empty row before it could render

## Test plan
- [ ] Open the widget form (create new widget or edit existing)
- [ ] Click "Add filter" button
- [ ] Verify a new empty filter row appears
- [ ] Fill in the filter details and verify it persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes 'Add filter' button in `InlineFilterBuilder` by ensuring `onChange` is only called when valid filters change, preventing race condition.
> 
>   - **Behavior**:
>     - Fixes 'Add filter' button in `InlineFilterBuilder` not responding due to race condition.
>     - `onChange` in `setWipFilterState` now only called if valid filters change, preventing `useEffect` from overwriting new empty filter rows.
>   - **Functions**:
>     - Modifies `setWipFilterState` in `InlineFilterBuilder` to compare `validFilters` and `prevValidFilters` before calling `onChange`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 962acfae556d50642fafc6167567e230d9abef64. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->