### PR TITLE
chore: set defaul refresh interval for events table to 1min

### DIFF
--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -220,7 +220,7 @@ export default function ObservationsEventsTable({
   const [rawRefreshInterval, setRawRefreshInterval] =
     useSessionStorage<RefreshInterval>(
       `tableRefreshInterval-events-${projectId}`,
-      null,
+      60_000,
     );
 
   // Validate session storage value against allowed intervals


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set default refresh interval to 1 minute for `ObservationsEventsTable` in `EventsTable.tsx`.
> 
>   - **Behavior**:
>     - Set default refresh interval to 60,000 ms (1 minute) for `ObservationsEventsTable` in `EventsTable.tsx`.
>     - Uses `useSessionStorage` to store the interval with key `tableRefreshInterval-events-${projectId}`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 01f5590928c1262e364a7ccd119dd5f235b86de0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->