### PR TITLE
chore(events-table): more than 100 observations per trace through tRPC

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -283,7 +283,7 @@ const TRACES_ORDER_BY_COLUMNS = TRACES_FROM_EVENTS_UI_COLUMN_DEFINITIONS.filter(
   queryPrefix: "t", // Use 't' prefix because we're selecting from traces CTE
 }));
 
-// TODO: remove limit?
+// TODO: introduce pagination
 export const MAX_OBSERVATIONS_PER_TRACE = 10_000;
 
 export const getObservationsForTraceFromEventsTable = async (params: {

--- a/web/src/components/table/peek/hooks/usePeekData.ts
+++ b/web/src/components/table/peek/hooks/usePeekData.ts
@@ -46,8 +46,6 @@ export const usePeekData = ({
       data: eventsData.data,
       isLoading: eventsData.isLoading,
       error: eventsData.error,
-      cutoffObservationsAfterMaxCount:
-        eventsData.cutoffObservationsAfterMaxCount,
       // Provide stub for other fields to match tracesQuery return type
       isError: !!eventsData.error,
       isFetching: eventsData.isLoading,

--- a/web/src/components/table/peek/hooks/usePeekData.ts
+++ b/web/src/components/table/peek/hooks/usePeekData.ts
@@ -46,6 +46,8 @@ export const usePeekData = ({
       data: eventsData.data,
       isLoading: eventsData.isLoading,
       error: eventsData.error,
+      cutoffObservationsAfterMaxCount:
+        eventsData.cutoffObservationsAfterMaxCount,
       // Provide stub for other fields to match tracesQuery return type
       isError: !!eventsData.error,
       isFetching: eventsData.isLoading,

--- a/web/src/components/trace2/TracePage.tsx
+++ b/web/src/components/trace2/TracePage.tsx
@@ -92,6 +92,23 @@ export function TracePage({
       />
     );
 
+  // show backend error to user if present (e.g., too many observations)
+  if (isBetaEnabled && !eventsData.isLoading && eventsData.error) {
+    const message =
+      (eventsData.error as { message?: string })?.message ??
+      "An error occurred loading this trace.";
+    return (
+      <ErrorPage
+        title="Error loading trace"
+        message={message}
+        additionalButton={{
+          label: "Retry",
+          onClick: () => void window.location.reload(),
+        }}
+      />
+    );
+  }
+
   // For events path: show not found if no observations found after loading
   if (isBetaEnabled && !eventsData.isLoading && !eventsData.data)
     return (

--- a/web/src/components/trace2/TracePage.tsx
+++ b/web/src/components/trace2/TracePage.tsx
@@ -16,7 +16,6 @@ import { stripBasePath } from "@/src/utils/redirect";
 import { Badge } from "@/src/components/ui/badge";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { useEventsTraceData } from "@/src/features/events/hooks/useEventsTraceData";
-import { MAX_OBSERVATIONS_PER_TRACE } from "@langfuse/shared/src/server";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { useEffect } from "react";
 
@@ -83,7 +82,7 @@ export function TracePage({
     if (isBetaEnabled && eventsData.cutoffObservationsAfterMaxCount) {
       showErrorToast(
         "Trace truncated",
-        `This trace exceeds the maximum of ${MAX_OBSERVATIONS_PER_TRACE.toLocaleString()} observations for the detail view. Only the first ${MAX_OBSERVATIONS_PER_TRACE.toLocaleString()} are shown.`,
+        "This trace has too many observations for the detail view. Only a subset is shown.",
         "WARNING",
       );
     }

--- a/web/src/components/trace2/TracePage.tsx
+++ b/web/src/components/trace2/TracePage.tsx
@@ -16,6 +16,9 @@ import { stripBasePath } from "@/src/utils/redirect";
 import { Badge } from "@/src/components/ui/badge";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { useEventsTraceData } from "@/src/features/events/hooks/useEventsTraceData";
+import { MAX_OBSERVATIONS_PER_TRACE } from "@langfuse/shared/src/server";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import { useEffect } from "react";
 
 export function TracePage({
   traceId,
@@ -76,6 +79,16 @@ export function TracePage({
     withDefault(StringParam, "details"),
   );
 
+  useEffect(() => {
+    if (isBetaEnabled && eventsData.cutoffObservationsAfterMaxCount) {
+      showErrorToast(
+        "Trace truncated",
+        `This trace exceeds the maximum of ${MAX_OBSERVATIONS_PER_TRACE.toLocaleString()} observations for the detail view. Only the first ${MAX_OBSERVATIONS_PER_TRACE.toLocaleString()} are shown.`,
+        "WARNING",
+      );
+    }
+  }, [isBetaEnabled, eventsData.cutoffObservationsAfterMaxCount]);
+
   // Handle errors - for events path, we check if there's no data after loading
   if (!isBetaEnabled && tracesQuery.error?.data?.code === "UNAUTHORIZED")
     return <ErrorPage message="You do not have access to this trace." />;
@@ -91,23 +104,6 @@ export function TracePage({
         }}
       />
     );
-
-  // show backend error to user if present (e.g., too many observations)
-  if (isBetaEnabled && !eventsData.isLoading && eventsData.error) {
-    const message =
-      (eventsData.error as { message?: string })?.message ??
-      "An error occurred loading this trace.";
-    return (
-      <ErrorPage
-        title="Error loading trace"
-        message={message}
-        additionalButton={{
-          label: "Retry",
-          onClick: () => void window.location.reload(),
-        }}
-      />
-    );
-  }
 
   // For events path: show not found if no observations found after loading
   if (isBetaEnabled && !eventsData.isLoading && !eventsData.data)

--- a/web/src/features/events/hooks/useEventsTableData.ts
+++ b/web/src/features/events/hooks/useEventsTableData.ts
@@ -66,7 +66,6 @@ export function useEventsTableData({
     ],
   );
 
-  // Fetch observations
   const observations = api.events.all.useQuery(getAllPayload, {
     refetchOnWindowFocus: true,
   });

--- a/web/src/features/events/hooks/useEventsTraceData.ts
+++ b/web/src/features/events/hooks/useEventsTraceData.ts
@@ -10,6 +10,7 @@ import {
   ScoreDataTypeEnum,
   type ScoreDomain,
 } from "@langfuse/shared";
+import type { FullEventsObservations } from "@langfuse/shared/src/server";
 import {
   type WithStringifiedMetadata,
   toDomainArrayWithStringifiedMetadata,
@@ -52,24 +53,20 @@ export function useEventsTraceData(
   const { projectId, traceId, enabled = true } = props;
 
   // Step 1: Fetch all observations for this trace (without I/O for performance)
-  // TODO: paginationZod caps limit at 100 - for traces with >100 observations,
-  // implement pagination or create a dedicated byTraceId endpoint with higher limit
-  const eventsQuery = api.events.all.useQuery(
+  const eventsQuery = api.events.byTraceId.useQuery(
     {
       projectId,
-      filter: [
-        { column: "traceId", operator: "=", value: traceId, type: "string" },
-      ],
-      searchQuery: null,
-      searchType: [],
-      orderBy: { column: "startTime", order: "ASC" },
-      page: 1,
-      limit: 100,
+      traceId,
+      timestamp: props.timestamp,
     },
     {
       enabled: enabled && !!traceId,
       retry(failureCount, error) {
-        if (error.data?.code === "UNAUTHORIZED") return false;
+        if (
+          error.data?.code === "UNAUTHORIZED" ||
+          error.data?.code === "BAD_REQUEST"
+        )
+          return false;
         return failureCount < 3;
       },
       staleTime: 60 * 1000, // 1 minute
@@ -77,21 +74,23 @@ export function useEventsTraceData(
   );
 
   // Step 2: Find root observation and calculate time range for batchIO
+  const observations = eventsQuery.data?.observations as
+    | FullEventsObservations
+    | undefined;
+
   const rootObservation = useMemo(() => {
-    if (!eventsQuery.data?.observations?.length) return null;
-    return eventsQuery.data.observations.find((o) => !o.parentObservationId);
-  }, [eventsQuery.data]);
+    if (!observations?.length) return null;
+    return observations.find((o) => !o.parentObservationId);
+  }, [observations]);
 
   const timeRange = useMemo(() => {
-    if (!eventsQuery.data?.observations?.length) return null;
-    const times = eventsQuery.data.observations.map((o) =>
-      o.startTime.getTime(),
-    );
+    if (!observations?.length) return null;
+    const times = observations.map((o) => o.startTime.getTime());
     return {
       min: new Date(Math.min(...times)),
       max: new Date(Math.max(...times)),
     };
-  }, [eventsQuery.data]);
+  }, [observations]);
 
   // Step 3: Fetch I/O for root observation (for trace-level I/O display)
   const rootIOQuery = api.events.batchIO.useQuery(
@@ -112,7 +111,7 @@ export function useEventsTraceData(
 
   // Step 4: Fetch scores for the trace
   const scoresQuery = api.events.scoresForTrace.useQuery(
-    { traceId, projectId },
+    { traceId, projectId, timestamp: props.timestamp },
     {
       enabled: enabled && !!traceId,
       staleTime: 60 * 1000,
@@ -121,7 +120,7 @@ export function useEventsTraceData(
 
   // Step 5: Transform and merge data
   const transformed = useMemo(() => {
-    if (!eventsQuery.data?.observations?.length) return null;
+    if (!observations?.length) return null;
 
     // Validate and partition scores
     const validatedScores = filterAndValidateDbScoreList({
@@ -143,7 +142,7 @@ export function useEventsTraceData(
 
     // Adapt events to trace format
     const adapted = adaptEventsToTraceFormat({
-      events: eventsQuery.data.observations,
+      events: observations,
       traceId,
       rootIO: rootIO
         ? { input: rootIO.input, output: rootIO.output }
@@ -156,7 +155,7 @@ export function useEventsTraceData(
       scores: scoresDomain,
       corrections,
     };
-  }, [eventsQuery.data, traceId, rootIOQuery.data, scoresQuery.data]);
+  }, [observations, traceId, rootIOQuery.data, scoresQuery.data]);
 
   return {
     data: transformed ?? undefined,

--- a/web/src/features/events/hooks/useEventsTraceData.ts
+++ b/web/src/features/events/hooks/useEventsTraceData.ts
@@ -34,6 +34,7 @@ interface UseEventsTraceDataResult {
     | undefined;
   isLoading: boolean;
   error: unknown;
+  cutoffObservationsAfterMaxCount: boolean;
 }
 
 /**
@@ -62,11 +63,7 @@ export function useEventsTraceData(
     {
       enabled: enabled && !!traceId,
       retry(failureCount, error) {
-        if (
-          error.data?.code === "UNAUTHORIZED" ||
-          error.data?.code === "BAD_REQUEST"
-        )
-          return false;
+        if (error.data?.code === "UNAUTHORIZED") return false;
         return failureCount < 3;
       },
       staleTime: 60 * 1000, // 1 minute
@@ -157,9 +154,13 @@ export function useEventsTraceData(
     };
   }, [observations, traceId, rootIOQuery.data, scoresQuery.data]);
 
+  const cutoffObservationsAfterMaxCount =
+    eventsQuery.data?.cutoffObservationsAfterMaxCount ?? false;
+
   return {
     data: transformed ?? undefined,
     isLoading: eventsQuery.isLoading || scoresQuery.isLoading,
     error: eventsQuery.error || scoresQuery.error,
+    cutoffObservationsAfterMaxCount,
   };
 }

--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -25,7 +25,7 @@ import {
   getObservationsForTraceFromEventsTable,
   MAX_OBSERVATIONS_PER_TRACE,
 } from "@langfuse/shared/src/server";
-import { TRPCError } from "@trpc/server";
+
 import {
   AgentGraphDataSchema,
   type AgentGraphDataResponse,
@@ -181,8 +181,8 @@ export const eventsRouter = createTRPCRouter({
     }),
   /**
    * Fetch all observations for a trace from the events table.
-   * returns up to MAX_OBSERVATIONS_PER_TRACE observations.
-   * Throws BAD_REQUEST if trace exceeds the cap.
+   * Returns up to MAX_OBSERVATIONS_PER_TRACE observations.
+   * Sets cutoffObservationsAfterMaxCount=true if trace exceeds the cap.
    */
   byTraceId: protectedProjectProcedure
     .input(
@@ -206,14 +206,11 @@ export const eventsRouter = createTRPCRouter({
               timestamp: input.timestamp,
             });
 
-          if (totalCount > MAX_OBSERVATIONS_PER_TRACE) {
-            throw new TRPCError({
-              code: "BAD_REQUEST",
-              message: `Trace has ${totalCount} observations, exceeding the maximum of ${MAX_OBSERVATIONS_PER_TRACE} for the trace detail view.`,
-            });
-          }
-
-          return { observations };
+          return {
+            observations,
+            cutoffObservationsAfterMaxCount:
+              totalCount > MAX_OBSERVATIONS_PER_TRACE,
+          };
         },
       );
     }),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes 100 observation limit per trace, sets new limit to 10,000, and updates error handling in related components.
> 
>   - **Behavior**:
>     - Removes 100 observation limit per trace in `getObservationsForTraceFromEventsTable` in `events.ts`.
>     - Introduces `MAX_OBSERVATIONS_PER_TRACE` set to 10,000 in `events.ts`.
>     - If trace exceeds 10,000 observations, throws `BAD_REQUEST` error in `eventsRouter.ts`.
>   - **Components**:
>     - `TracePage.tsx`: Displays error page if `eventsData.error` is present, indicating too many observations.
>   - **Hooks**:
>     - `useEventsTraceData.ts`: Uses `byTraceId` query to fetch observations, handles `BAD_REQUEST` error.
>     - `useEventsTableData.ts`: Removes comment about fetching observations, no functional change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6586bcdcba33a077cc47874eb87d2a4909ac0be6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->