### PR TITLE
feat(events-table): add EventsSessionAggregationQueryBuilder for single-step session aggregation

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -1054,6 +1054,150 @@ export class EventsAggregationQueryBuilder extends BaseEventsQueryBuilder<
 }
 
 /**
+ * ClickHouse row type for session-level metrics queries from the events table.
+ * Matches the columns produced by EVENTS_SESSION_AGGREGATION_FIELDS below.
+ */
+export type SessionEventsMetricsRow = {
+  session_id: string;
+  max_timestamp: string;
+  min_timestamp: string;
+  trace_ids: string[];
+  user_ids: string[];
+  trace_count: number;
+  trace_tags: string[];
+  environment?: string;
+  total_observations: number;
+  duration: number;
+  session_usage_details: Record<string, number>;
+  session_cost_details: Record<string, number>;
+  session_input_cost: string;
+  session_output_cost: string;
+  session_total_cost: string;
+  session_input_usage: string;
+  session_output_usage: string;
+  session_total_usage: string;
+};
+
+/**
+ * Aggregation fields for session-level queries.
+ * These fields use ClickHouse aggregation functions and require GROUP BY session_id.
+ */
+const EVENTS_SESSION_AGGREGATION_FIELDS = {
+  session_id: "session_id",
+  max_timestamp: "max(start_time) AS max_timestamp",
+  min_timestamp: "min(start_time) AS min_timestamp",
+  trace_ids: "groupUniqArray(trace_id) AS trace_ids",
+  user_ids:
+    "groupUniqArrayIf(user_id, user_id IS NOT NULL AND user_id != '') AS user_ids",
+  trace_count: "uniq(trace_id) AS trace_count",
+  trace_tags: "groupUniqArrayArrayIf(tags, notEmpty(tags)) AS trace_tags",
+  environment:
+    "argMaxIf(environment, event_ts, environment <> '') AS environment",
+  total_observations:
+    "uniqIf(span_id, parent_span_id != '') AS total_observations",
+  duration:
+    "date_diff('second', min(start_time), max(if(isNull(end_time), start_time, end_time))) AS duration",
+  session_usage_details: "sumMap(usage_details) AS session_usage_details",
+  session_cost_details: "sumMap(cost_details) AS session_cost_details",
+  session_input_cost:
+    "arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'input') > 0, sumMap(cost_details)))) AS session_input_cost",
+  session_output_cost:
+    "arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'output') > 0, sumMap(cost_details)))) AS session_output_cost",
+  session_total_cost: "sumMap(cost_details)['total'] AS session_total_cost",
+  session_input_usage:
+    "arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'input') > 0, sumMap(usage_details)))) AS session_input_usage",
+  session_output_usage:
+    "arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'output') > 0, sumMap(usage_details)))) AS session_output_usage",
+  session_total_usage: "sumMap(usage_details)['total'] AS session_total_usage",
+} as const;
+
+/**
+ * Field sets for session aggregation queries
+ */
+const SESSION_AGGREGATION_FIELD_SETS = {
+  all: Object.keys(EVENTS_SESSION_AGGREGATION_FIELDS) as Array<
+    keyof typeof EVENTS_SESSION_AGGREGATION_FIELDS
+  >,
+} as const;
+
+/**
+ * EventsSessionAggregationQueryBuilder - A fluent query builder for session-level
+ * aggregated events table queries.
+ *
+ * This builder aggregates events directly by session_id in a single step,
+ * avoiding the two-step trace→session aggregation.
+ *
+ * @example
+ * const builder = new EventsSessionAggregationQueryBuilder({ projectId: "my-project-id" })
+ *   .selectFieldSet("all")
+ *   .withSessionIds(["session-1", "session-2"])
+ *   .withStartTimeFrom(startTimeFrom);
+ *
+ * const { query, params } = builder.buildWithParams();
+ */
+export class EventsSessionAggregationQueryBuilder extends BaseEventsQueryBuilder<
+  typeof EVENTS_SESSION_AGGREGATION_FIELDS
+> {
+  constructor(options: { projectId: string }) {
+    super(EVENTS_SESSION_AGGREGATION_FIELDS, options);
+  }
+
+  /**
+   * Add SELECT fields from predefined session aggregation field sets
+   */
+  selectFieldSet(
+    ...setNames: Array<keyof typeof SESSION_AGGREGATION_FIELD_SETS>
+  ): this {
+    setNames
+      .flatMap((s) => SESSION_AGGREGATION_FIELD_SETS[s])
+      .forEach((field) => this.selectFields.add(field));
+    return this;
+  }
+
+  /**
+   * Add session ID filter
+   */
+  withSessionIds(sessionIds?: string[]): this {
+    return this.when(Boolean(sessionIds && sessionIds.length > 0), (b) =>
+      b.whereRaw("session_id IN ({sessionIds: Array(String)})", { sessionIds }),
+    );
+  }
+
+  /**
+   * Add start time filter with OBSERVATIONS_TO_TRACE_INTERVAL
+   */
+  withStartTimeFrom(startTimeFrom?: string | null): this {
+    return this.when(Boolean(startTimeFrom), (b) =>
+      b.whereRaw(
+        `start_time >= {startTimeFrom: DateTime64(3)} - ${OBSERVATIONS_TO_TRACE_INTERVAL}`,
+        { startTimeFrom },
+      ),
+    );
+  }
+
+  /**
+   * Build the SELECT clause for session aggregation queries
+   */
+  protected buildSelectClause(): string {
+    const fieldExpressions = [...this.selectFields]
+      .map((key) => {
+        return this.fields[
+          key as keyof typeof EVENTS_SESSION_AGGREGATION_FIELDS
+        ];
+      })
+      .filter(Boolean);
+    return `SELECT\n  ${fieldExpressions.join(",\n  ")}`;
+  }
+
+  /**
+   * Build the GROUP BY clause for session aggregations
+   */
+  protected buildGroupByClause(): string {
+    return "GROUP BY session_id";
+  }
+}
+
+/**
  * Query builder that composes CTEs with type-safe CTE name tracking.
  *
  * Generic type parameters:

--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -1195,6 +1195,17 @@ export class EventsSessionAggregationQueryBuilder extends BaseEventsQueryBuilder
   protected buildGroupByClause(): string {
     return "GROUP BY session_id";
   }
+
+  /**
+   * Build with schema for use in CTEQueryBuilder.
+   * Returns query, params, and list of column names this CTE exposes.
+   */
+  buildWithSchema(): CTEWithSchema {
+    return {
+      ...this.buildWithParams(),
+      schema: [...this.selectFields],
+    };
+  }
 }
 
 /**

--- a/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
@@ -5,6 +5,7 @@
 import {
   EventsAggregationQueryBuilder,
   EventsSessionAggregationQueryBuilder,
+  type CTEWithSchema,
 } from "./event-query-builder";
 
 interface EventsTracesAggregationParams {
@@ -205,4 +206,60 @@ export const eventsSessionsAggregation = (params: {
     .withSessionIds(params.sessionIds)
     .withStartTimeFrom(params.startTimeFrom)
     .whereRaw("session_id != ''");
+};
+
+/**
+ * Session-level scores aggregation CTE.
+ * Groups scores by (project_id, session_id), computing numeric/boolean averages
+ * and categorical value lists.
+ *
+ * Returns a query and params object suitable for CTEQueryBuilder.withCTE().
+ */
+export const eventsSessionScoresAggregation = (params: {
+  projectId: string;
+}): CTEWithSchema => {
+  const query = `
+    SELECT
+      project_id,
+      session_id AS score_session_id,
+      groupArrayIf(
+        tuple(name, avg_value),
+        data_type IN ('NUMERIC', 'BOOLEAN')
+      ) AS scores_avg,
+      groupArrayIf(
+        concat(name, ':', string_value),
+        data_type = 'CATEGORICAL' AND notEmpty(string_value)
+      ) AS score_categories
+    FROM (
+      SELECT
+        project_id,
+        session_id,
+        name,
+        data_type,
+        string_value,
+        avg(value) avg_value
+      FROM scores s FINAL
+      WHERE
+        project_id = {projectId: String}
+      GROUP BY
+        project_id,
+        session_id,
+        name,
+        data_type,
+        string_value
+    ) tmp
+    GROUP BY
+      project_id, session_id
+  `.trim();
+
+  return {
+    query,
+    params: { projectId: params.projectId },
+    schema: [
+      "project_id",
+      "score_session_id",
+      "scores_avg",
+      "score_categories",
+    ],
+  };
 };

--- a/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
@@ -2,7 +2,10 @@
  * Reusable ClickHouse query fragments and CTEs
  */
 
-import { EventsAggregationQueryBuilder } from "./event-query-builder";
+import {
+  EventsAggregationQueryBuilder,
+  EventsSessionAggregationQueryBuilder,
+} from "./event-query-builder";
 
 interface EventsTracesAggregationParams {
   projectId: string;
@@ -181,4 +184,25 @@ export const eventsTracesScoresAggregation = (
   `.trim();
 
   return { query, params: queryParams };
+};
+
+/**
+ * Aggregates events directly by session_id in a single step.
+ * Mirrors eventsTracesAggregation but groups by session_id instead of trace_id.
+ *
+ * Use this for session-level queries instead of the two-step
+ * eventsTracesAggregation → re-aggregate by session_id approach.
+ */
+export const eventsSessionsAggregation = (params: {
+  projectId: string;
+  sessionIds?: string[];
+  startTimeFrom?: string | null;
+}): EventsSessionAggregationQueryBuilder => {
+  return new EventsSessionAggregationQueryBuilder({
+    projectId: params.projectId,
+  })
+    .selectFieldSet("all")
+    .withSessionIds(params.sessionIds)
+    .withStartTimeFrom(params.startTimeFrom)
+    .whereRaw("session_id != ''");
 };

--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -46,6 +46,7 @@ export {
 export {
   eventsScoresAggregation,
   eventsSessionsAggregation,
+  eventsSessionScoresAggregation,
   eventsTracesAggregation,
   eventsTracesScoresAggregation,
 } from "./clickhouse-sql/query-fragments";

--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -35,14 +35,17 @@ export {
   CTEQueryBuilder,
   EventsAggQueryBuilder,
   EventsAggregationQueryBuilder,
+  EventsSessionAggregationQueryBuilder,
   EventsQueryBuilder,
   buildEventsFullTableSplitQuery,
   type CTESchema,
   type CTEWithSchema,
+  type SessionEventsMetricsRow,
   type SplitQueryBuilder,
 } from "./clickhouse-sql/event-query-builder";
 export {
   eventsScoresAggregation,
+  eventsSessionsAggregation,
   eventsTracesAggregation,
   eventsTracesScoresAggregation,
 } from "./clickhouse-sql/query-fragments";

--- a/packages/shared/src/server/services/sessions-ui-table-events-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-events-service.ts
@@ -4,6 +4,7 @@ import { FilterState } from "../../types";
 import { convertDateToClickhouseDateTime } from "../clickhouse/client";
 import { measureAndReturn } from "../clickhouse/measureAndReturn";
 import {
+  CTEQueryBuilder,
   DateTimeFilter,
   FilterList,
   StringOptionsFilter,
@@ -12,6 +13,7 @@ import {
 import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
 import {
   eventsSessionsAggregation,
+  eventsSessionScoresAggregation,
   eventsTracesAggregation,
 } from "../queries/clickhouse-sql/query-fragments";
 import { queryClickhouse } from "../repositories";
@@ -166,51 +168,6 @@ const getSessionsTableFromEventsGeneric = async <T>(
   const { select, projectId, filter, orderBy, limit, page, clickhouseConfigs } =
     props;
 
-  let sqlSelect: string;
-  switch (select) {
-    case "count":
-      sqlSelect = "count(s.session_id) as count";
-      break;
-    case "rows":
-      sqlSelect = `
-          s.session_id,
-          s.max_timestamp,
-          s.min_timestamp,
-          s.trace_ids,
-          s.user_ids,
-          s.trace_count,
-          s.trace_tags,
-          s.environment`;
-      break;
-    case "metrics":
-      sqlSelect = `
-        s.session_id,
-        s.max_timestamp,
-        s.min_timestamp,
-        s.trace_ids,
-        s.user_ids,
-        s.trace_count,
-        s.trace_tags,
-        s.environment,
-        s.total_observations,
-        s.duration,
-        s.session_usage_details,
-        s.session_cost_details,
-        s.session_input_cost,
-        s.session_output_cost,
-        s.session_total_cost,
-        s.session_input_usage,
-        s.session_output_usage,
-        s.session_total_usage,
-        sc.scores_avg,
-        sc.score_categories`;
-      break;
-    default: {
-      const exhaustiveCheckDefault: never = select;
-      throw new Error(`Unknown select type: ${exhaustiveCheckDefault}`);
-    }
-  }
-
   const sessionFilters = new FilterList(
     createFilterFromFilterState(filter, sessionCols),
   );
@@ -233,40 +190,7 @@ const getSessionsTableFromEventsGeneric = async <T>(
         c.uiTableName === orderBy?.column || c.uiTableId === orderBy?.column,
     )?.clickhouseTableName === "scores";
 
-  const scoresCte = `scores_agg AS (
-    SELECT
-      project_id,
-      session_id AS score_session_id,
-      groupArrayIf(
-        tuple(name, avg_value),
-        data_type IN ('NUMERIC', 'BOOLEAN')
-      ) AS scores_avg,
-      groupArrayIf(
-        concat(name, ':', string_value),
-        data_type = 'CATEGORICAL' AND notEmpty(string_value)
-      ) AS score_categories
-    FROM (
-      SELECT
-        project_id,
-        session_id,
-        name,
-        data_type,
-        string_value,
-        avg(value) avg_value
-      FROM scores s FINAL
-      WHERE
-        project_id = {projectId: String}
-      GROUP BY
-        project_id,
-        session_id,
-        name,
-        data_type,
-        string_value
-      ) tmp
-    GROUP BY
-      project_id, session_id
-  )`;
-
+  // Build session_data CTE
   const sessionsBuilder = eventsSessionsAggregation({
     projectId,
     sessionIds: sessionIdFilter?.values,
@@ -275,29 +199,92 @@ const getSessionsTableFromEventsGeneric = async <T>(
       : null,
   });
 
-  const sessionsCte = sessionsBuilder.buildWithParams();
+  // Compose query using CTEQueryBuilder
+  let queryBuilder = new CTEQueryBuilder()
+    .withCTEFromBuilder("session_data", sessionsBuilder)
+    .from("session_data", "s");
 
-  const query = `
-        WITH ${select === "metrics" || requiresScoresJoin ? `${scoresCte},` : ""}
-        session_data AS (${sessionsCte.query})
-        SELECT ${sqlSelect}
-        FROM session_data s
-        ${select === "metrics" || requiresScoresJoin ? `LEFT JOIN scores_agg sc ON sc.project_id = {projectId: String} AND sc.score_session_id = s.session_id` : ""}
-        ${sessionsFilterRes.query ? `WHERE ${sessionsFilterRes.query}` : ""}
-        ${orderByToClickhouseSql(orderBy ?? null, sessionCols)}
-        ${limit !== undefined && page !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
-        `;
+  // Conditionally add scores CTE
+  if (select === "metrics" || requiresScoresJoin) {
+    queryBuilder = queryBuilder
+      .withCTE("scores_agg", eventsSessionScoresAggregation({ projectId }))
+      .leftJoin(
+        "scores_agg",
+        "sc",
+        "ON sc.project_id = {projectId: String} AND sc.score_session_id = s.session_id",
+      );
+  }
+
+  // Select fields based on query type
+  switch (select) {
+    case "count":
+      queryBuilder.select("count(s.session_id) as count");
+      break;
+    case "rows":
+      queryBuilder.selectColumns(
+        "s.session_id",
+        "s.max_timestamp",
+        "s.min_timestamp",
+        "s.trace_ids",
+        "s.user_ids",
+        "s.trace_count",
+        "s.trace_tags",
+        "s.environment",
+      );
+      break;
+    case "metrics":
+      queryBuilder
+        .selectColumns(
+          "s.session_id",
+          "s.max_timestamp",
+          "s.min_timestamp",
+          "s.trace_ids",
+          "s.user_ids",
+          "s.trace_count",
+          "s.trace_tags",
+          "s.environment",
+          "s.total_observations",
+          "s.duration",
+          "s.session_usage_details",
+          "s.session_cost_details",
+          "s.session_input_cost",
+          "s.session_output_cost",
+          "s.session_total_cost",
+          "s.session_input_usage",
+          "s.session_output_usage",
+          "s.session_total_usage",
+        )
+        .select("sc.scores_avg", "sc.score_categories");
+      break;
+    default: {
+      const exhaustiveCheckDefault: never = select;
+      throw new Error(`Unknown select type: ${exhaustiveCheckDefault}`);
+    }
+  }
+
+  // Apply filters, ordering, and pagination
+  if (sessionsFilterRes.query) {
+    queryBuilder.whereRaw(sessionsFilterRes.query, sessionsFilterRes.params);
+  }
+
+  const orderBySql = orderByToClickhouseSql(orderBy ?? null, sessionCols);
+  if (orderBySql) {
+    queryBuilder.orderBy(orderBySql);
+  }
+
+  if (limit !== undefined && page !== undefined) {
+    queryBuilder.limit(limit, limit * page);
+  }
+
+  const { query, params } = queryBuilder.buildWithParams();
 
   return measureAndReturn({
     operationName: "getSessionsTableFromEventsGeneric",
     projectId,
     input: {
       params: {
+        ...params,
         projectId,
-        limit: limit,
-        offset: limit && page ? limit * page : 0,
-        ...sessionsCte.params,
-        ...sessionsFilterRes.params,
       },
       tags: {
         ...(props.tags ?? {}),

--- a/packages/shared/src/server/services/sessions-ui-table-events-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-events-service.ts
@@ -3,14 +3,22 @@ import { OrderByState } from "../../interfaces/orderBy";
 import { FilterState } from "../../types";
 import { convertDateToClickhouseDateTime } from "../clickhouse/client";
 import { measureAndReturn } from "../clickhouse/measureAndReturn";
-import { DateTimeFilter, FilterList, orderByToClickhouseSql } from "../queries";
+import {
+  DateTimeFilter,
+  FilterList,
+  StringOptionsFilter,
+  orderByToClickhouseSql,
+} from "../queries";
 import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
-import { eventsTracesAggregation } from "../queries/clickhouse-sql/query-fragments";
+import {
+  eventsSessionsAggregation,
+  eventsTracesAggregation,
+} from "../queries/clickhouse-sql/query-fragments";
 import { queryClickhouse } from "../repositories";
 import { sessionCols } from "../tableMappings/mapSessionTable";
 import { parseClickhouseUTCDateTimeFormat } from "../repositories/clickhouse";
 
-export type SessionEventsDataReturnType = {
+type SessionEventsBaseReturnType = {
   session_id: string;
   max_timestamp: string;
   min_timestamp: string;
@@ -19,22 +27,15 @@ export type SessionEventsDataReturnType = {
   trace_count: number;
   trace_tags: string[];
   environment?: string;
+};
+
+type SessionScoreFields = {
   scores_avg?: Array<Array<[string, number]>>;
   score_categories?: Array<Array<string>>;
 };
 
-export type SessionEventsWithMetricsReturnType = SessionEventsDataReturnType & {
-  total_observations: number;
-  duration: number;
-  session_usage_details: Record<string, number>;
-  session_cost_details: Record<string, number>;
-  session_input_cost: string;
-  session_output_cost: string;
-  session_total_cost: string;
-  session_input_usage: string;
-  session_output_usage: string;
-  session_total_usage: string;
-};
+export type SessionEventsDataReturnType = SessionEventsBaseReturnType &
+  SessionScoreFields;
 
 export type SessionTraceFromEvents = {
   id: string;
@@ -147,35 +148,6 @@ export const getSessionsTableFromEvents = async (props: {
   }));
 };
 
-export const getSessionsWithMetricsFromEvents = async (props: {
-  projectId: string;
-  filter: FilterState;
-  orderBy?: OrderByState;
-  limit?: number;
-  page?: number;
-  clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
-}) => {
-  const rows =
-    await getSessionsTableFromEventsGeneric<SessionEventsWithMetricsReturnType>(
-      {
-        select: "metrics",
-        projectId: props.projectId,
-        filter: props.filter,
-        orderBy: props.orderBy,
-        limit: props.limit,
-        page: props.page,
-        clickhouseConfigs: props.clickhouseConfigs,
-        tags: { kind: "analytic" },
-      },
-    );
-
-  return rows.map((row) => ({
-    ...row,
-    trace_count: Number(row.trace_count),
-    total_observations: Number(row.total_observations),
-  }));
-};
-
 export type FetchSessionsTableFromEventsProps = {
   select: "count" | "rows" | "metrics";
   projectId: string;
@@ -197,41 +169,41 @@ const getSessionsTableFromEventsGeneric = async <T>(
   let sqlSelect: string;
   switch (select) {
     case "count":
-      sqlSelect = "count(session_id) as count";
+      sqlSelect = "count(s.session_id) as count";
       break;
     case "rows":
       sqlSelect = `
-          session_id,
-          max_timestamp,
-          min_timestamp,
-          trace_ids,
-          user_ids,
-          trace_count,
-          trace_tags,
-          environment`;
+          s.session_id,
+          s.max_timestamp,
+          s.min_timestamp,
+          s.trace_ids,
+          s.user_ids,
+          s.trace_count,
+          s.trace_tags,
+          s.environment`;
       break;
     case "metrics":
       sqlSelect = `
-        session_id,
-        max_timestamp,
-        min_timestamp,
-        trace_ids,
-        user_ids,
-        trace_count,
-        trace_tags,
-        environment,
-        total_observations,
-        duration,
-        session_usage_details,
-        session_cost_details,
-        session_input_cost,
-        session_output_cost,
-        session_total_cost,
-        session_input_usage,
-        session_output_usage,
-        session_total_usage,
-        scores_avg,
-        score_categories`;
+        s.session_id,
+        s.max_timestamp,
+        s.min_timestamp,
+        s.trace_ids,
+        s.user_ids,
+        s.trace_count,
+        s.trace_tags,
+        s.environment,
+        s.total_observations,
+        s.duration,
+        s.session_usage_details,
+        s.session_cost_details,
+        s.session_input_cost,
+        s.session_output_cost,
+        s.session_total_cost,
+        s.session_input_usage,
+        s.session_output_usage,
+        s.session_total_usage,
+        sc.scores_avg,
+        sc.score_categories`;
       break;
     default: {
       const exhaustiveCheckDefault: never = select;
@@ -250,6 +222,10 @@ const getSessionsTableFromEventsGeneric = async <T>(
       (f.operator === ">=" || f.operator === ">"),
   ) as DateTimeFilter | undefined;
 
+  const sessionIdFilter = sessionFilters.find(
+    (f) => f instanceof StringOptionsFilter && f.field === "session_id",
+  ) as StringOptionsFilter | undefined;
+
   const requiresScoresJoin =
     sessionFilters.some((f) => f.clickhouseTable === "scores") ||
     sessionCols.find(
@@ -257,44 +233,14 @@ const getSessionsTableFromEventsGeneric = async <T>(
         c.uiTableName === orderBy?.column || c.uiTableId === orderBy?.column,
     )?.clickhouseTableName === "scores";
 
-  const hasMetricsFilter =
-    sessionFilters.some((f) =>
-      [
-        "session_total_cost",
-        "session_input_cost",
-        "session_output_cost",
-        "duration",
-        "session_total_usage",
-        "session_output_usage",
-        "session_input_usage",
-        "scores_avg",
-        "score_categories",
-      ].includes(f.field),
-    ) ||
-    (orderBy &&
-      [
-        "totalCost",
-        "inputCost",
-        "outputCost",
-        "sessionDuration",
-        "totalTokens",
-        "outputTokens",
-        "inputTokens",
-        "usage",
-      ].includes(orderBy?.column));
-
-  const selectMetrics = select === "metrics" || hasMetricsFilter;
-
   const scoresCte = `scores_agg AS (
     SELECT
       project_id,
       session_id AS score_session_id,
-      -- For numeric scores, use tuples of (name, avg_value)
       groupArrayIf(
         tuple(name, avg_value),
         data_type IN ('NUMERIC', 'BOOLEAN')
       ) AS scores_avg,
-      -- For categorical scores, use name:value format for improved query performance
       groupArrayIf(
         concat(name, ':', string_value),
         data_type = 'CATEGORICAL' AND notEmpty(string_value)
@@ -321,64 +267,22 @@ const getSessionsTableFromEventsGeneric = async <T>(
       project_id, session_id
   )`;
 
-  const tracesBuilder = eventsTracesAggregation({
+  const sessionsBuilder = eventsSessionsAggregation({
     projectId,
+    sessionIds: sessionIdFilter?.values,
     startTimeFrom: traceTimestampFilter
       ? convertDateToClickhouseDateTime(traceTimestampFilter.value)
       : null,
   });
 
-  const tracesCte = tracesBuilder.buildWithParams();
+  const sessionsCte = sessionsBuilder.buildWithParams();
 
   const query = `
         WITH ${select === "metrics" || requiresScoresJoin ? `${scoresCte},` : ""}
-        traces AS (${tracesCte.query}),
-        session_data AS (
-            SELECT
-                t.session_id as session_id,
-                anyLast(t.project_id) as project_id,
-                max(t.timestamp) as max_timestamp,
-                min(t.timestamp) as min_timestamp,
-                groupArray(t.id) AS trace_ids,
-                groupUniqArrayIf(t.user_id, t.user_id IS NOT NULL AND t.user_id != '') AS user_ids,
-                count(*) as trace_count,
-                groupUniqArrayArray(t.tags) as trace_tags,
-                anyLast(t.environment) as environment
-                -- Aggregate observations data at session level
-                ${
-                  selectMetrics
-                    ? `,
-                      sum(length(t.observation_ids)) as total_observations,
-                      date_diff(
-                        'second',
-                        min(t.timestamp),
-                        max(t.timestamp + toIntervalMillisecond(ifNull(t.latency_milliseconds, 0)))
-                      ) as duration,
-                      sumMap(t.usage_details) as session_usage_details,
-                      sumMap(t.cost_details) as session_cost_details,
-                      ${
-                        select === "metrics" || requiresScoresJoin
-                          ? `groupUniqArrayArray(s.scores_avg) as scores_avg,
-                      groupUniqArrayArray(s.score_categories) as score_categories,`
-                          : ""
-                      }
-                      arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'input') > 0, sumMap(t.cost_details)))) as session_input_cost,
-                      arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'output') > 0, sumMap(t.cost_details)))) as session_output_cost,
-                      sumMap(t.cost_details)['total'] as session_total_cost,
-                      arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'input') > 0, sumMap(t.usage_details)))) as session_input_usage,
-                      arraySum(mapValues(mapFilter(x -> positionCaseInsensitive(x.1, 'output') > 0, sumMap(t.usage_details)))) as session_output_usage,
-                      sumMap(t.usage_details)['total'] as session_total_usage`
-                    : ""
-                }
-            FROM traces t
-           ${select === "metrics" || requiresScoresJoin ? `LEFT JOIN scores_agg s on s.project_id = t.project_id and t.session_id = s.score_session_id` : ""}
-            WHERE t.session_id IS NOT NULL
-                AND t.session_id != ''
-                AND t.project_id = {projectId: String}
-            GROUP BY t.session_id
-        )
+        session_data AS (${sessionsCte.query})
         SELECT ${sqlSelect}
         FROM session_data s
+        ${select === "metrics" || requiresScoresJoin ? `LEFT JOIN scores_agg sc ON sc.project_id = {projectId: String} AND sc.score_session_id = s.session_id` : ""}
         ${sessionsFilterRes.query ? `WHERE ${sessionsFilterRes.query}` : ""}
         ${orderByToClickhouseSql(orderBy ?? null, sessionCols)}
         ${limit !== undefined && page !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
@@ -392,7 +296,7 @@ const getSessionsTableFromEventsGeneric = async <T>(
         projectId,
         limit: limit,
         offset: limit && page ? limit * page : 0,
-        ...tracesCte.params,
+        ...sessionsCte.params,
         ...sessionsFilterRes.params,
       },
       tags: {

--- a/web/src/__tests__/async/sessions-ui-table.servertest.ts
+++ b/web/src/__tests__/async/sessions-ui-table.servertest.ts
@@ -8,9 +8,163 @@ import {
   createSessionScore,
   createTracesCh,
   getSessionsWithMetrics,
+  getSessionMetricsFromEvents,
+  getSessionsTable,
+  getSessionsTableFromEvents,
+  createEvent,
+  createEventsCh,
+  type TraceRecordInsertType,
+  type ObservationRecordInsertType,
+  type EventRecordInsertType,
 } from "@langfuse/shared/src/server";
-import { createTrace, getSessionsTable } from "@langfuse/shared/src/server";
+import { createTrace } from "@langfuse/shared/src/server";
 import { type FilterState } from "@langfuse/shared";
+import { env } from "@/src/env.mjs";
+
+const isEventsPath = env.LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS === "true";
+
+// Pick the right listing function based on env flag
+const sessionsTable = isEventsPath
+  ? getSessionsTableFromEvents
+  : getSessionsTable;
+
+// Adapter for metrics: legacy takes filter/orderBy, events-based takes sessionIds
+async function sessionsWithMetrics(props: {
+  projectId: string;
+  filter: FilterState;
+}) {
+  if (!isEventsPath) {
+    return getSessionsWithMetrics(props);
+  }
+  const idFilter = props.filter.find(
+    (f): f is Extract<FilterState[number], { column: "id" }> =>
+      f.column === "id",
+  );
+  const sessionIds =
+    idFilter && "value" in idFilter ? (idFilter.value as string[]) : [];
+  return getSessionMetricsFromEvents({
+    projectId: props.projectId,
+    sessionIds,
+  });
+}
+
+/**
+ * Derive v2 events from v1 traces + observations.
+ * Reused from dashboard-v1-v2-consistency.servertest.ts.
+ *
+ * One root event per trace (parent_span_id = ''), plus one event per
+ * observation with trace-level fields denormalized.
+ * Timestamps are converted from ms to µs (* 1000).
+ */
+function buildMatchingEvents(
+  traces: TraceRecordInsertType[],
+  observations: ObservationRecordInsertType[],
+): EventRecordInsertType[] {
+  const traceMap = new Map(traces.map((t) => [t.id, t]));
+  const events: EventRecordInsertType[] = [];
+
+  // Root events — one per trace.
+  for (const t of traces) {
+    events.push(
+      createEvent({
+        id: `t-${t.id}`,
+        span_id: `t-${t.id}`,
+        trace_id: t.id,
+        project_id: t.project_id,
+        parent_span_id: "",
+        name: t.name ?? "",
+        type: "SPAN",
+        environment: t.environment,
+        trace_name: t.name ?? "",
+        user_id: t.user_id ?? "",
+        session_id: t.session_id ?? null,
+        tags: t.tags ?? [],
+        release: t.release ?? null,
+        version: t.version ?? null,
+        public: t.public,
+        bookmarked: t.bookmarked,
+        input: t.input ?? null,
+        output: t.output ?? null,
+        metadata: t.metadata ?? {},
+        start_time: t.timestamp * 1000,
+        end_time: null,
+        cost_details: {},
+        provided_cost_details: {},
+        usage_details: {},
+        provided_usage_details: {},
+        created_at: t.created_at * 1000,
+        updated_at: t.updated_at * 1000,
+        event_ts: t.event_ts * 1000,
+      }),
+    );
+  }
+
+  // Observation events.
+  for (const o of observations) {
+    const traceId = o.trace_id!;
+    const t = traceMap.get(traceId)!;
+    events.push(
+      createEvent({
+        id: o.id,
+        span_id: o.id,
+        trace_id: traceId,
+        project_id: o.project_id,
+        parent_span_id: o.parent_observation_id ?? `t-${traceId}`,
+        name: o.name ?? "",
+        type: o.type as string,
+        environment: o.environment,
+        trace_name: t.name ?? "",
+        user_id: t.user_id ?? "",
+        session_id: t.session_id ?? undefined,
+        tags: t.tags ?? [],
+        release: t.release ?? null,
+        version: o.version ?? null,
+        level: o.level ?? "DEFAULT",
+        status_message: o.status_message ?? null,
+        provided_model_name: o.provided_model_name ?? null,
+        model_parameters: o.model_parameters ?? "{}",
+        input: o.input ?? null,
+        output: o.output ?? null,
+        metadata: { ...(t.metadata ?? {}), ...(o.metadata ?? {}) },
+        provided_usage_details: o.provided_usage_details ?? {},
+        usage_details: o.usage_details ?? {},
+        provided_cost_details: o.provided_cost_details ?? {},
+        cost_details: o.cost_details ?? {},
+        prompt_id: o.prompt_id ?? null,
+        prompt_name: o.prompt_name ?? null,
+        prompt_version: o.prompt_version ? String(o.prompt_version) : null,
+        tool_definitions: o.tool_definitions ?? {},
+        tool_calls: o.tool_calls ?? [],
+        tool_call_names: o.tool_call_names ?? [],
+        start_time: o.start_time * 1000,
+        end_time: o.end_time ? o.end_time * 1000 : null,
+        completion_start_time: o.completion_start_time
+          ? o.completion_start_time * 1000
+          : null,
+        created_at: o.created_at * 1000,
+        updated_at: o.updated_at * 1000,
+        event_ts: o.event_ts * 1000,
+      }),
+    );
+  }
+
+  return events;
+}
+
+/**
+ * Seed both legacy tables (traces + observations) and events table.
+ * This ensures the same test data is available for both code paths.
+ */
+async function seedSessionData(
+  traces: TraceRecordInsertType[],
+  observations?: ObservationRecordInsertType[],
+) {
+  await createTracesCh(traces);
+  if (observations?.length) await createObservationsCh(observations);
+
+  const events = buildMatchingEvents(traces, observations ?? []);
+  await createEventsCh(events);
+}
 
 describe("trpc.sessions", () => {
   describe("GET sessions.all", () => {
@@ -30,9 +184,9 @@ describe("trpc.sessions", () => {
         createTrace({ session_id: sessionId, project_id: projectId }),
       ];
 
-      await createTracesCh(traces);
+      await seedSessionData(traces);
 
-      const uiSessions = await getSessionsTable({
+      const uiSessions = await sessionsTable({
         projectId: projectId,
         filter: [],
         orderBy: null,
@@ -71,9 +225,9 @@ describe("trpc.sessions", () => {
       }),
     ];
 
-    await createTracesCh(traces);
+    await seedSessionData(traces);
 
-    const uiSessions = await getSessionsTable({
+    const uiSessions = await sessionsTable({
       projectId: projectId,
       filter: [
         {
@@ -147,10 +301,9 @@ describe("trpc.sessions", () => {
       }),
     ];
 
-    await createTracesCh(traces);
-    await createObservationsCh(observations);
+    await seedSessionData(traces, observations);
 
-    const uiSessions = await getSessionsTable({
+    const uiSessions = await sessionsTable({
       projectId: projectId,
       filter: [],
       orderBy: {
@@ -188,10 +341,12 @@ describe("trpc.sessions", () => {
       createTrace({
         session_id: sessionId1,
         project_id: projectId,
+        timestamp: new Date("2024-01-01T00:00:00Z").getTime(),
       }),
       createTrace({
         session_id: sessionId2,
         project_id: projectId,
+        timestamp: new Date("2024-01-01T00:00:00Z").getTime(),
       }),
     ];
     const observations = [
@@ -209,10 +364,9 @@ describe("trpc.sessions", () => {
       }),
     ];
 
-    await createTracesCh(traces);
-    await createObservationsCh(observations);
+    await seedSessionData(traces, observations);
 
-    const uiSessions = await getSessionsTable({
+    const uiSessions = await sessionsTable({
       projectId: projectId,
       filter: [],
       orderBy: {
@@ -275,11 +429,9 @@ describe("trpc.sessions", () => {
       }),
     ]);
 
-    await createObservationsCh(observations);
+    await seedSessionData(traces, observations);
 
-    await createTracesCh(traces);
-
-    const sessions = await getSessionsWithMetrics({
+    const sessions = await sessionsWithMetrics({
       projectId: projectId,
       filter: [
         {
@@ -352,8 +504,6 @@ describe("trpc.sessions", () => {
       }),
     ];
 
-    await createTracesCh(traces);
-
     // Only trace 2 has observations
     const observations = [
       createObservation({
@@ -368,9 +518,9 @@ describe("trpc.sessions", () => {
       }),
     ];
 
-    await createObservationsCh(observations);
+    await seedSessionData(traces, observations);
 
-    const sessions = await getSessionsWithMetrics({
+    const sessions = await sessionsWithMetrics({
       projectId: projectId,
       filter: [
         {
@@ -388,6 +538,7 @@ describe("trpc.sessions", () => {
     expect(sessions[0]?.trace_count).toBe(2);
     expect(parseInt(sessions[0]?.duration as any)).toBe(1);
   });
+
   it("should GET correct session data with filters", async () => {
     const project_id = v4();
     const trace_id_with_score = v4();
@@ -415,7 +566,7 @@ describe("trpc.sessions", () => {
       project_id,
       session_id: session_id_without_score,
     });
-    await createTracesCh([trace_with_score, trace_without_score]);
+    await seedSessionData([trace_with_score, trace_without_score]);
 
     const score = createSessionScore({
       project_id,
@@ -426,7 +577,7 @@ describe("trpc.sessions", () => {
     });
     await createScoresCh([score]);
 
-    const tableRows = await getSessionsTable({
+    const tableRows = await sessionsTable({
       projectId: project_id,
       filter: filterState,
       limit: 10,

--- a/web/src/__tests__/async/sessions-ui-table.servertest.ts
+++ b/web/src/__tests__/async/sessions-ui-table.servertest.ts
@@ -162,8 +162,10 @@ async function seedSessionData(
   await createTracesCh(traces);
   if (observations?.length) await createObservationsCh(observations);
 
-  const events = buildMatchingEvents(traces, observations ?? []);
-  await createEventsCh(events);
+  if (isEventsPath) {
+    const events = buildMatchingEvents(traces, observations ?? []);
+    await createEventsCh(events);
+  }
 }
 
 describe("trpc.sessions", () => {

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -340,6 +340,7 @@ export default function SessionsTable({
     {
       projectId,
       sessionIds: sessionsV4.data?.sessions.map((s) => s.id) ?? [],
+      queryFromTimestamp: dateRange?.from ?? null,
     },
     {
       enabled: sessionsV4.data !== undefined && isBetaEnabled,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduce `EventsSessionAggregationQueryBuilder` for efficient session-level event aggregation, updating services, API, and tests to utilize the new method.
> 
>   - **Query Builder**:
>     - Add `EventsSessionAggregationQueryBuilder` in `event-query-builder.ts` for session-level aggregation.
>     - Define `EVENTS_SESSION_AGGREGATION_FIELDS` and `SESSION_AGGREGATION_FIELD_SETS` for session queries.
>   - **Query Fragments**:
>     - Add `eventsSessionsAggregation` and `eventsSessionScoresAggregation` in `query-fragments.ts` for session-level queries.
>   - **Repositories**:
>     - Implement `getSessionMetricsFromEvents` in `events.ts` to fetch session metrics using the new builder.
>   - **Services**:
>     - Update `sessions-ui-table-events-service.ts` to use `eventsSessionsAggregation` for session data retrieval.
>   - **API**:
>     - Modify `sessions.ts` to include new endpoints `allFromEvents`, `countAllFromEvents`, and `metricsFromEvents` using the new aggregation method.
>   - **Tests**:
>     - Update `sessions-ui-table.servertest.ts` to test session retrieval and metrics using the new aggregation method.
>   - **UI**:
>     - Update `sessions.tsx` to handle session data and metrics using the new API endpoints.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 559f68e2f3f4b86ee8058794f603ab24a4277f34. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->