### PR TITLE
feat(dashboard): enable single-level query optimization for v2 and route events_core to read replica

### DIFF
--- a/web/src/__tests__/async/dashboard-v1-v2-consistency.servertest.ts
+++ b/web/src/__tests__/async/dashboard-v1-v2-consistency.servertest.ts
@@ -509,7 +509,7 @@ describe("dashboard v1 vs v2 consistency", () => {
   }> {
     const [v1, v2] = await Promise.all([
       executeQuery(projectId, query, "v1"),
-      executeQuery(projectId, query, "v2"),
+      executeQuery(projectId, query, "v2", true),
     ]);
     return { v1, v2 };
   }

--- a/web/src/features/dashboard/server/dashboard-router.ts
+++ b/web/src/features/dashboard/server/dashboard-router.ts
@@ -365,6 +365,7 @@ export const dashboardRouter = createTRPCRouter({
           input.projectId,
           input.query as QueryType,
           input.version,
+          input.version === "v2",
         );
       } catch (error) {
         if (error instanceof InvalidRequestError) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable single-level query optimization for v2 and route `events_core` queries to a read replica in `executeQuery()`.
> 
>   - **Behavior**:
>     - Enable single-level query optimization for v2 queries in `executeQuery()` in `queryExecutor.ts`.
>     - Route `events_core` queries to a dedicated read replica in `executeQuery()` in `queryExecutor.ts`.
>   - **Tests**:
>     - Update `runBothVersions()` in `dashboard-v1-v2-consistency.servertest.ts` to pass `true` for `enableSingleLevelOptimization` for v2 queries.
>   - **Misc**:
>     - Add `enableSingleLevelOptimization` parameter to `executeQuery()` in `dashboard-router.ts` and `queryExecutor.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6b6f2fdbb8cd569f8570a9881b5be7fc6368c193. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->