### PR TITLE
fix(mcp): attempting to fix unbounded mcp memory use

### DIFF
--- a/web/src/pages/api/public/mcp/index.ts
+++ b/web/src/pages/api/public/mcp/index.ts
@@ -174,6 +174,8 @@ export default async function handler(
  */
 export const config = {
   api: {
-    bodyParser: true,
+    bodyParser: {
+      sizeLimit: "1mb",
+    },
   },
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes unbounded memory use in MCP by ensuring server cleanup and limiting request body size.
> 
>   - **Memory Management**:
>     - Wraps `server.connect()` and `transport.handleRequest()` in a `try-finally` block in `handleMcpRequest()` in `transport.ts` to ensure `server.close()` is called, preventing memory leaks.
>     - Logs a warning if `server.close()` fails.
>   - **Request Handling**:
>     - Sets `bodyParser.sizeLimit` to `1mb` in `index.ts` to limit request body size and prevent unbounded memory use.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e81af79ecf6e03d41456796d628400cc2f00c21d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->