### PR TITLE
feat(blob-storage): add granular export source selection

### DIFF
--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -88,6 +88,18 @@ types:
       exportStartDate:
         type: optional<datetime>
         docs: Custom start date for exports (required when exportMode is FROM_CUSTOM_DATE)
+      exportTraces:
+        type: optional<boolean>
+        docs: Export traces (overrides exportSource preset when provided)
+      exportObservations:
+        type: optional<boolean>
+        docs: Export observations (overrides exportSource preset when provided)
+      exportScores:
+        type: optional<boolean>
+        docs: Export scores (overrides exportSource preset when provided)
+      exportEvents:
+        type: optional<boolean>
+        docs: Export events/enriched observations (overrides exportSource preset when provided)
 
   BlobStorageIntegrationResponse:
     properties:
@@ -109,6 +121,10 @@ types:
       lastSyncAt: optional<datetime>
       createdAt: datetime
       updatedAt: datetime
+      exportTraces: optional<boolean>
+      exportObservations: optional<boolean>
+      exportScores: optional<boolean>
+      exportEvents: optional<boolean>
 
   BlobStorageIntegrationsResponse:
     properties:

--- a/packages/shared/prisma/generated/types.ts
+++ b/packages/shared/prisma/generated/types.ts
@@ -368,6 +368,10 @@ export type BlobStorageIntegration = {
   export_mode: Generated<BlobStorageExportMode>;
   export_start_date: Timestamp | null;
   export_source: Generated<AnalyticsIntegrationExportSource>;
+  export_traces: boolean | null;
+  export_observations: boolean | null;
+  export_scores: boolean | null;
+  export_events: boolean | null;
   created_at: Generated<Timestamp>;
   updated_at: Generated<Timestamp>;
 };

--- a/packages/shared/prisma/migrations/20260218004547_add_granular_export_flags/migration.sql
+++ b/packages/shared/prisma/migrations/20260218004547_add_granular_export_flags/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "blob_storage_integrations" ADD COLUMN     "export_events" BOOLEAN,
+ADD COLUMN     "export_observations" BOOLEAN,
+ADD COLUMN     "export_scores" BOOLEAN,
+ADD COLUMN     "export_traces" BOOLEAN;

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -1114,6 +1114,12 @@ model BlobStorageIntegration {
   exportStartDate DateTime?                         @map("export_start_date")
   exportSource    AnalyticsIntegrationExportSource  @default(TRACES_OBSERVATIONS) @map("export_source")
 
+  // Granular export source flags (optional - null means use exportSource enum behavior)
+  exportTraces       Boolean? @map("export_traces")
+  exportObservations Boolean? @map("export_observations")
+  exportScores       Boolean? @map("export_scores")
+  exportEvents       Boolean? @map("export_events")
+
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -33,6 +33,10 @@ const BlobStorageIntegrationResponseSchema = z.object({
   lastSyncAt: z.coerce.date().nullable(),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
+  exportTraces: z.boolean().nullable(),
+  exportObservations: z.boolean().nullable(),
+  exportScores: z.boolean().nullable(),
+  exportEvents: z.boolean().nullable(),
 });
 
 const BlobStorageIntegrationsResponseSchema = z.object({
@@ -464,6 +468,40 @@ describe("Blob Storage Integrations API", () => {
       expect(response.status).toBe(200);
       expect(response.body.exportMode).toBe("FROM_CUSTOM_DATE");
       expect(response.body.exportStartDate).toBeDefined();
+    });
+
+    it("should handle granular export flags", async () => {
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+        exportTraces: true,
+        exportObservations: false,
+        exportScores: true,
+        exportEvents: null,
+      };
+
+      const response = await makeZodVerifiedAPICall(
+        BlobStorageIntegrationResponseSchema,
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.exportTraces).toBe(true);
+      expect(response.body.exportObservations).toBe(false);
+      expect(response.body.exportScores).toBe(true);
+      expect(response.body.exportEvents).toBeNull();
+
+      // Verify in database
+      const saved = await prisma.blobStorageIntegration.findUnique({
+        where: { projectId: testProject1Id },
+      });
+      expect(saved?.exportTraces).toBe(true);
+      expect(saved?.exportObservations).toBe(false);
+      expect(saved?.exportScores).toBe(true);
+      expect(saved?.exportEvents).toBeNull();
     });
 
     it("should store secretAccessKey encrypted in database", async () => {

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -89,6 +89,10 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
           exportMode,
           exportStartDate,
           exportSource,
+          exportTraces,
+          exportObservations,
+          exportScores,
+          exportEvents,
         } = input;
 
         const isSelfHosted = !env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
@@ -127,6 +131,10 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
           exportMode,
           exportStartDate: finalExportStartDate,
           exportSource,
+          exportTraces,
+          exportObservations,
+          exportScores,
+          exportEvents,
         };
 
         // Use a transaction to check if record exists, then create or update

--- a/web/src/features/blobstorage-integration/types.ts
+++ b/web/src/features/blobstorage-integration/types.ts
@@ -6,34 +6,61 @@ import {
   AnalyticsIntegrationExportSource,
 } from "@langfuse/shared";
 
-export const blobStorageIntegrationFormSchema = z.object({
-  type: z.enum(BlobStorageIntegrationType),
-  bucketName: z.string().min(1, { message: "Bucket name is required" }),
-  endpoint: z.string().url().optional().nullable(),
-  region: z.string().default("auto"),
-  accessKeyId: z.string().optional(),
-  secretAccessKey: z.string().nullable().optional(),
-  prefix: z
-    .string()
-    .refine((value) => !value || value === "" || value.endsWith("/"), {
-      message: "Prefix must end with a forward slash (/)",
-    })
-    .optional()
-    .or(z.literal("")),
-  exportFrequency: z.enum(["hourly", "daily", "weekly"]),
-  enabled: z.boolean(),
-  forcePathStyle: z.boolean(),
-  fileType: z
-    .enum(BlobStorageIntegrationFileType)
-    .default(BlobStorageIntegrationFileType.JSONL),
-  exportMode: z
-    .enum(BlobStorageExportMode)
-    .default(BlobStorageExportMode.FULL_HISTORY),
-  exportStartDate: z.coerce.date().optional().nullable(),
-  exportSource: z
-    .enum(AnalyticsIntegrationExportSource)
-    .default(AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
-});
+export const blobStorageIntegrationFormSchema = z
+  .object({
+    type: z.enum(BlobStorageIntegrationType),
+    bucketName: z.string().min(1, { message: "Bucket name is required" }),
+    endpoint: z.string().url().optional().nullable(),
+    region: z.string().default("auto"),
+    accessKeyId: z.string().optional(),
+    secretAccessKey: z.string().nullable().optional(),
+    prefix: z
+      .string()
+      .refine((value) => !value || value === "" || value.endsWith("/"), {
+        message: "Prefix must end with a forward slash (/)",
+      })
+      .optional()
+      .or(z.literal("")),
+    exportFrequency: z.enum(["hourly", "daily", "weekly"]),
+    enabled: z.boolean(),
+    forcePathStyle: z.boolean(),
+    fileType: z
+      .enum(BlobStorageIntegrationFileType)
+      .default(BlobStorageIntegrationFileType.JSONL),
+    exportMode: z
+      .enum(BlobStorageExportMode)
+      .default(BlobStorageExportMode.FULL_HISTORY),
+    exportStartDate: z.coerce.date().optional().nullable(),
+    exportSource: z
+      .enum(AnalyticsIntegrationExportSource)
+      .default(AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+    // Granular export controls (optional - overrides exportSource when provided)
+    exportTraces: z.boolean().optional().nullable(),
+    exportObservations: z.boolean().optional().nullable(),
+    exportScores: z.boolean().optional().nullable(),
+    exportEvents: z.boolean().optional().nullable(),
+  })
+  .refine(
+    (data) => {
+      // At least one export type must be true, unless all are null (legacy fallback)
+      const hasTrue =
+        data.exportTraces === true ||
+        data.exportObservations === true ||
+        data.exportScores === true ||
+        data.exportEvents === true;
+      const hasFalse =
+        data.exportTraces === false ||
+        data.exportObservations === false ||
+        data.exportScores === false ||
+        data.exportEvents === false;
+      // Pass if has at least one true, or no explicit false (all null = legacy)
+      return hasTrue || !hasFalse;
+    },
+    {
+      message: "At least one data type must be selected for export",
+      path: ["_exportValidation"],
+    },
+  );
 
 export type BlobStorageIntegrationFormSchema = z.infer<
   typeof blobStorageIntegrationFormSchema

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -45,6 +45,11 @@ export const CreateBlobStorageIntegrationRequest = z
     fileType: BlobStorageIntegrationFileType,
     exportMode: BlobStorageExportMode,
     exportStartDate: z.coerce.date().nullable().optional(),
+    // Granular export controls (optional - overrides exportSource when provided)
+    exportTraces: z.boolean().nullable().optional(),
+    exportObservations: z.boolean().nullable().optional(),
+    exportScores: z.boolean().nullable().optional(),
+    exportEvents: z.boolean().nullable().optional(),
   })
   .strict()
   .refine(
@@ -78,6 +83,11 @@ export const BlobStorageIntegrationResponse = z
     lastSyncAt: z.coerce.date().nullable(),
     createdAt: z.coerce.date(),
     updatedAt: z.coerce.date(),
+    // Granular export controls
+    exportTraces: z.boolean().nullable(),
+    exportObservations: z.boolean().nullable(),
+    exportScores: z.boolean().nullable(),
+    exportEvents: z.boolean().nullable(),
   })
   .strict();
 

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -89,6 +89,10 @@ async function handleGetBlobStorageIntegrations(
       lastSyncAt: integration.lastSyncAt,
       createdAt: integration.createdAt,
       updatedAt: integration.updatedAt,
+      exportTraces: integration.exportTraces,
+      exportObservations: integration.exportObservations,
+      exportScores: integration.exportScores,
+      exportEvents: integration.exportEvents,
     }),
   );
 
@@ -162,6 +166,10 @@ async function handleUpsertBlobStorageIntegration(
     fileType: validatedData.fileType,
     exportMode: validatedData.exportMode,
     exportStartDate: validatedData.exportStartDate || null,
+    exportTraces: validatedData.exportTraces,
+    exportObservations: validatedData.exportObservations,
+    exportScores: validatedData.exportScores,
+    exportEvents: validatedData.exportEvents,
   };
 
   // Upsert the integration (create or update)
@@ -191,6 +199,10 @@ async function handleUpsertBlobStorageIntegration(
     lastSyncAt: integration.lastSyncAt,
     createdAt: integration.createdAt,
     updatedAt: integration.updatedAt,
+    exportTraces: integration.exportTraces,
+    exportObservations: integration.exportObservations,
+    exportScores: integration.exportScores,
+    exportEvents: integration.exportEvents,
   };
 
   return res.status(200).json(responseData);

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -14,6 +14,7 @@ import {
 import { Input } from "@/src/components/ui/input";
 import { PasswordInput } from "@/src/components/ui/password-input";
 import { Switch } from "@/src/components/ui/switch";
+import { Checkbox } from "@/src/components/ui/checkbox";
 import {
   Select,
   SelectContent,
@@ -203,6 +204,10 @@ const BlobStorageIntegrationSettingsForm = ({
         (isBetaEnabled
           ? AnalyticsIntegrationExportSource.EVENTS
           : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+      exportTraces: state?.exportTraces ?? true,
+      exportObservations: state?.exportObservations ?? true,
+      exportScores: state?.exportScores ?? true,
+      exportEvents: state?.exportEvents ?? null,
     },
     disabled: isLoading,
   });
@@ -231,6 +236,10 @@ const BlobStorageIntegrationSettingsForm = ({
         (isBetaEnabled
           ? AnalyticsIntegrationExportSource.EVENTS
           : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+      exportTraces: state?.exportTraces ?? true,
+      exportObservations: state?.exportObservations ?? true,
+      exportScores: state?.exportScores ?? true,
+      exportEvents: state?.exportEvents ?? null,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state]);
@@ -650,6 +659,99 @@ const BlobStorageIntegrationSettingsForm = ({
           />
         )}
 
+        {/* Granular Export Selection */}
+        <FormItem>
+          <FormLabel>Export Data Types</FormLabel>
+          <div className="grid grid-cols-2 gap-4 rounded-md border p-4">
+            <FormField
+              control={blobStorageForm.control}
+              name="exportTraces"
+              render={({ field }) => (
+                <FormItem className="flex items-center gap-2 space-y-0">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value ?? false}
+                      onCheckedChange={(checked) =>
+                        field.onChange(checked ? true : false)
+                      }
+                    />
+                  </FormControl>
+                  <FormLabel className="font-normal">Traces</FormLabel>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={blobStorageForm.control}
+              name="exportObservations"
+              render={({ field }) => (
+                <FormItem className="flex items-center gap-2 space-y-0">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value ?? false}
+                      onCheckedChange={(checked) =>
+                        field.onChange(checked ? true : false)
+                      }
+                    />
+                  </FormControl>
+                  <FormLabel className="font-normal">Observations</FormLabel>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={blobStorageForm.control}
+              name="exportScores"
+              render={({ field }) => (
+                <FormItem className="flex items-center gap-2 space-y-0">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value ?? false}
+                      onCheckedChange={(checked) =>
+                        field.onChange(checked ? true : false)
+                      }
+                    />
+                  </FormControl>
+                  <FormLabel className="font-normal">Scores</FormLabel>
+                </FormItem>
+              )}
+            />
+            {isBetaEnabled && (
+              <FormField
+                control={blobStorageForm.control}
+                name="exportEvents"
+                render={({ field }) => (
+                  <FormItem className="flex items-center gap-2 space-y-0">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value ?? false}
+                        onCheckedChange={(checked) =>
+                          field.onChange(checked ? true : false)
+                        }
+                      />
+                    </FormControl>
+                    <FormLabel className="font-normal">
+                      Events (Enriched Observations)
+                    </FormLabel>
+                  </FormItem>
+                )}
+              />
+            )}
+          </div>
+          <FormDescription>
+            Choose which data types to include in your exports.
+          </FormDescription>
+          {(blobStorageForm.formState.errors as Record<string, unknown>)
+            ._exportValidation && (
+            <p className="text-sm font-medium text-destructive">
+              {
+                (
+                  (blobStorageForm.formState.errors as Record<string, unknown>)
+                    ._exportValidation as { message?: string }
+                )?.message
+              }
+            </p>
+          )}
+        </FormItem>
+
         {blobStorageForm.watch("exportMode") ===
           BlobStorageExportMode.FROM_CUSTOM_DATE && (
           <FormField
@@ -715,8 +817,11 @@ const BlobStorageIntegrationSettingsForm = ({
           loading={mutValidate.isPending}
           disabled={isLoading || !state}
           title="Test your saved configuration by uploading a small test file to your storage"
-          onClick={() => {
-            mutValidate.mutate({ projectId });
+          onClick={async () => {
+            const isValid = await blobStorageForm.trigger();
+            if (isValid) {
+              mutValidate.mutate({ projectId });
+            }
           }}
         >
           Validate

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -527,6 +527,98 @@ describe("BlobStorageIntegrationProcessingJob", () => {
     });
   });
 
+  describe("Granular export flags", () => {
+    maybeIt(
+      "should only export data types with exportX flag set to true",
+      async () => {
+        const { projectId } = await createOrgProjectAndApiKey();
+        s3Prefix = projectId;
+        const now = new Date();
+        const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000);
+
+        // Create integration with only traces and scores enabled
+        await prisma.blobStorageIntegration.create({
+          data: {
+            projectId,
+            type: BlobStorageIntegrationType.S3,
+            bucketName,
+            prefix: s3Prefix,
+            accessKeyId: minioAccessKeyId,
+            secretAccessKey: encrypt(minioAccessKeySecret),
+            region: region ? region : "auto",
+            endpoint: minioEndpoint,
+            forcePathStyle:
+              env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+            enabled: true,
+            exportFrequency: "hourly",
+            nextSyncAt: twoHoursAgo,
+            lastSyncAt: twoHoursAgo,
+            // Granular flags: only traces and scores
+            exportTraces: true,
+            exportObservations: false,
+            exportScores: true,
+            exportEvents: false,
+          },
+        });
+
+        // Create test data
+        const traceId = randomUUID();
+        const observationId = randomUUID();
+        const scoreId = randomUUID();
+
+        await Promise.all([
+          createTracesCh([
+            createTrace({
+              id: traceId,
+              project_id: projectId,
+              timestamp: now.getTime() - 90 * 60 * 1000,
+              name: "Test Trace",
+            }),
+          ]),
+          createObservationsCh([
+            createObservation({
+              id: observationId,
+              trace_id: traceId,
+              project_id: projectId,
+              start_time: now.getTime() - 90 * 60 * 1000,
+              name: "Test Observation",
+            }),
+          ]),
+          createScoresCh([
+            createTraceScore({
+              id: scoreId,
+              trace_id: traceId,
+              project_id: projectId,
+              timestamp: now.getTime() - 90 * 60 * 1000,
+              name: "Test Score",
+              value: 0.95,
+            }),
+          ]),
+        ]);
+
+        await handleBlobStorageIntegrationProjectJob({
+          data: { payload: { projectId } },
+        } as Job);
+
+        const files = await s3StorageService.listFiles(s3Prefix);
+        const projectFiles = files.filter((f) => f.file.includes(projectId));
+
+        // Should have 2 files (traces and scores only)
+        expect(projectFiles).toHaveLength(2);
+
+        const traceFile = projectFiles.find((f) => f.file.includes("/traces/"));
+        const observationFile = projectFiles.find((f) =>
+          f.file.includes("/observations/"),
+        );
+        const scoreFile = projectFiles.find((f) => f.file.includes("/scores/"));
+
+        expect(traceFile).toBeDefined();
+        expect(observationFile).toBeUndefined(); // Should NOT exist
+        expect(scoreFile).toBeDefined();
+      },
+    );
+  });
+
   describe("BlobStorageExportMode minTimestamp behavior", () => {
     maybeIt(
       "should export old data for FULL_HISTORY mode when data exists",

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -368,21 +368,38 @@ export const handleBlobStorageIntegrationProjectJob = async (
       );
       await processBlobStorageExport({ ...executionConfig, table: "traces" });
     } else {
-      // Process tables based on exportSource setting
+      // Resolve export flags - use explicit boolean if provided, otherwise derive from exportSource
+      const { exportSource } = blobStorageIntegration;
+      const shouldExportTraces =
+        blobStorageIntegration.exportTraces ??
+        (exportSource === "TRACES_OBSERVATIONS" ||
+          exportSource === "TRACES_OBSERVATIONS_EVENTS");
+      const shouldExportObservations =
+        blobStorageIntegration.exportObservations ??
+        (exportSource === "TRACES_OBSERVATIONS" ||
+          exportSource === "TRACES_OBSERVATIONS_EVENTS");
+      const shouldExportScores = blobStorageIntegration.exportScores ?? true;
+      const shouldExportEvents =
+        blobStorageIntegration.exportEvents ??
+        (exportSource === "EVENTS" ||
+          exportSource === "TRACES_OBSERVATIONS_EVENTS");
+
       const processPromises: Promise<void>[] = [];
 
-      // Always include scores
-      processPromises.push(
-        processBlobStorageExport({ ...executionConfig, table: "scores" }),
-      );
+      if (shouldExportScores) {
+        processPromises.push(
+          processBlobStorageExport({ ...executionConfig, table: "scores" }),
+        );
+      }
 
-      // Traces and observations - for TRACES_OBSERVATIONS and TRACES_OBSERVATIONS_EVENTS
-      if (
-        blobStorageIntegration.exportSource === "TRACES_OBSERVATIONS" ||
-        blobStorageIntegration.exportSource === "TRACES_OBSERVATIONS_EVENTS"
-      ) {
+      if (shouldExportTraces) {
         processPromises.push(
           processBlobStorageExport({ ...executionConfig, table: "traces" }),
+        );
+      }
+
+      if (shouldExportObservations) {
+        processPromises.push(
           processBlobStorageExport({
             ...executionConfig,
             table: "observations",
@@ -390,12 +407,8 @@ export const handleBlobStorageIntegrationProjectJob = async (
         );
       }
 
-      // Events - for EVENTS and TRACES_OBSERVATIONS_EVENTS
-      // events are stored in the observations_v2 directory in blob storage
-      if (
-        blobStorageIntegration.exportSource === "EVENTS" ||
-        blobStorageIntegration.exportSource === "TRACES_OBSERVATIONS_EVENTS"
-      ) {
+      // Events are stored in the observations_v2 directory in blob storage
+      if (shouldExportEvents) {
         processPromises.push(
           processBlobStorageExport({
             ...executionConfig,


### PR DESCRIPTION
## Summary
- Adds 4 boolean fields (`exportTraces`, `exportObservations`, `exportScores`, `exportEvents`) for granular control over exported data types. `exportEvents` is behind the beta flag.

- Traces, observations, and scores default to checked. Unchecking sets to `false` (explicit disable). Existing
  integrations with `null` values default to exporting traces, observations, and scores.

- Validates that at least one export data type is checked.

- Resolves #12051 (part 1)

- See Part 2, which adds tag filtering,  [here](https://github.com/langfuse/langfuse/pull/12244)

## Changes
- **Prisma schema**: added 4 optional boolean fields to `BlobStorageIntegration` model
- **Worker**: updated job processor with fallback logic
- **Frontend**: added "Export Data Types" section with checkboxes
- **API**: updated tRPC router, public API types, and Fern spec

<img width="1398" height="488" alt="Screenshot 2026-02-18 at 2 32 03 pm" src="https://github.com/user-attachments/assets/01e5c57c-8cd6-4167-bbc6-db9bbaa7ad22" />

<img width="1389" height="412" alt="Screenshot 2026-02-18 at 4 22 09 pm" src="https://github.com/user-attachments/assets/7cac51f5-eab2-4593-a687-1ce46cb34a46" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds granular export type selection to blob storage integrations with new boolean fields and updates API, frontend, and tests.
> 
>   - **Behavior**:
>     - Adds boolean fields `exportTraces`, `exportObservations`, `exportScores`, `exportEvents` to control export types in `blob-storage-integrations.yml` and `schema.prisma`.
>     - Defaults: `exportTraces`, `exportObservations`, `exportScores` are true; `exportEvents` is null.
>     - Validates at least one export type is selected in `types.ts`.
>   - **API**:
>     - Updates `blobstorage-integration-router.ts` and `index.ts` to handle new fields.
>     - Adds validation for new fields in `blob-storage-integrations.ts`.
>   - **Frontend**:
>     - Adds checkboxes for export types in `blobstorage.tsx`.
>     - Updates form schema in `types.ts`.
>   - **Tests**:
>     - Adds tests for granular export flags in `blob-storage-integration-api.servertest.ts` and `blobStorageIntegrationProcessing.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1cd78102c9ec1cd6bcaf3f9ef6a6f0d411efff9e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->