### PR TITLE
feat(events-table): add tooltip support to filter facets

### DIFF
--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -193,6 +193,7 @@ export function DataTableControls({
                   key={filter.column}
                   filterKey={filter.column}
                   label={filter.label}
+                  tooltip={filter.tooltip}
                   expanded={filter.expanded}
                   options={filter.options}
                   counts={filter.counts}
@@ -219,6 +220,7 @@ export function DataTableControls({
                   key={filter.column}
                   filterKey={filter.column}
                   label={filter.label}
+                  tooltip={filter.tooltip}
                   expanded={filter.expanded}
                   loading={filter.loading}
                   min={filter.min}
@@ -240,6 +242,7 @@ export function DataTableControls({
                   key={filter.column}
                   filterKey={filter.column}
                   label={filter.label}
+                  tooltip={filter.tooltip}
                   expanded={filter.expanded}
                   loading={filter.loading}
                   value={filter.value}
@@ -258,6 +261,7 @@ export function DataTableControls({
                   key={filter.column}
                   filterKey={filter.column}
                   label={filter.label}
+                  tooltip={filter.tooltip}
                   expanded={filter.expanded}
                   loading={filter.loading}
                   keyOptions={filter.keyOptions}
@@ -279,6 +283,7 @@ export function DataTableControls({
                   key={filter.column}
                   filterKey={filter.column}
                   label={filter.label}
+                  tooltip={filter.tooltip}
                   expanded={filter.expanded}
                   loading={filter.loading}
                   keyOptions={filter.keyOptions}
@@ -299,6 +304,7 @@ export function DataTableControls({
                   key={filter.column}
                   filterKey={filter.column}
                   label={filter.label}
+                  tooltip={filter.tooltip}
                   expanded={filter.expanded}
                   loading={filter.loading}
                   keyOptions={filter.keyOptions}
@@ -318,6 +324,7 @@ export function DataTableControls({
                   key={filter.column}
                   filterKey={filter.column}
                   label={filter.label}
+                  tooltip={filter.tooltip}
                   expanded={filter.expanded}
                   loading={filter.loading}
                   mode={filter.mode}
@@ -342,6 +349,7 @@ export function DataTableControls({
 
 interface BaseFacetProps {
   label: string;
+  tooltip?: string;
   children?: React.ReactNode;
   filterKey: string;
   filterKeyShort?: string | null;
@@ -441,6 +449,7 @@ const FilterAccordionContent = ({
 
 interface FilterAccordionItemProps {
   label: string;
+  tooltip?: string;
   filterKey: string;
   filterKeyShort?: string | null;
   children: React.ReactNode;
@@ -452,6 +461,7 @@ interface FilterAccordionItemProps {
 
 export function FilterAccordionItem({
   label,
+  tooltip,
   filterKey,
   filterKeyShort,
   children,
@@ -484,6 +494,22 @@ export function FilterAccordionItem({
               </TooltipTrigger>
               <TooltipContent className="max-w-80 text-xs">
                 {disabledReason}
+              </TooltipContent>
+            </Tooltip>
+          ) : tooltip ? (
+            <Tooltip delayDuration={80}>
+              <TooltipTrigger asChild>
+                <span className="flex grow items-baseline gap-1">
+                  {label}
+                  {filterKeyShort && (
+                    <code className="hidden font-mono text-xs text-muted-foreground/70">
+                      {filterKeyShort}
+                    </code>
+                  )}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-80 text-xs">
+                {tooltip}
               </TooltipContent>
             </Tooltip>
           ) : (
@@ -537,6 +563,7 @@ export function FilterAccordionItem({
 
 export function CategoricalFacet({
   label,
+  tooltip,
   filterKey,
   filterKeyShort,
   expanded,
@@ -602,6 +629,7 @@ export function CategoricalFacet({
   return (
     <FilterAccordionItem
       label={label}
+      tooltip={tooltip}
       filterKey={filterKey}
       filterKeyShort={filterKeyShort}
       isActive={isActive}
@@ -814,6 +842,7 @@ export function CategoricalFacet({
 
 export function NumericFacet({
   label,
+  tooltip,
   filterKey,
   filterKeyShort,
   expanded: _expanded,
@@ -896,6 +925,7 @@ export function NumericFacet({
   return (
     <FilterAccordionItem
       label={label}
+      tooltip={tooltip}
       filterKey={filterKey}
       filterKeyShort={filterKeyShort}
       isActive={isActive}
@@ -976,6 +1006,7 @@ export function NumericFacet({
 
 export function StringFacet({
   label,
+  tooltip,
   filterKey,
   filterKeyShort,
   expanded: _expanded,
@@ -1024,6 +1055,7 @@ export function StringFacet({
   return (
     <FilterAccordionItem
       label={label}
+      tooltip={tooltip}
       filterKey={filterKey}
       filterKeyShort={filterKeyShort}
       isActive={isActive}
@@ -1051,6 +1083,7 @@ export function StringFacet({
 
 export function KeyValueFacet({
   label,
+  tooltip,
   filterKey,
   filterKeyShort,
   expanded: _expanded,
@@ -1068,6 +1101,7 @@ export function KeyValueFacet({
   return (
     <FilterAccordionItem
       label={label}
+      tooltip={tooltip}
       filterKey={filterKey}
       filterKeyShort={filterKeyShort}
       isActive={isActive}
@@ -1095,6 +1129,7 @@ export function KeyValueFacet({
 
 export function NumericKeyValueFacet({
   label,
+  tooltip,
   filterKey,
   filterKeyShort,
   expanded: _expanded,
@@ -1111,6 +1146,7 @@ export function NumericKeyValueFacet({
   return (
     <FilterAccordionItem
       label={label}
+      tooltip={tooltip}
       filterKey={filterKey}
       filterKeyShort={filterKeyShort}
       isActive={isActive}
@@ -1137,6 +1173,7 @@ export function NumericKeyValueFacet({
 
 export function StringKeyValueFacet({
   label,
+  tooltip,
   filterKey,
   filterKeyShort,
   expanded: _expanded,
@@ -1153,6 +1190,7 @@ export function StringKeyValueFacet({
   return (
     <FilterAccordionItem
       label={label}
+      tooltip={tooltip}
       filterKey={filterKey}
       filterKeyShort={filterKeyShort}
       isActive={isActive}
@@ -1196,6 +1234,7 @@ const POSITION_MODES: {
 
 function PositionInTraceFacetComponent({
   label,
+  tooltip,
   filterKey,
   filterKeyShort,
   expanded: _expanded,
@@ -1214,6 +1253,7 @@ function PositionInTraceFacetComponent({
   return (
     <FilterAccordionItem
       label={label}
+      tooltip={tooltip}
       filterKey={filterKey}
       filterKeyShort={filterKeyShort}
       isActive={isActive}

--- a/web/src/features/events/config/filter-config.ts
+++ b/web/src/features/events/config/filter-config.ts
@@ -42,7 +42,7 @@ export const observationEventsFilterConfig: FilterConfig = {
       column: "hasParentObservation",
       label: "Is Root Observation",
       tooltip:
-        "A root observation is the top-level observation in a trace with no parent observation. Filter to 'True' to see only root-level observations.",
+        "A root observation is the top-level observation in a trace. It has no parent observation ID. Filter to 'True' to see only root-level observations.",
       invertValue: true, // "True" = hasParentObservation=false (is root)
     },
     {

--- a/web/src/features/events/config/filter-config.ts
+++ b/web/src/features/events/config/filter-config.ts
@@ -41,6 +41,8 @@ export const observationEventsFilterConfig: FilterConfig = {
       type: "boolean" as const,
       column: "hasParentObservation",
       label: "Is Root Observation",
+      tooltip:
+        "A root observation is the top-level observation in a trace with no parent observation. Filter to 'True' to see only root-level observations.",
       invertValue: true, // "True" = hasParentObservation=false (is root)
     },
     {

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -82,6 +82,7 @@ function computeNumericRange(
 export interface BaseUIFilter {
   column: string;
   label: string;
+  tooltip?: string;
   loading: boolean;
   expanded: boolean;
   isActive: boolean;
@@ -1012,6 +1013,7 @@ export function useSidebarFilterState(
             type: "numeric",
             column: facet.column,
             label: facet.label,
+            tooltip: facet.tooltip,
 
             value: currentRange,
             min: facet.min,
@@ -1044,6 +1046,7 @@ export function useSidebarFilterState(
             type: "string",
             column: facet.column,
             label: facet.label,
+            tooltip: facet.tooltip,
 
             value: currentValue,
             loading: false,
@@ -1097,6 +1100,7 @@ export function useSidebarFilterState(
             type: "keyValue",
             column: facet.column,
             label: facet.label,
+            tooltip: facet.tooltip,
 
             value: activeFilters,
             keyOptions,
@@ -1185,6 +1189,7 @@ export function useSidebarFilterState(
             type: "numericKeyValue",
             column: facet.column,
             label: facet.label,
+            tooltip: facet.tooltip,
 
             value: activeFilters,
             keyOptions,
@@ -1268,6 +1273,7 @@ export function useSidebarFilterState(
             type: "stringKeyValue",
             column: facet.column,
             label: facet.label,
+            tooltip: facet.tooltip,
 
             value: activeFilters,
             keyOptions,
@@ -1359,6 +1365,7 @@ export function useSidebarFilterState(
             type: "categorical",
             column: facet.column,
             label: facet.label,
+            tooltip: facet.tooltip,
 
             value: selectedOptions,
             options: availableOptions,
@@ -1484,6 +1491,7 @@ export function useSidebarFilterState(
           type: "categorical",
           column: facet.column,
           label: facet.label,
+          tooltip: facet.tooltip,
 
           value: selectedValues,
           options: availableValues,

--- a/web/src/features/filters/lib/filter-config.ts
+++ b/web/src/features/filters/lib/filter-config.ts
@@ -3,6 +3,7 @@ import type { ColumnDefinition } from "@langfuse/shared";
 interface BaseFacet {
   column: string;
   label: string;
+  tooltip?: string;
   isDisabled?: boolean;
   disabledReason?: string;
   // Mutually exclusive with these facet columns. If both are active,


### PR DESCRIPTION

> [!IMPORTANT]
> Adds optional tooltip support to filter facets in data table controls, enhancing user context and help text.
> 
>   - **Behavior**:
>     - Adds `tooltip?: string` to `BaseFacet` interface in `filter-config.ts`.
>     - Updates `CategoricalFacet`, `NumericFacet`, `StringFacet`, `KeyValueFacet`, `NumericKeyValueFacet`, `StringKeyValueFacet`, and `PositionInTraceFacetComponent` in `data-table-controls.tsx` to accept and pass `tooltip` prop.
>     - Implements tooltip rendering in `FilterAccordionItem` in `data-table-controls.tsx`.
>     - Updates `useSidebarFilterState` in `useSidebarFilterState.tsx` to propagate tooltip values.
>   - **Example**:
>     - Adds tooltip to "Is Root Observation" filter in `filter-config.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1133b9e9446eee80f362411fdcdd2a6ac43ef468. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->