### PR TITLE
fix: reset gauges in batch retention to prevent stale metrics

### DIFF
--- a/worker/src/features/media-retention-cleaner/index.ts
+++ b/worker/src/features/media-retention-cleaner/index.ts
@@ -64,6 +64,10 @@ export class MediaRetentionCleaner extends PeriodicExclusiveRunner {
    * Preflight and deletion are both under lock to avoid redundant expensive queries.
    */
   protected async execute(): Promise<void> {
+    // Reset gauge before attempting lock - ensures it doesn't appear stuck
+    // if another worker holds the lock
+    recordGauge(`${METRIC_PREFIX}.seconds_past_cutoff`, 0);
+
     await this.withLock(
       async () => {
         // Get the project with most expired media (single project per iteration)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reset gauges in `BatchDataRetentionCleaner` and `MediaRetentionCleaner` to prevent stale metrics before acquiring locks.
> 
>   - **Behavior**:
>     - Reset gauges in `execute()` of `BatchDataRetentionCleaner` in `batch-data-retention-cleaner/index.ts` before acquiring lock to prevent stale metrics.
>     - Reset gauge in `execute()` of `MediaRetentionCleaner` in `media-retention-cleaner/index.ts` before acquiring lock to prevent stale metrics.
>   - **Metrics**:
>     - Resets `pending_projects` and `seconds_past_cutoff` gauges in `BatchDataRetentionCleaner`.
>     - Resets `seconds_past_cutoff` gauge in `MediaRetentionCleaner`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5a4569f287d553995132eac1cc326b5431852ae7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->