### PR TITLE
fix(dataset-items): api version specs

### DIFF
--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -925,7 +925,12 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateDatasetItemRequest'
     get:
-      description: Get dataset items
+      description: >-
+        Get dataset items. Optionally specify a version to get the items as they
+        existed at that point in time.
+
+        Note: If version parameter is provided, datasetName must also be
+        provided.
       operationId: datasetItems_list
       tags:
         - DatasetItems
@@ -947,6 +952,21 @@ paths:
           required: false
           schema:
             type: string
+            nullable: true
+        - name: version
+          in: query
+          description: >-
+            ISO 8601 timestamp (RFC 3339, Section 5.6) in UTC (e.g.,
+            "2026-01-21T14:35:42Z").
+
+            If provided, returns state of dataset at this timestamp.
+
+            If not provided, returns the latest version. Requires datasetName to
+            be specified.
+          required: false
+          schema:
+            type: string
+            format: date-time
             nullable: true
         - name: page
           in: query
@@ -7981,6 +8001,20 @@ components:
           description: >-
             traceId should always be provided. For compatibility with older SDK
             versions it can also be inferred from the provided observationId.
+        datasetVersion:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            ISO 8601 timestamp (RFC 3339, Section 5.6) in UTC (e.g.,
+            "2026-01-21T14:35:42Z").
+
+            Specifies the dataset version to use for this experiment run. 
+
+            If provided, the experiment will use dataset items as they existed
+            at or before this timestamp.
+
+            If not provided, uses the latest version of dataset items.
       required:
         - runName
         - datasetItemId

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -739,9 +739,9 @@
           "_type": "endpoint",
           "name": "List",
           "request": {
-            "description": "Get dataset items",
+            "description": "Get dataset items. Optionally specify a version to get the items as they existed at that point in time.\nNote: If version parameter is provided, datasetName must also be provided.",
             "url": {
-              "raw": "{{baseUrl}}/api/public/dataset-items?datasetName=&sourceTraceId=&sourceObservationId=&page=&limit=",
+              "raw": "{{baseUrl}}/api/public/dataset-items?datasetName=&sourceTraceId=&sourceObservationId=&version=&page=&limit=",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -765,6 +765,11 @@
                   "key": "sourceObservationId",
                   "value": "",
                   "description": null
+                },
+                {
+                  "key": "version",
+                  "value": "",
+                  "description": "ISO 8601 timestamp (RFC 3339, Section 5.6) in UTC (e.g., \"2026-01-21T14:35:42Z\").\nIf provided, returns state of dataset at this timestamp.\nIf not provided, returns the latest version. Requires datasetName to be specified."
                 },
                 {
                   "key": "page",
@@ -848,7 +853,7 @@
             "auth": null,
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"runName\": \"example\",\n    \"runDescription\": \"example\",\n    \"metadata\": \"UNKNOWN\",\n    \"datasetItemId\": \"example\",\n    \"observationId\": \"example\",\n    \"traceId\": \"example\"\n}",
+              "raw": "{\n    \"runName\": \"example\",\n    \"runDescription\": \"example\",\n    \"metadata\": \"UNKNOWN\",\n    \"datasetItemId\": \"example\",\n    \"observationId\": \"example\",\n    \"traceId\": \"example\",\n    \"datasetVersion\": \"1994-11-05T13:15:30Z\"\n}",
               "options": {
                 "raw": {
                   "language": "json"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `version` parameter to dataset items API for retrieving historical data, updating `openapi.yml` and `collection.json`.
> 
>   - **Behavior**:
>     - Updated `GET /api/public/dataset-items` to support `version` query parameter in `openapi.yml` and `collection.json`.
>     - `version` parameter allows retrieval of dataset items as they existed at a specific timestamp.
>     - Requires `datasetName` to be specified if `version` is used.
>   - **Schema**:
>     - Added `datasetVersion` field to `CreateDatasetItemRequest` schema in `openapi.yml`.
>     - Describes `datasetVersion` as an ISO 8601 timestamp for specifying dataset state.
>   - **Documentation**:
>     - Updated descriptions in `openapi.yml` and `collection.json` to reflect new `version` parameter functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e214434a3fb7de0637d029ec1f0a79c726527b22. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->