### PR TITLE
feat(mixpanel): add project name to Mixpanel integration events

### DIFF
--- a/packages/shared/src/server/analytics-integrations/types.ts
+++ b/packages/shared/src/server/analytics-integrations/types.ts
@@ -11,6 +11,7 @@ export type AnalyticsTraceEvent = {
   langfuse_count_observations?: unknown;
   langfuse_session_id?: unknown;
   langfuse_project_id?: unknown;
+  langfuse_project_name?: unknown;
   langfuse_user_id?: unknown;
   langfuse_latency?: unknown;
   langfuse_release?: unknown;
@@ -36,6 +37,7 @@ export type AnalyticsGenerationEvent = {
   langfuse_total_units?: unknown;
   langfuse_session_id?: unknown;
   langfuse_project_id?: unknown;
+  langfuse_project_name?: unknown;
   langfuse_user_id?: unknown;
   langfuse_latency?: unknown;
   langfuse_time_to_first_token?: unknown;
@@ -64,6 +66,7 @@ export type AnalyticsScoreEvent = {
   langfuse_user_url?: unknown;
   langfuse_session_id?: unknown;
   langfuse_project_id?: unknown;
+  langfuse_project_name?: unknown;
   langfuse_user_id?: unknown;
   langfuse_release?: unknown;
   langfuse_tags?: unknown;
@@ -89,6 +92,7 @@ export type AnalyticsObservationEvent = {
   langfuse_total_units?: unknown;
   langfuse_session_id?: unknown;
   langfuse_project_id?: unknown;
+  langfuse_project_name?: unknown;
   langfuse_user_id?: unknown;
   langfuse_latency?: unknown;
   langfuse_time_to_first_token?: unknown;

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -2482,6 +2482,7 @@ export const getEventsForBlobStorageExport = function (
  */
 export const getEventsForAnalyticsIntegrations = async function* (
   projectId: string,
+  projectName: string,
   minTimestamp: Date,
   maxTimestamp: Date,
 ) {
@@ -2543,6 +2544,7 @@ export const getEventsForAnalyticsIntegrations = async function* (
       langfuse_total_units: record.total_tokens,
       langfuse_session_id: record.session_id,
       langfuse_project_id: projectId,
+      langfuse_project_name: projectName,
       langfuse_user_id: record.user_id || null,
       langfuse_latency: record.latency,
       langfuse_time_to_first_token: record.time_to_first_token,

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1822,6 +1822,7 @@ export const getObservationsForBlobStorageExport = function (
 
 export const getGenerationsForAnalyticsIntegrations = async function* (
   projectId: string,
+  projectName: string,
   minTimestamp: Date,
   maxTimestamp: Date,
 ) {
@@ -1902,6 +1903,7 @@ export const getGenerationsForAnalyticsIntegrations = async function* (
       langfuse_total_units: record.total_tokens,
       langfuse_session_id: record.trace_session_id,
       langfuse_project_id: projectId,
+      langfuse_project_name: projectName,
       langfuse_user_id: record.trace_user_id || null,
       langfuse_latency: record.latency,
       langfuse_time_to_first_token: record.time_to_first_token,

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1575,6 +1575,7 @@ export const getScoresForBlobStorageExport = function (
 
 export const getScoresForAnalyticsIntegrations = async function* (
   projectId: string,
+  projectName: string,
   minTimestamp: Date,
   maxTimestamp: Date,
 ) {
@@ -1671,6 +1672,7 @@ export const getScoresForAnalyticsIntegrations = async function* (
       langfuse_id: record.id,
       langfuse_session_id: effectiveSessionId,
       langfuse_project_id: projectId,
+      langfuse_project_name: projectName,
       langfuse_user_id: record.trace_user_id || null,
       langfuse_release: record.trace_release,
       langfuse_tags: record.trace_tags,

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -1375,6 +1375,7 @@ export const getTracesForBlobStorageExport = function (
 
 export const getTracesForAnalyticsIntegrations = async function* (
   projectId: string,
+  projectName: string,
   minTimestamp: Date,
   maxTimestamp: Date,
 ) {
@@ -1453,6 +1454,7 @@ export const getTracesForAnalyticsIntegrations = async function* (
       langfuse_count_observations: record.observation_count,
       langfuse_session_id: record.session_id,
       langfuse_project_id: projectId,
+      langfuse_project_name: projectName,
       langfuse_user_id: record.user_id || null,
       langfuse_latency: record.latency,
       langfuse_release: record.release,

--- a/worker/src/__tests__/mixpanelTransformers.test.ts
+++ b/worker/src/__tests__/mixpanelTransformers.test.ts
@@ -32,6 +32,7 @@ describe("Mixpanel transformers", () => {
         langfuse_total_units: 150,
         langfuse_session_id: "session-abc",
         langfuse_project_id: projectId,
+        langfuse_project_name: "Test Project",
         langfuse_user_id: "user-789",
         langfuse_latency: 1.5,
         langfuse_time_to_first_token: 0.3,
@@ -72,6 +73,7 @@ describe("Mixpanel transformers", () => {
         timestamp: new Date("2024-01-15T10:00:00Z"),
         langfuse_observation_name: "anonymous-event",
         langfuse_project_id: projectId,
+        langfuse_project_name: "Test Project",
         langfuse_user_id: null,
         langfuse_event_version: "1.0.0",
         posthog_session_id: null,
@@ -94,6 +96,7 @@ describe("Mixpanel transformers", () => {
         timestamp: new Date("2024-01-15T10:00:00Z"),
         langfuse_observation_name: "consistent-event",
         langfuse_project_id: projectId,
+        langfuse_project_name: "Test Project",
         langfuse_user_id: null,
         langfuse_event_version: "1.0.0",
         posthog_session_id: null,
@@ -113,6 +116,7 @@ describe("Mixpanel transformers", () => {
         langfuse_observation_name: "session-event",
         langfuse_session_id: "langfuse-session-123",
         langfuse_project_id: projectId,
+        langfuse_project_name: "Test Project",
         langfuse_user_id: "user-456",
         langfuse_event_version: "1.0.0",
         posthog_session_id: null,
@@ -131,6 +135,7 @@ describe("Mixpanel transformers", () => {
         langfuse_observation_name: "session-event",
         langfuse_session_id: "langfuse-session-123",
         langfuse_project_id: projectId,
+        langfuse_project_name: "Test Project",
         langfuse_user_id: "user-456",
         langfuse_event_version: "1.0.0",
         posthog_session_id: "posthog-session-789",
@@ -140,6 +145,26 @@ describe("Mixpanel transformers", () => {
       const result = transformEventForMixpanel(event, projectId);
 
       expect(result.properties.session_id).toBe("mixpanel-session-456");
+    });
+
+    it("should include langfuse_project_name in properties", () => {
+      const event: AnalyticsObservationEvent = {
+        langfuse_id: "event-with-project-name",
+        timestamp: new Date("2024-01-15T10:00:00Z"),
+        langfuse_observation_name: "test-event",
+        langfuse_project_id: projectId,
+        langfuse_project_name: "My Custom Project Name",
+        langfuse_user_id: "user-123",
+        langfuse_event_version: "1.0.0",
+        posthog_session_id: null,
+        mixpanel_session_id: null,
+      };
+
+      const result = transformEventForMixpanel(event, projectId);
+
+      expect(result.properties.langfuse_project_name).toBe(
+        "My Custom Project Name",
+      );
     });
   });
 
@@ -155,6 +180,7 @@ describe("Mixpanel transformers", () => {
         langfuse_count_observations: 5,
         langfuse_session_id: "session-abc",
         langfuse_project_id: projectId,
+        langfuse_project_name: "Test Project",
         langfuse_user_id: "user-789",
         langfuse_latency: 2.5,
         langfuse_release: "v1.0.0",
@@ -192,6 +218,7 @@ describe("Mixpanel transformers", () => {
         langfuse_total_units: 300,
         langfuse_session_id: "session-abc",
         langfuse_project_id: projectId,
+        langfuse_project_name: "Test Project",
         langfuse_user_id: "user-789",
         langfuse_latency: 1.2,
         langfuse_time_to_first_token: 0.2,
@@ -232,6 +259,7 @@ describe("Mixpanel transformers", () => {
         langfuse_user_url: "https://langfuse.com/project/test/users/user-789",
         langfuse_session_id: "session-abc",
         langfuse_project_id: projectId,
+        langfuse_project_name: "Test Project",
         langfuse_user_id: "user-789",
         langfuse_release: "v1.0.0",
         langfuse_tags: ["human-eval"],


### PR DESCRIPTION
## Summary

Add `langfuse_project_name` property to all events sent to Mixpanel and PostHog integrations alongside the existing `langfuse_project_id`. This allows users to filter and analyze data using human-readable project names instead of opaque UUIDs.

## Changes

- **Job Handlers**: Fetch project name from PostgreSQL and pass through data flow
  - Mixpanel: `handleMixpanelIntegrationProjectJob.ts`
  - PostHog: `handlePostHogIntegrationProjectJob.ts`
- **Repository Functions**: Updated all 4 analytics integration functions to accept and include project name
  - `getTracesForAnalyticsIntegrations`
  - `getGenerationsForAnalyticsIntegrations`
  - `getScoresForAnalyticsIntegrations`
  - `getEventsForAnalyticsIntegrations`
- **Type Definitions**: Added `langfuse_project_name?: unknown` to all event types
- **Tests**: Updated test suite with new field and added specific test case for project name validation

## Technical Details

- Single PostgreSQL query at job start to fetch project name (zero performance impact on ClickHouse queries)
- Purely additive change - no breaking changes
- Project name flows through existing architecture: job context → repository queries → transformers → Mixpanel/PostHog
- All tests passing ✅ (Mixpanel: 9, PostHog: 7)

## Testing

```bash
pnpm run test --filter=worker -- mixpanelTransformers
pnpm run test --filter=worker -- posthogTransformers
```

Result: ✓ All 16 tests passed

Closes: https://github.com/langfuse/langfuse/issues/12037