### PR TITLE
feat: head based opt-in for the direct writes into v4 tables

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -40,6 +40,9 @@ export interface OtelIngestionProcessorConfig {
   publicKey?: string;
   orgId?: string;
   propagatedHeaders?: Record<string, string>;
+  sdkName?: string;
+  sdkVersion?: string;
+  ingestionVersion?: string;
 }
 
 interface CreateTraceEventParams {
@@ -118,12 +121,18 @@ export class OtelIngestionProcessor {
   private readonly publicKey?: string;
   private readonly orgId?: string;
   private readonly propagatedHeaders?: Record<string, string>;
+  private readonly sdkName?: string;
+  private readonly sdkVersion?: string;
+  private readonly ingestionVersion?: string;
 
   constructor(config: OtelIngestionProcessorConfig) {
     this.projectId = config.projectId;
     this.publicKey = config.publicKey;
     this.orgId = config.orgId;
     this.propagatedHeaders = config.propagatedHeaders;
+    this.sdkName = config.sdkName;
+    this.sdkVersion = config.sdkVersion;
+    this.ingestionVersion = config.ingestionVersion;
   }
 
   /**
@@ -167,6 +176,9 @@ export class OtelIngestionProcessor {
               },
             },
             propagatedHeaders: this.propagatedHeaders,
+            sdkName: this.sdkName,
+            sdkVersion: this.sdkVersion,
+            ingestionVersion: this.ingestionVersion,
           },
         })
       : Promise.reject("Failed to instantiate otel ingestion queue");

--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -40,6 +40,9 @@ export const OtelIngestionEvent = z.object({
     }),
   }),
   propagatedHeaders: z.record(z.string(), z.string()).optional(),
+  sdkName: z.string().optional(),
+  sdkVersion: z.string().optional(),
+  ingestionVersion: z.string().optional(),
 });
 
 export const BatchExportJobSchema = z.object({

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -11,6 +11,18 @@ import { gunzip } from "node:zlib";
 import { ForbiddenError } from "@langfuse/shared";
 import { env } from "@/src/env.mjs";
 
+/** Read a Langfuse header that may arrive with hyphens or underscores. */
+function getLangfuseHeader(
+  headers: Record<string, string | string[] | undefined>,
+  name: string,
+): string | undefined {
+  const hyphenVal = headers[name];
+  if (typeof hyphenVal === "string") return hyphenVal;
+  const underscoreVal = headers[name.replaceAll("-", "_")];
+  if (typeof underscoreVal === "string") return underscoreVal;
+  return undefined;
+}
+
 export const config = {
   api: {
     bodyParser: false,
@@ -104,19 +116,16 @@ export default withMiddlewares({
         return {};
       }
 
-      // Extract SDK headers for write path decision
-      const sdkName =
-        typeof req.headers["x-langfuse-sdk-name"] === "string"
-          ? req.headers["x-langfuse-sdk-name"]
-          : undefined;
-      const sdkVersion =
-        typeof req.headers["x-langfuse-sdk-version"] === "string"
-          ? req.headers["x-langfuse-sdk-version"]
-          : undefined;
-      const ingestionVersion =
-        typeof req.headers["x-langfuse-ingestion-version"] === "string"
-          ? req.headers["x-langfuse-ingestion-version"]
-          : undefined;
+      // Extract SDK headers for write path decision (supports both hyphen and underscore formats)
+      const sdkName = getLangfuseHeader(req.headers, "x-langfuse-sdk-name");
+      const sdkVersion = getLangfuseHeader(
+        req.headers,
+        "x-langfuse-sdk-version",
+      );
+      const ingestionVersion = getLangfuseHeader(
+        req.headers,
+        "x-langfuse-ingestion-version",
+      );
 
       // Reject unsupported future ingestion versions (> 4)
       // Lower versions are valid but use dual write (path A)

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -104,6 +104,35 @@ export default withMiddlewares({
         return {};
       }
 
+      // Extract SDK headers for write path decision
+      const sdkName =
+        typeof req.headers["x-langfuse-sdk-name"] === "string"
+          ? req.headers["x-langfuse-sdk-name"]
+          : undefined;
+      const sdkVersion =
+        typeof req.headers["x-langfuse-sdk-version"] === "string"
+          ? req.headers["x-langfuse-sdk-version"]
+          : undefined;
+      const ingestionVersion =
+        typeof req.headers["x-langfuse-ingestion-version"] === "string"
+          ? req.headers["x-langfuse-ingestion-version"]
+          : undefined;
+
+      // Reject unsupported future ingestion versions (> 4)
+      // Lower versions are valid but use dual write (path A)
+      const parsedIngestionVersion = ingestionVersion
+        ? parseInt(ingestionVersion, 10)
+        : undefined;
+      if (
+        parsedIngestionVersion !== undefined &&
+        (isNaN(parsedIngestionVersion) || parsedIngestionVersion > 4)
+      ) {
+        res.status(400);
+        return {
+          error: `Unsupported x-langfuse-ingestion-version: "${ingestionVersion}". Maximum supported: "4".`,
+        };
+      }
+
       // Extract headers to propagate for ingestion masking
       const propagatedHeaderNames =
         env.LANGFUSE_INGESTION_MASKING_PROPAGATED_HEADERS;
@@ -123,6 +152,9 @@ export default withMiddlewares({
           Object.keys(propagatedHeaders).length > 0
             ? propagatedHeaders
             : undefined,
+        sdkName,
+        sdkVersion,
+        ingestionVersion,
       });
 
       // At this point, we have the raw OpenTelemetry Span body. We upload the full batch to S3

--- a/worker/src/queues/__tests__/otelDirectEventWrite.test.ts
+++ b/worker/src/queues/__tests__/otelDirectEventWrite.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from "vitest";
+import {
+  checkHeaderBasedDirectWrite,
+  checkSdkVersionRequirements,
+  getSdkInfoFromResourceSpans,
+  type SdkInfo,
+} from "../otelIngestionQueue";
+
+describe("checkHeaderBasedDirectWrite", () => {
+  it.each<{
+    input: Parameters<typeof checkHeaderBasedDirectWrite>[0];
+    expected: boolean;
+    label: string;
+  }>([
+    // Python SDK version checks
+    {
+      input: { sdkName: "python", sdkVersion: "4.0.0" },
+      expected: true,
+      label: "python 4.0.0 (exact minimum)",
+    },
+    {
+      input: { sdkName: "python", sdkVersion: "4.2.1" },
+      expected: true,
+      label: "python 4.2.1 (above minimum)",
+    },
+    {
+      input: { sdkName: "python", sdkVersion: "3.9.0" },
+      expected: false,
+      label: "python 3.9.0 (below minimum)",
+    },
+
+    // JS SDK version checks
+    {
+      input: { sdkName: "javascript", sdkVersion: "5.0.0" },
+      expected: true,
+      label: "javascript 5.0.0 (exact minimum)",
+    },
+    {
+      input: { sdkName: "javascript", sdkVersion: "5.1.3" },
+      expected: true,
+      label: "javascript 5.1.3 (above minimum)",
+    },
+    {
+      input: { sdkName: "javascript", sdkVersion: "4.6.0" },
+      expected: false,
+      label: "javascript 4.6.0 (below minimum)",
+    },
+
+    // Pre-release versions (stripped before comparison)
+    {
+      input: { sdkName: "python", sdkVersion: "4.0.0-rc.1" },
+      expected: true,
+      label: "python 4.0.0-rc.1 (pre-release at minimum)",
+    },
+    {
+      input: { sdkName: "javascript", sdkVersion: "5.0.0-beta.1" },
+      expected: true,
+      label: "javascript 5.0.0-beta.1 (pre-release at minimum)",
+    },
+    {
+      input: { sdkName: "python", sdkVersion: "4.1.0-rc.1" },
+      expected: true,
+      label: "python 4.1.0-rc.1 (pre-release above minimum)",
+    },
+    {
+      input: { sdkName: "python", sdkVersion: "3.9.0-rc.1" },
+      expected: false,
+      label: "python 3.9.0-rc.1 (pre-release below minimum)",
+    },
+
+    // Unknown / missing SDK name
+    {
+      input: { sdkName: "ruby", sdkVersion: "1.0.0" },
+      expected: false,
+      label: "unknown SDK name",
+    },
+    {
+      input: { sdkName: "python" },
+      expected: false,
+      label: "sdkName without sdkVersion",
+    },
+    {
+      input: { sdkVersion: "4.0.0" },
+      expected: false,
+      label: "sdkVersion without sdkName",
+    },
+
+    // Malformed versions
+    {
+      input: { sdkName: "python", sdkVersion: "not-a-version" },
+      expected: false,
+      label: "non-semver sdkVersion",
+    },
+    {
+      input: { sdkName: "python", sdkVersion: "" },
+      expected: false,
+      label: "empty sdkVersion",
+    },
+
+    // ingestionVersion
+    {
+      input: { ingestionVersion: "4" },
+      expected: true,
+      label: "ingestionVersion '4'",
+    },
+    {
+      input: {
+        ingestionVersion: "4",
+        sdkName: undefined,
+        sdkVersion: undefined,
+      },
+      expected: true,
+      label: "ingestionVersion '4' without SDK headers",
+    },
+    {
+      input: { ingestionVersion: "3" },
+      expected: false,
+      label: "ingestionVersion '3' (below)",
+    },
+    {
+      input: { ingestionVersion: "1" },
+      expected: false,
+      label: "ingestionVersion '1' (below)",
+    },
+    {
+      input: { sdkName: "python", sdkVersion: "3.0.0", ingestionVersion: "4" },
+      expected: true,
+      label: "ingestionVersion '4' overrides old SDK version",
+    },
+
+    // No headers
+    { input: {}, expected: false, label: "empty input" },
+    {
+      input: {
+        sdkName: undefined,
+        sdkVersion: undefined,
+        ingestionVersion: undefined,
+      },
+      expected: false,
+      label: "all undefined",
+    },
+  ])("$label → $expected", ({ input, expected }) => {
+    expect(checkHeaderBasedDirectWrite(input)).toBe(expected);
+  });
+});
+
+describe("checkSdkVersionRequirements (legacy fallback)", () => {
+  it.each<{
+    sdkInfo: SdkInfo;
+    isExperiment: boolean;
+    expected: boolean;
+    label: string;
+  }>([
+    {
+      sdkInfo: {
+        scopeName: "openlit",
+        scopeVersion: "3.9.0",
+        telemetrySdkLanguage: "python",
+      },
+      isExperiment: true,
+      expected: false,
+      label: "non-Langfuse scope name",
+    },
+    {
+      sdkInfo: {
+        scopeName: "langfuse-sdk",
+        scopeVersion: "3.9.0",
+        telemetrySdkLanguage: "python",
+      },
+      isExperiment: false,
+      expected: false,
+      label: "experiment batch false",
+    },
+    {
+      sdkInfo: {
+        scopeName: "langfuse-sdk",
+        scopeVersion: "3.9.0",
+        telemetrySdkLanguage: "python",
+      },
+      isExperiment: true,
+      expected: true,
+      label: "python 3.9.0 (exact minimum)",
+    },
+    {
+      sdkInfo: {
+        scopeName: "langfuse-sdk",
+        scopeVersion: "4.4.0",
+        telemetrySdkLanguage: "js",
+      },
+      isExperiment: true,
+      expected: true,
+      label: "js 4.4.0 (exact minimum)",
+    },
+  ])("$label → $expected", ({ sdkInfo, isExperiment, expected }) => {
+    expect(checkSdkVersionRequirements(sdkInfo, isExperiment)).toBe(expected);
+  });
+});
+
+describe("getSdkInfoFromResourceSpans (legacy fallback)", () => {
+  it.each<{
+    input: Parameters<typeof getSdkInfoFromResourceSpans>[0];
+    expected: ReturnType<typeof getSdkInfoFromResourceSpans>;
+    label: string;
+  }>([
+    {
+      input: {
+        resource: {
+          attributes: [
+            { key: "telemetry.sdk.language", value: { stringValue: "python" } },
+          ],
+        },
+        scopeSpans: [
+          { scope: { name: "langfuse-sdk", version: "3.14.1" }, spans: [] },
+        ],
+      },
+      expected: {
+        scopeName: "langfuse-sdk",
+        scopeVersion: "3.14.1",
+        telemetrySdkLanguage: "python",
+      },
+      label: "well-formed input",
+    },
+    {
+      input: {},
+      expected: {
+        scopeName: null,
+        scopeVersion: null,
+        telemetrySdkLanguage: null,
+      },
+      label: "empty input",
+    },
+  ])("$label", ({ input, expected }) => {
+    expect(getSdkInfoFromResourceSpans(input)).toEqual(expected);
+  });
+});


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds head-based opt-in for direct writes into v4 tables by introducing SDK header checks and updating the `OtelIngestionProcessor` configuration.
> 
>   - **Behavior**:
>     - Adds `sdkName`, `sdkVersion`, and `ingestionVersion` to `OtelIngestionProcessorConfig` in `OtelIngestionProcessor.ts`.
>     - Updates `OtelIngestionProcessor` to handle new config fields and propagate them to the ingestion queue.
>     - Introduces `checkHeaderBasedDirectWrite()` in `otelIngestionQueue.ts` to determine direct write eligibility based on SDK headers.
>     - Adds logic to reject unsupported `ingestionVersion` (> 4) in `index.ts`.
>   - **Tests**:
>     - Adds `otelDirectEventWrite.test.ts` to test `checkHeaderBasedDirectWrite()` and `checkSdkVersionRequirements()`.
>   - **Misc**:
>     - Updates `OtelIngestionEvent` schema in `queues.ts` to include new fields.
>     - Modifies `processToIngestionEvents()` in `otelIngestionQueue.ts` to decide write path based on headers and SDK info.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 188720eab4bd9267ebae5a366b5dc2455c9ec107. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->