### PR TITLE
feat(events-table): add icon rendering support to categorical filters

### DIFF
--- a/web/src/components/ItemBadge.tsx
+++ b/web/src/components/ItemBadge.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import { Badge } from "@/src/components/ui/badge";
 import {
   CircleDot,
@@ -87,6 +88,15 @@ const iconVariants = cva(cn("h-4 w-4"), {
     },
   },
 });
+
+export function renderFilterIcon(value: string): React.ReactNode {
+  const type = value as LangfuseItemType;
+  const Icon = iconMap[type];
+  if (!Icon) return null;
+  return (
+    <Icon className={cn("h-3.5 w-3.5 shrink-0", iconVariants({ type }))} />
+  );
+}
 
 export function ItemBadge({
   type,

--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import {
   createContext,
   useContext,
@@ -200,6 +201,7 @@ export function DataTableControls({
                   value={filter.value}
                   onChange={filter.onChange}
                   onOnlyChange={filter.onOnlyChange}
+                  renderIcon={filter.renderIcon}
                   isActive={filter.isActive}
                   onReset={filter.onReset}
                   operator={filter.operator}
@@ -359,6 +361,7 @@ interface CategoricalFacetProps extends BaseFacetProps {
   value: string[];
   onChange: (values: string[]) => void;
   onOnlyChange?: (value: string) => void;
+  renderIcon?: (value: string) => React.ReactNode;
   operator?: "any of" | "all of";
   onOperatorChange?: (operator: "any of" | "all of") => void;
   textFilters?: TextFilterEntry[];
@@ -546,6 +549,7 @@ export function CategoricalFacet({
   value,
   onChange,
   onOnlyChange,
+  renderIcon,
   isActive,
   isDisabled,
   disabledReason,
@@ -747,6 +751,7 @@ export function CategoricalFacet({
                         key={option}
                         id={`${filterKey}-${option}`}
                         label={option}
+                        icon={renderIcon?.(option)}
                         count={counts.get(option) || 0}
                         checked={value.includes(option)}
                         onCheckedChange={(checked) => {
@@ -1426,6 +1431,7 @@ function TextFilterSection({
 interface FilterValueCheckboxProps {
   id: string;
   label: string;
+  icon?: React.ReactNode;
   count: number;
   checked?: boolean;
   onCheckedChange?: (checked: boolean) => void;
@@ -1437,6 +1443,7 @@ interface FilterValueCheckboxProps {
 export function FilterValueCheckbox({
   id,
   label,
+  icon,
   count,
   checked = false,
   onCheckedChange,
@@ -1477,6 +1484,7 @@ export function FilterValueCheckbox({
         )}
         onClick={onLabelClick}
       >
+        {icon}
         <span
           className={cn(
             "min-w-0 flex-1 truncate text-xs",

--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -1524,7 +1524,7 @@ export function FilterValueCheckbox({
         )}
         onClick={onLabelClick}
       >
-        {icon}
+        {icon ? <span className="mr-2">{icon}</span> : null}
         <span
           className={cn(
             "min-w-0 flex-1 truncate text-xs",

--- a/web/src/features/events/config/filter-config.ts
+++ b/web/src/features/events/config/filter-config.ts
@@ -1,6 +1,7 @@
 import { eventsTableCols } from "@langfuse/shared";
 import type { FilterConfig } from "@/src/features/filters/lib/filter-config";
 import type { ColumnToBackendKeyMap } from "@/src/features/filters/lib/filter-transform";
+import { renderFilterIcon } from "@/src/components/ItemBadge";
 
 // Helper function to get column name from eventsTableCols by ID
 export const getEventsColumnName = (id: string): string => {
@@ -36,6 +37,7 @@ export const observationEventsFilterConfig: FilterConfig = {
       type: "categorical" as const,
       column: "type",
       label: getEventsColumnName("type"),
+      renderIcon: renderFilterIcon,
     },
     {
       type: "boolean" as const,

--- a/web/src/features/filters/config/observations-config.ts
+++ b/web/src/features/filters/config/observations-config.ts
@@ -1,6 +1,7 @@
 import { observationsTableCols } from "@langfuse/shared";
 import type { FilterConfig } from "@/src/features/filters/lib/filter-config";
 import type { ColumnToBackendKeyMap } from "@/src/features/filters/lib/filter-transform";
+import { renderFilterIcon } from "@/src/components/ItemBadge";
 
 /**
  * Maps frontend column IDs to backend-expected column IDs
@@ -27,6 +28,7 @@ export const observationFilterConfig: FilterConfig = {
       type: "categorical" as const,
       column: "type",
       label: "Type",
+      renderIcon: renderFilterIcon,
     },
     {
       type: "categorical" as const,

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import { useCallback, useMemo, useEffect, useRef } from "react";
 import { StringParam, useQueryParam, withDefault } from "use-query-params";
 import {
@@ -106,6 +107,8 @@ export interface CategoricalUIFilter extends BaseUIFilter {
   counts: Map<string, number>;
   onChange: (values: string[]) => void;
   onOnlyChange?: (value: string) => void;
+  /** Optional function to render an icon next to filter option labels */
+  renderIcon?: (value: string) => React.ReactNode;
   /**
    * Current operator for arrayOptions columns (tags, labels, etc.)
    * - "any of": OR logic - match if item has ANY selected value
@@ -1493,6 +1496,8 @@ export function useSidebarFilterState(
           isActive,
           isDisabled: disableState.isDisabled,
           disabledReason: disableState.reason,
+          renderIcon:
+            facet.type === "categorical" ? facet.renderIcon : undefined,
           onChange: (values: string[]) => updateFilter(facet.column, values),
           onOnlyChange: (value: string) => {
             if (selectedValues.length === 1 && selectedValues.includes(value)) {

--- a/web/src/features/filters/lib/filter-config.ts
+++ b/web/src/features/filters/lib/filter-config.ts
@@ -1,3 +1,4 @@
+import type React from "react";
 import type { ColumnDefinition } from "@langfuse/shared";
 
 interface BaseFacet {
@@ -12,6 +13,8 @@ interface BaseFacet {
 
 interface CategoricalFacet extends BaseFacet {
   type: "categorical";
+  /** Optional function to render an icon next to filter option labels */
+  renderIcon?: (value: string) => React.ReactNode;
 }
 
 interface BooleanFacet extends BaseFacet {


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds icon rendering support to categorical filters using a new optional `renderIcon` callback, enhancing UI with type icons.
> 
>   - **Behavior**:
>     - Adds `renderIcon` callback to `CategoricalFacet` in `filter-config.ts` and `CategoricalUIFilter` in `useSidebarFilterState.tsx`.
>     - Updates `CategoricalFacet` component in `data-table-controls.tsx` to use `renderIcon` in `FilterValueCheckbox`.
>     - Configures `observations-config.ts` and `events/filter-config.ts` to use `renderFilterIcon` for type filters.
>   - **Functions**:
>     - Extracts `renderFilterIcon` from `ItemBadge.tsx` to render icons for filter options.
>   - **Misc**:
>     - Updates interfaces in `filter-config.ts` and `useSidebarFilterState.tsx` to support `renderIcon`.
>     - Ensures backward compatibility by making `renderIcon` optional.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2f256eb4d29a8fad0a169bdc55935674715aadc9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<img width="686" height="330" alt="CleanShot 2026-02-20 at 16 39 56@2x" src="https://github.com/user-attachments/assets/806c56f7-25f8-4273-8323-e0fb29bd5cd7" />
