### PR TITLE
fix(dataset-items): patch timestamp logic to infer version

### DIFF
--- a/packages/shared/src/server/repositories/dataset-items.ts
+++ b/packages/shared/src/server/repositories/dataset-items.ts
@@ -1741,16 +1741,17 @@ export async function getDatasetVersionForRun(params: {
       const maxDatasetItemVersion =
         maxCreatedAtResult[0]?.max_dataset_item_version ?? null;
 
-      if (!maxCreatedAt && !maxDatasetItemVersion) {
+      if (maxDatasetItemVersion) {
+        return parseClickhouseUTCDateTimeFormat(maxDatasetItemVersion);
+      }
+
+      if (!maxCreatedAt) {
         return null;
       }
 
       // dataset item version takes precedence over created_at
       // max_created_at as fallback for experiments that ran before dataset item versioning was introduced
-      const relevantTimestamp = maxDatasetItemVersion ?? maxCreatedAt;
-      const formattedTimestamp = parseClickhouseUTCDateTimeFormat(
-        relevantTimestamp as string,
-      );
+      const formattedTimestamp = parseClickhouseUTCDateTimeFormat(maxCreatedAt);
       // Step 2: Resolve to dataset version using temporal query (PostgreSQL)
       const result = await prisma.$queryRaw<Array<{ valid_from: Date | null }>>(
         Prisma.sql`


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prioritize `max_dataset_item_version` over `max_created_at` in `getDatasetVersionForRun` to improve dataset version inference accuracy.
> 
>   - **Behavior**:
>     - In `getDatasetVersionForRun` in `dataset-items.ts`, prioritize `max_dataset_item_version` over `max_created_at` for determining dataset version.
>     - If `max_dataset_item_version` is available, use it to parse the version date.
>     - If `max_created_at` is not available, return `null`.
>   - **Misc**:
>     - Adjusted logic to ensure dataset item versioning is used when available, improving accuracy of version inference.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5e1ed8eefb9c60f75000389911b4666e9f41f96f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->