### PR TITLE
fix(ui-single-observation-eval): refine wording

### DIFF
--- a/web/src/features/evals/components/eval-version-callout.tsx
+++ b/web/src/features/evals/components/eval-version-callout.tsx
@@ -1,5 +1,5 @@
 import { Alert, AlertDescription } from "@/src/components/ui/alert";
-import { Info, AlertTriangle } from "lucide-react";
+import { Info } from "lucide-react";
 import { type EvalCapabilities } from "@/src/features/evals/hooks/useEvalCapabilities";
 import {
   isTraceTarget,
@@ -13,10 +13,8 @@ interface EvalVersionCalloutProps {
   evalCapabilities: EvalCapabilities;
 }
 
-type CalloutVariant = "info" | "warning" | "hidden";
-
 interface CalloutContent {
-  variant: CalloutVariant;
+  visible: boolean;
   title: string;
   description: React.ReactNode;
 }
@@ -25,33 +23,29 @@ const getCalloutContent = (
   targetObject: string,
   evalCapabilities: EvalCapabilities,
 ): CalloutContent => {
+  const hidden = { visible: false, title: "", description: "" };
+
   // For event/observation target
   if (isEventTarget(targetObject)) {
-    // If user IS compatible with OTEL, don't show callout
     if (evalCapabilities.isNewCompatible) {
-      return {
-        variant: "hidden",
-        title: "",
-        description: "",
-      };
+      return hidden;
     }
 
-    // If user is NOT compatible with OTEL, show warning
     return {
-      variant: "warning",
-      title: "Newer version of the Langfuse SDK required",
+      visible: true,
+      title: "Live observations require a newer Langfuse SDK",
       description: (
         <>
-          Running evaluators on live observations require JS SDK v4+ or Python
-          SDK v3+. You can still set up this evaluator now—it will start running
-          once you upgrade your SDK to latest.{" "}
+          This evaluator targets live observations, which require JS SDK v4+ or
+          Python SDK v3+. You can still configure this evaluator now—it will
+          start running once you upgrade.{" "}
           <a
             href="https://langfuse.com/docs/tracing/overview#langfuse-tracing-vs-opentelemetry"
             target="_blank"
             rel="noopener noreferrer"
             className="font-medium text-dark-blue hover:opacity-80"
           >
-            Learn how to upgrade
+            Learn more
           </a>
           .
         </>
@@ -59,73 +53,83 @@ const getCalloutContent = (
     };
   }
 
-  // For experiment target (OTEL-based experiments)
+  // For experiment target (Experiment Runner SDK)
   if (isExperimentTarget(targetObject)) {
-    // If user is NOT compatible with OTEL, show warning
     if (!evalCapabilities.isNewCompatible) {
       return {
-        variant: "warning",
-        title: "Are you sure you are already on the recommended SDK version?",
+        visible: true,
+        title: "The Experiment Runner SDK requires a newer Langfuse SDK",
         description: (
           <>
-            Running observation-targeting evaluators for experiments requires JS
-            SDK v4.4+ or Python SDK v3.9+. You can still set your evaluator up
-            now—it will start running once you upgrade to the latest SDK
-            version.{" "}
+            The Experiment Runner SDK requires JS SDK v4.4+ or Python SDK v3.9+.
+            You can still configure this evaluator now—it will start running
+            once you upgrade.{" "}
             <a
-              href="https://langfuse.com/docs/tracing/overview#langfuse-tracing-vs-opentelemetry"
+              href="https://langfuse.com/docs/evaluation/experiments/experiments-via-sdk#experiment-runner-sdk"
               target="_blank"
               rel="noopener noreferrer"
               className="font-medium text-dark-blue hover:opacity-80"
             >
-              Learn how to upgrade
+              Learn more
             </a>
             .
           </>
         ),
       };
     }
+
+    return hidden;
   }
 
-  // For dataset target (now represents non-OTEL experiments when selected via second tab)
+  // For dataset target (legacy dataset run methods)
   if (isDatasetTarget(targetObject)) {
     return {
-      variant: "info",
-      title: "You selected an old SDK version",
-      description:
-        "Please consider upgrading to the latest SDK version for improved performance and features. You can even set up the evaluator for the new version now—it will start running once you upgrade to the latest SDK version.",
+      visible: true,
+      title: "Legacy dataset run methods",
+      description: (
+        <>
+          This evaluator targets traces from legacy low-level SDK methods for
+          dataset runs. Consider upgrading to the Experiment Runner SDK for
+          improved performance and features.{" "}
+          <a
+            href="https://langfuse.com/docs/evaluation/experiments/experiments-via-sdk#experiment-runner-sdk"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-dark-blue hover:opacity-80"
+          >
+            Learn more
+          </a>
+          .
+        </>
+      ),
     };
   }
 
-  // For trace target - always show deprecation info
+  // For trace target
   if (isTraceTarget(targetObject)) {
     return {
-      variant: "info",
+      visible: true,
       title: "Consider upgrading to live observations evaluators",
       description: (
         <>
           Live observations evaluators provide more granular control and an
           easier workflow. We strongly recommend upgrading to live observations
-          evaluators.
+          evaluators.{" "}
           <a
             href="https://langfuse.com/faq/all/llm-as-a-judge-migration"
             target="_blank"
             rel="noopener noreferrer"
             className="font-medium text-dark-blue hover:opacity-80"
           >
-            Learn more.
+            Learn more
           </a>
+          .
         </>
       ),
     };
   }
 
-  // Default: hidden
-  return {
-    variant: "hidden",
-    title: "",
-    description: "",
-  };
+  return hidden;
 };
 
 export function EvalVersionCallout({
@@ -134,26 +138,13 @@ export function EvalVersionCallout({
 }: EvalVersionCalloutProps) {
   const content = getCalloutContent(targetObject, evalCapabilities);
 
-  if (content.variant === "hidden") {
+  if (!content.visible) {
     return null;
   }
 
-  const isWarning = content.variant === "warning";
-
   return (
-    <Alert
-      variant="default"
-      className={
-        isWarning
-          ? "mt-2 border-light-yellow bg-light-yellow"
-          : "mt-2 border-light-blue bg-light-blue"
-      }
-    >
-      {isWarning ? (
-        <AlertTriangle className="h-4 w-4 text-dark-yellow dark:text-dark-yellow" />
-      ) : (
-        <Info className="h-4 w-4 text-dark-blue dark:text-dark-blue" />
-      )}
+    <Alert variant="default" className="mt-2 border-light-blue bg-light-blue">
+      <Info className="h-4 w-4 text-dark-blue dark:text-dark-blue" />
       <AlertDescription>
         <div className="flex flex-col gap-2">
           <div className="flex flex-col gap-1">

--- a/web/src/features/evals/components/eval-version-callout.tsx
+++ b/web/src/features/evals/components/eval-version-callout.tsx
@@ -68,9 +68,9 @@ const getCalloutContent = (
         title: "Are you sure you are already on the recommended SDK version?",
         description: (
           <>
-            Running evaluators requires JS SDK &ge; 4.4.0 or Python SDK &ge;
-            3.9.0. You can still set your evaluator up now—it will start running
-            once you upgrade to the latest SDK version.{" "}
+            Running observation-targeting evaluators requires JS SDK &ge; 4.4.0
+            or Python SDK &ge; 3.9.0. You can still set your evaluator up now—it
+            will start running once you upgrade to the latest SDK version.{" "}
             <a
               href="https://langfuse.com/docs/tracing/overview#langfuse-tracing-vs-opentelemetry"
               target="_blank"

--- a/web/src/features/evals/components/eval-version-callout.tsx
+++ b/web/src/features/evals/components/eval-version-callout.tsx
@@ -33,7 +33,7 @@ const getCalloutContent = (
 
     return {
       visible: true,
-      title: "Live observations require a newer Langfuse SDK",
+      title: "Please check your SDK version",
       description: (
         <>
           This evaluator targets live observations, which require JS SDK v4+ or

--- a/web/src/features/evals/components/eval-version-callout.tsx
+++ b/web/src/features/evals/components/eval-version-callout.tsx
@@ -58,7 +58,7 @@ const getCalloutContent = (
     if (!evalCapabilities.isNewCompatible) {
       return {
         visible: true,
-        title: "The Experiment Runner SDK requires a newer Langfuse SDK",
+        title: "Please check your SDK version",
         description: (
           <>
             The Experiment Runner SDK requires JS SDK v4.4+ or Python SDK v3.9+.

--- a/web/src/features/evals/components/eval-version-callout.tsx
+++ b/web/src/features/evals/components/eval-version-callout.tsx
@@ -42,9 +42,9 @@ const getCalloutContent = (
       title: "Newer version of the Langfuse SDK required",
       description: (
         <>
-          Running evaluators on live observations require JS SDK &ge; 4.0.0 or
-          Python SDK &ge; 3.0.0. You can still set up this evaluator now—it will
-          start running once you upgrade your SDK to latest.{" "}
+          Running evaluators on live observations require JS SDK v4+ or Python
+          SDK v3+. You can still set up this evaluator now—it will start running
+          once you upgrade your SDK to latest.{" "}
           <a
             href="https://langfuse.com/docs/tracing/overview#langfuse-tracing-vs-opentelemetry"
             target="_blank"
@@ -68,9 +68,10 @@ const getCalloutContent = (
         title: "Are you sure you are already on the recommended SDK version?",
         description: (
           <>
-            Running observation-targeting evaluators requires JS SDK &ge; 4.4.0
-            or Python SDK &ge; 3.9.0. You can still set your evaluator up now—it
-            will start running once you upgrade to the latest SDK version.{" "}
+            Running observation-targeting evaluators for experiments requires JS
+            SDK v4.4+ or Python SDK v3.9+. You can still set your evaluator up
+            now—it will start running once you upgrade to the latest SDK
+            version.{" "}
             <a
               href="https://langfuse.com/docs/tracing/overview#langfuse-tracing-vs-opentelemetry"
               target="_blank"
@@ -101,8 +102,21 @@ const getCalloutContent = (
     return {
       variant: "info",
       title: "Consider upgrading to live observations evaluators",
-      description:
-        "Live observations evaluators provide more granular control and an easier workflow. We strongly recommend upgrading to live observations evaluators.",
+      description: (
+        <>
+          Live observations evaluators provide more granular control and an
+          easier workflow. We strongly recommend upgrading to live observations
+          evaluators.
+          <a
+            href="https://langfuse.com/faq/all/llm-as-a-judge-migration"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-dark-blue hover:opacity-80"
+          >
+            Learn more.
+          </a>
+        </>
+      ),
     };
   }
 

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/src/components/ui/form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
+import { Badge } from "@/src/components/ui/badge";
 import {
   tracesTableColsWithOptions,
   singleFilter,
@@ -71,7 +72,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@/src/components/ui/tooltip";
-import { InfoIcon } from "lucide-react";
+import { CircleDot, FlaskConical, InfoIcon, ListTree } from "lucide-react";
 import {
   isDatasetTarget,
   isEventTarget,
@@ -582,31 +583,50 @@ export const InnerEvaluatorForm = (props: {
                           field.onChange(actualTarget);
                         }}
                       >
-                        <TabsList className="grid w-fit max-w-fit grid-flow-col">
+                        <TabsList className="grid w-fit max-w-fit grid-flow-col gap-4">
                           {isBetaEnabled && (
                             <TabsTrigger
                               value="event"
                               disabled={props.disabled || props.mode === "edit"}
-                              className="min-w-[100px]"
+                              className="min-w-[100px] gap-1.5"
                             >
-                              Live Observations [New]
+                              <CircleDot className="h-3.5 w-3.5" />
+                              Live Observations
+                              <Badge
+                                variant="secondary"
+                                size="sm"
+                                className="border border-border font-normal"
+                              >
+                                New
+                              </Badge>
                             </TabsTrigger>
                           )}
                           {allowLegacy && (
                             <TabsTrigger
                               value="trace"
                               disabled={props.disabled || props.mode === "edit"}
-                              className="min-w-[100px]"
+                              className="min-w-[100px] gap-1.5"
                             >
-                              Live Traces {isBetaEnabled ? "[Legacy]" : ""}
+                              <ListTree className="h-3.5 w-3.5" />
+                              Live Traces
+                              {isBetaEnabled && (
+                                <Badge
+                                  variant="secondary"
+                                  size="sm"
+                                  className="border border-border font-normal"
+                                >
+                                  Legacy
+                                </Badge>
+                              )}
                             </TabsTrigger>
                           )}
                           <TabsTrigger
                             value="offline-experiment"
                             disabled={props.disabled || props.mode === "edit"}
-                            className="min-w-[100px]"
+                            className="min-w-[100px] gap-1.5"
                           >
-                            Offline Experiments
+                            <FlaskConical className="h-3.5 w-3.5" />
+                            Experiments
                           </TabsTrigger>
                         </TabsList>
                       </Tabs>
@@ -623,7 +643,7 @@ export const InnerEvaluatorForm = (props: {
               userFacingTarget === "offline-experiment" &&
               props.evalCapabilities.allowLegacy && (
                 <div className="flex flex-col gap-2">
-                  <FormLabel className="text-sm">SDK Version</FormLabel>
+                  <FormLabel className="text-sm">Experiment Method</FormLabel>
                   <Tabs
                     value={useOtelDataForExperiment ? "otel" : "non-otel"}
                     onValueChange={(value) => {
@@ -657,29 +677,39 @@ export const InnerEvaluatorForm = (props: {
                       );
                     }}
                   >
-                    <TabsList className="grid w-fit max-w-fit grid-cols-2">
+                    <TabsList className="grid w-fit max-w-fit grid-flow-col gap-4">
                       <TabsTrigger
                         value="otel"
-                        className="min-w-[150px]"
+                        className="min-w-[100px] gap-1.5"
                         disabled={props.mode === "edit" || props.disabled}
                       >
-                        {"JS SDK >= 4.4.0, Python SDK >= 3.9.0 [New]"}
+                        <FlaskConical className="h-3.5 w-3.5" />
+                        Experiment Runner SDK
+                        <Badge
+                          variant="secondary"
+                          size="sm"
+                          className="border border-border font-normal"
+                        >
+                          New
+                        </Badge>
                       </TabsTrigger>
                       <TabsTrigger
                         value="non-otel"
-                        className="min-w-[150px]"
+                        className="min-w-[100px] gap-1.5"
                         disabled={props.mode === "edit" || props.disabled}
                       >
-                        {"JS SDK < 4.4.0, Python SDK < 3.9.0 [Legacy]"}
+                        <ListTree className="h-3.5 w-3.5" />
+                        Dataset Run
+                        <Badge
+                          variant="secondary"
+                          size="sm"
+                          className="border border-border font-normal"
+                        >
+                          Legacy
+                        </Badge>
                       </TabsTrigger>
                     </TabsList>
                   </Tabs>
-                  {!props.disabled && (
-                    <FormDescription>
-                      Check with your technical team to see which version of the
-                      Langfuse SDK you are using.
-                    </FormDescription>
-                  )}
                 </div>
               )}
 

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -72,7 +72,13 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@/src/components/ui/tooltip";
-import { CircleDot, FlaskConical, InfoIcon, ListTree } from "lucide-react";
+import {
+  BetweenHorizonalStart,
+  CircleDot,
+  FlaskConical,
+  InfoIcon,
+  ListTree,
+} from "lucide-react";
 import {
   isDatasetTarget,
   isEventTarget,
@@ -698,7 +704,7 @@ export const InnerEvaluatorForm = (props: {
                         className="min-w-[100px] gap-1.5"
                         disabled={props.mode === "edit" || props.disabled}
                       >
-                        <ListTree className="h-3.5 w-3.5" />
+                        <BetweenHorizonalStart className="h-3.5 w-3.5" />
                         Dataset Run
                         <Badge
                           variant="secondary"

--- a/web/src/features/evals/pages/remap-evaluator.tsx
+++ b/web/src/features/evals/pages/remap-evaluator.tsx
@@ -170,8 +170,8 @@ export default function RemapEvaluatorPage() {
               <AlertDescription>
                 <div className="flex flex-col gap-2">
                   {isEventTarget(mappedConfig.targetObject ?? "event")
-                    ? "Running evaluators requires JS SDK ≥ 4.0.0 or Python SDK ≥ 3.0.0."
-                    : "Running evaluators requires JS SDK ≥ 4.4.0 or Python SDK ≥ 3.9.0."}
+                    ? "Running observation-targeting evaluators requires JS SDK ≥ 4.0.0 or Python SDK ≥ 3.0.0."
+                    : "Running observation-targeting evaluators requires JS SDK ≥ 4.4.0 or Python SDK ≥ 3.9.0."}
                 </div>
               </AlertDescription>
             </Alert>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refine wording in `eval-version-callout.tsx` and `remap-evaluator.tsx` to specify SDK requirements for "observation-targeting evaluators".
> 
>   - **Wording Refinement**:
>     - In `eval-version-callout.tsx`, change wording to "Running observation-targeting evaluators requires JS SDK ≥ 4.4.0 or Python SDK ≥ 3.9.0".
>     - In `remap-evaluator.tsx`, change wording to "Running observation-targeting evaluators requires JS SDK ≥ 4.0.0 or Python SDK ≥ 3.0.0" for event targets, and "Running observation-targeting evaluators requires JS SDK ≥ 4.4.0 or Python SDK ≥ 3.9.0" for non-event targets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 43efbfb3dd4e86a9155f23e3f99675a261a30321. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<img width="2556" height="982" alt="CleanShot 2026-02-12 at 19 07 34@2x" src="https://github.com/user-attachments/assets/c130d8aa-a3f9-4048-a520-e8723f73c476" />
<img width="2568" height="1092" alt="CleanShot 2026-02-12 at 19 08 12@2x" src="https://github.com/user-attachments/assets/cae3aa85-dfd7-4b37-a1d6-8d41f4e6186c" />
<img width="2402" height="1094" alt="CleanShot 2026-02-12 at 19 08 26@2x" src="https://github.com/user-attachments/assets/4255af58-22a8-492d-8713-4f9397e39cc9" />
<img width="3014" height="1590" alt="CleanShot 2026-02-12 at 19 08 42@2x" src="https://github.com/user-attachments/assets/13c9e942-b76e-4041-bfdf-1ad4991620fe" />