### PR TITLE
chore(cloud): update data access on pro/teams/enterprise plan, pricing page

### DIFF
--- a/web/src/ee/features/billing/utils/stripeCatalogue.ts
+++ b/web/src/ee/features/billing/utils/stripeCatalogue.ts
@@ -59,7 +59,7 @@ export const stripeProducts: StripeProduct[] = [
       usagePrice: "$8-6/100k units (100k included, graduated pricing)",
       mainFeatures: [
         "Everything in Core",
-        "Unlimited data access",
+        "3 years data access",
         "Unlimited annotation queues",
         "Data retention management",
         "High rate limits",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Pro plan feature from "Unlimited data access" to "3 years data access" in `stripeCatalogue.ts`.
> 
>   - **Behavior**:
>     - Update `mainFeatures` in `stripeProducts` for Pro plan from "Unlimited data access" to "3 years data access" in `stripeCatalogue.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5aaa3d22ed5f2ba04beaf8bbe79424f93abf6ad2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->