### PR TITLE
feat: add deepseek adapter and normalize line endings

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -402,6 +402,24 @@ export async function fetchLLMCompletion(
         additionalModelRequestFields: modelParams.providerOptions,
       }),
     });
+  } else if (modelParams.adapter === LLMAdapter.DeepSeek) {
+    chatModel = new ChatOpenAI({
+      openAIApiKey: apiKey,
+      modelName: modelParams.model,
+      temperature: modelParams.temperature,
+      maxTokens: modelParams.max_tokens,
+      topP: modelParams.top_p,
+      streamUsage: false,
+      callbacks: finalCallbacks,
+      maxRetries,
+      configuration: {
+        baseURL: baseURL ?? "https://api.deepseek.com",
+        defaultHeaders: extraHeaders,
+        ...(proxyAgent && { httpAgent: proxyAgent }),
+      },
+      modelKwargs: modelParams.providerOptions,
+      timeout: timeoutMs,
+    });
   } else {
     const _exhaustiveCheck: never = modelParams.adapter;
     throw new Error(
@@ -417,13 +435,65 @@ export async function fetchLLMCompletion(
   };
 
   try {
+    const supportsStructuredOutput =
+      modelParams.adapter !== LLMAdapter.DeepSeek;
+
     // Important: await all generations in the try block as otherwise `processTracedEvents` will run too early in finally block
-    if (params.structuredOutputSchema) {
+    if (params.structuredOutputSchema && supportsStructuredOutput) {
       const structuredOutput = await (chatModel as ChatOpenAI) // Typecast necessary due to https://github.com/langchain-ai/langchainjs/issues/6795
         .withStructuredOutput(params.structuredOutputSchema)
         .invoke(finalMessages, runConfig);
 
       return structuredOutput;
+    }
+
+    // Fallback for providers (e.g. DeepSeek) without json_schema / structured output support
+    if (params.structuredOutputSchema && !supportsStructuredOutput) {
+      const schemaKeys =
+        (params.structuredOutputSchema as any)?._def?.shape &&
+        typeof (params.structuredOutputSchema as any)._def.shape === "function"
+          ? Object.keys((params.structuredOutputSchema as any)._def.shape())
+          : [];
+
+      const formatInstruction =
+        schemaKeys.length > 0
+          ? `Return JSON only with keys: ${schemaKeys.join(", ")}, matching the required types. Do not include extra text or code fences.`
+          : "Return only a JSON object that matches the requested schema. Do not include extra text or code fences.";
+
+      const messagesWithFormatHint = [
+        new SystemMessage(formatInstruction),
+        ...finalMessages,
+      ];
+
+      const completion = await chatModel
+        .pipe(new StringOutputParser())
+        .invoke(messagesWithFormatHint, runConfig);
+
+      let parsedOutput: unknown;
+      try {
+        parsedOutput = JSON.parse(completion);
+      } catch {
+        throw new LLMCompletionError({
+          message: `Failed to parse DeepSeek response as JSON: ${completion}`,
+          responseStatusCode: 400,
+          isRetryable: false,
+        });
+      }
+
+      const validator: any = params.structuredOutputSchema;
+      if (validator?.safeParse) {
+        const result = validator.safeParse(parsedOutput);
+        if (!result.success) {
+          throw new LLMCompletionError({
+            message: `DeepSeek response does not match schema: ${result.error}`,
+            responseStatusCode: 400,
+            isRetryable: false,
+          });
+        }
+        return result.data;
+      }
+
+      return parsedOutput as Record<string, unknown>;
     }
 
     if (tools && tools.length > 0) {

--- a/packages/shared/src/server/llm/testModelCall.ts
+++ b/packages/shared/src/server/llm/testModelCall.ts
@@ -37,7 +37,7 @@ export const testModelCall = async ({
       ...modelConfig,
     },
     structuredOutputSchema: zodV3.object({
-      score: zodV3.string(),
+      score: zodV3.union([zodV3.string(), zodV3.number()]).transform(String),
       reasoning: zodV3.string(),
     }),
   });

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -252,6 +252,7 @@ export enum LLMAdapter {
   Bedrock = "bedrock",
   VertexAI = "google-vertex-ai",
   GoogleAIStudio = "google-ai-studio",
+  DeepSeek = "deepseek",
 }
 
 export const TextPromptContentSchema = z.string().min(1, "Enter a prompt");
@@ -428,6 +429,8 @@ export const anthropicModels = [
   "claude-instant-1.2",
 ] as const;
 
+export const deepSeekModels = ["deepseek-chat", "deepseek-reasoner"] as const;
+
 // WARNING: The first entry in the array is chosen as the default model to add LLM API keys
 export const vertexAIModels = [
   "gemini-2.5-flash",
@@ -470,6 +473,7 @@ export const supportedModels = {
   [LLMAdapter.GoogleAIStudio]: googleAIStudioModels,
   [LLMAdapter.Azure]: [],
   [LLMAdapter.Bedrock]: [],
+  [LLMAdapter.DeepSeek]: deepSeekModels,
 } as const;
 
 export type LLMFunctionCall = {

--- a/web/src/features/playground/page/hooks/useModelParams.ts
+++ b/web/src/features/playground/page/hooks/useModelParams.ts
@@ -292,5 +292,19 @@ function getDefaultAdapterParams(
         maxReasoningTokens: { value: 0, enabled: false },
         providerOptions: { value: {}, enabled: false },
       };
+
+    case LLMAdapter.DeepSeek:
+      // DeepSeek API is OpenAI-compatible
+      return {
+        adapter: {
+          value: adapter,
+          enabled: true,
+        },
+        temperature: { value: 0, enabled: false },
+        maxTemperature: { value: 2, enabled: false },
+        max_tokens: { value: 4096, enabled: false },
+        top_p: { value: 1, enabled: false },
+        providerOptions: { value: {}, enabled: false },
+      };
   }
 }

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -217,6 +217,8 @@ export function CreateLLMApiKeyForm({
         return customization?.defaultBaseUrlAzure ?? "";
       case LLMAdapter.Anthropic:
         return customization?.defaultBaseUrlAnthropic ?? "";
+      case LLMAdapter.DeepSeek:
+        return "https://api.deepseek.com";
       default:
         return "";
     }
@@ -276,7 +278,8 @@ export function CreateLLMApiKeyForm({
     adapter === LLMAdapter.OpenAI ||
     adapter === LLMAdapter.Anthropic ||
     adapter === LLMAdapter.VertexAI ||
-    adapter === LLMAdapter.GoogleAIStudio;
+    adapter === LLMAdapter.GoogleAIStudio ||
+    adapter === LLMAdapter.DeepSeek;
 
   const { fields, append, remove } = useFieldArray({
     control: form.control,


### PR DESCRIPTION
## Summary
- Add DeepSeek adapter and default model list support in shared LLM types
- Implement DeepSeek fallback handling for structured output (JSON-only prompt + parse + validate)
- Relax eval test schema to accept numeric `score` and normalize to string
- Ensure shell scripts use LF via `.gitattributes` to avoid container entrypoint issues
- Normalize line endings

## Notes
- DeepSeek does not support `response_format/json_schema`, so the adapter uses a prompt-based JSON fallback
- Eval test now accepts numeric `score` to improve compatibility with DeepSeek responses

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add DeepSeek adapter with JSON-only prompt fallback, update model handling, and normalize line endings.
> 
>   - **DeepSeek Adapter**:
>     - Add `DeepSeek` to `LLMAdapter` enum in `types.ts`.
>     - Implement DeepSeek handling in `fetchLLMCompletion()` in `fetchLLMCompletion.ts`.
>     - Add DeepSeek models to `deepSeekModels` in `types.ts`.
>   - **Structured Output**:
>     - Implement JSON-only prompt fallback for DeepSeek in `fetchLLMCompletion.ts`.
>     - Update `testModelCall.ts` to accept numeric `score` and normalize to string.
>   - **Shell Scripts**:
>     - Ensure LF line endings via `.gitattributes` to avoid container issues.
>   - **Misc**:
>     - Normalize line endings across the codebase.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1e1586cf8e380c08487ad8e096b6fb15b353b666. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->