### PR TITLE
fix(redis): log MOVED cluster redirects at debug instead of warn

### DIFF
--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -22,6 +22,12 @@ export const redisQueueRetryOptions: Partial<RedisOptions> = {
     return Math.max(Math.min(Math.exp(times), 20000), 1000);
   },
   reconnectOnError: (err) => {
+    // MOVED/ASK are normal cluster redirections handled by ioredis — not real errors.
+    if (err.message.includes("MOVED")) {
+      logger.debug(`Redis cluster redirect: ${err.message}`);
+      return false;
+    }
+
     // Reconnects on READONLY errors and auto-retries the command.
     logger.warn(`Redis connection error: ${err.message}`);
     return err.message.includes("READONLY") ? 2 : false;


### PR DESCRIPTION
## Summary
- Log Redis Cluster `MOVED` redirect responses at `debug` level instead of `warn` in `reconnectOnError`
- `MOVED` is a normal cluster response (slot redirection), not a connection error — ioredis Cluster follows these automatically
- Reduces log noise for self-hosted customers running Redis Cluster, especially those with high shard counts where `MOVED` warnings were frequent and misleading

## Test plan
- [ ] Deploy to staging with Redis Cluster and verify `MOVED` messages no longer appear at warn level
- [ ] Verify `READONLY` errors still log at warn and trigger reconnection
- [ ] Verify actual connection errors still log at warn level

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Log Redis `MOVED` cluster redirects at debug level to reduce misleading log noise.
> 
>   - **Behavior**:
>     - Log `MOVED` cluster redirects at `debug` level instead of `warn` in `reconnectOnError` function in `redis.ts`.
>     - `MOVED` is a normal cluster response, not a connection error.
>   - **Logging**:
>     - Reduces misleading log noise for Redis Cluster users, especially with high shard counts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 8f616cd06e144f4bd4f8ae283c12b3ed4d1f2dcd. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->