### PR TITLE
fix: make too slow error more actionable

### DIFF
--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -42,8 +42,8 @@ type ErrorType = keyof typeof ERROR_TYPE_CONFIG;
 
 export class ClickHouseResourceError extends Error {
   static ERROR_ADVICE_MESSAGE = [
-    "We got notified about this issue and are looking into it.",
-    "We are continuously improving our API performance.",
+    "Your query could not be completed because it required too many resources.",
+    "Please narrow your request by adding more specific filters (e.g., a shorter date range).",
   ].join(" ");
 
   public readonly errorType: ErrorType;

--- a/web/src/__tests__/withMiddlewares.servertest.ts
+++ b/web/src/__tests__/withMiddlewares.servertest.ts
@@ -21,6 +21,7 @@ jest.mock("@langfuse/shared/src/server", () => ({
   ...jest.requireActual("@langfuse/shared/src/server"),
   logger: {
     info: jest.fn(),
+    warn: jest.fn(),
     error: jest.fn(),
     debug: jest.fn(),
   },
@@ -181,7 +182,7 @@ describe("withMiddlewares error handling", () => {
   });
 
   describe("ClickHouseResourceError handling", () => {
-    it("should handle ClickHouseResourceError with 400 status", async () => {
+    it("should handle ClickHouseResourceError with 422 status", async () => {
       const originalError = new Error("Memory limit exceeded: maximum: 10GB");
       const resourceError = new ClickHouseResourceError(
         "MEMORY_LIMIT",
@@ -203,12 +204,13 @@ describe("withMiddlewares error handling", () => {
 
       await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(524);
+      expect(res._getStatusCode()).toBe(422);
       const jsonData = JSON.parse(res._getData());
       expect(jsonData["message"]).toBeDefined();
       expect(jsonData["message"]).toContain(
         ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
       );
+      expect(jsonData["error"]).toBe("Unprocessable Content");
     });
   });
 

--- a/web/src/features/public-api/server/withMiddlewares.ts
+++ b/web/src/features/public-api/server/withMiddlewares.ts
@@ -85,15 +85,15 @@ export function withMiddlewares(handlers: Handlers) {
         if (error instanceof ClickHouseResourceError) {
           const resourceError = error as ClickHouseResourceError;
 
-          logger.error("ClickHouse resource limit exceeded", {
+          logger.warn("ClickHouse resource limit exceeded", {
             errorType: resourceError.errorType,
             message: resourceError.message,
             suggestion: CH_ERROR_ADVICE_FULL,
           });
 
-          return res.status(524).json({
+          return res.status(422).json({
             message: CH_ERROR_ADVICE_FULL,
-            error: "Request is taking too long to process.",
+            error: "Unprocessable Content",
           });
         }
 

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -143,6 +143,10 @@ const logErrorByCode = (errorCode: TRPCError["code"], error: TRPCError) => {
     logger.info(`middleware intercepted error with code ${errorCode}`, {
       error,
     });
+  } else if (errorCode === "UNPROCESSABLE_CONTENT") {
+    logger.warn(`middleware intercepted error with code ${errorCode}`, {
+      error,
+    });
   } else {
     logger.error(`middleware intercepted error with code ${errorCode}`, {
       error,
@@ -158,9 +162,9 @@ const withErrorHandling = t.middleware(async ({ ctx, next }) => {
     if (res.error.cause instanceof ClickHouseResourceError) {
       // Surface ClickHouse errors using an advice message
       // which is supposed to provide a bit of guidance to the user.
-      logErrorByCode("SERVICE_UNAVAILABLE", res.error);
+      logErrorByCode("UNPROCESSABLE_CONTENT", res.error);
       res.error = new TRPCError({
-        code: "SERVICE_UNAVAILABLE",
+        code: "UNPROCESSABLE_CONTENT",
         message: ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
       });
     } else {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve ClickHouse resource error handling by updating error messages, changing status codes to 422, and adjusting logging behavior.
> 
>   - **Behavior**:
>     - Update `ClickHouseResourceError` message in `clickhouse.ts` to advise narrowing requests with specific filters.
>     - Change HTTP status code from 524 to 422 for `ClickHouseResourceError` in `withMiddlewares.ts` and `withMiddlewares.servertest.ts`.
>     - Log `ClickHouseResourceError` as a warning instead of an error in `withMiddlewares.ts`.
>   - **Tests**:
>     - Update test in `withMiddlewares.servertest.ts` to expect 422 status and new error message for `ClickHouseResourceError`.
>   - **Logging**:
>     - Add logging for `UNPROCESSABLE_CONTENT` error code in `trpc.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ca0f717c8f2e170f0cd62d4eefee798fc43eea78. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->