### PR TITLE
fix: add filters values for event/experiment evals

### DIFF
--- a/packages/shared/src/features/evals/observationForEval.ts
+++ b/packages/shared/src/features/evals/observationForEval.ts
@@ -109,7 +109,7 @@ export const observationEvalFilterColumns: ObservationEvalFilterColumn[] = [
   { id: "level", name: "Level", type: "stringOptions" },
   { id: "version", name: "Version", type: "string" },
   { id: "release", name: "Release", type: "string" },
-  { id: "trace_name", name: "Trace Name", type: "string" },
+  { id: "trace_name", name: "Trace Name", type: "stringOptions" },
   { id: "user_id", name: "User ID", type: "string" },
   { id: "session_id", name: "Session ID", type: "string" },
   { id: "tags", name: "Tags", type: "arrayOptions" },

--- a/packages/shared/src/observationsTable.ts
+++ b/packages/shared/src/observationsTable.ts
@@ -432,6 +432,7 @@ export const evalExperimentFilterCols: ColumnDefinition[] = [
 export type ObservationEvalOptions = {
   environment?: Array<SingleValueOption>;
   tags?: Array<SingleValueOption>;
+  trace_name?: Array<SingleValueOption>;
 };
 
 export type ExperimentEvalOptions = {
@@ -448,6 +449,9 @@ export function observationEvalFilterColsWithOptions(
     }
     if (col.id === "tags") {
       return formatColumnOptions(col, options?.tags ?? []);
+    }
+    if (col.id === "trace_name") {
+      return formatColumnOptions(col, options?.trace_name ?? []);
     }
     return col;
   });

--- a/packages/shared/src/observationsTable.ts
+++ b/packages/shared/src/observationsTable.ts
@@ -1,4 +1,8 @@
-import { ObservationLevelType } from "./domain";
+import {
+  ObservationLevel,
+  ObservationLevelType,
+  ObservationType,
+} from "./domain";
 import {
   type SingleValueOption,
   type ColumnDefinition,
@@ -320,6 +324,142 @@ export function observationsTableColsWithOptions(
     }
     if (col.id === "calledToolNames") {
       return formatColumnOptions(col, options?.calledToolNames ?? []);
+    }
+    return col;
+  });
+}
+
+// Eval-specific observation filter columns
+// These columns map to fields in ObservationForEval (event records)
+// and are used for filtering in observation-based evaluators
+
+export const observationEvalOnlyCols: ColumnDefinition[] = [
+  {
+    name: "Type",
+    id: "type",
+    type: "stringOptions",
+    internal: "type",
+    options: Object.values(ObservationType).map((key) => ({ value: key })),
+  },
+  {
+    name: "Name",
+    id: "name",
+    type: "string",
+    internal: "name",
+  },
+  {
+    name: "Environment",
+    id: "environment",
+    type: "stringOptions",
+    internal: "environment",
+    options: [], // to be filled at runtime
+  },
+  {
+    name: "Level",
+    id: "level",
+    type: "stringOptions",
+    internal: "level",
+    options: Object.values(ObservationLevel).map((key) => ({ value: key })),
+  },
+  {
+    name: "Version",
+    id: "version",
+    type: "string",
+    internal: "version",
+    nullable: true,
+  },
+  {
+    name: "Release",
+    id: "release",
+    type: "string",
+    internal: "release",
+    nullable: true,
+  },
+  {
+    name: "Trace Name",
+    id: "trace_name",
+    type: "string",
+    internal: "trace_name",
+    nullable: true,
+  },
+  {
+    name: "User ID",
+    id: "user_id",
+    type: "string",
+    internal: "user_id",
+    nullable: true,
+  },
+  {
+    name: "Session ID",
+    id: "session_id",
+    type: "string",
+    internal: "session_id",
+    nullable: true,
+  },
+  {
+    name: "Tags",
+    id: "tags",
+    type: "arrayOptions",
+    internal: "tags",
+    options: [], // to be filled at runtime
+  },
+  {
+    name: "Metadata",
+    id: "metadata",
+    type: "stringObject",
+    internal: "metadata",
+  },
+];
+
+// Dataset column for experiment evaluators
+export const datasetColForExperiment: ColumnDefinition = {
+  name: "Dataset",
+  id: "experiment_dataset_id",
+  type: "stringOptions",
+  internal: "experiment_dataset_id",
+  options: [], // to be filled at runtime
+};
+
+// For event evaluators - all observation columns except dataset
+export const evalEventFilterCols: ColumnDefinition[] = observationEvalOnlyCols;
+
+// For experiment evaluators - just dataset column
+export const evalExperimentFilterCols: ColumnDefinition[] = [
+  datasetColForExperiment,
+];
+
+// Options type for observation eval filters
+export type ObservationEvalOptions = {
+  environment?: Array<SingleValueOption>;
+  tags?: Array<SingleValueOption>;
+};
+
+export type ExperimentEvalOptions = {
+  experiment_dataset_id?: Array<SingleValueOption>;
+};
+
+export function observationEvalFilterColsWithOptions(
+  options?: ObservationEvalOptions,
+  cols: ColumnDefinition[] = evalEventFilterCols,
+): ColumnDefinition[] {
+  return cols.map((col) => {
+    if (col.id === "environment") {
+      return formatColumnOptions(col, options?.environment ?? []);
+    }
+    if (col.id === "tags") {
+      return formatColumnOptions(col, options?.tags ?? []);
+    }
+    return col;
+  });
+}
+
+export function experimentEvalFilterColsWithOptions(
+  options?: ExperimentEvalOptions,
+  cols: ColumnDefinition[] = evalEventFilterCols,
+): ColumnDefinition[] {
+  return cols.map((col) => {
+    if (col.id === "experiment_dataset_id") {
+      return formatColumnOptions(col, options?.experiment_dataset_id ?? []);
     }
     return col;
   });

--- a/web/src/features/evals/components/eval-version-callout.tsx
+++ b/web/src/features/evals/components/eval-version-callout.tsx
@@ -42,8 +42,8 @@ const getCalloutContent = (
       title: "Newer version of the Langfuse SDK required",
       description: (
         <>
-          Running evaluators on live observations require JS SDK &ge; 4.4.0 or
-          Python SDK &ge; 3.9.0. You can still set up this evaluator now—it will
+          Running evaluators on live observations require JS SDK &ge; 4.0.0 or
+          Python SDK &ge; 3.0.0. You can still set up this evaluator now—it will
           start running once you upgrade your SDK to latest.{" "}
           <a
             href="https://langfuse.com/docs/tracing/overview#langfuse-tracing-vs-opentelemetry"
@@ -68,8 +68,9 @@ const getCalloutContent = (
         title: "Are you sure you are already on the recommended SDK version?",
         description: (
           <>
-            You can still set your evaluator up now—it will start running once
-            you upgrade to the latest SDK version.{" "}
+            Running evaluators requires JS SDK &ge; 4.4.0 or Python SDK &ge;
+            3.9.0. You can still set your evaluator up now—it will start running
+            once you upgrade to the latest SDK version.{" "}
             <a
               href="https://langfuse.com/docs/tracing/overview#langfuse-tracing-vs-opentelemetry"
               target="_blank"

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -34,9 +34,9 @@ import {
   type ObservationEvalOptions,
   type ObservationType,
   LangfuseInternalTraceEnvironment,
-  ExperimentEvalOptions,
+  type ExperimentEvalOptions,
   experimentEvalFilterColsWithOptions,
-  ColumnDefinition,
+  type ColumnDefinition,
 } from "@langfuse/shared";
 import { z } from "zod/v4";
 import { useEffect, useMemo, useState, memo } from "react";

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -101,6 +101,7 @@ import {
 } from "@/src/components/ui/tooltip";
 import { InfoIcon } from "lucide-react";
 import {
+  isDatasetTarget,
   isEventTarget,
   isExperimentTarget,
   isLegacyEvalTarget,
@@ -979,6 +980,11 @@ export const InnerEvaluatorForm = (props: {
                           </p>
                         ) : (
                           <InlineFilterBuilder
+                            columnIdentifier={
+                              isDatasetTarget(target) || isTraceTarget(target)
+                                ? "name"
+                                : "id"
+                            }
                             columns={getFilterColumns()}
                             filterState={field.value ?? []}
                             onChange={(

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -440,6 +440,9 @@ export const InnerEvaluatorForm = (props: {
       tags: traceFilterOptionsResponse.data?.tags?.map((t) => ({
         value: t.value,
       })),
+      trace_name: traceFilterOptionsResponse.data?.name?.map((n) => ({
+        value: n.value,
+      })),
     };
   }, [traceFilterOptionsResponse.data, environmentFilterOptionsResponse.data]);
 

--- a/web/src/features/evals/components/remap-eval-wizard.tsx
+++ b/web/src/features/evals/components/remap-eval-wizard.tsx
@@ -12,6 +12,7 @@ import {
   mapLegacyToModernTarget,
   isLegacyEvalTarget,
   isTraceTarget,
+  isEventTarget,
 } from "@/src/features/evals/utils/typeHelpers";
 import { type PartialConfig } from "@/src/features/evals/types";
 import { Alert, AlertDescription } from "@/src/components/ui/alert";
@@ -187,6 +188,20 @@ export function RemapEvalWizard({
             </a>{" "}
             to upgrade successfully.
           </DialogDescription>
+          {mappedConfig ? (
+            <Alert
+              variant="default"
+              className="mt-2 border-light-yellow bg-light-yellow"
+            >
+              <AlertDescription>
+                <div className="flex flex-col gap-2">
+                  {isEventTarget(mappedConfig.targetObject ?? "event")
+                    ? "Running evaluators requires JS SDK ≥ 4.0.0 or Python SDK ≥ 3.0.0."
+                    : "Running evaluators requires JS SDK ≥ 4.4.0 or Python SDK ≥ 3.9.0."}
+                </div>
+              </AlertDescription>
+            </Alert>
+          ) : null}
         </DialogHeader>
 
         {isLoading ? (

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -72,15 +72,18 @@ export function PopoverFilterBuilder({
   columns,
   filterState,
   onChange,
+  columnIdentifier = "name",
   columnsWithCustomSelect = [],
   filterWithAI = false,
   buttonType = "default",
 }: {
+  /** Which column field to persist in filter.column: 'id' for stable refs, 'name' for legacy compatibility */
   columns: ColumnDefinitionWithAlert[];
   filterState: FilterState;
   onChange:
     | Dispatch<SetStateAction<FilterState>>
     | ((newState: FilterState) => void);
+  columnIdentifier?: ColumnIdentifier;
   columnsWithCustomSelect?: string[];
   filterWithAI?: boolean;
   buttonType?: "default" | "icon";
@@ -185,6 +188,7 @@ export function PopoverFilterBuilder({
           align="start"
         >
           <FilterBuilderForm
+            columnIdentifier={columnIdentifier}
             columns={columns}
             filterState={wipFilterState}
             onChange={setWipFilterState}
@@ -267,10 +271,13 @@ export function InlineFilterState({
   });
 }
 
+type ColumnIdentifier = "id" | "name";
+
 export function InlineFilterBuilder({
   columns,
   filterState,
   onChange,
+  columnIdentifier = "name",
   disabled,
   columnsWithCustomSelect,
   filterWithAI = false,
@@ -280,6 +287,8 @@ export function InlineFilterBuilder({
   onChange:
     | Dispatch<SetStateAction<FilterState>>
     | ((newState: FilterState) => void);
+  /** Which column field to persist in filter.column: 'id' for stable refs, 'name' for legacy compatibility */
+  columnIdentifier?: ColumnIdentifier;
   disabled?: boolean;
   columnsWithCustomSelect?: string[];
   filterWithAI?: boolean;
@@ -316,6 +325,7 @@ export function InlineFilterBuilder({
   return (
     <div className="flex flex-col">
       <FilterBuilderForm
+        columnIdentifier={columnIdentifier}
         columns={columns}
         filterState={wipFilterState}
         onChange={setWipFilterState}
@@ -358,6 +368,7 @@ const getAlertStyles = (severity: "info" | "warning" | "error") => {
 };
 
 function FilterBuilderForm({
+  columnIdentifier,
   columns,
   filterState,
   onChange,
@@ -365,6 +376,7 @@ function FilterBuilderForm({
   columnsWithCustomSelect = [],
   filterWithAI = false,
 }: {
+  columnIdentifier: ColumnIdentifier;
   columns: ColumnDefinitionWithAlert[];
   filterState: WipFilterState;
   onChange: Dispatch<SetStateAction<WipFilterState>>;
@@ -604,7 +616,7 @@ function FilterBuilderForm({
 
                                         handleFilterChange(
                                           {
-                                            column: col?.name,
+                                            column: col?.[columnIdentifier],
                                             type: col?.type,
                                             operator: defaultOperator,
                                             value: undefined,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance filtering for event/experiment evaluations with new columns, external control props, and updated SDK requirements.
> 
>   - **Behavior**:
>     - Change `trace_name` filter type to `stringOptions` in `observationForEval.ts`.
>     - Add `observationEvalOnlyCols`, `datasetColForExperiment`, `evalEventFilterCols`, and `evalExperimentFilterCols` in `observationsTable.ts`.
>     - Add `observationEvalFilterColsWithOptions()` and `experimentEvalFilterColsWithOptions()` in `observationsTable.ts`.
>     - Add external control props (`hideControls`, `externalFilterState`, `externalDateRange`, `limitRows`) to `ObservationsTable` in `observations.tsx`.
>   - **Components**:
>     - Update `EvalVersionCallout` in `eval-version-callout.tsx` to reflect new SDK version requirements.
>     - Update `InnerEvaluatorForm` in `inner-evaluator-form.tsx` to use new filter columns and options.
>     - Update `RemapEvalWizard` in `remap-eval-wizard.tsx` to show SDK version requirements.
>     - Update `FilterBuilderForm` in `filter-builder.tsx` to handle new column types and alerts.
>   - **Misc**:
>     - Add `addPropagationWarnings()` function in `inner-evaluator-form.tsx` to add warnings for columns requiring OTEL SDK.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 06e49e5a8dca918efd8d0b9ca3dde77f7f01ee96. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->