### PR TITLE
fix(evals): allow observation filter options to pull all names

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -969,6 +969,7 @@ export const getObservationsGroupedByModelId = async (
 export const getObservationsGroupedByName = async (
   projectId: string,
   filter: FilterState,
+  type = "GENERATION",
 ) => {
   const observationsFilter = new FilterList([
     new StringFilter({
@@ -995,7 +996,7 @@ export const getObservationsGroupedByName = async (
     SELECT o.name as name
     FROM observations o
     WHERE ${appliedObservationsFilter.query}
-    AND o.type = 'GENERATION'
+    ${type ? `AND o.type = {type: String}` : ""}
     GROUP BY o.name
     ORDER BY count() DESC
     LIMIT 1000;
@@ -1005,6 +1006,7 @@ export const getObservationsGroupedByName = async (
     query,
     params: {
       ...appliedObservationsFilter.params,
+      ...(type ? { type } : {}),
     },
     tags: {
       feature: "tracing",

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -969,7 +969,7 @@ export const getObservationsGroupedByModelId = async (
 export const getObservationsGroupedByName = async (
   projectId: string,
   filter: FilterState,
-  type = "GENERATION",
+  type: ObservationType | null = "GENERATION",
 ) => {
   const observationsFilter = new FilterList([
     new StringFilter({

--- a/web/src/features/evals/hooks/useEvalConfigFilterOptions.ts
+++ b/web/src/features/evals/hooks/useEvalConfigFilterOptions.ts
@@ -38,6 +38,7 @@ export function useEvalConfigFilterOptions({
   const observationsFilterOptionsResponse =
     api.generations.filterOptions.useQuery({
       projectId,
+      observationType: "ALL",
     });
 
   const traceFilterOptions = useMemo(() => {

--- a/web/src/features/events/hooks/useObservationEvals.ts
+++ b/web/src/features/events/hooks/useObservationEvals.ts
@@ -5,5 +5,5 @@ export function useObservationEvals() {
 }
 
 export function useIsObservationEvalsBeta() {
-  return true;
+  return false;
 }

--- a/web/src/server/api/routers/generations/filterOptionsQuery.ts
+++ b/web/src/server/api/routers/generations/filterOptionsQuery.ts
@@ -1,6 +1,10 @@
 import { z } from "zod/v4";
 
-import { timeFilter, type ObservationOptions } from "@langfuse/shared";
+import {
+  ObservationType,
+  timeFilter,
+  type ObservationOptions,
+} from "@langfuse/shared";
 import { protectedProjectProcedure } from "@/src/server/api/trpc";
 import {
   getCategoricalScoresGroupedByName,
@@ -21,6 +25,9 @@ export const filterOptionsQuery = protectedProjectProcedure
     z.object({
       projectId: z.string(),
       startTimeFilter: z.array(timeFilter).optional(),
+      observationType: z
+        .union([z.enum(ObservationType), z.literal("ALL")])
+        .default("GENERATION"),
     }),
   )
   .query(async ({ input }) => {
@@ -77,7 +84,11 @@ export const filterOptionsQuery = protectedProjectProcedure
       //model
       getObservationsGroupedByModel(input.projectId, startTimeFilter ?? []),
       //name
-      getObservationsGroupedByName(input.projectId, startTimeFilter ?? []),
+      getObservationsGroupedByName(
+        input.projectId,
+        startTimeFilter ?? [],
+        input.observationType === "ALL" ? undefined : input.observationType,
+      ),
       //prompt name
       getObservationsGroupedByPromptName(
         input.projectId,

--- a/web/src/server/api/routers/generations/filterOptionsQuery.ts
+++ b/web/src/server/api/routers/generations/filterOptionsQuery.ts
@@ -87,7 +87,7 @@ export const filterOptionsQuery = protectedProjectProcedure
       getObservationsGroupedByName(
         input.projectId,
         startTimeFilter ?? [],
-        input.observationType === "ALL" ? undefined : input.observationType,
+        input.observationType === "ALL" ? null : input.observationType,
       ),
       //prompt name
       getObservationsGroupedByPromptName(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance observation filtering to support 'ALL' types, modifying `getObservationsGroupedByName` and related API queries.
> 
>   - **Behavior**:
>     - `getObservationsGroupedByName` in `observations.ts` now accepts a `type` parameter, defaulting to "GENERATION". If `type` is "ALL", the type filter is omitted.
>     - `useEvalConfigFilterOptions` in `useEvalConfigFilterOptions.ts` sets `observationType` to "ALL" for `api.generations.filterOptions.useQuery`.
>     - `filterOptionsQuery` in `filterOptionsQuery.ts` allows `observationType` to be "ALL", defaulting to "GENERATION" if not specified.
>   - **Misc**:
>     - Adds `ObservationType` import in `filterOptionsQuery.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 552cfeefb7a906b83515e227bb4decdd0b151c94. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->