### PR TITLE
chore(events-table): properly show usage and cost on top level obs

### DIFF
--- a/web/src/components/trace2/components/ObservationDetailView/ObservationDetailViewHeader.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationDetailViewHeader.tsx
@@ -46,6 +46,8 @@ import {
   type MetadataDomainClient,
 } from "@/src/utils/clientSideDomainTypes";
 import { type ScoreDomain } from "@langfuse/shared";
+import { type AggregatedTraceMetrics } from "@/src/components/trace2/lib/trace-aggregation";
+import type Decimal from "decimal.js";
 
 export interface ObservationDetailViewHeaderProps {
   observation: ObservationReturnTypeWithMetadata;
@@ -67,6 +69,8 @@ export interface ObservationDetailViewHeaderProps {
   onSelectionUsed?: () => void;
   isCommentDrawerOpen?: boolean;
   onCommentDrawerOpenChange?: (open: boolean) => void;
+  subtreeMetrics?: AggregatedTraceMetrics | null;
+  treeNodeTotalCost?: Decimal;
 }
 
 export const ObservationDetailViewHeader = memo(
@@ -82,6 +86,8 @@ export const ObservationDetailViewHeader = memo(
     onSelectionUsed,
     isCommentDrawerOpen,
     onCommentDrawerOpenChange,
+    subtreeMetrics,
+    treeNodeTotalCost,
   }: ObservationDetailViewHeaderProps) {
     // Format cost and usage values
     const totalCost = observation.totalCost;
@@ -193,16 +199,35 @@ export const ObservationDetailViewHeader = memo(
             />
             <EnvironmentBadge environment={observation.environment} />
             <CostBadge
-              totalCost={totalCost}
-              costDetails={observation.costDetails}
+              totalCost={
+                subtreeMetrics
+                  ? (treeNodeTotalCost?.toNumber() ?? subtreeMetrics.totalCost)
+                  : totalCost
+              }
+              costDetails={
+                subtreeMetrics?.costDetails ?? observation.costDetails
+              }
             />
-            <UsageBadge
-              type={observation.type}
-              inputUsage={inputUsage}
-              outputUsage={outputUsage}
-              totalUsage={totalUsage}
-              usageDetails={observation.usageDetails}
-            />
+            {subtreeMetrics ? (
+              subtreeMetrics.hasGenerationLike &&
+              subtreeMetrics.usageDetails && (
+                <UsageBadge
+                  type="GENERATION"
+                  inputUsage={subtreeMetrics.inputUsage}
+                  outputUsage={subtreeMetrics.outputUsage}
+                  totalUsage={subtreeMetrics.totalUsage}
+                  usageDetails={subtreeMetrics.usageDetails}
+                />
+              )
+            ) : (
+              <UsageBadge
+                type={observation.type}
+                inputUsage={inputUsage}
+                outputUsage={outputUsage}
+                totalUsage={totalUsage}
+                usageDetails={observation.usageDetails}
+              />
+            )}
             <VersionBadge version={observation.version} />
             <ModelBadge
               model={observation.model}

--- a/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
+++ b/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
@@ -192,6 +192,7 @@ export function TraceDetailView({
       {/* Header section (extracted component) */}
       <TraceDetailViewHeader
         trace={trace}
+        observations={observations}
         projectId={projectId}
         traceScores={traceScores}
         commentCount={comments.get(trace.id)}

--- a/web/src/components/trace2/lib/trace-aggregation.ts
+++ b/web/src/components/trace2/lib/trace-aggregation.ts
@@ -1,0 +1,95 @@
+/**
+ * Trace-level metrics aggregation utility
+ *
+ * Aggregates cost and usage data from observations for display in headers.
+ * Used for both trace-level (all observations) and observation-level (descendants) aggregation.
+ */
+
+import { type ObservationReturnTypeWithMetadata } from "@/src/server/api/routers/traces";
+import { type ObservationType, isGenerationLike } from "@langfuse/shared";
+import { type TreeNode } from "./types";
+
+export interface AggregatedTraceMetrics {
+  totalCost: number | null;
+  costDetails: Record<string, number> | undefined;
+  totalUsage: number;
+  inputUsage: number;
+  outputUsage: number;
+  usageDetails: Record<string, number> | undefined;
+  hasGenerationLike: boolean;
+}
+
+/**
+ * Aggregates metrics from all observations in a trace.
+ *
+ * - totalCost: sum of all observation costs (null if no costs)
+ * - costDetails: merged breakdown from all observations
+ * - usage fields: summed across all generation-like observations
+ * - hasGenerationLike: true if any observation is generation-like (for showing usage badge)
+ */
+export function aggregateTraceMetrics(
+  observations: ObservationReturnTypeWithMetadata[],
+): AggregatedTraceMetrics {
+  let totalCost: number | null = null;
+  const costDetails: Record<string, number> = {};
+  let totalUsage = 0;
+  let inputUsage = 0;
+  let outputUsage = 0;
+  const usageDetails: Record<string, number> = {};
+  let hasGenerationLike = false;
+
+  for (const obs of observations) {
+    // Aggregate cost
+    if (obs.totalCost != null) {
+      totalCost = (totalCost ?? 0) + Number(obs.totalCost);
+    }
+
+    // Merge cost details
+    if (obs.costDetails) {
+      for (const [key, value] of Object.entries(obs.costDetails)) {
+        costDetails[key] = (costDetails[key] ?? 0) + value;
+      }
+    }
+
+    // Only aggregate usage for generation-like observations
+    if (isGenerationLike(obs.type as ObservationType)) {
+      hasGenerationLike = true;
+      totalUsage += obs.totalUsage ?? 0;
+      inputUsage += obs.inputUsage ?? 0;
+      outputUsage += obs.outputUsage ?? 0;
+
+      // Merge usage details
+      if (obs.usageDetails) {
+        for (const [key, value] of Object.entries(obs.usageDetails)) {
+          usageDetails[key] = (usageDetails[key] ?? 0) + value;
+        }
+      }
+    }
+  }
+
+  return {
+    totalCost,
+    costDetails: Object.keys(costDetails).length > 0 ? costDetails : undefined,
+    totalUsage,
+    inputUsage,
+    outputUsage,
+    usageDetails:
+      Object.keys(usageDetails).length > 0 ? usageDetails : undefined,
+    hasGenerationLike,
+  };
+}
+
+/**
+ * Collects all descendant IDs from a TreeNode using iterative DFS.
+ * Does NOT include the node itself - only its descendants.
+ */
+export function getDescendantIds(node: TreeNode): string[] {
+  const ids: string[] = [];
+  const stack = [...node.children];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    ids.push(current.id);
+    stack.push(...current.children);
+  }
+  return ids;
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhances observation and trace detail views to display aggregated usage and cost metrics using new utility functions.
> 
>   - **Behavior**:
>     - Adds `aggregateTraceMetrics` and `getDescendantIds` functions in `trace-aggregation.ts` to compute aggregated cost and usage metrics for observations and traces.
>     - Updates `ObservationDetailView.tsx` to compute and display subtree metrics for root observations using `aggregateTraceMetrics`.
>     - Updates `TraceDetailView.tsx` to display aggregated metrics for all observations in a trace.
>   - **Components**:
>     - Modifies `ObservationDetailViewHeader.tsx` to use subtree metrics for cost and usage badges.
>     - Modifies `TraceDetailViewHeader.tsx` to use aggregated metrics for cost and usage badges.
>   - **Misc**:
>     - Passes `observations` to `TraceDetailViewHeader` in `TraceDetailView.tsx` for metric aggregation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3b4ebddf66ea08b8b9a05971f5ff035acc458d9c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->