### PR TITLE
fix(dashboard): pass metricsVersion to cost/usage-by-type chart queries

### DIFF
--- a/web/src/features/dashboard/components/ModelUsageChart.tsx
+++ b/web/src/features/dashboard/components/ModelUsageChart.tsx
@@ -151,6 +151,7 @@ export const ModelUsageChart = ({
         { column: "calculatedTotalCost", direction: "DESC", agg: "SUM" },
       ],
       queryName: "observations-cost-by-type-timeseries",
+      version: metricsVersion,
     },
     {
       enabled: !isLoading && selectedModels.length > 0 && allModels.length > 0,
@@ -200,6 +201,7 @@ export const ModelUsageChart = ({
       ],
       orderBy: [{ column: "totalTokens", direction: "DESC", agg: "SUM" }],
       queryName: "observations-usage-by-type-timeseries",
+      version: metricsVersion,
     },
     {
       enabled: !isLoading && selectedModels.length > 0 && allModels.length > 0,


### PR DESCRIPTION
The queryCostByType and queryUsageByType calls in ModelUsageChart were not passing the version prop, so they always defaulted to v1 and hit the legacy `observations FINAL` path instead of the faster v2 `events_core` path.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Pass `metricsVersion` to `queryCostByType` and `queryUsageByType` in `ModelUsageChart` to use the faster v2 path.
> 
>   - **Behavior**:
>     - Pass `metricsVersion` to `queryCostByType` and `queryUsageByType` in `ModelUsageChart` to use the faster v2 `events_core` path instead of defaulting to v1.
>   - **Misc**:
>     - No changes to other files or functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f43056144afce6f8db7439d4bc32523b1b7391ac. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->