### PR TITLE
chore(events-table): auto switch to obs view mode if there are no roo…

### DIFF
--- a/web/src/features/events/hooks/useObservationCountCheck.ts
+++ b/web/src/features/events/hooks/useObservationCountCheck.ts
@@ -1,0 +1,38 @@
+import { api } from "@/src/utils/api";
+import { type FilterState } from "@langfuse/shared";
+
+/**
+ * Checks if there are root observations for current filter conditions.
+ * If no, default to the observation view mode instead.
+ */
+export function useObservationCountCheck({
+  projectId,
+  filterStateWithoutViewMode,
+  enabled,
+}: {
+  projectId: string;
+  filterStateWithoutViewMode: FilterState;
+  enabled: boolean;
+}) {
+  const query = api.events.countAll.useQuery(
+    {
+      projectId,
+      filter: filterStateWithoutViewMode,
+      searchQuery: null,
+      searchType: ["id", "content"],
+      page: 1,
+      limit: 1,
+      orderBy: null,
+    },
+    {
+      enabled,
+      staleTime: 60_000, // 1 minute stale time to prevent spam
+    },
+  );
+
+  return {
+    observationCount: query.data?.totalCount ?? null,
+    isSuccess: query.isSuccess,
+    isPending: query.isPending,
+  };
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Auto-switches to observation view mode in `EventsTable.tsx` if no root observations are found in trace mode, using `useObservationCountCheck` hook.
> 
>   - **Behavior**:
>     - Auto-switch to observation view mode in `EventsTable.tsx` if no root observations in trace mode.
>     - Tracks user explicit choice and date ranges to avoid repeated switches.
>   - **Hooks**:
>     - Adds `useObservationCountCheck` in `useObservationCountCheck.ts` to check root observation count.
>     - Uses `api.events.countAll.useQuery` to fetch observation count with a 1-minute stale time.
>   - **Misc**:
>     - Updates `setViewMode` in `EventsTable.tsx` to reset pagination and track user choice.
>     - Adds `isAutoSwitchPending` to handle loading state during auto-switch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9228bbf0eb75e41115d75fdaab4d767caad1573a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->