### PR TITLE
feat: add v2 backend path for score-aggregate dashboard query

### DIFF
--- a/web/src/features/dashboard/components/ScoresTable.tsx
+++ b/web/src/features/dashboard/components/ScoresTable.tsx
@@ -48,7 +48,7 @@ export const ScoresTable = ({
   projectId,
   globalFilterState,
   isLoading = false,
-  metricsVersion: _metricsVersion,
+  metricsVersion,
 }: {
   className: string;
   projectId: string;
@@ -86,6 +86,7 @@ export const ScoresTable = ({
       ],
       orderBy: [{ column: "scoreId", direction: "DESC", agg: "COUNT" }],
       queryName: "score-aggregate",
+      version: metricsVersion ?? "v1",
     },
     {
       trpc: {
@@ -130,6 +131,7 @@ export const ScoresTable = ({
         ],
         orderBy: [{ column: "scoreId", direction: "DESC", agg: "COUNT" }],
         queryName: "score-aggregate",
+        version: metricsVersion ?? "v1",
       },
       {
         trpc: {

--- a/web/src/features/query/dashboardUiTableToViewMapping.ts
+++ b/web/src/features/query/dashboardUiTableToViewMapping.ts
@@ -117,6 +117,11 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       viewName: "value",
     },
     {
+      // Legacy column name from dashboardColumnDefinitions (uiTableName: "value")
+      uiTableName: "value",
+      viewName: "value",
+    },
+    {
       uiTableName: "Scores Data Type",
       viewName: "dataType",
     },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add v2 backend path for score-aggregate dashboard queries, updating server logic, UI components, and tests for v1-v2 consistency.
> 
>   - **Backend Logic**:
>     - Adds `getScoreAggregateV2` function in `dashboard-router.ts` to handle v2 score-aggregate queries.
>     - Modifies `dashboardRouter` to support `version` parameter, defaulting to "v1".
>   - **UI Components**:
>     - Updates `ScoresTable` in `ScoresTable.tsx` to use `metricsVersion` for query versioning.
>     - Ensures `ScoresTable` handles both v1 and v2 data formats.
>   - **Testing**:
>     - Extends `dashboard-v1-v2-consistency.servertest.ts` to include tests for v2 score-aggregate queries.
>     - Validates field renaming and data consistency between v1 and v2.
>   - **Misc**:
>     - Updates `dashboardUiTableToViewMapping.ts` to map legacy UI table filters to v2 views.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1b686d96135909cb499abc490dc8a34063cbd706. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->