### PR TITLE
fix: fail fast on posthog errors to avoid HOL blocking

### DIFF
--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -47,28 +47,30 @@ const processPostHogTraces = async (config: PostHogExecutionConfig) => {
     ...postHogSettings,
   });
 
+  let sendError: Error | undefined;
   posthog.on("error", (error) => {
     logger.error(
       `[POSTHOG] Error sending traces to PostHog for project ${config.projectId}: ${error}`,
     );
-    throw new Error(
-      `[POSTHOG] Error sending traces to PostHog for project ${config.projectId}: ${error}`,
-    );
+    sendError = error instanceof Error ? error : new Error(String(error));
   });
 
   let count = 0;
   for await (const trace of traces) {
+    if (sendError) throw sendError;
     count++;
     const event = transformTraceForPostHog(trace, config.projectId);
     posthog.capture(event);
     if (count % 10000 === 0) {
       await posthog.flush();
+      if (sendError) throw sendError;
       logger.info(
         `[POSTHOG] Sent ${count} traces to PostHog for project ${config.projectId}`,
       );
     }
   }
   await posthog.flush();
+  if (sendError) throw sendError;
   logger.info(
     `[POSTHOG] Sent ${count} traces to PostHog for project ${config.projectId}`,
   );
@@ -91,28 +93,30 @@ const processPostHogGenerations = async (config: PostHogExecutionConfig) => {
     ...postHogSettings,
   });
 
+  let sendError: Error | undefined;
   posthog.on("error", (error) => {
     logger.error(
       `[POSTHOG] Error sending generations to PostHog for project ${config.projectId}: ${error}`,
     );
-    throw new Error(
-      `[POSTHOG] Error sending generations to PostHog for project ${config.projectId}: ${error}`,
-    );
+    sendError = error instanceof Error ? error : new Error(String(error));
   });
 
   let count = 0;
   for await (const generation of generations) {
+    if (sendError) throw sendError;
     count++;
     const event = transformGenerationForPostHog(generation, config.projectId);
     posthog.capture(event);
     if (count % 10000 === 0) {
       await posthog.flush();
+      if (sendError) throw sendError;
       logger.info(
         `[POSTHOG] Sent ${count} generations to PostHog for project ${config.projectId}`,
       );
     }
   }
   await posthog.flush();
+  if (sendError) throw sendError;
   logger.info(
     `[POSTHOG] Sent ${count} generations to PostHog for project ${config.projectId}`,
   );
@@ -135,27 +139,30 @@ const processPostHogScores = async (config: PostHogExecutionConfig) => {
     ...postHogSettings,
   });
 
+  let sendError: Error | undefined;
   posthog.on("error", (error) => {
     logger.error(
       `[POSTHOG] Error sending scores to PostHog for project ${config.projectId}: ${error}`,
     );
-    throw new Error(
-      `[POSTHOG] Error sending scores to PostHog for project ${config.projectId}: ${error}`,
-    );
+    sendError = error instanceof Error ? error : new Error(String(error));
   });
+
   let count = 0;
   for await (const score of scores) {
+    if (sendError) throw sendError;
     count++;
     const event = transformScoreForPostHog(score, config.projectId);
     posthog.capture(event);
     if (count % 10000 === 0) {
       await posthog.flush();
+      if (sendError) throw sendError;
       logger.info(
         `[POSTHOG] Sent ${count} scores to PostHog for project ${config.projectId}`,
       );
     }
   }
   await posthog.flush();
+  if (sendError) throw sendError;
   logger.info(
     `[POSTHOG] Sent ${count} scores to PostHog for project ${config.projectId}`,
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve error handling in PostHog integration functions to prevent head-of-line blocking by deferring error throwing until after processing checks.
> 
>   - **Error Handling**:
>     - In `processPostHogTraces`, `processPostHogGenerations`, and `processPostHogScores`, replace immediate error throwing with setting `sendError` and checking it before processing each item.
>     - Ensure `sendError` is checked after every `flush()` call and at the end of processing to throw if an error occurred.
>   - **Logging**:
>     - Log errors when they occur in the PostHog event sending process, but delay throwing until after processing checks.
>   - **Misc**:
>     - No changes to the overall logic of data processing or structure, only error handling adjustments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 10c2094c78fad32212f26adb02e11779fefe2bed. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->