### PR TITLE
fix(prompts): add folder path when creating prompt from folder

### DIFF
--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -217,6 +217,9 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
       ) {
         setInitialMessages(draft.chatPrompt);
       }
+      if (folderPath && !initialPrompt) {
+        form.setValue("name", `${folderPath}/`);
+      }
     },
   });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set prompt `name` to include `folderPath` in `NewPromptForm` when creating a new prompt without an `initialPrompt`.
> 
>   - **Behavior**:
>     - In `NewPromptForm`, set `name` to include `folderPath` when creating a new prompt without an `initialPrompt`.
>     - This change occurs in the `useFormPersistence` hook's `onDraftRestored` callback and the `useEffect` hook for form initialization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4f82df252238a5654b705ea235194cd60aa36f69. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->