### PR TITLE
feat(observation-api): parentObservationId is null filter

### DIFF
--- a/packages/shared/src/observationsTable.ts
+++ b/packages/shared/src/observationsTable.ts
@@ -33,6 +33,13 @@ export const observationsTableCols: ColumnDefinition[] = [
   },
   { name: "Trace ID", id: "traceId", type: "string", internal: 't."id"' },
   {
+    name: "Parent Observation ID",
+    id: "parentObservationId",
+    type: "string",
+    internal: 'o."parent_observation_id"',
+    nullable: true,
+  },
+  {
     name: "Trace Name",
     id: "traceName",
     type: "stringOptions",

--- a/packages/shared/src/server/tableMappings/mapEventsTable.ts
+++ b/packages/shared/src/server/tableMappings/mapEventsTable.ts
@@ -228,6 +228,12 @@ export const eventsTableNativeUiColumnDefinitions: UiColumnMappings = [
     clickhouseSelect: "e.parent_span_id != ''",
   },
   {
+    uiTableName: "Parent Observation ID",
+    uiTableId: "parentObservationId",
+    clickhouseTableName: "events",
+    clickhouseSelect: 'e."parent_span_id"',
+  },
+  {
     uiTableName: "Experiment Dataset ID",
     uiTableId: "experimentDatasetId",
     clickhouseTableName: "events",

--- a/packages/shared/src/server/tableMappings/mapObservationsTable.ts
+++ b/packages/shared/src/server/tableMappings/mapObservationsTable.ts
@@ -68,6 +68,12 @@ export const observationsTableUiColumnDefinitions: UiColumnMappings = [
     clickhouseTableName: "observations",
     clickhouseSelect: 'o."trace_id"',
   },
+  {
+    uiTableName: "Parent Observation ID",
+    uiTableId: "parentObservationId",
+    clickhouseTableName: "observations",
+    clickhouseSelect: 'o."parent_observation_id"',
+  },
 
   {
     uiTableName: "Start Time",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `parentObservationId` filter to observations API, supporting null, not null, and specific ID filtering, with tests for both events and observations tables.
> 
>   - **Behavior**:
>     - Adds `parentObservationId` filter to `createFilterFromFilterState()` in `factory.ts` to handle null, not null, and specific ID cases.
>     - Updates `observationsTableCols` in `observationsTable.ts` to include `parentObservationId` as a nullable string.
>   - **Table Mappings**:
>     - Adds `parentObservationId` to `eventsTableNativeUiColumnDefinitions` in `mapEventsTable.ts`.
>     - Adds `parentObservationId` to `observationsTableUiColumnDefinitions` in `mapObservationsTable.ts`.
>   - **Tests**:
>     - Adds tests for `parentObservationId` filter in `observations-api.servertest.ts` to verify filtering by null, not null, and specific parent IDs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1f8dd16281c6e3a1163556d17ae7fa09bb84b1e6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->