### PR TITLE
fix: revert hourly-key jobId in favor of removeOnFail for integration queues

### DIFF
--- a/worker/src/features/mixpanel/handleMixpanelIntegrationSchedule.ts
+++ b/worker/src/features/mixpanel/handleMixpanelIntegrationSchedule.ts
@@ -34,10 +34,26 @@ export const handleMixpanelIntegrationSchedule = async () => {
     `[MIXPANEL] Scheduling ${mixpanelIntegrationProjects.length} Mixpanel integrations for sync`,
   );
 
-  // Include an hourly key in the jobId so that failed jobs from a previous hour
-  // don't permanently block re-queuing (BullMQ skips adds when a job with the
-  // same ID already exists in a failed state).
-  const hourKey = new Date().toISOString().slice(0, 13); // e.g. "2026-02-11T08"
+  // One-time migration: clean up jobs with the old hourly-key jobId format
+  // (e.g. "<projectId>--2026-02-11T08") that may have accumulated.
+  // Can be removed once all deployments have run this code.
+  const hourlyKeyPattern = /\d{4}-\d{2}-\d{2}T\d{2}$/;
+  const waitingJobs = await mixpanelIntegrationProcessingQueue.getWaiting(
+    0,
+    1000,
+  );
+  const failedJobs = await mixpanelIntegrationProcessingQueue.getFailed(
+    0,
+    1000,
+  );
+  const hasLegacyJobs = [...waitingJobs, ...failedJobs].some(
+    (job) => job.id && hourlyKeyPattern.test(job.id),
+  );
+  if (hasLegacyJobs) {
+    logger.info("[MIXPANEL] Cleaning up legacy hourly-key jobs");
+    await mixpanelIntegrationProcessingQueue.drain();
+    await mixpanelIntegrationProcessingQueue.clean(0, 0, "failed");
+  }
 
   await mixpanelIntegrationProcessingQueue.addBulk(
     mixpanelIntegrationProjects.map(
@@ -52,8 +68,11 @@ export const handleMixpanelIntegrationSchedule = async () => {
           },
         },
         opts: {
-          jobId: `${integration.projectId}-${integration.lastSyncAt?.toISOString() ?? ""}-${hourKey}`,
-          removeOnFail: { count: 5 },
+          // Deduplicate by projectId + lastSyncAt so the same project isn't queued
+          // twice for the same sync window. removeOnFail ensures failed jobs are
+          // immediately cleaned up so they don't block re-queuing on the next cycle.
+          jobId: `${integration.projectId}-${integration.lastSyncAt?.toISOString() ?? ""}`,
+          removeOnFail: true,
         },
       }),
     ),


### PR DESCRIPTION
The hourly-key approach from #11988 broke jobId deduplication, causing an
ever-growing queue where each scheduler cycle added new jobs regardless of
whether previous ones had completed. Revert to static jobId (projectId +
lastSyncAt) for proper deduplication and use removeOnFail: true so failed
jobs are immediately cleaned from Redis and don't block re-queuing.

Includes a one-time migration that drains legacy hourly-key jobs on first
scheduler run after deploy.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts hourly-key jobId to static jobId for Mixpanel and PostHog queues, adds one-time migration to clean legacy jobs, and ensures failed jobs are removed immediately.
> 
>   - **Behavior**:
>     - Reverts to static `jobId` (projectId + lastSyncAt) in `handleMixpanelIntegrationSchedule.ts` and `handlePostHogIntegrationSchedule.ts` for proper job deduplication.
>     - Uses `removeOnFail: true` to immediately clean failed jobs from Redis, preventing re-queuing blocks.
>   - **Migration**:
>     - One-time migration in `handleMixpanelIntegrationSchedule.ts` and `handlePostHogIntegrationSchedule.ts` to drain legacy hourly-key jobs on first scheduler run after deploy.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 67a90c76f87bc90826794bf570774dd5742efddc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->