### PR TITLE
fix(redis): add sentinelTLS support for Redis Sentinel mode

### DIFF
--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -153,6 +153,10 @@ const createRedisSentinelInstance = (
 
   const sentinels = parseSentinelNodes(env.REDIS_SENTINEL_NODES);
   const tlsOptions = buildTlsOptions();
+  const sentinelTlsOptions =
+    env.REDIS_TLS_ENABLED === "true"
+      ? { sentinelTLS: tlsOptions.tls, enableTLSForSentinelMode: true }
+      : {};
 
   const instance = new Redis({
     sentinels,
@@ -164,6 +168,7 @@ const createRedisSentinelInstance = (
     ...defaultRedisOptions,
     ...additionalOptions,
     ...tlsOptions,
+    ...sentinelTlsOptions,
   });
 
   instance.on("error", (error) => {


### PR DESCRIPTION
## What does this PR do?

Adds sentinelTLS configuration support for Redis Sentinel mode. Previously, TLS was only applied to Redis master/replica connections, not to Sentinel node connections, causing failures when Sentinels require TLS.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds TLS support for Redis Sentinel connections in `createRedisSentinelInstance()` in `redis.ts`.
> 
>   - **Behavior**:
>     - Adds `sentinelTLS` and `enableTLSForSentinelMode` options in `createRedisSentinelInstance()` in `redis.ts` to support TLS for Sentinel connections.
>     - Uses `buildTlsOptions()` to configure TLS settings for Sentinel nodes when `REDIS_TLS_ENABLED` is `true`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2bd392a3f9f34d782f3ee0d6d829db590393201c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->