### PR TITLE
fix(public-api): add trace_id to observations query filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langfuse",
-  "version": "3.150.0",
+  "version": "3.150.1-0",
   "author": "engineering@langfuse.com",
   "license": "MIT",
   "private": true,

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "3.150.0",
+  "version": "3.150.1-0",
   "private": true,
   "license": "MIT",
   "engines": {

--- a/web/src/constants/VERSION.ts
+++ b/web/src/constants/VERSION.ts
@@ -1,1 +1,1 @@
-export const VERSION = "v3.150.0";
+export const VERSION = "v3.150.1-0";

--- a/web/src/features/public-api/server/observations.ts
+++ b/web/src/features/public-api/server/observations.ts
@@ -40,6 +40,7 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
     with clickhouse_keys as (
       SELECT DISTINCT
         id,
+        trace_id,
         project_id,
         type,
         toDate(start_time)
@@ -84,7 +85,7 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
       event_ts
     FROM observations o ${disableObservationsFinal ? "" : "FINAL"}
     WHERE o.project_id = {projectId: String}
-      AND (id, project_id, type, toDate(start_time)) in (select * from clickhouse_keys)
+      AND (id, trace_id, project_id, type, toDate(start_time)) in (select * from clickhouse_keys)
     ORDER BY start_time DESC
   `;
 

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "3.150.0",
+  "version": "3.150.1-0",
   "description": "",
   "license": "MIT",
   "private": true,

--- a/worker/src/constants/VERSION.ts
+++ b/worker/src/constants/VERSION.ts
@@ -1,1 +1,1 @@
-export const VERSION = "v3.150.0";
+export const VERSION = "v3.150.1-0";


### PR DESCRIPTION
## Summary
- Adds `trace_id` to the `clickhouse_keys` CTE in the observations query
- Updates the IN clause filter to include `trace_id` for better index utilization
- Improves query performance by allowing ClickHouse to use more selective indexes

## Test plan
- [ ] Verify observations API returns correct results
- [ ] Check query performance in ClickHouse query logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `trace_id` to observations query in `observations.ts` for improved performance and update version to `3.150.1-0`.
> 
>   - **Behavior**:
>     - Adds `trace_id` to `clickhouse_keys` CTE in `observations.ts` to improve query performance and index utilization.
>     - Updates IN clause filter in `observations.ts` to include `trace_id`.
>   - **Versioning**:
>     - Bumps version to `3.150.1-0` in `package.json`, `web/package.json`, and `worker/package.json`.
>     - Updates `VERSION` constant in `web/src/constants/VERSION.ts` and `worker/src/constants/VERSION.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a3156d254b502c7e42b85f8fababaab02ef557da. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->