### PR TITLE
chore(v4): update environment variable references to events table for tests and observation trpc routes

### DIFF
--- a/web/src/__tests__/async/observation-api.servertest.ts
+++ b/web/src/__tests__/async/observation-api.servertest.ts
@@ -471,7 +471,7 @@ describe("/api/public/observations API Endpoint", () => {
   };
 
   // Run tests with both implementations
-  if (env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true") {
+  if (env.LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS === "true") {
     runTestSuite(true); // with events table
   }
   runTestSuite(false); // with observations table

--- a/web/src/__tests__/async/observations-api.servertest.ts
+++ b/web/src/__tests__/async/observations-api.servertest.ts
@@ -553,7 +553,7 @@ describe("/api/public/observations API Endpoint", () => {
   };
 
   // Run tests with both implementations
-  if (env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true") {
+  if (env.LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS === "true") {
     runTestSuite(true); // with events table
   }
   runTestSuite(false); // with observations table
@@ -885,7 +885,7 @@ describe("/api/public/observations API Endpoint", () => {
     };
 
     // Run all advanced filtering tests for both implementations
-    if (env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true") {
+    if (env.LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS === "true") {
       runAdvancedFilterTestSuite(true); // with events table
     }
     runAdvancedFilterTestSuite(false); // with observations table
@@ -1221,7 +1221,7 @@ describe("/api/public/observations API Endpoint", () => {
     };
 
     // Run parentObservationId filter tests for both implementations
-    if (env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true") {
+    if (env.LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS === "true") {
       runParentObservationIdFilterTestSuite(true); // with events table
     }
     runParentObservationIdFilterTestSuite(false); // with observations table

--- a/web/src/__tests__/async/observations-comment-filter.servertest.ts
+++ b/web/src/__tests__/async/observations-comment-filter.servertest.ts
@@ -17,8 +17,7 @@ import { env } from "@/src/env.mjs";
 
 describe("Observations Comment Filtering", () => {
   const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
-  const useEventsTable =
-    env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true";
+  const useEventsTable = env.LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS === "true";
 
   const session: Session = {
     expires: "1",

--- a/web/src/__tests__/async/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/async/repositories/event-repository.servertest.ts
@@ -19,7 +19,7 @@ import waitForExpect from "wait-for-expect";
 const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
 
 const maybe =
-  env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true"
+  env.LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS === "true"
     ? describe
     : describe.skip;
 

--- a/web/src/__tests__/async/traces-api.servertest.ts
+++ b/web/src/__tests__/async/traces-api.servertest.ts
@@ -1796,7 +1796,7 @@ describe("/api/public/traces API Endpoint", () => {
 
     // Run test suite twice - once for each implementation
     runTestSuite(false); // old traces table
-    if (env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true") {
+    if (env.LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS === "true") {
       runTestSuite(true); // Events table
     }
   });
@@ -2123,7 +2123,7 @@ describe("/api/public/traces API Endpoint", () => {
 
     // Run test suite twice - once for each implementation
     runTestSuite(false); // Good old traces table
-    if (env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true") {
+    if (env.LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS === "true") {
       runTestSuite(true); // Events table
     }
   });
@@ -2359,7 +2359,7 @@ describe("/api/public/traces API Endpoint", () => {
 
     // Run for both table implementations
     runFilterTests(false);
-    if (env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true") {
+    if (env.LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS === "true") {
       runFilterTests(true);
     }
   });

--- a/web/src/server/api/routers/generations/db/getAllGenerationsSqlQuery.ts
+++ b/web/src/server/api/routers/generations/db/getAllGenerationsSqlQuery.ts
@@ -1,4 +1,3 @@
-import { env } from "@/src/env.mjs";
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
 import {
   AGGREGATABLE_SCORE_TYPES,
@@ -6,7 +5,6 @@ import {
 } from "@langfuse/shared";
 import {
   getObservationsTableWithModelData,
-  getObservationsWithModelDataFromEventsTable,
   getScoresForObservations,
   traceException,
 } from "@langfuse/shared/src/server";
@@ -29,10 +27,7 @@ export async function getAllGenerations({
     offset: input.page * input.limit,
     limit: input.limit,
   };
-  let generations =
-    env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true"
-      ? await getObservationsWithModelDataFromEventsTable(queryOpts)
-      : await getObservationsTableWithModelData(queryOpts);
+  let generations = await getObservationsTableWithModelData(queryOpts);
 
   const scores = await getScoresForObservations({
     projectId: input.projectId,

--- a/web/src/server/api/routers/generations/getAllQueries.ts
+++ b/web/src/server/api/routers/generations/getAllQueries.ts
@@ -3,11 +3,7 @@ import { protectedProjectProcedure } from "@/src/server/api/trpc";
 import { paginationZod } from "@langfuse/shared";
 import { GenerationTableOptions } from "./utils/GenerationTableOptions";
 import { getAllGenerations } from "@/src/server/api/routers/generations/db/getAllGenerationsSqlQuery";
-import {
-  getObservationsCountFromEventsTable,
-  getObservationsTableCount,
-} from "@langfuse/shared/src/server";
-import { env } from "@/src/env.mjs";
+import { getObservationsTableCount } from "@langfuse/shared/src/server";
 import { applyCommentFilters } from "@langfuse/shared/src/server";
 
 const GetAllGenerationsInput = GenerationTableOptions.extend({
@@ -60,10 +56,7 @@ export const getAllQueries = {
         limit: 1,
         offset: 0,
       };
-      const countQuery =
-        env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true"
-          ? await getObservationsCountFromEventsTable(queryOpts)
-          : await getObservationsTableCount(queryOpts);
+      const countQuery = await getObservationsTableCount(queryOpts);
       return {
         totalCount: countQuery,
       };

--- a/web/src/server/api/routers/observations.ts
+++ b/web/src/server/api/routers/observations.ts
@@ -1,13 +1,9 @@
-import { env } from "@/src/env.mjs";
 import {
   createTRPCRouter,
   protectedGetTraceProcedure,
 } from "@/src/server/api/trpc";
 import { LangfuseNotFoundError, parseIO } from "@langfuse/shared";
-import {
-  getObservationById,
-  getObservationByIdFromEventsTable,
-} from "@langfuse/shared/src/server";
+import { getObservationById } from "@langfuse/shared/src/server";
 import { z } from "zod/v4";
 import { toDomainWithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
 
@@ -34,10 +30,7 @@ export const observationsRouter = createTRPCRouter({
           shouldJsonParse: false,
         },
       };
-      const obs =
-        env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true"
-          ? await getObservationByIdFromEventsTable(queryOpts)
-          : await getObservationById(queryOpts);
+      const obs = await getObservationById(queryOpts);
       if (!obs) {
         throw new LangfuseNotFoundError(
           "Observation not found within authorized project",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update environment variable references to `LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS` in test files and server routes for consistency.
> 
>   - **Environment Variable Update**:
>     - Renames `LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS` to `LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS` in `observation-api.servertest.ts`, `observations-api.servertest.ts`, `traces-api.servertest.ts`, and `observations-comment-filter.servertest.ts`.
>     - Updates `getAllGenerationsSqlQuery.ts`, `getAllQueries.ts`, and `observations.ts` to use the new environment variable.
>   - **Behavior**:
>     - Tests and routes now check `LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS` to determine if the events table should be used.
>     - No changes to test logic or functionality, only environment variable reference updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f53fd7d1ecd3316db629797e268fb57bc861cc04. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->