### PR TITLE
fix(prisma): make pending_deletions index migration schema-agnostic

### DIFF
--- a/packages/shared/prisma/migrations/20260203220622_pending_deletions_object_id_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20260203220622_pending_deletions_object_id_idx/migration.sql
@@ -1,5 +1,6 @@
 -- DropIndex
-DROP INDEX "public"."pending_deletions_project_id_object_is_deleted_idx";
+DROP INDEX IF EXISTS "pending_deletions_project_id_object_is_deleted_idx";
 
 -- CreateIndex
-CREATE INDEX "pending_deletions_project_id_object_is_deleted_object_id_id_idx" ON "pending_deletions"("project_id", "object", "is_deleted", "object_id", "id");
+CREATE INDEX IF NOT EXISTS "pending_deletions_project_id_object_is_deleted_object_id_id_idx"
+ON "pending_deletions"("project_id", "object", "is_deleted", "object_id", "id");

--- a/packages/shared/scripts/cleanup.sql
+++ b/packages/shared/scripts/cleanup.sql
@@ -2,6 +2,6 @@ DO $$
 BEGIN
  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = '_prisma_migrations') THEN
   DELETE FROM _prisma_migrations
-  WHERE migration_name IN ('20240606090858_pricings_add_latest_gemini_models', '20240530212419_model_price_anthropic_via_google_vertex', '20240604133340_backfill_manual_scores');
+  WHERE migration_name IN ('20240606090858_pricings_add_latest_gemini_models', '20240530212419_model_price_anthropic_via_google_vertex', '20240604133340_backfill_manual_scores', '20260203220622_pending_deletions_object_id_idx');
  END IF;
 END $$;


### PR DESCRIPTION
Remove hardcoded "public" schema prefix and add IF EXISTS/IF NOT EXISTS
guards so the migration works with custom Postgres schemas. Add cleanup.sql
entry to force re-application on existing deployments with stale checksum.

Fixes #11946

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `pending_deletions` index migration schema-agnostic and update cleanup script for re-application on stale deployments.
> 
>   - **Migration Script**:
>     - Removes hardcoded "public" schema prefix in `migration.sql`.
>     - Adds `IF EXISTS` and `IF NOT EXISTS` guards to `DROP INDEX` and `CREATE INDEX` statements in `migration.sql`.
>   - **Cleanup Script**:
>     - Updates `cleanup.sql` to include `20260203220622_pending_deletions_object_id_idx` in the list of migrations to delete, ensuring re-application on deployments with stale checksums.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 84ae30fbefd8b263aa6d289bf28a417fe98effa9. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->