### PR TITLE
fix: update order by clauses to include project_id (sometimes drastically improves perf)

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/orderby-factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/orderby-factory.ts
@@ -2,6 +2,7 @@ import z from "zod/v4";
 import { OrderByState } from "../../../interfaces/orderBy";
 import { UiColumnMappings } from "../../../tableDefinitions";
 import { logger } from "../../logger";
+import type { OrderByDirection, OrderByEntry } from "./event-query-builder";
 
 type OrderByStateNotNull = Exclude<OrderByState, null>;
 
@@ -55,4 +56,55 @@ export function orderByToClickhouseSql(
 
   // Join all order by clauses with a comma and return
   return `ORDER BY ${orderByClauses.join(", ")}`;
+}
+
+/**
+ * Convert OrderByState to structured OrderByEntry array for use with BaseEventsQueryBuilder.
+ * Returns empty array if no valid orderBy is provided.
+ */
+export function orderByToEntries(
+  orderBy: OrderByState | OrderByState[] = [],
+  tableColumns: UiColumnMappings,
+): OrderByEntry[] {
+  if (
+    !orderBy ||
+    (Array.isArray(orderBy) && orderBy.filter(Boolean).length === 0)
+  ) {
+    return [];
+  }
+
+  if (!Array.isArray(orderBy)) {
+    orderBy = [orderBy];
+  }
+
+  const entries: OrderByEntry[] = [];
+
+  for (const ob of orderBy.filter((o): o is OrderByStateNotNull =>
+    Boolean(o),
+  )) {
+    const col = tableColumns.find(
+      (c) => c.uiTableName === ob.column || c.uiTableId === ob.column,
+    );
+
+    if (!col) {
+      logger.warn(`Invalid order by column: ${ob.column}`);
+      throw new Error("Invalid order by column: " + ob.column);
+    }
+
+    const orderByOrder = z.enum(["ASC", "DESC"]);
+    const order = orderByOrder.safeParse(ob.order);
+    if (!order.success) {
+      logger.warn(`Invalid order: ${ob.order}. Expected "ASC" or "DESC"`);
+      throw new Error("Invalid order: " + ob.order);
+    }
+
+    const column = `${col.queryPrefix ? col.queryPrefix + "." : ""}${col.clickhouseSelect}`;
+
+    entries.push({
+      column,
+      direction: order.data as OrderByDirection,
+    });
+  }
+
+  return entries;
 }

--- a/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
@@ -28,7 +28,7 @@ export const eventsTracesAggregation = (
       .selectFieldSet("all")
       .withTraceIds(params.traceIds)
       .withStartTimeFrom(params.startTimeFrom)
-      .orderBy("ORDER BY timestamp DESC")
+      .orderByColumns([{ column: "timestamp", direction: "DESC" }])
   );
 };
 

--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -18,7 +18,10 @@ export {
   NullFilter,
   type ClickhouseOperator,
 } from "./clickhouse-sql/clickhouse-filter";
-export { orderByToClickhouseSql } from "./clickhouse-sql/orderby-factory";
+export {
+  orderByToClickhouseSql,
+  orderByToEntries,
+} from "./clickhouse-sql/orderby-factory";
 export { createFilterFromFilterState } from "./clickhouse-sql/factory";
 export { clickhouseSearchCondition } from "./clickhouse-sql/search";
 export {

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -527,7 +527,7 @@ async function getObservationByIdFromEventsTableInternal({
     .when(Boolean(traceId), (b) =>
       b.whereRaw("trace_id = {traceId: String}", { traceId }),
     )
-    .orderBy("ORDER BY start_time DESC, event_ts DESC")
+    .orderBy("ORDER BY project_id DESC, start_time DESC, event_ts DESC")
     .limit(1, 0);
 
   const { query, params } = queryBuilder.buildWithParams();
@@ -763,7 +763,7 @@ function applyOrderByForObservationsQuery(
     queryBuilder
       // Order by to match table ordering
       .orderBy(
-        "ORDER BY e.start_time DESC, xxHash32(e.trace_id) DESC, e.span_id DESC",
+        "ORDER BY e.project_id DESC, e.start_time DESC, xxHash32(e.trace_id) DESC, e.span_id DESC",
       )
   );
 }
@@ -1128,7 +1128,7 @@ async function getTracesFromEventsTableForPublicApiInternal<T>(
       orderByToClickhouseSql(
         orderBy ? [orderBy] : [],
         TRACES_ORDER_BY_COLUMNS,
-      ) || "ORDER BY t.timestamp DESC";
+      ) || "ORDER BY t.project_id DESC, t.timestamp DESC";
 
     queryBuilder.orderBy(chOrderBy).limit(limit, (page - 1) * limit);
   }

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -18,6 +18,7 @@ import {
   FilterList,
   FullEventsObservations,
   orderByToClickhouseSql,
+  orderByToEntries,
   createPublicApiObservationsColumnMapping,
   createPublicApiTracesColumnMapping,
   deriveFilters,
@@ -357,7 +358,7 @@ async function getObservationsFromEventsTableInternal<T>(
   // TODO further optimize by checking if specific trace fields are filtered on.
   const needsTraceJoin = search.query;
 
-  const chOrderBy = orderByToClickhouseSql(
+  const orderByEntries = orderByToEntries(
     [orderBy ?? null],
     eventsTableUiColumnDefinitions,
   );
@@ -403,7 +404,7 @@ async function getObservationsFromEventsTableInternal<T>(
     )
     .where(appliedObservationsFilter)
     .where(search)
-    .orderBy(chOrderBy)
+    .when(orderByEntries.length > 0, (b) => b.orderByColumns(orderByEntries))
     .limit(limit, offset);
 
   const { query, params } = queryBuilder.buildWithParams();
@@ -527,7 +528,10 @@ async function getObservationByIdFromEventsTableInternal({
     .when(Boolean(traceId), (b) =>
       b.whereRaw("trace_id = {traceId: String}", { traceId }),
     )
-    .orderBy("ORDER BY project_id DESC, start_time DESC, event_ts DESC")
+    .orderByColumns([
+      { column: "start_time", direction: "DESC" },
+      { column: "event_ts", direction: "DESC" },
+    ])
     .limit(1, 0);
 
   const { query, params } = queryBuilder.buildWithParams();
@@ -762,9 +766,11 @@ function applyOrderByForObservationsQuery(
   return (
     queryBuilder
       // Order by to match table ordering
-      .orderBy(
-        "ORDER BY e.project_id DESC, e.start_time DESC, xxHash32(e.trace_id) DESC, e.span_id DESC",
-      )
+      .orderByColumns([
+        { column: "e.start_time", direction: "DESC" },
+        { column: "xxHash32(e.trace_id)", direction: "DESC" },
+        { column: "e.span_id", direction: "DESC" },
+      ])
   );
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimize query performance by updating ORDER BY clauses to include `project_id` in various query builders and functions.
> 
>   - **Behavior**:
>     - Add `orderByColumns()` method in `BaseEventsQueryBuilder` to prepend `project_id` to ORDER BY clauses for better ClickHouse performance.
>     - Introduce `orderByToEntries()` in `orderby-factory.ts` to convert `OrderByState` to `OrderByEntry` array.
>   - **Functions**:
>     - Update `getObservationsFromEventsTableInternal()` to use `orderByToEntries()` and `orderByColumns()`.
>     - Update `getObservationByIdFromEventsTableInternal()` to use `orderByColumns()`.
>   - **Misc**:
>     - Export `orderByToEntries` from `index.ts`.
>     - Modify `eventsTracesAggregation` in `query-fragments.ts` to use `orderByColumns()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for afdd6cf8dd06697068b6b765465b33b7f6995fd5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->