### PR TITLE
fix(prisma): make pending_deletions index migration schema-agnostic

### DIFF
--- a/packages/shared/prisma/migrations/20260203220622_pending_deletions_object_id_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20260203220622_pending_deletions_object_id_idx/migration.sql
@@ -1,5 +1,6 @@
 -- DropIndex
-DROP INDEX "public"."pending_deletions_project_id_object_is_deleted_idx";
+DROP INDEX IF EXISTS "pending_deletions_project_id_object_is_deleted_idx";
 
 -- CreateIndex
-CREATE INDEX "pending_deletions_project_id_object_is_deleted_object_id_id_idx" ON "pending_deletions"("project_id", "object", "is_deleted", "object_id", "id");
+CREATE INDEX IF NOT EXISTS "pending_deletions_project_id_object_is_deleted_object_id_id_idx"
+ON "pending_deletions"("project_id", "object", "is_deleted", "object_id", "id");


### PR DESCRIPTION
## What does this PR do?

Fixes #11946 

This PR makes the `pending_deletions` index migration schema-agnostic.

When running Langfuse with a custom Prisma schema (e.g. `?schema=langfuse`)
on self-hosted PostgreSQL, the following migration fails:

```sql
DROP INDEX "public"."pending_deletions_project_id_object_is_deleted_idx";
```

If the database objects exist in a non-public schema (e.g. langfuse),
PostgreSQL throws error 42704 (index does not exist), which causes:

- Prisma error P3018 (migration failed)
- Prisma error P3009 (failed migration blocks further deploys)

This change:

- Removes the hardcoded "public" schema
- Adds IF EXISTS / IF NOT EXISTS
- Makes the migration idempotent and compatible with custom schemas

This ensures compatibility with:

- Custom Prisma schemas (?schema=...)
- Self-hosted PostgreSQL deployments
- Re-runs of migrations in production environments

Tested with:

- Langfuse 3.112 → 3.152 upgrade
- Self-hosted Postgres (Docker)
- Custom schema: langfuse

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks
 - [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Makes `pending_deletions` index migration schema-agnostic by removing hardcoded schema and adding idempotency checks in `migration.sql`.
> 
>   - **Behavior**:
>     - Makes `pending_deletions` index migration schema-agnostic by removing hardcoded "public" schema in `migration.sql`.
>     - Adds `IF EXISTS` to `DROP INDEX` and `IF NOT EXISTS` to `CREATE INDEX` to handle non-existent indexes gracefully.
>   - **Compatibility**:
>     - Ensures compatibility with custom Prisma schemas and self-hosted PostgreSQL deployments.
>     - Supports re-runs of migrations in production environments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 163c3b00d116e145f125c52f53f45c1212b42362. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->