### PR TITLE
feat: limit height for eval template text area

### DIFF
--- a/web/src/components/editor/CodeMirrorEditor.tsx
+++ b/web/src/components/editor/CodeMirrorEditor.tsx
@@ -169,6 +169,7 @@ export function CodeMirrorEditor({
   onBlur,
   mode,
   minHeight,
+  maxHeight,
   placeholder,
   editorRef,
 }: {
@@ -181,6 +182,7 @@ export function CodeMirrorEditor({
   className?: string;
   mode: "json" | "text" | "prompt";
   minHeight: "none" | 30 | 100 | 200;
+  maxHeight?: string;
   placeholder?: string;
   editorRef?: React.RefObject<ReactCodeMirrorRef | null>;
 }) {
@@ -235,6 +237,14 @@ export function CodeMirrorEditor({
                 ".cm-scroller": { overflow: "auto" },
               }),
             ]),
+        // Add max height support for very long bodies of text
+        ...(maxHeight
+          ? [
+              EditorView.theme({
+                ".cm-scroller": { maxHeight: maxHeight },
+              }),
+            ]
+          : []),
         ...(mode === "json" ? [json()] : []),
         ...(mode === "json" && linterEnabled
           ? [linter(jsonParseLinter())]

--- a/web/src/features/evals/components/template-form.tsx
+++ b/web/src/features/evals/components/template-form.tsx
@@ -459,6 +459,7 @@ export const InnerEvalTemplateForm = (props: {
                         editable={props.isEditing}
                         mode="prompt"
                         minHeight={200}
+                        maxHeight="30dvh"
                       />
                     </FormControl>
                     <FormMessage />


### PR DESCRIPTION
## What does this PR do?

This pull request adds support for specifying a maximum height for the `CodeMirrorEditor` component, allowing for better control of editor sizing, especially when displaying large amounts of text. The new `maxHeight` prop is utilized in the eval template form to limit the editor's height, improving the user experience by preventing excessively tall editors which require a lot of scrolling.

Enhancements to editor sizing:

* Added a new optional `maxHeight` prop to the `CodeMirrorEditor` component and its props interface, allowing consumers to set a maximum height for the editor (`web/src/components/editor/CodeMirrorEditor.tsx`). [[1]](diffhunk://#diff-712d12ba832815de3538375b2a958cc0095690881401cfdda7242b7aae2f3e5cR172) [[2]](diffhunk://#diff-712d12ba832815de3538375b2a958cc0095690881401cfdda7242b7aae2f3e5cR185)
* Updated the editor's style logic to apply a `maxHeight` to the `.cm-scroller` element when the prop is provided, ensuring long text bodies do not cause the editor to grow excessively (`web/src/components/editor/CodeMirrorEditor.tsx`).

Usage in eval template form:

* Set `maxHeight="30dvh"` on the prompt editor in the eval template form, limiting its height to 30% of the viewport for better usability (`web/src/features/evals/components/template-form.tsx`).

---

https://www.loom.com/share/7f606b5b47134a7f8cef6f7252ddd4a5

Video shows the height limited text area versus the current implementation in the hosted web view which requires the user to scroll through the entire prompt to get to the bottom of the page. This is especially noticeable when editing an evaluator since you need to scroll to the bottom of the page in order to click 'Update' and save your changes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `maxHeight` prop to `CodeMirrorEditor` to limit editor height, applied in eval template form to improve usability.
> 
>   - **Behavior**:
>     - Adds `maxHeight` prop to `CodeMirrorEditor` to limit editor height (`CodeMirrorEditor.tsx`).
>     - Applies `maxHeight` to `.cm-scroller` when provided, preventing excessive growth (`CodeMirrorEditor.tsx`).
>   - **Usage**:
>     - Sets `maxHeight="30dvh"` in eval template form to limit editor height to 30% of viewport (`template-form.tsx`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 70387858a99be739251504b34cfa7aa097c3146f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->