### PR TITLE
feat(dashboard): pass v2 metrics version to custom dashboard widgets

### DIFF
--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -21,6 +21,8 @@ import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAcces
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { DownloadButton } from "@/src/features/widgets/chart-library/DownloadButton";
 import { formatMetricName } from "@/src/features/widgets/utils";
+import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
+import { type ViewVersion } from "@/src/features/query";
 
 export interface WidgetPlacement {
   id: string;
@@ -51,6 +53,8 @@ export function DashboardWidget({
 }) {
   const router = useRouter();
   const utils = api.useUtils();
+  const { isBetaEnabled } = useV4Beta();
+  const metricsVersion: ViewVersion = isBetaEnabled ? "v2" : "v1";
   const widget = api.dashboardWidgets.get.useQuery(
     {
       widgetId: placement.widgetId,
@@ -94,6 +98,7 @@ export function DashboardWidget({
   const queryResult = api.dashboard.executeQuery.useQuery(
     {
       projectId,
+      version: metricsVersion,
       query: {
         view: (widget.data?.view as z.infer<typeof views>) ?? "traces",
         dimensions: widget.data?.dimensions ?? [],


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `DashboardWidget` now uses `useV4Beta` to determine and pass the metrics version to queries, supporting a beta feature flag.
> 
>   - **Behavior**:
>     - `DashboardWidget` now uses `useV4Beta` to determine metrics version (`v2` if beta enabled, otherwise `v1`).
>     - Passes `metricsVersion` to `executeQuery` in `DashboardWidget`.
>   - **Imports**:
>     - Adds `useV4Beta` and `ViewVersion` imports in `DashboardWidget.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2362cb9866a91840e4a0a116be1b71a2f93c609c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->