### PR TITLE
fix(session): open user id link in new tab

### DIFF
--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -63,6 +63,8 @@ export function SessionUsers({
         <Link
           key={userId}
           href={`/project/${projectId}/users/${encodeURIComponent(userId ?? "")}`}
+          target="_blank"
+          rel="noopener noreferrer"
         >
           <Badge className="max-w-[300px]">
             <span className="truncate">User ID: {userId}</span>
@@ -92,6 +94,8 @@ export function SessionUsers({
                       key={userId}
                       href={`/project/${projectId}/users/${encodeURIComponent(userId ?? "")}`}
                       className="block hover:bg-accent"
+                      target="_blank"
+                      rel="noopener noreferrer"
                     >
                       <Badge className="max-w-[260px]">
                         <span className="truncate">User ID: {userId}</span>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> User ID links in `SessionUsers` now open in a new tab by adding `target="_blank"` and `rel="noopener noreferrer"`.
> 
>   - **Behavior**:
>     - In `SessionUsers` in `index.tsx`, user ID links now open in a new tab by adding `target="_blank"` and `rel="noopener noreferrer"` to `Link` components.
>     - Affects initial user links and remaining user links in popover.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e4a707e3b82338c8f6a776f495bee08d138da4d1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->