### PR TITLE
feat(evals-ui): add clickable trace reference badge in LLM-as-a-Judge evaluation traces

### DIFF
--- a/web/src/components/trace2/TracePreview.tsx
+++ b/web/src/components/trace2/TracePreview.tsx
@@ -4,6 +4,7 @@ import {
   type TraceDomain,
   AnnotationQueueObjectType,
   isGenerationLike,
+  LangfuseInternalTraceEnvironment,
 } from "@langfuse/shared";
 import { AggUsageBadge } from "@/src/components/token-usage-badge";
 import { Badge } from "@/src/components/ui/badge";
@@ -63,6 +64,7 @@ import {
   AlertDialogTitle,
 } from "@/src/components/ui/alert-dialog";
 import { type WithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
+import { resolveEvalExecutionMetadata } from "@/src/components/trace2/lib/resolve-metadata";
 
 const LOG_VIEW_CONFIRMATION_THRESHOLD = 150;
 const LOG_VIEW_DISABLED_THRESHOLD = 350;
@@ -185,6 +187,11 @@ export const TracePreview = ({
     setSelectedTab("log");
   };
 
+  const targetTraceId =
+    trace.environment === LangfuseInternalTraceEnvironment.LLMJudge
+      ? resolveEvalExecutionMetadata(parsedMetadata)
+      : null;
+
   return (
     <div className="col-span-2 flex h-full flex-1 flex-col overflow-hidden md:col-span-3">
       <div className="flex h-full flex-1 flex-col items-start gap-1 overflow-hidden @container">
@@ -280,6 +287,19 @@ export const TracePreview = ({
                 >
                   <Badge>
                     <span className="truncate">User ID: {trace.userId}</span>
+                    <ExternalLinkIcon className="ml-1 h-3 w-3" />
+                  </Badge>
+                </Link>
+              ) : null}
+              {targetTraceId ? (
+                <Link
+                  href={`/project/${trace.projectId as string}/traces/${encodeURIComponent(targetTraceId)}`}
+                  className="inline-flex"
+                >
+                  <Badge>
+                    <span className="truncate">
+                      Target Trace: {targetTraceId}
+                    </span>
                     <ExternalLinkIcon className="ml-1 h-3 w-3" />
                   </Badge>
                 </Link>

--- a/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
+++ b/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
@@ -193,6 +193,7 @@ export function TraceDetailView({
       <TraceDetailViewHeader
         trace={trace}
         observations={observations}
+        parsedMetadata={parsedMetadata}
         projectId={projectId}
         traceScores={traceScores}
         commentCount={comments.get(trace.id)}

--- a/web/src/components/trace2/components/TraceDetailView/TraceMetadataBadges.tsx
+++ b/web/src/components/trace2/components/TraceDetailView/TraceMetadataBadges.tsx
@@ -51,6 +51,27 @@ export function UserIdBadge({
   );
 }
 
+export function TargetTraceBadge({
+  targetTraceId,
+  projectId,
+}: {
+  targetTraceId: string | null;
+  projectId: string;
+}) {
+  if (!targetTraceId) return null;
+  return (
+    <Link
+      href={`/project/${projectId}/traces/${encodeURIComponent(targetTraceId)}`}
+      className="inline-flex"
+    >
+      <Badge>
+        <span className="truncate">Target Trace: {targetTraceId}</span>
+        <ExternalLinkIcon className="ml-1 h-3 w-3" />
+      </Badge>
+    </Link>
+  );
+}
+
 export function EnvironmentBadge({
   environment,
 }: {

--- a/web/src/components/trace2/lib/resolve-metadata.ts
+++ b/web/src/components/trace2/lib/resolve-metadata.ts
@@ -1,0 +1,13 @@
+export const resolveEvalExecutionMetadata = (
+  parsedMetadata: unknown,
+): string | null => {
+  try {
+    if (typeof parsedMetadata !== "object" || parsedMetadata === null)
+      return null;
+    return (parsedMetadata as Record<string, unknown>)[
+      "target_trace_id"
+    ] as string;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a clickable "Target Trace" badge in LLM-as-a-Judge evaluation traces, linking to the target trace using metadata.
> 
>   - **Behavior**:
>     - Adds clickable "Target Trace" badge in `TracePreview` and `TraceDetailViewHeader` for LLM-as-a-Judge traces.
>     - Badge links to the target trace using `target_trace_id` from metadata.
>   - **Functions**:
>     - Adds `resolveEvalExecutionMetadata()` in `resolve-metadata.ts` to extract `target_trace_id` from metadata.
>   - **Components**:
>     - Updates `TracePreview.tsx` to include `TargetTraceBadge` when `target_trace_id` is present.
>     - Updates `TraceDetailViewHeader.tsx` to include `TargetTraceBadge`.
>     - Adds `TargetTraceBadge` component in `TraceMetadataBadges.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f4db956e147bdfdfa02b936f44409723eacb4def. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->