### PR TITLE
feat: add v2 backend path for score histogram dashboard query

### DIFF
--- a/web/src/features/dashboard/components/score-analytics/NumericScoreHistogram.tsx
+++ b/web/src/features/dashboard/components/score-analytics/NumericScoreHistogram.tsx
@@ -19,9 +19,11 @@ export function NumericScoreHistogram(props: {
   globalFilterState: FilterState;
   metricsVersion?: ViewVersion;
 }) {
+  const version = props.metricsVersion ?? "v1";
   const histogram = api.dashboard.scoreHistogram.useQuery(
     {
       projectId: props.projectId,
+      version,
       from: "traces_scores",
       select: [{ column: "value" }],
       filter: [
@@ -45,7 +47,9 @@ export function NumericScoreHistogram(props: {
           operator: "=",
         },
       ],
-      limit: 10000,
+      // v1 fetches raw values client-side (capped at 10k rows).
+      // v2 aggregates server-side via histogram() — limit is unused.
+      ...(version === "v1" ? { limit: 10000 } : {}),
     },
     {
       trpc: {

--- a/web/src/features/dashboard/components/score-analytics/ScoreAnalytics.tsx
+++ b/web/src/features/dashboard/components/score-analytics/ScoreAnalytics.tsx
@@ -114,6 +114,8 @@ export function ScoreAnalytics(props: {
                     <div className="mb-2 text-sm text-muted-foreground">
                       Total aggregate scores
                       {isNumericDataType(dataType) && (
+                        // TODO: v2 histogram aggregates all rows server-side (no 10k cap).
+                        // Make this tooltip conditional on metricsVersion.
                         <DocPopup description="Aggregate of up to 10,000 scores" />
                       )}
                     </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add v2 backend path for score histogram queries using ClickHouse for server-side aggregation, ensuring consistency with v1 results.
> 
>   - **Behavior**:
>     - Adds v2 backend path for `scoreHistogram` query in `dashboard-router.ts`, using ClickHouse for server-side aggregation.
>     - Updates `NumericScoreHistogram.tsx` to use v2 path if `metricsVersion` is set to v2.
>     - Ensures v1 and v2 histogram shapes match for NUMERIC and BOOLEAN scores in `dashboard-v1-v2-consistency.servertest.ts`.
>   - **Functions**:
>     - Adds `prepareScoresNumericV2Params()` and `clickhouseHistogramToChartData()` in `dashboard-router.ts` for v2 query preparation and result transformation.
>   - **Tests**:
>     - Adds tests for v2 `scoreHistogram` endpoint in `dashboard-v1-v2-consistency.servertest.ts` to validate histogram data and shape consistency with v1.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for cbee441fcb812e59b7ed9cc90fa0745302f7d827. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->