### PR TITLE
docs(evals): observation evals as open beta

### DIFF
--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -20,7 +20,7 @@ import { cn } from "@/src/utils/tailwind";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { api } from "@/src/utils/api";
 import { LegacyEvalCallout } from "@/src/features/evals/components/legacy-eval-callout";
-import { useObservationEvals } from "@/src/features/events/hooks/useObservationEvals";
+import { useIsObservationEvalsBeta } from "@/src/features/events/hooks/useObservationEvals";
 
 export const PeekViewEvaluatorConfigDetail = ({
   projectId,
@@ -28,7 +28,7 @@ export const PeekViewEvaluatorConfigDetail = ({
   projectId: string;
 }) => {
   const router = useRouter();
-  const isBetaEnabled = useObservationEvals();
+  const isBetaEnabled = useIsObservationEvalsBeta();
   const peekId = router.query.peek as string | undefined;
   const [isEditMode, setIsEditMode] = useState(false);
   const utils = api.useUtils();

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -73,7 +73,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
-import { useObservationEvals } from "@/src/features/events/hooks/useObservationEvals";
+import { useIsObservationEvalsBeta } from "@/src/features/events/hooks/useObservationEvals";
 
 export type EvaluatorDataRow = {
   id: string;
@@ -139,7 +139,7 @@ function LegacyBadgeCell({ status }: { status: string }) {
 }
 
 export default function EvaluatorTable({ projectId }: { projectId: string }) {
-  const isBetaEnabled = useObservationEvals();
+  const isBetaEnabled = useIsObservationEvalsBeta();
   const router = useRouter();
   const { setDetailPageList } = useDetailPageLists();
   const [paginationState, setPaginationState] = useQueryParams({

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -96,7 +96,10 @@ import {
 } from "@/src/features/evals/utils/evaluator-constants";
 import { useEvalConfigFilterOptions } from "@/src/features/evals/hooks/useEvalConfigFilterOptions";
 import { VariableMappingCard } from "@/src/features/evals/components/variable-mapping-card";
-import { useObservationEvals } from "@/src/features/events/hooks/useObservationEvals";
+import {
+  useIsObservationEvalsBeta,
+  useObservationEvals,
+} from "@/src/features/events/hooks/useObservationEvals";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 
 /**
@@ -275,6 +278,7 @@ export const InnerEvaluatorForm = (props: {
 }) => {
   const [formError, setFormError] = useState<string | null>(null);
   const isBetaEnabled = useObservationEvals();
+  const isObservationEvalsBeta = useIsObservationEvalsBeta();
   const capture = usePostHogClientCapture();
   const router = useRouter();
   const [showTraceConfirmDialog, setShowTraceConfirmDialog] = useState(false);
@@ -603,7 +607,7 @@ export const InnerEvaluatorForm = (props: {
                                 size="sm"
                                 className="border border-border font-normal"
                               >
-                                New
+                                Beta
                               </Badge>
                             </TabsTrigger>
                           )}
@@ -615,7 +619,7 @@ export const InnerEvaluatorForm = (props: {
                             >
                               <ListTree className="h-3.5 w-3.5" />
                               Live Traces
-                              {isBetaEnabled && (
+                              {isObservationEvalsBeta && (
                                 <Badge
                                   variant="secondary"
                                   size="sm"

--- a/web/src/features/evals/components/template-selector.tsx
+++ b/web/src/features/evals/components/template-selector.tsx
@@ -37,7 +37,7 @@ import {
 import { useSingleTemplateValidation } from "@/src/features/evals/hooks/useSingleTemplateValidation";
 import { getMaintainer } from "@/src/features/evals/utils/typeHelpers";
 import { MaintainerTooltip } from "@/src/features/evals/components/maintainer-tooltip";
-import { useObservationEvals } from "@/src/features/events/hooks/useObservationEvals";
+import { useIsObservationEvalsBeta } from "@/src/features/events/hooks/useObservationEvals";
 
 type TemplateSelectorProps = {
   projectId: string;
@@ -68,7 +68,7 @@ export const TemplateSelector = ({
 }: TemplateSelectorProps) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [search, setSearch] = useState("");
-  const isBetaEnabled = useObservationEvals();
+  const isBetaEnabled = useIsObservationEvalsBeta();
   const {
     activeTemplates,
     isTemplateActive,

--- a/web/src/features/events/hooks/useObservationEvals.ts
+++ b/web/src/features/events/hooks/useObservationEvals.ts
@@ -3,3 +3,7 @@ import useIsFeatureEnabled from "@/src/features/feature-flags/hooks/useIsFeature
 export function useObservationEvals() {
   return useIsFeatureEnabled("observationEvals") ?? false;
 }
+
+export function useIsObservationEvalsBeta() {
+  return true;
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renames `useObservationEvals` to `useIsObservationEvalsBeta` and updates its usage across multiple files, with `useIsObservationEvalsBeta` now always returning `true`.
> 
>   - **Renaming**:
>     - Rename `useObservationEvals` to `useIsObservationEvalsBeta` in `useObservationEvals.ts`.
>     - Update references in `peek-evaluator-config-detail.tsx`, `evaluator-table.tsx`, `inner-evaluator-form.tsx`, and `template-selector.tsx`.
>   - **Behavior**:
>     - `useIsObservationEvalsBeta` now always returns `true` in `useObservationEvals.ts`.
>   - **UI Changes**:
>     - Change badge label from "New" to "Beta" in `inner-evaluator-form.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0ea458c1bd0ba820aba1985fda35cb3b7922a139. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->