### PR TITLE
feat(api): add performance controls for GET /api/public/traces

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -220,6 +220,15 @@ LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG=true
 # LANGFUSE_INGESTION_CLICKHOUSE_WRITE_INTERVAL_MS=
 # LANGFUSE_INGESTION_CLICKHOUSE_MAX_ATTEMPTS=
 
+# API Traces endpoint controls (may induce breaking changes on API when changed!)
+# Reject GET /api/public/traces requests that do not include a fromTimestamp parameter (returns 400)
+# LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE=false
+# Apply a default date range (in days) to GET /api/public/traces when no fromTimestamp is provided
+# LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS=
+# Comma-separated default field groups for GET /api/public/traces when no fields param is provided
+# Valid values: core, io, scores, observations, metrics
+# LANGFUSE_API_TRACES_DEFAULT_FIELDS=
+
 ### START Enterprise Edition Configuration
 
 # Allowlisted users that can create new organizations, by default all users can create organizations

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -363,6 +363,17 @@ export const env = createEnv({
       .enum(["true", "false"])
       .default("false"),
 
+    // API Traces endpoint controls (may induce breaking changes on API when changed!)
+    LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS: z.coerce
+      .number()
+      .int()
+      .positive()
+      .optional(),
+    LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE: z
+      .enum(["true", "false"])
+      .default("false"),
+    LANGFUSE_API_TRACES_DEFAULT_FIELDS: z.string().optional(),
+
     // Events table migration
     LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS: z
       .enum(["true", "false"])
@@ -721,6 +732,13 @@ export const env = createEnv({
       process.env.LANGFUSE_AI_FEATURES_SECRET_KEY,
     LANGFUSE_AI_FEATURES_PROJECT_ID:
       process.env.LANGFUSE_AI_FEATURES_PROJECT_ID,
+    // API Traces endpoint controls
+    LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS:
+      process.env.LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS,
+    LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE:
+      process.env.LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE,
+    LANGFUSE_API_TRACES_DEFAULT_FIELDS:
+      process.env.LANGFUSE_API_TRACES_DEFAULT_FIELDS,
     // Events table migration
     LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS:
       process.env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS,


### PR DESCRIPTION
## Summary

- Add three environment variables to control `GET /api/public/traces` performance for self-hosters:
  - `LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE` — reject requests without `fromTimestamp` (returns 400)
  - `LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS` — auto-apply a default date range when no `fromTimestamp` is provided
  - `LANGFUSE_API_TRACES_DEFAULT_FIELDS` — restrict default field groups (e.g. `"core"`) to avoid expensive joins
- Enforcement logic runs before `filterProps` construction: rejection > default date range > default fields
- Tests use `(env as any)` mocking pattern (currently `describe.skip` — requires running dev server)

## Test plan

- [ ] Verify `LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE=true` returns 400 when no `fromTimestamp`
- [ ] Verify requests with `fromTimestamp` still succeed when rejection is enabled
- [ ] Verify `LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS=7` auto-applies date filter
- [ ] Verify `LANGFUSE_API_TRACES_DEFAULT_FIELDS=core` restricts returned fields
- [ ] Verify explicit `fields` query param overrides `DEFAULT_FIELDS`
- [ ] Verify build passes (`pnpm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add environment variable controls for `GET /api/public/traces` to manage date range and fields for self-hosters, with corresponding API logic and tests.
> 
>   - **Environment Variables**:
>     - Add `LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE`, `LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS`, and `LANGFUSE_API_TRACES_DEFAULT_FIELDS` to control `GET /api/public/traces` behavior.
>   - **API Logic** (`index.ts`):
>     - Reject requests without `fromTimestamp` if `LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE` is true.
>     - Apply default date range if `LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS` is set and `fromTimestamp` is missing.
>     - Use default fields from `LANGFUSE_API_TRACES_DEFAULT_FIELDS` if `fields` query param is absent.
>   - **Testing** (`traces-api.servertest.ts`):
>     - Add tests for new environment variable controls using `(env as any)` mocking pattern.
>     - Tests are currently skipped and require a running dev server.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8183f9a25325ecb0d02737d542b6f2a80bcdab3d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->