### PR TITLE
feat(peek): support showing tables

### DIFF
--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -13,6 +13,7 @@ import { type ListEntry } from "@/src/features/navigate-detail-pages/context";
 import { cn } from "@/src/utils/tailwind";
 import { memo } from "react";
 import { useRouter } from "next/router";
+import { PeekTableStateProvider } from "@/src/components/table/peek/contexts/PeekTableStateContext";
 
 type PeekViewItemType = Extract<
   LangfuseItemType,
@@ -159,11 +160,13 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
           </div>
         </SheetHeader>
         <Separator />
-        <div className="flex max-h-full min-h-0 flex-1 flex-col">
-          <div className="flex-1 overflow-auto" key={itemId}>
-            {peekView.children}
+        <PeekTableStateProvider>
+          <div className="flex max-h-full min-h-0 flex-1 flex-col">
+            <div className="flex-1 overflow-auto" key={itemId}>
+              {peekView.children}
+            </div>
           </div>
-        </div>
+        </PeekTableStateProvider>
       </SheetContent>
     </Sheet>
   );

--- a/web/src/components/table/peek/README.md
+++ b/web/src/components/table/peek/README.md
@@ -1,0 +1,258 @@
+# Peek View Table State Management
+
+This document describes how table state (filters, sorting, pagination, search) is managed and persisted in peek views when navigating between items using K/J keyboard shortcuts.
+
+## Overview
+
+Peek views allow users to quickly preview table items in a side panel. When navigating between items using K/J shortcuts, tables inside the peek view remount, which would normally reset their state. The peek state management system prevents this by storing table state in a context that persists across navigation.
+
+## Architecture
+
+The peek state architecture separates the persisting context provider from the remounting content:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ TablePeekView (peek.tsx)                                    │
+│                                                             │
+│  <PeekTableStateProvider>  ← Persists across itemId changes│
+│    <div key={itemId}>      ← Only this remounts            │
+│      {children}            ← Tables remount here           │
+│    </div>                                                   │
+│  </PeekTableStateProvider>                                  │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+        ┌───────────────────────────────────────┐
+        │ Table Components (e.g., ScoresTable)  │
+        │                                       │
+        │  Hooks automatically detect peek:     │
+        │  • useSidebarFilterState()            │
+        │  • useOrderByState()                  │
+        │  • usePaginationState()               │
+        │  • useFullTextSearch()                │
+        └───────────────────────────────────────┘
+                            │
+                            ▼
+        ┌────────────────────────────────────────┐
+        │ Hook reads from peek context:          │
+        │                                        │
+        │ const peekContext = usePeekTableState()│
+        │ if (peekContext) {                     │
+        │   return peekContext.tableState.X      │
+        │ }                                      │
+        │ return urlState                        │
+        └────────────────────────────────────────┘
+```
+
+### Key Components
+
+#### PeekTableStateProvider
+
+**Location:** [`contexts/PeekTableStateContext.tsx`](./contexts/PeekTableStateContext.tsx)
+
+- Provides persistent state storage across peek item navigation
+- Stores filters, sorting, pagination, and search state
+- Does NOT remount when `itemId` changes during K/J navigation
+- Tables inside the peek view automatically use this context when available
+
+#### Peek-Aware Hooks
+
+All state management hooks automatically detect when they're running inside a peek view and read/write state accordingly:
+
+1. **`useSidebarFilterState`** - Manages filter state
+   - Location: `web/src/features/filters/hooks/useSidebarFilterState.tsx`
+   - Checks for `usePeekTableState()` and reads from `peekContext.tableState.filters`
+
+2. **`useOrderByState`** - Manages sorting state
+   - Location: `web/src/features/orderBy/hooks/useOrderByState.ts`
+   - Returns peek context state or URL state based on context availability
+
+3. **`usePaginationState`** - Manages pagination state
+   - Location: `web/src/hooks/usePaginationState.ts`
+   - Supports both `page/limit` and `pageIndex/pageSize` formats
+   - Automatically detects peek context and uses it if available
+
+4. **`useFullTextSearch`** - Manages search query state
+   - Location: `web/src/components/table/use-cases/useFullTextSearch.tsx`
+   - Handles both search query and search type state
+
+## Behavior
+
+### ✅ Expected Behavior (Fully Integrated Tables)
+
+When using K/J navigation in peek view for fully integrated tables:
+
+1. User applies filter/sort/pagination/search
+2. State is stored in `PeekTableStateContext`
+3. User presses K/J → `itemId` changes → peek content remounts
+4. `PeekTableStateProvider` does NOT remount
+5. Remounted table hooks read from the same context instance
+6. Table automatically restores previous state
+
+**Fully Integrated Tables:**
+
+- Traces table
+- Observations table
+- Scores table
+- Evaluators table
+- Events table
+- Eval Templates table (search now peek-aware)
+
+### 🔄 Future-Proofed Tables (Peek-Aware Hooks Added)
+
+These tables don't currently have peek views but now use peek-aware hooks, making them ready if peek views are added:
+
+- Sessions table
+- Models table
+- Score Configs table
+
+## Table State Interface
+
+The `PeekTableState` interface defines what state is persisted:
+
+```typescript
+interface PeekTableState {
+  filters: FilterState;
+  sorting: OrderByState;
+  pagination: { pageIndex: number; pageSize: number };
+  search: { query: string | null; type: string[] };
+}
+```
+
+## Implementation Guide
+
+### Adding Peek Views to a New Table
+
+To make a table work with peek state persistence:
+
+1. **Use peek-aware hooks instead of direct URL state management:**
+
+   ```typescript
+   // ❌ Don't use useQueryParams directly
+   const [paginationState, setPaginationState] = useQueryParams({
+     pageIndex: withDefault(NumberParam, 0),
+     pageSize: withDefault(NumberParam, 50),
+   });
+
+   // ✅ Use usePaginationState (automatically peek-aware)
+   const [paginationState, setPaginationState] = usePaginationState(0, 50);
+   ```
+
+2. **For search, use useFullTextSearch:**
+
+   ```typescript
+   // ❌ Don't use useQueryParam directly
+   const [searchQuery, setSearchQuery] = useQueryParam("search", StringParam);
+
+   // ✅ Use useFullTextSearch (automatically peek-aware)
+   const { searchQuery, setSearchQuery } = useFullTextSearch();
+   ```
+
+3. **For filters, use useSidebarFilterState:**
+
+   ```typescript
+   // Already peek-aware, no changes needed if already using this hook
+   const queryFilter = useSidebarFilterState(filterConfig, options, projectId);
+   ```
+
+4. **For sorting, use useOrderByState:**
+
+   ```typescript
+   // Already peek-aware, no changes needed if already using this hook
+   const [orderByState, setOrderByState] = useOrderByState({
+     column: "createdAt",
+     order: "DESC",
+   });
+   ```
+
+### How It Works Internally
+
+Each peek-aware hook follows the same pattern:
+
+```typescript
+export const useSomeState = () => {
+  const peekContext = usePeekTableState();
+
+  // URL-based state (fallback)
+  const [urlState, setUrlState] = useQueryParam(...);
+
+  if (peekContext) {
+    // In peek view: read/write from context
+    const value = peekContext.tableState.someProperty;
+    const setValue = (newValue) => {
+      peekContext.setTableState({
+        ...peekContext.tableState,
+        someProperty: newValue,
+      });
+    };
+    return { value, setValue };
+  }
+
+  // Not in peek view: use URL state
+  return { value: urlState, setValue: setUrlState };
+};
+```
+
+## State Lifecycle and Caveats
+
+### When State Persists (Intended ✓)
+
+Table state **persists** during K/J keyboard navigation within the same peek view:
+
+```
+1. Open trace T1 → apply filter to ScoresTable
+2. Press K/J → navigate to trace T2
+3. ScoresTable in T2 retains the filter ✓
+```
+
+**Reason:** `PeekTableStateProvider` remains mounted during K/J navigation. Only the content with `key={itemId}` remounts, preserving user's filter/sort/pagination preferences across items of the same type.
+
+### When State Resets (Safe ✓)
+
+Table state **resets** when the peek view closes:
+
+```
+1. Open trace T1 → apply filter
+2. Close peek (X button/Escape/click outside)
+3. Open observation O1 → fresh state ✓
+```
+
+**Reason:** Closing the peek removes the `peek` URL parameter. This causes the `<Sheet>` component to close and unmount `<SheetContent>`, which unmounts `PeekTableStateProvider` and destroys all state.
+
+### Known Risk: Multiple Tables in One Peek View
+
+**Risk Level:** LOW (theoretical edge case)
+
+**Issue:** All tables in the same peek view share a single `PeekTableState` object. If a peek view contains multiple independent paginated tables, they share pagination/filter/sort state.
+
+**Example:**
+
+```
+Hypothetical: Trace peek with both Scores table AND Events table
+→ Navigate to page 2 of Scores table
+→ context.pagination = { pageIndex: 1, pageSize: 50 }
+→ Events table also shows page 2 ❌
+```
+
+**Current Reality:**
+
+- Peek views typically contain one primary table (e.g., ScoresTable in trace details)
+- Multiple instances of the same table type (e.g., trace-level scores + observation-level scores) intentionally share state
+- Tables use `disableUrlPersistence` and scope data via props (`traceId`, `observationId`)
+
+**Future Solution (if multiple independent table types are needed):**
+Namespace state by table identifier:
+
+```typescript
+const filters = useSidebarFilterState(config, options, projectId, loading, {
+  tableId: "scores", // Unique identifier per table
+});
+```
+
+## Related Files
+
+- Peek state context: [`contexts/PeekTableStateContext.tsx`](./contexts/PeekTableStateContext.tsx)
+- Pagination hook: [`web/src/hooks/usePaginationState.ts`](../../../hooks/usePaginationState.ts)
+- Full text search hook: [`use-cases/useFullTextSearch.tsx`](../use-cases/useFullTextSearch.tsx)
+- Filter state hook: [`web/src/features/filters/hooks/useSidebarFilterState.tsx`](../../../features/filters/hooks/useSidebarFilterState.tsx)
+- Order by hook: [`web/src/features/orderBy/hooks/useOrderByState.ts`](../../../features/orderBy/hooks/useOrderByState.ts)

--- a/web/src/components/table/peek/contexts/PeekTableStateContext.tsx
+++ b/web/src/components/table/peek/contexts/PeekTableStateContext.tsx
@@ -5,8 +5,7 @@ import {
   useMemo,
   type ReactNode,
 } from "react";
-import type { FilterState } from "@langfuse/shared";
-import type { OrderByState } from "@/src/features/orderBy/types";
+import type { FilterState, OrderByState } from "@langfuse/shared";
 
 interface PeekTableState {
   filters: FilterState;

--- a/web/src/components/table/peek/contexts/PeekTableStateContext.tsx
+++ b/web/src/components/table/peek/contexts/PeekTableStateContext.tsx
@@ -1,0 +1,46 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  type ReactNode,
+} from "react";
+import type { FilterState } from "@langfuse/shared";
+import type { OrderByState } from "@/src/features/orderBy/types";
+
+interface PeekTableState {
+  filters: FilterState;
+  sorting: OrderByState;
+  pagination: { pageIndex: number; pageSize: number };
+  search: { query: string | null; type: string[] };
+}
+
+interface PeekTableStateContextValue {
+  tableState: PeekTableState;
+  setTableState: (state: PeekTableState) => void;
+}
+
+const PeekTableStateContext = createContext<
+  PeekTableStateContextValue | undefined
+>(undefined);
+
+export function PeekTableStateProvider({ children }: { children: ReactNode }) {
+  const [tableState, setTableState] = useState<PeekTableState>({
+    filters: [],
+    sorting: null,
+    pagination: { pageIndex: 0, pageSize: 50 },
+    search: { query: null, type: ["id"] },
+  });
+
+  const value = useMemo(() => ({ tableState, setTableState }), [tableState]);
+
+  return (
+    <PeekTableStateContext.Provider value={value}>
+      {children}
+    </PeekTableStateContext.Provider>
+  );
+}
+
+export function usePeekTableState() {
+  return useContext(PeekTableStateContext);
+}

--- a/web/src/components/table/use-cases/models.tsx
+++ b/web/src/components/table/use-cases/models.tsx
@@ -4,12 +4,8 @@ import useColumnVisibility from "@/src/features/column-visibility/hooks/useColum
 import { api } from "@/src/utils/api";
 import { safeExtract } from "@/src/utils/map-utils";
 import { type Prisma } from "@langfuse/shared/src/db";
-import {
-  useQueryParams,
-  withDefault,
-  NumberParam,
-  StringParam,
-} from "use-query-params";
+import { useQueryParams, withDefault, StringParam } from "use-query-params";
+import { usePaginationState } from "@/src/hooks/usePaginationState";
 import { IOTableCell } from "../../ui/IOTableCell";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
@@ -68,9 +64,9 @@ const modelConfigDescriptions = {
 export default function ModelTable({ projectId }: { projectId: string }) {
   const router = useRouter();
   const capture = usePostHogClientCapture();
-  const [paginationState, setPaginationState] = useQueryParams({
-    pageIndex: withDefault(NumberParam, 0),
-    pageSize: withDefault(NumberParam, 50),
+  const [paginationState, setPaginationState] = usePaginationState(0, 50, {
+    page: "pageIndex",
+    limit: "pageSize",
   });
   const [queryParams, setQueryParams] = useQueryParams({
     search: withDefault(StringParam, ""),

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -8,8 +8,8 @@ import {
 import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import { useEffect, useMemo, useState, useRef, useCallback } from "react";
 import { TokenUsageBadge } from "@/src/components/token-usage-badge";
-import { NumberParam, useQueryParams, withDefault } from "use-query-params";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
+import { usePaginationState } from "@/src/hooks/usePaginationState";
 import { useSidebarFilterState } from "@/src/features/filters/hooks/useSidebarFilterState";
 import {
   observationFilterConfig,
@@ -200,9 +200,9 @@ export default function ObservationsTable({
   const { selectAll, setSelectAll } = useSelectAll(projectId, "observations");
   const [showAddToDatasetDialog, setShowAddToDatasetDialog] = useState(false);
 
-  const [paginationState, setPaginationState] = useQueryParams({
-    pageIndex: withDefault(NumberParam, 0),
-    pageSize: withDefault(NumberParam, 50),
+  const [paginationState, setPaginationState] = usePaginationState(0, 50, {
+    page: "pageIndex",
+    limit: "pageSize",
   });
 
   const [storedRowHeight, setRowHeight] = useRowHeightLocalStorage(

--- a/web/src/components/table/use-cases/score-configs.tsx
+++ b/web/src/components/table/use-cases/score-configs.tsx
@@ -11,7 +11,7 @@ import {
   type ScoreConfigCategoryDomain,
 } from "@langfuse/shared";
 import { IOTableCell } from "../../ui/IOTableCell";
-import { NumberParam, useQueryParams, withDefault } from "use-query-params";
+import { usePaginationState } from "@/src/hooks/usePaginationState";
 import {
   isBooleanDataType,
   isCategoricalDataType,
@@ -74,9 +74,9 @@ function getConfigRange(
 export function ScoreConfigsTable({ projectId }: { projectId: string }) {
   const [editConfigId, setEditConfigId] = useState<string | null>(null);
   const [createConfigOpen, setCreateConfigOpen] = useState(false);
-  const [paginationState, setPaginationState] = useQueryParams({
-    pageIndex: withDefault(NumberParam, 0),
-    pageSize: withDefault(NumberParam, 50),
+  const [paginationState, setPaginationState] = usePaginationState(0, 50, {
+    page: "pageIndex",
+    limit: "pageSize",
   });
 
   const hasAccess = useHasProjectAccess({

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -33,7 +33,6 @@ import {
   TableViewPresetTableName,
   type TimeFilter,
 } from "@langfuse/shared";
-import { useQueryParams, withDefault, NumberParam } from "use-query-params";
 import TagList from "@/src/features/tag/components/TagList";
 import { cn } from "@/src/utils/tailwind";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
@@ -50,6 +49,7 @@ import { useSelectAll } from "@/src/features/table/hooks/useSelectAll";
 import { TableSelectionManager } from "@/src/features/table/components/TableSelectionManager";
 import { useTableViewManager } from "@/src/components/table/table-view-presets/hooks/useTableViewManager";
 import TableIdOrName from "@/src/components/table/table-id";
+import { usePaginationState } from "@/src/hooks/usePaginationState";
 
 export type ScoresTableRow = {
   id: string;
@@ -112,9 +112,9 @@ export default function ScoresTable({
 }) {
   const utils = api.useUtils();
   const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
-  const [paginationState, setPaginationState] = useQueryParams({
-    pageIndex: withDefault(NumberParam, 0),
-    pageSize: withDefault(NumberParam, 50),
+  const [paginationState, setPaginationState] = usePaginationState(0, 50, {
+    page: "pageIndex",
+    limit: "pageSize",
   });
   const { selectAll, setSelectAll } = useSelectAll(projectId, "scores");
 

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -33,7 +33,7 @@ import { numberFormatter, usdFormatter } from "@/src/utils/numbers";
 import { type RouterOutput } from "@/src/utils/types";
 import type Decimal from "decimal.js";
 import { useEffect, useState, useMemo, useRef, useCallback } from "react";
-import { NumberParam, useQueryParams, withDefault } from "use-query-params";
+import { usePaginationState } from "@/src/hooks/usePaginationState";
 import { useTableDateRange } from "@/src/hooks/useTableDateRange";
 import { toAbsoluteTimeRange } from "@/src/utils/date-range-utils";
 import { joinTableCoreAndMetrics } from "@/src/components/table/utils/joinTableCoreAndMetrics";
@@ -152,9 +152,9 @@ export default function SessionsTable({
 
   const { selectAll, setSelectAll } = useSelectAll(projectId, "sessions");
 
-  const [paginationState, setPaginationState] = useQueryParams({
-    pageIndex: withDefault(NumberParam, 0),
-    pageSize: withDefault(NumberParam, 50),
+  const [paginationState, setPaginationState] = usePaginationState(0, 50, {
+    page: "pageIndex",
+    limit: "pageSize",
   });
 
   const [rowHeight, setRowHeight] = useRowHeightLocalStorage("sessions", "s");

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -15,7 +15,7 @@ import { formatIntervalSeconds } from "@/src/utils/dates";
 import { type RouterOutput } from "@/src/utils/types";
 import { type Row, type RowSelectionState } from "@tanstack/react-table";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { NumberParam, useQueryParams, withDefault } from "use-query-params";
+import { usePaginationState } from "@/src/hooks/usePaginationState";
 import type Decimal from "decimal.js";
 import {
   compactNumberFormatter,
@@ -340,9 +340,9 @@ export default function TracesTable({
   // Use external filter state if provided, otherwise use combined filter state
   const filterState = externalFilterState || combinedFilterState;
 
-  const [paginationState, setPaginationState] = useQueryParams({
-    pageIndex: withDefault(NumberParam, 0),
-    pageSize: withDefault(NumberParam, 50),
+  const [paginationState, setPaginationState] = usePaginationState(0, 50, {
+    page: "pageIndex",
+    limit: "pageSize",
   });
   const { selectAll, setSelectAll } = useSelectAll(projectId, "traces");
 

--- a/web/src/components/table/use-cases/useFullTextSearch.tsx
+++ b/web/src/components/table/use-cases/useFullTextSearch.tsx
@@ -5,8 +5,11 @@ import {
   StringParam,
   ArrayParam,
 } from "use-query-params";
+import { usePeekTableState } from "@/src/components/table/peek/contexts/PeekTableStateContext";
 
 export const useFullTextSearch = () => {
+  const peekContext = usePeekTableState();
+
   const [searchQuery, setSearchQuery] = useQueryParam(
     "search",
     withDefault(StringParam, null),
@@ -19,6 +22,31 @@ export const useFullTextSearch = () => {
     "searchType",
     withDefault(ArrayParam, ["id"]),
   );
+
+  if (peekContext) {
+    const { query, type } = peekContext.tableState.search;
+
+    const setSearchQuery = (newQuery: string | null) => {
+      peekContext.setTableState({
+        ...peekContext.tableState,
+        search: { ...peekContext.tableState.search, query: newQuery },
+      });
+    };
+
+    const setSearchType = (newType: string[]) => {
+      peekContext.setTableState({
+        ...peekContext.tableState,
+        search: { ...peekContext.tableState.search, type: newType },
+      });
+    };
+
+    return {
+      searchQuery: query,
+      searchType: type as TracingSearchType[],
+      setSearchQuery,
+      setSearchType,
+    };
+  }
 
   const setSearchType = (newSearchType: TracingSearchType[]) => {
     handleSearchTypeChange(newSearchType);

--- a/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
+++ b/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
@@ -177,10 +177,9 @@ export function TraceDetailView({
     observations.length >= TRACE_VIEW_CONFIG.logView.virtualizationThreshold;
 
   // Scores tab visibility: hide for public trace viewers and in peek mode (annotation queues)
-  const { isPeekMode } = useViewPreferences();
   const isAuthenticatedAndProjectMember =
     useIsAuthenticatedAndProjectMember(projectId);
-  const showScoresTab = isAuthenticatedAndProjectMember && !isPeekMode;
+  const showScoresTab = isAuthenticatedAndProjectMember;
 
   // Handle tab change
   const handleTabChange = (value: string) => {

--- a/web/src/features/auth/hooks.ts
+++ b/web/src/features/auth/hooks.ts
@@ -10,10 +10,13 @@ export const useIsAuthenticatedAndProjectMember = (
 
   if (projectId === "") return false;
 
+  const isAdmin = session.data?.user?.admin ?? false;
+
   return (
-    session.status === "authenticated" &&
-    !!session.data?.user?.organizations
-      .flatMap((org) => org.projects)
-      .find(({ id }) => id === projectId)
+    isAdmin ||
+    (session.status === "authenticated" &&
+      !!session.data?.user?.organizations
+        .flatMap((org) => org.projects)
+        .find(({ id }) => id === projectId))
   );
 };

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -7,9 +7,8 @@ import { IOTableCell } from "@/src/components/ui/IOTableCell";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import { getDatasetRunAggregateColumnProps } from "@/src/features/datasets/components/DatasetRunAggregateColumnHelpers";
 import { useDatasetRunAggregateColumns } from "@/src/features/datasets/hooks/useDatasetRunAggregateColumns";
-import { NumberParam } from "use-query-params";
-import { useQueryParams, withDefault } from "use-query-params";
 import { useState, useEffect } from "react";
+import { usePaginationState } from "@/src/hooks/usePaginationState";
 import { api } from "@/src/utils/api";
 import { Button } from "@/src/components/ui/button";
 import { LayoutList } from "lucide-react";
@@ -68,9 +67,9 @@ function DatasetCompareRunsTableInternal(props: {
     });
   }, [props.runIds, convertToColumnFilterList, updateRunFilters]);
 
-  const [paginationState, setPaginationState] = useQueryParams({
-    pageIndex: withDefault(NumberParam, 0),
-    pageSize: withDefault(NumberParam, 50),
+  const [paginationState, setPaginationState] = usePaginationState(0, 50, {
+    page: "pageIndex",
+    limit: "pageSize",
   });
 
   const datasetItemsWithRunData = api.datasets.datasetItemsWithRunData.useQuery(

--- a/web/src/features/evals/components/eval-templates-table.tsx
+++ b/web/src/features/evals/components/eval-templates-table.tsx
@@ -6,14 +6,9 @@ import { type RouterOutputs, api } from "@/src/utils/api";
 import { safeExtract } from "@/src/utils/map-utils";
 import { createColumnHelper } from "@tanstack/react-table";
 import { Copy, Pen } from "lucide-react";
-import {
-  useQueryParams,
-  withDefault,
-  NumberParam,
-  useQueryParam,
-  StringParam,
-} from "use-query-params";
+import { useQueryParam, StringParam } from "use-query-params";
 import { useEffect, useState } from "react";
+import { usePaginationState } from "@/src/hooks/usePaginationState";
 import TableIdOrName from "@/src/components/table/table-id";
 import { PeekViewEvaluatorTemplateDetail } from "@/src/components/table/peek/peek-evaluator-template-detail";
 import { usePeekNavigation } from "@/src/components/table/peek/hooks/usePeekNavigation";
@@ -59,9 +54,9 @@ export default function EvalsTemplateTable({
 }) {
   const router = useRouter();
   const { setDetailPageList } = useDetailPageLists();
-  const [paginationState, setPaginationState] = useQueryParams({
-    pageIndex: withDefault(NumberParam, 0),
-    pageSize: withDefault(NumberParam, 50),
+  const [paginationState, setPaginationState] = usePaginationState(0, 50, {
+    page: "pageIndex",
+    limit: "pageSize",
   });
   const [searchQuery, setSearchQuery] = useQueryParam(
     "search",

--- a/web/src/features/evals/components/eval-templates-table.tsx
+++ b/web/src/features/evals/components/eval-templates-table.tsx
@@ -6,7 +6,7 @@ import { type RouterOutputs, api } from "@/src/utils/api";
 import { safeExtract } from "@/src/utils/map-utils";
 import { createColumnHelper } from "@tanstack/react-table";
 import { Copy, Pen } from "lucide-react";
-import { useQueryParam, StringParam } from "use-query-params";
+import { useQueryParam, StringParam, withDefault } from "use-query-params";
 import { useEffect, useState } from "react";
 import { usePaginationState } from "@/src/hooks/usePaginationState";
 import TableIdOrName from "@/src/components/table/table-id";

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -18,7 +18,7 @@ import { safeExtract } from "@/src/utils/map-utils";
 import { type FilterState, singleFilter } from "@langfuse/shared";
 import { createColumnHelper } from "@tanstack/react-table";
 import { useEffect, useState, useMemo } from "react";
-import { useQueryParam, StringParam } from "use-query-params";
+import { useQueryParam, StringParam, withDefault } from "use-query-params";
 import { usePaginationState } from "@/src/hooks/usePaginationState";
 import { z } from "zod/v4";
 import { generateJobExecutionCounts } from "@/src/features/evals/utils/job-execution-utils";

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -18,13 +18,8 @@ import { safeExtract } from "@/src/utils/map-utils";
 import { type FilterState, singleFilter } from "@langfuse/shared";
 import { createColumnHelper } from "@tanstack/react-table";
 import { useEffect, useState, useMemo } from "react";
-import {
-  useQueryParams,
-  withDefault,
-  NumberParam,
-  useQueryParam,
-  StringParam,
-} from "use-query-params";
+import { useQueryParam, StringParam } from "use-query-params";
+import { usePaginationState } from "@/src/hooks/usePaginationState";
 import { z } from "zod/v4";
 import { generateJobExecutionCounts } from "@/src/features/evals/utils/job-execution-utils";
 import {
@@ -142,9 +137,9 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
   const isFullyReleased = useIsObservationEvalsFullyReleased();
   const router = useRouter();
   const { setDetailPageList } = useDetailPageLists();
-  const [paginationState, setPaginationState] = useQueryParams({
-    pageIndex: withDefault(NumberParam, 0),
-    pageSize: withDefault(NumberParam, 50),
+  const [paginationState, setPaginationState] = usePaginationState(0, 50, {
+    page: "pageIndex",
+    limit: "pageSize",
   });
   const [searchQuery, setSearchQuery] = useQueryParam(
     "search",

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -6,8 +6,8 @@ import {
 } from "@/src/components/table/data-table-controls";
 import { ResizableFilterLayout } from "@/src/components/table/resizable-filter-layout";
 import { useEffect, useMemo, useState, useRef, useCallback } from "react";
-import { NumberParam, useQueryParams, withDefault } from "use-query-params";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
+import { usePaginationState } from "@/src/hooks/usePaginationState";
 import { useSidebarFilterState } from "@/src/features/filters/hooks/useSidebarFilterState";
 import {
   getEventsColumnName,
@@ -174,10 +174,7 @@ export default function ObservationsEventsTable({
 
   const { selectAll, setSelectAll } = useSelectAll(projectId, "observations");
 
-  const [paginationState, setPaginationState] = useQueryParams({
-    page: withDefault(NumberParam, 1),
-    limit: withDefault(NumberParam, 50),
-  });
+  const [paginationState, setPaginationState] = usePaginationState(1, 50);
 
   const [rowHeight, setRowHeight] = useRowHeightLocalStorage(
     "observations",
@@ -240,7 +237,7 @@ export default function ObservationsEventsTable({
     (mode: EventsViewMode) => {
       setUserExplicitChoice(mode); // Track explicit choice
       setViewModeRaw(mode);
-      setPaginationState({ page: 1 });
+      setPaginationState({ page: 1, limit: 50 });
     },
     [setUserExplicitChoice, setViewModeRaw, setPaginationState],
   );

--- a/web/src/features/filters/hooks/useFilterState.ts
+++ b/web/src/features/filters/hooks/useFilterState.ts
@@ -26,6 +26,7 @@ import {
   splitOnUnescapedPipe,
   unescapePipeInValue,
 } from "../lib/filter-query-encoding";
+import { usePeekTableState } from "@/src/components/table/peek/contexts/PeekTableStateContext";
 
 const DEBUG_QUERY_STATE = false;
 
@@ -121,6 +122,8 @@ export const useQueryFilterState = (
   table: TableName,
   projectId?: string, // Passing projectId is expected as filters might differ across projects. However, we can't call hooks conditionally. There is a case in the prompts table where this will only be used if projectId is defined, but it's not defined in all cases.
 ) => {
+  const peekContext = usePeekTableState();
+
   const [sessionFilterState, setSessionFilterState] =
     useSessionStorage<FilterState>(
       !!projectId ? `${table}FilterState-${projectId}` : `${table}FilterState`,
@@ -148,6 +151,16 @@ export const useQueryFilterState = (
     "filter",
     withDefault(getCommaArrayParam(table), sessionFilterState),
   );
+
+  if (peekContext) {
+    const setState = (newFilters: FilterState) => {
+      peekContext.setTableState({
+        ...peekContext.tableState,
+        filters: newFilters,
+      });
+    };
+    return [peekContext.tableState.filters, setState] as const;
+  }
 
   const setFilterStateWithSession = (newState: FilterState): void => {
     setFilterState(newState);

--- a/web/src/features/navigate-detail-pages/DetailPageNav.tsx
+++ b/web/src/features/navigate-detail-pages/DetailPageNav.tsx
@@ -50,19 +50,17 @@ export const DetailPageNav = (props: {
       }
 
       if (event.key === "k" && previousPageEntry) {
-        void router.push(
-          props.path({
-            id: encodeURIComponent(previousPageEntry.id),
-            params: previousPageEntry.params,
-          }),
-        );
+        const newPath = props.path({
+          id: encodeURIComponent(previousPageEntry.id),
+          params: previousPageEntry.params,
+        });
+        void router.push(newPath);
       } else if (event.key === "j" && nextPageEntry) {
-        void router.push(
-          props.path({
-            id: encodeURIComponent(nextPageEntry.id),
-            params: nextPageEntry.params,
-          }),
-        );
+        const newPath = props.path({
+          id: encodeURIComponent(nextPageEntry.id),
+          params: nextPageEntry.params,
+        });
+        void router.push(newPath);
       }
     };
     window.addEventListener("keydown", handleKeyDown);

--- a/web/src/features/orderBy/hooks/useOrderByState.ts
+++ b/web/src/features/orderBy/hooks/useOrderByState.ts
@@ -1,5 +1,6 @@
 import { type OrderByState } from "@langfuse/shared";
 import { ObjectParam, useQueryParam, withDefault } from "use-query-params";
+import { usePeekTableState } from "@/src/components/table/peek/contexts/PeekTableStateContext";
 
 type OrderByQueryParamState =
   | OrderByState
@@ -12,10 +13,25 @@ type OrderByQueryParamState =
  * @returns [orderByState, setOrderByState]
  */
 export const useOrderByState = (initialState: OrderByState = null) => {
+  const peekContext = usePeekTableState();
+
   const [orderByState, setOrderByState] = useQueryParam<OrderByQueryParamState>(
     "orderBy",
     withDefault(ObjectParam, initialState),
   );
+
+  if (peekContext) {
+    const setState = (newSorting: OrderByState) => {
+      peekContext.setTableState({
+        ...peekContext.tableState,
+        sorting: newSorting,
+      });
+    };
+    return [peekContext.tableState.sorting, setState] as [
+      OrderByState,
+      (orderByState: OrderByState) => void,
+    ];
+  }
 
   return [orderByState, setOrderByState] as [
     OrderByState,

--- a/web/src/hooks/usePaginationState.ts
+++ b/web/src/hooks/usePaginationState.ts
@@ -2,9 +2,6 @@ import { useQueryParams, withDefault, NumberParam } from "use-query-params";
 import { usePeekTableState } from "@/src/components/table/peek/contexts/PeekTableStateContext";
 import type { PaginationState, OnChangeFn } from "@tanstack/react-table";
 
-type PaginationParams = "page" | "pageIndex";
-type LimitParams = "limit" | "pageSize";
-
 // Overload for pageIndex/pageSize (returns TanStack types)
 export function usePaginationState(
   defaultPageIndex: number,

--- a/web/src/hooks/usePaginationState.ts
+++ b/web/src/hooks/usePaginationState.ts
@@ -1,0 +1,100 @@
+import { useQueryParams, withDefault, NumberParam } from "use-query-params";
+import { usePeekTableState } from "@/src/components/table/peek/contexts/PeekTableStateContext";
+import type { PaginationState, OnChangeFn } from "@tanstack/react-table";
+
+type PaginationParams = "page" | "pageIndex";
+type LimitParams = "limit" | "pageSize";
+
+// Overload for pageIndex/pageSize (returns TanStack types)
+export function usePaginationState(
+  defaultPageIndex: number,
+  defaultPageSize: number,
+  paramNames: { page: "pageIndex"; limit: "pageSize" },
+): readonly [PaginationState, OnChangeFn<PaginationState>];
+
+// Overload for page/limit (returns custom format)
+export function usePaginationState(
+  defaultPage?: number,
+  defaultLimit?: number,
+): readonly [
+  { page: number; limit: number },
+  (value: { page: number; limit: number }) => void,
+];
+
+// Implementation
+export function usePaginationState(
+  defaultPageOrIndex: number = 1,
+  defaultLimitOrSize: number = 50,
+  paramNames?: { page: "page" | "pageIndex"; limit: "limit" | "pageSize" },
+): readonly [
+  { page: number; limit: number } | PaginationState,
+  ((value: { page: number; limit: number }) => void) | OnChangeFn<PaginationState>,
+] {
+  const peekContext = usePeekTableState();
+  const pageParam = paramNames?.page ?? "page";
+  const limitParam = paramNames?.limit ?? "limit";
+
+  const [paginationState, setPaginationState] = useQueryParams({
+    [pageParam]: withDefault(NumberParam, defaultPageOrIndex),
+    [limitParam]: withDefault(NumberParam, defaultLimitOrSize),
+  });
+
+  if (peekContext) {
+    const { pageIndex, pageSize } = peekContext.tableState.pagination;
+
+    if (pageParam === "pageIndex") {
+      // Return TanStack PaginationState format
+      const contextState: PaginationState = { pageIndex, pageSize };
+      const setState: OnChangeFn<PaginationState> = (updaterOrValue) => {
+        const newValue =
+          typeof updaterOrValue === "function"
+            ? updaterOrValue(contextState)
+            : updaterOrValue;
+        peekContext.setTableState({
+          ...peekContext.tableState,
+          pagination: newValue,
+        });
+      };
+      return [contextState, setState] as const;
+    } else {
+      // Return page/limit format
+      const contextState = { page: pageIndex + 1, limit: pageSize };
+      const setState = (newPagination: { page: number; limit: number }) => {
+        peekContext.setTableState({
+          ...peekContext.tableState,
+          pagination: {
+            pageIndex: newPagination.page - 1,
+            pageSize: newPagination.limit,
+          },
+        });
+      };
+      return [contextState, setState] as const;
+    }
+  }
+
+  // Not in peek context
+  if (pageParam === "pageIndex") {
+    // Convert to TanStack format
+    const urlState: PaginationState = {
+      pageIndex: paginationState.pageIndex as number,
+      pageSize: paginationState.pageSize as number,
+    };
+    const setUrlState: OnChangeFn<PaginationState> = (updaterOrValue) => {
+      const newValue =
+        typeof updaterOrValue === "function"
+          ? updaterOrValue(urlState)
+          : updaterOrValue;
+      setPaginationState({
+        pageIndex: newValue.pageIndex,
+        pageSize: newValue.pageSize,
+      });
+    };
+    return [urlState, setUrlState] as const;
+  } else {
+    // Return page/limit format as-is
+    return [
+      paginationState as { page: number; limit: number },
+      setPaginationState as (value: { page: number; limit: number }) => void,
+    ] as const;
+  }
+}

--- a/web/src/hooks/usePaginationState.ts
+++ b/web/src/hooks/usePaginationState.ts
@@ -28,7 +28,10 @@ export function usePaginationState(
   paramNames?: { page: "page" | "pageIndex"; limit: "limit" | "pageSize" },
 ): readonly [
   { page: number; limit: number } | PaginationState,
-  ((value: { page: number; limit: number }) => void) | OnChangeFn<PaginationState>,
+  (
+    | ((value: { page: number; limit: number }) => void)
+    | OnChangeFn<PaginationState>
+  ),
 ] {
   const peekContext = usePeekTableState();
   const pageParam = paramNames?.page ?? "page";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for table state persistence in peek views using `PeekTableStateProvider`, enhancing navigation and state management across various table components.
> 
>   - **Behavior**:
>     - Introduces `PeekTableStateProvider` in `peek.tsx` to persist table state (filters, sorting, pagination, search) across item navigation.
>     - Updates `TablePeekViewComponent` to wrap content with `PeekTableStateProvider`.
>     - Adds `README.md` in `peek` directory to document table state management.
>   - **Hooks**:
>     - Modifies `usePaginationState`, `useOrderByState`, `useFullTextSearch`, `useQueryFilterState`, and `useSidebarFilterState` to utilize `PeekTableStateContext` when available.
>     - Adds peek-aware logic to handle state persistence in `use-cases/useFullTextSearch.tsx` and `usePaginationState.ts`.
>   - **Components**:
>     - Updates various table components (`scores.tsx`, `sessions.tsx`, `traces.tsx`, etc.) to use `usePaginationState` with peek-aware functionality.
>     - Adjusts `TraceDetailView.tsx` to show scores tab based on authentication and peek mode.
>   - **Misc**:
>     - Refactors keyboard navigation in `DetailPageNav.tsx` to use `router.push` with new path logic.
>     - Updates `useIsAuthenticatedAndProjectMember` to include admin check.
>     - Minor refactoring and cleanup in several components to integrate new state management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cc14609146703b3a4564c6b219e886d678a98f0b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->