### PR TITLE
feat(query): enable ClickHouse query condition cache for analytics queries

### DIFF
--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -240,6 +240,9 @@ export const env = createEnv({
     CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY: z.coerce
       .number()
       .default(32_000_000_000), // ~32GB
+    CLICKHOUSE_USE_QUERY_CONDITION_CACHE: z
+      .enum(["true", "false"])
+      .default("false"),
 
     // EE ui customization
     LANGFUSE_UI_API_HOST: z.string().optional(),
@@ -650,6 +653,8 @@ export const env = createEnv({
     CLICKHOUSE_CLUSTER_ENABLED: process.env.CLICKHOUSE_CLUSTER_ENABLED,
     CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY:
       process.env.CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY,
+    CLICKHOUSE_USE_QUERY_CONDITION_CACHE:
+      process.env.CLICKHOUSE_USE_QUERY_CONDITION_CACHE,
     // EE ui customization
     LANGFUSE_UI_API_HOST: process.env.LANGFUSE_UI_API_HOST,
     LANGFUSE_UI_DOCUMENTATION_HREF: process.env.LANGFUSE_UI_DOCUMENTATION_HREF,

--- a/web/src/features/query/server/queryExecutor.ts
+++ b/web/src/features/query/server/queryExecutor.ts
@@ -182,6 +182,9 @@ export async function executeQuery(
       clickhouseConfigs: {
         clickhouse_settings: {
           date_time_output_format: "iso",
+          ...(env.CLICKHOUSE_USE_QUERY_CONDITION_CACHE === "true"
+            ? { use_query_condition_cache: "true" }
+            : {}),
           max_bytes_before_external_group_by: String(
             env.CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY,
           ),
@@ -212,6 +215,9 @@ export async function executeQuery(
         clickhouseConfigs: {
           clickhouse_settings: {
             date_time_output_format: "iso",
+            ...(env.CLICKHOUSE_USE_QUERY_CONDITION_CACHE === "true"
+              ? { use_query_condition_cache: "true" }
+              : {}),
             max_bytes_before_external_group_by: String(
               env.CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY,
             ),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enables ClickHouse query condition cache for analytics queries in `executeQuery()` in `queryExecutor.ts`.
> 
>   - **Behavior**:
>     - Enables ClickHouse query condition cache by setting `use_query_condition_cache: "true"` in `executeQuery()` in `queryExecutor.ts`.
>     - Applied to both normal and trace table queries within `executeQuery()`.
>   - **Misc**:
>     - No changes to function signatures or other logic in `queryExecutor.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 35205a47dc4067882e49deaa9df5a14024302ece. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->