### PR TITLE
chore: temporarily remove prod-hipaa from automatic deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,8 +80,9 @@ jobs:
               if (context.ref === "refs/heads/main") {
                 return `["staging"]`
               }
+              // TODO revert to: `["prod-eu", "prod-us", "prod-hipaa"]`
               if (context.ref === "refs/heads/production") {
-                return `["prod-eu", "prod-us", "prod-hipaa"]`
+                return `["prod-eu", "prod-us"]`
               }
             }
             return "[]"


### PR DESCRIPTION
Until `events_core` and `events_full` become available everywhere.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Temporarily remove `prod-hipaa` from automatic deployment in `deploy.yml` for `production` branch pushes.
> 
>   - **Behavior**:
>     - Temporarily remove `prod-hipaa` from automatic deployment targets in `deploy.yml` for `production` branch pushes.
>     - Add a `TODO` comment to revert the change once `events_core` and `events_full` are available.
>   - **Files**:
>     - Modify `.github/workflows/deploy.yml` to adjust deployment environments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5010e2f8c6c47e607fde040a5cb71b8863b8308c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->