### PR TITLE
feat(evals): support default filter active status

### DIFF
--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -168,6 +168,15 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
     newFilterOptions,
     projectId,
     false,
+    false,
+    [
+      {
+        column: "status",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["ACTIVE"],
+      },
+    ],
   );
 
   const evaluators = api.evals.allConfigs.useQuery({

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -110,10 +110,10 @@ const addPropagationWarnings = (
           severity: "warning" as const,
           content: (
             <>
-              This filter requires JS SDK &ge; 4.4.0 or Python SDK &ge; 3.9.0
+              This filter requires JS SDK &ge; 4.0.0 or Python SDK &ge; 3.0.0
               with attribute propagation enabled. Please{" "}
               <a
-                href="https://langfuse.com/integrations/native/opentelemetry"
+                href="https://langfuse.com/integrations/native/opentelemetry#propagating-attributes"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-dark-blue hover:opacity-80"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds default 'ACTIVE' status filter to evaluator table and updates SDK version warning in evaluator form.
> 
>   - **Behavior**:
>     - Adds default filter for `status` column with value `ACTIVE` in `evaluator-table.tsx`.
>     - Applies default filter when no URL filters are present in `useSidebarFilterState`.
>   - **Warnings**:
>     - Updates SDK version requirements in `addPropagationWarnings()` in `inner-evaluator-form.tsx`.
>     - Corrects URL in warning message in `inner-evaluator-form.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 00741a4ebfd7daa1fc15d8a694ab606c59087c97. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->