### PR TITLE
fix(evals): add default generation filter to single obs evals

### DIFF
--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -1,4 +1,5 @@
 import { type UseFormReturn, useForm } from "react-hook-form";
+import { Alert, AlertDescription } from "@/src/components/ui/alert";
 import { Input } from "@/src/components/ui/input";
 import { Button } from "@/src/components/ui/button";
 import {
@@ -75,6 +76,7 @@ import {
 import {
   BetweenHorizonalStart,
   CircleDot,
+  AlertTriangle,
   FlaskConical,
   InfoIcon,
   ListTree,
@@ -908,6 +910,17 @@ export const InnerEvaluatorForm = (props: {
                         )}
                       </div>
                     </FormControl>
+                    {!props.disabled && !hasFilters && (
+                      <Alert className="max-w-[500px]">
+                        <AlertTriangle className="h-4 w-4" />
+                        <AlertDescription>
+                          No filters set. This evaluator will run on{" "}
+                          <span className="font-semibold">all</span>{" "}
+                          {getTargetDisplayName(target)}. Verify this is
+                          intended.
+                        </AlertDescription>
+                      </Alert>
+                    )}
                     <FormMessage />
                   </FormItem>
                 );

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -92,6 +92,7 @@ import {
 } from "@/src/features/evals/hooks/useEvaluatorTarget";
 import {
   COLUMN_IDENTIFIERS_THAT_REQUIRE_PROPAGATION,
+  DEFAULT_OBSERVATION_FILTER,
   DEFAULT_TRACE_FILTER,
 } from "@/src/features/evals/utils/evaluator-constants";
 import { useEvalConfigFilterOptions } from "@/src/features/evals/hooks/useEvalConfigFilterOptions";
@@ -308,11 +309,15 @@ export const InnerEvaluatorForm = (props: {
       target: props.existingEvaluator?.targetObject ?? EvalTargetObject.EVENT,
       filter: props.existingEvaluator?.filter
         ? z.array(singleFilter).parse(props.existingEvaluator.filter)
-        : // For new trace evaluators, exclude internal environments by default
-          (props.existingEvaluator?.targetObject ?? EvalTargetObject.TRACE) ===
+        : (props.existingEvaluator?.targetObject ?? EvalTargetObject.EVENT) ===
             EvalTargetObject.TRACE
-          ? DEFAULT_TRACE_FILTER
-          : [],
+          ? // For new trace evaluators, exclude internal environments by default
+            DEFAULT_TRACE_FILTER
+          : (props.existingEvaluator?.targetObject ??
+                EvalTargetObject.EVENT) === EvalTargetObject.EVENT
+            ? // For new observation evaluators, default to GENERATION type
+              DEFAULT_OBSERVATION_FILTER
+            : [],
       mapping: props.existingEvaluator?.variableMapping
         ? isEventTarget(props.existingEvaluator.targetObject) ||
           isExperimentTarget(props.existingEvaluator.targetObject)
@@ -530,8 +535,15 @@ export const InnerEvaluatorForm = (props: {
       actualTarget,
     );
 
-    // Update form state
-    form.setValue("filter", []);
+    // Update form state with target-appropriate default filters
+    form.setValue(
+      "filter",
+      actualTarget === EvalTargetObject.TRACE
+        ? DEFAULT_TRACE_FILTER
+        : actualTarget === EvalTargetObject.EVENT
+          ? DEFAULT_OBSERVATION_FILTER
+          : [],
+    );
     form.setValue("mapping", newMapping);
     setAvailableVariables(targetState.getAvailableVariables(actualTarget));
     return actualTarget;
@@ -1066,7 +1078,7 @@ export const InnerEvaluatorForm = (props: {
                   ...field,
                   langfuseObject,
                 }));
-                form.setValue("filter", []);
+                form.setValue("filter", DEFAULT_TRACE_FILTER);
                 form.setValue("mapping", newMapping);
                 setAvailableVariables(availableTraceEvalVariables);
                 form.setValue("target", actualTarget);

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -1,5 +1,5 @@
 import { type UseFormReturn, useForm } from "react-hook-form";
-import { Alert, AlertDescription } from "@/src/components/ui/alert";
+import { AlertDescription } from "@/src/components/ui/alert";
 import { Input } from "@/src/components/ui/input";
 import { Button } from "@/src/components/ui/button";
 import {

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -911,15 +911,13 @@ export const InnerEvaluatorForm = (props: {
                       </div>
                     </FormControl>
                     {!props.disabled && !hasFilters && (
-                      <Alert className="max-w-[500px]">
-                        <AlertTriangle className="h-4 w-4" />
-                        <AlertDescription>
-                          No filters set. This evaluator will run on{" "}
-                          <span className="font-semibold">all</span>{" "}
-                          {getTargetDisplayName(target)}. Verify this is
-                          intended.
+                      <div className="align-center flex max-w-[500px] gap-1">
+                        <AlertTriangle className="h-4 w-4 text-dark-yellow" />
+                        <AlertDescription className="text-dark-yellow">
+                          No filters set. This evaluator will run on all{" "}
+                          {getTargetDisplayName(target)}.
                         </AlertDescription>
-                      </Alert>
+                      </div>
                     )}
                     <FormMessage />
                   </FormItem>

--- a/web/src/features/evals/utils/evaluator-constants.ts
+++ b/web/src/features/evals/utils/evaluator-constants.ts
@@ -54,3 +54,14 @@ export const DEFAULT_TRACE_FILTER = [
     type: "stringOptions" as const,
   },
 ];
+
+// Default filter for new observation evaluators - restricts to GENERATION type
+// to prevent evaluators from running on every observation by default
+export const DEFAULT_OBSERVATION_FILTER = [
+  {
+    column: "type",
+    operator: "any of" as const,
+    value: ["GENERATION"],
+    type: "stringOptions" as const,
+  },
+];


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds default GENERATION filter for observation evaluators and alert for missing filters in `InnerEvaluatorForm`.
> 
>   - **Behavior**:
>     - Adds `DEFAULT_OBSERVATION_FILTER` in `evaluator-constants.ts` to restrict new observation evaluators to GENERATION type.
>     - Updates `InnerEvaluatorForm` in `inner-evaluator-form.tsx` to apply `DEFAULT_OBSERVATION_FILTER` for new observation evaluators.
>     - Adds alert in `InnerEvaluatorForm` to notify users when no filters are set, indicating evaluators will run on all targets.
>   - **Constants**:
>     - Defines `DEFAULT_OBSERVATION_FILTER` in `evaluator-constants.ts` to prevent evaluators from running on every observation by default.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 66c16647025980784753565f413a23a17105c16f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->