### PR TITLE
feat: introducing preferredClickhouseService: EventsReadOnly

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -46,6 +46,8 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres"
 # Clickhouse
 CLICKHOUSE_MIGRATION_URL="clickhouse://localhost:9000"
 CLICKHOUSE_URL="http://localhost:8123"
+# CLICKHOUSE_READ_ONLY_URL="http://localhost:8123"  # Optional: read replica for legacy tables
+# CLICKHOUSE_EVENTS_READ_ONLY_URL="http://localhost:8123"  # Optional: read replica for events table queries
 CLICKHOUSE_USER="clickhouse"
 CLICKHOUSE_PASSWORD="clickhouse"
 CLICKHOUSE_CLUSTER_ENABLED="false"

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -51,6 +51,7 @@ const EnvSchema = z.object({
   LANGFUSE_CACHE_PROMPT_TTL_SECONDS: z.coerce.number().default(300), // 5 minutes
   CLICKHOUSE_URL: z.string().url(),
   CLICKHOUSE_READ_ONLY_URL: z.string().url().optional(),
+  CLICKHOUSE_EVENTS_READ_ONLY_URL: z.string().url().optional(),
   CLICKHOUSE_CLUSTER_NAME: z.string().default("default"),
   CLICKHOUSE_DB: z.string().default("default"),
   CLICKHOUSE_USER: z.string(),

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -7,7 +7,10 @@ import { ClickHouseLogger, mapLogLevel } from "./clickhouse-logger";
 
 export type ClickhouseClientType = ReturnType<typeof createClient>;
 
-export type PreferredClickhouseService = "ReadWrite" | "ReadOnly";
+export type PreferredClickhouseService =
+  | "ReadWrite"
+  | "ReadOnly"
+  | "EventsReadOnly";
 
 /**
  * ClickHouseClientManager provides a singleton pattern for managing ClickHouse clients.
@@ -67,9 +70,19 @@ export class ClickHouseClientManager {
   private getClickhouseUrl = (
     preferredClickhouseService: PreferredClickhouseService,
   ) => {
-    return preferredClickhouseService === "ReadWrite"
-      ? env.CLICKHOUSE_URL
-      : env.CLICKHOUSE_READ_ONLY_URL || env.CLICKHOUSE_URL;
+    switch (preferredClickhouseService) {
+      case "ReadWrite":
+        return env.CLICKHOUSE_URL;
+      case "EventsReadOnly":
+        return (
+          env.CLICKHOUSE_EVENTS_READ_ONLY_URL ||
+          env.CLICKHOUSE_READ_ONLY_URL ||
+          env.CLICKHOUSE_URL
+        );
+      case "ReadOnly":
+      default:
+        return env.CLICKHOUSE_READ_ONLY_URL || env.CLICKHOUSE_URL;
+    }
   };
 
   /**

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -832,7 +832,7 @@ async function getObservationsRowsFromBuilder<T>(
         query,
         params: input.params,
         tags: input.tags,
-        preferredClickhouseService: "ReadOnly",
+        preferredClickhouseService: "EventsReadOnly",
       });
     },
   });
@@ -871,7 +871,7 @@ async function getObservationsCountFromEventsTableForPublicApiInternal(
         query,
         params: input.params,
         tags: input.tags,
-        preferredClickhouseService: "ReadOnly",
+        preferredClickhouseService: "EventsReadOnly",
       });
     },
   });
@@ -1158,7 +1158,7 @@ async function getTracesFromEventsTableForPublicApiInternal<T>(
         query,
         params: input.params,
         tags: input.tags,
-        preferredClickhouseService: "ReadOnly",
+        preferredClickhouseService: "EventsReadOnly",
       });
     },
   });
@@ -2139,7 +2139,7 @@ export const getObservationsBatchIOFromEventsTable = async (opts: {
       kind: "batchIO",
       projectId: opts.projectId,
     },
-    preferredClickhouseService: "ReadOnly",
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   return results.map((r) => ({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduce `EventsReadOnly` service type for Clickhouse to optimize read operations on events table.
> 
>   - **Environment Variables**:
>     - Add `CLICKHOUSE_EVENTS_READ_ONLY_URL` to `.env.dev.example` and `env.ts` for optional read replica for events table queries.
>   - **Type Definitions**:
>     - Add `EventsReadOnly` to `PreferredClickhouseService` in `client.ts`.
>   - **Functionality**:
>     - Update `getClickhouseUrl()` in `client.ts` to handle `EventsReadOnly` service.
>     - Change `preferredClickhouseService` to `EventsReadOnly` in `getObservationsRowsFromBuilder()`, `getObservationsCountFromEventsTableForPublicApiInternal()`, `getTracesFromEventsTableForPublicApiInternal()`, and `getObservationsBatchIOFromEventsTable()` in `events.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4ba32bf81df91b5ecfdb22e08fb011d0779992fc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->