### PR TITLE
fix: prevent Mixpanel/PostHog integration jobs from permanently stalling

### DIFF
--- a/packages/shared/src/server/redis/mixpanelIntegrationQueue.ts
+++ b/packages/shared/src/server/redis/mixpanelIntegrationQueue.ts
@@ -7,6 +7,8 @@ import {
 } from "./redis";
 import { logger } from "../logger";
 
+export const MIXPANEL_SYNC_CRON_PATTERN = "30 * * * *"; // every hour at :30
+
 export class MixpanelIntegrationQueue {
   private static instance: Queue | null = null;
 
@@ -47,7 +49,7 @@ export class MixpanelIntegrationQueue {
           QueueJobs.MixpanelIntegrationJob,
           {},
           {
-            repeat: { pattern: "30 * * * *" }, // every hour at 30 minutes past
+            repeat: { pattern: MIXPANEL_SYNC_CRON_PATTERN },
           },
         )
         .catch((err) => {

--- a/packages/shared/src/server/redis/postHogIntegrationQueue.ts
+++ b/packages/shared/src/server/redis/postHogIntegrationQueue.ts
@@ -7,6 +7,8 @@ import {
 } from "./redis";
 import { logger } from "../logger";
 
+export const POSTHOG_SYNC_CRON_PATTERN = "30 * * * *"; // every hour at :30
+
 export class PostHogIntegrationQueue {
   private static instance: Queue | null = null;
 
@@ -47,7 +49,7 @@ export class PostHogIntegrationQueue {
           QueueJobs.PostHogIntegrationJob,
           {},
           {
-            repeat: { pattern: "30 * * * *" }, // every hour at 30 minutes past
+            repeat: { pattern: POSTHOG_SYNC_CRON_PATTERN },
           },
         )
         .catch((err) => {

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -447,6 +447,13 @@ if (env.QUEUE_CONSUMER_MIXPANEL_INTEGRATION_QUEUE_IS_ENABLED === "true") {
         max: 1,
         duration: 10_000,
       },
+      // The default lockDuration is 30s and the lockRenewTime 1/2 of that.
+      // We set it to 60s to reduce the number of lock renewals and also be less sensitive to high CPU wait times.
+      // We also update the stalledInterval check to 120s from 30s default to perform the check less frequently.
+      // Finally, we set the maxStalledCount to 3 (default 1) to perform repeated attempts on stalled jobs.
+      lockDuration: 60000, // 60 seconds
+      stalledInterval: 120000, // 120 seconds
+      maxStalledCount: 3,
     },
   );
 }

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -37,7 +37,9 @@ const processPostHogTraces = async (config: PostHogExecutionConfig) => {
     config.maxTimestamp,
   );
 
-  logger.info(`Sending traces for project ${config.projectId} to PostHog`);
+  logger.info(
+    `[POSTHOG] Sending traces for project ${config.projectId} to PostHog`,
+  );
 
   // Send each via PostHog SDK
   const posthog = new PostHog(config.decryptedPostHogApiKey, {
@@ -47,10 +49,10 @@ const processPostHogTraces = async (config: PostHogExecutionConfig) => {
 
   posthog.on("error", (error) => {
     logger.error(
-      `Error sending traces to PostHog for project ${config.projectId}: ${error}`,
+      `[POSTHOG] Error sending traces to PostHog for project ${config.projectId}: ${error}`,
     );
     throw new Error(
-      `Error sending traces to PostHog for project ${config.projectId}: ${error}`,
+      `[POSTHOG] Error sending traces to PostHog for project ${config.projectId}: ${error}`,
     );
   });
 
@@ -62,13 +64,13 @@ const processPostHogTraces = async (config: PostHogExecutionConfig) => {
     if (count % 10000 === 0) {
       await posthog.flush();
       logger.info(
-        `Sent ${count} traces to PostHog for project ${config.projectId}`,
+        `[POSTHOG] Sent ${count} traces to PostHog for project ${config.projectId}`,
       );
     }
   }
   await posthog.flush();
   logger.info(
-    `Sent ${count} traces to PostHog for project ${config.projectId}`,
+    `[POSTHOG] Sent ${count} traces to PostHog for project ${config.projectId}`,
   );
 };
 
@@ -79,7 +81,9 @@ const processPostHogGenerations = async (config: PostHogExecutionConfig) => {
     config.maxTimestamp,
   );
 
-  logger.info(`Sending generations for project ${config.projectId} to PostHog`);
+  logger.info(
+    `[POSTHOG] Sending generations for project ${config.projectId} to PostHog`,
+  );
 
   // Send each via PostHog SDK
   const posthog = new PostHog(config.decryptedPostHogApiKey, {
@@ -89,10 +93,10 @@ const processPostHogGenerations = async (config: PostHogExecutionConfig) => {
 
   posthog.on("error", (error) => {
     logger.error(
-      `Error sending generations to PostHog for project ${config.projectId}: ${error}`,
+      `[POSTHOG] Error sending generations to PostHog for project ${config.projectId}: ${error}`,
     );
     throw new Error(
-      `Error sending generations to PostHog for project ${config.projectId}: ${error}`,
+      `[POSTHOG] Error sending generations to PostHog for project ${config.projectId}: ${error}`,
     );
   });
 
@@ -104,13 +108,13 @@ const processPostHogGenerations = async (config: PostHogExecutionConfig) => {
     if (count % 10000 === 0) {
       await posthog.flush();
       logger.info(
-        `Sent ${count} generations to PostHog for project ${config.projectId}`,
+        `[POSTHOG] Sent ${count} generations to PostHog for project ${config.projectId}`,
       );
     }
   }
   await posthog.flush();
   logger.info(
-    `Sent ${count} generations to PostHog for project ${config.projectId}`,
+    `[POSTHOG] Sent ${count} generations to PostHog for project ${config.projectId}`,
   );
 };
 
@@ -121,7 +125,9 @@ const processPostHogScores = async (config: PostHogExecutionConfig) => {
     config.maxTimestamp,
   );
 
-  logger.info(`Sending scores for project ${config.projectId} to PostHog`);
+  logger.info(
+    `[POSTHOG] Sending scores for project ${config.projectId} to PostHog`,
+  );
 
   // Send each via PostHog SDK
   const posthog = new PostHog(config.decryptedPostHogApiKey, {
@@ -131,10 +137,10 @@ const processPostHogScores = async (config: PostHogExecutionConfig) => {
 
   posthog.on("error", (error) => {
     logger.error(
-      `Error sending scores to PostHog for project ${config.projectId}: ${error}`,
+      `[POSTHOG] Error sending scores to PostHog for project ${config.projectId}: ${error}`,
     );
     throw new Error(
-      `Error sending scores to PostHog for project ${config.projectId}: ${error}`,
+      `[POSTHOG] Error sending scores to PostHog for project ${config.projectId}: ${error}`,
     );
   });
   let count = 0;
@@ -145,13 +151,13 @@ const processPostHogScores = async (config: PostHogExecutionConfig) => {
     if (count % 10000 === 0) {
       await posthog.flush();
       logger.info(
-        `Sent ${count} scores to PostHog for project ${config.projectId}`,
+        `[POSTHOG] Sent ${count} scores to PostHog for project ${config.projectId}`,
       );
     }
   }
   await posthog.flush();
   logger.info(
-    `Sent ${count} scores to PostHog for project ${config.projectId}`,
+    `[POSTHOG] Sent ${count} scores to PostHog for project ${config.projectId}`,
   );
 };
 
@@ -166,7 +172,9 @@ export const handlePostHogIntegrationProjectJob = async (
     span.setAttribute("messaging.bullmq.job.input.projectId", projectId);
   }
 
-  logger.info(`Processing PostHog integration for project ${projectId}`);
+  logger.info(
+    `[POSTHOG] Processing PostHog integration for project ${projectId}`,
+  );
 
   // Fetch PostHog integration information for project
   const postHogIntegration = await prisma.posthogIntegration.findFirst({
@@ -178,7 +186,7 @@ export const handlePostHogIntegrationProjectJob = async (
 
   if (!postHogIntegration) {
     logger.warn(
-      `Enabled PostHog integration not found for project ${projectId}`,
+      `[POSTHOG] Enabled PostHog integration not found for project ${projectId}`,
     );
     return;
   }
@@ -188,7 +196,7 @@ export const handlePostHogIntegrationProjectJob = async (
     await validateWebhookURL(postHogIntegration.posthogHostName);
   } catch (error) {
     logger.error(
-      `PostHog integration for project ${projectId} has invalid hostname: ${postHogIntegration.posthogHostName}. Error: ${error instanceof Error ? error.message : String(error)}`,
+      `[POSTHOG] PostHog integration for project ${projectId} has invalid hostname: ${postHogIntegration.posthogHostName}. Error: ${error instanceof Error ? error.message : String(error)}`,
     );
     throw new Error(
       `Invalid PostHog hostname for project ${projectId}: ${error instanceof Error ? error.message : "Unknown error"}`,
@@ -205,22 +213,30 @@ export const handlePostHogIntegrationProjectJob = async (
     postHogHost: postHogIntegration.posthogHostName,
   };
 
-  await Promise.all([
-    processPostHogTraces(executionConfig),
-    processPostHogGenerations(executionConfig),
-    processPostHogScores(executionConfig),
-  ]);
+  try {
+    await Promise.all([
+      processPostHogTraces(executionConfig),
+      processPostHogGenerations(executionConfig),
+      processPostHogScores(executionConfig),
+    ]);
 
-  // Update the last run information for the postHogIntegration record
-  await prisma.posthogIntegration.update({
-    where: {
-      projectId,
-    },
-    data: {
-      lastSyncAt: executionConfig.maxTimestamp,
-    },
-  });
-  logger.info(
-    `PostHog integration processing complete for project ${projectId}`,
-  );
+    // Update the last run information for the postHogIntegration record.
+    await prisma.posthogIntegration.update({
+      where: {
+        projectId,
+      },
+      data: {
+        lastSyncAt: executionConfig.maxTimestamp,
+      },
+    });
+    logger.info(
+      `[POSTHOG] PostHog integration processing complete for project ${projectId}`,
+    );
+  } catch (error) {
+    logger.error(
+      `[POSTHOG] Error processing PostHog integration for project ${projectId}`,
+      error,
+    );
+    throw error;
+  }
 };


### PR DESCRIPTION
Addresses https://github.com/langfuse/langfuse/issues/11827

Add an hourly key to the BullMQ processing jobId so that failed jobs
from a previous hour don't permanently block re-queuing of the same
project. Previously, when lastSyncAt was NULL the jobId was static,
causing a single failure to deadlock the integration forever.

Also add stalling protection (lockDuration/stalledInterval/maxStalledCount)
to the Mixpanel processing worker, [MIXPANEL]/[POSTHOG] log
prefixes, try/catch around both processing pipelines, and extract cron
patterns into named constants.

----
<!-- ELLIPSIS_HIDDEN -->
> [!IMPORTANT]
> Extracted cron patterns into named constants, added job queue locking configuration, improved logging with prefixes and error handling, and implemented hourly job ID keys to prevent failed jobs from blocking re-queuing in Mixpanel and PostHog integration handlers.
> 
>   ## Queue Configuration and Cron Patterns
>   - Extracted hardcoded cron pattern `"30 * * * *"` into exported constants `MIXPANEL_SYNC_CRON_PATTERN` and `POSTHOG_SYNC_CRON_PATTERN` in `mixpanelIntegrationQueue.ts` and `postHogIntegrationQueue.ts`.
>   - Added job queue locking configuration in `worker/src/app.ts`: `lockDuration` (60 seconds), `stalledInterval` (120 seconds), and `maxStalledCount` (3) to reduce lock renewals and improve handling of high CPU wait times.
>   ## Logging Improvements
>   - Added `[MIXPANEL]` and `[POSTHOG]` prefixes to all logger messages in `handleMixpanelIntegrationProjectJob.ts`, `handlePostHogIntegrationProjectJob.ts`, and their respective schedule handlers for better log filtering and identification.
>   - Wrapped main processing logic in try-catch blocks in both project job handlers to capture and re-throw errors during integration processing.
>   ## Job Queue Resilience
>   - Added hourly key component to job IDs in `handleMixpanelIntegrationSchedule.ts` and `handlePostHogIntegrationSchedule.ts` to prevent failed jobs from previous hours from blocking re-queuing.
>   - Added `removeOnFail` option to job configuration to remove failed jobs after 5 attempts.
>   - Added early return with info logging when no integrations are ready for sync in both schedule handlers.
>   - Added info logging when scheduling integrations for sync.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 034cb4cdea4c3944c22ad09b77985da612873134. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>
<!-- ELLIPSIS_HIDDEN -->