### PR TITLE
feat(model-prices): add gemini-3.1-pro-preview model pricing and support

### DIFF
--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -435,6 +435,7 @@ export const anthropicModels = [
 export const vertexAIModels = [
   "gemini-2.5-flash",
   "gemini-2.5-pro",
+  "gemini-3.1-pro-preview",
   "gemini-3-pro-preview",
   "gemini-3-flash-preview",
   "gemini-2.5-flash-preview-09-2025",
@@ -453,6 +454,7 @@ export const vertexAIModels = [
 export const googleAIStudioModels = [
   "gemini-2.5-flash",
   "gemini-2.5-pro",
+  "gemini-3.1-pro-preview",
   "gemini-3-pro-preview",
   "gemini-3-flash-preview",
   "gemini-2.5-flash-lite",

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -3439,6 +3439,66 @@
     ]
   },
   {
+    "id": "55106bba-a5dd-441b-bc0d-5652582b349d",
+    "modelName": "gemini-3.1-pro-preview",
+    "matchPattern": "(?i)^(google\/)?(gemini-3.1-pro-preview(-customtools)?)$",
+    "createdAt": "2026-02-19T00:00:00.000Z",
+    "updatedAt": "2026-02-19T00:00:00.000Z",
+    "pricingTiers": [
+      {
+        "id": "55106bba-a5dd-441b-bc0d-5652582b349d_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 2e-6,
+          "input_modality_1": 2e-6,
+          "prompt_token_count": 2e-6,
+          "promptTokenCount": 2e-6,
+          "input_cached_tokens": 0.2e-6,
+          "cached_content_token_count": 0.2e-6,
+          "output": 12e-6,
+          "output_modality_1": 12e-6,
+          "candidates_token_count": 12e-6,
+          "candidatesTokenCount": 12e-6,
+          "thoughtsTokenCount": 12e-6,
+          "thoughts_token_count": 12e-6,
+          "output_reasoning": 12e-6
+        }
+      },
+      {
+        "id": "ada11e9f-fe0d-465a-92af-ce334d0eedeb",
+        "name": "Large Context",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "(input|prompt|cached)",
+            "operator": "gt",
+            "value": 200000,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 4e-6,
+          "input_modality_1": 4e-6,
+          "prompt_token_count": 4e-6,
+          "promptTokenCount": 4e-6,
+          "input_cached_tokens": 0.4e-6,
+          "cached_content_token_count": 0.4e-6,
+          "output": 18e-6,
+          "output_modality_1": 18e-6,
+          "candidates_token_count": 18e-6,
+          "candidatesTokenCount": 18e-6,
+          "thoughtsTokenCount": 18e-6,
+          "thoughts_token_count": 18e-6,
+          "output_reasoning": 18e-6
+        }
+      }
+    ]
+  },
+  {
     "id": "cmj2n4f2a000304kz49g4c43u",
     "modelName": "gpt-5.2",
     "matchPattern": "(?i)^(openai\/)?(gpt-5.2)$",


### PR DESCRIPTION
## What does this PR do?

Adds support for the `gemini-3.1-pro-preview` model by:
1. Adding pricing configuration with two tiers (Standard and Large Context)
2. Registering the model in both Vertex AI and Google AI Studio model lists

The Standard tier provides base pricing of $2/M input tokens and $12/M output tokens, while the Large Context tier (triggered when usage exceeds 200k tokens) increases to $4/M input and $18/M output tokens. Cached token pricing is also included at reduced rates.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Chore (refactoring code, technical debt, workflow improvements)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked if my changes generate no new warnings
- [x] No new tests needed - this is a configuration addition for an existing model pricing system

https://claude.ai/code/session_01Cn1PsAdzvzSRz9r7mgBz4E
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `gemini-3.1-pro-preview` model with pricing tiers and registration in `types.ts` and `default-model-prices.json`.
> 
>   - **Behavior**:
>     - Adds `gemini-3.1-pro-preview` to `vertexAIModels` and `googleAIStudioModels` in `types.ts`.
>     - Configures pricing for `gemini-3.1-pro-preview` in `default-model-prices.json` with Standard and Large Context tiers.
>   - **Pricing**:
>     - Standard tier: $2/M input tokens, $12/M output tokens.
>     - Large Context tier: $4/M input tokens, $18/M output tokens, triggered above 200k tokens.
>     - Includes reduced rates for cached tokens.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 167daddafee58816184f510b8c238d14546a2ff3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->