### PR TITLE
fix(playground): add mutual exclusion between temperature and top_p for Anthropic models

### DIFF
--- a/web/src/features/playground/page/hooks/useModelParams.ts
+++ b/web/src/features/playground/page/hooks/useModelParams.ts
@@ -104,10 +104,24 @@ export const useModelParams = (windowId?: string) => {
     key,
     enabled,
   ) => {
-    setModelParams((prev) => ({
-      ...prev,
-      [key]: { ...prev[key], enabled },
-    }));
+    setModelParams((prev) => {
+      const updated = {
+        ...prev,
+        [key]: { ...prev[key], enabled },
+      };
+
+      // For Anthropic models, temperature and top_p are mutually exclusive
+      // When enabling one, disable the other
+      if (updated.adapter.value === LLMAdapter.Anthropic && enabled) {
+        if (key === "temperature" && prev.top_p.enabled) {
+          updated.top_p = { ...prev.top_p, enabled: false };
+        } else if (key === "top_p" && prev.temperature.enabled) {
+          updated.temperature = { ...prev.temperature, enabled: false };
+        }
+      }
+
+      return updated;
+    });
   };
 
   // Set default provider and model


### PR DESCRIPTION
Fixes #11965

## Summary

This PR fixes a bug where the Playground allows enabling both `temperature` and `top_p` simultaneously for Anthropic models, even though the Anthropic API rejects requests with both parameters set.

## Problem

When using Anthropic models (e.g., `claude-sonnet-4-5-20250929`) in the Playground:
- Users can enable both `temperature` and `top_p` in Model Advanced Settings
- Submitting causes a 400 error: `'temperature' and 'top_p' cannot both be specified for this model. Please use only one.`
- The UI provides no warning before the failed request

## Solution

Added automatic mutual exclusion logic in the `useModelParams` hook:
- When enabling `temperature` for Anthropic models → automatically disable `top_p`
- When enabling `top_p` for Anthropic models → automatically disable `temperature`
- Other providers (OpenAI, etc.) are completely unaffected

## Changes

**File: `web/src/features/playground/page/hooks/useModelParams.ts`**
- Modified `setModelParamEnabled` function to handle mutual exclusion
- Only applies when **enabling** a parameter (users can still disable both)
- Only affects **Anthropic adapter**

## Testing

**Manual testing steps:**
1. Open Playground
2. Select Anthropic model (e.g., `anthropic: claude-sonnet-4-5-20250929`)
3. Open Model Advanced Settings
4. Enable `temperature` → `top_p` is automatically disabled ✅
5. Enable `top_p` → `temperature` is automatically disabled ✅
6. Switch to OpenAI model → both can be enabled independently ✅

## Risk Assessment

**Low** - Change is scoped to Anthropic models only and prevents invalid API calls.
- Non-Anthropic providers are completely unaffected
- The logic only runs when enabling a parameter, not during normal operation
- Improves UX by preventing configuration errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds mutual exclusion between `temperature` and `top_p` for Anthropic models in `useModelParams.ts`.
> 
>   - **Behavior**:
>     - Adds mutual exclusion logic in `setModelParamEnabled` in `useModelParams.ts` for Anthropic models.
>     - Enabling `temperature` disables `top_p` and vice versa for Anthropic models.
>     - Other providers remain unaffected.
>   - **Testing**:
>     - Manual testing confirms mutual exclusion for Anthropic models and no impact on other providers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e91d40e2b7c1a6c528e6ccf8e751b42877dd4ce7. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->