### PR TITLE
chore(preview-data): adjust usePreviewData to read from event batch IO for v4

### DIFF
--- a/packages/shared/src/server/tableMappings/mapObservationsTable.ts
+++ b/packages/shared/src/server/tableMappings/mapObservationsTable.ts
@@ -17,6 +17,12 @@ export const observationsTableTraceUiColumnDefinitions: UiColumnMappings = [
     clickhouseSelect: 't."user_id"',
   },
   {
+    uiTableName: "Session ID",
+    uiTableId: "sessionId",
+    clickhouseTableName: "traces",
+    clickhouseSelect: 't."session_id"',
+  },
+  {
     uiTableName: "Trace Name",
     uiTableId: "traceName",
     clickhouseTableName: "traces",

--- a/web/src/features/evals/hooks/usePreviewData.ts
+++ b/web/src/features/evals/hooks/usePreviewData.ts
@@ -1,6 +1,6 @@
 import { type EvalFormType } from "@/src/features/evals/utils/evaluator-form-utils";
 import { api, type RouterOutputs } from "@/src/utils/api";
-import { EvalTargetObject } from "@langfuse/shared";
+import { EvalTargetObject, FilterState } from "@langfuse/shared";
 import { type UseFormReturn } from "react-hook-form";
 import { isEventTarget } from "@/src/features/evals/utils/typeHelpers";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
@@ -20,6 +20,20 @@ export type PreviewData =
         | RouterOutputs["events"]["batchIO"][number]
         | undefined;
     };
+
+// Temporary workaround to make filter backwards compatible with generations table
+const transformFilterForGenerations = (filter: FilterState | null) => {
+  if (!filter) return [];
+  return filter.map((f) => {
+    if (f.column === "tags") {
+      return {
+        ...f,
+        column: "traceTags",
+      };
+    }
+    return f;
+  });
+};
 
 export function usePreviewData(
   projectId: string,
@@ -65,7 +79,7 @@ export function usePreviewData(
   const latestObservation = api.generations.all.useQuery(
     {
       projectId,
-      filter: form.watch("filter") ?? [],
+      filter: transformFilterForGenerations(form.watch("filter")) ?? [],
       searchQuery: "",
       searchType: [],
       limit: 1,

--- a/web/src/features/evals/hooks/usePreviewData.ts
+++ b/web/src/features/evals/hooks/usePreviewData.ts
@@ -15,7 +15,10 @@ export type PreviewData =
       type: typeof EvalTargetObject.EVENT;
       traceId: string;
       observationId: string;
-      data: RouterOutputs["observations"]["byId"];
+      data:
+        | RouterOutputs["observations"]["byId"]
+        | RouterOutputs["events"]["batchIO"][number]
+        | undefined;
     };
 
 export function usePreviewData(
@@ -106,6 +109,12 @@ export function usePreviewData(
       ? latestObservationBeta.data?.observations[0]?.id
       : latestObservation.data?.generations[0]?.id;
 
+  const latestObservationStartTime =
+    latestObservationBeta.data?.observations[0]?.startTime ??
+    new Date(Date.now() - 2 * 60 * 60 * 1000);
+  const latestObservationEndTime =
+    latestObservationBeta.data?.observations[0]?.endTime ?? new Date();
+
   // For event evals: fetch only the single observation
   const observationDetails = api.observations.byId.useQuery(
     {
@@ -119,19 +128,47 @@ export function usePreviewData(
         enabled &&
         !!latestObservationTraceId &&
         !!latestObservationObservationId &&
-        isEventEval,
+        isEventEval &&
+        !isBetaEnabled,
+    },
+  );
+
+  const observationDetailsBeta = api.events.batchIO.useQuery(
+    {
+      projectId,
+      observations: [
+        {
+          id: latestObservationObservationId as string,
+          traceId: latestObservationTraceId as string,
+        },
+      ],
+      minStartTime: latestObservationStartTime,
+      maxStartTime: latestObservationEndTime,
+      truncated: false,
+    },
+    {
+      enabled:
+        enabled &&
+        !!latestObservationTraceId &&
+        !!latestObservationObservationId &&
+        isEventEval &&
+        isBetaEnabled,
     },
   );
 
   const previewData: PreviewData | null = isEventEval
-    ? observationDetails.data &&
+    ? (isBetaEnabled
+        ? observationDetailsBeta.data?.[0]
+        : observationDetails.data) &&
       latestObservationTraceId &&
       latestObservationObservationId
       ? {
           type: EvalTargetObject.EVENT,
           traceId: latestObservationTraceId,
           observationId: latestObservationObservationId,
-          data: observationDetails.data,
+          data: isBetaEnabled
+            ? observationDetailsBeta.data?.[0]
+            : observationDetails.data,
         }
       : null
     : traceDetails.data && actualTraceId
@@ -145,7 +182,9 @@ export function usePreviewData(
   const isLoading =
     latestTrace.isLoading ||
     traceDetails.isLoading ||
-    observationDetails.isLoading;
+    (isBetaEnabled
+      ? observationDetailsBeta.isLoading
+      : observationDetails.isLoading);
 
   return {
     previewData,

--- a/web/src/features/evals/hooks/usePreviewData.ts
+++ b/web/src/features/evals/hooks/usePreviewData.ts
@@ -1,6 +1,6 @@
 import { type EvalFormType } from "@/src/features/evals/utils/evaluator-form-utils";
 import { api, type RouterOutputs } from "@/src/utils/api";
-import { EvalTargetObject, FilterState } from "@langfuse/shared";
+import { EvalTargetObject, type FilterState } from "@langfuse/shared";
 import { type UseFormReturn } from "react-hook-form";
 import { isEventTarget } from "@/src/features/evals/utils/typeHelpers";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";

--- a/web/src/features/evals/hooks/usePreviewData.ts
+++ b/web/src/features/evals/hooks/usePreviewData.ts
@@ -124,10 +124,9 @@ export function usePreviewData(
       : latestObservation.data?.generations[0]?.id;
 
   const latestObservationStartTime =
-    latestObservationBeta.data?.observations[0]?.startTime ??
-    new Date(Date.now() - 2 * 60 * 60 * 1000);
+    latestObservationBeta.data?.observations[0]?.startTime;
   const latestObservationEndTime =
-    latestObservationBeta.data?.observations[0]?.endTime ?? new Date();
+    latestObservationBeta.data?.observations[0]?.endTime;
 
   // For event evals: fetch only the single observation
   const observationDetails = api.observations.byId.useQuery(
@@ -156,8 +155,8 @@ export function usePreviewData(
           traceId: latestObservationTraceId as string,
         },
       ],
-      minStartTime: latestObservationStartTime,
-      maxStartTime: latestObservationEndTime,
+      minStartTime: latestObservationStartTime as Date,
+      maxStartTime: latestObservationEndTime as Date,
       truncated: false,
     },
     {
@@ -165,6 +164,8 @@ export function usePreviewData(
         enabled &&
         !!latestObservationTraceId &&
         !!latestObservationObservationId &&
+        !!latestObservationStartTime &&
+        !!latestObservationEndTime &&
         isEventEval &&
         isBetaEnabled,
     },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `usePreviewData` hook updated to support event evaluations using `events.batchIO` for beta feature.
> 
>   - **Behavior**:
>     - `usePreviewData` now reads from `events.batchIO` when `isBetaEnabled` is true, otherwise from `observations.byId`.
>     - Adds handling for `undefined` data in `PreviewData` type.
>   - **API Queries**:
>     - Adds `observationDetailsBeta` using `api.events.batchIO.useQuery` for beta-enabled event evaluations.
>     - Adjusts `observationDetails` to disable when `isBetaEnabled` is true.
>   - **Data Handling**:
>     - Computes `latestObservationStartTime` and `latestObservationEndTime` for beta queries.
>     - Updates `previewData` and `isLoading` logic to accommodate beta feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6f524a1ee96a8cfec0ed90f91a45721ff4efaa63. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->