### PR TITLE
fix: further tighten the difference between v1 views and their v2 implementations

### DIFF
--- a/packages/shared/src/server/clickhouse/schema.ts
+++ b/packages/shared/src/server/clickhouse/schema.ts
@@ -9,6 +9,8 @@ export const ClickhouseTableNames = {
   // TODO: Check if we can do this more elegantly
   scores_numeric: "scores_numeric",
   scores_categorical: "scores_categorical",
+  events_traces: "events_traces",
+  events_observations: "events_observations",
 } as const;
 
 export type ClickhouseTableName = keyof typeof ClickhouseTableNames;

--- a/web/src/features/query/server/queryBuilder.ts
+++ b/web/src/features/query/server/queryBuilder.ts
@@ -446,7 +446,7 @@ export class QueryBuilder {
         uiTableId: relation.timeDimension,
         clickhouseTableName: relation.name,
         clickhouseSelect: relation.timeDimension,
-        queryPrefix: relation.name,
+        queryPrefix: relationTableName,
         type: "datetime",
       };
 
@@ -571,9 +571,10 @@ export class QueryBuilder {
     );
 
     // Optionally wrap in aggregation function (e.g., "any" for two-level inner SELECT)
-    const wrappedSql = wrapInAgg
-      ? `${wrapInAgg}(${timeDimensionSql})`
-      : timeDimensionSql;
+    const agg = wrapInAgg
+      ? (view.timeDimensionAggregation ?? wrapInAgg)
+      : undefined;
+    const wrappedSql = agg ? `${agg}(${timeDimensionSql})` : timeDimensionSql;
 
     return `${wrappedSql} as time_dimension`;
   }

--- a/web/src/features/query/types.ts
+++ b/web/src/features/query/types.ts
@@ -48,6 +48,7 @@ export const viewDeclaration = z.object({
   // Segments are used to apply "constant" filters to the query. For example, if we only want one type of observations.
   segments: z.array(singleFilter),
   timeDimension: z.string(),
+  timeDimensionAggregation: z.string().optional(),
 });
 
 export const stringDateTime = z.string().datetime({ offset: true });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refined SQL logic for v2 views in `dataModel.ts` and `queryBuilder.ts` to enhance compatibility with v1 views, focusing on conditional aggregations and time dimension handling.
> 
>   - **Behavior**:
>     - Updated SQL logic in `dataModel.ts` for `eventsTracesView` and `eventsObservationsView` to use conditional aggregations like `countIf`, `uniqIf`, `minIf`, and `sumIf`.
>     - Added `timeDimensionAggregation` to `eventsTracesView` to specify aggregation method for time dimensions.
>   - **Schema**:
>     - Added `events_traces` and `events_observations` to `ClickhouseTableNames` in `schema.ts`.
>   - **Query Building**:
>     - Modified `buildTimeDimensionSql()` in `queryBuilder.ts` to use `timeDimensionAggregation` if available.
>     - Adjusted `queryPrefix` logic in `queryBuilder.ts` to use `relationTableName` instead of `relation.name`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a2f7622f14d244163f15e9baa336da6276b7a8e5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->