### PR TITLE
feat(web): add Meta Prompt - AI-assisted prompt creation

### DIFF
--- a/web/src/__tests__/meta-prompt/buildMetaPromptMessages.servertest.ts
+++ b/web/src/__tests__/meta-prompt/buildMetaPromptMessages.servertest.ts
@@ -1,0 +1,139 @@
+/** @jest-environment node */
+
+import { buildMetaPromptMessages } from "@/src/features/meta-prompt/server/buildMetaPromptMessages";
+import {
+  META_PROMPT_SYSTEM_PROMPT,
+  PLATFORM_RULES,
+} from "@/src/features/meta-prompt/constants/systemPrompt";
+import {
+  ChatMessageRole,
+  ChatMessageType,
+  type ChatMessage,
+} from "@langfuse/shared/src/server";
+
+describe("buildMetaPromptMessages", () => {
+  const createUserMessage = (content: string): ChatMessage => ({
+    type: ChatMessageType.User as const,
+    role: ChatMessageRole.User as const,
+    content,
+  });
+
+  it("should place system prompt as the first message", () => {
+    const userMessages: ChatMessage[] = [
+      createUserMessage("Improve my prompt"),
+    ];
+
+    const result = buildMetaPromptMessages({
+      userMessages,
+      targetPlatform: "generic",
+    });
+
+    expect(result.length).toBe(2);
+    expect(result[0].role).toBe(ChatMessageRole.System);
+    expect(result[0].type).toBe(ChatMessageType.System);
+  });
+
+  it("should append user messages after system prompt", () => {
+    const userMessages: ChatMessage[] = [
+      createUserMessage("First message"),
+      createUserMessage("Second message"),
+    ];
+
+    const result = buildMetaPromptMessages({
+      userMessages,
+      targetPlatform: "generic",
+    });
+
+    expect(result.length).toBe(3);
+    expect(result[1]).toEqual(userMessages[0]);
+    expect(result[2]).toEqual(userMessages[1]);
+  });
+
+  it("should inject OpenAI platform rules for openai target", () => {
+    const result = buildMetaPromptMessages({
+      userMessages: [createUserMessage("test")],
+      targetPlatform: "openai",
+    });
+
+    const systemContent = result[0].content as string;
+    expect(systemContent).toContain("PLATFORM FORMATTING RULES (OpenAI)");
+    expect(systemContent).toContain("Use ### blocks or triple quotes");
+    expect(systemContent).not.toContain("{{PLATFORM_FORMATTING_RULES}}");
+  });
+
+  it("should inject Claude platform rules for claude target", () => {
+    const result = buildMetaPromptMessages({
+      userMessages: [createUserMessage("test")],
+      targetPlatform: "claude",
+    });
+
+    const systemContent = result[0].content as string;
+    expect(systemContent).toContain(
+      "PLATFORM FORMATTING RULES (Claude/Anthropic)",
+    );
+    expect(systemContent).toContain("Use XML tags for structure");
+  });
+
+  it("should inject Gemini platform rules for gemini target", () => {
+    const result = buildMetaPromptMessages({
+      userMessages: [createUserMessage("test")],
+      targetPlatform: "gemini",
+    });
+
+    const systemContent = result[0].content as string;
+    expect(systemContent).toContain(
+      "PLATFORM FORMATTING RULES (Google Gemini)",
+    );
+    expect(systemContent).toContain("System Instruction");
+  });
+
+  it("should inject Generic platform rules for generic target", () => {
+    const result = buildMetaPromptMessages({
+      userMessages: [createUserMessage("test")],
+      targetPlatform: "generic",
+    });
+
+    const systemContent = result[0].content as string;
+    expect(systemContent).toContain("PLATFORM FORMATTING RULES (Generic)");
+    expect(systemContent).toContain(
+      "Ensure compatibility across different LLM providers",
+    );
+  });
+
+  it("should fall back to generic rules for unknown platform", () => {
+    const result = buildMetaPromptMessages({
+      userMessages: [createUserMessage("test")],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      targetPlatform: "unknown-platform" as any,
+    });
+
+    const systemContent = result[0].content as string;
+    expect(systemContent).toContain("PLATFORM FORMATTING RULES (Generic)");
+  });
+
+  it("should replace the placeholder in system prompt template", () => {
+    const result = buildMetaPromptMessages({
+      userMessages: [createUserMessage("test")],
+      targetPlatform: "openai",
+    });
+
+    const systemContent = result[0].content as string;
+    expect(systemContent).not.toContain("{{PLATFORM_FORMATTING_RULES}}");
+
+    const expectedContent = META_PROMPT_SYSTEM_PROMPT.replace(
+      "{{PLATFORM_FORMATTING_RULES}}",
+      PLATFORM_RULES.openai,
+    );
+    expect(systemContent).toBe(expectedContent);
+  });
+
+  it("should handle empty user messages array", () => {
+    const result = buildMetaPromptMessages({
+      userMessages: [],
+      targetPlatform: "generic",
+    });
+
+    expect(result.length).toBe(1);
+    expect(result[0].role).toBe(ChatMessageRole.System);
+  });
+});

--- a/web/src/__tests__/meta-prompt/parsePromptFromResponse.servertest.ts
+++ b/web/src/__tests__/meta-prompt/parsePromptFromResponse.servertest.ts
@@ -1,0 +1,148 @@
+/** @jest-environment node */
+
+import { parsePromptFromResponse } from "@/src/features/meta-prompt/utils/parsePromptFromResponse";
+
+describe("parsePromptFromResponse", () => {
+  it("should parse a complete response with all sections", () => {
+    const response = `## Clarifying Questions
+None needed.
+
+## Assumptions
+1. The user wants a REST API.
+2. The output should be in JSON.
+
+## Improved Prompt
+### Task
+Build a REST API endpoint.
+### Objective
+Create a reliable endpoint.
+
+## User Fill-in Checklist
+- [ ] Replace {domain} with your specific domain
+- [ ] Set the API version`;
+
+    const result = parsePromptFromResponse(response);
+
+    expect(result.clarifyingQuestions).toBe("None needed.");
+    expect(result.assumptions).toBe(
+      "1. The user wants a REST API.\n2. The output should be in JSON.",
+    );
+    expect(result.improvedPrompt).toContain("### Task");
+    expect(result.improvedPrompt).toContain("Build a REST API endpoint.");
+    expect(result.improvedPrompt).toContain("### Objective");
+    expect(result.fillInChecklist).toContain(
+      "Replace {domain} with your specific domain",
+    );
+  });
+
+  it("should parse a response with only Improved Prompt", () => {
+    const response = `## Improved Prompt
+### Task
+Summarize the document.
+### Output Format
+A bullet-point list.`;
+
+    const result = parsePromptFromResponse(response);
+
+    expect(result.improvedPrompt).toContain("Summarize the document.");
+    expect(result.improvedPrompt).toContain("### Output Format");
+    expect(result.clarifyingQuestions).toBeNull();
+    expect(result.assumptions).toBeNull();
+    expect(result.fillInChecklist).toBeNull();
+  });
+
+  it("should parse a response with only Clarifying Questions", () => {
+    const response = `## Clarifying Questions
+1. What is the target audience?
+2. What format should the output be in?
+3. Is there a word limit?`;
+
+    const result = parsePromptFromResponse(response);
+
+    expect(result.clarifyingQuestions).toContain(
+      "What is the target audience?",
+    );
+    expect(result.clarifyingQuestions).toContain(
+      "What format should the output be in?",
+    );
+    expect(result.improvedPrompt).toBeNull();
+    expect(result.assumptions).toBeNull();
+    expect(result.fillInChecklist).toBeNull();
+  });
+
+  it("should return all nulls for an empty response", () => {
+    const result = parsePromptFromResponse("");
+
+    expect(result.improvedPrompt).toBeNull();
+    expect(result.clarifyingQuestions).toBeNull();
+    expect(result.assumptions).toBeNull();
+    expect(result.fillInChecklist).toBeNull();
+  });
+
+  it("should return all nulls for plain text without section headers", () => {
+    const response =
+      "This is just some plain text without any section markers.";
+
+    const result = parsePromptFromResponse(response);
+
+    expect(result.improvedPrompt).toBeNull();
+    expect(result.clarifyingQuestions).toBeNull();
+    expect(result.assumptions).toBeNull();
+    expect(result.fillInChecklist).toBeNull();
+  });
+
+  it("should handle sections with empty content", () => {
+    const response = `## Clarifying Questions
+
+## Assumptions
+
+## Improved Prompt
+Some prompt content here.
+
+## User Fill-in Checklist
+`;
+
+    const result = parsePromptFromResponse(response);
+
+    expect(result.clarifyingQuestions).toBe("");
+    expect(result.assumptions).toBe("");
+    expect(result.improvedPrompt).toBe("Some prompt content here.");
+    expect(result.fillInChecklist).toBe("");
+  });
+
+  it("should handle headers with trailing annotations like (0-5)", () => {
+    const response = `## Clarifying Questions (0-5)
+What is the target?
+
+## Assumptions (0-3)
+None.
+
+## Improved Prompt
+The prompt.`;
+
+    const result = parsePromptFromResponse(response);
+
+    // extractSection finds "## Clarifying Questions" then includes " (0-5)" as part of content
+    expect(result.clarifyingQuestions).toContain("What is the target?");
+    expect(result.assumptions).toContain("None.");
+    expect(result.improvedPrompt).toBe("The prompt.");
+  });
+
+  it("should correctly separate content between adjacent sections", () => {
+    const response = `## Clarifying Questions
+Question 1?
+Question 2?
+
+## Assumptions
+Assumption A.
+
+## Improved Prompt
+The prompt text.`;
+
+    const result = parsePromptFromResponse(response);
+
+    expect(result.clarifyingQuestions).toBe("Question 1?\nQuestion 2?");
+    expect(result.assumptions).toBe("Assumption A.");
+    expect(result.improvedPrompt).toBe("The prompt text.");
+  });
+});

--- a/web/src/__tests__/meta-prompt/validation.servertest.ts
+++ b/web/src/__tests__/meta-prompt/validation.servertest.ts
@@ -1,0 +1,168 @@
+/** @jest-environment node */
+
+import { MetaPromptCompletionBodySchema } from "@/src/features/meta-prompt/server/validation";
+
+describe("MetaPromptCompletionBodySchema", () => {
+  const validModelParams = {
+    provider: "openai",
+    adapter: "openai",
+    model: "gpt-4o",
+  };
+
+  const validMessages = [
+    {
+      type: "user",
+      role: "user",
+      content: "Improve this prompt: Write a poem",
+    },
+  ];
+
+  it("should accept valid input with all fields", () => {
+    const input = {
+      projectId: "project-123",
+      messages: validMessages,
+      modelParams: validModelParams,
+      targetPlatform: "openai",
+      streaming: false,
+    };
+
+    const result = MetaPromptCompletionBodySchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.targetPlatform).toBe("openai");
+      expect(result.data.streaming).toBe(false);
+    }
+  });
+
+  it("should apply default values for optional fields", () => {
+    const input = {
+      projectId: "project-123",
+      messages: validMessages,
+      modelParams: validModelParams,
+    };
+
+    const result = MetaPromptCompletionBodySchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.targetPlatform).toBe("generic");
+      expect(result.data.streaming).toBe(true);
+    }
+  });
+
+  it("should reject missing projectId", () => {
+    const input = {
+      messages: validMessages,
+      modelParams: validModelParams,
+    };
+
+    const result = MetaPromptCompletionBodySchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject missing messages", () => {
+    const input = {
+      projectId: "project-123",
+      modelParams: validModelParams,
+    };
+
+    const result = MetaPromptCompletionBodySchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject missing modelParams", () => {
+    const input = {
+      projectId: "project-123",
+      messages: validMessages,
+    };
+
+    const result = MetaPromptCompletionBodySchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject invalid targetPlatform value", () => {
+    const input = {
+      projectId: "project-123",
+      messages: validMessages,
+      modelParams: validModelParams,
+      targetPlatform: "invalid-platform",
+    };
+
+    const result = MetaPromptCompletionBodySchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it("should accept all valid targetPlatform values", () => {
+    const platforms = ["openai", "claude", "gemini", "generic"];
+
+    for (const platform of platforms) {
+      const input = {
+        projectId: "project-123",
+        messages: validMessages,
+        modelParams: validModelParams,
+        targetPlatform: platform,
+      };
+
+      const result = MetaPromptCompletionBodySchema.safeParse(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.targetPlatform).toBe(platform);
+      }
+    }
+  });
+
+  it("should accept modelParams with optional fields", () => {
+    const input = {
+      projectId: "project-123",
+      messages: validMessages,
+      modelParams: {
+        ...validModelParams,
+        temperature: 0.7,
+        max_tokens: 2048,
+        top_p: 0.9,
+      },
+    };
+
+    const result = MetaPromptCompletionBodySchema.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject modelParams missing required provider field", () => {
+    const input = {
+      projectId: "project-123",
+      messages: validMessages,
+      modelParams: {
+        adapter: "openai",
+        model: "gpt-4o",
+      },
+    };
+
+    const result = MetaPromptCompletionBodySchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject modelParams with invalid adapter", () => {
+    const input = {
+      projectId: "project-123",
+      messages: validMessages,
+      modelParams: {
+        provider: "openai",
+        adapter: "invalid-adapter",
+        model: "gpt-4o",
+      },
+    };
+
+    const result = MetaPromptCompletionBodySchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it("should accept empty messages array", () => {
+    const input = {
+      projectId: "project-123",
+      messages: [],
+      modelParams: validModelParams,
+    };
+
+    const result = MetaPromptCompletionBodySchema.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+});

--- a/web/src/app/api/metaPromptCompletion/route.ts
+++ b/web/src/app/api/metaPromptCompletion/route.ts
@@ -1,0 +1,6 @@
+import metaPromptCompletionHandler from "@/src/features/meta-prompt/server/metaPromptCompletionHandler";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+export const POST = metaPromptCompletionHandler;

--- a/web/src/features/meta-prompt/components/ApplyToEditorButton.tsx
+++ b/web/src/features/meta-prompt/components/ApplyToEditorButton.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { ArrowRight } from "lucide-react";
+
+import { Button } from "@/src/components/ui/button";
+import { useMetaPromptContext } from "@/src/features/meta-prompt/context/MetaPromptProvider";
+
+export const ApplyToEditorButton: React.FC = () => {
+  const { latestImprovedPrompt, applyToEditor } = useMetaPromptContext();
+
+  return (
+    <Button
+      variant="secondary"
+      onClick={applyToEditor}
+      disabled={!latestImprovedPrompt}
+      className="w-full"
+    >
+      <ArrowRight className="mr-2 h-4 w-4" />
+      Apply to editor
+    </Button>
+  );
+};

--- a/web/src/features/meta-prompt/components/ChatHistory.tsx
+++ b/web/src/features/meta-prompt/components/ChatHistory.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useRef } from "react";
+import { Bot, User } from "lucide-react";
+
+import { cn } from "@/src/utils/tailwind";
+import type { MetaPromptMessage } from "@/src/features/meta-prompt/types";
+import { MarkdownView } from "@/src/components/ui/MarkdownViewer";
+
+// Simple markdown wrapper that removes the padding/grid from MarkdownView
+const AssistantMarkdown: React.FC<{ content: string }> = ({ content }) => (
+  <div className="text-sm [&_.io-message-content]:gap-1 [&_.io-message-content]:p-0">
+    <MarkdownView markdown={content} />
+  </div>
+);
+
+type ChatHistoryProps = {
+  chatHistory: MetaPromptMessage[];
+  isStreaming: boolean;
+};
+
+export const ChatHistory: React.FC<ChatHistoryProps> = ({
+  chatHistory,
+  isStreaming,
+}) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [chatHistory]);
+
+  return (
+    <div ref={scrollRef} className="flex-1 overflow-y-auto p-3">
+      {chatHistory.length === 0 && (
+        <div className="flex flex-col items-center justify-center gap-2 py-12 text-center text-muted-foreground">
+          <Bot className="h-8 w-8" />
+          <p className="text-sm font-medium">
+            What kind of prompt would you like to create?
+          </p>
+          <p className="text-xs">
+            Describe your requirements and I will help you craft a
+            well-structured prompt.
+          </p>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-3">
+        {chatHistory.map((message) => (
+          <ChatBubble
+            key={message.id}
+            message={message}
+            isStreamingMessage={
+              isStreaming &&
+              message.role === "assistant" &&
+              message.id === chatHistory[chatHistory.length - 1]?.id
+            }
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+type ChatBubbleProps = {
+  message: MetaPromptMessage;
+  isStreamingMessage: boolean;
+};
+
+const ChatBubble: React.FC<ChatBubbleProps> = ({
+  message,
+  isStreamingMessage,
+}) => {
+  const isUser = message.role === "user";
+
+  return (
+    <div className={cn("flex gap-2", isUser ? "flex-row-reverse" : "flex-row")}>
+      <div
+        className={cn(
+          "flex h-7 w-7 shrink-0 items-center justify-center rounded-full",
+          isUser
+            ? "bg-primary text-primary-foreground"
+            : "bg-muted text-muted-foreground",
+        )}
+      >
+        {isUser ? <User className="h-4 w-4" /> : <Bot className="h-4 w-4" />}
+      </div>
+
+      <div
+        className={cn(
+          "max-w-[85%] rounded-lg px-3 py-2",
+          isUser ? "bg-primary text-primary-foreground" : "bg-muted",
+        )}
+      >
+        {isUser ? (
+          <p className="whitespace-pre-wrap text-sm">{message.content}</p>
+        ) : message.content ? (
+          <AssistantMarkdown content={message.content} />
+        ) : isStreamingMessage ? (
+          <div className="flex items-center gap-1 py-1">
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.3s]" />
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.15s]" />
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-muted-foreground" />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};

--- a/web/src/features/meta-prompt/components/ChatInput.tsx
+++ b/web/src/features/meta-prompt/components/ChatInput.tsx
@@ -1,0 +1,95 @@
+import React, { useCallback, useRef, useState } from "react";
+import { Send, Square } from "lucide-react";
+
+import { Button } from "@/src/components/ui/button";
+import { Textarea } from "@/src/components/ui/textarea";
+
+type ChatInputProps = {
+  onSend: (content: string) => void;
+  onStop: () => void;
+  isStreaming: boolean;
+  disabled: boolean;
+};
+
+export const ChatInput: React.FC<ChatInputProps> = ({
+  onSend,
+  onStop,
+  isStreaming,
+  disabled,
+}) => {
+  const [input, setInput] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleSend = useCallback(() => {
+    const trimmed = input.trim();
+    if (!trimmed || isStreaming || disabled) return;
+
+    onSend(trimmed);
+    setInput("");
+
+    // Reset textarea height
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "auto";
+    }
+  }, [input, isStreaming, disabled, onSend]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setInput(e.target.value);
+
+    // Auto-resize
+    const textarea = e.target;
+    textarea.style.height = "auto";
+    textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`;
+  };
+
+  return (
+    <div className="border-t p-2">
+      <div className="flex gap-2">
+        <Textarea
+          ref={textareaRef}
+          value={input}
+          onChange={handleInput}
+          onKeyDown={handleKeyDown}
+          placeholder="Describe the prompt you want to create..."
+          className="min-h-[40px] resize-none text-sm"
+          rows={1}
+          disabled={disabled}
+        />
+        <div className="flex flex-col gap-1">
+          {isStreaming ? (
+            <Button
+              variant="destructive"
+              size="icon"
+              onClick={onStop}
+              className="h-8 w-8 shrink-0"
+              title="Stop generation"
+            >
+              <Square className="h-4 w-4" />
+            </Button>
+          ) : (
+            <Button
+              variant="default"
+              size="icon"
+              onClick={handleSend}
+              disabled={!input.trim() || disabled}
+              className="h-8 w-8 shrink-0"
+              title="Send message"
+            >
+              <Send className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Press Enter to send, Shift+Enter for new line
+      </p>
+    </div>
+  );
+};

--- a/web/src/features/meta-prompt/components/ChatPanel.tsx
+++ b/web/src/features/meta-prompt/components/ChatPanel.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+import { useMetaPromptContext } from "@/src/features/meta-prompt/context/MetaPromptProvider";
+import { ModelSelector } from "./ModelSelector";
+import { ChatHistory } from "./ChatHistory";
+import { ChatInput } from "./ChatInput";
+
+type ChatPanelProps = {
+  availableProviders: string[];
+  availableModels: string[];
+  onProviderChange: (provider: string) => void;
+  onModelChange: (model: string) => void;
+};
+
+export const ChatPanel: React.FC<ChatPanelProps> = ({
+  availableProviders,
+  availableModels,
+  onProviderChange,
+  onModelChange,
+}) => {
+  const {
+    chatHistory,
+    sendMessage,
+    isStreaming,
+    stopStreaming,
+    selectedProvider,
+    selectedModel,
+    targetPlatform,
+    setTargetPlatform,
+  } = useMetaPromptContext();
+
+  const hasModel = Boolean(selectedProvider && selectedModel);
+
+  return (
+    <div className="flex h-full flex-col">
+      <ModelSelector
+        availableProviders={availableProviders}
+        availableModels={availableModels}
+        selectedProvider={selectedProvider}
+        selectedModel={selectedModel}
+        targetPlatform={targetPlatform}
+        onProviderChange={onProviderChange}
+        onModelChange={onModelChange}
+        onTargetPlatformChange={setTargetPlatform}
+      />
+
+      <ChatHistory chatHistory={chatHistory} isStreaming={isStreaming} />
+
+      <ChatInput
+        onSend={(content) => void sendMessage(content)}
+        onStop={stopStreaming}
+        isStreaming={isStreaming}
+        disabled={!hasModel}
+      />
+    </div>
+  );
+};

--- a/web/src/features/meta-prompt/components/MetaPromptPage.tsx
+++ b/web/src/features/meta-prompt/components/MetaPromptPage.tsx
@@ -1,0 +1,97 @@
+import React, { useRef, useState } from "react";
+import { MessageSquare, FileText } from "lucide-react";
+
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/src/components/ui/tabs";
+import { MetaPromptProvider } from "@/src/features/meta-prompt/context/MetaPromptProvider";
+import { ChatPanel } from "./ChatPanel";
+import { PromptEditorPanel } from "./PromptEditorPanel";
+import type { NewPromptFormHandle } from "@/src/features/prompts/components/NewPromptForm";
+import { useModelParams } from "@/src/features/playground/page/hooks/useModelParams";
+
+export const MetaPromptPage: React.FC = () => {
+  const promptFormRef = useRef<NewPromptFormHandle | null>(null);
+  const [mobileTab, setMobileTab] = useState("chat");
+
+  const {
+    modelParams,
+    availableProviders,
+    availableModels,
+    updateModelParamValue,
+  } = useModelParams();
+
+  const handleProviderChange = (provider: string) => {
+    updateModelParamValue("provider", provider);
+  };
+
+  const handleModelChange = (model: string) => {
+    updateModelParamValue("model", model);
+  };
+
+  return (
+    <MetaPromptProvider modelParams={modelParams} promptFormRef={promptFormRef}>
+      {/* Desktop: 2-column layout */}
+      <div className="hidden h-full lg:flex">
+        <div className="flex h-full w-1/2 flex-col border-r">
+          <div className="border-b px-3 py-2">
+            <h2 className="text-sm font-medium">AI Assistant</h2>
+          </div>
+          <div className="flex-1 overflow-hidden">
+            <ChatPanel
+              availableProviders={availableProviders}
+              availableModels={availableModels}
+              onProviderChange={handleProviderChange}
+              onModelChange={handleModelChange}
+            />
+          </div>
+        </div>
+
+        <div className="flex h-full w-1/2 flex-col">
+          <div className="border-b px-3 py-2">
+            <h2 className="text-sm font-medium">Prompt Editor</h2>
+          </div>
+          <div className="flex-1 overflow-hidden">
+            <PromptEditorPanel promptFormRef={promptFormRef} />
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile: Tab-based layout */}
+      <div className="flex h-full flex-col lg:hidden">
+        <Tabs
+          value={mobileTab}
+          onValueChange={setMobileTab}
+          className="flex h-full flex-col"
+        >
+          <TabsList className="mx-2 mt-2 flex w-auto">
+            <TabsTrigger value="chat" className="flex-1 gap-1">
+              <MessageSquare className="h-4 w-4" />
+              AI Assistant
+            </TabsTrigger>
+            <TabsTrigger value="editor" className="flex-1 gap-1">
+              <FileText className="h-4 w-4" />
+              Editor
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="chat" className="flex-1 overflow-hidden">
+            <ChatPanel
+              availableProviders={availableProviders}
+              availableModels={availableModels}
+              onProviderChange={handleProviderChange}
+              onModelChange={handleModelChange}
+            />
+          </TabsContent>
+
+          <TabsContent value="editor" className="flex-1 overflow-hidden">
+            <PromptEditorPanel promptFormRef={promptFormRef} />
+          </TabsContent>
+        </Tabs>
+      </div>
+    </MetaPromptProvider>
+  );
+};

--- a/web/src/features/meta-prompt/components/ModelSelector.tsx
+++ b/web/src/features/meta-prompt/components/ModelSelector.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { AlertCircle, Settings } from "lucide-react";
+import Link from "next/link";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/src/components/ui/select";
+import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
+import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
+import type { TargetPlatform } from "@/src/features/meta-prompt/types";
+
+type ModelSelectorProps = {
+  availableProviders: string[];
+  availableModels: string[];
+  selectedProvider: string;
+  selectedModel: string;
+  targetPlatform: TargetPlatform;
+  onProviderChange: (provider: string) => void;
+  onModelChange: (model: string) => void;
+  onTargetPlatformChange: (platform: TargetPlatform) => void;
+};
+
+const TARGET_PLATFORMS: { value: TargetPlatform; label: string }[] = [
+  { value: "generic", label: "Generic" },
+  { value: "openai", label: "OpenAI" },
+  { value: "claude", label: "Claude" },
+  { value: "gemini", label: "Gemini" },
+];
+
+export const ModelSelector: React.FC<ModelSelectorProps> = ({
+  availableProviders,
+  availableModels,
+  selectedProvider,
+  selectedModel,
+  targetPlatform,
+  onProviderChange,
+  onModelChange,
+  onTargetPlatformChange,
+}) => {
+  const projectId = useProjectIdFromURL();
+
+  if (availableProviders.length === 0) {
+    return (
+      <div className="p-2">
+        <Alert
+          variant="default"
+          className="border-yellow-500/50 bg-yellow-50 dark:bg-yellow-950/20"
+        >
+          <AlertCircle className="h-4 w-4 text-yellow-600 dark:text-yellow-500" />
+          <AlertTitle className="text-yellow-800 dark:text-yellow-400">
+            No LLM Connection Configured
+          </AlertTitle>
+          <AlertDescription className="text-yellow-700 dark:text-yellow-500">
+            To use AI-assisted prompt creation, please configure an LLM
+            connection first. Go to{" "}
+            <Link
+              href={`/project/${projectId}/settings/llm-connections`}
+              className="font-medium underline underline-offset-4 hover:text-yellow-900 dark:hover:text-yellow-300"
+            >
+              <Settings className="inline h-3 w-3" /> LLM Connection Settings
+            </Link>{" "}
+            to add an API key.
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2 border-b p-2">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <label className="text-xs text-muted-foreground">Provider</label>
+        <Select value={selectedProvider} onValueChange={onProviderChange}>
+          <SelectTrigger className="h-8 text-xs">
+            <SelectValue placeholder="Select provider" />
+          </SelectTrigger>
+          <SelectContent>
+            {availableProviders.map((provider) => (
+              <SelectItem key={provider} value={provider}>
+                {provider}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <label className="text-xs text-muted-foreground">Model</label>
+        <Select value={selectedModel} onValueChange={onModelChange}>
+          <SelectTrigger className="h-8 text-xs">
+            <SelectValue placeholder="Select model" />
+          </SelectTrigger>
+          <SelectContent>
+            {availableModels.map((model) => (
+              <SelectItem key={model} value={model}>
+                {model}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <label className="text-xs text-muted-foreground">Target Platform</label>
+        <Select
+          value={targetPlatform}
+          onValueChange={(v) => onTargetPlatformChange(v as TargetPlatform)}
+        >
+          <SelectTrigger className="h-8 text-xs">
+            <SelectValue placeholder="Select platform" />
+          </SelectTrigger>
+          <SelectContent>
+            {TARGET_PLATFORMS.map((platform) => (
+              <SelectItem key={platform.value} value={platform.value}>
+                {platform.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+};

--- a/web/src/features/meta-prompt/components/PromptEditorPanel.tsx
+++ b/web/src/features/meta-prompt/components/PromptEditorPanel.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+import {
+  NewPromptForm,
+  type NewPromptFormHandle,
+} from "@/src/features/prompts/components/NewPromptForm";
+import { ApplyToEditorButton } from "./ApplyToEditorButton";
+
+type PromptEditorPanelProps = {
+  promptFormRef: React.RefObject<NewPromptFormHandle | null>;
+};
+
+export const PromptEditorPanel: React.FC<PromptEditorPanelProps> = ({
+  promptFormRef,
+}) => {
+  return (
+    <div className="flex h-full flex-col overflow-y-auto p-4">
+      <div className="mb-4">
+        <ApplyToEditorButton />
+      </div>
+
+      <NewPromptForm ref={promptFormRef} />
+    </div>
+  );
+};

--- a/web/src/features/meta-prompt/constants/systemPrompt.ts
+++ b/web/src/features/meta-prompt/constants/systemPrompt.ts
@@ -1,0 +1,66 @@
+import type { TargetPlatform } from "../types";
+
+export const META_PROMPT_SYSTEM_PROMPT = `
+MISSION: Rewrite <original_prompt> into a clearer, more executable, copy-paste-ready prompt while preserving the original intent and scope.
+
+HARD RULES:
+1) Preserve intent and scope. No feature creep.
+2) Do not invent facts. If critical info is missing, ask clarifying questions (max 5).
+3) Make at most 3 minimal assumptions and list them explicitly.
+4) Keep instructions separate from data/context using clear delimiters or tags.
+5) Define output contract: format, length, language, tone, required fields, strictness.
+6) Add acceptance criteria (3-7 checkable items).
+7) Add "When unsure" policy.
+8) Do NOT add Role/persona section. No "You are ..." framing.
+
+{{PLATFORM_FORMATTING_RULES}}
+
+OUTPUT FORMAT:
+Your response MUST follow this structure exactly:
+
+## Clarifying Questions (0-5)
+[If critical information is missing, ask questions here. If none needed, write "None needed."]
+
+## Assumptions (0-3)
+[List minimal assumptions. If none, write "None."]
+
+## Improved Prompt
+[The complete, ready-to-use prompt containing:]
+### Task
+### Objective
+### Context
+### Inputs
+### Output Format
+### Constraints
+### Process
+### Quality Bar
+### When Unsure
+### Examples (if applicable)
+
+## User Fill-in Checklist
+[List items the user should customize, e.g., "[ ] Replace {domain} with your specific domain"]
+`;
+
+export const PLATFORM_RULES: Record<TargetPlatform, string> = {
+  openai: `PLATFORM FORMATTING RULES (OpenAI):
+- Place instructions first, then context
+- Use ### blocks or triple quotes for context separation
+- Use markdown formatting for structure
+- Leverage system/developer message role effectively`,
+
+  claude: `PLATFORM FORMATTING RULES (Claude/Anthropic):
+- Use XML tags for structure: <task>, <constraints>, <context>, <examples>, <output_format>
+- Place most important instructions at the beginning and end
+- Use clear section delimiters
+- Leverage Claude's strength with structured XML input`,
+
+  gemini: `PLATFORM FORMATTING RULES (Google Gemini):
+- Separate "System Instruction" and "User Prompt" blocks
+- Use clear section headers
+- Keep formatting simple and direct`,
+
+  generic: `PLATFORM FORMATTING RULES (Generic):
+- Use OpenAI-style formatting without vendor-specific features
+- Use ### blocks or triple quotes for context
+- Ensure compatibility across different LLM providers`,
+};

--- a/web/src/features/meta-prompt/context/MetaPromptProvider.tsx
+++ b/web/src/features/meta-prompt/context/MetaPromptProvider.tsx
@@ -1,0 +1,232 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+} from "react";
+import { v4 as uuidv4 } from "uuid";
+
+import { env } from "@/src/env.mjs";
+import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import { parsePromptFromResponse } from "@/src/features/meta-prompt/utils/parsePromptFromResponse";
+import type {
+  MetaPromptContextType,
+  MetaPromptMessage,
+  TargetPlatform,
+} from "@/src/features/meta-prompt/types";
+import { ChatMessageRole, ChatMessageType } from "@langfuse/shared";
+import type { UIModelParams } from "@langfuse/shared";
+import { getFinalModelParams } from "@/src/utils/getFinalModelParams";
+
+const MetaPromptContext = createContext<MetaPromptContextType | undefined>(
+  undefined,
+);
+
+export const useMetaPromptContext = () => {
+  const context = useContext(MetaPromptContext);
+  if (!context) {
+    throw new Error(
+      "useMetaPromptContext must be used within a MetaPromptProvider",
+    );
+  }
+  return context;
+};
+
+type MetaPromptProviderProps = {
+  children: React.ReactNode;
+  modelParams: UIModelParams;
+  promptFormRef: React.RefObject<{
+    setTextPrompt: (content: string) => void;
+  } | null>;
+};
+
+export const MetaPromptProvider: React.FC<MetaPromptProviderProps> = ({
+  children,
+  modelParams,
+  promptFormRef,
+}) => {
+  const projectId = useProjectIdFromURL();
+  const [chatHistory, setChatHistory] = useState<MetaPromptMessage[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [latestImprovedPrompt, setLatestImprovedPrompt] = useState<
+    string | null
+  >(null);
+  const [targetPlatform, setTargetPlatform] =
+    useState<TargetPlatform>("generic");
+
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const stopStreaming = useCallback(() => {
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+    setIsStreaming(false);
+  }, []);
+
+  const sendMessage = useCallback(
+    async (content: string) => {
+      if (!projectId) {
+        showErrorToast("Error", "Project ID is not set");
+        return;
+      }
+
+      if (!modelParams.provider.value || !modelParams.model.value) {
+        showErrorToast("Error", "Please select a model first");
+        return;
+      }
+
+      const userMessage: MetaPromptMessage = {
+        id: uuidv4(),
+        role: "user",
+        content,
+        timestamp: new Date(),
+      };
+
+      setChatHistory((prev) => [...prev, userMessage]);
+
+      const assistantMessage: MetaPromptMessage = {
+        id: uuidv4(),
+        role: "assistant",
+        content: "",
+        timestamp: new Date(),
+      };
+
+      setChatHistory((prev) => [...prev, assistantMessage]);
+      setIsStreaming(true);
+
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+
+      try {
+        // Build messages array for the API call using all history + new user message
+        const apiMessages = [
+          ...chatHistory
+            .filter((msg) => msg.content.length > 0)
+            .map((msg) => ({
+              type:
+                msg.role === "user"
+                  ? (ChatMessageType.User as const)
+                  : (ChatMessageType.AssistantText as const),
+              role:
+                msg.role === "user"
+                  ? (ChatMessageRole.User as const)
+                  : (ChatMessageRole.Assistant as const),
+              content: msg.content,
+            })),
+          {
+            type: ChatMessageType.User as const,
+            role: ChatMessageRole.User as const,
+            content,
+          },
+        ];
+
+        const finalParams = getFinalModelParams(modelParams);
+
+        const response = await fetch(
+          `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/metaPromptCompletion`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              projectId,
+              messages: apiMessages,
+              modelParams: finalParams,
+              targetPlatform,
+              streaming: true,
+            }),
+            signal: abortController.signal,
+          },
+        );
+
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(
+            errorData.message ||
+              `Request failed with status ${response.status}`,
+          );
+        }
+
+        const reader = response.body?.getReader();
+        if (!reader) {
+          throw new Error("Failed to read response body");
+        }
+
+        const decoder = new TextDecoder("utf-8");
+        let fullResponse = "";
+
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            const token = decoder.decode(value);
+            fullResponse += token;
+
+            setChatHistory((prev) =>
+              prev.map((msg) =>
+                msg.id === assistantMessage.id
+                  ? { ...msg, content: fullResponse }
+                  : msg,
+              ),
+            );
+          }
+        } finally {
+          reader.releaseLock();
+        }
+
+        // Parse the response for improved prompt
+        const parsed = parsePromptFromResponse(fullResponse);
+        if (parsed.improvedPrompt) {
+          setLatestImprovedPrompt(parsed.improvedPrompt);
+        }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          // User stopped streaming, keep partial response
+          return;
+        }
+        const errorMessage =
+          err instanceof Error ? err.message : "An error occurred";
+        showErrorToast("Error", errorMessage);
+
+        // Remove the empty assistant message if there was an error
+        setChatHistory((prev) =>
+          prev.filter(
+            (msg) => msg.id !== assistantMessage.id || msg.content.length > 0,
+          ),
+        );
+      } finally {
+        setIsStreaming(false);
+        abortControllerRef.current = null;
+      }
+    },
+    [projectId, modelParams, chatHistory, targetPlatform],
+  );
+
+  const applyToEditor = useCallback(() => {
+    if (latestImprovedPrompt && promptFormRef.current) {
+      promptFormRef.current.setTextPrompt(latestImprovedPrompt);
+    }
+  }, [latestImprovedPrompt, promptFormRef]);
+
+  return (
+    <MetaPromptContext.Provider
+      value={{
+        chatHistory,
+        sendMessage,
+        isStreaming,
+        stopStreaming,
+        selectedProvider: modelParams.provider.value,
+        setSelectedProvider: () => {},
+        selectedModel: modelParams.model.value,
+        setSelectedModel: () => {},
+        targetPlatform,
+        setTargetPlatform,
+        latestImprovedPrompt,
+        applyToEditor,
+      }}
+    >
+      {children}
+    </MetaPromptContext.Provider>
+  );
+};

--- a/web/src/features/meta-prompt/server/buildMetaPromptMessages.ts
+++ b/web/src/features/meta-prompt/server/buildMetaPromptMessages.ts
@@ -1,0 +1,33 @@
+import {
+  META_PROMPT_SYSTEM_PROMPT,
+  PLATFORM_RULES,
+} from "../constants/systemPrompt";
+import {
+  type ChatMessage,
+  ChatMessageRole,
+  ChatMessageType,
+} from "@langfuse/shared";
+import type { TargetPlatform } from "../types";
+
+export function buildMetaPromptMessages(params: {
+  userMessages: ChatMessage[];
+  targetPlatform: TargetPlatform;
+}): ChatMessage[] {
+  const { userMessages, targetPlatform } = params;
+
+  const platformRules =
+    PLATFORM_RULES[targetPlatform] ?? PLATFORM_RULES.generic;
+  const systemPromptContent = META_PROMPT_SYSTEM_PROMPT.replace(
+    "{{PLATFORM_FORMATTING_RULES}}",
+    platformRules,
+  );
+
+  return [
+    {
+      type: ChatMessageType.System as const,
+      role: ChatMessageRole.System as const,
+      content: systemPromptContent,
+    },
+    ...userMessages,
+  ];
+}

--- a/web/src/features/meta-prompt/server/metaPromptCompletionHandler.ts
+++ b/web/src/features/meta-prompt/server/metaPromptCompletionHandler.ts
@@ -1,0 +1,120 @@
+import { StreamingTextResponse } from "ai";
+import { NextResponse, type NextRequest } from "next/server";
+
+import {
+  BaseError,
+  ForbiddenError,
+  InternalServerError,
+  InvalidRequestError,
+} from "@langfuse/shared";
+
+import { authorizeRequestOrThrow } from "@/src/features/playground/server/authorizeRequest";
+import { MetaPromptCompletionBodySchema } from "./validation";
+import { buildMetaPromptMessages } from "./buildMetaPromptMessages";
+
+import { env } from "@/src/env.mjs";
+import { prisma } from "@langfuse/shared/src/db";
+import {
+  LLMApiKeySchema,
+  logger,
+  fetchLLMCompletion,
+} from "@langfuse/shared/src/server";
+
+export default async function metaPromptCompletionHandler(req: NextRequest) {
+  try {
+    const body = MetaPromptCompletionBodySchema.parse(await req.json());
+    const { userId } = await authorizeRequestOrThrow(body.projectId);
+
+    const blockedUsers = env.LANGFUSE_BLOCKED_USERIDS_CHATCOMPLETION;
+    if (blockedUsers.has(userId)) {
+      const reason = blockedUsers.get(userId);
+      logger.warn("Blocked meta prompt completion access", { userId, reason });
+      throw new ForbiddenError("Access denied");
+    }
+
+    const { messages, modelParams, targetPlatform, streaming } = body;
+
+    // 1. Look up API key
+    const LLMApiKey = await prisma.llmApiKeys.findFirst({
+      where: {
+        projectId: body.projectId,
+        provider: modelParams.provider,
+      },
+    });
+
+    if (!LLMApiKey) {
+      throw new InvalidRequestError(
+        `No ${modelParams.provider} API key found in project. Please add one in the project settings.`,
+      );
+    }
+
+    const parsedKey = LLMApiKeySchema.safeParse(LLMApiKey);
+    if (!parsedKey.success) {
+      throw new InternalServerError(
+        `Could not parse API key for provider ${modelParams.provider}: ${parsedKey.error.message}`,
+      );
+    }
+
+    // 2. Inject meta prompt system prompt
+    const fullMessages = buildMetaPromptMessages({
+      userMessages: messages,
+      targetPlatform,
+    });
+
+    // 3. Call LLM
+    const fetchParams = {
+      llmConnection: parsedKey.data,
+      messages: fullMessages,
+      modelParams,
+    };
+
+    if (streaming) {
+      const stream = await fetchLLMCompletion({
+        ...fetchParams,
+        streaming: true,
+      });
+      return new StreamingTextResponse(stream);
+    } else {
+      const completion = await fetchLLMCompletion({
+        ...fetchParams,
+        streaming: false,
+      });
+      return NextResponse.json({ content: completion });
+    }
+  } catch (err) {
+    logger.error("Failed to handle meta prompt completion", err);
+
+    if (err instanceof BaseError) {
+      return NextResponse.json(
+        {
+          error: err.name,
+          message: err.message,
+        },
+        { status: err.httpCode },
+      );
+    }
+
+    if (err instanceof Error) {
+      const statusCode =
+        (
+          err as unknown as Record<string, unknown> & {
+            response?: { status?: number };
+          }
+        )?.response?.status ??
+        (err as unknown as Record<string, unknown> & { status?: number })
+          ?.status ??
+        500;
+      const errorMessage = err.message || "An unknown error occurred";
+
+      return NextResponse.json(
+        {
+          message: errorMessage,
+          error: err.name || "Error",
+        },
+        { status: statusCode },
+      );
+    }
+
+    throw err;
+  }
+}

--- a/web/src/features/meta-prompt/server/validation.ts
+++ b/web/src/features/meta-prompt/server/validation.ts
@@ -1,0 +1,31 @@
+import { z } from "zod/v4";
+import {
+  LLMAdapter,
+  ChatMessageSchema,
+  JSONObjectSchema,
+} from "@langfuse/shared";
+
+const ModelParamsSchema = z.object({
+  provider: z.string(),
+  adapter: z.enum(LLMAdapter),
+  model: z.string(),
+  temperature: z.number().optional(),
+  max_tokens: z.number().optional(),
+  top_p: z.number().optional(),
+  maxReasoningTokens: z.number().optional(),
+  providerOptions: JSONObjectSchema.optional(),
+});
+
+export const MetaPromptCompletionBodySchema = z.object({
+  projectId: z.string(),
+  messages: z.array(ChatMessageSchema),
+  modelParams: ModelParamsSchema,
+  targetPlatform: z
+    .enum(["openai", "claude", "gemini", "generic"])
+    .default("generic"),
+  streaming: z.boolean().optional().default(true),
+});
+
+export type ValidatedMetaPromptCompletionBody = z.infer<
+  typeof MetaPromptCompletionBodySchema
+>;

--- a/web/src/features/meta-prompt/types.ts
+++ b/web/src/features/meta-prompt/types.ts
@@ -1,0 +1,28 @@
+export type MetaPromptMessage = {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: Date;
+};
+
+export type TargetPlatform = "openai" | "claude" | "gemini" | "generic";
+
+export type MetaPromptContextType = {
+  // Chat state
+  chatHistory: MetaPromptMessage[];
+  sendMessage: (content: string) => Promise<void>;
+  isStreaming: boolean;
+  stopStreaming: () => void;
+
+  // Model selection
+  selectedProvider: string;
+  setSelectedProvider: (provider: string) => void;
+  selectedModel: string;
+  setSelectedModel: (model: string) => void;
+  targetPlatform: TargetPlatform;
+  setTargetPlatform: (platform: TargetPlatform) => void;
+
+  // Prompt editor integration
+  latestImprovedPrompt: string | null;
+  applyToEditor: () => void;
+};

--- a/web/src/features/meta-prompt/utils/parsePromptFromResponse.ts
+++ b/web/src/features/meta-prompt/utils/parsePromptFromResponse.ts
@@ -1,0 +1,30 @@
+export type ParsedPromptResponse = {
+  improvedPrompt: string | null;
+  clarifyingQuestions: string | null;
+  assumptions: string | null;
+  fillInChecklist: string | null;
+};
+
+export function parsePromptFromResponse(
+  response: string,
+): ParsedPromptResponse {
+  return {
+    improvedPrompt: extractSection(response, "## Improved Prompt"),
+    clarifyingQuestions: extractSection(response, "## Clarifying Questions"),
+    assumptions: extractSection(response, "## Assumptions"),
+    fillInChecklist: extractSection(response, "## User Fill-in Checklist"),
+  };
+}
+
+function extractSection(text: string, header: string): string | null {
+  const headerIndex = text.indexOf(header);
+  if (headerIndex === -1) return null;
+
+  const contentStart = headerIndex + header.length;
+  const nextHeaderMatch = text.slice(contentStart).match(/\n## /);
+  const contentEnd = nextHeaderMatch
+    ? contentStart + (nextHeaderMatch.index ?? text.length)
+    : text.length;
+
+  return text.slice(contentStart, contentEnd).trim();
+}

--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -1,6 +1,6 @@
 import capitalize from "lodash/capitalize";
 import router from "next/router";
-import { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useImperativeHandle } from "react";
 import { useForm } from "react-hook-form";
 import { Button } from "@/src/components/ui/button";
 import { Checkbox } from "@/src/components/ui/checkbox";
@@ -51,12 +51,20 @@ import { useQueryParam } from "use-query-params";
 import { usePromptNameValidation } from "@/src/features/prompts/hooks/usePromptNameValidation";
 import { useFormPersistence } from "@/src/hooks/useFormPersistence";
 
+export type NewPromptFormHandle = {
+  setTextPrompt: (content: string) => void;
+  setChatPrompt: (messages: unknown[]) => void;
+};
+
 type NewPromptFormProps = {
   initialPrompt?: Prompt | null;
   onFormSuccess?: () => void;
 };
 
-export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
+export const NewPromptForm = React.forwardRef<
+  NewPromptFormHandle,
+  NewPromptFormProps
+>(function NewPromptForm(props, ref) {
   const { onFormSuccess, initialPrompt } = props;
   const projectId = useProjectIdFromURL();
   const [shouldLoadPlaygroundCache] = useQueryParam("loadPlaygroundCache");
@@ -99,6 +107,18 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
     mode: "onTouched",
     defaultValues,
   });
+
+  useImperativeHandle(ref, () => ({
+    setTextPrompt: (content: string) => {
+      form.setValue("type", PromptType.Text);
+      form.setValue("textPrompt", content);
+    },
+    setChatPrompt: (messages: unknown[]) => {
+      form.setValue("type", PromptType.Chat);
+      form.setValue("chatPrompt", messages);
+      setInitialMessages(messages);
+    },
+  }));
 
   const currentName = form.watch("name");
   const currentType = form.watch("type");
@@ -497,4 +517,4 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
       )}
     </Form>
   );
-};
+});

--- a/web/src/pages/project/[projectId]/prompts/[[...folder]].tsx
+++ b/web/src/pages/project/[projectId]/prompts/[[...folder]].tsx
@@ -4,7 +4,7 @@ import Page from "@/src/components/layouts/page";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { PromptTable } from "@/src/features/prompts/components/prompts-table";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
-import { PlusIcon } from "lucide-react";
+import { PlusIcon, Sparkles } from "lucide-react";
 import { api } from "@/src/utils/api";
 import { PromptsOnboarding } from "@/src/components/onboarding/PromptsOnboarding";
 import { useEntitlementLimit } from "@/src/features/entitlements/hooks";
@@ -91,6 +91,19 @@ export default function PromptsWithFolder() {
         actionButtonsRight: (
           <>
             {projectId && <AutomationButton projectId={projectId} />}
+            <ActionButton
+              icon={<Sparkles className="h-4 w-4" aria-hidden="true" />}
+              hasAccess={hasCUDAccess}
+              href={`/project/${projectId}/prompts/new-with-ai`}
+              variant="secondary"
+              limit={promptLimit}
+              limitValue={Number(count?.totalCount ?? 0)}
+              onClick={() => {
+                capture("prompts:new_with_ai_form_open");
+              }}
+            >
+              New prompt with AI
+            </ActionButton>
             <ActionButton
               icon={<PlusIcon className="h-4 w-4" aria-hidden="true" />}
               hasAccess={hasCUDAccess}

--- a/web/src/pages/project/[projectId]/prompts/new-with-ai.tsx
+++ b/web/src/pages/project/[projectId]/prompts/new-with-ai.tsx
@@ -1,0 +1,31 @@
+import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
+import Page from "@/src/components/layouts/page";
+import { MetaPromptPage } from "@/src/features/meta-prompt/components/MetaPromptPage";
+
+export default function NewPromptWithAI() {
+  const projectId = useProjectIdFromURL();
+
+  return (
+    <Page
+      headerProps={{
+        title: "New prompt with AI",
+        help: {
+          description:
+            "Use AI to help you create well-structured prompts. Describe your requirements in the chat and the AI assistant will generate an optimized prompt for you.",
+          href: "https://langfuse.com/docs/prompts",
+        },
+        breadcrumb: [
+          {
+            name: "Prompts",
+            href: `/project/${projectId}/prompts/`,
+          },
+          {
+            name: "New prompt with AI",
+          },
+        ],
+      }}
+    >
+      <MetaPromptPage />
+    </Page>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a conversational AI interface ("Meta Prompt") that helps users generate and refine prompts through natural language dialogue
- Accessible via "New prompt with AI" button on the prompts list page
- Supports platform-specific formatting rules for OpenAI, Claude, Gemini, and generic targets

## Motivation

Creating effective prompts is one of the most challenging aspects of working with LLMs. This feature provides an AI-powered assistant that guides users through prompt creation via conversation, applying meta-prompting techniques to produce well-structured prompts optimized for the target platform.

## What's included

### Backend (7 files)
- Streaming completion API endpoint (`POST /api/metaPromptCompletion`) built on `fetchLLMCompletion`
- Platform-specific system prompts with formatting rules (OpenAI `###` blocks, Claude XML tags, Gemini System/User separation)
- Zod v4 request validation
- Response parser that extracts `## Improved Prompt`, `## Clarifying Questions`, `## Assumptions` sections from AI output

### Frontend (11 files)
- **2-column layout**: ChatPanel (AI conversation) + PromptEditorPanel (prompt form)
- Model/provider/target platform selector using project's existing LLM API keys
- Real-time streaming chat with markdown rendering
- "Apply to Editor" button to transfer generated prompts into `NewPromptForm`
- Mobile-responsive tabs layout
- "New prompt with AI" button added to prompts list page

### Tests (3 files, 28 tests)
- `parsePromptFromResponse` - AI response section extraction (8 tests)
- `buildMetaPromptMessages` - platform-specific message construction (9 tests)
- `validation` - request schema validation (11 tests)

## How it works

1. User clicks "New prompt with AI" on the prompts page
2. Selects an LLM provider/model and target platform from project's configured API keys
3. Describes their prompt needs in natural language
4. AI generates/refines the prompt with clarifying questions and assumptions
5. User clicks "Apply to Editor" to transfer the prompt into the standard NewPromptForm
6. User can further edit and save as a regular Langfuse prompt

## Test plan

- [x] Unit tests pass: `pnpm test-sync --testPathPatterns="meta-prompt"` (28/28 pass)
- [x] TypeScript typecheck passes: `pnpm tc`
- [x] Prettier formatting passes
- [x] Manual testing with local dev server
- [x] E2E testing with different LLM providers (OpenAI, Anthropic)