### PR TITLE
chore(evals): allow free-text observation/trace name for evals

### DIFF
--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -214,7 +214,7 @@ const ObservationsPreview = memo(
             Preview sample matched observations
           </span>
           <FormDescription>
-            Sample over the last 24 hours that match these filters
+            Sample over the last 24 hours that match filters
           </FormDescription>
         </div>
         <div className="mb-4 flex max-h-[30dvh] w-full flex-col overflow-hidden border-b border-l border-r">

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -860,7 +860,7 @@ export const InnerEvaluatorForm = (props: {
                             disabled={props.disabled}
                             columnsWithCustomSelect={
                               isEventTarget(target) || isTraceTarget(target)
-                                ? ["tags"]
+                                ? ["tags", "name"]
                                 : undefined
                             }
                           />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `FormDescription` text in `inner-evaluator-form.tsx` for clarity.
> 
>   - **Text Update**:
>     - In `inner-evaluator-form.tsx`, update `FormDescription` text from "Sample over the last 24 hours that match these filters" to "Sample over the last 24 hours that match filters".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5b060541f7e829801552c98246d4b667fc7e6b56. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->