### PR TITLE
fix(datasets): graph formatting for seconds

### DIFF
--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -7,11 +7,7 @@ import { formatIntervalSeconds } from "@/src/utils/dates";
 import { useQueryParams, withDefault, NumberParam } from "use-query-params";
 import { type RouterOutput } from "@/src/utils/types";
 import { useEffect, useMemo, useState } from "react";
-import {
-  compactNumberFormatter,
-  latencyFormatter,
-  usdFormatter,
-} from "@/src/utils/numbers";
+import { compactNumberFormatter, usdFormatter } from "@/src/utils/numbers";
 import { DataTableToolbar } from "@/src/components/table/data-table-toolbar";
 import useColumnVisibility from "@/src/features/column-visibility/hooks/useColumnVisibility";
 import { type Prisma, datasetRunsTableColsWithOptions } from "@langfuse/shared";
@@ -646,9 +642,10 @@ export function DatasetRunsTable(props: {
                   );
                   const { chartData, chartLabels } = adapter.toChartData();
 
+                  // TODO: remove when revamping the datasets api for it to directly return ms
                   const valueFormatter =
                     key === "latency"
-                      ? latencyFormatter
+                      ? formatIntervalSeconds
                       : key === "cost"
                         ? usdFormatter
                         : compactNumberFormatter;

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/compare/charts.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/compare/charts.tsx
@@ -19,11 +19,8 @@ import {
 } from "@/src/features/dashboard/lib/score-analytics-utils";
 import { compareViewChartDataToDataPoints } from "@/src/features/dashboard/lib/chart-data-adapters";
 import { Chart } from "@/src/features/widgets/chart-library/Chart";
-import {
-  compactNumberFormatter,
-  latencyFormatter,
-  usdFormatter,
-} from "@/src/utils/numbers";
+import { compactNumberFormatter, usdFormatter } from "@/src/utils/numbers";
+import { formatIntervalSeconds } from "@/src/utils/dates";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import Page from "@/src/components/layouts/page";
 import { SubHeaderLabel } from "@/src/components/layouts/header";
@@ -202,9 +199,10 @@ export default function DatasetCompare() {
                     : (RESOURCE_METRICS.find((metric) => metric.key === key)
                         ?.label ?? key);
 
+                  // TODO: remove when revamping the datasets api for it to directly return ms
                   const valueFormatter =
                     key === "latency"
-                      ? latencyFormatter
+                      ? formatIntervalSeconds
                       : key === "cost"
                         ? usdFormatter
                         : (v: number) =>


### PR DESCRIPTION
closes #12139 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `latencyFormatter` with `formatIntervalSeconds` for latency values in charts, affecting `DatasetRunsTable.tsx` and `charts.tsx`.
> 
>   - **Behavior**:
>     - Replaces `latencyFormatter` with `formatIntervalSeconds` for latency values in `DatasetRunsTable.tsx` and `charts.tsx`.
>     - Affects latency formatting in charts for dataset runs.
>   - **Misc**:
>     - Removes unused `latencyFormatter` import from `DatasetRunsTable.tsx` and `charts.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 26fa85134e9b35d29d6123e99797c170266e813e. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->