### PR TITLE
feat(observation-evals): support parent observation is null filter

### DIFF
--- a/packages/shared/src/features/evals/observationForEval.ts
+++ b/packages/shared/src/features/evals/observationForEval.ts
@@ -273,7 +273,7 @@ export const observationEvalFilterColumns: ObservationEvalColumnDef[] = [
   },
   {
     name: "Parent Observation",
-    id: "parentSpanId",
+    id: "parentObservationId",
     type: "null",
     internal: "parent_span_id",
     nullable: true,

--- a/packages/shared/src/features/evals/observationForEval.ts
+++ b/packages/shared/src/features/evals/observationForEval.ts
@@ -89,6 +89,7 @@ export type ObservationEvalFilterColumnInternal =
     | "tags"
     | "experiment_dataset_id"
     | "metadata"
+    | "parent_span_id"
   >;
 
 export type ObservationEvalMappingColumnInternal = keyof Pick<
@@ -269,6 +270,13 @@ export const observationEvalFilterColumns: ObservationEvalColumnDef[] = [
     id: "metadata",
     type: "stringObject",
     internal: "metadata",
+  },
+  {
+    name: "Parent Observation",
+    id: "parentSpanId",
+    type: "null",
+    internal: "parent_span_id",
+    nullable: true,
   },
 ];
 

--- a/packages/shared/src/tableDefinitions/types.ts
+++ b/packages/shared/src/tableDefinitions/types.ts
@@ -26,7 +26,7 @@ export type ColumnDefinition =
   | {
       name: string;
       id: string;
-      type: "number" | "string" | "datetime" | "boolean";
+      type: "number" | "string" | "datetime" | "boolean" | "null";
       internal: string;
       nullable?: boolean;
     }

--- a/web/src/features/evals/pages/remap-evaluator.tsx
+++ b/web/src/features/evals/pages/remap-evaluator.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/src/components/ui/dropdown-menu";
 import { ChevronDown } from "lucide-react";
 import { useEvalCapabilities } from "@/src/features/evals/hooks/useEvalCapabilities";
+import { DEFAULT_OBSERVATION_FILTER_WHEN_REMAPPING } from "@/src/features/evals/utils/evaluator-constants";
 
 type LegacyEvalAction = "keep-active" | "mark-inactive" | "delete";
 
@@ -87,7 +88,10 @@ export default function RemapEvaluatorPage() {
       scoreName: oldConfig.scoreName,
       targetObject: mapLegacyToModernTarget(oldConfig.targetObject),
       jobType: oldConfig.jobType,
-      filter: [],
+      filter:
+        oldConfig.targetObject === "trace"
+          ? DEFAULT_OBSERVATION_FILTER_WHEN_REMAPPING
+          : [],
       variableMapping: [],
       sampling: oldConfig.sampling,
       delay: oldConfig.delay,

--- a/web/src/features/evals/utils/evaluator-constants.ts
+++ b/web/src/features/evals/utils/evaluator-constants.ts
@@ -75,7 +75,7 @@ export const DEFAULT_OBSERVATION_FILTER = [
 // Default filter when remapping an evaluator from trace-level to observation-level
 export const DEFAULT_OBSERVATION_FILTER_WHEN_REMAPPING = [
   {
-    column: "parentSpanId",
+    column: "parentObservationId",
     operator: "is null" as const,
     value: "",
     type: "null" as const,

--- a/web/src/features/evals/utils/evaluator-constants.ts
+++ b/web/src/features/evals/utils/evaluator-constants.ts
@@ -64,4 +64,20 @@ export const DEFAULT_OBSERVATION_FILTER = [
     value: ["GENERATION"],
     type: "stringOptions" as const,
   },
+  {
+    column: "environment",
+    operator: "none of" as const,
+    value: [...INTERNAL_ENVIRONMENTS],
+    type: "stringOptions" as const,
+  },
+];
+
+// Default filter when remapping an evaluator from trace-level to observation-level
+export const DEFAULT_OBSERVATION_FILTER_WHEN_REMAPPING = [
+  {
+    column: "parentSpanId",
+    operator: "is null" as const,
+    value: "",
+    type: "null" as const,
+  },
 ];

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -304,7 +304,9 @@ export function InlineFilterState({
                 ? filter.value
                 : filter.type === "boolean"
                   ? `${filter.value}`
-                  : `"${filter.value}"`}
+                  : filter.type === "null"
+                    ? ""
+                    : `"${filter.value}"`}
       </span>
     );
   });
@@ -658,7 +660,10 @@ function FilterBuilderForm({
                                             column: col?.[columnIdentifier],
                                             type: col?.type,
                                             operator: defaultOperator,
-                                            value: undefined,
+                                            value:
+                                              col?.type === "null"
+                                                ? ""
+                                                : undefined,
                                             key:
                                               col?.type === "positionInTrace"
                                                 ? "last"
@@ -820,8 +825,12 @@ function FilterBuilderForm({
                           handleFilterChange(
                             {
                               ...filter,
-
                               operator: value as any,
+                              // Ensure null filters always have empty string value
+                              value:
+                                filter.type === "null"
+                                  ? ""
+                                  : (filter.value as any),
                             },
                             i,
                           );
@@ -986,7 +995,7 @@ function FilterBuilderForm({
                         ) : (
                           <Input disabled placeholder="-" />
                         )
-                      ) : (
+                      ) : filter.type === "null" ? null : (
                         <Input disabled />
                       )}
                     </td>

--- a/worker/src/features/evaluation/observationEval/__tests__/filterEvaluation.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/filterEvaluation.test.ts
@@ -961,8 +961,8 @@ describe("Filter Evaluation for Observation Evals", () => {
     });
   });
 
-  describe("null filters (parentSpanId)", () => {
-    it("should match observations where parentSpanId is null (root observations)", async () => {
+  describe("null filters (parentObservationId)", () => {
+    it("should match observations where parentObservationId is null (root observations)", async () => {
       const observation = createTestObservation({
         project_id: projectId,
         parent_span_id: null,
@@ -970,7 +970,7 @@ describe("Filter Evaluation for Observation Evals", () => {
 
       const matched = await testFilterMatch(observation, [
         {
-          column: "parentSpanId",
+          column: "parentObservationId",
           type: "null",
           operator: "is null",
           value: "",
@@ -980,7 +980,7 @@ describe("Filter Evaluation for Observation Evals", () => {
       expect(matched).toBe(true);
     });
 
-    it("should not match observations where parentSpanId is not null (child observations)", async () => {
+    it("should not match observations where parentObservationId is not null (child observations)", async () => {
       const observation = createTestObservation({
         project_id: projectId,
         parent_span_id: "some-parent-span-id",
@@ -988,7 +988,7 @@ describe("Filter Evaluation for Observation Evals", () => {
 
       const matched = await testFilterMatch(observation, [
         {
-          column: "parentSpanId",
+          column: "parentObservationId",
           type: "null",
           operator: "is null",
           value: "",
@@ -998,7 +998,7 @@ describe("Filter Evaluation for Observation Evals", () => {
       expect(matched).toBe(false);
     });
 
-    it("should match observations where parentSpanId is not null using 'is not null' operator", async () => {
+    it("should match observations where parentObservationId is not null using 'is not null' operator", async () => {
       const observation = createTestObservation({
         project_id: projectId,
         parent_span_id: "some-parent-span-id",
@@ -1006,7 +1006,7 @@ describe("Filter Evaluation for Observation Evals", () => {
 
       const matched = await testFilterMatch(observation, [
         {
-          column: "parentSpanId",
+          column: "parentObservationId",
           type: "null",
           operator: "is not null",
           value: "",
@@ -1016,7 +1016,7 @@ describe("Filter Evaluation for Observation Evals", () => {
       expect(matched).toBe(true);
     });
 
-    it("should not match root observations with 'is not null' operator", async () => {
+    it("should not match root observations with parentObservationId is not null using 'is not null' operator", async () => {
       const observation = createTestObservation({
         project_id: projectId,
         parent_span_id: null,
@@ -1024,7 +1024,7 @@ describe("Filter Evaluation for Observation Evals", () => {
 
       const matched = await testFilterMatch(observation, [
         {
-          column: "parentSpanId",
+          column: "parentObservationId",
           type: "null",
           operator: "is not null",
           value: "",
@@ -1043,7 +1043,7 @@ describe("Filter Evaluation for Observation Evals", () => {
 
       const matched = await testFilterMatch(observation, [
         {
-          column: "parentSpanId",
+          column: "parentObservationId",
           type: "null",
           operator: "is null",
           value: "",
@@ -1068,7 +1068,7 @@ describe("Filter Evaluation for Observation Evals", () => {
 
       const matched = await testFilterMatch(observation, [
         {
-          column: "parentSpanId",
+          column: "parentObservationId",
           type: "null",
           operator: "is null",
           value: "",

--- a/worker/src/features/evaluation/observationEval/__tests__/filterEvaluation.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/filterEvaluation.test.ts
@@ -960,4 +960,128 @@ describe("Filter Evaluation for Observation Evals", () => {
       expect(matched).toBe(false);
     });
   });
+
+  describe("null filters (parentSpanId)", () => {
+    it("should match observations where parentSpanId is null (root observations)", async () => {
+      const observation = createTestObservation({
+        project_id: projectId,
+        parent_span_id: null,
+      });
+
+      const matched = await testFilterMatch(observation, [
+        {
+          column: "parentSpanId",
+          type: "null",
+          operator: "is null",
+          value: "",
+        },
+      ]);
+
+      expect(matched).toBe(true);
+    });
+
+    it("should not match observations where parentSpanId is not null (child observations)", async () => {
+      const observation = createTestObservation({
+        project_id: projectId,
+        parent_span_id: "some-parent-span-id",
+      });
+
+      const matched = await testFilterMatch(observation, [
+        {
+          column: "parentSpanId",
+          type: "null",
+          operator: "is null",
+          value: "",
+        },
+      ]);
+
+      expect(matched).toBe(false);
+    });
+
+    it("should match observations where parentSpanId is not null using 'is not null' operator", async () => {
+      const observation = createTestObservation({
+        project_id: projectId,
+        parent_span_id: "some-parent-span-id",
+      });
+
+      const matched = await testFilterMatch(observation, [
+        {
+          column: "parentSpanId",
+          type: "null",
+          operator: "is not null",
+          value: "",
+        },
+      ]);
+
+      expect(matched).toBe(true);
+    });
+
+    it("should not match root observations with 'is not null' operator", async () => {
+      const observation = createTestObservation({
+        project_id: projectId,
+        parent_span_id: null,
+      });
+
+      const matched = await testFilterMatch(observation, [
+        {
+          column: "parentSpanId",
+          type: "null",
+          operator: "is not null",
+          value: "",
+        },
+      ]);
+
+      expect(matched).toBe(false);
+    });
+
+    it("should combine null filter with other filters using AND logic", async () => {
+      const observation = createTestObservation({
+        project_id: projectId,
+        parent_span_id: null,
+        type: "GENERATION",
+      });
+
+      const matched = await testFilterMatch(observation, [
+        {
+          column: "parentSpanId",
+          type: "null",
+          operator: "is null",
+          value: "",
+        },
+        {
+          column: "type",
+          type: "stringOptions",
+          operator: "any of",
+          value: ["GENERATION"],
+        },
+      ]);
+
+      expect(matched).toBe(true);
+    });
+
+    it("should not match when null filter passes but other filter fails", async () => {
+      const observation = createTestObservation({
+        project_id: projectId,
+        parent_span_id: null,
+        type: "SPAN",
+      });
+
+      const matched = await testFilterMatch(observation, [
+        {
+          column: "parentSpanId",
+          type: "null",
+          operator: "is null",
+          value: "",
+        },
+        {
+          column: "type",
+          type: "stringOptions",
+          operator: "any of",
+          value: ["GENERATION"],
+        },
+      ]);
+
+      expect(matched).toBe(false);
+    });
+  });
 });

--- a/worker/src/features/evaluation/observationEval/__tests__/observationForEvalSchema.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationForEvalSchema.test.ts
@@ -199,7 +199,7 @@ describe("observationForEvalSchema", () => {
       expect(columnIds).toContain("environment");
       expect(columnIds).toContain("level");
       expect(columnIds).toContain("version");
-      expect(columnIds).toContain("parentSpanId");
+      expect(columnIds).toContain("parentObservationId");
 
       // Trace-level properties
       expect(columnIds).toContain("traceName");

--- a/worker/src/features/evaluation/observationEval/__tests__/observationForEvalSchema.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationForEvalSchema.test.ts
@@ -199,6 +199,7 @@ describe("observationForEvalSchema", () => {
       expect(columnIds).toContain("environment");
       expect(columnIds).toContain("level");
       expect(columnIds).toContain("version");
+      expect(columnIds).toContain("parentSpanId");
 
       // Trace-level properties
       expect(columnIds).toContain("traceName");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for filtering observations with null `parentSpanId` in evaluation process, including schema updates and comprehensive tests.
> 
>   - **Behavior**:
>     - Add support for `parent_span_id` as a nullable filter column in `observationForEval.ts`.
>     - Introduce `DEFAULT_OBSERVATION_FILTER_WHEN_REMAPPING` in `evaluator-constants.ts` to filter observations with null `parentSpanId`.
>     - Update `remap-evaluator.tsx` to use `DEFAULT_OBSERVATION_FILTER_WHEN_REMAPPING` when remapping evaluators.
>   - **Filter Handling**:
>     - Extend `ColumnDefinition` in `types.ts` to include `null` type.
>     - Modify `filter-builder.tsx` to handle `null` type filters, ensuring empty string values for null filters.
>   - **Tests**:
>     - Add tests for null filters in `filterEvaluation.test.ts` to verify behavior for `parentSpanId` being null or not null.
>     - Update `observationForEvalSchema.test.ts` to include `parentSpanId` in filter column checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 11d5a1e45100ac20ce636648fe6bd63f4408c9c6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->