### PR TITLE
chore: add a secondary index to speed up media retention workload estimator

### DIFF
--- a/packages/shared/prisma/migrations/20260129183823_add_media_project_id_created_at_index/migration.sql
+++ b/packages/shared/prisma/migrations/20260129183823_add_media_project_id_created_at_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY "media_project_id_created_at_idx" ON "media"("project_id", "created_at");

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -1208,6 +1208,7 @@ model Media {
 
   @@unique([projectId, id])
   @@unique([projectId, sha256Hash])
+  @@index([projectId, createdAt])
   @@map("media")
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add a secondary index to the `Media` model to optimize media retention workload estimation queries.
> 
>   - **Database Index**:
>     - Adds a new index `media_project_id_created_at_idx` on `media` table for columns `project_id` and `created_at` in `migration.sql`.
>     - Updates `schema.prisma` to include `@@index([projectId, createdAt])` in `Media` model.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1454cead1776c66dd1d5e5139ad8e2086b05ad46. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->