### PR TITLE
fix(app): apply custom base path to sign-out callback URL

### DIFF
--- a/web/src/components/layouts/app-layout/index.tsx
+++ b/web/src/components/layouts/app-layout/index.tsx
@@ -132,7 +132,9 @@ export function AppLayout(props: PropsWithChildren) {
     if (env.NEXT_PUBLIC_POSTHOG_KEY && env.NEXT_PUBLIC_POSTHOG_HOST) {
       posthog.reset();
     }
-    await signOut({ callbackUrl: `/auth/sign-in` });
+    await signOut({
+      callbackUrl: `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/auth/sign-in`,
+    });
   };
 
   return (


### PR DESCRIPTION
## What does this PR do?
Fixes the issue where the sign-out redirection fails to respect the custom base path configuration.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes sign-out callback URL in `AppLayout` to respect custom base path using `NEXT_PUBLIC_BASE_PATH`.
> 
>   - **Behavior**:
>     - Fixes sign-out callback URL in `AppLayout` to respect `NEXT_PUBLIC_BASE_PATH`.
>     - Updates `handleSignOut` function to use `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/auth/sign-in` as `callbackUrl`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 61ccf74e042d5daa4e9e79379fda44a25bc6465f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->