### PR TITLE
feat(dashboard): optimize v2 traces queries with uniq(trace_id) on observations view

### DIFF
--- a/web/src/features/dashboard/components/TracesBarListChart.tsx
+++ b/web/src/features/dashboard/components/TracesBarListChart.tsx
@@ -31,14 +31,13 @@ export const TracesBarListChart = ({
   const [isExpanded, setIsExpanded] = useState(false);
 
   const isV2 = metricsVersion === "v2";
-  const traceBase = traceViewQuery(metricsVersion, globalFilterState);
   const traceNameField = isV2 ? "traceName" : "name";
+  const countField = isV2 ? "uniq_traceId" : "count_count";
 
   // Total traces query using executeQuery
   const totalTracesQuery: QueryType = {
-    ...traceBase,
+    ...traceViewQuery({ metricsVersion, globalFilterState }),
     dimensions: [],
-    metrics: [{ measure: "count", aggregation: "count" }],
     timeDimension: null,
     fromTimestamp: fromTimestamp.toISOString(),
     toTimestamp: toTimestamp.toISOString(),
@@ -63,13 +62,16 @@ export const TracesBarListChart = ({
 
   // Traces grouped by name query using executeQuery
   const tracesQuery: QueryType = {
-    ...traceBase,
+    ...traceViewQuery({
+      metricsVersion,
+      globalFilterState,
+      groupedByName: true,
+    }),
     dimensions: [{ field: traceNameField }],
-    metrics: [{ measure: "count", aggregation: "count" }],
     timeDimension: null,
     fromTimestamp: fromTimestamp.toISOString(),
     toTimestamp: toTimestamp.toISOString(),
-    orderBy: [{ field: "count_count", direction: "desc" }],
+    orderBy: [{ field: countField, direction: "desc" }],
     chartConfig: { type: "table", row_limit: 20 },
   };
 
@@ -96,7 +98,7 @@ export const TracesBarListChart = ({
         name: item[traceNameField]
           ? (item[traceNameField] as string)
           : "Unknown",
-        value: Number(item.count_count),
+        value: Number(item[countField]),
       };
     }) ?? [];
 
@@ -120,8 +122,8 @@ export const TracesBarListChart = ({
       <>
         <TotalMetric
           metric={compactNumberFormatter(
-            totalTraces.data?.[0]?.count_count
-              ? Number(totalTraces.data[0].count_count)
+            totalTraces.data?.[0]?.[countField]
+              ? Number(totalTraces.data[0][countField])
               : 0,
           )}
           description={"Total traces tracked"}

--- a/web/src/features/dashboard/components/UserChart.tsx
+++ b/web/src/features/dashboard/components/UserChart.tsx
@@ -78,10 +78,12 @@ export const UserChart = ({
     },
   );
 
+  const isV2 = metricsVersion === "v2";
+  const countField = isV2 ? "uniq_traceId" : "count_count";
+
   const traceCountQuery: QueryType = {
-    ...traceViewQuery(metricsVersion, globalFilterState),
+    ...traceViewQuery({ metricsVersion, globalFilterState }),
     dimensions: [{ field: "userId" }],
-    metrics: [{ measure: "count", aggregation: "count" }],
     timeDimension: null,
     fromTimestamp: fromTimestamp.toISOString(),
     toTimestamp: toTimestamp.toISOString(),
@@ -110,7 +112,7 @@ export const UserChart = ({
         .map((item) => {
           return {
             name: item.userId as string,
-            value: item.count_count ? Number(item.count_count) : 0,
+            value: item[countField] ? Number(item[countField]) : 0,
           };
         })
     : [];
@@ -132,7 +134,7 @@ export const UserChart = ({
   );
 
   const totalTraces = traces.data?.reduce(
-    (acc, curr) => acc + (Number(curr.count_count) || 0),
+    (acc, curr) => acc + (Number(curr[countField]) || 0),
     0,
   );
 

--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -1136,6 +1136,14 @@ export const eventsObservationsView: ViewDeclarationType = {
       description: "Total number of observations.",
       unit: "observations",
     },
+    traceId: {
+      sql: "@@AGG@@(events_observations.trace_id)",
+      aggs: { agg: "any" },
+      alias: "traceId",
+      type: "string",
+      description:
+        "Trace identifier; apply uniq aggregation to count distinct traces.",
+    },
     latency: {
       sql: "date_diff('millisecond', @@AGG1@@(events_observations.start_time), @@AGG1@@(events_observations.end_time))",
       aggs: { agg1: "any" },

--- a/web/src/features/query/server/queryBuilder.ts
+++ b/web/src/features/query/server/queryBuilder.ts
@@ -77,6 +77,8 @@ export class QueryBuilder {
         // Get histogram bins from chart config, fallback to 10
         const bins = this.chartConfig?.bins ?? 10;
         return `histogram(${bins})(toFloat64(${metric.alias || metric.sql}))`;
+      case "uniq":
+        return `uniq(${metric.alias || metric.sql})`;
       default:
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const exhaustiveCheck: never = metric.aggregation;
@@ -1018,7 +1020,7 @@ export class QueryBuilder {
 
       // Check if the field is a metric (with aggregation prefix)
       const metricNamePattern =
-        /^(sum|avg|count|max|min|p50|p75|p90|p95|p99)_(.+)$/;
+        /^(sum|avg|count|max|min|p50|p75|p90|p95|p99|uniq)_(.+)$/;
       const metricMatch = item.field.match(metricNamePattern);
 
       if (metricMatch) {

--- a/web/src/features/query/types.ts
+++ b/web/src/features/query/types.ts
@@ -107,6 +107,7 @@ export const metricAggregations = z.enum([
   "p95",
   "p99",
   "histogram",
+  "uniq",
 ]);
 
 export const metric = z.object({


### PR DESCRIPTION
Replace the slow eventsTracesView path (rootEventCondition subquery +
high-cardinality GROUP BY trace_id) with uniq(trace_id) on the
eventsObservationsView for dashboard trace tiles in v2.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimizes dashboard v2 trace queries by using `uniq(trace_id)` on `eventsObservationsView`, updating components, tests, and data models accordingly.
> 
>   - **Behavior**:
>     - Replaces `eventsTracesView` path with `uniq(trace_id)` on `eventsObservationsView` for trace queries in dashboard v2.
>     - Updates `traceViewQuery()` in `dashboard-utils.ts` to use `uniq(trace_id)` for v2.
>   - **Components**:
>     - Updates `TracesBarListChart.tsx`, `TracesTimeSeriesChart.tsx`, and `UserChart.tsx` to use `uniq(trace_id)` for v2 metrics.
>   - **Tests**:
>     - Modifies `dashboard-v1-v2-consistency.servertest.ts` to test `uniq(trace_id)` behavior in v2.
>   - **Data Model**:
>     - Adds `traceId` measure with `uniq` aggregation to `eventsObservationsView` in `dataModel.ts`.
>   - **Query Builder**:
>     - Adds support for `uniq` aggregation in `queryBuilder.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for bb5c2b7129d0b89a3a0037b0fd022d95e8e2fce2. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->