### PR TITLE
fix(prompt-automations): filter events by trigger eventActions array

### DIFF
--- a/web/src/__tests__/async/prompts.v2.servertest.ts
+++ b/web/src/__tests__/async/prompts.v2.servertest.ts
@@ -69,7 +69,7 @@ const setupTriggerAndAction = async (projectId: string) => {
       id: v4(),
       projectId: projectId,
       eventSource: "prompt",
-      eventActions: ["updated"],
+      eventActions: ["created", "updated"],
       filter: [],
       status: "ACTIVE",
     },

--- a/worker/src/features/entityChange/promptVersionProcessor.ts
+++ b/worker/src/features/entityChange/promptVersionProcessor.ts
@@ -48,6 +48,23 @@ export const promptVersionProcessor = async (
     // Process each trigger
     for (const trigger of triggers) {
       try {
+        // Check if the event action is in the trigger's configured eventActions
+        if (
+          trigger.eventActions.length > 0 &&
+          !trigger.eventActions.includes(event.action)
+        ) {
+          logger.debug(
+            `Event action ${event.action} not in trigger ${trigger.id} eventActions`,
+            {
+              promptId: event.promptId,
+              projectId: event.projectId,
+              action: event.action,
+              triggerEventActions: trigger.eventActions,
+            },
+          );
+          continue;
+        }
+
         // Create a unified data object that includes both prompt data and the action
         const eventData = {
           ...event.prompt,


### PR DESCRIPTION
Previously, prompt automation triggers ignored the eventActions array configured via the GUI, causing automations set to only trigger on "created" events to also fire on "updated" events.

## What does this PR do?

Fixes prompt automation triggers to properly filter events based on the eventActions array configured via the GUI.
 
**Problem**: Prompt automation triggers ignored the eventActions array and only checked the filter field. This caused automations set to trigger only on "created" events to also fire on "updated" events when a new prompt version was created (due to label changes on previous versions).

 **Solution**: Added a check in promptVersionProcessor to verify that the event action is included in the trigger's eventActions array before processing. If not included, the trigger is skipped.

Fixes #9630 


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- [x] I have read the https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md
 -  [x] My code follows the style guidelines of this project (pnpm run format)
-  [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have checked if my PR needs changes to the documentation
  - [x] I have checked if my changes generate no new warnings (npm run lint)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have checked if new and existing unit tests pass locally with my changes