### PR TITLE
fix(llm-connection-google): allow passing thinking config for google adapters via provider options

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -1,4 +1,4 @@
-import { type ZodSchema } from "zod/v4";
+import { type ZodSchema, z } from "zod/v4";
 
 import { ChatAnthropic } from "@langchain/anthropic";
 import { ChatVertexAI } from "@langchain/google-vertexai";
@@ -65,6 +65,13 @@ const transformSystemMessageToUserMessage = (
       : JSON.stringify(messages[0].content);
   return [new HumanMessage(safeContent)];
 };
+
+const googleProviderOptionsSchema = z
+  .object({
+    thinkingBudget: z.number().optional(),
+    thinkingLevel: z.string().optional(), // intentionally loose as types differ / may be extended in the future and are passed through to API
+  })
+  .default({});
 
 type ProcessTracedEvents = () => Promise<void>;
 
@@ -358,6 +365,10 @@ export async function fetchLLMCompletion(
       ? VertexAIConfigSchema.parse(config)
       : { location: undefined };
 
+    const googleProviderOptions = googleProviderOptionsSchema.parse(
+      modelParams.providerOptions,
+    );
+
     // Handle both explicit credentials and default provider chain (ADC)
     // Only allow default provider chain in self-hosted or internal AI features
     const shouldUseDefaultCredentials =
@@ -389,11 +400,13 @@ export async function fetchLLMCompletion(
       ...(modelParams.maxReasoningTokens !== undefined && {
         maxReasoningTokens: modelParams.maxReasoningTokens,
       }),
-      ...(modelParams.providerOptions && {
-        additionalModelRequestFields: modelParams.providerOptions,
-      }),
+      ...(googleProviderOptions as any), // Typecast as thinkingLevel is intentionally looser typed
     });
   } else if (modelParams.adapter === LLMAdapter.GoogleAIStudio) {
+    const googleProviderOptions = googleProviderOptionsSchema.parse(
+      modelParams.providerOptions,
+    );
+
     chatModel = new ChatGoogleGenerativeAI({
       model: modelParams.model,
       baseUrl: baseURL ?? undefined,
@@ -403,9 +416,7 @@ export async function fetchLLMCompletion(
       callbacks: finalCallbacks,
       maxRetries,
       apiKey,
-      ...(modelParams.providerOptions && {
-        additionalModelRequestFields: modelParams.providerOptions,
-      }),
+      thinkingConfig: googleProviderOptions as any, // Typecast as thinkingLevel is intentionally looser typed
     });
   } else {
     const _exhaustiveCheck: never = modelParams.adapter;

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -66,12 +66,10 @@ const transformSystemMessageToUserMessage = (
   return [new HumanMessage(safeContent)];
 };
 
-const googleProviderOptionsSchema = z
-  .object({
-    thinkingBudget: z.number().optional(),
-    thinkingLevel: z.string().optional(), // intentionally loose as types differ / may be extended in the future and are passed through to API
-  })
-  .default({});
+const googleProviderOptionsSchema = z.object({
+  thinkingBudget: z.number().optional(),
+  thinkingLevel: z.string().optional(), // intentionally loose as types differ / may be extended in the future and are passed through to API
+});
 
 type ProcessTracedEvents = () => Promise<void>;
 
@@ -400,7 +398,7 @@ export async function fetchLLMCompletion(
       ...(modelParams.maxReasoningTokens !== undefined && {
         maxReasoningTokens: modelParams.maxReasoningTokens,
       }),
-      ...(googleProviderOptions as any), // Typecast as thinkingLevel is intentionally looser typed
+      ...((googleProviderOptions as any) ?? {}), // Typecast as thinkingLevel is intentionally looser typed
     });
   } else if (modelParams.adapter === LLMAdapter.GoogleAIStudio) {
     const googleProviderOptions = googleProviderOptionsSchema.parse(
@@ -416,7 +414,11 @@ export async function fetchLLMCompletion(
       callbacks: finalCallbacks,
       maxRetries,
       apiKey,
-      thinkingConfig: googleProviderOptions as any, // Typecast as thinkingLevel is intentionally looser typed
+      ...(googleProviderOptions
+        ? {
+            thinkingConfig: googleProviderOptions as any, // Typecast as thinkingLevel is intentionally looser typed
+          }
+        : {}),
     });
   } else {
     const _exhaustiveCheck: never = modelParams.adapter;

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -66,10 +66,12 @@ const transformSystemMessageToUserMessage = (
   return [new HumanMessage(safeContent)];
 };
 
-const googleProviderOptionsSchema = z.object({
-  thinkingBudget: z.number().optional(),
-  thinkingLevel: z.string().optional(), // intentionally loose as types differ / may be extended in the future and are passed through to API
-});
+const googleProviderOptionsSchema = z
+  .object({
+    thinkingBudget: z.number().optional(),
+    thinkingLevel: z.string().optional(), // intentionally loose as types differ / may be extended in the future and are passed through to API
+  })
+  .optional();
 
 type ProcessTracedEvents = () => Promise<void>;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds schema for Google provider options in `fetchLLMCompletion.ts` to support `thinkingBudget` and `thinkingLevel` configurations for Google adapters.
> 
>   - **Behavior**:
>     - Adds `googleProviderOptionsSchema` in `fetchLLMCompletion.ts` to define `thinkingBudget` and `thinkingLevel`.
>     - Updates `fetchLLMCompletion` to parse `modelParams.providerOptions` using `googleProviderOptionsSchema` for Google adapters.
>     - Passes parsed `googleProviderOptions` to `ChatVertexAI` and `ChatGoogleGenerativeAI` as `thinkingConfig`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 82cab2473af4614423fd4a1f63fc5f846719a0bf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->