### PR TITLE
fix(otel): correct pydantic-ai v0.7.x+ cache token attribute names and type conversion

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2039,16 +2039,18 @@ export class OtelIngestionProcessor {
       const outputTokens = attributes["gen_ai.usage.output_tokens"];
       const cacheReadTokens =
         attributes["gen_ai.usage.cache_read_tokens"] ??
-        attributes["gen_ai.usage.details.cache_read_input_tokens"];
+        attributes["gen_ai.usage.details.cache_read_tokens"];
       const cacheWriteTokens =
         attributes["gen_ai.usage.cache_write_tokens"] ??
-        attributes["gen_ai.usage.details.cache_creation_input_tokens"];
+        attributes["gen_ai.usage.details.cache_write_tokens"];
 
       return {
-        input: inputTokens,
-        output: outputTokens,
-        input_cache_read: cacheReadTokens,
-        input_cache_creation: cacheWriteTokens,
+        input: inputTokens !== undefined ? Number(inputTokens) : undefined,
+        output: outputTokens !== undefined ? Number(outputTokens) : undefined,
+        input_cache_read:
+          cacheReadTokens !== undefined ? Number(cacheReadTokens) : undefined,
+        input_cache_creation:
+          cacheWriteTokens !== undefined ? Number(cacheWriteTokens) : undefined,
       };
     }
 

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -1560,6 +1560,136 @@ describe("OTel Resource Span Mapping", () => {
       expect(metadataAttributes).not.toHaveProperty("pydantic_ai.all_messages");
     });
 
+    it("should extract pydantic-ai v0.7.x+ cache tokens from gen_ai.usage.details.* attributes", async () => {
+      const traceId = "abcdef1234567890abcdef1234567890";
+
+      const pydanticAiCacheSpan = {
+        scopeSpans: [
+          {
+            scope: {
+              name: "pydantic-ai",
+              version: "0.7.4",
+            },
+            spans: [
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from("1234567890abcdef", "hex"),
+                name: "model-request",
+                kind: 1,
+                startTimeUnixNano: { low: 1000000, high: 406528574 },
+                endTimeUnixNano: { low: 2000000, high: 406528574 },
+                attributes: [
+                  {
+                    key: "gen_ai.usage.input_tokens",
+                    value: { stringValue: "174" },
+                  },
+                  {
+                    key: "gen_ai.usage.output_tokens",
+                    value: { stringValue: "31" },
+                  },
+                  {
+                    key: "gen_ai.usage.details.cache_read_tokens",
+                    value: { stringValue: "100" },
+                  },
+                  {
+                    key: "gen_ai.usage.details.cache_write_tokens",
+                    value: { stringValue: "200" },
+                  },
+                ],
+                events: [],
+                status: { code: 1 },
+              },
+            ],
+          },
+        ],
+      };
+
+      const events = await convertOtelSpanToIngestionEvent(
+        pydanticAiCacheSpan,
+        new Set([traceId]),
+      );
+
+      const observationEvent = events.find(
+        (e) => e.type === "generation-create" || e.type === "span-create",
+      );
+
+      expect(observationEvent).toBeDefined();
+      expect(observationEvent?.body.usageDetails.input).toBe(174);
+      expect(observationEvent?.body.usageDetails.output).toBe(31);
+      expect(observationEvent?.body.usageDetails.input_cache_read).toBe(100);
+      expect(observationEvent?.body.usageDetails.input_cache_creation).toBe(
+        200,
+      );
+    });
+
+    it("should prefer primary pydantic-ai cache token keys over gen_ai.usage.details.* fallbacks", async () => {
+      const traceId = "abcdef1234567890abcdef1234567890";
+
+      const pydanticAiCacheSpan = {
+        scopeSpans: [
+          {
+            scope: {
+              name: "pydantic-ai",
+              version: "0.7.4",
+            },
+            spans: [
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from("1234567890abcdef", "hex"),
+                name: "model-request",
+                kind: 1,
+                startTimeUnixNano: { low: 1000000, high: 406528574 },
+                endTimeUnixNano: { low: 2000000, high: 406528574 },
+                attributes: [
+                  {
+                    key: "gen_ai.usage.input_tokens",
+                    value: { stringValue: "174" },
+                  },
+                  {
+                    key: "gen_ai.usage.output_tokens",
+                    value: { stringValue: "31" },
+                  },
+                  // Primary keys take precedence
+                  {
+                    key: "gen_ai.usage.cache_read_tokens",
+                    value: { stringValue: "50" },
+                  },
+                  {
+                    key: "gen_ai.usage.cache_write_tokens",
+                    value: { stringValue: "60" },
+                  },
+                  // Fallback keys should be ignored when primary keys are present
+                  {
+                    key: "gen_ai.usage.details.cache_read_tokens",
+                    value: { stringValue: "999" },
+                  },
+                  {
+                    key: "gen_ai.usage.details.cache_write_tokens",
+                    value: { stringValue: "999" },
+                  },
+                ],
+                events: [],
+                status: { code: 1 },
+              },
+            ],
+          },
+        ],
+      };
+
+      const events = await convertOtelSpanToIngestionEvent(
+        pydanticAiCacheSpan,
+        new Set([traceId]),
+      );
+
+      const observationEvent = events.find(
+        (e) => e.type === "generation-create" || e.type === "span-create",
+      );
+
+      expect(observationEvent).toBeDefined();
+      expect(observationEvent?.body.usageDetails.input_cache_read).toBe(50);
+      expect(observationEvent?.body.usageDetails.input_cache_creation).toBe(60);
+    });
+
     it("should prioritize OpenInference over OTel GenAI and model detection", async () => {
       const resourceSpan = {
         scopeSpans: [


### PR DESCRIPTION
## Summary

- Correct cache token attribute key names for pydantic-ai v0.7.x+ compatibility: `gen_ai.usage.details.cache_read_tokens` and `gen_ai.usage.details.cache_write_tokens` (previously `cache_read_input_tokens` / `cache_creation_input_tokens`)
- Add explicit `Number()` conversions for token values, which pydantic-ai sends as strings
- Add tests covering the new attribute names and key precedence logic

Fixes #12245 



