### PR TITLE
feat(ui-events-table): add to dataset batch action

### DIFF
--- a/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/FinalPreviewStep.tsx
+++ b/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/FinalPreviewStep.tsx
@@ -1,9 +1,11 @@
 import { useMemo } from "react";
 import { Button } from "@/src/components/ui/button";
-import { Pencil } from "lucide-react";
+import { AlertTriangle, Pencil } from "lucide-react";
 import { JSONView } from "@/src/components/ui/CodeJsonViewer";
+import { cn } from "@/src/utils/tailwind";
 import type { FinalPreviewStepProps, DialogStep } from "./types";
 import { applyFullMapping } from "@langfuse/shared";
+import type { MappingError } from "@langfuse/shared";
 
 export function FinalPreviewStep({
   dataset,
@@ -26,6 +28,27 @@ export function FinalPreviewStep({
     });
   }, [observationData, mapping]);
 
+  // Group errors by target field
+  const errorsByField = useMemo(() => {
+    const errors = previewResult?.errors ?? [];
+    const grouped: Record<string, MappingError[]> = {};
+    for (const err of errors) {
+      if (!grouped[err.targetField]) {
+        grouped[err.targetField] = [];
+      }
+      grouped[err.targetField].push(err);
+    }
+    return grouped;
+  }, [previewResult?.errors]);
+
+  const hasWarnings = (previewResult?.errors?.length ?? 0) > 0;
+
+  const stepForField: Record<string, DialogStep> = {
+    input: "input-mapping" as DialogStep,
+    expectedOutput: "output-mapping" as DialogStep,
+    metadata: "metadata-mapping" as DialogStep,
+  };
+
   return (
     <div className="h-[62vh] space-y-6 p-6">
       <div>
@@ -36,6 +59,42 @@ export function FinalPreviewStep({
           {dataset.name}&quot;
         </p>
       </div>
+
+      {/* Overall warning banner */}
+      {hasWarnings && (
+        <div className="rounded-md border border-amber-500/50 bg-amber-50 p-3 dark:bg-amber-950/30">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-500" />
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-amber-600 dark:text-amber-500">
+                Some JSON paths did not match the preview observation
+              </p>
+              <p className="text-xs text-amber-600/80 dark:text-amber-500/80">
+                Observations with failed mappings will be skipped during
+                processing.
+              </p>
+              <div className="flex flex-wrap gap-2 pt-1">
+                {Object.entries(errorsByField).map(([field]) => (
+                  <Button
+                    key={field}
+                    variant="link"
+                    size="sm"
+                    className="h-auto p-0 text-xs text-amber-600 underline dark:text-amber-500"
+                    onClick={() => {
+                      const step = stepForField[field];
+                      if (step) onEditStep(step);
+                    }}
+                  >
+                    Edit{" "}
+                    {field === "expectedOutput" ? "expected output" : field}{" "}
+                    mapping
+                  </Button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
 
       <div className="text-sm text-muted-foreground">
         Sample dataset item preview (from first selected observation):
@@ -54,6 +113,7 @@ export function FinalPreviewStep({
             label="Input"
             data={previewResult?.input}
             onEdit={() => onEditStep("input-mapping" as DialogStep)}
+            errors={errorsByField["input"]}
           />
 
           {/* Expected Output Preview */}
@@ -61,6 +121,7 @@ export function FinalPreviewStep({
             label="Expected Output"
             data={previewResult?.expectedOutput}
             onEdit={() => onEditStep("output-mapping" as DialogStep)}
+            errors={errorsByField["expectedOutput"]}
           />
 
           {/* Metadata Preview */}
@@ -68,6 +129,7 @@ export function FinalPreviewStep({
             label="Metadata"
             data={previewResult?.metadata}
             onEdit={() => onEditStep("metadata-mapping" as DialogStep)}
+            errors={errorsByField["metadata"]}
           />
         </div>
       )}
@@ -79,13 +141,23 @@ type PreviewCardProps = {
   label: string;
   data: unknown;
   onEdit: () => void;
+  errors?: MappingError[];
 };
 
-function PreviewCard({ label, data, onEdit }: PreviewCardProps) {
+function PreviewCard({ label, data, onEdit, errors }: PreviewCardProps) {
+  const hasErrors = errors && errors.length > 0;
+
   return (
-    <div className="rounded-lg border">
+    <div
+      className={cn("rounded-lg border", hasErrors && "border-amber-500/50")}
+    >
       <div className="flex items-center justify-between border-b bg-muted/30 px-4 py-2">
-        <span className="text-sm font-medium">{label}</span>
+        <span className="flex items-center gap-1.5 text-sm font-medium">
+          {hasErrors && (
+            <AlertTriangle className="h-3.5 w-3.5 text-amber-600 dark:text-amber-500" />
+          )}
+          {label}
+        </span>
         <Button
           variant="ghost"
           size="sm"
@@ -103,6 +175,15 @@ function PreviewCard({ label, data, onEdit }: PreviewCardProps) {
           <JSONView json={data} className="text-xs" />
         )}
       </div>
+      {hasErrors && (
+        <div className="border-t border-amber-500/50 bg-amber-50 px-4 py-2 dark:bg-amber-950/30">
+          <p className="text-xs text-amber-600 dark:text-amber-500">
+            {errors.length} path{errors.length !== 1 ? "s" : ""} did not match
+            in preview observation. These items will be skipped during
+            processing.
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/JsonPathInput.tsx
+++ b/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/JsonPathInput.tsx
@@ -79,6 +79,7 @@ export function JsonPathInput({
   const codeMirrorTheme = resolvedTheme === "dark" ? darkTheme : lightTheme;
 
   const [resolveError, setResolveError] = useState<string | null>(null);
+  const [noMatchWarning, setNoMatchWarning] = useState(false);
 
   // Parse source data once
   const parsedSourceData = useMemo(() => {
@@ -103,18 +104,23 @@ export function JsonPathInput({
       // Try to resolve the JSON path
       if (newValue && newValue.startsWith("$") && parsedSourceData) {
         try {
-          evaluateJsonPath(parsedSourceData, newValue);
+          const result = evaluateJsonPath(parsedSourceData, newValue);
+          setResolveError(null);
+          setNoMatchWarning(result === undefined);
         } catch (e) {
           setResolveError(e instanceof Error ? e.message : "Invalid JSON path");
+          setNoMatchWarning(false);
         }
       } else {
         setResolveError(null);
+        setNoMatchWarning(false);
       }
     },
     [onChange, parsedSourceData],
   );
 
   const displayError = error || resolveError;
+  const showWarning = !displayError && noMatchWarning;
 
   return (
     <div className="space-y-1">
@@ -151,11 +157,17 @@ export function JsonPathInput({
         className={cn(
           "overflow-hidden rounded-md border text-sm",
           displayError && "border-destructive",
+          showWarning && "border-amber-500/50",
           className,
         )}
       />
       {displayError && (
         <p className="text-xs text-destructive">{displayError}</p>
+      )}
+      {showWarning && (
+        <p className="text-xs text-amber-600 dark:text-amber-500">
+          No match found in source data
+        </p>
       )}
     </div>
   );

--- a/web/src/features/batch-actions/components/RunEvaluationDialog/index.tsx
+++ b/web/src/features/batch-actions/components/RunEvaluationDialog/index.tsx
@@ -26,6 +26,11 @@ type RunEvaluationDialogProps = {
   selectAll: boolean;
   totalCount: number;
   onClose: () => void;
+  exampleObservation: {
+    id: string;
+    traceId: string;
+    startTime?: Date;
+  };
 };
 
 type DialogStep = "select-evaluator" | "confirm";
@@ -55,41 +60,16 @@ export function RunEvaluationDialog(props: RunEvaluationDialogProps) {
 
   const displayCount = selectAll ? totalCount : selectedObservationIds.length;
 
-  const previewFilter = useMemo(
-    () =>
-      buildQueryWithSelectedIds({ query, selectAll, selectedObservationIds })
-        .filter ?? [],
-    [query, selectAll, selectedObservationIds],
-  );
-
-  const previewObservationSeedQuery = api.events.all.useQuery(
-    {
-      projectId,
-      filter: previewFilter,
-      searchQuery: selectAll ? (query.searchQuery ?? null) : null,
-      searchType: selectAll ? (query.searchType ?? ["id", "content"]) : [],
-      page: 1,
-      limit: 1,
-      orderBy: query.orderBy,
-    },
-    {
-      enabled: displayCount > 0,
-    },
-  );
-
-  const previewObservationSeed =
-    previewObservationSeedQuery.data?.observations?.[0];
-
   const previewObservationQuery = api.observations.byId.useQuery(
     {
       projectId,
-      observationId: previewObservationSeed?.id ?? "",
-      traceId: previewObservationSeed?.traceId ?? "",
-      startTime: previewObservationSeed?.startTime ?? null,
+      observationId: props.exampleObservation.id,
+      traceId: props.exampleObservation.traceId,
+      startTime: props.exampleObservation.startTime ?? null,
     },
     {
       enabled: Boolean(
-        previewObservationSeed?.id && previewObservationSeed?.traceId,
+        props.exampleObservation.id && props.exampleObservation.traceId,
       ),
     },
   );
@@ -174,10 +154,7 @@ export function RunEvaluationDialog(props: RunEvaluationDialogProps) {
                 isQueryError={evaluatorsQuery.isError}
                 queryErrorMessage={evaluatorsQuery.error?.message}
                 previewObservation={previewObservationQuery.data}
-                isPreviewLoading={
-                  previewObservationSeedQuery.isLoading ||
-                  previewObservationQuery.isLoading
-                }
+                isPreviewLoading={previewObservationQuery.isLoading}
                 selectedEvaluatorIds={selectedEvaluatorIds}
                 evaluatorSearchQuery={evaluatorSearchQuery}
                 onSearchQueryChange={setEvaluatorSearchQuery}

--- a/web/src/features/batch-actions/server/addToDatasetRouter.ts
+++ b/web/src/features/batch-actions/server/addToDatasetRouter.ts
@@ -37,6 +37,12 @@ export const addToDatasetRouter = createTRPCRouter({
 
         const { projectId, query, config } = input;
 
+        const useEventsTable =
+          env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true";
+        const tableName = useEventsTable
+          ? BatchTableNames.Events
+          : BatchTableNames.Observations;
+
         // Check observation count doesn't exceed maximum
         const queryOpts = {
           projectId,
@@ -44,10 +50,9 @@ export const addToDatasetRouter = createTRPCRouter({
           limit: 1,
           offset: 0,
         };
-        const observationCount =
-          env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true"
-            ? await getObservationsCountFromEventsTable(queryOpts)
-            : await getObservationsTableCount(queryOpts);
+        const observationCount = useEventsTable
+          ? await getObservationsCountFromEventsTable(queryOpts)
+          : await getObservationsTableCount(queryOpts);
 
         if (observationCount > MAX_BATCH_ADD_TO_DATASET_ITEMS) {
           throw new TRPCError({
@@ -67,7 +72,7 @@ export const addToDatasetRouter = createTRPCRouter({
             projectId,
             userId,
             actionType: ActionId.ObservationAddToDataset,
-            tableName: BatchTableNames.Observations,
+            tableName,
             status: BatchActionStatus.Queued,
             query,
             config,
@@ -95,7 +100,7 @@ export const addToDatasetRouter = createTRPCRouter({
               batchActionId: batchAction.id,
               projectId,
               actionId: ActionId.ObservationAddToDataset,
-              tableName: BatchTableNames.Observations,
+              tableName,
               cutoffCreatedAt: new Date(),
               query,
               config,

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -472,6 +472,16 @@ export default function ObservationsEventsTable({
       },
     },
     {
+      id: ActionId.ObservationAddToDataset,
+      type: BatchActionType.Create,
+      label: "Add to Dataset",
+      description: "Add selected observations to a dataset",
+      customDialog: true,
+      accessCheck: {
+        scope: "datasets:CUD",
+      },
+    },
+    {
       id: ActionId.ObservationBatchEvaluation,
       type: BatchActionType.Create,
       label: "Evaluate",
@@ -480,16 +490,6 @@ export default function ObservationsEventsTable({
       icon: <LightbulbIcon className="mr-2 h-4 w-4" />,
       accessCheck: {
         scope: "evalJob:CUD",
-      },
-    },
-    {
-      id: ActionId.ObservationAddToDataset,
-      type: BatchActionType.Create,
-      label: "Add to Dataset",
-      description: "Add selected observations to a dataset",
-      customDialog: true,
-      accessCheck: {
-        scope: "datasets:CUD",
       },
     },
   ];

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -83,6 +83,7 @@ import {
 import useSessionStorage from "@/src/components/useSessionStorage";
 import { api } from "@/src/utils/api";
 import { RunEvaluationDialog } from "@/src/features/batch-actions/components/RunEvaluationDialog/index";
+import { AddObservationsToDatasetDialog } from "@/src/features/batch-actions/components/AddObservationsToDatasetDialog/index";
 
 export type EventsTableRow = {
   // Identity fields
@@ -180,6 +181,7 @@ export default function ObservationsEventsTable({
 
   const { selectAll, setSelectAll } = useSelectAll(projectId, "observations");
   const [showRunEvaluationDialog, setShowRunEvaluationDialog] = useState(false);
+  const [showAddToDatasetDialog, setShowAddToDatasetDialog] = useState(false);
 
   const [paginationState, setPaginationState] = usePaginationState(1, 50);
 
@@ -478,6 +480,16 @@ export default function ObservationsEventsTable({
       icon: <LightbulbIcon className="mr-2 h-4 w-4" />,
       accessCheck: {
         scope: "evalJob:CUD",
+      },
+    },
+    {
+      id: ActionId.ObservationAddToDataset,
+      type: BatchActionType.Create,
+      label: "Add to Dataset",
+      description: "Add selected observations to a dataset",
+      customDialog: true,
+      accessCheck: {
+        scope: "datasets:CUD",
       },
     },
   ];
@@ -1159,6 +1171,21 @@ export default function ObservationsEventsTable({
     return result;
   }, [observations]);
 
+  const selectedObservationIds = useMemo(() => {
+    const rowIds = new Set(observations.rows?.map((o) => o.id));
+    return Object.keys(selectedRows).filter((id) => rowIds.has(id));
+  }, [observations.rows, selectedRows]);
+
+  const exampleObservation = useMemo(() => {
+    const firstId = selectedObservationIds[0];
+    const firstObs = observations.rows?.find((o) => o.id === firstId);
+    return {
+      id: firstObs?.id ?? "",
+      traceId: firstObs?.traceId ?? "",
+      startTime: firstObs?.startTime ?? undefined,
+    };
+  }, [selectedObservationIds, observations.rows]);
+
   return (
     <DataTableControlsProvider>
       <div className="flex h-full w-full flex-col">
@@ -1220,9 +1247,7 @@ export default function ObservationsEventsTable({
                 tableName={BatchExportTableName.Events}
                 key="batchExport"
               />,
-              Object.keys(selectedRows).filter((observationId) =>
-                observations.rows?.map((o) => o.id).includes(observationId),
-              ).length > 0 ? (
+              selectedObservationIds.length > 0 ? (
                 <TableActionMenu
                   key="observations-multi-select-actions"
                   projectId={projectId}
@@ -1232,6 +1257,9 @@ export default function ObservationsEventsTable({
                     if (actionType === ActionId.ObservationBatchEvaluation) {
                       setShowRunEvaluationDialog(true);
                     }
+                    if (actionType === ActionId.ObservationAddToDataset) {
+                      setShowAddToDatasetDialog(true);
+                    }
                   }}
                 />
               ) : null,
@@ -1239,10 +1267,7 @@ export default function ObservationsEventsTable({
             multiSelect={{
               selectAll,
               setSelectAll,
-              selectedRowIds:
-                Object.keys(selectedRows).filter((observationId) =>
-                  observations.rows?.map((o) => o.id).includes(observationId),
-                ) ?? [],
+              selectedRowIds: selectedObservationIds,
               setRowSelection: setSelectedRows,
               totalCount,
               pageSize: paginationState.limit,
@@ -1362,10 +1387,7 @@ export default function ObservationsEventsTable({
       {showRunEvaluationDialog && (
         <RunEvaluationDialog
           projectId={projectId}
-          selectedObservationIds={(() => {
-            const rowIds = new Set(observations.rows?.map((o) => o.id));
-            return Object.keys(selectedRows).filter((id) => rowIds.has(id));
-          })()}
+          selectedObservationIds={selectedObservationIds}
           query={{
             filter: filterState,
             orderBy: orderByState,
@@ -1379,6 +1401,28 @@ export default function ObservationsEventsTable({
             setSelectedRows({});
             setSelectAll(false);
           }}
+          exampleObservation={exampleObservation}
+        />
+      )}
+
+      {showAddToDatasetDialog && (
+        <AddObservationsToDatasetDialog
+          projectId={projectId}
+          selectedObservationIds={selectedObservationIds}
+          query={{
+            filter: filterState,
+            orderBy: orderByState,
+            searchQuery: searchQuery ?? undefined,
+            searchType,
+          }}
+          selectAll={selectAll}
+          totalCount={totalCount ?? 0}
+          onClose={() => {
+            setShowAddToDatasetDialog(false);
+            setSelectedRows({});
+            setSelectAll(false);
+          }}
+          exampleObservation={exampleObservation}
         />
       )}
     </DataTableControlsProvider>

--- a/worker/src/__tests__/batchAction.test.ts
+++ b/worker/src/__tests__/batchAction.test.ts
@@ -30,6 +30,11 @@ import { prisma } from "@langfuse/shared/src/db";
 import { Decimal } from "decimal.js";
 import waitForExpect from "wait-for-expect";
 
+const maybeDescribe =
+  process.env.LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS === "true"
+    ? describe
+    : describe.skip;
+
 describe("select all test suite", () => {
   it("should schedule trace deletions via pending_deletions table", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
@@ -582,7 +587,9 @@ describe("select all test suite", () => {
       expect(jobs).toHaveLength(0);
     });
   });
+});
 
+maybeDescribe("events table batch actions", () => {
   it("should add observations to dataset from events table with full mapping", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
 

--- a/worker/src/__tests__/batchAction.test.ts
+++ b/worker/src/__tests__/batchAction.test.ts
@@ -1,6 +1,8 @@
 import {
   BatchExportTableName,
   BatchActionType,
+  BatchTableNames,
+  BatchActionStatus,
   EvalTargetObject,
 } from "@langfuse/shared";
 import { expect, describe, it, vi } from "vitest";
@@ -13,6 +15,8 @@ import {
   createScoresCh,
   createTrace,
   createTracesCh,
+  createEvent,
+  createEventsCh,
   getQueue,
   getScoresByIds,
   QueueJobs,
@@ -577,5 +581,263 @@ describe("select all test suite", () => {
       const jobs = await queue?.getJobs();
       expect(jobs).toHaveLength(0);
     });
+  });
+
+  it("should add observations to dataset from events table with full mapping", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const traceId = uuidv4();
+    const trace = createTrace({
+      project_id: projectId,
+      id: traceId,
+      timestamp: new Date().getTime(),
+    });
+    await createTracesCh([trace]);
+
+    const eventInput1 = { prompt: "Hello, how are you?" };
+    const eventOutput1 = { response: "I'm fine, thank you!" };
+    const eventInput2 = { prompt: "What is 2+2?" };
+    const eventOutput2 = { response: "4" };
+
+    const event1 = createEvent({
+      project_id: projectId,
+      trace_id: traceId,
+      input: eventInput1,
+      output: eventOutput1,
+      metadata: { source: "test" },
+    });
+    const event2 = createEvent({
+      project_id: projectId,
+      trace_id: traceId,
+      input: eventInput2,
+      output: eventOutput2,
+      metadata: { source: "test" },
+    });
+
+    await createEventsCh([event1, event2]);
+
+    const datasetName = uuidv4();
+    const dataset = await prisma.dataset.create({
+      data: {
+        id: uuidv4(),
+        projectId,
+        name: datasetName,
+      },
+    });
+
+    const batchAction = await prisma.batchAction.create({
+      data: {
+        projectId,
+        userId: "test-user",
+        actionType: "observation-add-to-dataset",
+        tableName: BatchTableNames.Events,
+        status: BatchActionStatus.Queued,
+        query: { filter: [], orderBy: null },
+      },
+    });
+
+    await handleBatchActionJob({
+      id: uuidv4(),
+      timestamp: new Date(),
+      name: QueueJobs.BatchActionProcessingJob as const,
+      payload: {
+        batchActionId: batchAction.id,
+        projectId,
+        actionId: "observation-add-to-dataset" as const,
+        tableName: BatchTableNames.Events,
+        cutoffCreatedAt: new Date(),
+        query: { filter: [], orderBy: null },
+        config: {
+          datasetId: dataset.id,
+          datasetName: dataset.name,
+          mapping: {
+            input: { mode: "full" as const },
+            expectedOutput: { mode: "full" as const },
+            metadata: { mode: "none" as const },
+          },
+        },
+        type: BatchActionType.Create,
+      },
+    });
+
+    const datasetItems = await prisma.datasetItem.findMany({
+      where: { datasetId: dataset.id },
+    });
+
+    expect(datasetItems).toHaveLength(2);
+
+    const eventSpanIds = [event1.span_id, event2.span_id];
+    for (const item of datasetItems) {
+      expect(eventSpanIds).toContain(item.sourceObservationId);
+      expect(item.sourceTraceId).toBe(traceId);
+      expect(item.metadata).toBeNull();
+    }
+
+    // Verify each item's input/output matches the corresponding event
+    const item1 = datasetItems.find(
+      (i) => i.sourceObservationId === event1.span_id,
+    );
+    const item2 = datasetItems.find(
+      (i) => i.sourceObservationId === event2.span_id,
+    );
+
+    expect(item1?.input).toEqual(eventInput1);
+    expect(item1?.expectedOutput).toEqual(eventOutput1);
+    expect(item2?.input).toEqual(eventInput2);
+    expect(item2?.expectedOutput).toEqual(eventOutput2);
+
+    // Verify batch action status
+    const updatedBatchAction = await prisma.batchAction.findUnique({
+      where: { id: batchAction.id },
+    });
+    expect(updatedBatchAction?.status).toBe(BatchActionStatus.Completed);
+    expect(updatedBatchAction?.processedCount).toBe(2);
+  });
+
+  it("should apply jsonSelector mapping when adding events to dataset", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const traceId = uuidv4();
+    const trace = createTrace({
+      project_id: projectId,
+      id: traceId,
+      timestamp: new Date().getTime(),
+    });
+    await createTracesCh([trace]);
+
+    const eventInput = {
+      messages: [
+        { role: "system", content: "You are helpful." },
+        { role: "user", content: "What is 2+2?" },
+      ],
+    };
+    const eventOutput = {
+      choices: [{ message: { content: "4", role: "assistant" } }],
+    };
+    const eventMetadata = { user_id: "user-123", session_id: "session-456" };
+
+    const event = createEvent({
+      project_id: projectId,
+      trace_id: traceId,
+      input: eventInput,
+      output: eventOutput,
+      metadata: eventMetadata,
+    });
+
+    await createEventsCh([event]);
+
+    const datasetName = uuidv4();
+    const dataset = await prisma.dataset.create({
+      data: {
+        id: uuidv4(),
+        projectId,
+        name: datasetName,
+      },
+    });
+
+    const batchAction = await prisma.batchAction.create({
+      data: {
+        projectId,
+        userId: "test-user",
+        actionType: "observation-add-to-dataset",
+        tableName: BatchTableNames.Events,
+        status: BatchActionStatus.Queued,
+        query: { filter: [], orderBy: null },
+      },
+    });
+
+    await handleBatchActionJob({
+      id: uuidv4(),
+      timestamp: new Date(),
+      name: QueueJobs.BatchActionProcessingJob as const,
+      payload: {
+        batchActionId: batchAction.id,
+        projectId,
+        actionId: "observation-add-to-dataset" as const,
+        tableName: BatchTableNames.Events,
+        cutoffCreatedAt: new Date(),
+        query: { filter: [], orderBy: null },
+        config: {
+          datasetId: dataset.id,
+          datasetName: dataset.name,
+          mapping: {
+            input: {
+              mode: "custom" as const,
+              custom: {
+                type: "keyValueMap" as const,
+                keyValueMapConfig: {
+                  entries: [
+                    {
+                      id: "1",
+                      key: "prompt",
+                      sourceField: "input" as const,
+                      value: "$.messages[1].content",
+                    },
+                    {
+                      id: "2",
+                      key: "system",
+                      sourceField: "input" as const,
+                      value: "$.messages[0].content",
+                    },
+                  ],
+                },
+              },
+            },
+            expectedOutput: {
+              mode: "custom" as const,
+              custom: {
+                type: "root" as const,
+                rootConfig: {
+                  sourceField: "output" as const,
+                  jsonPath: "$.choices[0].message.content",
+                },
+              },
+            },
+            metadata: {
+              mode: "custom" as const,
+              custom: {
+                type: "keyValueMap" as const,
+                keyValueMapConfig: {
+                  entries: [
+                    {
+                      id: "3",
+                      key: "user",
+                      sourceField: "metadata" as const,
+                      value: "$.user_id",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+        type: BatchActionType.Create,
+      },
+    });
+
+    const datasetItems = await prisma.datasetItem.findMany({
+      where: { datasetId: dataset.id },
+    });
+
+    expect(datasetItems).toHaveLength(1);
+
+    const item = datasetItems[0];
+    expect(item.sourceObservationId).toBe(event.span_id);
+    expect(item.sourceTraceId).toBe(traceId);
+    expect(item.input).toEqual({
+      prompt: "What is 2+2?",
+      system: "You are helpful.",
+    });
+    // The jsonPath extracts the string "4" from output, but it's stored as a
+    // JSON scalar in Postgres. Prisma deserializes the JSON column as a number.
+    expect(item.expectedOutput).toBe(4);
+    expect(item.metadata).toEqual({ user: "user-123" });
+
+    // Verify batch action status
+    const updatedBatchAction = await prisma.batchAction.findUnique({
+      where: { id: batchAction.id },
+    });
+    expect(updatedBatchAction?.status).toBe(BatchActionStatus.Completed);
+    expect(updatedBatchAction?.processedCount).toBe(1);
   });
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add feature to batch add observations to dataset from events table with support for full and custom JSON selector mapping.
> 
>   - **Behavior**:
>     - Adds `AddObservationsToDatasetDialog` to `EventsTable.tsx` for adding observations to a dataset.
>     - Supports both full mapping and custom JSON selector mapping for dataset items.
>     - Uses `exampleObservation` for previewing selected observations.
>   - **Server**:
>     - Updates `addToDatasetRouter.ts` to handle dataset addition using events table when `LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS` is true.
>     - Introduces `getEventsStreamForDataset` in `event-stream.ts` for fetching necessary fields for dataset item creation.
>   - **Tests**:
>     - Adds tests in `batchAction.test.ts` for adding observations to dataset with full mapping and JSON selector mapping.
>   - **Misc**:
>     - Modifies `handleBatchActionJob.ts` to process `observation-add-to-dataset` action using events table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 7f5dfc92b2add11ba8aa3d20110eee6e9c24b981. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->