### PR TITLE
feat(dashboard): optimize v2 traces queries via observations view with root-event filter

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/factory.ts
@@ -25,6 +25,9 @@ export class QueryBuilderError extends Error {
   }
 }
 
+// Matches nullIf(expr, '') wrappers used in dimension SQL for display purposes.
+const NULL_IF_EMPTY_RE = /^nullIf\((.+),\s*''\)$/;
+
 // This function ensures that the user only selects valid columns from the clickhouse schema.
 // The filter property in this column needs to be zod verified.
 // User input for values (e.g. project_id = <value>) are sent to Clickhouse as parameters to prevent SQL injection
@@ -124,20 +127,23 @@ export const createFilterFromFilterState = (
           column.clickhouseTableName.startsWith("events")
         ) {
           const isNull = frontEndFilter.operator === "is null";
+          // When the dimension SQL wraps the column with nullIf(col, ''), the value
+          // is already NULL for empty strings — use a standard IS NULL / IS NOT NULL check.
+          // When there is no nullIf wrapper, the column stores '' directly — use = '' / != ''.
+          const hasNullIf = NULL_IF_EMPTY_RE.test(column.clickhouseSelect);
           const fieldWithPrefix = column.queryPrefix
             ? `${column.queryPrefix}.${column.clickhouseSelect}`
             : column.clickhouseSelect;
+          const query = hasNullIf
+            ? `${fieldWithPrefix} IS ${isNull ? "" : "NOT "}NULL`
+            : `${fieldWithPrefix} ${isNull ? "=" : "!="} ''`;
 
-          // Create an inline filter for empty string comparison
           return {
             clickhouseTable: column.clickhouseTableName,
             field: column.clickhouseSelect,
             operator: isNull ? ("=" as const) : ("!=" as const),
             tablePrefix: column.queryPrefix,
-            apply: () => ({
-              query: `${fieldWithPrefix} ${isNull ? "=" : "!="} ''`,
-              params: {},
-            }),
+            apply: () => ({ query, params: {} }),
           };
         }
 

--- a/web/src/__tests__/createFilterFromFilterState-nullIf.servertest.ts
+++ b/web/src/__tests__/createFilterFromFilterState-nullIf.servertest.ts
@@ -1,0 +1,97 @@
+import { createFilterFromFilterState } from "@langfuse/shared/src/server";
+
+/**
+ * Unit tests for the parentObservationId null-filter special case in
+ * createFilterFromFilterState (factory.ts).
+ *
+ * events_core stores parent_span_id as a non-nullable String — root events
+ * have ''. The view layer may wrap this with nullIf(col, '') so the UI sees
+ * NULL instead. The factory must detect the wrapper and emit IS NULL / IS NOT
+ * NULL (not = '' / != '') when nullIf is present.
+ */
+describe("createFilterFromFilterState parentObservationId on events tables", () => {
+  const baseMapping = {
+    uiTableName: "parentObservationId",
+    uiTableId: "parentObservationId",
+    type: "string",
+  };
+
+  // Column mapping that mirrors eventsObservationsView (nullIf wrapper present)
+  const withNullIf = {
+    ...baseMapping,
+    clickhouseTableName: "events_core",
+    clickhouseSelect: "nullIf(events_observations.parent_span_id, '')",
+    queryPrefix: "",
+  };
+
+  // Column mapping without nullIf (raw column, e.g. eventsTracesView)
+  const withoutNullIf = {
+    ...baseMapping,
+    clickhouseTableName: "events_core",
+    clickhouseSelect: "events_traces.parent_span_id",
+    queryPrefix: "",
+  };
+
+  // Non-events table — should fall through to standard NullFilter
+  const nonEvents = {
+    ...baseMapping,
+    clickhouseTableName: "observations",
+    clickhouseSelect: "observations.parent_observation_id",
+    queryPrefix: "",
+  };
+
+  it.each<{
+    desc: string;
+    operator: "is null" | "is not null";
+    mapping: typeof withNullIf;
+    expected: string;
+  }>([
+    {
+      desc: "nullIf + is null → IS NULL",
+      operator: "is null",
+      mapping: withNullIf,
+      expected: "nullIf(events_observations.parent_span_id, '') IS NULL",
+    },
+    {
+      desc: "nullIf + is not null → IS NOT NULL",
+      operator: "is not null",
+      mapping: withNullIf,
+      expected: "nullIf(events_observations.parent_span_id, '') IS NOT NULL",
+    },
+    {
+      desc: "raw column + is null → = ''",
+      operator: "is null",
+      mapping: withoutNullIf,
+      expected: "events_traces.parent_span_id = ''",
+    },
+    {
+      desc: "raw column + is not null → != ''",
+      operator: "is not null",
+      mapping: withoutNullIf,
+      expected: "events_traces.parent_span_id != ''",
+    },
+    {
+      desc: "raw column + queryPrefix",
+      operator: "is null",
+      mapping: { ...withoutNullIf, queryPrefix: "eo" },
+      expected: "eo.events_traces.parent_span_id = ''",
+    },
+    {
+      desc: "non-events table falls through to standard NullFilter",
+      operator: "is null",
+      mapping: nonEvents,
+      expected: "observations.parent_observation_id is null",
+    },
+  ])("$desc", ({ operator, mapping, expected }) => {
+    const filter = {
+      type: "null" as const,
+      column: "parentObservationId",
+      operator,
+      value: "" as const,
+    };
+    const [result] = createFilterFromFilterState([filter], [mapping]);
+    const { query, params } = result.apply();
+    expect(query).toBe(expected);
+    expect(params).toEqual({});
+  });
+});

--- a/web/src/features/dashboard/components/TracesTimeSeriesChart.tsx
+++ b/web/src/features/dashboard/components/TracesTimeSeriesChart.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/src/features/query";
 import { Chart } from "@/src/features/widgets/chart-library/Chart";
 import { timeSeriesToDataPoints } from "@/src/features/dashboard/lib/chart-data-adapters";
+import { traceViewQuery } from "@/src/features/dashboard/lib/dashboard-utils";
 
 export const TracesAndObservationsTimeSeriesChart = ({
   className,
@@ -38,10 +39,9 @@ export const TracesAndObservationsTimeSeriesChart = ({
   metricsVersion?: ViewVersion;
 }) => {
   const tracesQuery: QueryType = {
-    view: "traces",
+    ...traceViewQuery(metricsVersion, globalFilterState),
     dimensions: [],
     metrics: [{ measure: "count", aggregation: "count" }],
-    filters: mapLegacyUiTableFilterToView("traces", globalFilterState),
     timeDimension: {
       granularity:
         dashboardDateRangeAggregationSettings[agg].dateTrunc ?? "day",

--- a/web/src/features/dashboard/components/UserChart.tsx
+++ b/web/src/features/dashboard/components/UserChart.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/src/features/query";
 import { Chart } from "@/src/features/widgets/chart-library/Chart";
 import { barListToDataPoints } from "@/src/features/dashboard/lib/chart-data-adapters";
+import { traceViewQuery } from "@/src/features/dashboard/lib/dashboard-utils";
 
 type BarChartDataPoint = {
   name: string;
@@ -78,10 +79,9 @@ export const UserChart = ({
   );
 
   const traceCountQuery: QueryType = {
-    view: "traces",
+    ...traceViewQuery(metricsVersion, globalFilterState),
     dimensions: [{ field: "userId" }],
     metrics: [{ measure: "count", aggregation: "count" }],
-    filters: mapLegacyUiTableFilterToView("traces", globalFilterState),
     timeDimension: null,
     fromTimestamp: fromTimestamp.toISOString(),
     toTimestamp: toTimestamp.toISOString(),

--- a/web/src/features/dashboard/lib/dashboard-utils.ts
+++ b/web/src/features/dashboard/lib/dashboard-utils.ts
@@ -1,5 +1,11 @@
-import { type FilterState } from "@langfuse/shared";
+import { type z } from "zod/v4";
+import { type FilterState, type singleFilter } from "@langfuse/shared";
 import { usdFormatter } from "@/src/utils/numbers";
+import {
+  type QueryType,
+  type ViewVersion,
+  mapLegacyUiTableFilterToView,
+} from "@/src/features/query";
 
 // traces do not have a startTime or endTime column, so we need to map these to the timestamp column
 export const createTracesTimeFilter = (
@@ -25,3 +31,34 @@ export const totalCostDashboardFormatted = (totalCost?: number) => {
       : usdFormatter(totalCost, 2, 2)
     : usdFormatter(0);
 };
+
+export const ROOT_OBSERVATION_FILTER: z.infer<typeof singleFilter> = {
+  type: "null",
+  column: "parentObservationId",
+  operator: "is null",
+  value: "",
+};
+
+/**
+ * Returns the view name and filters for a "traces-like" query that works in
+ * both v1 (queries the traces table) and v2 (queries observations with a
+ * root-event filter so counting root observations equals counting traces).
+ */
+export function traceViewQuery(
+  metricsVersion: ViewVersion | undefined,
+  globalFilterState: FilterState,
+): Pick<QueryType, "view" | "filters"> {
+  if (metricsVersion === "v2") {
+    return {
+      view: "observations",
+      filters: [
+        ...mapLegacyUiTableFilterToView("observations", globalFilterState),
+        ROOT_OBSERVATION_FILTER,
+      ],
+    };
+  }
+  return {
+    view: "traces",
+    filters: mapLegacyUiTableFilterToView("traces", globalFilterState),
+  };
+}


### PR DESCRIPTION
In v2, traces queries on the eventsTracesView are slow due to a trace_id IN
(subquery) double-scan and two-level aggregation. Reformulate them to query
eventsObservationsView with a parentObservationId IS NULL filter instead,
which enables single-level query optimization.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimizes v2 trace queries by using observations view with root-event filter, simplifying query structure and improving performance.
> 
>   - **Behavior**:
>     - Optimizes v2 trace queries by using `observations` view with `parentObservationId IS NULL` filter instead of `eventsTracesView`.
>     - Simplifies query structure, reducing double-scan and two-level aggregation.
>   - **Code Changes**:
>     - Adds `traceViewQuery()` in `dashboard-utils.ts` to handle view and filter selection for traces.
>     - Updates `TracesBarListChart.tsx`, `TracesTimeSeriesChart.tsx`, and `UserChart.tsx` to use `traceViewQuery()`.
>     - Modifies `createFilterFromFilterState()` in `factory.ts` to handle `nullIf` SQL wrappers for `parentObservationId`.
>   - **Tests**:
>     - Adds `createFilterFromFilterState-nullIf.servertest.ts` to test `nullIf` handling in filters.
>     - Updates `dashboard-v1-v2-consistency.servertest.ts` to include tests for observations-based queries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 800c7902873fa5bda8ac6c4d9bdd108a406205dc. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->