### PR TITLE
fix: changing index to speed up pending_deletions lookup

### DIFF
--- a/packages/shared/prisma/migrations/20260203220622_pending_deletions_object_id_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20260203220622_pending_deletions_object_id_idx/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "public"."pending_deletions_project_id_object_is_deleted_idx";
+
+-- CreateIndex
+CREATE INDEX "pending_deletions_project_id_object_is_deleted_object_id_id_idx" ON "pending_deletions"("project_id", "object", "is_deleted", "object_id", "id");

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -1539,7 +1539,7 @@ model PendingDeletion {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 
-  @@index([projectId, object, isDeleted])
+  @@index([projectId, object, isDeleted, objectId, id])
   @@index([objectId, object])
   @@map("pending_deletions")
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves `pending_deletions` lookup speed by updating the index to include `objectId` and `id`.
> 
>   - **Database Index**:
>     - Drops index `pending_deletions_project_id_object_is_deleted_idx` in `migration.sql`.
>     - Creates new index `pending_deletions_project_id_object_is_deleted_object_id_id_idx` on `pending_deletions` table in `migration.sql`.
>     - Updates index definition in `schema.prisma` for `PendingDeletion` model to include `objectId` and `id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c9484624cb31e7f3ecb52cf966b1ff62c476911a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->