### PR TITLE
refactor: improve text truncation and wrapping in scores table cell

### DIFF
--- a/web/src/components/scores-table-cell.tsx
+++ b/web/src/components/scores-table-cell.tsx
@@ -33,13 +33,13 @@ const ScoreValueCounts = ({
   wrap: boolean;
 }) => {
   return valueCounts.map(({ value, count }, index) => (
-    <div key={value} className="flex flex-row">
+    <span key={value} className="inline-block">
       <span className="truncate">{value}</span>
       <span>{`: ${numberFormatter(count, 0)}`}</span>
-      {!wrap && index < valueCounts.length - 1 && (
-        <span className="mr-1">{";"}</span>
+      {index < valueCounts.length - 1 && (
+        <span className="mr-1">{wrap ? "" : "; "}</span>
       )}
-    </div>
+    </span>
   ));
 };
 
@@ -124,11 +124,11 @@ export const ScoresTableCell = ({
     <div className="group">
       {aggregate.valueCounts.length > COLLAPSE_CATEGORICAL_SCORES_AFTER ? (
         <HoverCard>
-          <HoverCardTrigger>
+          <HoverCardTrigger asChild>
             <div
               className={cn(
-                "flex cursor-pointer group-hover:text-accent-dark-blue/55",
-                wrap ? "flex-col" : "flex-row",
+                "cursor-pointer overflow-hidden group-hover:text-accent-dark-blue/55",
+                wrap ? "line-clamp-5" : "text-ellipsis whitespace-nowrap",
               )}
             >
               <ScoreValueCounts
@@ -141,7 +141,7 @@ export const ScoresTableCell = ({
             </div>
           </HoverCardTrigger>
           <HoverCardContent className="z-20 flex max-h-[40vh] max-w-64 flex-col overflow-y-auto whitespace-normal break-normal text-xs">
-            <ScoreValueCounts valueCounts={aggregate.valueCounts} wrap={wrap} />
+            <ScoreValueCounts valueCounts={aggregate.valueCounts} wrap />
           </HoverCardContent>
         </HoverCard>
       ) : (


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `ScoresTableCell` to improve text truncation and wrapping using `span` elements and conditional styling.
> 
>   - **Behavior**:
>     - `ScoreValueCounts` now uses `span` instead of `div` for inline display.
>     - Conditional semicolon rendering in `ScoreValueCounts` based on `wrap`.
>     - `HoverCardTrigger` in `ScoresTableCell` uses `asChild` for better wrapping control.
>   - **Styling**:
>     - `ScoresTableCell` uses `line-clamp-5` or `text-ellipsis` for text overflow based on `wrap`.
>     - Removed `flex-row` and added `overflow-hidden` to `HoverCardTrigger` for better text handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 38940a89c065746f9b444c87b74a88efc6885c26. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->