### PR TITLE
fix(playground): always show tool/schema edit/delete buttons

### DIFF
--- a/web/src/features/playground/page/components/PlaygroundTools/index.tsx
+++ b/web/src/features/playground/page/components/PlaygroundTools/index.tsx
@@ -253,29 +253,30 @@ export const PlaygroundTools = () => {
                   : undefined
               }
             >
-              <div className="cursor-pointer rounded-md border bg-background p-2 transition-colors duration-200 hover:bg-accent/50">
+              <div className="cursor-pointer overflow-hidden rounded-md border bg-background p-2 transition-colors duration-200 hover:bg-accent/50">
                 <div className="mb-1 flex items-center justify-between">
-                  <div className="flex items-center gap-1">
-                    <WrenchIcon className="h-4 w-4 text-muted-foreground" />
+                  <div className="flex min-w-0 items-center gap-1">
+                    <WrenchIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
                     <h3
-                      className="max-w-[145px] truncate text-ellipsis text-sm font-medium"
+                      className="truncate text-sm font-medium"
                       title={tool.name}
                     >
                       {tool.name}
                     </h3>
                     {!isToolSaved(tool) ? (
-                      <span className="rounded bg-muted px-1 py-0.5 text-xs text-muted-foreground">
+                      <span className="shrink-0 rounded bg-muted px-1 py-0.5 text-xs text-muted-foreground">
                         Unsaved
                       </span>
                     ) : null}
                   </div>
-                  <div className="flex items-center gap-1">
+                  <div className="flex shrink-0 items-center gap-1">
                     <Button
                       variant="ghost"
                       size="sm"
                       className="h-6 w-6 p-0"
                       onClick={(e) => {
                         e.stopPropagation();
+                        e.preventDefault();
                         handleRemoveTool(tool.id);
                       }}
                     >

--- a/web/src/features/playground/page/components/StructuredOutputSchemaSection.tsx
+++ b/web/src/features/playground/page/components/StructuredOutputSchemaSection.tsx
@@ -106,9 +106,9 @@ export const StructuredOutputSchemaPopover = () => {
               onSelect={() => handleSelectSchema(schema)}
               className="flex items-center justify-between px-1 py-2"
             >
-              <div className="flex items-center gap-2">
-                <BoxIcon className="h-4 w-4 text-muted-foreground" />
-                <div className="flex-1 overflow-hidden">
+              <div className="flex min-w-0 flex-1 items-center gap-2">
+                <BoxIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <div className="min-w-0 flex-1">
                   <div className="truncate font-medium">{schema.name}</div>
                   <div className="line-clamp-1 text-xs text-muted-foreground">
                     {schema.description}
@@ -264,29 +264,30 @@ export const StructuredOutputSchemaSection = () => {
                 : undefined
             }
           >
-            <div className="cursor-pointer rounded-md border bg-background p-2 transition-colors duration-200 hover:bg-accent/50">
+            <div className="cursor-pointer overflow-hidden rounded-md border bg-background p-2 transition-colors duration-200 hover:bg-accent/50">
               <div className="mb-1 flex items-center justify-between">
-                <div className="flex items-center gap-1">
-                  <BoxIcon className="h-4 w-4 text-muted-foreground" />
+                <div className="flex min-w-0 items-center gap-1">
+                  <BoxIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
                   <h3
-                    className="max-w-[200px] truncate text-ellipsis text-sm font-medium"
+                    className="truncate text-sm font-medium"
                     title={structuredOutputSchema.name}
                   >
                     {structuredOutputSchema.name}
                   </h3>
                   {!isSchemaSaved(structuredOutputSchema) ? (
-                    <span className="rounded bg-muted px-1 py-0.5 text-xs text-muted-foreground">
+                    <span className="shrink-0 rounded bg-muted px-1 py-0.5 text-xs text-muted-foreground">
                       Unsaved
                     </span>
                   ) : null}
                 </div>
-                <div className="flex items-center gap-1">
+                <div className="flex shrink-0 items-center gap-1">
                   <Button
                     variant="ghost"
                     size="sm"
                     className="h-6 w-6 p-0"
                     onClick={(e) => {
                       e.stopPropagation();
+                      e.preventDefault();
                       handleRemoveSchema();
                     }}
                   >


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure tool/schema edit/delete buttons are always visible and functional in `PlaygroundTools` and `StructuredOutputSchemaSection`, with CSS adjustments for overflow handling.
> 
>   - **Behavior**:
>     - Ensure tool/schema edit/delete buttons are always visible in `PlaygroundTools` and `StructuredOutputSchemaSection`.
>     - Prevent default event behavior in `handleRemoveTool` and `handleRemoveSchema` to ensure proper button functionality.
>   - **CSS Adjustments**:
>     - Add `overflow-hidden` to containers in `PlaygroundTools` and `StructuredOutputSchemaSection` to handle long names/descriptions.
>     - Use `shrink-0` on icons and buttons to prevent shrinking in `PlaygroundTools` and `StructuredOutputSchemaSection`.
>     - Remove fixed width constraints on tool/schema names to allow full use of available space.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e50b875105384980a2678a3df92d63804af46d0f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->