### PR TITLE
feat: allow observation_id in v2 scores filtering

### DIFF
--- a/fern/apis/server/definition/score-v2.yml
+++ b/fern/apis/server/definition/score-v2.yml
@@ -59,6 +59,9 @@ service:
           traceId:
             type: optional<string>
             docs: Retrieve only scores with a specific traceId.
+          observationId:
+            type: optional<string>
+            docs: Comma-separated list of observation IDs to filter scores by.
           queueId:
             type: optional<string>
             docs: Retrieve only scores with a specific annotation queueId.

--- a/packages/shared/src/features/scores/interfaces/api/v2/endpoints.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v2/endpoints.ts
@@ -12,6 +12,13 @@ export const GetScoresQueryV2 = GetScoresQuery.extend({
   sessionId: z.string().nullish(),
   traceId: z.string().nullish(),
   datasetRunId: z.string().nullish(),
+  observationId: z
+    .string()
+    .transform((str) => str.split(",").map((id) => id.trim()))
+    .refine((arr) => arr.every((id) => typeof id === "string"), {
+      message: "Each observation ID must be a string",
+    })
+    .nullish(),
 });
 export const GetScoreResponseDataV2 = z
   .intersection(

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -4526,7 +4526,7 @@ paths:
         API key)
       operationId: scim_getServiceProviderConfig
       tags:
-        - Scim
+        - SCIM
       parameters: []
       responses:
         '200':
@@ -4567,7 +4567,7 @@ paths:
       description: Get SCIM Resource Types (requires organization-scoped API key)
       operationId: scim_getResourceTypes
       tags:
-        - Scim
+        - SCIM
       parameters: []
       responses:
         '200':
@@ -4608,7 +4608,7 @@ paths:
       description: Get SCIM Schemas (requires organization-scoped API key)
       operationId: scim_getSchemas
       tags:
-        - Scim
+        - SCIM
       parameters: []
       responses:
         '200':
@@ -4649,7 +4649,7 @@ paths:
       description: List users in the organization (requires organization-scoped API key)
       operationId: scim_listUsers
       tags:
-        - Scim
+        - SCIM
       parameters:
         - name: filter
           in: query
@@ -4712,7 +4712,7 @@ paths:
         key)
       operationId: scim_createUser
       tags:
-        - Scim
+        - SCIM
       parameters: []
       responses:
         '200':
@@ -4783,7 +4783,7 @@ paths:
       description: Get a specific user by ID (requires organization-scoped API key)
       operationId: scim_getUser
       tags:
-        - Scim
+        - SCIM
       parameters:
         - name: userId
           in: path
@@ -4831,7 +4831,7 @@ paths:
         does not delete the user entity itself.
       operationId: scim_deleteUser
       tags:
-        - Scim
+        - SCIM
       parameters:
         - name: userId
           in: path
@@ -5197,6 +5197,13 @@ paths:
         - name: traceId
           in: query
           description: Retrieve only scores with a specific traceId.
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: observationId
+          in: query
+          description: Comma-separated list of observation IDs to filter scores by.
           required: false
           schema:
             type: string

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -3241,7 +3241,7 @@
           "request": {
             "description": "Get a list of scores (supports both trace and session scores)",
             "url": {
-              "raw": "{{baseUrl}}/api/public/v2/scores?page=&limit=&userId=&name=&fromTimestamp=&toTimestamp=&environment=&source=&operator=&value=&scoreIds=&configId=&sessionId=&datasetRunId=&traceId=&queueId=&dataType=&traceTags=&fields=",
+              "raw": "{{baseUrl}}/api/public/v2/scores?page=&limit=&userId=&name=&fromTimestamp=&toTimestamp=&environment=&source=&operator=&value=&scoreIds=&configId=&sessionId=&datasetRunId=&traceId=&observationId=&queueId=&dataType=&traceTags=&fields=",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -3326,6 +3326,11 @@
                   "key": "traceId",
                   "value": "",
                   "description": "Retrieve only scores with a specific traceId."
+                },
+                {
+                  "key": "observationId",
+                  "value": "",
+                  "description": "Comma-separated list of observation IDs to filter scores by."
                 },
                 {
                   "key": "queueId",

--- a/web/src/features/public-api/server/scores.ts
+++ b/web/src/features/public-api/server/scores.ts
@@ -52,6 +52,7 @@ export type ScoreQueryType = {
   traceTags?: string | string[];
   operator?: string;
   scoreIds?: string[];
+  observationId?: string[];
   dataType?: string;
   environment?: string | string[];
   fields?: string[] | null;
@@ -287,6 +288,13 @@ const secureScoreFilterOptions = [
     clickhouseSelect: "trace_id",
     clickhouseTable: "scores",
     filterType: "StringFilter",
+    clickhousePrefix: "s",
+  },
+  {
+    id: "observationId",
+    clickhouseSelect: "observation_id",
+    clickhouseTable: "scores",
+    filterType: "StringOptionsFilter",
     clickhousePrefix: "s",
   },
   {

--- a/web/src/pages/api/public/v2/scores/index.ts
+++ b/web/src/pages/api/public/v2/scores/index.ts
@@ -44,6 +44,7 @@ export default withMiddlewares({
         configId: query.configId ?? undefined,
         sessionId: query.sessionId ?? undefined,
         traceId: query.traceId ?? undefined,
+        observationId: query.observationId ?? undefined,
         datasetRunId: query.datasetRunId ?? undefined,
         queueId: query.queueId ?? undefined,
         traceTags: query.traceTags ?? undefined,


### PR DESCRIPTION
- **feat: allow observation_id in v2 scores filtering**
- **chore: fern**

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `observationId` filtering to v2 scores API and update SCIM tags in OpenAPI spec.
> 
>   - **Behavior**:
>     - Add `observationId` filter to v2 scores API in `score-v2.yml` and `endpoints.ts`.
>     - Update `GetScoresQueryV2` to handle `observationId` as a comma-separated string.
>     - Add tests for filtering by single and multiple `observationId` in `scores-api-v2.servertest.ts`.
>   - **Misc**:
>     - Rename SCIM tags from `Scim` to `SCIM` in `openapi.yml`.
>     - Update Postman collection URL in `collection.json` to include `observationId` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7d06520d0c2bfe53d7cb8402469126674630468c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->