### PR TITLE
chore: parallelize dual write inserts

### DIFF
--- a/worker/src/features/eventPropagation/handleEventPropagationJob.ts
+++ b/worker/src/features/eventPropagation/handleEventPropagationJob.ts
@@ -303,6 +303,8 @@ export const handleEventPropagationJob = async (
         request_timeout: 600000, // 10 minutes timeout
       },
       clickhouseSettings: {
+        parallel_view_processing: 1,
+        max_insert_threads: "8",
         type_json_skip_duplicated_paths: true,
       },
     });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds parallel processing settings to Clickhouse configuration in `handleEventPropagationJob` for dual write inserts.
> 
>   - **Performance**:
>     - Adds `parallel_view_processing: 1` and `max_insert_threads: "8"` to Clickhouse settings in `handleEventPropagationJob` to enable parallel processing of dual write inserts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 209e55c02293f476c620401f32c0680bc4b17372. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->