### PR TITLE
chore(evals): add adapter to eval.call-llm span

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -262,6 +262,7 @@ export async function fetchLLMCompletion(
       temperature: modelParams.temperature,
       topP: modelParams.top_p,
       invocationKwargs: modelParams.providerOptions,
+      timeout: timeoutMs,
     };
 
     chatModel = new ChatAnthropic(chatOptions);
@@ -306,6 +307,7 @@ export async function fetchLLMCompletion(
       maxRetries,
       configuration: {
         baseURL: processedBaseURL,
+        timeout: timeoutMs,
         defaultHeaders: extraHeaders,
         ...(proxyDispatcher && {
           fetchOptions: { dispatcher: proxyDispatcher },
@@ -327,6 +329,7 @@ export async function fetchLLMCompletion(
       maxRetries,
       timeout: timeoutMs,
       configuration: {
+        timeout: timeoutMs,
         defaultHeaders: extraHeaders,
         ...(proxyDispatcher && {
           fetchOptions: { dispatcher: proxyDispatcher },

--- a/packages/shared/src/server/services/DefaultEvaluationModelService/DefaultEvalModelService.ts
+++ b/packages/shared/src/server/services/DefaultEvaluationModelService/DefaultEvalModelService.ts
@@ -1,13 +1,14 @@
 import z from "zod/v4";
 import { prisma } from "../../../db";
 import { ForbiddenError, LangfuseNotFoundError } from "../../../errors";
-import { LLMApiKeySchema, ZodModelConfig } from "../../llm/types";
+import { LLMAdapter, LLMApiKeySchema, ZodModelConfig } from "../../llm/types";
 import { testModelCall } from "../../llm/testModelCall";
 
 type ValidConfig = {
   provider: string;
   model: string;
   modelParams: z.infer<typeof ZodModelConfig>;
+  adapter: LLMAdapter;
 };
 
 export class DefaultEvalModelService {
@@ -136,6 +137,7 @@ export class DefaultEvalModelService {
           model: string;
           modelParams?: z.infer<typeof ZodModelConfig>;
           apiKey: z.infer<typeof LLMApiKeySchema>;
+          adapter: LLMAdapter;
         };
       }
     | {

--- a/worker/src/features/evaluation/evalExecutionDeps.ts
+++ b/worker/src/features/evaluation/evalExecutionDeps.ts
@@ -5,6 +5,7 @@ import {
   DefaultEvalModelService,
   fetchLLMCompletion,
   IngestionQueue,
+  LLMAdapter,
   QueueJobs,
   ScoreEventType,
 } from "@langfuse/shared/src/server";
@@ -25,6 +26,7 @@ export type ModelConfigResult =
           adapter: string;
           [key: string]: unknown;
         };
+        adapter: LLMAdapter;
         modelParams: Record<string, unknown>;
       };
     }

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -829,6 +829,10 @@ export async function executeLLMAsJudgeEvaluation({
             modelConfig.config.provider,
           );
           llmSpan.setAttribute("eval.model.name", modelConfig.config.model);
+          llmSpan.setAttribute(
+            "eval.model.adapter",
+            modelConfig.config.adapter,
+          );
 
           return deps.callLLM({
             messages,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `adapter` attribute to model configuration and spans in evaluation services, updating types and imports accordingly.
> 
>   - **Behavior**:
>     - Add `adapter` attribute to model configuration in `DefaultEvalModelService.ts`, `evalExecutionDeps.ts`, and `evalService.ts`.
>     - Set `eval.model.adapter` attribute in spans within `executeLLMAsJudgeEvaluation()`.
>   - **Types**:
>     - Add `LLMAdapter` to `ValidConfig` type in `DefaultEvalModelService.ts`.
>     - Update `ModelConfigResult` type in `evalExecutionDeps.ts` to include `adapter`.
>   - **Misc**:
>     - Import `LLMAdapter` in `evalExecutionDeps.ts` and `DefaultEvalModelService.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 464e5d9a091cb1b39e1c3df90a335fd84fcc5acf. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->