### PR TITLE
fix: catch a few more events read replica cases

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -461,7 +461,7 @@ export const getObservationByIdFromEventsTable = async ({
     type,
     traceId,
     renderingProps,
-    preferredClickhouseService,
+    preferredClickhouseService: preferredClickhouseService ?? "EventsReadOnly",
   });
   const mapped = records.map((record) =>
     convertObservation(record, renderingProps),

--- a/web/src/pages/api/public/observations/[observationId].ts
+++ b/web/src/pages/api/public/observations/[observationId].ts
@@ -31,7 +31,6 @@ export default withMiddlewares({
             id: query.observationId,
             projectId: auth.scope.projectId,
             fetchWithInputOutput: true,
-            preferredClickhouseService: "ReadOnly",
           })
         : await getObservationById({
             id: query.observationId,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Default `preferredClickhouseService` to `EventsReadOnly` in `getObservationByIdFromEventsTable` and remove explicit service selection in `observations/[observationId].ts`.
> 
>   - **Behavior**:
>     - Default `preferredClickhouseService` to `EventsReadOnly` in `getObservationByIdFromEventsTable` in `events.ts`.
>     - Remove `preferredClickhouseService: "ReadOnly"` from `getObservationById` call in `observations/[observationId].ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 65cd6137b08dc1a94d3ec44a16d10db829f4b079. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->