### PR TITLE
fix(project-settings): remove spurious whitespace from example .env

### DIFF
--- a/web/src/features/public-api/hooks/useLangfuseEnvCode.ts
+++ b/web/src/features/public-api/hooks/useLangfuseEnvCode.ts
@@ -9,12 +9,12 @@ export function useLangfuseEnvCode(keys?: {
   const baseUrl = `${uiCustomization?.hostname ?? window.origin}${env.NEXT_PUBLIC_BASE_PATH ?? ""}`;
 
   if (keys) {
-    return `LANGFUSE_SECRET_KEY = "${keys.secretKey}"
-LANGFUSE_PUBLIC_KEY = "${keys.publicKey}"
-LANGFUSE_BASE_URL = "${baseUrl}"`;
+    return `LANGFUSE_SECRET_KEY="${keys.secretKey}"
+LANGFUSE_PUBLIC_KEY="${keys.publicKey}"
+LANGFUSE_BASE_URL="${baseUrl}"`;
   }
 
-  return `LANGFUSE_SECRET_KEY = "sk-lf-..."
-LANGFUSE_PUBLIC_KEY = "pk-lf-..."
-LANGFUSE_BASE_URL = "${baseUrl}"`;
+  return `LANGFUSE_SECRET_KEY="sk-lf-..."
+LANGFUSE_PUBLIC_KEY="pk-lf-..."
+LANGFUSE_BASE_URL="${baseUrl}"`;
 }


### PR DESCRIPTION


## What does this PR do?

Avoid whitespace around the = operator (eg KEY=VALUE, not KEY = VALUE) to prevent parsing errors, esp in Docker and standard .env parsers

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes whitespace issue around `=` in `useLangfuseEnvCode()` to ensure compatibility with Docker and .env parsers.
> 
>   - **Behavior**:
>     - Removes whitespace around `=` in environment variable strings in `useLangfuseEnvCode()` in `useLangfuseEnvCode.ts`.
>     - Ensures compatibility with Docker and standard .env parsers by using `KEY=VALUE` format.
>   - **Misc**:
>     - Refactor to improve code consistency and prevent parsing errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for a0ed7ad854b05f20c1325ba7c460d950a0315eac. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->