### PR TITLE
chore: remove integration queue cleanup

### DIFF
--- a/worker/src/features/posthog/handlePostHogIntegrationSchedule.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationSchedule.ts
@@ -32,24 +32,6 @@ export const handlePostHogIntegrationSchedule = async () => {
     `[POSTHOG] Scheduling ${postHogIntegrationProjects.length} PostHog integrations for sync`,
   );
 
-  // One-time migration: clean up jobs with the old hourly-key jobId format
-  // (e.g. "<projectId>--2026-02-11T08") that may have accumulated.
-  // Can be removed once all deployments have run this code.
-  const hourlyKeyPattern = /\d{4}-\d{2}-\d{2}T\d{2}$/;
-  const waitingJobs = await postHogIntegrationProcessingQueue.getWaiting(
-    0,
-    1000,
-  );
-  const failedJobs = await postHogIntegrationProcessingQueue.getFailed(0, 1000);
-  const hasLegacyJobs = [...waitingJobs, ...failedJobs].some(
-    (job) => job.id && hourlyKeyPattern.test(job.id),
-  );
-  if (hasLegacyJobs) {
-    logger.info("[POSTHOG] Cleaning up legacy hourly-key jobs");
-    await postHogIntegrationProcessingQueue.drain();
-    await postHogIntegrationProcessingQueue.clean(0, 1000, "failed");
-  }
-
   await postHogIntegrationProcessingQueue.addBulk(
     postHogIntegrationProjects.map((integration) => ({
       name: QueueJobs.PostHogIntegrationProcessingJob,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove legacy job cleanup code from Mixpanel and PostHog integration scheduling.
> 
>   - **Removal**:
>     - Remove legacy job cleanup code from `handleMixpanelIntegrationSchedule.ts`.
>     - Remove legacy job cleanup code from `handlePostHogIntegrationSchedule.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 54dcea22752b385717ece1a3be9ddad3650da83b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->