### PR TITLE
perf: reduce scan size for event prop by converting OR to GREATEST

### DIFF
--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -168,8 +168,7 @@ export const handleEventPropagationJob = async (
               -- For some reason clickhouse detects any "date >= '1969-12-31'" as false.
               -- Therefore, we add a fallback condition that limits actively to last 7 days.
               -- This means that 7 days becomes the maximum trace data propagation interval.
-              t.timestamp >= (select min(min_start_time) - interval 1 day from batch_stats) OR
-              t.timestamp >= now() - interval 7 day
+              t.timestamp >= greatest((select min(min_start_time) - interval 1 day from batch_stats), now() - interval 7 day)
             )
             and t.timestamp <= (select max(max_start_time) + interval 1 day from batch_stats)
           order by t.event_ts desc


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize `handleEventPropagationJob` in `handleEventPropagationJob.ts` by replacing `OR` with `GREATEST` to reduce scan size.
> 
>   - **Performance Optimization**:
>     - In `handleEventPropagationJob` in `handleEventPropagationJob.ts`, replace `OR` condition with `GREATEST` function to reduce scan size and improve performance.
>     - Specifically, change `t.timestamp >= (select min(min_start_time) - interval 1 day from batch_stats) OR t.timestamp >= now() - interval 7 day` to `t.timestamp >= greatest((select min(min_start_time) - interval 1 day from batch_stats), now() - interval 7 day)`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 801f28cc1335522981bf9cb9518d7f0dd3e3a552. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->