### PR TITLE
fix: show no data when runs are not loading

### DIFF
--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -636,7 +636,9 @@ export function DatasetRunsTable(props: {
                         <span className="shrink-0 text-sm font-medium">
                           {title}
                         </span>
-                        <NoDataOrLoading isLoading={true} />
+                        <NoDataOrLoading
+                          isLoading={runs.isPending || runsMetrics.isPending}
+                        />
                       </div>
                     );
                   }


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Show explicit "no data" when runs are 0.

Fixes https://github.com/langfuse/langfuse/issues/12092

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

**now**
<img width="1235" height="615" alt="image" src="https://github.com/user-attachments/assets/ddac376e-8396-4767-86c3-7cecebe3a445" />


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue where 'no data' was not shown when runs were not loading in `DatasetRunsTable.tsx`.
> 
>   - **Behavior**:
>     - Updates `NoDataOrLoading` component in `DatasetRunsTable.tsx` to show 'no data' when `runs` and `runsMetrics` are not loading and there are no runs.
>   - **Misc**:
>     - Fixes issue #12092.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d029cb6c1f78316660ba48d4fef18f8dea31edd1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->