### PR TITLE
fix: deleting running evaluator gets stuck

### DIFF
--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -438,7 +438,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
                   aria-label="delete"
                   itemId={id}
                   projectId={projectId}
-                  redirectUrl={`/project/${projectId}/evals`}
+                  isTableAction
                   deleteConfirmation={row.original.scoreName}
                 />
               </DropdownMenuItem>


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This was happening because after clicking the delete button, the data was not refetched.

Fixes https://github.com/langfuse/langfuse/issues/12102

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes UI update issue when deleting a running evaluator by changing a prop in `evaluator-table.tsx`.
> 
>   - **Behavior**:
>     - Fixes issue where deleting a running evaluator did not update the UI in `evaluator-table.tsx`.
>     - Changes `DeleteEvalConfigButton` prop from `redirectUrl` to `isTableAction` to trigger data refetch.
>   - **Misc**:
>     - Fixes issue #12102.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 98058872dabdf15d4b821986789ecc5abc5118c5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->