### PR TITLE
fix(playground): always show tool edit button

### DIFF
--- a/web/src/features/playground/page/components/PlaygroundTools/index.tsx
+++ b/web/src/features/playground/page/components/PlaygroundTools/index.tsx
@@ -91,10 +91,15 @@ export const PlaygroundToolsPopover = () => {
               onSelect={() => handleSelectTool(tool)}
               className="flex items-center justify-between px-1 py-2"
             >
-              <div className="flex items-center gap-2">
-                <WrenchIcon size={12} className="text-muted-foreground" />
-                <div className="flex-1 overflow-hidden">
-                  <div className="truncate font-medium">{tool.name}</div>
+              <div className="flex min-w-0 flex-1 items-center gap-2">
+                <WrenchIcon
+                  size={12}
+                  className="shrink-0 text-muted-foreground"
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate font-medium" title={tool.name}>
+                    {tool.name}
+                  </div>
                   <div className="line-clamp-1 text-xs text-muted-foreground">
                     {tool.description}
                   </div>


### PR DESCRIPTION
fixes #11899 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensures the tool edit button is always visible in `PlaygroundToolsPopover` by adjusting layout to prevent overflow issues.
> 
>   - **UI Fix**:
>     - Ensures the tool edit button is always visible in `PlaygroundToolsPopover` in `index.tsx` by adjusting the layout to prevent overflow and truncation issues.
>     - Adds `min-w-0` to flex containers to ensure proper truncation and visibility of tool names and descriptions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 566b0998c79614f07d07ec54bebb6389e3543e6f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->