### PR TITLE
feat: release single span evals in open beta

### DIFF
--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -20,7 +20,7 @@ import { cn } from "@/src/utils/tailwind";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { api } from "@/src/utils/api";
 import { LegacyEvalCallout } from "@/src/features/evals/components/legacy-eval-callout";
-import { useIsObservationEvalsBeta } from "@/src/features/events/hooks/useObservationEvals";
+import { useIsObservationEvalsFullyReleased } from "@/src/features/events/hooks/useObservationEvals";
 
 export const PeekViewEvaluatorConfigDetail = ({
   projectId,
@@ -28,7 +28,7 @@ export const PeekViewEvaluatorConfigDetail = ({
   projectId: string;
 }) => {
   const router = useRouter();
-  const isBetaEnabled = useIsObservationEvalsBeta();
+  const isFullyReleased = useIsObservationEvalsFullyReleased();
   const peekId = router.query.peek as string | undefined;
   const [isEditMode, setIsEditMode] = useState(false);
   const utils = api.useUtils();
@@ -79,7 +79,7 @@ export const PeekViewEvaluatorConfigDetail = ({
         </div>
       </div>
 
-      {isBetaEnabled &&
+      {isFullyReleased &&
         evalConfig &&
         evalConfig.targetObject &&
         evalConfig.evalTemplate &&

--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -79,8 +79,7 @@ export const PeekViewEvaluatorConfigDetail = ({
         </div>
       </div>
 
-      {isFullyReleased &&
-        evalConfig &&
+      {evalConfig &&
         evalConfig.targetObject &&
         evalConfig.evalTemplate &&
         evalConfig.finalStatus === "ACTIVE" && (

--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -20,7 +20,6 @@ import { cn } from "@/src/utils/tailwind";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { api } from "@/src/utils/api";
 import { LegacyEvalCallout } from "@/src/features/evals/components/legacy-eval-callout";
-import { useIsObservationEvalsFullyReleased } from "@/src/features/events/hooks/useObservationEvals";
 
 export const PeekViewEvaluatorConfigDetail = ({
   projectId,
@@ -28,7 +27,6 @@ export const PeekViewEvaluatorConfigDetail = ({
   projectId: string;
 }) => {
   const router = useRouter();
-  const isFullyReleased = useIsObservationEvalsFullyReleased();
   const peekId = router.query.peek as string | undefined;
   const [isEditMode, setIsEditMode] = useState(false);
   const utils = api.useUtils();

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -73,7 +73,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
-import { useIsObservationEvalsBeta } from "@/src/features/events/hooks/useObservationEvals";
+import { useIsObservationEvalsFullyReleased } from "@/src/features/events/hooks/useObservationEvals";
 
 export type EvaluatorDataRow = {
   id: string;
@@ -139,7 +139,7 @@ function LegacyBadgeCell({ status }: { status: string }) {
 }
 
 export default function EvaluatorTable({ projectId }: { projectId: string }) {
-  const isBetaEnabled = useIsObservationEvalsBeta();
+  const isFullyReleased = useIsObservationEvalsFullyReleased();
   const router = useRouter();
   const { setDetailPageList } = useDetailPageLists();
   const [paginationState, setPaginationState] = useQueryParams({
@@ -340,7 +340,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       enableSorting: true,
       size: 150,
     }),
-    ...(isBetaEnabled
+    ...(isFullyReleased
       ? [
           columnHelper.accessor("isLegacy", {
             id: "isLegacy",
@@ -508,7 +508,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       defaultSidebarCollapsed={evaluatorFilterConfig.defaultSidebarCollapsed}
     >
       <div className="flex h-full w-full flex-col">
-        {isBetaEnabled && hasLegacyEvals && (
+        {isFullyReleased && hasLegacyEvals && (
           <div className="p-2 pb-0">
             <Callout
               id="eval-remapping-table"

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -688,7 +688,7 @@ export const InnerEvaluatorForm = (props: {
                           size="sm"
                           className="border border-border font-normal"
                         >
-                          New
+                          Beta
                         </Badge>
                       </TabsTrigger>
                       <TabsTrigger
@@ -698,13 +698,15 @@ export const InnerEvaluatorForm = (props: {
                       >
                         <BetweenHorizonalStart className="h-3.5 w-3.5" />
                         Dataset Run
-                        <Badge
-                          variant="secondary"
-                          size="sm"
-                          className="border border-border font-normal"
-                        >
-                          Legacy
-                        </Badge>
+                        {isFullyReleased && (
+                          <Badge
+                            variant="secondary"
+                            size="sm"
+                            className="border border-border font-normal"
+                          >
+                            Legacy
+                          </Badge>
+                        )}
                       </TabsTrigger>
                     </TabsList>
                   </Tabs>

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -96,10 +96,7 @@ import {
 } from "@/src/features/evals/utils/evaluator-constants";
 import { useEvalConfigFilterOptions } from "@/src/features/evals/hooks/useEvalConfigFilterOptions";
 import { VariableMappingCard } from "@/src/features/evals/components/variable-mapping-card";
-import {
-  useIsObservationEvalsBeta,
-  useObservationEvals,
-} from "@/src/features/events/hooks/useObservationEvals";
+import { useIsObservationEvalsBeta } from "@/src/features/events/hooks/useObservationEvals";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 
 /**
@@ -277,7 +274,6 @@ export const InnerEvaluatorForm = (props: {
   oldConfigId?: string;
 }) => {
   const [formError, setFormError] = useState<string | null>(null);
-  const isBetaEnabled = useObservationEvals();
   const isObservationEvalsBeta = useIsObservationEvalsBeta();
   const capture = usePostHogClientCapture();
   const router = useRouter();
@@ -309,9 +305,7 @@ export const InnerEvaluatorForm = (props: {
     defaultValues: {
       scoreName:
         props.existingEvaluator?.scoreName ?? `${props.evalTemplate.name}`,
-      target:
-        props.existingEvaluator?.targetObject ??
-        (isBetaEnabled ? EvalTargetObject.EVENT : EvalTargetObject.TRACE),
+      target: props.existingEvaluator?.targetObject ?? EvalTargetObject.EVENT,
       filter: props.existingEvaluator?.filter
         ? z.array(singleFilter).parse(props.existingEvaluator.filter)
         : // For new trace evaluators, exclude internal environments by default
@@ -382,8 +376,7 @@ export const InnerEvaluatorForm = (props: {
     typeof availableTraceEvalVariables | typeof availableDatasetEvalVariables
   >(() =>
     targetState.getAvailableVariables(
-      props.existingEvaluator?.targetObject ??
-        (isBetaEnabled ? EvalTargetObject.EVENT : EvalTargetObject.TRACE),
+      props.existingEvaluator?.targetObject ?? EvalTargetObject.EVENT,
     ),
   );
 
@@ -525,10 +518,9 @@ export const InnerEvaluatorForm = (props: {
       actualTarget = EvalTargetObject.EVENT;
     } else {
       // offline-experiment: only use EXPERIMENT if beta is enabled AND OTEL is selected
-      actualTarget =
-        isBetaEnabled && useOtelDataForExperiment
-          ? EvalTargetObject.EXPERIMENT
-          : EvalTargetObject.DATASET;
+      actualTarget = useOtelDataForExperiment
+        ? EvalTargetObject.EXPERIMENT
+        : EvalTargetObject.DATASET;
     }
 
     // Transform variable mapping for new target type
@@ -594,23 +586,21 @@ export const InnerEvaluatorForm = (props: {
                         }}
                       >
                         <TabsList className="grid w-fit max-w-fit grid-flow-col gap-4">
-                          {isBetaEnabled && (
-                            <TabsTrigger
-                              value="event"
-                              disabled={props.disabled || props.mode === "edit"}
-                              className="min-w-[100px] gap-1.5"
+                          <TabsTrigger
+                            value="event"
+                            disabled={props.disabled || props.mode === "edit"}
+                            className="min-w-[100px] gap-1.5"
+                          >
+                            <CircleDot className="h-3.5 w-3.5" />
+                            Live Observations
+                            <Badge
+                              variant="secondary"
+                              size="sm"
+                              className="border border-border font-normal"
                             >
-                              <CircleDot className="h-3.5 w-3.5" />
-                              Live Observations
-                              <Badge
-                                variant="secondary"
-                                size="sm"
-                                className="border border-border font-normal"
-                              >
-                                Beta
-                              </Badge>
-                            </TabsTrigger>
-                          )}
+                              Beta
+                            </Badge>
+                          </TabsTrigger>
                           {allowLegacy && (
                             <TabsTrigger
                               value="trace"
@@ -648,8 +638,7 @@ export const InnerEvaluatorForm = (props: {
             )}
 
             {/* Second tab bar for experiment data source selection */}
-            {isBetaEnabled &&
-              !props.hideTargetSelection &&
+            {!props.hideTargetSelection &&
               userFacingTarget === "offline-experiment" &&
               props.evalCapabilities.allowLegacy && (
                 <div className="flex flex-col gap-2">
@@ -666,10 +655,9 @@ export const InnerEvaluatorForm = (props: {
                       setUseOtelDataForExperiment(useOtel);
 
                       // Update the actual form target: only use EXPERIMENT if beta is enabled
-                      const actualTarget =
-                        isBetaEnabled && useOtel
-                          ? EvalTargetObject.EXPERIMENT
-                          : EvalTargetObject.DATASET;
+                      const actualTarget = useOtel
+                        ? EvalTargetObject.EXPERIMENT
+                        : EvalTargetObject.DATASET;
                       form.setValue("target", actualTarget);
 
                       // Transform variable mapping for new target type
@@ -723,8 +711,7 @@ export const InnerEvaluatorForm = (props: {
                 </div>
               )}
 
-            {isBetaEnabled &&
-              !props.hideTargetSelection &&
+            {!props.hideTargetSelection &&
               props.mode !== "edit" &&
               !props.disabled && (
                 <EvalVersionCallout

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -96,7 +96,7 @@ import {
 } from "@/src/features/evals/utils/evaluator-constants";
 import { useEvalConfigFilterOptions } from "@/src/features/evals/hooks/useEvalConfigFilterOptions";
 import { VariableMappingCard } from "@/src/features/evals/components/variable-mapping-card";
-import { useIsObservationEvalsBeta } from "@/src/features/events/hooks/useObservationEvals";
+import { useIsObservationEvalsFullyReleased } from "@/src/features/events/hooks/useObservationEvals";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 
 /**
@@ -274,7 +274,7 @@ export const InnerEvaluatorForm = (props: {
   oldConfigId?: string;
 }) => {
   const [formError, setFormError] = useState<string | null>(null);
-  const isObservationEvalsBeta = useIsObservationEvalsBeta();
+  const isFullyReleased = useIsObservationEvalsFullyReleased();
   const capture = usePostHogClientCapture();
   const router = useRouter();
   const [showTraceConfirmDialog, setShowTraceConfirmDialog] = useState(false);
@@ -609,7 +609,7 @@ export const InnerEvaluatorForm = (props: {
                             >
                               <ListTree className="h-3.5 w-3.5" />
                               Live Traces
-                              {isObservationEvalsBeta && (
+                              {isFullyReleased && (
                                 <Badge
                                   variant="secondary"
                                   size="sm"

--- a/web/src/features/evals/components/template-selector.tsx
+++ b/web/src/features/evals/components/template-selector.tsx
@@ -37,7 +37,7 @@ import {
 import { useSingleTemplateValidation } from "@/src/features/evals/hooks/useSingleTemplateValidation";
 import { getMaintainer } from "@/src/features/evals/utils/typeHelpers";
 import { MaintainerTooltip } from "@/src/features/evals/components/maintainer-tooltip";
-import { useIsObservationEvalsBeta } from "@/src/features/events/hooks/useObservationEvals";
+import { useIsObservationEvalsFullyReleased } from "@/src/features/events/hooks/useObservationEvals";
 
 type TemplateSelectorProps = {
   projectId: string;
@@ -68,7 +68,7 @@ export const TemplateSelector = ({
 }: TemplateSelectorProps) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [search, setSearch] = useState("");
-  const isBetaEnabled = useIsObservationEvalsBeta();
+  const isFullyReleased = useIsObservationEvalsFullyReleased();
   const {
     activeTemplates,
     isTemplateActive,
@@ -224,7 +224,7 @@ export const TemplateSelector = ({
                               <div className="mr-2 h-4 w-4" />
                             )}
                             {name}
-                            {isBetaEnabled && isLegacy && (
+                            {isFullyReleased && isLegacy && (
                               <Badge variant="outline" className="ml-2 text-xs">
                                 legacy
                               </Badge>
@@ -316,7 +316,7 @@ export const TemplateSelector = ({
                           <MaintainerTooltip
                             maintainer={getMaintainer(latestTemplate)}
                           />
-                          {isBetaEnabled && isLegacy && (
+                          {isFullyReleased && isLegacy && (
                             <Badge variant="outline" className="ml-2 text-xs">
                               legacy
                             </Badge>

--- a/web/src/features/evals/hooks/useEvaluatorTarget.ts
+++ b/web/src/features/evals/hooks/useEvaluatorTarget.ts
@@ -15,14 +15,12 @@ import {
   type LangfuseObject,
 } from "../utils/evaluator-form-utils";
 import { OBSERVATION_VARIABLES } from "../utils/evaluator-constants";
-import { useObservationEvals } from "@/src/features/events/hooks/useObservationEvals";
 
 /**
  * Custom hook to manage user-facing target state.
  * Maps internal target objects to UI tabs (trace/event/offline-experiment).
  */
 export const useUserFacingTarget = (targetObject?: string) => {
-  const isBetaEnabled = useObservationEvals();
   const [userFacingTarget, setUserFacingTarget] = useState<
     "trace" | "event" | "offline-experiment"
   >("event");
@@ -30,9 +28,7 @@ export const useUserFacingTarget = (targetObject?: string) => {
     useState(true);
 
   useEffect(() => {
-    const currentTarget =
-      targetObject ??
-      (isBetaEnabled ? EvalTargetObject.EVENT : EvalTargetObject.TRACE);
+    const currentTarget = targetObject ?? EvalTargetObject.EVENT;
 
     if (isTraceTarget(currentTarget)) {
       setUserFacingTarget("trace");
@@ -46,7 +42,7 @@ export const useUserFacingTarget = (targetObject?: string) => {
       setUserFacingTarget("offline-experiment");
       setUseOtelDataForExperiment(false);
     }
-  }, [targetObject, isBetaEnabled]);
+  }, [targetObject]);
 
   return {
     userFacingTarget,

--- a/web/src/features/evals/hooks/useExtractVariables.ts
+++ b/web/src/features/evals/hooks/useExtractVariables.ts
@@ -1,6 +1,5 @@
 import { type PreviewData } from "@/src/features/evals/hooks/usePreviewData";
 import { type VariableMapping } from "@/src/features/evals/utils/evaluator-form-utils";
-import { useObservationEvals } from "@/src/features/events/hooks/useObservationEvals";
 import { api } from "@/src/utils/api";
 import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
 import { EvalTargetObject, extractValueFromObject } from "@langfuse/shared";
@@ -36,7 +35,6 @@ export function useExtractVariables({
   isLoading: boolean;
 }) {
   const utils = api.useUtils();
-  const isBetaEnabled = useObservationEvals();
   const [extractedVariables, setExtractedVariables] = useState<
     ExtractedVariable[]
   >([]);
@@ -110,8 +108,7 @@ export function useExtractVariables({
       if (
         !mapping ||
         !mapping.selectedColumnId ||
-        (!mapping.langfuseObject &&
-          !(isBetaEnabled && previewData.type === "event"))
+        (!mapping.langfuseObject && !(previewData.type === "event"))
       ) {
         return { variable, value: "n/a" };
       }
@@ -196,7 +193,6 @@ export function useExtractVariables({
     id,
     utils.observations.byId,
     previewData,
-    isBetaEnabled,
   ]);
 
   return { extractedVariables, isExtracting };

--- a/web/src/features/events/hooks/useObservationEvals.ts
+++ b/web/src/features/events/hooks/useObservationEvals.ts
@@ -1,3 +1,3 @@
-export function useIsObservationEvalsBeta() {
+export function useIsObservationEvalsFullyReleased() {
   return false;
 }

--- a/web/src/features/events/hooks/useObservationEvals.ts
+++ b/web/src/features/events/hooks/useObservationEvals.ts
@@ -1,9 +1,3 @@
-import useIsFeatureEnabled from "@/src/features/feature-flags/hooks/useIsFeatureEnabled";
-
-export function useObservationEvals() {
-  return useIsFeatureEnabled("observationEvals") ?? false;
-}
-
 export function useIsObservationEvalsBeta() {
   return true;
 }

--- a/web/src/features/experiments/components/MultiStepExperimentForm.tsx
+++ b/web/src/features/experiments/components/MultiStepExperimentForm.tsx
@@ -28,7 +28,6 @@ import { useEvaluatorDefaults } from "@/src/features/experiments/hooks/useEvalua
 import { useExperimentEvaluatorData } from "@/src/features/experiments/hooks/useExperimentEvaluatorData";
 import { useExperimentNameValidation } from "@/src/features/experiments/hooks/useExperimentNameValidation";
 import { useExperimentPromptData } from "@/src/features/experiments/hooks/useExperimentPromptData";
-import { useObservationEvals } from "@/src/features/events/hooks/useObservationEvals";
 import { getFinalModelParams } from "@/src/utils/getFinalModelParams";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { Skeleton } from "@/src/components/ui/skeleton";
@@ -117,8 +116,6 @@ export const MultiStepExperimentForm = ({
     scope: "evalJob:CUD",
   });
 
-  const isBetaEnabled = useObservationEvals();
-
   const form = useForm({
     resolver: zodResolver(CreateExperimentData),
     defaultValues: {
@@ -144,7 +141,7 @@ export const MultiStepExperimentForm = ({
   const evaluators = api.evals.jobConfigsByTarget.useQuery(
     {
       projectId,
-      targetObject: isBetaEnabled ? ["dataset", "experiment"] : ["dataset"],
+      targetObject: ["dataset", "experiment"],
     },
     {
       enabled: hasEvalReadAccess && !!datasetId,
@@ -259,16 +256,6 @@ export const MultiStepExperimentForm = ({
   // For new experiment evaluators (beta enabled), we only run on new data (not historic)
   // For legacy dataset evaluators (beta disabled), allow user to choose
   const preprocessFormValues = (values: any) => {
-    if (!isBetaEnabled) {
-      const shouldRunOnHistoric = confirm(
-        "Do you also want to execute this evaluator on historic data? If not, click cancel.",
-      );
-
-      if (shouldRunOnHistoric && !values.timeScope.includes("EXISTING")) {
-        values.timeScope = [...values.timeScope, "EXISTING"];
-      }
-    }
-
     return values;
   };
 

--- a/web/src/features/experiments/hooks/useEvaluatorDefaults.ts
+++ b/web/src/features/experiments/hooks/useEvaluatorDefaults.ts
@@ -2,7 +2,6 @@ import { Decimal } from "decimal.js";
 import { type EvalTemplate, EvalTargetObject } from "@langfuse/shared";
 import { type PartialConfig } from "@/src/features/evals/types";
 import { createDefaultVariableMappings } from "@/src/features/experiments/utils/evaluatorMappingUtils";
-import { useObservationEvals } from "@/src/features/events/hooks/useObservationEvals";
 
 export const CONFIG_BASE = {
   sampling: new Decimal(1),
@@ -18,7 +17,6 @@ export function useEvaluatorDefaults() {
    * @param scoreName - Optional custom score name (defaults to template name)
    * @returns The configured evaluator with defaults
    */
-  const isBetaEnabled = useObservationEvals();
 
   const createDefaultEvaluator = (
     template: EvalTemplate,
@@ -31,9 +29,7 @@ export function useEvaluatorDefaults() {
     // Return the configured evaluator for dataset target
     return {
       ...CONFIG_BASE,
-      targetObject: isBetaEnabled
-        ? EvalTargetObject.EXPERIMENT
-        : EvalTargetObject.DATASET,
+      targetObject: EvalTargetObject.EXPERIMENT,
       evalTemplate: template,
       scoreName: scoreName || template.name,
       variableMapping: variableMappings,
@@ -43,7 +39,7 @@ export function useEvaluatorDefaults() {
           value: [datasetId],
           // Use the column id (not display name) for EXPERIMENT target
           // This maps to observation.experimentDatasetId in the filter service
-          column: isBetaEnabled ? "experimentDatasetId" : "Dataset",
+          column: "experimentDatasetId",
           operator: "any of",
         },
       ],


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes feature flag for observation evaluations, making them default and updating related configurations.
> 
>   - **Behavior**:
>     - Removes `useObservationEvals` feature flag checks in `inner-evaluator-form.tsx`, `useEvaluatorTarget.ts`, `useExtractVariables.ts`, and `MultiStepExperimentForm.tsx`.
>     - Default target for evaluators is now `EvalTargetObject.EVENT` instead of conditional on feature flag.
>   - **Hooks**:
>     - `useIsObservationEvalsBeta` in `useObservationEvals.ts` always returns `true`.
>   - **Forms**:
>     - `InnerEvaluatorForm` and `MultiStepExperimentForm` no longer conditionally handle legacy dataset evaluators.
>   - **Defaults**:
>     - `useEvaluatorDefaults` sets `targetObject` to `EvalTargetObject.EXPERIMENT` by default.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 11774675b02cb0c00973c4d0650a499b93a3a052. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->