### PR TITLE
fix(llm-completion): honor timeout setting

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -256,11 +256,11 @@ const EnvSchema = z.object({
     .positive()
     .default(10),
 
-  LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_MS: z.coerce
+  LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_SECONDS: z.coerce
     .number()
     .int()
     .positive()
-    .default(120_000), // 2 minutes
+    .default(120),
 
   LANGFUSE_AWS_BEDROCK_REGION: z.string().optional(),
 

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -230,7 +230,7 @@ export async function fetchLLMCompletion(
   // Common proxy configuration for all adapters
   const proxyUrl = env.HTTPS_PROXY;
   const proxyDispatcher = proxyUrl ? new ProxyAgent(proxyUrl) : undefined;
-  const timeoutMs = env.LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_MS;
+  const timeoutSeconds = env.LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_SECONDS;
 
   let chatModel:
     | ChatOpenAI
@@ -254,7 +254,7 @@ export async function fetchLLMCompletion(
       callbacks: finalCallbacks,
       clientOptions: {
         maxRetries,
-        timeout: timeoutMs,
+        timeout: timeoutSeconds,
         ...(proxyDispatcher && {
           fetchOptions: { dispatcher: proxyDispatcher },
         }),
@@ -312,7 +312,7 @@ export async function fetchLLMCompletion(
         }),
       },
       modelKwargs: modelParams.providerOptions,
-      timeout: timeoutMs,
+      timeout: timeoutSeconds,
     });
   } else if (modelParams.adapter === LLMAdapter.Azure) {
     chatModel = new AzureChatOpenAI({
@@ -325,7 +325,7 @@ export async function fetchLLMCompletion(
       topP: modelParams.top_p,
       callbacks: finalCallbacks,
       maxRetries,
-      timeout: timeoutMs,
+      timeout: timeoutSeconds,
       configuration: {
         defaultHeaders: extraHeaders,
         ...(proxyDispatcher && {
@@ -357,7 +357,7 @@ export async function fetchLLMCompletion(
       topP: modelParams.top_p,
       callbacks: finalCallbacks,
       maxRetries,
-      timeout: timeoutMs,
+      timeout: timeoutSeconds,
       additionalModelRequestFields: modelParams.providerOptions as any,
     });
   } else if (modelParams.adapter === LLMAdapter.VertexAI) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change LLM completion timeout from milliseconds to seconds, updating environment variable and code usage accordingly.
> 
>   - **Behavior**:
>     - Change timeout unit from milliseconds to seconds for LLM completion in `fetchLLMCompletion()`.
>     - Update default timeout value from 120,000 ms to 120 seconds in `env.ts`.
>   - **Environment Variables**:
>     - Rename `LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_MS` to `LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_SECONDS`.
>   - **Code Updates**:
>     - Update `fetchLLMCompletion()` in `fetchLLMCompletion.ts` to use `LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_SECONDS` for timeout configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d6b13144cf34f6d92942256cb8116e417293f049. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->