### PR TITLE
fix(llm-connections): opus-4.6 in playground should not set top_p to -1

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -238,6 +238,7 @@ export async function fetchLLMCompletion(
       modelParams.model?.includes("claude-sonnet-4-5") ||
       modelParams.model?.includes("claude-opus-4-1") ||
       modelParams.model?.includes("claude-opus-4-5") ||
+      modelParams.model?.includes("claude-opus-4-6") ||
       modelParams.model?.includes("claude-haiku-4-5");
 
     const chatOptions: Record<string, any> = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `claude-opus-4-6` to `isClaude45Family` check in `fetchLLMCompletion.ts` to prevent `top_p` from being set to `-1`.
> 
>   - **Behavior**:
>     - Adds `claude-opus-4-6` to the `isClaude45Family` check in `fetchLLMCompletion()` in `fetchLLMCompletion.ts`.
>     - Ensures `top_p` is not set to `-1` for `claude-opus-4-6`, aligning with other `claude` models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 3113d293542350a6e2364f81876304cd612e3ee1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->