### PR TITLE
feat(dashboard): add v2 backend path for ModelUsageChart cost/usage-by-type timeseries

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -228,6 +228,18 @@ jobs:
         run: |
           pnpm run db:migrate
           pnpm --filter=shared ch:up
+      - name: Download and extract ClickHouse client for dev-tables setup
+        run: |
+          CH_VERSION="24.9.3.128"
+          ARCH="amd64"
+          wget "https://packages.clickhouse.com/deb/pool/main/c/clickhouse/clickhouse-common-static_${CH_VERSION}_${ARCH}.deb" -O clickhouse-client.deb
+
+          # The binary is usually located in ./usr/bin/clickhouse in the archive
+          dpkg-deb -x clickhouse-client.deb ch_client_dir
+          sudo cp ch_client_dir/usr/bin/clickhouse /usr/local/bin/
+      - name: Setup Dev Tables
+        run: |
+          pnpm --filter=shared ch:dev-tables
       - name: Build
         run: pnpm run build
         env:

--- a/web/src/__tests__/queryBuilder.servertest.ts
+++ b/web/src/__tests__/queryBuilder.servertest.ts
@@ -11,6 +11,8 @@ import {
   createObservationsCh,
   createTraceScore,
   createScoresCh,
+  createEvent,
+  createEventsCh,
 } from "@langfuse/shared/src/server";
 import { randomUUID } from "crypto";
 
@@ -3727,6 +3729,378 @@ describe("queryBuilder", () => {
       expect(resultWithoutOpt[0].sum_count).toBe(5);
       expect(resultWithOpt[0].sum_count).toBe(5);
       expect(resultWithOpt).toEqual(resultWithoutOpt);
+    });
+  });
+
+  describe("pairExpand map expansion (v2)", () => {
+    it("should emit ARRAY JOIN clause for pairExpand dimensions", async () => {
+      const projectId = randomUUID();
+      const builder = new QueryBuilder(undefined, "v2");
+      const { query: sql } = await builder.build(
+        {
+          view: "observations",
+          dimensions: [{ field: "costType" }],
+          metrics: [{ measure: "costByType", aggregation: "sum" }],
+          filters: [],
+          timeDimension: null,
+          fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
+          toTimestamp: new Date(Date.now() + 86400000).toISOString(),
+          orderBy: null,
+        },
+        projectId,
+        true,
+      );
+
+      expect(sql).toContain("ARRAY JOIN");
+      expect(sql).toContain(
+        "mapKeys(events_observations.cost_details) AS costType",
+      );
+      expect(sql).toContain(
+        "mapValues(events_observations.cost_details) AS cost_value",
+      );
+      // ARRAY JOIN must appear before WHERE
+      expect(sql.indexOf("ARRAY JOIN")).toBeLessThan(sql.indexOf("WHERE"));
+      // No inline arrayJoin() function call — must use clause form
+      expect(sql).not.toMatch(/arrayJoin\(mapKeys/);
+    });
+
+    it("should aggregate cost_details by type correctly", async () => {
+      const projectId = randomUUID();
+
+      const events = [
+        createEvent({
+          project_id: projectId,
+          type: "GENERATION",
+          cost_details: { input: 10, output: 20, total: 30 },
+          start_time: Date.now() * 1000,
+        }),
+        createEvent({
+          project_id: projectId,
+          type: "GENERATION",
+          cost_details: { input: 5, output: 15, total: 20 },
+          start_time: Date.now() * 1000,
+        }),
+      ];
+      await createEventsCh(events);
+
+      const result = await executeQuery(
+        projectId,
+        {
+          view: "observations",
+          dimensions: [{ field: "costType" }],
+          metrics: [{ measure: "costByType", aggregation: "sum" }],
+          filters: [],
+          timeDimension: null,
+          fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
+          toTimestamp: new Date(Date.now() + 86400000).toISOString(),
+          orderBy: null,
+        },
+        "v2",
+        true,
+      );
+
+      expect(result).toHaveLength(3);
+
+      const inputRow = result.find((r) => r["costType"] === "input");
+      expect(Number(inputRow?.["sum_costByType"])).toBeCloseTo(15, 2); // 10 + 5
+
+      const outputRow = result.find((r) => r["costType"] === "output");
+      expect(Number(outputRow?.["sum_costByType"])).toBeCloseTo(35, 2); // 20 + 15
+
+      const totalRow = result.find((r) => r["costType"] === "total");
+      expect(Number(totalRow?.["sum_costByType"])).toBeCloseTo(50, 2); // 30 + 20
+    });
+
+    it("should aggregate usage_details by type correctly", async () => {
+      const projectId = randomUUID();
+
+      const events = [
+        createEvent({
+          project_id: projectId,
+          type: "GENERATION",
+          usage_details: { input: 100, output: 200, total: 300 },
+          start_time: Date.now() * 1000,
+        }),
+        createEvent({
+          project_id: projectId,
+          type: "GENERATION",
+          usage_details: { input: 50, output: 75, total: 125 },
+          start_time: Date.now() * 1000,
+        }),
+      ];
+      await createEventsCh(events);
+
+      const result = await executeQuery(
+        projectId,
+        {
+          view: "observations",
+          dimensions: [{ field: "usageType" }],
+          metrics: [{ measure: "usageByType", aggregation: "sum" }],
+          filters: [],
+          timeDimension: null,
+          fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
+          toTimestamp: new Date(Date.now() + 86400000).toISOString(),
+          orderBy: null,
+        },
+        "v2",
+        true,
+      );
+
+      expect(result).toHaveLength(3);
+
+      const inputRow = result.find((r) => r["usageType"] === "input");
+      expect(Number(inputRow?.["sum_usageByType"])).toBe(150); // 100 + 50
+
+      const outputRow = result.find((r) => r["usageType"] === "output");
+      expect(Number(outputRow?.["sum_usageByType"])).toBe(275); // 200 + 75
+    });
+
+    it("should produce timeseries with costType dimension and WITH FILL", async () => {
+      const projectId = randomUUID();
+      const now = new Date();
+
+      const events = [
+        createEvent({
+          project_id: projectId,
+          type: "GENERATION",
+          cost_details: { input: 10, output: 20 },
+          start_time: now.getTime() * 1000,
+        }),
+      ];
+      await createEventsCh(events);
+
+      const builder = new QueryBuilder(undefined, "v2");
+      const { query: sql } = await builder.build(
+        {
+          view: "observations",
+          dimensions: [{ field: "costType" }],
+          metrics: [{ measure: "costByType", aggregation: "sum" }],
+          filters: [],
+          timeDimension: { granularity: "day" },
+          fromTimestamp: new Date(now.getTime() - 2 * 86400000).toISOString(),
+          toTimestamp: new Date(now.getTime() + 86400000).toISOString(),
+          orderBy: null,
+        },
+        projectId,
+        true,
+      );
+
+      expect(sql).toContain("WITH FILL");
+      expect(sql).toContain("time_dimension");
+      // GROUP BY parts may be newline-separated in the generated SQL
+      expect(sql).toContain("GROUP BY costType");
+      expect(sql).toMatch(/GROUP BY costType[\s,]+time_dimension/);
+
+      const result = await executeQuery(
+        projectId,
+        {
+          view: "observations",
+          dimensions: [{ field: "costType" }],
+          metrics: [{ measure: "costByType", aggregation: "sum" }],
+          filters: [],
+          timeDimension: { granularity: "day" },
+          fromTimestamp: new Date(now.getTime() - 2 * 86400000).toISOString(),
+          toTimestamp: new Date(now.getTime() + 86400000).toISOString(),
+          orderBy: null,
+        },
+        "v2",
+        true,
+      );
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0]).toHaveProperty("time_dimension");
+      expect(result[0]).toHaveProperty("costType");
+      expect(result[0]).toHaveProperty("sum_costByType");
+    });
+
+    it("should respect type filter with pairExpand dimensions", async () => {
+      const projectId = randomUUID();
+
+      const events = [
+        createEvent({
+          project_id: projectId,
+          type: "GENERATION",
+          cost_details: { input: 10 },
+          start_time: Date.now() * 1000,
+        }),
+        createEvent({
+          project_id: projectId,
+          type: "SPAN",
+          cost_details: { input: 999 },
+          start_time: Date.now() * 1000,
+        }),
+      ];
+      await createEventsCh(events);
+
+      const result = await executeQuery(
+        projectId,
+        {
+          view: "observations",
+          dimensions: [{ field: "costType" }],
+          metrics: [{ measure: "costByType", aggregation: "sum" }],
+          filters: [
+            {
+              column: "type",
+              operator: "=",
+              value: "GENERATION",
+              type: "string",
+            },
+          ],
+          timeDimension: null,
+          fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
+          toTimestamp: new Date(Date.now() + 86400000).toISOString(),
+          orderBy: null,
+        },
+        "v2",
+        true,
+      );
+
+      const inputRow = result.find((r) => r["costType"] === "input");
+      // Only GENERATION row contributes: 10, not 999
+      expect(Number(inputRow?.["sum_costByType"])).toBeCloseTo(10, 2);
+    });
+
+    it("should aggregate cost_details by type correctly via two-level query path", async () => {
+      // Forces the two-level path by passing useSingleLevelOptimization=false.
+      // Verifies that the bare alias reference in buildInnerDimensionsPart
+      // (not any()) is correct when the pairExpand dim is in GROUP BY.
+      const projectId = randomUUID();
+
+      const events = [
+        createEvent({
+          project_id: projectId,
+          type: "GENERATION",
+          cost_details: { input: 10, output: 20, total: 30 },
+          start_time: Date.now() * 1000,
+        }),
+        createEvent({
+          project_id: projectId,
+          type: "GENERATION",
+          cost_details: { input: 5, output: 15, total: 20 },
+          start_time: Date.now() * 1000,
+        }),
+      ];
+      await createEventsCh(events);
+
+      const result = await executeQuery(
+        projectId,
+        {
+          view: "observations",
+          dimensions: [{ field: "costType" }],
+          metrics: [{ measure: "costByType", aggregation: "sum" }],
+          filters: [],
+          timeDimension: null,
+          fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
+          toTimestamp: new Date(Date.now() + 86400000).toISOString(),
+          orderBy: null,
+        },
+        "v2",
+        false, // force two-level path
+      );
+
+      expect(result).toHaveLength(3);
+
+      const inputRow = result.find((r) => r["costType"] === "input");
+      expect(Number(inputRow?.["sum_costByType"])).toBeCloseTo(15, 2); // 10 + 5
+
+      const outputRow = result.find((r) => r["costType"] === "output");
+      expect(Number(outputRow?.["sum_costByType"])).toBeCloseTo(35, 2); // 20 + 15
+
+      const totalRow = result.find((r) => r["costType"] === "total");
+      expect(Number(totalRow?.["sum_costByType"])).toBeCloseTo(50, 2); // 30 + 20
+    });
+
+    it("should auto-include costType dimension when only costByType measure is requested", async () => {
+      // Verifies requiresDimension: the query builder must inject the costType
+      // dimension automatically so the ARRAY JOIN is emitted and cost_value is in scope.
+      const projectId = randomUUID();
+
+      const events = [
+        createEvent({
+          project_id: projectId,
+          type: "GENERATION",
+          cost_details: { input: 7, output: 3 },
+          start_time: Date.now() * 1000,
+        }),
+      ];
+      await createEventsCh(events);
+
+      // No costType dimension requested — the builder should add it automatically.
+      const result = await executeQuery(
+        projectId,
+        {
+          view: "observations",
+          dimensions: [], // intentionally empty
+          metrics: [{ measure: "costByType", aggregation: "sum" }],
+          filters: [],
+          timeDimension: null,
+          fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
+          toTimestamp: new Date(Date.now() + 86400000).toISOString(),
+          orderBy: null,
+        },
+        "v2",
+        true,
+      );
+
+      // costType should appear in results even though it was not explicitly requested
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0]).toHaveProperty("costType");
+
+      const inputRow = result.find((r) => r["costType"] === "input");
+      expect(Number(inputRow?.["sum_costByType"])).toBeCloseTo(7, 2);
+
+      const outputRow = result.find((r) => r["costType"] === "output");
+      expect(Number(outputRow?.["sum_costByType"])).toBeCloseTo(3, 2);
+    });
+
+    it("should throw when multiple pairExpand dimensions are requested directly", async () => {
+      // Two separate ARRAY JOIN clauses create a cartesian product in ClickHouse.
+      const projectId = randomUUID();
+      const builder = new QueryBuilder(undefined, "v2");
+
+      await expect(
+        builder.build(
+          {
+            view: "observations",
+            dimensions: [{ field: "costType" }, { field: "usageType" }],
+            metrics: [{ measure: "costByType", aggregation: "sum" }],
+            filters: [],
+            timeDimension: null,
+            fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
+            toTimestamp: new Date(Date.now() + 86400000).toISOString(),
+            orderBy: null,
+          },
+          projectId,
+          true,
+        ),
+      ).rejects.toThrow("Only one pairExpand dimension is supported per query");
+    });
+
+    it("should throw when both costByType and usageByType measures are requested (auto-inject creates two pairExpand dims)", async () => {
+      // Each measure auto-injects its required pairExpand dimension via requiresDimension.
+      // Requesting both triggers the multi-pairExpand guard.
+      const projectId = randomUUID();
+      const builder = new QueryBuilder(undefined, "v2");
+
+      await expect(
+        builder.build(
+          {
+            view: "observations",
+            dimensions: [],
+            metrics: [
+              { measure: "costByType", aggregation: "sum" },
+              { measure: "usageByType", aggregation: "sum" },
+            ],
+            filters: [],
+            timeDimension: null,
+            fromTimestamp: new Date(Date.now() - 86400000).toISOString(),
+            toTimestamp: new Date(Date.now() + 86400000).toISOString(),
+            orderBy: null,
+          },
+          projectId,
+          true,
+        ),
+      ).rejects.toThrow("Only one pairExpand dimension is supported per query");
     });
   });
 });

--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -1104,6 +1104,28 @@ export const eventsObservationsView: ViewDeclarationType = {
       description: "Names of tools that were called by the observation.",
       explodeArray: true,
     },
+    costType: {
+      sql: "mapKeys(events_observations.cost_details)",
+      alias: "costType",
+      type: "string",
+      description:
+        "Cost category key from cost_details map (e.g. 'input', 'output', 'total').",
+      pairExpand: {
+        valuesSql: "mapValues(events_observations.cost_details)",
+        valueAlias: "cost_value",
+      },
+    },
+    usageType: {
+      sql: "mapKeys(events_observations.usage_details)",
+      alias: "usageType",
+      type: "string",
+      description:
+        "Token usage category key from usage_details map (e.g. 'input', 'output', 'total').",
+      pairExpand: {
+        valuesSql: "mapValues(events_observations.usage_details)",
+        valueAlias: "usage_value",
+      },
+    },
   },
   measures: {
     count: {
@@ -1229,6 +1251,24 @@ export const eventsObservationsView: ViewDeclarationType = {
       type: "integer",
       description: "Number of tool calls per observation.",
       unit: "calls",
+    },
+    costByType: {
+      sql: "cost_value",
+      alias: "costByType",
+      type: "decimal",
+      unit: "USD",
+      requiresDimension: "costType",
+      description:
+        "Sum of cost per category. The costType dimension is auto-included to emit the ARRAY JOIN that brings cost_value into scope.",
+    },
+    usageByType: {
+      sql: "usage_value",
+      alias: "usageByType",
+      type: "integer",
+      unit: "tokens",
+      requiresDimension: "usageType",
+      description:
+        "Sum of token usage per category. The usageType dimension is auto-included to emit the ARRAY JOIN that brings usage_value into scope.",
     },
   },
   tableRelations: {

--- a/web/src/features/query/server/queryBuilder.ts
+++ b/web/src/features/query/server/queryBuilder.ts
@@ -26,6 +26,7 @@ type AppliedDimensionType = {
   relationTable?: string;
   aggregationFunction?: string;
   explodeArray?: boolean;
+  pairExpand?: { valuesSql: string; valueAlias: string };
 };
 
 type AppliedMetricType = {
@@ -35,6 +36,7 @@ type AppliedMetricType = {
   relationTable?: string;
   aggs?: Record<string, string>;
   measureName: string; // Original measure name for lookups
+  requiresDimension?: string;
 };
 
 export class QueryBuilder {
@@ -105,6 +107,7 @@ export class QueryBuilder {
         ...dim,
         table: dim.relationTable || view.name,
         explodeArray: dim.explodeArray,
+        pairExpand: dim.pairExpand,
       };
     });
   }
@@ -400,12 +403,19 @@ export class QueryBuilder {
     appliedMetrics: AppliedMetricType[],
   ): boolean {
     // Single-level query requires:
-    // 1. All metrics have aggs configuration
+    // 1. All metrics are single-level compatible, which means either:
+    //    a. They have aggs configuration (@@AGGN@@ templates that resolve to function
+    //       calls), OR
+    //    b. They are pairExpand value-alias measures (requiresDimension is set). These
+    //       reference a plain column brought into scope by the ARRAY JOIN clause and
+    //       work correctly with a direct sum()/avg() in a single SELECT.
     // 2. No custom aggregation functions on dimensions
-    // Measures without .aggs: {} (like uniq(scores.id)) must use two-level approach
+    // Measures without either (like uniq(scores.id)) must use the two-level approach.
     const allMetricsHaveAggs =
       appliedMetrics.length === 0 ||
-      appliedMetrics.every((m) => m.aggs !== undefined);
+      appliedMetrics.every(
+        (m) => m.aggs !== undefined || m.requiresDimension !== undefined,
+      );
 
     // Check if any dimension has custom aggregation
     const hasCustomDimensionAgg = appliedDimensions.some(
@@ -493,6 +503,22 @@ export class QueryBuilder {
       relationJoins.push(joinStatement);
     }
     return relationJoins;
+  }
+
+  private buildArrayJoinClause(
+    appliedDimensions: AppliedDimensionType[],
+  ): string {
+    const pairs = appliedDimensions.filter((d) => d.pairExpand);
+    if (pairs.length === 0) return "";
+    // Multiple pairExpand dimensions would produce separate ARRAY JOIN clauses
+    // which ClickHouse executes as a cartesian product — almost certainly wrong.
+    if (pairs.length > 1) {
+      throw new InvalidRequestError(
+        `Only one pairExpand dimension is supported per query. Found: ${pairs.map((d) => d.alias ?? d.sql).join(", ")}`,
+      );
+    }
+    const d = pairs[0];
+    return `ARRAY JOIN\n  ${d.sql} AS ${d.alias ?? d.sql},\n  ${d.pairExpand!.valuesSql} AS ${d.pairExpand!.valueAlias}`;
   }
 
   private buildWhereClause(
@@ -615,6 +641,11 @@ export class QueryBuilder {
           if (dimension.aggregationFunction) {
             return `${dimension.aggregationFunction} as ${dimension.alias ?? dimension.sql}`;
           }
+          // pairExpand dimensions: key column is in GROUP BY (see buildInnerSelect),
+          // so use a bare reference — wrapping in any() would be semantically misleading.
+          if (dimension.pairExpand) {
+            return `${dimension.alias} as ${dimension.alias ?? dimension.sql}`;
+          }
           // Explode array dimensions using arrayJoin
           if (dimension.explodeArray) {
             return `arrayJoin(${dimension.sql}) as ${dimension.alias ?? dimension.sql}`;
@@ -643,9 +674,19 @@ export class QueryBuilder {
       .map((metric) => {
         let sql = metric.sql;
 
-        // For two-level queries, substitute ${aggN} with actual agg function from template
+        // For two-level queries, substitute @@AGGN@@ with actual agg function from template
         if (metric.aggs) {
           sql = this.substituteAggTemplates(sql, metric.aggs);
+        }
+
+        // pairExpand value-alias measures (e.g. costByType, usageByType) reference a raw
+        // column brought into scope by the ARRAY JOIN clause. That column is not in the
+        // inner GROUP BY, so wrap it in any() to satisfy ClickHouse. The outer query then
+        // applies the real aggregation. We scope this to requiresDimension metrics only —
+        // other measures use @@AGGN@@ templates that resolve to function calls, so they
+        // never need this treatment.
+        if (metric.requiresDimension && !sql.includes("(")) {
+          sql = `any(${sql})`;
         }
 
         return `${sql} as ${metric.alias || metric.sql}`;
@@ -666,9 +707,10 @@ export class QueryBuilder {
     const projectIdSql = `${actualTableName}.project_id`;
 
     // Build inner GROUP BY - include exploded array dimensions (they must be in GROUP BY after arrayJoin)
+    // Also include pairExpand dimensions (their key column is in scope after ARRAY JOIN clause)
     const groupByParts = [projectIdSql, idSql];
     for (const dim of appliedDimensions) {
-      if (dim.explodeArray) {
+      if (dim.explodeArray || dim.pairExpand) {
         groupByParts.push(dim.alias ?? dim.sql);
       }
     }
@@ -864,6 +906,10 @@ export class QueryBuilder {
       dimensionsPart =
         appliedDimensions
           .map((d) => {
+            if (d.pairExpand) {
+              // Bare reference — already projected by the ARRAY JOIN clause
+              return `${d.alias} as ${d.alias ?? d.sql}`;
+            }
             if (d.explodeArray) {
               return `arrayJoin(${d.sql}) as ${d.alias ?? d.sql}`;
             }
@@ -1080,6 +1126,25 @@ export class QueryBuilder {
     const appliedDimensions = this.mapDimensions(query.dimensions, view);
     const appliedMetrics = this.mapMetrics(query.metrics, view);
 
+    // Auto-include dimensions required by pairExpand-dependent measures.
+    // e.g. costByType.requiresDimension = "costType": without that dimension the
+    // ARRAY JOIN is never emitted and ClickHouse errors with "unknown column cost_value".
+    for (const metric of appliedMetrics) {
+      if (
+        metric.requiresDimension &&
+        !appliedDimensions.some((d) => d.alias === metric.requiresDimension)
+      ) {
+        const requiredDimDef = view.dimensions[metric.requiresDimension];
+        if (requiredDimDef) {
+          appliedDimensions.push({
+            ...requiredDimDef,
+            table: requiredDimDef.relationTable || view.name,
+            pairExpand: requiredDimDef.pairExpand,
+          });
+        }
+      }
+    }
+
     // Create a new FilterList with the mapped filters
     let filterList = new FilterList(this.mapFilters(query.filters, view));
 
@@ -1111,6 +1176,12 @@ export class QueryBuilder {
         skipObservationsFinal,
       );
       fromClause += ` ${relationJoins.join(" ")}`;
+    }
+
+    // ARRAY JOIN must appear after regular JOINs and before WHERE
+    const arrayJoinClause = this.buildArrayJoinClause(appliedDimensions);
+    if (arrayJoinClause) {
+      fromClause += `\n${arrayJoinClause}`;
     }
 
     // Build WHERE clause with parameters

--- a/web/src/features/query/server/queryBuilder.ts
+++ b/web/src/features/query/server/queryBuilder.ts
@@ -641,8 +641,14 @@ export class QueryBuilder {
           if (dimension.aggregationFunction) {
             return `${dimension.aggregationFunction} as ${dimension.alias ?? dimension.sql}`;
           }
-          // pairExpand dimensions: key column is in GROUP BY (see buildInnerSelect),
-          // so use a bare reference — wrapping in any() would be semantically misleading.
+          // pairExpand key columns (e.g. costType) are added to the inner GROUP BY in
+          // buildInnerSelect, so they are already deterministic grouping keys here.
+          // Unlike regular dimensions (which are not in GROUP BY and need any() to satisfy
+          // ClickHouse's aggregation rules), wrapping in any() would be wrong: it implies
+          // the value is non-deterministic within the group when it's actually the axis
+          // being grouped on. Use a bare reference instead.
+          // Note: the paired value column (e.g. cost_value) is NOT in GROUP BY and IS
+          // wrapped in any() in buildInnerMetricsPart, so the outer query can re-aggregate it.
           if (dimension.pairExpand) {
             return `${dimension.alias} as ${dimension.alias ?? dimension.sql}`;
           }

--- a/web/src/features/query/types.ts
+++ b/web/src/features/query/types.ts
@@ -23,6 +23,12 @@ export const viewDeclaration = z.object({
       aggregationFunction: z.string().optional(),
       highCardinality: z.boolean().optional(),
       explodeArray: z.boolean().optional(),
+      pairExpand: z
+        .object({
+          valuesSql: z.string(),
+          valueAlias: z.string(),
+        })
+        .optional(),
     }),
   ),
   measures: z.record(
@@ -35,6 +41,10 @@ export const viewDeclaration = z.object({
       type: z.string().optional(),
       unit: z.string().optional(),
       aggs: z.record(z.string(), z.string()).optional(),
+      // When set, the query builder will auto-include this dimension if it is absent.
+      // Used for pairExpand value-alias measures (e.g. costByType requires costType so
+      // the ARRAY JOIN is emitted and "cost_value" is in scope).
+      requiresDimension: z.string().optional(),
     }),
   ),
   tableRelations: z.record(


### PR DESCRIPTION
Extends the executeQuery / QueryBuilder system with a pairExpand
concept for clause-level ARRAY JOIN on ClickHouse Map columns, enabling the
"Cost by type" and "Usage by type" tabs of ModelUsageChart to use the v2 events path.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces v2 backend path for ModelUsageChart cost/usage-by-type timeseries using ClickHouse Map columns with pairExpand support.
> 
>   - **Behavior**:
>     - Adds `getObservationsByTypeV2()` in `dashboard-router.ts` for v2 cost/usage by type timeseries.
>     - Extends `QueryBuilder` to support `pairExpand` for ARRAY JOIN on ClickHouse Map columns.
>     - Updates `dashboardRouter` to handle v2 queries for `observations-usage-by-type-timeseries` and `observations-cost-by-type-timeseries`.
>   - **Models**:
>     - Adds `costType` and `usageType` dimensions with `pairExpand` in `eventsObservationsView` in `dataModel.ts`.
>     - Adds `costByType` and `usageByType` measures in `eventsObservationsView`.
>   - **Tests**:
>     - Adds tests for `pairExpand` functionality in `queryBuilder.servertest.ts`.
>     - Updates `dashboard-v1-v2-consistency.servertest.ts` to test v2 path for cost/usage by type timeseries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 5b1529127da566d0a17fc7e32783e3f1d0df1112. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->