### PR TITLE
feat(redis): make slotsRefreshTimeout configurable for Redis clusters

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -33,6 +33,11 @@ const EnvSchema = z.object({
   // Redis Cluster Configuration
   REDIS_CLUSTER_ENABLED: z.enum(["true", "false"]).default("false"),
   REDIS_CLUSTER_NODES: z.string().optional(),
+  REDIS_CLUSTER_SLOTS_REFRESH_TIMEOUT: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(5000),
   REDIS_SENTINEL_ENABLED: z.enum(["true", "false"]).default("false"),
   REDIS_SENTINEL_NODES: z.string().optional(),
   REDIS_SENTINEL_MASTER_NAME: z.string().optional(),

--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -113,7 +113,7 @@ const createRedisClusterInstance = (
     dnsLookup: (address, callback) => {
       callback(null, address);
     },
-    slotsRefreshTimeout: 5000,
+    slotsRefreshTimeout: env.REDIS_CLUSTER_SLOTS_REFRESH_TIMEOUT,
     redisOptions: {
       username: env.REDIS_USERNAME || undefined,
       password: env.REDIS_AUTH || undefined,


### PR DESCRIPTION
## Summary
- Add `REDIS_CLUSTER_SLOTS_REFRESH_TIMEOUT` env variable to configure the ioredis `slotsRefreshTimeout` for Redis cluster connections
- Defaults to `5000` ms (unchanged behavior) when the env variable is not set
- Value is in milliseconds, validated as a positive integer

## Test plan
- [ ] Verify existing Redis cluster behavior is unchanged when env variable is not set (default 5000ms)
- [ ] Verify custom timeout is applied when `REDIS_CLUSTER_SLOTS_REFRESH_TIMEOUT` is set
- [ ] Verify `shared` package builds without type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `REDIS_CLUSTER_SLOTS_REFRESH_TIMEOUT` env variable to configure Redis cluster `slotsRefreshTimeout`, defaulting to 5000ms.
> 
>   - **Behavior**:
>     - Add `REDIS_CLUSTER_SLOTS_REFRESH_TIMEOUT` env variable in `env.ts` to configure `slotsRefreshTimeout` for Redis clusters.
>     - Defaults to `5000` ms if not set, maintaining existing behavior.
>     - Validated as a positive integer.
>   - **Implementation**:
>     - Update `createRedisClusterInstance()` in `redis.ts` to use `env.REDIS_CLUSTER_SLOTS_REFRESH_TIMEOUT` for `slotsRefreshTimeout`.
>   - **Test Plan**:
>     - Verify default behavior when env variable is not set.
>     - Verify custom timeout when `REDIS_CLUSTER_SLOTS_REFRESH_TIMEOUT` is set.
>     - Ensure `shared` package builds without type errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 72d12ed841f93c852a18a8f04185da96733b4408. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->