### PR TITLE
fix(web): prevent chain

### DIFF
--- a/web/src/features/rbac/utils/checkAccess.clienttest.ts
+++ b/web/src/features/rbac/utils/checkAccess.clienttest.ts
@@ -21,7 +21,9 @@ describe("RBAC access checks", () => {
     );
 
     expect(
-      hasOrganizationAccess(params as Parameters<typeof hasOrganizationAccess>[0]),
+      hasOrganizationAccess(
+        params as Parameters<typeof hasOrganizationAccess>[0],
+      ),
     ).toBe(false);
   });
 

--- a/web/src/features/rbac/utils/checkAccess.clienttest.ts
+++ b/web/src/features/rbac/utils/checkAccess.clienttest.ts
@@ -1,0 +1,70 @@
+import { hasOrganizationAccess } from "./checkOrganizationAccess";
+import { hasProjectAccess } from "./checkProjectAccess";
+
+describe("RBAC access checks", () => {
+  it("ignores inherited role/admin properties for organization access", () => {
+    const params = Object.assign(
+      Object.create({
+        role: "OWNER",
+        admin: true,
+      }),
+      {
+        session: {
+          user: {
+            admin: false,
+            organizations: [{ id: "org-1", role: "MEMBER" }],
+          },
+        },
+        organizationId: "org-1",
+        scope: "organizationMembers:CUD",
+      },
+    );
+
+    expect(
+      hasOrganizationAccess(params as Parameters<typeof hasOrganizationAccess>[0]),
+    ).toBe(false);
+  });
+
+  it("ignores inherited role/admin properties for project access", () => {
+    const params = Object.assign(
+      Object.create({
+        role: "OWNER",
+        admin: true,
+      }),
+      {
+        session: {
+          user: {
+            admin: false,
+            organizations: [
+              {
+                projects: [{ id: "project-1", role: "MEMBER" }],
+              },
+            ],
+          },
+        },
+        projectId: "project-1",
+        scope: "project:update",
+      },
+    );
+
+    expect(
+      hasProjectAccess(params as Parameters<typeof hasProjectAccess>[0]),
+    ).toBe(false);
+  });
+
+  it("still supports own role-based checks", () => {
+    expect(
+      hasOrganizationAccess({
+        role: "OWNER",
+        scope: "organizationMembers:CUD",
+      }),
+    ).toBe(true);
+
+    expect(
+      hasProjectAccess({
+        role: "ADMIN",
+        scope: "project:update",
+      }),
+    ).toBe(true);
+  });
+});

--- a/web/src/features/rbac/utils/checkOrganizationAccess.ts
+++ b/web/src/features/rbac/utils/checkOrganizationAccess.ts
@@ -59,12 +59,10 @@ export function hasOrganizationAccess(p: HasOrganizationAccessParams): boolean {
   const isAdmin = hasOwnRole(p) ? p.admin : p.session?.user?.admin;
   if (isAdmin) return true;
 
-  const organizationRole: Role | undefined =
-    hasOwnRole(p)
-      ? p.role
-      : p.session?.user?.organizations.find(
-          (org) => org.id === p.organizationId,
-        )?.role;
+  const organizationRole: Role | undefined = hasOwnRole(p)
+    ? p.role
+    : p.session?.user?.organizations.find((org) => org.id === p.organizationId)
+        ?.role;
   if (organizationRole === undefined) return false;
 
   return organizationRoleAccessRights[organizationRole].includes(p.scope);

--- a/web/src/features/rbac/utils/checkOrganizationAccess.ts
+++ b/web/src/features/rbac/utils/checkOrganizationAccess.ts
@@ -19,6 +19,11 @@ type HasOrganizationAccessParams =
       scope: OrganizationScope;
     };
 
+const hasOwnRole = (
+  p: HasOrganizationAccessParams,
+): p is Extract<HasOrganizationAccessParams, { role: Role }> =>
+  Object.prototype.hasOwnProperty.call(p, "role");
+
 /**
  * Check if user has access to the given scope, for use in TRPC resolvers
  * @throws TRPCError("FORBIDDEN") if user does not have access
@@ -55,16 +60,22 @@ export const useHasOrganizationAccess = (p: {
 
 // For use in UI components as function, if session is already available
 export function hasOrganizationAccess(p: HasOrganizationAccessParams): boolean {
-  const isAdmin = "role" in p ? p.admin : p.session?.user?.admin;
-  if (isAdmin) return true;
+  if (hasOwnRole(p)) {
+    if (p.admin) return true;
+    const organizationRole = p.role;
+    return (
+      organizationRoleAccessRights[organizationRole]?.includes(p.scope) ?? false
+    );
+  }
 
-  const organizationRole: Role | undefined =
-    "role" in p
-      ? p.role
-      : p.session?.user?.organizations.find(
-          (org) => org.id === p.organizationId,
-        )?.role;
+  if (p.session?.user?.admin) return true;
+
+  const organizationRole = p.session?.user?.organizations.find(
+    (org) => org.id === p.organizationId,
+  )?.role;
   if (organizationRole === undefined) return false;
 
-  return organizationRoleAccessRights[organizationRole].includes(p.scope);
+  return (
+    organizationRoleAccessRights[organizationRole]?.includes(p.scope) ?? false
+  );
 }

--- a/web/src/features/rbac/utils/checkOrganizationAccess.ts
+++ b/web/src/features/rbac/utils/checkOrganizationAccess.ts
@@ -19,11 +19,6 @@ type HasOrganizationAccessParams =
       scope: OrganizationScope;
     };
 
-const hasOwnRole = (
-  p: HasOrganizationAccessParams,
-): p is Extract<HasOrganizationAccessParams, { role: Role }> =>
-  Object.prototype.hasOwnProperty.call(p, "role");
-
 /**
  * Check if user has access to the given scope, for use in TRPC resolvers
  * @throws TRPCError("FORBIDDEN") if user does not have access
@@ -60,22 +55,19 @@ export const useHasOrganizationAccess = (p: {
 
 // For use in UI components as function, if session is already available
 export function hasOrganizationAccess(p: HasOrganizationAccessParams): boolean {
-  if (hasOwnRole(p)) {
-    if (p.admin) return true;
-    const organizationRole = p.role;
-    return (
-      organizationRoleAccessRights[organizationRole]?.includes(p.scope) ?? false
-    );
-  }
+  const isAdmin =
+    "role" in p && Object.prototype.hasOwnProperty.call(p, "role")
+      ? p.admin
+      : p.session?.user?.admin;
+  if (isAdmin) return true;
 
-  if (p.session?.user?.admin) return true;
-
-  const organizationRole = p.session?.user?.organizations.find(
-    (org) => org.id === p.organizationId,
-  )?.role;
+  const organizationRole: Role | undefined =
+    "role" in p && Object.prototype.hasOwnProperty.call(p, "role")
+      ? p.role
+      : p.session?.user?.organizations.find(
+          (org) => org.id === p.organizationId,
+        )?.role;
   if (organizationRole === undefined) return false;
 
-  return (
-    organizationRoleAccessRights[organizationRole]?.includes(p.scope) ?? false
-  );
+  return organizationRoleAccessRights[organizationRole].includes(p.scope);
 }

--- a/web/src/features/rbac/utils/checkOrganizationAccess.ts
+++ b/web/src/features/rbac/utils/checkOrganizationAccess.ts
@@ -6,6 +6,7 @@ import { type Role } from "@langfuse/shared/src/db";
 import { TRPCError } from "@trpc/server";
 import { type Session } from "next-auth";
 import { useSession } from "next-auth/react";
+import { hasOwnRole } from "./hasOwnRole";
 
 type HasOrganizationAccessParams =
   | {
@@ -55,14 +56,11 @@ export const useHasOrganizationAccess = (p: {
 
 // For use in UI components as function, if session is already available
 export function hasOrganizationAccess(p: HasOrganizationAccessParams): boolean {
-  const isAdmin =
-    "role" in p && Object.prototype.hasOwnProperty.call(p, "role")
-      ? p.admin
-      : p.session?.user?.admin;
+  const isAdmin = hasOwnRole(p) ? p.admin : p.session?.user?.admin;
   if (isAdmin) return true;
 
   const organizationRole: Role | undefined =
-    "role" in p && Object.prototype.hasOwnProperty.call(p, "role")
+    hasOwnRole(p)
       ? p.role
       : p.session?.user?.organizations.find(
           (org) => org.id === p.organizationId,

--- a/web/src/features/rbac/utils/checkProjectAccess.ts
+++ b/web/src/features/rbac/utils/checkProjectAccess.ts
@@ -6,6 +6,7 @@ import { type Role } from "@langfuse/shared/src/db";
 import { TRPCError } from "@trpc/server";
 import { type Session } from "next-auth";
 import { useSession } from "next-auth/react";
+import { hasOwnRole } from "./hasOwnRole";
 
 type HasProjectAccessParams = (
   | {
@@ -53,14 +54,11 @@ export const useHasProjectAccess = (p: {
 
 // For use in UI components as function, if session is already available
 export function hasProjectAccess(p: HasProjectAccessParams): boolean {
-  const isAdmin =
-    "role" in p && Object.prototype.hasOwnProperty.call(p, "role")
-      ? p.admin
-      : p.session?.user?.admin;
+  const isAdmin = hasOwnRole(p) ? p.admin : p.session?.user?.admin;
   if (isAdmin) return true;
 
   const projectRole: Role | undefined =
-    "role" in p && Object.prototype.hasOwnProperty.call(p, "role")
+    hasOwnRole(p)
       ? p.role
       : p.session?.user?.organizations
           .flatMap((org) => org.projects)

--- a/web/src/features/rbac/utils/checkProjectAccess.ts
+++ b/web/src/features/rbac/utils/checkProjectAccess.ts
@@ -20,11 +20,6 @@ type HasProjectAccessParams = (
     }
 ) & { forbiddenErrorMessage?: string };
 
-const hasOwnRole = (
-  p: HasProjectAccessParams,
-): p is Extract<HasProjectAccessParams, { role: Role }> =>
-  Object.prototype.hasOwnProperty.call(p, "role");
-
 /**
  * Check if user has access to the given scope, for use in TRPC resolvers
  * @throws TRPCError("FORBIDDEN") if user does not have access
@@ -58,18 +53,19 @@ export const useHasProjectAccess = (p: {
 
 // For use in UI components as function, if session is already available
 export function hasProjectAccess(p: HasProjectAccessParams): boolean {
-  if (hasOwnRole(p)) {
-    if (p.admin) return true;
-    const projectRole = p.role;
-    return projectRoleAccessRights[projectRole]?.includes(p.scope) ?? false;
-  }
+  const isAdmin =
+    "role" in p && Object.prototype.hasOwnProperty.call(p, "role")
+      ? p.admin
+      : p.session?.user?.admin;
+  if (isAdmin) return true;
 
-  if (p.session?.user?.admin) return true;
-
-  const projectRole = p.session?.user?.organizations
-    .flatMap((org) => org.projects)
-    .find((project) => project.id === p.projectId)?.role;
+  const projectRole: Role | undefined =
+    "role" in p && Object.prototype.hasOwnProperty.call(p, "role")
+      ? p.role
+      : p.session?.user?.organizations
+          .flatMap((org) => org.projects)
+          .find((project) => project.id === p.projectId)?.role;
   if (projectRole === undefined) return false;
 
-  return projectRoleAccessRights[projectRole]?.includes(p.scope) ?? false;
+  return projectRoleAccessRights[projectRole].includes(p.scope);
 }

--- a/web/src/features/rbac/utils/checkProjectAccess.ts
+++ b/web/src/features/rbac/utils/checkProjectAccess.ts
@@ -20,6 +20,11 @@ type HasProjectAccessParams = (
     }
 ) & { forbiddenErrorMessage?: string };
 
+const hasOwnRole = (
+  p: HasProjectAccessParams,
+): p is Extract<HasProjectAccessParams, { role: Role }> =>
+  Object.prototype.hasOwnProperty.call(p, "role");
+
 /**
  * Check if user has access to the given scope, for use in TRPC resolvers
  * @throws TRPCError("FORBIDDEN") if user does not have access
@@ -53,16 +58,18 @@ export const useHasProjectAccess = (p: {
 
 // For use in UI components as function, if session is already available
 export function hasProjectAccess(p: HasProjectAccessParams): boolean {
-  const isAdmin = "role" in p ? p.admin : p.session?.user?.admin;
-  if (isAdmin) return true;
+  if (hasOwnRole(p)) {
+    if (p.admin) return true;
+    const projectRole = p.role;
+    return projectRoleAccessRights[projectRole]?.includes(p.scope) ?? false;
+  }
 
-  const projectRole: Role | undefined =
-    "role" in p
-      ? p.role
-      : p.session?.user?.organizations
-          .flatMap((org) => org.projects)
-          .find((project) => project.id === p.projectId)?.role;
+  if (p.session?.user?.admin) return true;
+
+  const projectRole = p.session?.user?.organizations
+    .flatMap((org) => org.projects)
+    .find((project) => project.id === p.projectId)?.role;
   if (projectRole === undefined) return false;
 
-  return projectRoleAccessRights[projectRole].includes(p.scope);
+  return projectRoleAccessRights[projectRole]?.includes(p.scope) ?? false;
 }

--- a/web/src/features/rbac/utils/checkProjectAccess.ts
+++ b/web/src/features/rbac/utils/checkProjectAccess.ts
@@ -57,12 +57,11 @@ export function hasProjectAccess(p: HasProjectAccessParams): boolean {
   const isAdmin = hasOwnRole(p) ? p.admin : p.session?.user?.admin;
   if (isAdmin) return true;
 
-  const projectRole: Role | undefined =
-    hasOwnRole(p)
-      ? p.role
-      : p.session?.user?.organizations
-          .flatMap((org) => org.projects)
-          .find((project) => project.id === p.projectId)?.role;
+  const projectRole: Role | undefined = hasOwnRole(p)
+    ? p.role
+    : p.session?.user?.organizations
+        .flatMap((org) => org.projects)
+        .find((project) => project.id === p.projectId)?.role;
   if (projectRole === undefined) return false;
 
   return projectRoleAccessRights[projectRole].includes(p.scope);

--- a/web/src/features/rbac/utils/hasOwnRole.ts
+++ b/web/src/features/rbac/utils/hasOwnRole.ts
@@ -1,0 +1,6 @@
+import { type Role } from "@langfuse/shared/src/db";
+
+export const hasOwnRole = <T extends object>(
+  p: T,
+): p is Extract<T, { role: Role }> =>
+  Object.prototype.hasOwnProperty.call(p, "role");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes prototype-chain pollution in access checks by ensuring only own properties are considered in `hasOrganizationAccess` and `hasProjectAccess`.
> 
>   - **Security Fix**:
>     - Prevents prototype-chain pollution in `hasOrganizationAccess` and `hasProjectAccess` by using `hasOwnRole()` to check for own properties.
>   - **Functions**:
>     - Adds `hasOwnRole()` utility to `checkOrganizationAccess.ts` and `checkProjectAccess.ts` to verify if `role` is an own property.
>     - Updates `hasOrganizationAccess()` and `hasProjectAccess()` to use `hasOwnRole()` for role checks.
>   - **Tests**:
>     - Adds `checkAccess.clienttest.ts` to test ignoring inherited properties and verifying own role-based checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 351c86c9b90908c5d515ec0e3f2b0290b5f8611c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->