### PR TITLE
chore: try big gh runners

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -45,7 +45,7 @@ jobs:
               - 'packages/shared/src/server/llm/fetchLLMCompletion.ts'
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: linux_96_core
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
@@ -77,7 +77,7 @@ jobs:
         run: pnpm run lint
 
   prettier-check:
-    runs-on: ubuntu-latest
+    runs-on: linux_96_core
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
@@ -121,7 +121,7 @@ jobs:
 
   test-docker-build:
     timeout-minutes: 20
-    runs-on: ubuntu-latest
+    runs-on: linux_96_core
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
@@ -159,7 +159,7 @@ jobs:
 
   tests-web-sync:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: linux_96_core
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
@@ -254,7 +254,7 @@ jobs:
 
   tests-web-async:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: linux_96_core
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
@@ -364,7 +364,7 @@ jobs:
 
   tests-worker:
     timeout-minutes: 20
-    runs-on: ubuntu-latest
+    runs-on: linux_96_core
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
@@ -441,7 +441,7 @@ jobs:
 
   test-worker-llm-connections:
     timeout-minutes: 20
-    runs-on: ubuntu-latest
+    runs-on: linux_96_core
     needs:
       - pre-job
     if: startsWith(github.ref, 'refs/tags/') || (needs.pre-job.outputs.should_skip != 'true' && (needs.pre-job.outputs.llm_connections_changed == 'true' || github.event_name == 'workflow_dispatch'))
@@ -513,7 +513,7 @@ jobs:
           LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY: ${{ secrets.LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY }}
 
   e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on: linux_96_core
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
@@ -591,7 +591,7 @@ jobs:
         run: pnpm --filter=web run test:e2e
 
   e2e-server-tests:
-    runs-on: ubuntu-latest
+    runs-on: linux_96_core
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -45,7 +45,7 @@ jobs:
               - 'packages/shared/src/server/llm/fetchLLMCompletion.ts'
 
   lint:
-    runs-on: linux_96_core
+    runs-on: booster
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
@@ -77,7 +77,7 @@ jobs:
         run: pnpm run lint
 
   prettier-check:
-    runs-on: linux_96_core
+    runs-on: booster
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
@@ -121,7 +121,7 @@ jobs:
 
   test-docker-build:
     timeout-minutes: 20
-    runs-on: linux_96_core
+    runs-on: booster
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
@@ -159,7 +159,7 @@ jobs:
 
   tests-web-sync:
     timeout-minutes: 30
-    runs-on: linux_96_core
+    runs-on: booster
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
@@ -254,7 +254,7 @@ jobs:
 
   tests-web-async:
     timeout-minutes: 30
-    runs-on: linux_96_core
+    runs-on: booster
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
@@ -364,7 +364,7 @@ jobs:
 
   tests-worker:
     timeout-minutes: 20
-    runs-on: linux_96_core
+    runs-on: booster
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
@@ -441,7 +441,7 @@ jobs:
 
   test-worker-llm-connections:
     timeout-minutes: 20
-    runs-on: linux_96_core
+    runs-on: booster
     needs:
       - pre-job
     if: startsWith(github.ref, 'refs/tags/') || (needs.pre-job.outputs.should_skip != 'true' && (needs.pre-job.outputs.llm_connections_changed == 'true' || github.event_name == 'workflow_dispatch'))
@@ -513,7 +513,7 @@ jobs:
           LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY: ${{ secrets.LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY }}
 
   e2e-tests:
-    runs-on: linux_96_core
+    runs-on: booster
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'
@@ -591,7 +591,7 @@ jobs:
         run: pnpm --filter=web run test:e2e
 
   e2e-server-tests:
-    runs-on: linux_96_core
+    runs-on: booster
     needs:
       - pre-job
     if: needs.pre-job.outputs.should_skip != 'true'

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -2851,6 +2851,56 @@ export const hasAnySessionFromEventsTable = async (
   return rows.length > 0;
 };
 
+/**
+ * Fetch trace metadata (name, user_id, tags) for a list of trace IDs
+ * using the eventsTracesAggregation builder. Used by the scores table
+ * to enrich score rows with trace-level data.
+ */
+export const getTraceMetadataByIdsFromEvents = async (props: {
+  projectId: string;
+  traceIds: string[];
+}) => {
+  if (props.traceIds.length === 0) return [];
+
+  const tracesBuilder = eventsTracesAggregation({
+    projectId: props.projectId,
+    traceIds: props.traceIds,
+    truncated: true,
+  });
+
+  const cteResult = tracesBuilder.buildWithParams();
+
+  const query = `
+    WITH traces AS (${cteResult.query})
+    SELECT id, name, user_id, tags
+    FROM traces
+  `;
+
+  return measureAndReturn({
+    operationName: "getTraceMetadataByIdsFromEvents",
+    projectId: props.projectId,
+    input: {
+      params: cteResult.params,
+      tags: {
+        feature: "tracing",
+        type: "trace-metadata",
+        projectId: props.projectId,
+      },
+    },
+    fn: async (input) =>
+      queryClickhouse<{
+        id: string;
+        name: string;
+        user_id: string;
+        tags: string[];
+      }>({
+        query,
+        params: input.params,
+        tags: input.tags,
+      }),
+  });
+};
+
 export const getAvgCostByEvaluatorIds = async (
   projectId: string,
   evaluatorIds: string[],

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -43,6 +43,7 @@ import { recordDistribution } from "../instrumentation";
 import { prisma } from "../../db";
 import { measureAndReturn } from "../clickhouse/measureAndReturn";
 import { scoresColumnsTableUiColumnDefinitions } from "../tableMappings/mapScoresColumnsTable";
+import { eventsTracesAggregation } from "../queries/clickhouse-sql/query-fragments";
 
 export const searchExistingAnnotationScore = async (
   projectId: string,
@@ -1053,9 +1054,9 @@ const getScoresUiGeneric = async <T>(props: {
 };
 
 /**
- * v4 variant: scores query using events_core instead of traces table.
- * Trace-level filters use IN subqueries against events_core.
- * When sorting by trace columns, adds LEFT ANY JOIN with events_core subquery.
+ * v4 variant: scores query using eventsTracesAggregation CTE instead of
+ * raw events_core SQL. Trace-level filters and sort use a "traces" CTE
+ * built by the event query builder, joined as alias "e".
  * Does NOT select trace metadata (that comes via metricsFromEvents).
  */
 const getScoresUiGenericFromEvents = async <T>(props: {
@@ -1091,58 +1092,47 @@ const getScoresUiGenericFromEvents = async <T>(props: {
     ),
   );
 
-  // Separate trace filters (events_core) from score filters
+  // Separate trace filters (traces CTE) from score filters
   const traceFilters = scoresFilter.filter(
-    (f) => f.clickhouseTable === "events_core",
+    (f) => f.clickhouseTable === "traces",
   );
   const scoreOnlyFilters = scoresFilter.filter(
-    (f) => f.clickhouseTable !== "events_core",
+    (f) => f.clickhouseTable !== "traces",
   );
 
   const scoreOnlyFilterRes = scoreOnlyFilters.apply();
-
-  // Build IN subqueries for trace-level filters
-  const traceFilterSubqueries: string[] = [];
-  const traceFilterParams: Record<string, unknown> = {};
-
-  if (traceFilters.find(() => true)) {
-    const traceFilterRes = traceFilters.apply();
-    if (traceFilterRes.query) {
-      traceFilterSubqueries.push(
-        `s.trace_id IN (
-          SELECT DISTINCT trace_id FROM events_core
-          WHERE project_id = {projectId: String}
-          AND is_deleted = 0
-          AND ${traceFilterRes.query}
-        )`,
-      );
-      Object.assign(traceFilterParams, traceFilterRes.params);
-    }
-  }
+  const traceFilterRes = traceFilters.find(() => true)
+    ? traceFilters.apply()
+    : null;
 
   const orderByColumn = orderBy
     ? scoresTableUiColumnDefinitionsFromEvents.find(
         (c) =>
           (c.uiTableName === orderBy.column ||
             c.uiTableId === orderBy.column) &&
-          c.clickhouseTableName === "events_core",
+          c.clickhouseTableName === "traces",
       )
     : null;
 
-  const needsEventsJoinForSort = !!orderByColumn;
+  const needsTracesCTE = !!traceFilterRes?.query || !!orderByColumn;
 
-  const eventsSubqueryJoin = needsEventsJoinForSort
-    ? `LEFT ANY JOIN (
-        SELECT
-          trace_id,
-          anyIf(trace_name, trace_name <> '') as trace_name,
-          anyIf(user_id, user_id <> '') as user_id,
-          anyIf(tags, notEmpty(tags)) as tags
-        FROM events_core
-        WHERE project_id = {projectId: String}
-        AND is_deleted = 0
-        GROUP BY trace_id
-      ) e ON s.trace_id = e.trace_id`
+  // Build traces CTE using the event query builder when needed
+  let tracesCTEClause = "";
+  const tracesCTEParams: Record<string, unknown> = {};
+
+  if (needsTracesCTE) {
+    const tracesBuilder = eventsTracesAggregation({
+      projectId,
+      truncated: true,
+    });
+    const { query: cteQuery, params: cteParams } =
+      tracesBuilder.buildWithParams();
+    tracesCTEClause = `WITH traces AS (${cteQuery})`;
+    Object.assign(tracesCTEParams, cteParams);
+  }
+
+  const eventsJoin = needsTracesCTE
+    ? `LEFT ANY JOIN traces e ON s.trace_id = e.id`
     : "";
 
   const select =
@@ -1175,14 +1165,15 @@ const getScoresUiGenericFromEvents = async <T>(props: {
       `;
 
   const query = `
+      ${tracesCTEClause}
       SELECT
           ${select}
       FROM scores s final
-      ${eventsSubqueryJoin}
+      ${eventsJoin}
       WHERE s.project_id = {projectId: String}
       AND s.data_type IN ({dataTypes: Array(String)})
       ${scoreOnlyFilterRes?.query ? `AND ${scoreOnlyFilterRes.query}` : ""}
-      ${traceFilterSubqueries.map((sq) => `AND ${sq}`).join("\n")}
+      ${traceFilterRes?.query ? `AND ${traceFilterRes.query}` : ""}
       ${orderByToClickhouseSql(orderBy ?? null, scoresTableUiColumnDefinitionsFromEvents)}
       ${limit !== undefined && offset !== undefined ? `limit {limit: Int32} offset {offset: Int32}` : ""}
     `;
@@ -1195,7 +1186,8 @@ const getScoresUiGenericFromEvents = async <T>(props: {
         projectId,
         dataTypes: AGGREGATABLE_SCORE_TYPES,
         ...(scoreOnlyFilterRes ? scoreOnlyFilterRes.params : {}),
-        ...traceFilterParams,
+        ...(traceFilterRes ? traceFilterRes.params : {}),
+        ...tracesCTEParams,
         limit,
         offset,
       },
@@ -2066,47 +2058,3 @@ export const getScoreCountsByProjectAndDay = async ({
     date: row.date,
   }));
 };
-
-export async function getScoresTraceMetricsFromEvents(params: {
-  projectId: string;
-  traceIds: string[];
-}) {
-  const { projectId, traceIds } = params;
-  if (traceIds.length === 0) return [];
-
-  const query = `
-    SELECT
-      trace_id,
-      anyIf(trace_name, trace_name <> '') as trace_name,
-      anyIf(user_id, user_id <> '') as user_id,
-      anyIf(tags, notEmpty(tags)) as tags
-    FROM events_core
-    WHERE project_id = {projectId: String}
-    AND trace_id IN ({traceIds: Array(String)})
-    AND is_deleted = 0
-    GROUP BY trace_id
-  `;
-
-  const rows = await queryClickhouse<{
-    trace_id: string;
-    trace_name: string | null;
-    user_id: string | null;
-    tags: string[] | null;
-  }>({
-    query,
-    params: { projectId, traceIds },
-    tags: {
-      feature: "tracing",
-      type: "score",
-      kind: "metrics",
-      projectId,
-    },
-  });
-
-  return rows.map((row) => ({
-    traceId: row.trace_id,
-    traceName: row.trace_name || null,
-    userId: row.user_id || null,
-    tags: row.tags && row.tags.length > 0 ? row.tags : null,
-  }));
-}

--- a/packages/shared/src/server/tableMappings/mapScoresTable.ts
+++ b/packages/shared/src/server/tableMappings/mapScoresTable.ts
@@ -106,8 +106,8 @@ export const scoresTableUiColumnDefinitions: UiColumnMappings = [
 ];
 
 /**
- * v4 column definitions for scores table — trace columns reference events_core
- * instead of traces table. Used with the events_core subquery JOIN (alias e).
+ * v4 column definitions for scores table — trace columns reference the traces
+ * CTE built by eventsTracesAggregation(). The CTE is joined as alias "e".
  */
 export const scoresTableUiColumnDefinitionsFromEvents: UiColumnMappings = [
   // All scores-native columns are identical to v3
@@ -117,19 +117,22 @@ export const scoresTableUiColumnDefinitionsFromEvents: UiColumnMappings = [
   {
     uiTableName: "Trace Name",
     uiTableId: "traceName",
-    clickhouseTableName: "events_core",
-    clickhouseSelect: "trace_name",
+    clickhouseTableName: "traces",
+    clickhouseSelect: "name",
+    queryPrefix: "e",
   },
   {
     uiTableName: "User ID",
     uiTableId: "userId",
-    clickhouseTableName: "events_core",
+    clickhouseTableName: "traces",
     clickhouseSelect: "user_id",
+    queryPrefix: "e",
   },
   {
     uiTableName: "Trace Tags",
     uiTableId: "trace_tags",
-    clickhouseTableName: "events_core",
+    clickhouseTableName: "traces",
     clickhouseSelect: "tags",
+    queryPrefix: "e",
   },
 ];

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -16,7 +16,6 @@ import { AppLayout } from "@/src/components/layouts/app-layout";
 import { useEffect, useRef } from "react";
 import { useRouter } from "next/router";
 
-// some change
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
 import prexit from "prexit";

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -16,6 +16,7 @@ import { AppLayout } from "@/src/components/layouts/app-layout";
 import { useEffect, useRef } from "react";
 import { useRouter } from "next/router";
 
+// some change
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
 import prexit from "prexit";

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -38,7 +38,7 @@ import {
   getScoresUiTable,
   getScoresUiCountFromEvents,
   getScoresUiTableFromEvents,
-  getScoresTraceMetricsFromEvents,
+  getTraceMetadataByIdsFromEvents,
   getScoreNames,
   getScoreStringValues,
   getTracesGroupedByTags,
@@ -276,7 +276,8 @@ export const scoresRouter = createTRPCRouter({
       };
     }),
   /**
-   * v4: Load trace metadata (name, userId, tags) from events_core for a page of scores.
+   * v4: Load trace metadata (name, userId, tags) via eventsTracesAggregation
+   * builder for a page of scores.
    */
   metricsFromEvents: protectedProjectProcedure
     .input(
@@ -287,10 +288,16 @@ export const scoresRouter = createTRPCRouter({
     )
     .query(async ({ input }) => {
       if (input.traceIds.length === 0) return [];
-      return getScoresTraceMetricsFromEvents({
+      const rows = await getTraceMetadataByIdsFromEvents({
         projectId: input.projectId,
         traceIds: input.traceIds,
       });
+      return rows.map((row) => ({
+        traceId: row.id,
+        traceName: row.name || null,
+        userId: row.user_id || null,
+        tags: row.tags && row.tags.length > 0 ? row.tags : null,
+      }));
     }),
   /**
    * v4: Filter options using events_core instead of traces table.

--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -85,7 +85,7 @@ export const handleEventPropagationJob = async (
         FROM system.parts
         WHERE table = 'observations_batch_staging'
           AND active = 1
-          AND toDateTime(partition) < now() - INTERVAL 10 MINUTE
+          AND toDateTime(partition) < now() - INTERVAL 1 MINUTE
           ${lastProcessedPartition ? `AND partition > {lastProcessedPartition: String}` : ""}
         ORDER BY partition ASC
       `,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switches CI/CD jobs to run on larger GitHub runners for improved performance.
> 
>   - **CI/CD Workflow**:
>     - Changes `runs-on` from `ubuntu-latest` to `linux_96_core` for jobs: `lint`, `prettier-check`, `test-docker-build`, `tests-web-sync`, `tests-web-async`, `tests-worker`, `test-worker-llm-connections`, `e2e-tests`, and `e2e-server-tests` in `pipeline.yml`.
>   - **Purpose**:
>     - Aims to utilize larger GitHub runners to potentially improve performance and reduce execution time for CI/CD jobs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f77359b145187f6704cb2f515b3550a9036a61ed. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->