### PR TITLE
feat(events-table): add bloom filter indexes on user_id and session_id

### DIFF
--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -400,7 +400,8 @@ CREATE TABLE IF NOT EXISTS events_full
       -- Indexes
       INDEX idx_span_id span_id TYPE bloom_filter(0.01) GRANULARITY 1,
       INDEX idx_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1,
-      INDEX idx_type type TYPE set(50) GRANULARITY 1,
+      INDEX idx_user_id user_id TYPE bloom_filter(0.01) GRANULARITY 1,
+      INDEX idx_session_id session_id TYPE bloom_filter(0.01) GRANULARITY 1,
       INDEX idx_created_at created_at TYPE minmax GRANULARITY 1,
       INDEX idx_updated_at updated_at TYPE minmax GRANULARITY 1,
 
@@ -532,7 +533,8 @@ CREATE TABLE IF NOT EXISTS events_core
     -- Indexes
     INDEX idx_span_id span_id TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1,
-    INDEX idx_type type TYPE set(50) GRANULARITY 1,
+    INDEX idx_user_id user_id TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_session_id session_id TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_created_at created_at TYPE minmax GRANULARITY 1,
     INDEX idx_updated_at updated_at TYPE minmax GRANULARITY 1
 )


### PR DESCRIPTION
## Summary
- Add `bloom_filter(0.01)` indexes on `user_id` and `session_id` to `events_core` and `events_full` tables
- Remove `idx_type` set index (type is LowCardinality and rarely filtered without `start_time` which already prunes via primary key)

## Migration commands

Run these on ClickHouse Cloud (ADD INDEX is instant, MATERIALIZE INDEX runs async in the background):

```sql
-- events_core
ALTER TABLE events_core ADD INDEX IF NOT EXISTS idx_user_id user_id TYPE bloom_filter(0.01) GRANULARITY 1;
ALTER TABLE events_core ADD INDEX IF NOT EXISTS idx_session_id session_id TYPE bloom_filter(0.01) GRANULARITY 1;
ALTER TABLE events_core DROP INDEX IF EXISTS idx_type;
ALTER TABLE events_core MATERIALIZE INDEX IF EXISTS idx_user_id;
ALTER TABLE events_core MATERIALIZE INDEX IF EXISTS idx_session_id;

-- events_full
ALTER TABLE events_full ADD INDEX IF NOT EXISTS idx_user_id user_id TYPE bloom_filter(0.01) GRANULARITY 1;
ALTER TABLE events_full ADD INDEX IF NOT EXISTS idx_session_id session_id TYPE bloom_filter(0.01) GRANULARITY 1;
ALTER TABLE events_full DROP INDEX IF EXISTS idx_type;
ALTER TABLE events_full MATERIALIZE INDEX IF EXISTS idx_user_id;
ALTER TABLE events_full MATERIALIZE INDEX IF EXISTS idx_session_id;
```

Monitor materialization progress:
```sql
SELECT * FROM system.mutations WHERE table IN ('events_core', 'events_full') AND is_done = 0;
```

## Notes
- `ADD INDEX` only applies to newly written parts — existing data needs `MATERIALIZE INDEX`
- `MATERIALIZE INDEX` is non-blocking (reads/writes continue), but rewrites all parts, so consider running during low-traffic window
- `IF NOT EXISTS` / `IF EXISTS` makes all statements idempotent

## Test plan
- [ ] Run `pnpm run ch:dev-tables` locally to verify table creation succeeds
- [ ] Verify queries filtering on `user_id` / `session_id` use the new indexes via `EXPLAIN indexes=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add bloom filter indexes on `user_id` and `session_id` to `events_core` and `events_full` tables, and remove unused `idx_type` index.
> 
>   - **Indexes**:
>     - Add `bloom_filter(0.01)` indexes on `user_id` and `session_id` in `events_core` and `events_full` tables.
>     - Remove `idx_type` set index from `events_core` and `events_full` tables.
>   - **Migration**:
>     - Provide SQL commands for adding and materializing indexes on ClickHouse Cloud.
>     - Explain `ADD INDEX` and `MATERIALIZE INDEX` behavior and usage.
>   - **Testing**:
>     - Verify table creation with `pnpm run ch:dev-tables`.
>     - Check index usage in queries with `EXPLAIN indexes=1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 69e9ad0969929392679c79f8dc6896a7b20955f5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->