### PR TITLE
feat: add metricsVersion prop to dashboard components to allow switching onto v4 Beta

### DIFF
--- a/web/src/features/dashboard/components/ChartScores.tsx
+++ b/web/src/features/dashboard/components/ChartScores.tsx
@@ -15,6 +15,7 @@ import { getScoreDataTypeIcon } from "@/src/features/scores/lib/scoreColumns";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 import {
   type QueryType,
+  type ViewVersion,
   mapLegacyUiTableFilterToView,
 } from "@/src/features/query";
 import { type DatabaseRow } from "@/src/server/api/services/sqlInterface";
@@ -29,6 +30,7 @@ export function ChartScores(props: {
   toTimestamp: Date;
   projectId: string;
   isLoading?: boolean;
+  metricsVersion?: ViewVersion;
 }) {
   const scoresQuery: QueryType = {
     view: "scores-numeric",
@@ -51,6 +53,7 @@ export function ChartScores(props: {
     {
       projectId: props.projectId,
       query: scoresQuery,
+      version: props.metricsVersion,
     },
     {
       trpc: {

--- a/web/src/features/dashboard/components/LatencyChart.tsx
+++ b/web/src/features/dashboard/components/LatencyChart.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/src/features/dashboard/components/ModelSelector";
 import {
   type QueryType,
+  type ViewVersion,
   mapLegacyUiTableFilterToView,
 } from "@/src/features/query";
 import type { DatabaseRow } from "@/src/server/api/services/sqlInterface";
@@ -33,6 +34,7 @@ export const GenerationLatencyChart = ({
   fromTimestamp,
   toTimestamp,
   isLoading = false,
+  metricsVersion,
 }: {
   className?: string;
   projectId: string;
@@ -41,6 +43,7 @@ export const GenerationLatencyChart = ({
   fromTimestamp: Date;
   toTimestamp: Date;
   isLoading?: boolean;
+  metricsVersion?: ViewVersion;
 }) => {
   const {
     allModels,
@@ -54,6 +57,7 @@ export const GenerationLatencyChart = ({
     globalFilterState,
     fromTimestamp,
     toTimestamp,
+    metricsVersion,
   );
 
   const latenciesQuery: QueryType = {
@@ -94,6 +98,7 @@ export const GenerationLatencyChart = ({
     {
       projectId,
       query: latenciesQuery,
+      version: metricsVersion,
     },
     {
       enabled: !isLoading && selectedModels.length > 0 && allModels.length > 0,

--- a/web/src/features/dashboard/components/LatencyTables.tsx
+++ b/web/src/features/dashboard/components/LatencyTables.tsx
@@ -9,6 +9,7 @@ import { truncate } from "@/src/utils/string";
 import { Popup } from "@/src/components/layouts/doc-popup";
 import {
   type QueryType,
+  type ViewVersion,
   mapLegacyUiTableFilterToView,
 } from "@/src/features/query";
 
@@ -18,12 +19,14 @@ export const LatencyTables = ({
   fromTimestamp,
   toTimestamp,
   isLoading = false,
+  metricsVersion,
 }: {
   projectId: string;
   globalFilterState: FilterState;
   fromTimestamp: Date;
   toTimestamp: Date;
   isLoading?: boolean;
+  metricsVersion?: ViewVersion;
 }) => {
   const generationsLatenciesQuery: QueryType = {
     view: "observations",
@@ -53,6 +56,7 @@ export const LatencyTables = ({
     {
       projectId,
       query: generationsLatenciesQuery,
+      version: metricsVersion,
     },
     {
       trpc: {
@@ -92,6 +96,7 @@ export const LatencyTables = ({
     {
       projectId,
       query: spansLatenciesQuery,
+      version: metricsVersion,
     },
     {
       trpc: {
@@ -123,6 +128,7 @@ export const LatencyTables = ({
     {
       projectId,
       query: tracesLatenciesQuery,
+      version: metricsVersion,
     },
     {
       trpc: {

--- a/web/src/features/dashboard/components/ModelCostTable.tsx
+++ b/web/src/features/dashboard/components/ModelCostTable.tsx
@@ -11,6 +11,7 @@ import { totalCostDashboardFormatted } from "@/src/features/dashboard/lib/dashbo
 import { truncate } from "@/src/utils/string";
 import {
   type QueryType,
+  type ViewVersion,
   mapLegacyUiTableFilterToView,
 } from "@/src/features/query";
 
@@ -21,6 +22,7 @@ export const ModelCostTable = ({
   fromTimestamp,
   toTimestamp,
   isLoading = false,
+  metricsVersion,
 }: {
   className: string;
   projectId: string;
@@ -28,6 +30,7 @@ export const ModelCostTable = ({
   fromTimestamp: Date;
   toTimestamp: Date;
   isLoading?: boolean;
+  metricsVersion?: ViewVersion;
 }) => {
   const modelCostQuery: QueryType = {
     view: "observations",
@@ -55,6 +58,7 @@ export const ModelCostTable = ({
     {
       projectId,
       query: modelCostQuery,
+      version: metricsVersion,
     },
     {
       trpc: {

--- a/web/src/features/dashboard/components/ModelSelector.tsx
+++ b/web/src/features/dashboard/components/ModelSelector.tsx
@@ -16,6 +16,7 @@ import {
 import { getAllModels } from "@/src/features/dashboard/components/hooks";
 import { cn } from "@/src/utils/tailwind";
 import { type FilterState } from "@langfuse/shared";
+import { type ViewVersion } from "@/src/features/query";
 import { Check, ChevronsUpDown } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -106,12 +107,14 @@ export const useModelSelection = (
   globalFilterState: FilterState,
   fromTimestamp: Date,
   toTimestamp: Date,
+  metricsVersion?: ViewVersion,
 ) => {
   const allModels = getAllModels(
     projectId,
     globalFilterState,
     fromTimestamp,
     toTimestamp,
+    metricsVersion,
   );
 
   const [selectedModels, setSelectedModels] = useState<string[]>([]);

--- a/web/src/features/dashboard/components/ModelUsageChart.tsx
+++ b/web/src/features/dashboard/components/ModelUsageChart.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/src/features/dashboard/components/ModelSelector";
 import {
   type QueryType,
+  type ViewVersion,
   mapLegacyUiTableFilterToView,
 } from "@/src/features/query";
 import { type DatabaseRow } from "@/src/server/api/services/sqlInterface";
@@ -36,6 +37,7 @@ export const ModelUsageChart = ({
   toTimestamp,
   userAndEnvFilterState,
   isLoading = false,
+  metricsVersion,
 }: {
   className?: string;
   projectId: string;
@@ -45,6 +47,7 @@ export const ModelUsageChart = ({
   toTimestamp: Date;
   userAndEnvFilterState: FilterState;
   isLoading?: boolean;
+  metricsVersion?: ViewVersion;
 }) => {
   const {
     allModels,
@@ -58,6 +61,7 @@ export const ModelUsageChart = ({
     userAndEnvFilterState,
     fromTimestamp,
     toTimestamp,
+    metricsVersion,
   );
 
   const modelUsageQuery: QueryType = {
@@ -95,6 +99,7 @@ export const ModelUsageChart = ({
     {
       projectId,
       query: modelUsageQuery,
+      version: metricsVersion,
     },
     {
       enabled: !isLoading && selectedModels.length > 0 && allModels.length > 0,

--- a/web/src/features/dashboard/components/ScoresTable.tsx
+++ b/web/src/features/dashboard/components/ScoresTable.tsx
@@ -5,6 +5,7 @@ import {
   type ScoreSourceType,
   type FilterState,
 } from "@langfuse/shared";
+import { type ViewVersion } from "@/src/features/query";
 import { api } from "@/src/utils/api";
 import { compactNumberFormatter } from "@/src/utils/numbers";
 import { RightAlignedCell } from "./RightAlignedCell";
@@ -47,11 +48,13 @@ export const ScoresTable = ({
   projectId,
   globalFilterState,
   isLoading = false,
+  metricsVersion: _metricsVersion,
 }: {
   className: string;
   projectId: string;
   globalFilterState: FilterState;
   isLoading?: boolean;
+  metricsVersion?: ViewVersion;
 }) => {
   const localFilters = createTracesTimeFilter(
     globalFilterState,

--- a/web/src/features/dashboard/components/TracesBarListChart.tsx
+++ b/web/src/features/dashboard/components/TracesBarListChart.tsx
@@ -8,6 +8,7 @@ import { compactNumberFormatter, numberFormatter } from "@/src/utils/numbers";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 import {
   type QueryType,
+  type ViewVersion,
   mapLegacyUiTableFilterToView,
 } from "@/src/features/query";
 import { Chart } from "@/src/features/widgets/chart-library/Chart";
@@ -20,6 +21,7 @@ export const TracesBarListChart = ({
   fromTimestamp,
   toTimestamp,
   isLoading = false,
+  metricsVersion,
 }: {
   className?: string;
   projectId: string;
@@ -27,6 +29,7 @@ export const TracesBarListChart = ({
   fromTimestamp: Date;
   toTimestamp: Date;
   isLoading?: boolean;
+  metricsVersion?: ViewVersion;
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -46,6 +49,7 @@ export const TracesBarListChart = ({
     {
       projectId,
       query: totalTracesQuery,
+      version: metricsVersion,
     },
     {
       trpc: {
@@ -73,6 +77,7 @@ export const TracesBarListChart = ({
     {
       projectId,
       query: tracesQuery,
+      version: metricsVersion,
     },
     {
       trpc: {

--- a/web/src/features/dashboard/components/TracesTimeSeriesChart.tsx
+++ b/web/src/features/dashboard/components/TracesTimeSeriesChart.tsx
@@ -12,6 +12,7 @@ import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 import { TabComponent } from "@/src/features/dashboard/components/TabsComponent";
 import {
   type QueryType,
+  type ViewVersion,
   mapLegacyUiTableFilterToView,
 } from "@/src/features/query";
 import { Chart } from "@/src/features/widgets/chart-library/Chart";
@@ -25,6 +26,7 @@ export const TracesAndObservationsTimeSeriesChart = ({
   toTimestamp,
   agg,
   isLoading = false,
+  metricsVersion,
 }: {
   className?: string;
   projectId: string;
@@ -33,6 +35,7 @@ export const TracesAndObservationsTimeSeriesChart = ({
   toTimestamp: Date;
   agg: DashboardDateRangeAggregationOption;
   isLoading?: boolean;
+  metricsVersion?: ViewVersion;
 }) => {
   const tracesQuery: QueryType = {
     view: "traces",
@@ -52,6 +55,7 @@ export const TracesAndObservationsTimeSeriesChart = ({
     {
       projectId,
       query: tracesQuery,
+      version: metricsVersion,
     },
     {
       trpc: {
@@ -99,6 +103,7 @@ export const TracesAndObservationsTimeSeriesChart = ({
     {
       projectId,
       query: observationsQuery,
+      version: metricsVersion,
     },
     {
       trpc: {

--- a/web/src/features/dashboard/components/UserChart.tsx
+++ b/web/src/features/dashboard/components/UserChart.tsx
@@ -10,6 +10,7 @@ import { totalCostDashboardFormatted } from "@/src/features/dashboard/lib/dashbo
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 import {
   type QueryType,
+  type ViewVersion,
   mapLegacyUiTableFilterToView,
 } from "@/src/features/query";
 import { Chart } from "@/src/features/widgets/chart-library/Chart";
@@ -27,6 +28,7 @@ export const UserChart = ({
   fromTimestamp,
   toTimestamp,
   isLoading = false,
+  metricsVersion,
 }: {
   className?: string;
   projectId: string;
@@ -34,6 +36,7 @@ export const UserChart = ({
   fromTimestamp: Date;
   toTimestamp: Date;
   isLoading?: boolean;
+  metricsVersion?: ViewVersion;
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const userCostQuery: QueryType = {
@@ -62,6 +65,7 @@ export const UserChart = ({
     {
       projectId,
       query: userCostQuery,
+      version: metricsVersion,
     },
     {
       trpc: {
@@ -88,6 +92,7 @@ export const UserChart = ({
     {
       projectId,
       query: traceCountQuery,
+      version: metricsVersion,
     },
     {
       trpc: {

--- a/web/src/features/dashboard/components/hooks.ts
+++ b/web/src/features/dashboard/components/hooks.ts
@@ -6,17 +6,22 @@ export type TimeSeriesChartDataPoint = {
 };
 import { type DatabaseRow } from "@/src/server/api/services/sqlInterface";
 import { api } from "@/src/utils/api";
-import { mapLegacyUiTableFilterToView } from "@/src/features/query";
+import {
+  type ViewVersion,
+  mapLegacyUiTableFilterToView,
+} from "@/src/features/query";
 
 export const getAllModels = (
   projectId: string,
   globalFilterState: FilterState,
   fromTimestamp: Date,
   toTimestamp: Date,
+  metricsVersion?: ViewVersion,
 ) => {
   const allModels = api.dashboard.executeQuery.useQuery(
     {
       projectId,
+      version: metricsVersion,
       query: {
         view: "observations",
         dimensions: [{ field: "providedModelName" }],

--- a/web/src/features/dashboard/components/score-analytics/CategoricalScoreChart.tsx
+++ b/web/src/features/dashboard/components/score-analytics/CategoricalScoreChart.tsx
@@ -10,6 +10,7 @@ import { DashboardCategoricalScoreAdapter } from "@/src/features/scores/adapters
 import { type ScoreData } from "@/src/features/scores/types";
 import {
   type QueryType,
+  type ViewVersion,
   mapLegacyUiTableFilterToView,
 } from "@/src/features/query";
 import { type DatabaseRow } from "@/src/server/api/services/sqlInterface";
@@ -25,6 +26,7 @@ export function CategoricalScoreChart(props: {
   fromTimestamp: Date;
   toTimestamp: Date;
   agg?: DashboardDateRangeAggregationOption;
+  metricsVersion?: ViewVersion;
 }) {
   const scoresQuery: QueryType = {
     view: "scores-categorical",
@@ -69,6 +71,7 @@ export function CategoricalScoreChart(props: {
     {
       projectId: props.projectId,
       query: scoresQuery,
+      version: props.metricsVersion,
     },
     {
       trpc: {

--- a/web/src/features/dashboard/components/score-analytics/NumericScoreHistogram.tsx
+++ b/web/src/features/dashboard/components/score-analytics/NumericScoreHistogram.tsx
@@ -4,6 +4,7 @@ import {
   type FilterState,
   type ScoreDataTypeType,
 } from "@langfuse/shared";
+import { type ViewVersion } from "@/src/features/query";
 import { createTracesTimeFilter } from "@/src/features/dashboard/lib/dashboard-utils";
 import React from "react";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
@@ -16,6 +17,7 @@ export function NumericScoreHistogram(props: {
   source: ScoreSourceType;
   dataType: Extract<ScoreDataTypeType, "NUMERIC" | "BOOLEAN">;
   globalFilterState: FilterState;
+  metricsVersion?: ViewVersion;
 }) {
   const histogram = api.dashboard.scoreHistogram.useQuery(
     {

--- a/web/src/features/dashboard/components/score-analytics/NumericScoreTimeSeriesChart.tsx
+++ b/web/src/features/dashboard/components/score-analytics/NumericScoreTimeSeriesChart.tsx
@@ -19,6 +19,7 @@ import React, { useMemo } from "react";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 import {
   type QueryType,
+  type ViewVersion,
   mapLegacyUiTableFilterToView,
 } from "@/src/features/query";
 import { type DatabaseRow } from "@/src/server/api/services/sqlInterface";
@@ -34,6 +35,7 @@ export function NumericScoreTimeSeriesChart(props: {
   globalFilterState: FilterState;
   fromTimestamp: Date;
   toTimestamp: Date;
+  metricsVersion?: ViewVersion;
 }) {
   const scoresQuery: QueryType = {
     view: "scores-numeric",
@@ -76,6 +78,7 @@ export function NumericScoreTimeSeriesChart(props: {
     {
       projectId: props.projectId,
       query: scoresQuery,
+      version: props.metricsVersion,
     },
     {
       trpc: {

--- a/web/src/features/dashboard/components/score-analytics/ScoreAnalytics.tsx
+++ b/web/src/features/dashboard/components/score-analytics/ScoreAnalytics.tsx
@@ -16,6 +16,7 @@ import { NumericScoreHistogram } from "@/src/features/dashboard/components/score
 import DocPopup from "@/src/components/layouts/doc-popup";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 import useLocalStorage from "@/src/components/useLocalStorage";
+import { type ViewVersion } from "@/src/features/query";
 import {
   convertScoreColumnsToAnalyticsData,
   getScoreDataTypeIcon,
@@ -29,6 +30,7 @@ export function ScoreAnalytics(props: {
   toTimestamp: Date;
   projectId: string;
   isLoading?: boolean;
+  metricsVersion?: ViewVersion;
 }) {
   // Stale score selections in localStorage are ignored as we only show scores that exist in scoreAnalyticsOptions
   const [selectedDashboardScoreKeys, setSelectedDashboardScoreKeys] =
@@ -122,6 +124,7 @@ export function ScoreAnalytics(props: {
                         globalFilterState={props.globalFilterState}
                         fromTimestamp={props.fromTimestamp}
                         toTimestamp={props.toTimestamp}
+                        metricsVersion={props.metricsVersion}
                       />
                     )}
                     {(isNumericDataType(dataType) ||
@@ -137,6 +140,7 @@ export function ScoreAnalytics(props: {
                           >
                         }
                         globalFilterState={props.globalFilterState}
+                        metricsVersion={props.metricsVersion}
                       />
                     )}
                   </div>
@@ -155,6 +159,7 @@ export function ScoreAnalytics(props: {
                         globalFilterState={props.globalFilterState}
                         fromTimestamp={props.fromTimestamp}
                         toTimestamp={props.toTimestamp}
+                        metricsVersion={props.metricsVersion}
                       />
                     )}
                     {(isNumericDataType(dataType) ||
@@ -173,6 +178,7 @@ export function ScoreAnalytics(props: {
                         globalFilterState={props.globalFilterState}
                         fromTimestamp={props.fromTimestamp}
                         toTimestamp={props.toTimestamp}
+                        metricsVersion={props.metricsVersion}
                       />
                     )}
                   </div>

--- a/web/src/features/dashboard/server/dashboard-router.ts
+++ b/web/src/features/dashboard/server/dashboard-router.ts
@@ -23,6 +23,7 @@ import { type DatabaseRow } from "@/src/server/api/services/sqlInterface";
 import {
   type QueryType,
   query as customQuery,
+  viewVersions,
 } from "@/src/features/query/types";
 import {
   paginationZod,
@@ -161,11 +162,16 @@ export const dashboardRouter = createTRPCRouter({
       z.object({
         projectId: z.string(),
         query: customQuery,
+        version: viewVersions.optional().default("v1"),
       }),
     )
     .query(async ({ input }) => {
       try {
-        return executeQuery(input.projectId, input.query as QueryType);
+        return executeQuery(
+          input.projectId,
+          input.query as QueryType,
+          input.version,
+        );
       } catch (error) {
         if (error instanceof InvalidRequestError) {
           logger.warn("Bad request in query execution", error, {

--- a/web/src/pages/project/[projectId]/index.tsx
+++ b/web/src/pages/project/[projectId]/index.tsx
@@ -36,10 +36,15 @@ import {
   convertSelectedEnvironmentsToFilter,
   useEnvironmentFilter,
 } from "@/src/hooks/use-environment-filter";
+import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
+import { type ViewVersion } from "@/src/features/query";
+
 export default function Dashboard() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
   const { timeRange, setTimeRange } = useDashboardDateRange();
+  const { isBetaEnabled } = useV4Beta();
+  const metricsVersion: ViewVersion = isBetaEnabled ? "v2" : "v1";
 
   const absoluteTimeRange = useMemo(
     () => toAbsoluteTimeRange(timeRange),
@@ -257,6 +262,7 @@ export default function Dashboard() {
           fromTimestamp={fromTimestamp}
           toTimestamp={toTimestamp}
           isLoading={environmentFilterOptions.isPending}
+          metricsVersion={metricsVersion}
         />
         <ModelCostTable
           className="col-span-1 xl:col-span-2"
@@ -265,12 +271,14 @@ export default function Dashboard() {
           fromTimestamp={fromTimestamp}
           toTimestamp={toTimestamp}
           isLoading={environmentFilterOptions.isPending}
+          metricsVersion={metricsVersion}
         />
         <ScoresTable
           className="col-span-1 xl:col-span-2"
           projectId={projectId}
           globalFilterState={mergedFilterState}
           isLoading={environmentFilterOptions.isPending}
+          metricsVersion={metricsVersion}
         />
         <TracesAndObservationsTimeSeriesChart
           className="col-span-1 xl:col-span-3"
@@ -280,6 +288,7 @@ export default function Dashboard() {
           toTimestamp={toTimestamp}
           agg={agg}
           isLoading={environmentFilterOptions.isPending}
+          metricsVersion={metricsVersion}
         />
         <ModelUsageChart
           className="col-span-1 min-h-24 xl:col-span-3"
@@ -290,6 +299,7 @@ export default function Dashboard() {
           userAndEnvFilterState={[...userFilterState, ...environmentFilter]}
           agg={agg}
           isLoading={environmentFilterOptions.isPending}
+          metricsVersion={metricsVersion}
         />
         <UserChart
           className="col-span-1 xl:col-span-3"
@@ -298,6 +308,7 @@ export default function Dashboard() {
           fromTimestamp={fromTimestamp}
           toTimestamp={toTimestamp}
           isLoading={environmentFilterOptions.isPending}
+          metricsVersion={metricsVersion}
         />
         <ChartScores
           className="col-span-1 xl:col-span-3"
@@ -307,6 +318,7 @@ export default function Dashboard() {
           fromTimestamp={fromTimestamp}
           toTimestamp={toTimestamp}
           isLoading={environmentFilterOptions.isPending}
+          metricsVersion={metricsVersion}
         />
         <LatencyTables
           projectId={projectId}
@@ -314,6 +326,7 @@ export default function Dashboard() {
           fromTimestamp={fromTimestamp}
           toTimestamp={toTimestamp}
           isLoading={environmentFilterOptions.isPending}
+          metricsVersion={metricsVersion}
         />
         <GenerationLatencyChart
           className="col-span-1 flex-auto justify-between lg:col-span-full"
@@ -323,6 +336,7 @@ export default function Dashboard() {
           fromTimestamp={fromTimestamp}
           toTimestamp={toTimestamp}
           isLoading={environmentFilterOptions.isPending}
+          metricsVersion={metricsVersion}
         />
         <ScoreAnalytics
           className="col-span-1 flex-auto justify-between lg:col-span-full"
@@ -332,6 +346,7 @@ export default function Dashboard() {
           fromTimestamp={fromTimestamp}
           toTimestamp={toTimestamp}
           isLoading={environmentFilterOptions.isPending}
+          metricsVersion={metricsVersion}
         />
       </div>
     </Page>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `metricsVersion` prop to dashboard components for v4 Beta metrics version support, controlled by `isBetaEnabled` flag.
> 
>   - **Behavior**:
>     - Add `metricsVersion` prop to components like `ChartScores`, `LatencyChart`, `LatencyTables`, `ModelCostTable`, `ModelUsageChart`, `ScoresTable`, `TracesBarListChart`, `TracesTimeSeriesChart`, `UserChart`, `ScoreAnalytics`, and `CategoricalScoreChart`.
>     - `metricsVersion` determines the version of metrics used, toggled by `isBetaEnabled` flag in `index.tsx`.
>   - **API**:
>     - Update `executeQuery` in `dashboard-router.ts` to accept `version` parameter, defaulting to "v1".
>   - **Misc**:
>     - Add `ViewVersion` type import to multiple files for `metricsVersion` prop.
>     - Update `getAllModels` in `hooks.ts` to use `metricsVersion`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a0528bdb0c31b74717cfc99e645ca516857eace3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->