### PR TITLE
feat(mcp): add listPromptVersions tool

### DIFF
--- a/web/src/__tests__/async/mcp-tools-versions.servertest.ts
+++ b/web/src/__tests__/async/mcp-tools-versions.servertest.ts
@@ -1,0 +1,152 @@
+/** @jest-environment node */
+
+// Mock queue operations to avoid Redis dependency in tests
+jest.mock("@langfuse/shared/src/server", () => {
+  const actual = jest.requireActual("@langfuse/shared/src/server");
+  return {
+    ...actual,
+    // Mock queue getInstance to return a no-op queue
+    EventPropagationQueue: {
+      getInstance: () => ({
+        add: jest.fn().mockResolvedValue(undefined),
+        disconnect: jest.fn(),
+      }),
+    },
+  };
+});
+
+import { nanoid } from "nanoid";
+import {
+  createMcpTestSetup,
+  createPromptInDb,
+  verifyToolAnnotations,
+} from "./mcp-helpers";
+
+import {
+  listPromptVersionsTool,
+  handleListPromptVersions,
+} from "@/src/features/mcp/features/prompts/tools/listPromptVersions";
+
+describe("MCP Version Tools", () => {
+  describe("listPromptVersions tool", () => {
+    it("should have readOnlyHint annotation", () => {
+      verifyToolAnnotations(listPromptVersionsTool, { readOnlyHint: true });
+    });
+
+    it("should list versions for a single prompt (sorted desc) with pagination", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const promptName = `versions-test-${nanoid()}`;
+
+      await createPromptInDb({
+        name: promptName,
+        prompt: "v1",
+        projectId,
+        version: 1,
+        labels: ["staging"],
+        tags: ["t1"],
+      });
+
+      await createPromptInDb({
+        name: promptName,
+        prompt: "v2",
+        projectId,
+        version: 2,
+        labels: ["production"],
+        tags: ["t2"],
+      });
+
+      await createPromptInDb({
+        name: promptName,
+        prompt: "v3",
+        projectId,
+        version: 3,
+        labels: ["latest"],
+        tags: ["t3"],
+      });
+
+      const page1 = (await handleListPromptVersions(
+        { name: promptName, page: 1, limit: 2 },
+        context,
+      )) as {
+        data: Array<{ version: number }>;
+        pagination: { totalItems: number; totalPages: number; page: number };
+      };
+
+      expect(page1.data.map((v) => v.version)).toEqual([3, 2]);
+      expect(page1.pagination.totalItems).toBe(3);
+      expect(page1.pagination.totalPages).toBe(2);
+      expect(page1.pagination.page).toBe(1);
+
+      const page2 = (await handleListPromptVersions(
+        { name: promptName, page: 2, limit: 2 },
+        context,
+      )) as {
+        data: Array<{ version: number }>;
+        pagination: { totalItems: number; totalPages: number; page: number };
+      };
+
+      expect(page2.data.map((v) => v.version)).toEqual([1]);
+      expect(page2.pagination.totalItems).toBe(3);
+      expect(page2.pagination.totalPages).toBe(2);
+      expect(page2.pagination.page).toBe(2);
+    });
+
+    it("should return empty results when prompt name does not exist", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `does-not-exist-${nanoid()}`;
+
+      const result = (await handleListPromptVersions(
+        { name: promptName, page: 1, limit: 100 },
+        context,
+      )) as {
+        data: Array<unknown>;
+        pagination: { totalItems: number; totalPages: number };
+      };
+
+      expect(result.data).toEqual([]);
+      expect(result.pagination.totalItems).toBe(0);
+      expect(result.pagination.totalPages).toBe(0);
+    });
+
+    it("should use context.projectId for tenant isolation", async () => {
+      const { context: context1, projectId: projectId1 } =
+        await createMcpTestSetup();
+      const { context: context2, projectId: projectId2 } =
+        await createMcpTestSetup();
+
+      const promptName = `isolation-versions-${nanoid()}`;
+
+      await createPromptInDb({
+        name: promptName,
+        prompt: "p1-v1",
+        projectId: projectId1,
+        version: 1,
+      });
+      await createPromptInDb({
+        name: promptName,
+        prompt: "p1-v2",
+        projectId: projectId1,
+        version: 2,
+      });
+
+      await createPromptInDb({
+        name: promptName,
+        prompt: "p2-v1",
+        projectId: projectId2,
+        version: 1,
+      });
+
+      const result1 = (await handleListPromptVersions(
+        { name: promptName, page: 1, limit: 100 },
+        context1,
+      )) as { data: Array<{ version: number }> };
+      expect(result1.data.map((v) => v.version)).toEqual([2, 1]);
+
+      const result2 = (await handleListPromptVersions(
+        { name: promptName, page: 1, limit: 100 },
+        context2,
+      )) as { data: Array<{ version: number }> };
+      expect(result2.data.map((v) => v.version)).toEqual([1]);
+    });
+  });
+});

--- a/web/src/features/mcp/README.md
+++ b/web/src/features/mcp/README.md
@@ -44,11 +44,12 @@ Model Context Protocol (MCP) server for Langfuse, enabling AI assistants to inte
 
 ## Available Tools
 
-The MCP server provides 6 tools for prompt management:
+The MCP server provides 7 tools for prompt management:
 
 - **`getPrompt`** - Fetch a specific prompt by name with optional label or version (fully resolved with dependencies)
 - **`getPromptUnresolved`** - Fetch a specific prompt WITHOUT resolving dependencies (useful for prompt composition analysis)
 - **`listPrompts`** - List all prompts in the project with filtering and pagination
+- **`listPromptVersions`** - List versions for a specific prompt name (metadata only; avoids N+1 getPrompt calls)
 - **`createTextPrompt`** - Create a new text prompt version
 - **`createChatPrompt`** - Create a new chat prompt version (OpenAI-style messages)
 - **`updatePromptLabels`** - Add/move labels across prompt versions

--- a/web/src/features/mcp/features/prompts/index.ts
+++ b/web/src/features/mcp/features/prompts/index.ts
@@ -8,6 +8,7 @@
  * - getPrompt: Fetch specific prompts by name/label/version (read-only)
  * - getPromptUnresolved: Fetch prompts without resolving dependencies (read-only)
  * - listPrompts: List and filter prompts with pagination (read-only)
+ * - listPromptVersions: List versions for a single prompt name (read-only)
  * - createTextPrompt: Create new text prompt versions (destructive)
  * - createChatPrompt: Create new chat prompt versions (destructive)
  * - updatePromptLabels: Update labels on prompt versions (destructive)
@@ -20,6 +21,10 @@ import {
   handleGetPromptUnresolved,
 } from "./tools/getPromptUnresolved";
 import { listPromptsTool, handleListPrompts } from "./tools/listPrompts";
+import {
+  listPromptVersionsTool,
+  handleListPromptVersions,
+} from "./tools/listPromptVersions";
 import {
   createTextPromptTool,
   handleCreateTextPrompt,
@@ -56,6 +61,10 @@ export const promptsFeature: McpFeatureModule = {
     {
       definition: listPromptsTool,
       handler: handleListPrompts,
+    },
+    {
+      definition: listPromptVersionsTool,
+      handler: handleListPromptVersions,
     },
     {
       definition: createTextPromptTool,

--- a/web/src/features/mcp/features/prompts/tools/listPromptVersions.ts
+++ b/web/src/features/mcp/features/prompts/tools/listPromptVersions.ts
@@ -1,0 +1,112 @@
+/**
+ * MCP Tool: listPromptVersions
+ *
+ * Lists versions for a specific prompt name in the project.
+ * Read-only operation intended to avoid N+1 calls (listPrompts -> getPrompt per version).
+ */
+
+import { z } from "zod/v4";
+import { defineTool } from "../../../core/define-tool";
+import { ParamPromptName } from "../validation";
+import { ParamLimit, ParamPage } from "../../../core/validation";
+import { instrumentAsync } from "@langfuse/shared/src/server";
+import { SpanKind } from "@opentelemetry/api";
+import { prisma } from "@langfuse/shared/src/db";
+
+/**
+ * Base schema for JSON Schema generation (no refinements needed)
+ */
+const ListPromptVersionsBaseSchema = z.object({
+  name: ParamPromptName.describe("The prompt name to list versions for"),
+  page: ParamPage,
+  limit: ParamLimit,
+});
+
+export const [listPromptVersionsTool, handleListPromptVersions] = defineTool({
+  name: "listPromptVersions",
+  description: [
+    "List versions for a single prompt name (metadata only).",
+    "",
+    "Use this to avoid calling getPrompt N times when you just need version history and labels/tags.",
+    "",
+    "Returns versions sorted by version number descending. Does NOT include prompt content.",
+    "",
+    "Pagination: page (default: 1), limit (default: 50, max: 100)",
+  ].join("\n"),
+  baseSchema: ListPromptVersionsBaseSchema,
+  inputSchema: ListPromptVersionsBaseSchema,
+  handler: async (input, context) => {
+    return await instrumentAsync(
+      { name: "mcp.prompts.list_versions", spanKind: SpanKind.INTERNAL },
+      async (span) => {
+        const { name, page, limit } = input;
+
+        span.setAttributes({
+          "langfuse.project.id": context.projectId,
+          "langfuse.org.id": context.orgId,
+          "mcp.api_key_id": context.apiKeyId,
+          "mcp.prompt_name": name,
+          "mcp.pagination_page": page ?? 1,
+          "mcp.pagination_limit": limit ?? 50,
+        });
+
+        // Same pagination semantics as listPrompts/getPromptsMeta (OFFSET = limit * (page - 1))
+        const [promptVersions, totalItems] = await Promise.all([
+          prisma.prompt.findMany({
+            where: {
+              projectId: context.projectId,
+              name,
+            },
+            select: {
+              id: true,
+              name: true,
+              version: true,
+              type: true,
+              labels: true,
+              tags: true,
+              createdAt: true,
+              updatedAt: true,
+              createdBy: true,
+              commitMessage: true,
+            },
+            orderBy: [{ version: "desc" }],
+            take: limit,
+            skip: limit * (page - 1),
+          }),
+          prisma.prompt.count({
+            where: {
+              projectId: context.projectId,
+              name,
+            },
+          }),
+        ]);
+
+        span.setAttribute("mcp.result_count", promptVersions.length);
+
+        const totalPages = Math.ceil(totalItems / limit);
+
+        return {
+          data: promptVersions.map((prompt) => ({
+            id: prompt.id,
+            name: prompt.name,
+            version: prompt.version,
+            type: prompt.type,
+            labels: prompt.labels,
+            tags: prompt.tags,
+            createdAt: prompt.createdAt,
+            updatedAt: prompt.updatedAt,
+            createdBy: prompt.createdBy,
+            commitMessage: prompt.commitMessage,
+          })),
+          pagination: {
+            page,
+            limit,
+            totalPages,
+            totalItems,
+          },
+        };
+      },
+    );
+  },
+  readOnlyHint: true,
+});


### PR DESCRIPTION
## What does this PR do?

Adds a read-only MCP tool to list versions for a single prompt name with pagination, avoiding N+1 getPrompt calls for version history/rollout workflows.

Also registers the tool, updates MCP README, and adds Jest coverage. 

## WHY?
`listPrompts` returns one row per prompt name (plus an array of version numbers), but it does not include per-version metadata (e.g. which labels are attached to which version, per-version timestamps, commit messages). To reconstruct “version history” for a single prompt, clients have to:

1. call `listPrompts` to find the prompt name + version numbers, then
2. call `getPrompt` once per version to fetch metadata (and prompt content) for each version.

That pattern is effectively an N+1 workflow and forces unnecessary prompt-content payloads into the MCP context. `listPromptVersions` provides the version list + per-version metadata for a given prompt name in a single read-only call.

This is particularly useful for comparing tagged versions of prompts, with less context pollution.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] `pnpm --filter web test -- --testPathPatterns="mcp-tools"` passes
- [x] Test end to end with the following manual e2e (HTTP MCP route)

1. Test registered:

headers - 
`Content-Type: application/json`
`Accept: application/json, text/event-stream`

```
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "tools/list",
  "params": {}
}
```

gives:
```
{
        "name": "listPromptVersions",
        "description": "List versions for a single prompt name (metadata only).\n\nUse this to avoid calling getPrompt N times when you just need version history and labels/tags.\n\nReturns versions sorted by version number descending. Does NOT include prompt content.\n\nPagination: page (default: 1), limit (default: 50, max: 100)",
        "inputSchema": {
          "$schema": "http://json-schema.org/draft-07/schema#",
          "type": "object",
          "properties": {
            "name": {
              "description": "The prompt name to list versions for",
              "type": "string",
              "minLength": 1,
              "maxLength": 255
            },
            "page": {
              "description": "Page number for pagination (default: 1)",
              "default": 1,
              "type": "integer",
              "minimum": 1,
              "maximum": 9007199254740991
            },
            "limit": {
              "description": "Number of items to return (1-100, default: 50)",
              "default": 50,
              "type": "integer",
              "minimum": 1,
              "maximum": 100
            }
          },
          "required": [
            "name",
            "page",
            "limit"
          ],
          "additionalProperties": false
        },
        "annotations": {
          "readOnlyHint": true
        }
      }
 ```

3. Create prompt versions:
```
{
  "jsonrpc": "2.0",
  "id": 2,
  "method": "tools/call",
  "params": {
    "name": "createTextPrompt",
    "arguments": {
      "name": "mcp-smoke",
      "prompt": "v1",
      "labels": [
        "staging"
      ],
      "tags": [
        "mcp"
      ],
      "commitMessage": "v1"
    }
  }
}

{
  "jsonrpc": "2.0",
  "id": 3,
  "method": "tools/call",
  "params": {
    "name": "createTextPrompt",
    "arguments": {
      "name": "mcp-smoke",
      "prompt": "v2",
      "labels": [
        "production"
      ],
      "tags": [
        "mcp"
      ],
      "commitMessage": "v2"
    }
  }
}

{
  "jsonrpc": "2.0",
  "id": 3,
  "method": "tools/call",
  "params": {
    "name": "createTextPrompt",
    "arguments": {
      "name": "mcp-smoke",
      "prompt": "v3",
      "labels": ["production"],
      "tags": ["mcp"],
      "config": { "model": "gpt-4", "temperature": 0.7 },
      "commitMessage": "v3 blahblah"
    }
  }
}
```

4. Call listPromptVersions and verify:

- versions sorted desc
- metadata present (labels/tags/commitMessage/timestamps)
- pagination fields populated

```
{
  "jsonrpc": "2.0",
  "id": 4,
  "method": "tools/call",
  "params": {
    "name": "listPromptVersions",
    "arguments": {
      "name": "mcp-smoke",
      "page": 1,
      "limit": 50
    }
  }
}
```

-> response:
```
{
  "result": {
    "content": [
      {
        "type": "text",
        "text": "{\n  \"data\": [\n    {\n      \"id\": \"1ee6432d-6854-4681-8b73-4fc46d278eb8\",\n      \"name\": \"mcp-smoke\",\n      \"version\": 3,\n      \"type\": \"text\",\n      \"labels\": [\n        \"production\",\n        \"latest\"\n      ],\n      \"tags\": [\n        \"mcp\"\n      ],\n      \"createdAt\": \"2026-02-02T04:09:41.546Z\",\n      \"updatedAt\": \"2026-02-02T04:09:41.546Z\",\n      \"createdBy\": \"API\",\n      \"commitMessage\": \"v3 blahblah\"\n    },\n    {\n      \"id\": \"c1fa905c-3d69-4839-ba0e-2f4dfef78571\",\n      \"name\": \"mcp-smoke\",\n      \"version\": 2,\n      \"type\": \"text\",\n      \"labels\": [],\n      \"tags\": [\n        \"mcp\"\n      ],\n      \"createdAt\": \"2026-02-02T04:07:48.480Z\",\n      \"updatedAt\": \"2026-02-02T04:09:41.546Z\",\n      \"createdBy\": \"API\",\n      \"commitMessage\": \"v2\"\n    },\n    {\n      \"id\": \"d7e7d783-be7d-4423-b15c-3a20d9f8e09d\",\n      \"name\": \"mcp-smoke\",\n      \"version\": 1,\n      \"type\": \"text\",\n      \"labels\": [\n        \"staging\"\n      ],\n      \"tags\": [\n        \"mcp\"\n      ],\n      \"createdAt\": \"2026-02-02T04:05:59.095Z\",\n      \"updatedAt\": \"2026-02-02T04:07:48.480Z\",\n      \"createdBy\": \"API\",\n      \"commitMessage\": \"v1\"\n    }\n  ],\n  \"pagination\": {\n    \"page\": 1,\n    \"limit\": 50,\n    \"totalPages\": 1,\n    \"totalItems\": 3\n  }\n}"
      }
    ]
  },
  "jsonrpc": "2.0",
  "id": 4
}
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `listPromptVersions` tool to MCP server for listing prompt versions with pagination, including Jest tests and documentation updates.
> 
>   - **Behavior**:
>     - Adds `listPromptVersions` tool in `listPromptVersions.ts` to list versions of a specific prompt with pagination, avoiding N+1 `getPrompt` calls.
>     - Versions are sorted by version number descending and include metadata (labels, tags, commitMessage, timestamps).
>     - Pagination supports `page` (default: 1) and `limit` (default: 50, max: 100).
>   - **Tests**:
>     - Adds Jest tests in `mcp-tools-versions.servertest.ts` to verify tool functionality, including pagination, non-existent prompt handling, and tenant isolation.
>   - **Documentation**:
>     - Updates `README.md` to include `listPromptVersions` in the list of available tools.
>   - **Registration**:
>     - Registers `listPromptVersions` tool in `index.ts` for MCP server.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for de813aed635ea51039f31e39caa2aece401d1117. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->