### PR TITLE
fix(evals): coerce to number when streaming usage details from CH events table

### DIFF
--- a/packages/shared/src/features/evals/observationForEval.ts
+++ b/packages/shared/src/features/evals/observationForEval.ts
@@ -6,7 +6,10 @@ import { SingleValueOption } from "../../tableDefinitions";
 import { ColumnDefinition } from "../../tableDefinitions";
 import { formatColumnOptions } from "../../tableDefinitions/typeHelpers";
 
-const flexibleUsageCostSchema = z.record(z.string(), z.number().nullable());
+const flexibleUsageCostSchema = z.record(
+  z.string(),
+  z.coerce.number().nullable(),
+);
 
 export const observationForEvalSchema = z.object({
   // Identifiers


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `flexibleUsageCostSchema` in `observationForEval.ts` to coerce values to numbers for streaming usage details.
> 
>   - **Schema Update**:
>     - In `observationForEval.ts`, update `flexibleUsageCostSchema` to use `z.coerce.number().nullable()` to coerce values to numbers.
>   - **Behavior**:
>     - Ensures usage details are coerced to numbers when streaming from ClickHouse events table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0e60e8418951ad6cb6d99b2a079c0c50de04449e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->