### PR TITLE
fix: enable e2e tests again

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -577,7 +577,7 @@ jobs:
         tests-web,
         tests-worker,
         test-worker-llm-connections,
-        # e2e-tests, # Temporarily disabled - flaky timeouts
+        e2e-tests,
         test-docker-build,
         e2e-server-tests,
       ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Re-enables `e2e-tests` job in the CI/CD pipeline, previously disabled due to flaky timeouts.
> 
>   - **CI/CD Pipeline**:
>     - Re-enables `e2e-tests` job in `.github/workflows/pipeline.yml`, which was previously disabled due to flaky timeouts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 2faf2dd73f7395008400ac4f4329189becf2bf35. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->