### PR TITLE
fix(docs): clarify fromTimestamp/toTimestamp filter on scores endpoint

### DIFF
--- a/fern/apis/server/definition/score-v2.yml
+++ b/fern/apis/server/definition/score-v2.yml
@@ -27,10 +27,10 @@ service:
             docs: Retrieve only scores with this name.
           fromTimestamp:
             type: optional<datetime>
-            docs: Optional filter to only include scores created on or after a certain datetime (ISO 8601)
+            docs: Optional filter to only include scores with a `timestamp` on or after a certain datetime (ISO 8601). For API-created scores, this is the client-supplied timestamp (defaults to the current time if not provided). For eval scores, this is when the evaluation completed.
           toTimestamp:
             type: optional<datetime>
-            docs: Optional filter to only include scores created before a certain datetime (ISO 8601)
+            docs: Optional filter to only include scores with a `timestamp` before a certain datetime (ISO 8601). For API-created scores, this is the client-supplied timestamp (defaults to the current time if not provided). For eval scores, this is when the evaluation completed.
           environment:
             type: optional<string>
             allow-multiple: true


### PR DESCRIPTION
## Summary

- The `fromTimestamp` / `toTimestamp` query parameter docs on `GET /api/public/v2/scores` previously said they filter scores "created on or after" a datetime, implying the filtering is based on the`createdAt` field
- In reality, the filter operates on the `timestamp` field (`clickhouseSelect: "timestamp"` in `scoresFilter`), which has different semantics depending on the score source
- Updated the Fern API spec to clarify that the filter matches against the `timestamp` field and explain what that field represents for different score sources (API-created vs eval-generated)

## Context

The scores response payload includes three timestamp fields (`timestamp`, `createdAt`, `updatedAt`):

| Field | Meaning |
|---|---|
| `timestamp` | Client-supplied event time for API scores; evaluation completion time for eval scores |
| `createdAt` | Server-side time when the score was first persisted |
| `updatedAt` | Server-side time when the score was last modified |

The `fromTimestamp`/`toTimestamp` filters operate on `timestamp`, not `createdAt`, so the docs should reflect that.

## Test plan

- [ ] Verify the generated OpenAPI spec reflects the updated descriptions after running the Fern CLI
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Clarify `fromTimestamp` and `toTimestamp` filters in `score-v2.yml` to operate on `timestamp`, detailing its semantics for different score sources.
> 
>   - **Documentation**:
>     - Update `fromTimestamp` and `toTimestamp` docs in `score-v2.yml` to clarify they filter on `timestamp`, not `createdAt`.
>     - Explain `timestamp` field semantics for API-created and eval-generated scores.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 405aac3cf7b297f606df44f026832539f9a8a210. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->