### PR TITLE
fix: solve BullMQ prefix clash by decoupling Redis connection logic

### DIFF
--- a/packages/shared/src/server/redis/batchActionQueue.ts
+++ b/packages/shared/src/server/redis/batchActionQueue.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, TQueueJobTypes } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -17,7 +17,7 @@ export class BatchActionQueue {
   > | null {
     if (BatchActionQueue.instance) return BatchActionQueue.instance;
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/batchExport.ts
+++ b/packages/shared/src/server/redis/batchExport.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, TQueueJobTypes } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -16,7 +16,7 @@ export class BatchExportQueue {
   > | null {
     if (BatchExportQueue.instance) return BatchExportQueue.instance;
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/blobStorageIntegrationProcessingQueue.ts
+++ b/packages/shared/src/server/redis/blobStorageIntegrationProcessingQueue.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -15,7 +15,7 @@ export class BlobStorageIntegrationProcessingQueue {
       return BlobStorageIntegrationProcessingQueue.instance;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/blobStorageIntegrationQueue.ts
+++ b/packages/shared/src/server/redis/blobStorageIntegrationQueue.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -15,7 +15,7 @@ export class BlobStorageIntegrationQueue {
       return BlobStorageIntegrationQueue.instance;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/cloudFreeTierUsageThresholdQueue.ts
+++ b/packages/shared/src/server/redis/cloudFreeTierUsageThresholdQueue.ts
@@ -2,7 +2,7 @@ import { Queue } from "bullmq";
 import { env } from "../../env";
 import { QueueName, QueueJobs } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -21,7 +21,7 @@ export class CloudFreeTierUsageThresholdQueue {
       return CloudFreeTierUsageThresholdQueue.instance;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/cloudSpendAlertQueue.ts
+++ b/packages/shared/src/server/redis/cloudSpendAlertQueue.ts
@@ -2,7 +2,7 @@ import { Queue } from "bullmq";
 import { env } from "../../env";
 import { QueueName } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -20,7 +20,7 @@ export class CloudSpendAlertQueue {
       return CloudSpendAlertQueue.instance;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/cloudUsageMeteringQueue.ts
+++ b/packages/shared/src/server/redis/cloudUsageMeteringQueue.ts
@@ -2,7 +2,7 @@ import { Queue } from "bullmq";
 import { env } from "../../env";
 import { QueueName, QueueJobs } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -20,7 +20,7 @@ export class CloudUsageMeteringQueue {
       return CloudUsageMeteringQueue.instance;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/coreDataS3ExportQueue.ts
+++ b/packages/shared/src/server/redis/coreDataS3ExportQueue.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -20,7 +20,7 @@ export class CoreDataS3ExportQueue {
       return CoreDataS3ExportQueue.instance;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/createEvalQueue.ts
+++ b/packages/shared/src/server/redis/createEvalQueue.ts
@@ -1,7 +1,7 @@
 import { QueueName, TQueueJobTypes } from "../queues";
 import { Queue } from "bullmq";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -17,7 +17,7 @@ export class CreateEvalQueue {
   > | null {
     if (CreateEvalQueue.instance) return CreateEvalQueue.instance;
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/dataRetentionProcessingQueue.ts
+++ b/packages/shared/src/server/redis/dataRetentionProcessingQueue.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -15,7 +15,7 @@ export class DataRetentionProcessingQueue {
       return DataRetentionProcessingQueue.instance;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/dataRetentionQueue.ts
+++ b/packages/shared/src/server/redis/dataRetentionQueue.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -15,7 +15,7 @@ export class DataRetentionQueue {
       return DataRetentionQueue.instance;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/datasetDelete.ts
+++ b/packages/shared/src/server/redis/datasetDelete.ts
@@ -1,7 +1,7 @@
 import { QueueName, TQueueJobTypes } from "../queues";
 import { Queue } from "bullmq";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -17,7 +17,7 @@ export class DatasetDeleteQueue {
   > | null {
     if (DatasetDeleteQueue.instance) return DatasetDeleteQueue.instance;
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/datasetRunItemUpsert.ts
+++ b/packages/shared/src/server/redis/datasetRunItemUpsert.ts
@@ -1,7 +1,7 @@
 import { QueueName, TQueueJobTypes } from "../queues";
 import { Queue } from "bullmq";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -18,7 +18,7 @@ export class DatasetRunItemUpsertQueue {
     if (DatasetRunItemUpsertQueue.instance)
       return DatasetRunItemUpsertQueue.instance;
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/dlqRetryQueue.ts
+++ b/packages/shared/src/server/redis/dlqRetryQueue.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -15,7 +15,7 @@ export class DeadLetterRetryQueue {
       return DeadLetterRetryQueue.instance;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/entityChangeQueue.ts
+++ b/packages/shared/src/server/redis/entityChangeQueue.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, TQueueJobTypes } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   getQueuePrefix,
   redisQueueRetryOptions,
 } from "./redis";
@@ -17,7 +17,7 @@ export class EntityChangeQueue {
   > | null {
     if (EntityChangeQueue.instance) return EntityChangeQueue.instance;
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/evalExecutionQueue.ts
+++ b/packages/shared/src/server/redis/evalExecutionQueue.ts
@@ -2,7 +2,7 @@ import { Queue } from "bullmq";
 import { logger } from "../logger";
 import { TQueueJobTypes, QueueName } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -17,7 +17,7 @@ export class EvalExecutionQueue {
   > | null {
     if (EvalExecutionQueue.instance) return EvalExecutionQueue.instance;
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/eventPropagationQueue.ts
+++ b/packages/shared/src/server/redis/eventPropagationQueue.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -15,7 +15,7 @@ export class EventPropagationQueue {
       return EventPropagationQueue.instance;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/experimentCreateQueue.ts
+++ b/packages/shared/src/server/redis/experimentCreateQueue.ts
@@ -2,7 +2,7 @@ import { Queue } from "bullmq";
 import { logger } from "../logger";
 import { TQueueJobTypes, QueueName } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -17,7 +17,7 @@ export class ExperimentCreateQueue {
   > | null {
     if (ExperimentCreateQueue.instance) return ExperimentCreateQueue.instance;
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/ingestionQueue.ts
+++ b/packages/shared/src/server/redis/ingestionQueue.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, TQueueJobTypes } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -60,7 +60,7 @@ export class IngestionQueue {
       return IngestionQueue.instances.get(shardIndex) || null;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });
@@ -103,7 +103,7 @@ export class SecondaryIngestionQueue {
     if (SecondaryIngestionQueue.instance)
       return SecondaryIngestionQueue.instance;
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/llmAsJudgeExecutionQueue.ts
+++ b/packages/shared/src/server/redis/llmAsJudgeExecutionQueue.ts
@@ -2,7 +2,7 @@ import { Queue } from "bullmq";
 import { logger } from "../logger";
 import { TQueueJobTypes, QueueName } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -18,7 +18,7 @@ export class LLMAsJudgeExecutionQueue {
     if (LLMAsJudgeExecutionQueue.instance)
       return LLMAsJudgeExecutionQueue.instance;
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/meteringDataPostgresExportQueue.ts
+++ b/packages/shared/src/server/redis/meteringDataPostgresExportQueue.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -20,7 +20,7 @@ export class MeteringDataPostgresExportQueue {
       return MeteringDataPostgresExportQueue.instance;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/mixpanelIntegrationProcessingQueue.ts
+++ b/packages/shared/src/server/redis/mixpanelIntegrationProcessingQueue.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -15,7 +15,7 @@ export class MixpanelIntegrationProcessingQueue {
       return MixpanelIntegrationProcessingQueue.instance;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/mixpanelIntegrationQueue.ts
+++ b/packages/shared/src/server/redis/mixpanelIntegrationQueue.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -17,7 +17,7 @@ export class MixpanelIntegrationQueue {
       return MixpanelIntegrationQueue.instance;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/notificationQueue.ts
+++ b/packages/shared/src/server/redis/notificationQueue.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, TQueueJobTypes } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -17,7 +17,7 @@ export class NotificationQueue {
   > | null {
     if (NotificationQueue.instance) return NotificationQueue.instance;
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/otelIngestionQueue.ts
+++ b/packages/shared/src/server/redis/otelIngestionQueue.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, TQueueJobTypes } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -64,7 +64,7 @@ export class OtelIngestionQueue {
       return OtelIngestionQueue.instances.get(shardIndex) || null;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/postHogIntegrationProcessingQueue.ts
+++ b/packages/shared/src/server/redis/postHogIntegrationProcessingQueue.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -15,7 +15,7 @@ export class PostHogIntegrationProcessingQueue {
       return PostHogIntegrationProcessingQueue.instance;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/postHogIntegrationQueue.ts
+++ b/packages/shared/src/server/redis/postHogIntegrationQueue.ts
@@ -1,7 +1,7 @@
 import { Queue } from "bullmq";
 import { QueueName, QueueJobs } from "../queues";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -17,7 +17,7 @@ export class PostHogIntegrationQueue {
       return PostHogIntegrationQueue.instance;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/projectDelete.ts
+++ b/packages/shared/src/server/redis/projectDelete.ts
@@ -1,7 +1,7 @@
 import { QueueName, TQueueJobTypes } from "../queues";
 import { Queue } from "bullmq";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -17,7 +17,7 @@ export class ProjectDeleteQueue {
   > | null {
     if (ProjectDeleteQueue.instance) return ProjectDeleteQueue.instance;
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -247,16 +247,16 @@ export const createNewRedisInstance = (
  * In single-node mode, returns the global REDIS_KEY_PREFIX if set
  */
 export const getQueuePrefix = (queueName: string): string | undefined => {
-  const basePrefix = env.REDIS_KEY_PREFIX
-    ? `${env.REDIS_KEY_PREFIX}:bull`
-    : undefined;
-
   if (env.REDIS_CLUSTER_ENABLED === "true") {
     // Use hash tags for Redis cluster compatibility
     // This ensures all keys for a queue are placed on the same hash slot
-    return `{${basePrefix ?? "bull"}}`;
+    // We include queueName to avoid all queues being on the same hash slot (bottleneck)
+    return env.REDIS_KEY_PREFIX
+      ? `{${env.REDIS_KEY_PREFIX}:bull}:${queueName}`
+      : `{${queueName}}`;
   }
-  return basePrefix;
+
+  return env.REDIS_KEY_PREFIX ? `${env.REDIS_KEY_PREFIX}:bull` : undefined;
 };
 
 /**

--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -10,6 +10,11 @@ const defaultRedisOptions: Partial<RedisOptions> = {
   keyPrefix: env.REDIS_KEY_PREFIX ?? undefined,
 };
 
+const defaultRedisQueueOptions: Partial<RedisOptions> = {
+  ...defaultRedisOptions,
+  keyPrefix: undefined, // BullMQ handles its own prefixing
+};
+
 const REDIS_SCAN_COUNT = 1000;
 
 export const redisQueueRetryOptions: Partial<RedisOptions> = {
@@ -179,6 +184,15 @@ const createRedisSentinelInstance = (
   return instance;
 };
 
+export const createNewRedisQueueInstance = (
+  additionalOptions: Partial<RedisOptions> = {},
+): Redis | Cluster | null => {
+  return createNewRedisInstance({
+    ...defaultRedisQueueOptions,
+    ...additionalOptions,
+  });
+};
+
 export const createNewRedisInstance = (
   additionalOptions: Partial<RedisOptions> = {},
 ): Redis | Cluster | null => {
@@ -230,15 +244,19 @@ export const createNewRedisInstance = (
 /**
  * Get the queue prefix for BullMQ cluster compatibility
  * In cluster mode, uses hash tags to ensure queue keys are on the same node
- * In single-node mode, returns undefined (no prefix needed)
+ * In single-node mode, returns the global REDIS_KEY_PREFIX if set
  */
 export const getQueuePrefix = (queueName: string): string | undefined => {
+  const basePrefix = env.REDIS_KEY_PREFIX
+    ? `${env.REDIS_KEY_PREFIX}:bull`
+    : undefined;
+
   if (env.REDIS_CLUSTER_ENABLED === "true") {
     // Use hash tags for Redis cluster compatibility
     // This ensures all keys for a queue are placed on the same hash slot
-    return `{${queueName}}`;
+    return `{${basePrefix ?? "bull"}}`;
   }
-  return undefined;
+  return basePrefix;
 };
 
 /**

--- a/packages/shared/src/server/redis/scoreDelete.ts
+++ b/packages/shared/src/server/redis/scoreDelete.ts
@@ -1,7 +1,7 @@
 import { QueueName, TQueueJobTypes } from "../queues";
 import { Queue } from "bullmq";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -16,7 +16,7 @@ export class ScoreDeleteQueue {
   > | null {
     if (ScoreDeleteQueue.instance) return ScoreDeleteQueue.instance;
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/traceDelete.ts
+++ b/packages/shared/src/server/redis/traceDelete.ts
@@ -1,7 +1,7 @@
 import { QueueName, TQueueJobTypes } from "../queues";
 import { Queue } from "bullmq";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -16,7 +16,7 @@ export class TraceDeleteQueue {
   > | null {
     if (TraceDeleteQueue.instance) return TraceDeleteQueue.instance;
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/traceUpsert.ts
+++ b/packages/shared/src/server/redis/traceUpsert.ts
@@ -1,7 +1,7 @@
 import { QueueName, TQueueJobTypes } from "../queues";
 import { Queue } from "bullmq";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   redisQueueRetryOptions,
   getQueuePrefix,
 } from "./redis";
@@ -63,7 +63,7 @@ export class TraceUpsertQueue {
       return TraceUpsertQueue.instances.get(shardIndex) || null;
     }
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });

--- a/packages/shared/src/server/redis/webhookQueue.ts
+++ b/packages/shared/src/server/redis/webhookQueue.ts
@@ -1,7 +1,7 @@
 import { QueueName, TQueueJobTypes } from "../queues";
 import { Queue } from "bullmq";
 import {
-  createNewRedisInstance,
+  createNewRedisQueueInstance,
   getQueuePrefix,
   redisQueueRetryOptions,
 } from "./redis";
@@ -17,7 +17,7 @@ export class WebhookQueue {
   > | null {
     if (WebhookQueue.instance) return WebhookQueue.instance;
 
-    const newRedis = createNewRedisInstance({
+    const newRedis = createNewRedisQueueInstance({
       enableOfflineQueue: false,
       ...redisQueueRetryOptions,
     });


### PR DESCRIPTION

  Hey team,

  I've fixed issue #11586 regarding the REDIS_KEY_PREFIX clash.


  The problem:
  Currently, Langfuse applies keyPrefix directly to the ioredis instance for all connections. However, BullMQ doesn't like it when the underlying ioredis connection already has a
  prefix, leading to the error: "BullMQ: ioredis does not support ioredis prefixes, use the prefix option instead."


  The fix:
  I've decoupled the Redis connection factory in packages/shared/src/server/redis/redis.ts.
   - Created createNewRedisQueueInstance which initializes a "clean" ioredis instance (no internal keyPrefix).
   - Updated getQueuePrefix to properly pass the global REDIS_KEY_PREFIX into BullMQ's own prefix option instead.

  Scope of changes:
  I've refactored all 30+ queue definitions in packages/shared/src/server/redis/ to use this new connection factory. This ensures that self-hosters using shared Redis instances won't
  hit this conflict anymore.

  Tested this locally and confirmed that BullMQ now correctly handles the prefix without throwing ioredis-related errors.

  Fixes #11586.

  Let me know if you need any adjustments or more tests!
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Redis key prefix clash with BullMQ by decoupling connection logic and updating queue definitions.
> 
>   - **Behavior**:
>     - Decouples Redis connection logic by introducing `createNewRedisQueueInstance` in `redis.ts` to avoid key prefix clashes with BullMQ.
>     - Updates `getQueuePrefix` to use global `REDIS_KEY_PREFIX` for single-node mode and hash tags for cluster mode.
>   - **Refactoring**:
>     - Replaces `createNewRedisInstance` with `createNewRedisQueueInstance` in 30+ queue definitions, including `batchActionQueue.ts`, `batchExport.ts`, and `blobStorageIntegrationProcessingQueue.ts`.
>   - **Testing**:
>     - Verified locally that BullMQ handles prefixes correctly without ioredis-related errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d95657855f0cab4b2f411c7d5d8101c1639c965e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->