### PR TITLE
feat: allow advanced filters on scores v2 enpoint. thus enabling

### DIFF
--- a/fern/apis/server/definition/score-v2.yml
+++ b/fern/apis/server/definition/score-v2.yml
@@ -75,6 +75,14 @@ service:
           fields:
             type: optional<string>
             docs: "Comma-separated list of field groups to include in the response. Available field groups: 'score' (core score fields), 'trace' (trace properties: userId, tags, environment). If not specified, both 'score' and 'trace' are returned by default. Example: 'score' to exclude trace data, 'score,trace' to include both. Note: When filtering by trace properties (using userId or traceTags parameters), the 'trace' field group must be included, otherwise a 400 error will be returned."
+          filter:
+            type: optional<string>
+            docs: >
+              A JSON stringified array of filter objects. Each object requires type, column, operator, and value.
+              Supports filtering by score metadata using the stringObject type.
+              Example: [{"type":"stringObject","column":"metadata","key":"user_id","operator":"=","value":"abc123"}].
+              Supported types: stringObject (metadata key-value filtering), string, number, datetime, stringOptions, arrayOptions.
+              Supported operators for stringObject: =, contains, does not contain, starts with, ends with.
       response: GetScoresResponse
     get-by-id:
       docs: Get a score (supports both trace and session scores)

--- a/packages/shared/src/features/scores/interfaces/api/shared.ts
+++ b/packages/shared/src/features/scores/interfaces/api/shared.ts
@@ -7,6 +7,8 @@ import {
   ScoreDataTypeDomain,
   ScoreSourceDomain,
 } from "../../../../domain/scores";
+import { singleFilter } from "../../../../interfaces/filters";
+import { InvalidRequestError } from "../../../../errors";
 
 const operators = ["<", ">", "<=", ">=", "!=", "="] as const;
 
@@ -55,6 +57,20 @@ export const GetScoresQuery = z.object({
         .filter((f) => SCORE_FIELD_GROUPS.includes(f as ScoreFieldGroup));
     })
     .pipe(z.array(z.enum(SCORE_FIELD_GROUPS)).nullable()),
+  filter: z
+    .string()
+    .optional()
+    .transform((str) => {
+      if (!str) return undefined;
+      try {
+        const parsed = JSON.parse(str);
+        return parsed;
+      } catch (e) {
+        if (e instanceof InvalidRequestError) throw e;
+        throw new InvalidRequestError("Invalid JSON in filter parameter");
+      }
+    })
+    .pipe(z.array(singleFilter).optional()),
 });
 
 // POST /scores

--- a/packages/shared/src/server/tableMappings/mapScoresTable.ts
+++ b/packages/shared/src/server/tableMappings/mapScoresTable.ts
@@ -80,6 +80,12 @@ export const scoresTableUiColumnDefinitions: UiColumnMappings = [
     clickhouseSelect: "string_value",
   },
   {
+    uiTableName: "Metadata",
+    uiTableId: "metadata",
+    clickhouseTableName: "scores",
+    clickhouseSelect: "metadata",
+  },
+  {
     uiTableName: "Trace Name",
     uiTableId: "traceName",
     clickhouseTableName: "traces",

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -5248,6 +5248,21 @@ paths:
           schema:
             type: string
             nullable: true
+        - name: filter
+          in: query
+          description: >-
+            A JSON stringified array of filter objects. Each object requires
+            type, column, operator, and value. Supports filtering by score
+            metadata using the stringObject type. Example:
+            [{"type":"stringObject","column":"metadata","key":"user_id","operator":"=","value":"abc123"}].
+            Supported types: stringObject (metadata key-value filtering),
+            string, number, datetime, stringOptions, arrayOptions. Supported
+            operators for stringObject: =, contains, does not contain, starts
+            with, ends with.
+          required: false
+          schema:
+            type: string
+            nullable: true
       responses:
         '200':
           description: ''

--- a/web/public/generated/postman/collection.json
+++ b/web/public/generated/postman/collection.json
@@ -3241,7 +3241,7 @@
           "request": {
             "description": "Get a list of scores (supports both trace and session scores)",
             "url": {
-              "raw": "{{baseUrl}}/api/public/v2/scores?page=&limit=&userId=&name=&fromTimestamp=&toTimestamp=&environment=&source=&operator=&value=&scoreIds=&configId=&sessionId=&datasetRunId=&traceId=&observationId=&queueId=&dataType=&traceTags=&fields=",
+              "raw": "{{baseUrl}}/api/public/v2/scores?page=&limit=&userId=&name=&fromTimestamp=&toTimestamp=&environment=&source=&operator=&value=&scoreIds=&configId=&sessionId=&datasetRunId=&traceId=&observationId=&queueId=&dataType=&traceTags=&fields=&filter=",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -3351,6 +3351,11 @@
                   "key": "fields",
                   "value": "",
                   "description": "Comma-separated list of field groups to include in the response. Available field groups: 'score' (core score fields), 'trace' (trace properties: userId, tags, environment). If not specified, both 'score' and 'trace' are returned by default. Example: 'score' to exclude trace data, 'score,trace' to include both. Note: When filtering by trace properties (using userId or traceTags parameters), the 'trace' field group must be included, otherwise a 400 error will be returned."
+                },
+                {
+                  "key": "filter",
+                  "value": "",
+                  "description": "A JSON stringified array of filter objects. Each object requires type, column, operator, and value. Supports filtering by score metadata using the stringObject type. Example: [{\"type\":\"stringObject\",\"column\":\"metadata\",\"key\":\"user_id\",\"operator\":\"=\",\"value\":\"abc123\"}]. Supported types: stringObject (metadata key-value filtering), string, number, datetime, stringOptions, arrayOptions. Supported operators for stringObject: =, contains, does not contain, starts with, ends with."
                 }
               ],
               "variable": []

--- a/web/src/features/public-api/server/scores.ts
+++ b/web/src/features/public-api/server/scores.ts
@@ -1,17 +1,20 @@
-import { convertApiProvidedFilterToClickhouseFilter } from "@langfuse/shared/src/server";
 import {
+  convertApiProvidedFilterToClickhouseFilter,
+  deriveFilters,
   convertClickhouseScoreToDomain,
   StringFilter,
   StringOptionsFilter,
   type ScoreRecordReadType,
   queryClickhouse,
   measureAndReturn,
+  scoresTableUiColumnDefinitions,
 } from "@langfuse/shared/src/server";
 import {
   removeObjectKeys,
   ScoreDataTypeEnum,
   type ScoreDataTypeType,
   type ScoreDomain,
+  type FilterState,
 } from "@langfuse/shared";
 
 /**
@@ -56,6 +59,7 @@ export type ScoreQueryType = {
   dataType?: string;
   environment?: string | string[];
   fields?: string[] | null;
+  advancedFilters?: FilterState;
 };
 
 /**
@@ -420,9 +424,11 @@ const generateScoreFilter = (
   filter: ScoreQueryType,
   scoreDataTypes?: readonly ScoreDataTypeType[],
 ) => {
-  const scoresFilter = convertApiProvidedFilterToClickhouseFilter(
+  const scoresFilter = deriveFilters(
     filter,
     secureScoreFilterOptions,
+    filter.advancedFilters,
+    scoresTableUiColumnDefinitions,
   );
   scoresFilter.push(
     new StringFilter({

--- a/web/src/pages/api/public/scores/index.ts
+++ b/web/src/pages/api/public/scores/index.ts
@@ -70,6 +70,7 @@ export default withMiddlewares({
         value: query.value ?? undefined,
         operator: query.operator ?? undefined,
         scoreIds: query.scoreIds ?? undefined,
+        advancedFilters: query.filter,
       };
       const [items, count] = await Promise.all([
         scoresApiService.generateScoresForPublicApi(scoreParams),

--- a/web/src/pages/api/public/v2/scores/index.ts
+++ b/web/src/pages/api/public/v2/scores/index.ts
@@ -57,6 +57,7 @@ export default withMiddlewares({
         operator: query.operator ?? undefined,
         scoreIds: query.scoreIds ?? undefined,
         fields: query.fields ?? undefined,
+        advancedFilters: query.filter,
       };
       const scoresApiService = new ScoresApiService("v2");
       const [items, count] = await Promise.all([


### PR DESCRIPTION
- **feat: allow advanced filters on scores v2 enpoint. thus enabling metadata filtering.**
- **chore: fern**
----
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances scores v2 endpoint with advanced filtering capabilities, allowing metadata-based queries and precedence of advanced filters over simple parameters.
> 
>   - **Behavior**:
>     - Adds `filter` parameter to `score-v2.yml`, `shared.ts`, and `openapi.yml` for advanced filtering on scores v2 endpoint.
>     - Supports filtering by score metadata using `stringObject` type with operators like `=`, `contains`, etc.
>     - Advanced filters take precedence over simple query parameters.
>   - **Tests**:
>     - Adds tests in `scores-api-v2.servertest.ts` for filtering by metadata, multiple filters, and combining with simple parameters.
>   - **Misc**:
>     - Updates `mapScoresTable.ts` to include `metadata` in `scoresTableUiColumnDefinitions`.
>     - Modifies `scores.ts` to handle `advancedFilters` in `ScoreQueryType` and `generateScoreFilter()`.
>     - Updates `index.ts` in `public/v2/scores` to pass `advancedFilters` to `ScoresApiService`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9789286320f2d85b32a141c12a02953a75ed0a70. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->