### PR TITLE
chore: remove replica sync and move delay up to 30min for event prop

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -385,6 +385,10 @@ const EnvSchema = z.object({
   LANGFUSE_EXPERIMENT_EARLY_EXIT_EVENT_BATCH_JOB: z
     .enum(["true", "false"])
     .default("false"),
+  LANGFUSE_EXPERIMENT_EVENT_PROPAGATION_PARTITION_DELAY_MINUTES: z.coerce
+    .number()
+    .int()
+    .default(10),
 
   LANGFUSE_WEBHOOK_QUEUE_PROCESSING_CONCURRENCY: z.coerce
     .number()

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -387,6 +387,7 @@ const EnvSchema = z.object({
     .default("false"),
   LANGFUSE_EXPERIMENT_EVENT_PROPAGATION_PARTITION_DELAY_MINUTES: z.coerce
     .number()
+    .positive()
     .int()
     .default(10),
 

--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -91,14 +91,14 @@ export const handleEventPropagationJob = async (
     }
 
     // Query for the next partition after the last processed one
-    // Filter for partitions older than 6 minutes and order by partition ASC to get the oldest first
+    // Filter for partitions older than 30 minutes and order by partition ASC to get the oldest first
     const partitions = await queryClickhouse<{ partition: string }>({
       query: `
         SELECT DISTINCT partition
         FROM system.parts
         WHERE table = 'observations_batch_staging'
           AND active = 1
-          AND toDateTime(partition) < now() - INTERVAL 10 MINUTE
+          AND toDateTime(partition) < now() - INTERVAL 30 MINUTE
           ${lastProcessedPartition ? `AND partition > {lastProcessedPartition: String}` : ""}
         ORDER BY partition ASC
       `,
@@ -132,30 +132,6 @@ export const handleEventPropagationJob = async (
     // for the same span, this may create duplicates in the new events table. Deduplicating in this query
     // will significantly affect run-time. This may be an accepted degradation and we test the outcome
     // to check the likelihood of this happening in practice.
-
-    // Generate a session ID to ensure SYNC REPLICA and INSERT-SELECT
-    // are routed to the same ClickHouse node (sticky session via session_id).
-    // This is required per ClickHouse support guidance: SYNC REPLICA fetches
-    // all missing parts once upfront (unlike select_sequential_consistency=1
-    // which retries repeatedly), but both commands must hit the same replica.
-    const sessionId = randomUUID();
-
-    await commandClickhouse({
-      query: `SYSTEM SYNC REPLICA observations_batch_staging LIGHTWEIGHT`,
-      session_id: sessionId,
-      clickhouseConfigs: {
-        request_timeout: 300000, // 5 minutes timeout
-      },
-      tags: {
-        feature: "ingestion",
-        operation_name: "syncReplicaObservationsBatchStaging",
-      },
-    });
-
-    logger.info(
-      `[DUAL WRITE] Synced replica for observations_batch_staging before processing partition ${partitionToProcess}`,
-    );
-
     await commandClickhouse({
       query: `
         with batch_stats as (
@@ -314,7 +290,6 @@ export const handleEventPropagationJob = async (
         )
         WHERE obs._partition_value = tuple('${partitionToProcess}')
       `,
-      session_id: sessionId,
       tags: {
         feature: "ingestion",
         partition: partitionToProcess,

--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -91,14 +91,14 @@ export const handleEventPropagationJob = async (
     }
 
     // Query for the next partition after the last processed one
-    // Filter for partitions older than 30 minutes and order by partition ASC to get the oldest first
+    // Filter for partitions older than LANGFUSE_EXPERIMENT_EVENT_PROPAGATION_PARTITION_DELAY_MINUTES minutes and order by partition ASC to get the oldest first
     const partitions = await queryClickhouse<{ partition: string }>({
       query: `
         SELECT DISTINCT partition
         FROM system.parts
         WHERE table = 'observations_batch_staging'
           AND active = 1
-          AND toDateTime(partition) < now() - INTERVAL 30 MINUTE
+          AND toDateTime(partition) < now() - INTERVAL ${env.LANGFUSE_EXPERIMENT_EVENT_PROPAGATION_PARTITION_DELAY_MINUTES} MINUTE
           ${lastProcessedPartition ? `AND partition > {lastProcessedPartition: String}` : ""}
         ORDER BY partition ASC
       `,

--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -10,7 +10,6 @@ import {
   recordGauge,
 } from "@langfuse/shared/src/server";
 import { Job } from "bullmq";
-import { randomUUID } from "crypto";
 import { env } from "../../env";
 
 const LAST_PROCESSED_PARTITION_KEY =


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase partition delay to 30 minutes and remove replica sync in `handleEventPropagationJob`.
> 
>   - **Behavior**:
>     - In `handleEventPropagationJob`, increase partition delay filter from 10 to 30 minutes for processing in `handleEventPropagationJob`.
>     - Remove `SYSTEM SYNC REPLICA` command and related session ID logic.
>   - **Logging**:
>     - Remove log for syncing replica in `handleEventPropagationJob`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 355813eabe5e78daa99fb23d70c05eb40433d3e0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->