### PR TITLE
feat: add Claude Sonnet 4.6 model pricing

### DIFF
--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -413,6 +413,7 @@ export type OpenAIModel = (typeof openAIModels)[number];
 export const anthropicModels = [
   "claude-sonnet-4-5-20250929",
   "claude-haiku-4-5-20251001",
+  "claude-sonnet-4-6",
   "claude-opus-4-6",
   "claude-opus-4-5-20251101",
   "claude-sonnet-4-20250514",

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -3239,6 +3239,58 @@
     ]
   },
   {
+    "id": "90ec5ec3-1a48-4ff0-919c-70cdb8f632ed",
+    "modelName": "claude-sonnet-4-6",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4-6|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-sonnet-4-6-v1(:0)?|claude-sonnet-4-6)$",
+    "createdAt": "2026-02-18T00:00:00.000Z",
+    "updatedAt": "2026-02-18T00:00:00.000Z",
+    "tokenizerConfig": null,
+    "tokenizerId": "claude",
+    "pricingTiers": [
+      {
+        "id": "90ec5ec3-1a48-4ff0-919c-70cdb8f632ed_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 3e-6,
+          "input_tokens": 3e-6,
+          "output": 15e-6,
+          "output_tokens": 15e-6,
+          "cache_creation_input_tokens": 3.75e-6,
+          "input_cache_creation": 3.75e-6,
+          "cache_read_input_tokens": 3e-7,
+          "input_cache_read": 3e-7
+        }
+      },
+      {
+        "id": "7830bfc2-c464-4ffe-b9a2-6e741f6c5486",
+        "name": "Large Context",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "input",
+            "operator": "gt",
+            "value": 200000,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 6e-6,
+          "input_tokens": 6e-6,
+          "output": 22.5e-6,
+          "output_tokens": 22.5e-6,
+          "cache_creation_input_tokens": 7.5e-6,
+          "input_cache_creation": 7.5e-6,
+          "cache_read_input_tokens": 6e-7,
+          "input_cache_read": 6e-7
+        }
+      }
+    ]
+  },
+  {
     "id": "13458bc0-1c20-44c2-8753-172f54b67647",
     "modelName": "claude-opus-4-6",
     "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-6|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4-6-v1(:0)?|claude-opus-4-6)$",


### PR DESCRIPTION
Adds claude-sonnet-4-6 to the default model prices with standard and
large context pricing tiers (>200K tokens), and registers it in the
LLM types for playground/LLM-as-judge support.

Pricing from https://platform.claude.com/docs/en/about-claude/pricing:
- Input: $3/MTok, Output: $15/MTok
- Cache write (5min): $3.75/MTok, Cache read: $0.30/MTok
- Large context (>200K): Input $6/MTok, Output $22.50/MTok

https://claude.ai/code/session_016YDU8sqgSZuM1WgKssV4At
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `claude-sonnet-4-6` model with pricing tiers to Anthropic models and updates pricing configuration for playground and LLM-as-judge support.
> 
>   - **Behavior**:
>     - Adds `claude-sonnet-4-6` to `anthropicModels` in `types.ts` for playground and LLM-as-judge support.
>     - Updates `default-model-prices.json` with `claude-sonnet-4-6` pricing tiers: Standard and Large Context (>200K tokens).
>   - **Pricing**:
>     - Standard: Input $3/MTok, Output $15/MTok, Cache write $3.75/MTok, Cache read $0.30/MTok.
>     - Large Context: Input $6/MTok, Output $22.50/MTok, Cache write $7.5/MTok, Cache read $0.60/MTok.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1616dd6a20ee3d4945e16f870c1e05e8031587dc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->