### PR TITLE
fix(dashboard): add row_limit to unbounded dashboard queries (#12107)

### DIFF
--- a/web/src/features/dashboard/components/LatencyTables.tsx
+++ b/web/src/features/dashboard/components/LatencyTables.tsx
@@ -50,6 +50,7 @@ export const LatencyTables = ({
     fromTimestamp: fromTimestamp.toISOString(),
     toTimestamp: toTimestamp.toISOString(),
     orderBy: [{ field: "p95_latency", direction: "desc" }],
+    chartConfig: { type: "table", row_limit: 20 },
   };
 
   const generationsLatencies = api.dashboard.executeQuery.useQuery(
@@ -90,6 +91,7 @@ export const LatencyTables = ({
     fromTimestamp: fromTimestamp.toISOString(),
     toTimestamp: toTimestamp.toISOString(),
     orderBy: [{ field: "p95_latency", direction: "desc" }],
+    chartConfig: { type: "table", row_limit: 20 },
   };
 
   const spansLatencies = api.dashboard.executeQuery.useQuery(
@@ -122,6 +124,7 @@ export const LatencyTables = ({
     fromTimestamp: fromTimestamp.toISOString(),
     toTimestamp: toTimestamp.toISOString(),
     orderBy: [{ field: "p95_latency", direction: "desc" }],
+    chartConfig: { type: "table", row_limit: 20 },
   };
 
   const tracesLatencies = api.dashboard.executeQuery.useQuery(

--- a/web/src/features/dashboard/components/ModelCostTable.tsx
+++ b/web/src/features/dashboard/components/ModelCostTable.tsx
@@ -51,7 +51,8 @@ export const ModelCostTable = ({
     timeDimension: null,
     fromTimestamp: fromTimestamp.toISOString(),
     toTimestamp: toTimestamp.toISOString(),
-    orderBy: null,
+    orderBy: [{ field: "sum_totalCost", direction: "desc" }],
+    chartConfig: { type: "table", row_limit: 20 },
   };
 
   const metrics = api.dashboard.executeQuery.useQuery(

--- a/web/src/features/dashboard/components/TracesBarListChart.tsx
+++ b/web/src/features/dashboard/components/TracesBarListChart.tsx
@@ -70,7 +70,8 @@ export const TracesBarListChart = ({
     timeDimension: null,
     fromTimestamp: fromTimestamp.toISOString(),
     toTimestamp: toTimestamp.toISOString(),
-    orderBy: null,
+    orderBy: [{ field: "count_count", direction: "desc" }],
+    chartConfig: { type: "table", row_limit: 20 },
   };
 
   const traces = api.dashboard.executeQuery.useQuery(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `row_limit: 20` to dashboard queries in `LatencyTables`, `ModelCostTable`, and `TracesBarListChart` to limit results and update sorting.
> 
>   - **Behavior**:
>     - Add `row_limit: 20` to `chartConfig` in `LatencyTables`, `ModelCostTable`, and `TracesBarListChart` to limit query results.
>     - Update `orderBy` in `ModelCostTable` to sort by `sum_totalCost` and in `TracesBarListChart` to sort by `count_count`.
>   - **Components**:
>     - `LatencyTables`: Add `row_limit` to `generationsLatenciesQuery`, `spansLatenciesQuery`, and `tracesLatenciesQuery`.
>     - `ModelCostTable`: Add `row_limit` to `modelCostQuery`.
>     - `TracesBarListChart`: Add `row_limit` to `tracesQuery`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1b810cff1b327eb929d4deb63bf5e94661106ec5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->