### PR TITLE
fix(csv-upload): allow mapping entire columns in case of dataset schema

### DIFF
--- a/web/src/features/datasets/components/MappingCard.tsx
+++ b/web/src/features/datasets/components/MappingCard.tsx
@@ -6,12 +6,19 @@ import {
 } from "@/src/components/ui/card";
 import { cn } from "@/src/utils/tailwind";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
-import { X } from "lucide-react";
+import { InfoIcon, X } from "lucide-react";
 import {
   type CsvColumnPreview,
   type FieldMapping,
 } from "@/src/features/datasets/lib/csv/types";
 import { isSchemaField } from "@/src/features/datasets/lib/csv/helpers";
+import { Switch } from "@/src/components/ui/switch";
+import { Label } from "@/src/components/ui/label";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
 
 function SchemaKeyDropZone({
   schemaKey,
@@ -146,6 +153,12 @@ type MappingCardProps = {
   onRemoveInputColumn: (columnName: string, key?: string) => void;
   onRemoveExpectedColumn: (columnName: string, key?: string) => void;
   onRemoveMetadataColumn: (columnName: string) => void;
+  inputSchemaKeys: string[] | null;
+  expectedOutputSchemaKeys: string[] | null;
+  useDirectMappingForInput: boolean;
+  useDirectMappingForExpectedOutput: boolean;
+  onToggleDirectMappingForInput: (value: boolean) => void;
+  onToggleDirectMappingForExpectedOutput: (value: boolean) => void;
 };
 
 export function MappingCard({
@@ -155,6 +168,12 @@ export function MappingCard({
   onRemoveInputColumn,
   onRemoveExpectedColumn,
   onRemoveMetadataColumn,
+  inputSchemaKeys,
+  expectedOutputSchemaKeys,
+  useDirectMappingForInput,
+  useDirectMappingForExpectedOutput,
+  onToggleDirectMappingForInput,
+  onToggleDirectMappingForExpectedOutput,
 }: MappingCardProps) {
   return (
     <Card className="flex h-full flex-col overflow-hidden">
@@ -166,9 +185,37 @@ export function MappingCard({
       <CardContent className="min-h-0 flex-1 space-y-4 overflow-y-auto p-3">
         {/* INPUT SECTION */}
         <div className="space-y-2">
-          <h3 className="text-sm font-semibold tracking-wide text-muted-foreground">
-            Input
-          </h3>
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold tracking-wide text-muted-foreground">
+              Input
+            </h3>
+            {inputSchemaKeys && inputSchemaKeys.length > 0 && (
+              <div className="flex items-center gap-1.5">
+                <Switch
+                  id="direct-mapping-input"
+                  checked={useDirectMappingForInput}
+                  onCheckedChange={onToggleDirectMappingForInput}
+                  className="scale-75"
+                />
+                <Label
+                  htmlFor="direct-mapping-input"
+                  className="cursor-pointer text-xs font-normal text-muted-foreground"
+                >
+                  Direct Mapping
+                </Label>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <InfoIcon className="h-3 w-3 text-muted-foreground" />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-[250px]" side="left">
+                    {useDirectMappingForInput
+                      ? "Map entire CSV columns directly to the input field."
+                      : "Map CSV columns to individual schema fields."}
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+            )}
+          </div>
           {isSchemaField(input) ? (
             <div className="space-y-2">
               {input.entries.map((entry) => (
@@ -194,9 +241,38 @@ export function MappingCard({
 
         {/* OUTPUT SECTION */}
         <div className="space-y-2">
-          <h3 className="text-sm font-semibold tracking-wide text-muted-foreground">
-            Expected Output
-          </h3>
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold tracking-wide text-muted-foreground">
+              Expected Output
+            </h3>
+            {expectedOutputSchemaKeys &&
+              expectedOutputSchemaKeys.length > 0 && (
+                <div className="flex items-center gap-1.5">
+                  <Switch
+                    id="direct-mapping-expected"
+                    checked={useDirectMappingForExpectedOutput}
+                    onCheckedChange={onToggleDirectMappingForExpectedOutput}
+                    className="scale-75"
+                  />
+                  <Label
+                    htmlFor="direct-mapping-expected"
+                    className="cursor-pointer text-xs font-normal text-muted-foreground"
+                  >
+                    Direct mapping
+                  </Label>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <InfoIcon className="h-3 w-3 text-muted-foreground" />
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-[250px]" side="left">
+                      {useDirectMappingForExpectedOutput
+                        ? "Map entire CSV columns directly to the expected output field."
+                        : "Map CSV columns to individual schema fields."}
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+              )}
+          </div>
           {expectedOutput.type === "schema" ? (
             <div className="space-y-2">
               {expectedOutput.entries.map((entry) => (

--- a/web/src/features/datasets/hooks/useCsvImport.ts
+++ b/web/src/features/datasets/hooks/useCsvImport.ts
@@ -79,14 +79,14 @@ export function useCsvImport(options: UseCsvImportOptions) {
   const mutCreateManyDatasetItems =
     api.datasets.createManyDatasetItems.useMutation({});
 
-  const execute = async (wrapSingleColumn: boolean) => {
+  const execute = async (wrapSingleColumn: boolean): Promise<boolean> => {
     const { csvFile, projectId, datasetId, input, expectedOutput, metadata } =
       options;
 
-    if (!csvFile) return;
+    if (!csvFile) return false;
     if (csvFile.size > MAX_FILE_SIZE_BYTES) {
       showErrorToast("File too large", "Maximum file size is 10MB");
-      return;
+      return false;
     }
 
     setValidationErrors([]);
@@ -219,7 +219,7 @@ export function useCsvImport(options: UseCsvImportOptions) {
             processedItems: 0,
             status: "not-started",
           });
-          return;
+          return false;
         }
 
         processedCount += chunkItems.length;
@@ -248,7 +248,7 @@ export function useCsvImport(options: UseCsvImportOptions) {
           `Please try again starting from row ${processedCount + 1}.`,
         );
       }
-      return;
+      return false;
     }
 
     utils.datasets.invalidate();
@@ -258,6 +258,8 @@ export function useCsvImport(options: UseCsvImportOptions) {
       processedItems: items.length,
       status: "complete",
     });
+
+    return true;
   };
 
   const reset = () => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds direct mapping toggles for CSV columns in dataset import, with UI updates and improved error handling.
> 
>   - **Behavior**:
>     - Adds toggles for direct mapping of entire CSV columns in `MappingCard.tsx` for input and expected output fields.
>     - Updates `PreviewCsvImport.tsx` to handle direct mapping mode, resetting mappings on mode switch.
>     - `useCsvImport.ts` now returns a boolean indicating success or failure of the import process.
>   - **UI Components**:
>     - Adds `Switch`, `Label`, and `Tooltip` components in `MappingCard.tsx` for direct mapping toggles.
>     - Updates `PreviewCsvImport.tsx` to show wrapping checkbox based on mapping mode.
>   - **Error Handling**:
>     - Improves error handling in `useCsvImport.ts` by returning false on failure and showing error toasts for missing columns or import failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bf8b557bcbec809e5f8f6292927b343cb91dfa13. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->