### PR TITLE
fix: increase legacy job cleanup limits for integration queues

### DIFF
--- a/worker/src/features/mixpanel/handleMixpanelIntegrationSchedule.ts
+++ b/worker/src/features/mixpanel/handleMixpanelIntegrationSchedule.ts
@@ -52,7 +52,7 @@ export const handleMixpanelIntegrationSchedule = async () => {
   if (hasLegacyJobs) {
     logger.info("[MIXPANEL] Cleaning up legacy hourly-key jobs");
     await mixpanelIntegrationProcessingQueue.drain();
-    await mixpanelIntegrationProcessingQueue.clean(0, 0, "failed");
+    await mixpanelIntegrationProcessingQueue.clean(0, 1000, "failed");
   }
 
   await mixpanelIntegrationProcessingQueue.addBulk(

--- a/worker/src/features/posthog/handlePostHogIntegrationSchedule.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationSchedule.ts
@@ -47,7 +47,7 @@ export const handlePostHogIntegrationSchedule = async () => {
   if (hasLegacyJobs) {
     logger.info("[POSTHOG] Cleaning up legacy hourly-key jobs");
     await postHogIntegrationProcessingQueue.drain();
-    await postHogIntegrationProcessingQueue.clean(0, 0, "failed");
+    await postHogIntegrationProcessingQueue.clean(0, 1000, "failed");
   }
 
   await postHogIntegrationProcessingQueue.addBulk(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase legacy job cleanup limit from 0 to 1000 for Mixpanel and PostHog integration queues.
> 
>   - **Behavior**:
>     - Increase limit for cleaning failed legacy jobs from `0` to `1000` in `handleMixpanelIntegrationSchedule` and `handlePostHogIntegrationSchedule`.
>   - **Functions**:
>     - `mixpanelIntegrationProcessingQueue.clean()` and `postHogIntegrationProcessingQueue.clean()` now clean up to 1000 failed jobs.
>   - **Logging**:
>     - Logs cleanup of legacy hourly-key jobs in both Mixpanel and PostHog schedules.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 380600417abb22c3342f151defbaf918a1550a13. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->