### PR TITLE
fix(api-types): remove `.strict()` from public API request schemas

### DIFF
--- a/web/src/features/public-api/types/annotation-queues.ts
+++ b/web/src/features/public-api/types/annotation-queues.ts
@@ -44,11 +44,9 @@ export type AnnotationQueue = z.infer<typeof AnnotationQueueSchema>;
  */
 
 // GET /annotation-queues
-export const GetAnnotationQueuesQuery = z
-  .object({
-    ...publicApiPaginationZod,
-  })
-  .strict();
+export const GetAnnotationQueuesQuery = z.object({
+  ...publicApiPaginationZod,
+});
 
 export const GetAnnotationQueuesResponse = z
   .object({
@@ -58,33 +56,27 @@ export const GetAnnotationQueuesResponse = z
   .strict();
 
 // POST /annotation-queues
-export const CreateAnnotationQueueBody = z
-  .object({
-    name: z.string(),
-    description: z.string().nullable(),
-    scoreConfigIds: z.array(z.string()).min(1),
-  })
-  .strict();
+export const CreateAnnotationQueueBody = z.object({
+  name: z.string(),
+  description: z.string().nullable(),
+  scoreConfigIds: z.array(z.string()).min(1),
+});
 
 export const CreateAnnotationQueueResponse = AnnotationQueueSchema;
 
 // GET /annotation-queues/:queueId
-export const GetAnnotationQueueByIdQuery = z
-  .object({
-    queueId: z.string(),
-  })
-  .strict();
+export const GetAnnotationQueueByIdQuery = z.object({
+  queueId: z.string(),
+});
 
 export const GetAnnotationQueueByIdResponse = AnnotationQueueSchema;
 
 // GET /annotation-queues/:queueId/items
-export const GetAnnotationQueueItemsQuery = z
-  .object({
-    ...publicApiPaginationZod,
-    queueId: z.string(),
-    status: z.enum(AnnotationQueueStatus).optional(),
-  })
-  .strict();
+export const GetAnnotationQueueItemsQuery = z.object({
+  ...publicApiPaginationZod,
+  queueId: z.string(),
+  status: z.enum(AnnotationQueueStatus).optional(),
+});
 
 export const GetAnnotationQueueItemsResponse = z
   .object({
@@ -94,45 +86,37 @@ export const GetAnnotationQueueItemsResponse = z
   .strict();
 
 // GET /annotation-queues/:queueId/items/:itemId
-export const GetAnnotationQueueItemByIdQuery = z
-  .object({
-    queueId: z.string(),
-    itemId: z.string(),
-  })
-  .strict();
+export const GetAnnotationQueueItemByIdQuery = z.object({
+  queueId: z.string(),
+  itemId: z.string(),
+});
 
 export const GetAnnotationQueueItemByIdResponse = AnnotationQueueItemSchema;
 
 // POST /annotation-queues/:queueId/items
-export const CreateAnnotationQueueItemBody = z
-  .object({
-    objectId: z.string(),
-    objectType: z.enum(AnnotationQueueObjectType),
-    status: z
-      .enum(AnnotationQueueStatus)
-      .optional()
-      .default(AnnotationQueueStatus.PENDING),
-  })
-  .strict();
+export const CreateAnnotationQueueItemBody = z.object({
+  objectId: z.string(),
+  objectType: z.enum(AnnotationQueueObjectType),
+  status: z
+    .enum(AnnotationQueueStatus)
+    .optional()
+    .default(AnnotationQueueStatus.PENDING),
+});
 
 export const CreateAnnotationQueueItemResponse = AnnotationQueueItemSchema;
 
 // PATCH /annotation-queues/:queueId/items/:itemId
-export const UpdateAnnotationQueueItemBody = z
-  .object({
-    status: z.enum(AnnotationQueueStatus).optional(),
-  })
-  .strict();
+export const UpdateAnnotationQueueItemBody = z.object({
+  status: z.enum(AnnotationQueueStatus).optional(),
+});
 
 export const UpdateAnnotationQueueItemResponse = AnnotationQueueItemSchema;
 
 // DELETE /annotation-queues/:queueId/items/:itemId
-export const DeleteAnnotationQueueItemQuery = z
-  .object({
-    queueId: z.string(),
-    itemId: z.string(),
-  })
-  .strict();
+export const DeleteAnnotationQueueItemQuery = z.object({
+  queueId: z.string(),
+  itemId: z.string(),
+});
 
 export const DeleteAnnotationQueueItemResponse = z
   .object({
@@ -150,28 +134,22 @@ export const AnnotationQueueAssignmentSchema = z
   })
   .strict();
 
-export const AnnotationQueueAssignmentQuery = z
-  .object({
-    queueId: z.string(),
-  })
-  .strict();
+export const AnnotationQueueAssignmentQuery = z.object({
+  queueId: z.string(),
+});
 
 // POST /annotation-queues/:queueId/assignments
-export const CreateAnnotationQueueAssignmentBody = z
-  .object({
-    userId: z.string(),
-  })
-  .strict();
+export const CreateAnnotationQueueAssignmentBody = z.object({
+  userId: z.string(),
+});
 
 export const CreateAnnotationQueueAssignmentResponse =
   AnnotationQueueAssignmentSchema;
 
 // DELETE /annotation-queues/:queueId/assignments
-export const DeleteAnnotationQueueAssignmentBody = z
-  .object({
-    userId: z.string(),
-  })
-  .strict();
+export const DeleteAnnotationQueueAssignmentBody = z.object({
+  userId: z.string(),
+});
 
 export const DeleteAnnotationQueueAssignmentResponse = z
   .object({

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -46,7 +46,6 @@ export const CreateBlobStorageIntegrationRequest = z
     exportMode: BlobStorageExportMode,
     exportStartDate: z.coerce.date().nullable().optional(),
   })
-  .strict()
   .refine(
     (data) => {
       return !(data.exportMode === "FROM_CUSTOM_DATE" && !data.exportStartDate);

--- a/web/src/features/public-api/types/comments.ts
+++ b/web/src/features/public-api/types/comments.ts
@@ -34,11 +34,9 @@ export const PostCommentsV1Body = CreateCommentData.omit({
   path: true,
   rangeStart: true,
   rangeEnd: true,
-})
-  .extend({
-    authorUserId: z.string().nullish(),
-  })
-  .strict();
+}).extend({
+  authorUserId: z.string().nullish(),
+});
 export const PostCommentsV1Response = z.object({ id: z.string() }).strict();
 
 // GET /comments
@@ -49,7 +47,6 @@ export const GetCommentsV1Query = z
     authorUserId: z.string().nullish(),
     ...publicApiPaginationZod,
   })
-  .strict()
   .refine(
     ({ objectId, objectType }) => {
       return objectId ? !!objectType : true;
@@ -68,9 +65,7 @@ export const GetCommentsV1Response = z
   .strict();
 
 // GET /comments/:id
-export const GetCommentV1Query = z
-  .object({
-    commentId: z.string(),
-  })
-  .strict();
+export const GetCommentV1Query = z.object({
+  commentId: z.string(),
+});
 export const GetCommentV1Response = APIComment;

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -234,7 +234,6 @@ export const PostDatasetRunItemsV1Body = z
     traceId: z.string().nullish(),
     datasetVersion: versionZod.nullish(),
   })
-  .strict()
   .refine((data) => data.observationId || data.traceId, {
     message: "observationId or traceId must be provided",
     path: ["observationId", "traceId"], // Specify the path of the error

--- a/web/src/features/public-api/types/llm-connections.ts
+++ b/web/src/features/public-api/types/llm-connections.ts
@@ -20,11 +20,9 @@ export const LlmConnectionResponse = z
   .strict();
 
 // GET /api/public/llm-connections query parameters
-export const GetLlmConnectionsV1Query = z
-  .object({
-    ...paginationZod,
-  })
-  .strict();
+export const GetLlmConnectionsV1Query = z.object({
+  ...paginationZod,
+});
 
 // GET /api/public/llm-connections response
 export const GetLlmConnectionsV1Response = z

--- a/web/src/features/public-api/types/traces.ts
+++ b/web/src/features/public-api/types/traces.ts
@@ -142,14 +142,12 @@ export const DeleteTraceV1Response = z
   .strict();
 
 // DELETE /api/public/traces
-export const DeleteTracesV1Body = z
-  .object({
-    traceIds: z
-      .array(z.string())
-      .min(1, "At least 1 traceId is required.")
-      .max(1000, "Cannot specify more than 1000 traces in a single request."),
-  })
-  .strict();
+export const DeleteTracesV1Body = z.object({
+  traceIds: z
+    .array(z.string())
+    .min(1, "At least 1 traceId is required.")
+    .max(1000, "Cannot specify more than 1000 traces in a single request."),
+});
 export const DeleteTracesV1Response = z
   .object({
     message: z.string(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `.strict()` from Zod schemas in multiple files, affecting API request and response schemas.
> 
>   - **Behavior**:
>     - Removed `.strict()` from Zod schemas in `annotation-queues.ts`, `blob-storage-integrations.ts`, `comments.ts`, `datasets.ts`, `llm-connections.ts`, and `traces.ts`.
>     - Affects request and response schemas for various API endpoints, including `GET`, `POST`, `PATCH`, and `DELETE` operations.
>   - **Files**:
>     - `annotation-queues.ts`: Removed `.strict()` from schemas like `GetAnnotationQueuesQuery`, `CreateAnnotationQueueBody`, etc.
>     - `blob-storage-integrations.ts`: Removed `.strict()` from `CreateBlobStorageIntegrationRequest`.
>     - `comments.ts`: Removed `.strict()` from `PostCommentsV1Body` and `GetCommentsV1Query`.
>     - `datasets.ts`: Removed `.strict()` from `PostDatasetRunItemsV1Body`.
>     - `llm-connections.ts`: Removed `.strict()` from `GetLlmConnectionsV1Query`.
>     - `traces.ts`: Removed `.strict()` from `DeleteTracesV1Body`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 421b5c0eb59acbc20799fb332bac8f61b417a79f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->