### PR TITLE
feat(slack): Move fetching Slack channels to background job

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -231,6 +231,11 @@ const EnvSchema = z.object({
     .describe(
       "How many records should be fetched from Slack, before we give up",
     ),
+  SLACK_CHANNELS_CACHE_TTL_SECONDS: z.coerce
+    .number()
+    .positive()
+    .default(300) // 5 minutes
+    .describe("TTL in seconds for caching Slack channels in Redis"),
   HTTPS_PROXY: z.string().optional(),
 
   LANGFUSE_SERVER_SIDE_IO_CHAR_LIMIT: z.coerce

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -82,6 +82,7 @@ export * from "./redis/entityChangeQueue";
 export * from "./redis/eventPropagationQueue";
 export * from "./redis/otelProjectTracking";
 export * from "./redis/s3SlowdownTracking";
+export * from "./redis/slackChannelFetchQueue";
 export * from "./auth/types";
 export * from "./queues";
 export * from "./orderByToPrisma";

--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -205,6 +205,13 @@ export const DeadLetterRetryQueueEventSchema = z.object({
   timestamp: z.date(),
 });
 
+export const SlackChannelFetchEventSchema = z.object({
+  projectId: z.string(),
+});
+export type SlackChannelFetchEventType = z.infer<
+  typeof SlackChannelFetchEventSchema
+>;
+
 export const NotificationEventSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("COMMENT_MENTION"),
@@ -324,6 +331,7 @@ export enum QueueName {
   EntityChangeQueue = "entity-change-queue",
   EventPropagationQueue = "event-propagation-queue",
   NotificationQueue = "notification-queue",
+  SlackChannelFetchQueue = "slack-channel-fetch-queue",
 }
 
 export enum QueueJobs {
@@ -360,6 +368,7 @@ export enum QueueJobs {
   EntityChangeJob = "entity-change-job",
   EventPropagationJob = "event-propagation-job",
   NotificationJob = "notification-job",
+  SlackChannelFetchJob = "slack-channel-fetch-job",
 }
 
 export type TQueueJobTypes = {
@@ -520,5 +529,11 @@ export type TQueueJobTypes = {
     id: string;
     payload: NotificationEventType;
     name: QueueJobs.NotificationJob;
+  };
+  [QueueName.SlackChannelFetchQueue]: {
+    timestamp: Date;
+    id: string;
+    payload: SlackChannelFetchEventType;
+    name: QueueJobs.SlackChannelFetchJob;
   };
 };

--- a/packages/shared/src/server/redis/getQueue.ts
+++ b/packages/shared/src/server/redis/getQueue.ts
@@ -30,6 +30,7 @@ import { EntityChangeQueue } from "./entityChangeQueue";
 import { DatasetDeleteQueue } from "./datasetDelete";
 import { EventPropagationQueue } from "./eventPropagationQueue";
 import { NotificationQueue } from "./notificationQueue";
+import { SlackChannelFetchQueue } from "./slackChannelFetchQueue";
 
 // IngestionQueue, OtelIngestionQueue, and TraceUpsert are sharded and require a sharding key
 // Use IngestionQueue.getInstance({ shardName: queueName }) or TraceUpsertQueue.getInstance({ shardName: queueName }) directly instead
@@ -102,6 +103,8 @@ export function getQueue(
       return EventPropagationQueue.getInstance();
     case QueueName.NotificationQueue:
       return NotificationQueue.getInstance();
+    case QueueName.SlackChannelFetchQueue:
+      return SlackChannelFetchQueue.getInstance();
     default: {
       const _exhaustiveCheckDefault: never = queueName;
       throw new Error(`Queue ${queueName} not found`);

--- a/packages/shared/src/server/redis/slackChannelFetchQueue.ts
+++ b/packages/shared/src/server/redis/slackChannelFetchQueue.ts
@@ -1,0 +1,50 @@
+import { Queue } from "bullmq";
+import { QueueName, TQueueJobTypes } from "../queues";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  getQueuePrefix,
+} from "./redis";
+import { logger } from "../logger";
+
+export class SlackChannelFetchQueue {
+  private static instance: Queue<
+    TQueueJobTypes[QueueName.SlackChannelFetchQueue]
+  > | null = null;
+
+  public static getInstance(): Queue<
+    TQueueJobTypes[QueueName.SlackChannelFetchQueue]
+  > | null {
+    if (SlackChannelFetchQueue.instance) return SlackChannelFetchQueue.instance;
+
+    const newRedis = createNewRedisInstance({
+      enableOfflineQueue: false,
+      ...redisQueueRetryOptions,
+    });
+
+    SlackChannelFetchQueue.instance = newRedis
+      ? new Queue<TQueueJobTypes[QueueName.SlackChannelFetchQueue]>(
+          QueueName.SlackChannelFetchQueue,
+          {
+            connection: newRedis,
+            prefix: getQueuePrefix(QueueName.SlackChannelFetchQueue),
+            defaultJobOptions: {
+              removeOnComplete: true,
+              removeOnFail: 1_000,
+              attempts: 3,
+              backoff: {
+                type: "exponential",
+                delay: 5000,
+              },
+            },
+          },
+        )
+      : null;
+
+    SlackChannelFetchQueue.instance?.on("error", (err) => {
+      logger.error("SlackChannelFetchQueue error", err);
+    });
+
+    return SlackChannelFetchQueue.instance;
+  }
+}

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -73,6 +73,7 @@ import { datasetDeleteProcessor } from "./queues/datasetDelete";
 import { otelIngestionQueueProcessor } from "./queues/otelIngestionQueue";
 import { eventPropagationProcessor } from "./queues/eventPropagationQueue";
 import { notificationQueueProcessor } from "./queues/notificationQueue";
+import { slackChannelFetchQueueProcessor } from "./queues/slackQueue";
 import { MutationMonitor } from "./features/mutation-monitoring/mutationMonitor";
 import {
   BatchProjectCleaner,
@@ -553,6 +554,16 @@ if (env.QUEUE_CONSUMER_NOTIFICATION_QUEUE_IS_ENABLED === "true") {
     notificationQueueProcessor,
     {
       concurrency: 5, // Process up to 5 notification jobs concurrently
+    },
+  );
+}
+
+if (env.QUEUE_CONSUMER_SLACK_CHANNEL_FETCH_QUEUE_IS_ENABLED === "true") {
+  WorkerManager.register(
+    QueueName.SlackChannelFetchQueue,
+    slackChannelFetchQueueProcessor,
+    {
+      concurrency: 5, // Process up to 5 Slack channel fetch jobs concurrently
     },
   );
 }

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -238,6 +238,9 @@ const EnvSchema = z.object({
   QUEUE_CONSUMER_NOTIFICATION_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])
     .default("true"),
+  QUEUE_CONSUMER_SLACK_CHANNEL_FETCH_QUEUE_IS_ENABLED: z
+    .enum(["true", "false"])
+    .default("true"),
 
   LANGFUSE_EVENT_PROPAGATION_WORKER_GLOBAL_CONCURRENCY: z.coerce
     .number()

--- a/worker/src/queues/slackQueue.ts
+++ b/worker/src/queues/slackQueue.ts
@@ -1,0 +1,46 @@
+import { Job } from "bullmq";
+
+import {
+  logger,
+  QueueName,
+  TQueueJobTypes,
+  SlackService,
+  cacheSlackChannels,
+  traceException,
+} from "@langfuse/shared/src/server";
+
+export const slackChannelFetchQueueProcessor = async (
+  job: Job<TQueueJobTypes[QueueName.SlackChannelFetchQueue]>,
+) => {
+  const { projectId } = job.data.payload;
+
+  try {
+    logger.info("Processing Slack channel fetch job", {
+      projectId,
+      jobId: job.id,
+    });
+
+    const slackService = SlackService.getInstance();
+    const client = await slackService.getWebClientForProject(projectId);
+    const channels = await slackService.getChannels(client);
+
+    // Store channels in Redis cache
+    await cacheSlackChannels(projectId, channels);
+
+    logger.info("Finished Slack channel fetch job", {
+      projectId,
+      jobId: job.id,
+      channelCount: channels.length,
+    });
+
+    return true;
+  } catch (error) {
+    logger.error("Failed Slack channel fetch job", {
+      error,
+      projectId,
+      jobId: job.id,
+    });
+    traceException(error);
+    throw error;
+  }
+};


### PR DESCRIPTION


## What does this PR do?
Moves slack channel fetching to background job, as for bigger orgs the channel list may be huge, the processing should be done inside a background job to avoid browser timeouts.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

