### PR TITLE
chore(events-table): move obs switch

### DIFF
--- a/web/src/components/table/data-table-toolbar.tsx
+++ b/web/src/components/table/data-table-toolbar.tsx
@@ -185,7 +185,6 @@ export function DataTableToolbar<TData, TValue>({
             )}
           </Button>
         )}
-        {viewModeToggle}
         {searchConfig && (
           <div className="flex max-w-[30rem] flex-shrink-0 items-stretch md:min-w-[24rem]">
             <div
@@ -310,6 +309,7 @@ export function DataTableToolbar<TData, TValue>({
             )}
           </div>
         )}
+        {viewModeToggle}
         {timeRange && setTimeRange && (
           <TimeRangePicker
             timeRange={timeRange}

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -1145,11 +1145,12 @@ export default function ObservationsEventsTable({
             pageSize: paginationState.limit,
             pageIndex: paginationState.page - 1,
           }}
+          filterWithAI
         />
 
         {/* Content area with sidebar and table */}
         <ResizableFilterLayout>
-          <DataTableControls queryFilter={queryFilter} />
+          <DataTableControls queryFilter={queryFilter} filterWithAI />
 
           <div className="flex flex-1 flex-col overflow-hidden">
             <DataTable

--- a/web/src/features/events/components/EventsViewModeToggle.tsx
+++ b/web/src/features/events/components/EventsViewModeToggle.tsx
@@ -1,4 +1,11 @@
-import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/src/components/ui/dropdown-menu";
+import { Button } from "@/src/components/ui/button";
+import { ChevronDown } from "lucide-react";
 import { type EventsViewMode } from "@/src/features/events/hooks/useEventsViewMode";
 
 export interface EventsViewModeToggleProps {
@@ -6,23 +13,49 @@ export interface EventsViewModeToggleProps {
   onViewModeChange: (mode: EventsViewMode) => void;
 }
 
+const VIEW_MODE_OPTIONS: Record<
+  EventsViewMode,
+  { label: string; description: string }
+> = {
+  trace: {
+    label: "Traces",
+    description: "Root-level observations, the top nodes in a trace.",
+  },
+  observation: {
+    label: "Observations",
+    description: "All observations of all trace trees.",
+  },
+};
+
 export function EventsViewModeToggle({
   viewMode,
   onViewModeChange,
 }: EventsViewModeToggleProps) {
   return (
-    <Tabs
-      value={viewMode}
-      onValueChange={(value) => onViewModeChange(value as EventsViewMode)}
-    >
-      <TabsList className="h-8 p-0.5">
-        <TabsTrigger value="trace" className="h-7 px-2 text-xs">
-          Traces
-        </TabsTrigger>
-        <TabsTrigger value="observation" className="h-7 px-2 text-xs">
-          Observations
-        </TabsTrigger>
-      </TabsList>
-    </Tabs>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="h-8 gap-1">
+          {VIEW_MODE_OPTIONS[viewMode].label}
+          <ChevronDown className="h-4 w-4 opacity-50" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {(
+          Object.entries(VIEW_MODE_OPTIONS) as [
+            EventsViewMode,
+            { label: string; description: string },
+          ][]
+        ).map(([key, { label, description }]) => (
+          <DropdownMenuItem
+            key={key}
+            onClick={() => onViewModeChange(key)}
+            className="flex flex-col items-start"
+          >
+            <span>{label}</span>
+            <span className="text-xs text-muted-foreground">{description}</span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `EventsViewModeToggle` to use a dropdown menu and reposition it in `DataTableToolbar`, adding `filterWithAI` prop to relevant components.
> 
>   - **UI Changes**:
>     - Move `viewModeToggle` in `DataTableToolbar` from before `searchConfig` to after it.
>     - Update `EventsViewModeToggle` to use a dropdown menu instead of tabs.
>   - **Props and Functionality**:
>     - Add `filterWithAI` prop to `DataTableControls` and `DataTableToolbar` in `EventsTable.tsx`.
>     - Pass `filterWithAI` to `DataTableControls` in `EventsTable.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a398db80331d1cb9c95f87515d528db3686b38b9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->