### PR TITLE
chore(dialog-ui): prevent dialog propagation on enter space; add breadcrumb to dashboards detail page

### DIFF
--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -56,35 +56,46 @@ const DialogContent = React.forwardRef<
   (
     { className, children, closeOnInteractionOutside = false, size, ...props },
     ref,
-  ) => (
-    <DialogPortal>
-      <DialogOverlay />
-      <DialogPrimitive.Content
-        ref={ref}
-        className={cn(dialogContentVariants({ size, className }))}
-        aria-describedby={undefined}
-        onPointerDownOutside={(e) => {
-          if (!closeOnInteractionOutside) {
-            e.preventDefault();
-          }
-        }}
-        onInteractOutside={(e) => {
-          if (!closeOnInteractionOutside) {
-            e.preventDefault();
-          }
-        }}
-        {...props}
-      >
-        {children}
-        <div className="[&:has(.dialog-header)]:hidden [&:not(:has(.dialog-header))]:absolute [&:not(:has(.dialog-header))]:right-3 [&:not(:has(.dialog-header))]:top-3 [&:not(:has(.dialog-header))]:z-20">
-          <DialogPrimitive.Close className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-            <X className="h-4 w-4" />
-            <span className="sr-only">Close</span>
-          </DialogPrimitive.Close>
-        </div>
-      </DialogPrimitive.Content>
-    </DialogPortal>
-  ),
+  ) => {
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+      // Prevent Enter/Space key events from propagating to parent elements
+      // This prevents triggering actions like row clicks when submitting forms in dialogs
+      if (e.key === "Enter" || e.key === " ") {
+        e.stopPropagation();
+      }
+    };
+
+    return (
+      <DialogPortal>
+        <DialogOverlay />
+        <DialogPrimitive.Content
+          ref={ref}
+          className={cn(dialogContentVariants({ size, className }))}
+          aria-describedby={undefined}
+          onKeyDown={handleKeyDown}
+          onPointerDownOutside={(e) => {
+            if (!closeOnInteractionOutside) {
+              e.preventDefault();
+            }
+          }}
+          onInteractOutside={(e) => {
+            if (!closeOnInteractionOutside) {
+              e.preventDefault();
+            }
+          }}
+          {...props}
+        >
+          {children}
+          <div className="[&:has(.dialog-header)]:hidden [&:not(:has(.dialog-header))]:absolute [&:not(:has(.dialog-header))]:right-3 [&:not(:has(.dialog-header))]:top-3 [&:not(:has(.dialog-header))]:z-20">
+            <DialogPrimitive.Close className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+              <X className="h-4 w-4" />
+              <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPortal>
+    );
+  },
 );
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -51,16 +51,24 @@ const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
     closeOnInteractionOutside?: boolean;
+    stopPropagationOnEnterSpace?: boolean;
   } & VariantProps<typeof dialogContentVariants>
 >(
   (
-    { className, children, closeOnInteractionOutside = false, size, ...props },
+    {
+      className,
+      children,
+      closeOnInteractionOutside = false,
+      stopPropagationOnEnterSpace = true,
+      size,
+      ...props
+    },
     ref,
   ) => {
     const handleKeyDown = (e: React.KeyboardEvent) => {
       // Prevent Enter/Space key events from propagating to parent elements
       // This prevents triggering actions like row clicks when submitting forms in dialogs
-      if (e.key === "Enter" || e.key === " ") {
+      if (stopPropagationOnEnterSpace && (e.key === "Enter" || e.key === " ")) {
         e.stopPropagation();
       }
     };

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -404,6 +404,12 @@ export default function DashboardDetail() {
           (dashboard.data?.owner === "LANGFUSE"
             ? " (Langfuse Maintained)"
             : ""),
+        breadcrumb: [
+          {
+            name: "Dashboards",
+            href: `/project/${projectId}/dashboards`,
+          },
+        ],
         help: {
           description:
             dashboard.data?.description || "No description available",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `stopPropagationOnEnterSpace` to dialogs to prevent Enter/Space key propagation and enhances dashboard navigation with breadcrumbs.
> 
>   - **Behavior**:
>     - Adds `stopPropagationOnEnterSpace` prop to `DialogContent` in `dialog.tsx` to prevent Enter/Space key event propagation.
>     - Default behavior is to stop propagation, preventing unintended actions like row clicks.
>   - **UI Enhancements**:
>     - Adds breadcrumb navigation to `DashboardDetail` in `index.tsx` for better user navigation.
>   - **Misc**:
>     - Updates `DialogContent` to handle `onKeyDown` event for Enter/Space keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d1eab0d5545200d22778d8dfa09d43c8c06ee4d1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->