### PR TITLE
feat(events-table): add level in trace filter

### DIFF
--- a/packages/shared/src/eventsTable.ts
+++ b/packages/shared/src/eventsTable.ts
@@ -250,6 +250,12 @@ export const eventsTableCols: ColumnDefinition[] = [
     internal: "positionInTrace",
   },
   {
+    name: "Level in Trace",
+    id: "levelInTrace",
+    type: "number",
+    internal: "levelInTrace",
+  },
+  {
     name: "Has Parent Observation",
     id: "hasParentObservation",
     type: "boolean",

--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -508,6 +508,7 @@ abstract class AbstractQueryBuilder {
 abstract class AbstractCTEQueryBuilder extends AbstractQueryBuilder {
   protected ctes: string[] = [];
   protected joins: string[] = [];
+  protected hasRecursiveCTE = false;
 
   /**
    * Add a CTE (Common Table Expression) to the query
@@ -522,6 +523,17 @@ abstract class AbstractCTEQueryBuilder extends AbstractQueryBuilder {
   }
 
   /**
+   * Add a recursive CTE. Sets the RECURSIVE flag on the WITH clause.
+   */
+  withRecursiveCTE(
+    name: string,
+    queryWithParams: { query: string; params: Record<string, any> },
+  ): this {
+    this.hasRecursiveCTE = true;
+    return this.withCTE(name, queryWithParams);
+  }
+
+  /**
    * Add a LEFT JOIN
    */
   leftJoin(table: string, onClause: string): this {
@@ -533,7 +545,9 @@ abstract class AbstractCTEQueryBuilder extends AbstractQueryBuilder {
    * Helper to build WITH clause section
    */
   protected buildCTESection(): string {
-    return this.ctes.length > 0 ? `WITH ${this.ctes.join(",\n")}` : "";
+    if (this.ctes.length === 0) return "";
+    const keyword = this.hasRecursiveCTE ? "WITH RECURSIVE" : "WITH";
+    return `${keyword} ${this.ctes.join(",\n")}`;
   }
 
   /**

--- a/packages/shared/src/server/queries/clickhouse-sql/factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/factory.ts
@@ -35,9 +35,9 @@ export const createFilterFromFilterState = (
   filter: FilterCondition[],
   columnMapping: UiColumnMappings,
 ) => {
-  const applicableFilters = filter.filter(
-    (frontEndFilter) => frontEndFilter.type !== "positionInTrace",
-  );
+  const applicableFilters = filter
+    .filter((frontEndFilter) => frontEndFilter.type !== "positionInTrace")
+    .filter((frontEndFilter) => frontEndFilter.column !== "levelInTrace");
 
   return applicableFilters.map((frontEndFilter) => {
     // checks if the column exists in the clickhouse schema

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -421,8 +421,14 @@ async function getObservationsFromEventsTableInternal<T>(
 
   // Extract positionInTrace filter and build baseFilter without it
   const positionFilter = filter.find((f) => f.type === "positionInTrace");
+  // Extract levelInTrace filters (number type, may have multiple for range: >= and <=)
+  const levelFilters = filter.filter(
+    (f) => f.column === "levelInTrace" && f.type === "number",
+  );
   const baseFilter: typeof filter = [
-    ...filter.filter((f) => f.type !== "positionInTrace"),
+    ...filter.filter(
+      (f) => f.type !== "positionInTrace" && f.column !== "levelInTrace",
+    ),
   ];
 
   // Build filter list from baseFilter (without positionInTrace)
@@ -501,14 +507,66 @@ async function getObservationsFromEventsTableInternal<T>(
     if (nativeFilterClause) cteWhere += ` AND ${nativeFilterClause}`;
     if (searchClause) cteWhere += ` AND ${searchClause}`;
 
+    // TODO: Build this CTE via a query builder instead of raw SQL string
     queryBuilder.withCTE("qualifying_obs", {
-      query: `SELECT e.span_id, ROW_NUMBER() OVER (PARTITION BY e.trace_id ORDER BY e.start_time ${direction}, e.event_ts ${direction}, e.span_id ${direction}) as _rn FROM events e WHERE ${cteWhere}`,
+      query: `SELECT e.span_id, ROW_NUMBER() OVER (PARTITION BY e.trace_id ORDER BY e.start_time ${direction}, e.event_ts ${direction}, e.span_id ${direction}) as _rn FROM events_core e WHERE ${cteWhere}`,
       params: { projectId, ...appliedNativeFilter.params, ...search.params },
     });
 
     queryBuilder.whereRaw(
       "e.span_id IN (SELECT span_id FROM qualifying_obs WHERE _rn = {_posRn: UInt32})",
       { _posRn: Math.max(1, position) },
+    );
+  }
+
+  // Handle levelInTrace via recursive CTE
+  // Level 0 = root (no parent), level 1 = direct children of root, etc.
+  if (levelFilters.length > 0) {
+    const nativeLevelFilter = new FilterList(
+      createFilterFromFilterState(
+        baseFilter,
+        eventsTableNativeUiColumnDefinitions,
+      ),
+    );
+    const appliedNativeLevelFilter = nativeLevelFilter.apply();
+    const nativeLevelClause = appliedNativeLevelFilter.query
+      .trim()
+      .replace(/^(AND|OR)\s+/i, "");
+
+    let cteScope = "e.project_id = {projectId: String}";
+    if (nativeLevelClause) cteScope += ` AND ${nativeLevelClause}`;
+
+    // Each UNION ALL branch has its own namespace scope, so `e` can be reused safely.
+    const levelCteQuery = [
+      // Anchor: root observations (no parent)
+      `SELECT e.span_id, e.trace_id, 0 AS level FROM events_core e WHERE ${cteScope} AND e.parent_span_id = ''`,
+      "UNION ALL",
+      // Recursive: children
+      `SELECT e.span_id, e.trace_id, parent.level + 1 AS level FROM events_core e JOIN level_tree parent ON e.parent_span_id = parent.span_id AND e.trace_id = parent.trace_id WHERE e.project_id = {projectId: String}${nativeLevelClause ? ` AND ${nativeLevelClause}` : ""}`,
+    ].join(" ");
+
+    // TODO: Build this CTE via a query builder instead of raw SQL string
+    queryBuilder.withRecursiveCTE("level_tree", {
+      query: levelCteQuery,
+      params: { projectId, ...appliedNativeLevelFilter.params },
+    });
+
+    // Build WHERE conditions for each level filter
+    const levelConditions: string[] = [];
+    const levelParams: Record<string, number> = {};
+    levelFilters.forEach((lf, idx) => {
+      if (lf.type === "number") {
+        const paramName = `_levelVal${idx}`;
+        levelConditions.push(`level ${lf.operator} {${paramName}: UInt32}`);
+        // Round to integer — level is always a whole number depth
+        levelParams[paramName] = Math.round(lf.value);
+      }
+    });
+
+    const levelWhere = levelConditions.join(" AND ");
+    queryBuilder.whereRaw(
+      `e.span_id IN (SELECT span_id FROM level_tree WHERE ${levelWhere})`,
+      levelParams,
     );
   }
 

--- a/packages/shared/src/server/services/InMemoryFilterService.ts
+++ b/packages/shared/src/server/services/InMemoryFilterService.ts
@@ -49,6 +49,9 @@ export class InMemoryFilterService {
   ): boolean {
     const { column, type, operator } = condition;
 
+    // levelInTrace is computed via recursive CTE in DB queries, skip in-memory.
+    if (column === "levelInTrace") return true;
+
     // Get the data field value based on the column
     const fieldValue = fieldMapper(data, column);
 

--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -226,6 +226,7 @@ export function DataTableControls({
                   value={filter.value}
                   onChange={filter.onChange}
                   unit={filter.unit}
+                  step={filter.step}
                   isActive={filter.isActive}
                   onReset={filter.onReset}
                   isDisabled={filter.isDisabled}
@@ -378,6 +379,7 @@ interface NumericFacetProps extends BaseFacetProps {
   value: [number, number];
   onChange: (value: [number, number]) => void;
   unit?: string;
+  step?: number;
 }
 
 interface StringFacetProps extends BaseFacetProps {
@@ -823,6 +825,7 @@ export function NumericFacet({
   value,
   onChange,
   unit,
+  step: stepProp,
   isActive,
   isDisabled,
   disabledReason,
@@ -923,7 +926,7 @@ export function NumericFacet({
                     value={isActive ? localValue[0] : ""}
                     placeholder={String(min)}
                     min={min}
-                    step="any"
+                    step={stepProp ?? "any"}
                     onChange={handleMinInputChange}
                     className="h-8"
                   />
@@ -948,7 +951,7 @@ export function NumericFacet({
                     value={isActive ? localValue[1] : ""}
                     placeholder={String(max)}
                     min={min}
-                    step="any"
+                    step={stepProp ?? "any"}
                     onChange={handleMaxInputChange}
                     className="h-8"
                   />
@@ -963,7 +966,7 @@ export function NumericFacet({
             <Slider
               min={min}
               max={max}
-              step={max - min <= 1000 ? 0.01 : 1}
+              step={stepProp ?? (max - min <= 1000 ? 0.01 : 1)}
               value={localValue}
               onValueChange={handleSliderChange}
             />

--- a/web/src/features/events/config/filter-config.ts
+++ b/web/src/features/events/config/filter-config.ts
@@ -64,12 +64,16 @@ export const observationEventsFilterConfig: FilterConfig = {
       type: "positionInTrace" as const,
       column: "positionInTrace",
       label: getEventsColumnName("positionInTrace"),
+      tooltip:
+        "Filter observations for their relative position within a trace either from the bottom or top. Positions are calculated based on timings.",
       mutuallyExclusiveWith: ["score_categories", "scores_avg"],
     },
     {
       type: "numeric" as const,
       column: "levelInTrace",
       label: getEventsColumnName("levelInTrace"),
+      tooltip:
+        "Filter for observations at a specific depth level in a trace. The topmost observation has level 0.",
       min: 0,
       max: 50,
       step: 1,

--- a/web/src/features/events/config/filter-config.ts
+++ b/web/src/features/events/config/filter-config.ts
@@ -65,6 +65,14 @@ export const observationEventsFilterConfig: FilterConfig = {
       mutuallyExclusiveWith: ["score_categories", "scores_avg"],
     },
     {
+      type: "numeric" as const,
+      column: "levelInTrace",
+      label: getEventsColumnName("levelInTrace"),
+      min: 0,
+      max: 50,
+      step: 1,
+    },
+    {
       type: "categorical" as const,
       column: "providedModelName",
       label: getEventsColumnName("providedModelName"),

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -146,6 +146,7 @@ export interface NumericUIFilter extends BaseUIFilter {
   max: number;
   onChange: (value: [number, number]) => void;
   unit?: string;
+  step?: number;
 }
 
 export interface StringUIFilter extends BaseUIFilter {
@@ -1017,6 +1018,7 @@ export function useSidebarFilterState(
             min: facet.min,
             max: facet.max,
             unit: facet.unit,
+            step: facet.step,
             loading: false,
             expanded: expandedSet.has(facet.column),
             isActive,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `levelInTrace` filter to events table with recursive CTE support and UI integration.
> 
>   - **Behavior**:
>     - Add `levelInTrace` column to `eventsTableCols` in `eventsTable.ts` for filtering and sorting.
>     - Handle `levelInTrace` filter in `getObservationsFromEventsTableInternal()` in `events.ts` using recursive CTE.
>     - Exclude `levelInTrace` from in-memory filtering in `InMemoryFilterService.ts`.
>   - **UI Components**:
>     - Add `levelInTrace` filter configuration in `filter-config.ts` with numeric type and range 0-50.
>     - Update `NumericFacet` in `data-table-controls.tsx` to support `step` property for numeric filters.
>   - **Query Builders**:
>     - Add `withRecursiveCTE()` method in `event-query-builder.ts` to support recursive CTEs.
>     - Modify `createFilterFromFilterState()` in `factory.ts` to exclude `levelInTrace` from applicable filters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 02220bee8e3515ef2e9b0f236d73bc9a922d272d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->