### PR TITLE
chore: introduce secondary eval execution queue

### DIFF
--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -310,6 +310,7 @@ export enum QueueName {
   TraceDelete = "trace-delete",
   ProjectDelete = "project-delete",
   EvaluationExecution = "evaluation-execution-queue", // Worker executes Evals
+  EvaluationExecutionSecondaryQueue = "secondary-evaluation-execution-queue", // Separates high-throughput eval projects from other projects.
   LLMAsJudgeExecution = "llm-as-a-judge-execution-queue", // Observation-based eval execution
   DatasetRunItemUpsert = "dataset-run-item-upsert-queue",
   BatchExport = "batch-export-queue",
@@ -416,6 +417,13 @@ export type TQueueJobTypes = {
     retryBaggage?: RetryBaggage;
   };
   [QueueName.EvaluationExecution]: {
+    timestamp: Date;
+    id: string;
+    payload: EvalExecutionEventType;
+    name: QueueJobs.EvaluationExecution;
+    retryBaggage?: RetryBaggage;
+  };
+  [QueueName.EvaluationExecutionSecondaryQueue]: {
     timestamp: Date;
     id: string;
     payload: EvalExecutionEventType;

--- a/packages/shared/src/server/redis/evalExecutionQueue.ts
+++ b/packages/shared/src/server/redis/evalExecutionQueue.ts
@@ -48,3 +48,46 @@ export class EvalExecutionQueue {
     return EvalExecutionQueue.instance;
   }
 }
+
+export class SecondaryEvalExecutionQueue {
+  private static instance: Queue<
+    TQueueJobTypes[QueueName.EvaluationExecutionSecondaryQueue]
+  > | null = null;
+
+  public static getInstance(): Queue<
+    TQueueJobTypes[QueueName.EvaluationExecutionSecondaryQueue]
+  > | null {
+    if (SecondaryEvalExecutionQueue.instance)
+      return SecondaryEvalExecutionQueue.instance;
+
+    const newRedis = createNewRedisInstance({
+      enableOfflineQueue: false,
+      ...redisQueueRetryOptions,
+    });
+
+    SecondaryEvalExecutionQueue.instance = newRedis
+      ? new Queue<TQueueJobTypes[QueueName.EvaluationExecutionSecondaryQueue]>(
+          QueueName.EvaluationExecutionSecondaryQueue,
+          {
+            connection: newRedis,
+            prefix: getQueuePrefix(QueueName.EvaluationExecutionSecondaryQueue),
+            defaultJobOptions: {
+              removeOnComplete: true,
+              removeOnFail: 10_000,
+              attempts: 10,
+              backoff: {
+                type: "exponential",
+                delay: 1000,
+              },
+            },
+          },
+        )
+      : null;
+
+    SecondaryEvalExecutionQueue.instance?.on("error", (err) => {
+      logger.error("SecondaryEvalExecutionQueue error", err);
+    });
+
+    return SecondaryEvalExecutionQueue.instance;
+  }
+}

--- a/packages/shared/src/server/redis/getQueue.ts
+++ b/packages/shared/src/server/redis/getQueue.ts
@@ -5,7 +5,10 @@ import { CloudUsageMeteringQueue } from "./cloudUsageMeteringQueue";
 import { CloudSpendAlertQueue } from "./cloudSpendAlertQueue";
 import { CloudFreeTierUsageThresholdQueue } from "./cloudFreeTierUsageThresholdQueue";
 import { DatasetRunItemUpsertQueue } from "./datasetRunItemUpsert";
-import { EvalExecutionQueue } from "./evalExecutionQueue";
+import {
+  EvalExecutionQueue,
+  SecondaryEvalExecutionQueue,
+} from "./evalExecutionQueue";
 import { LLMAsJudgeExecutionQueue } from "./llmAsJudgeExecutionQueue";
 import { ExperimentCreateQueue } from "./experimentCreateQueue";
 import { SecondaryIngestionQueue } from "./ingestionQueue";
@@ -56,6 +59,8 @@ export function getQueue(
       return DatasetDeleteQueue.getInstance();
     case QueueName.EvaluationExecution:
       return EvalExecutionQueue.getInstance();
+    case QueueName.EvaluationExecutionSecondaryQueue:
+      return SecondaryEvalExecutionQueue.getInstance();
     case QueueName.LLMAsJudgeExecution:
       return LLMAsJudgeExecutionQueue.getInstance();
     case QueueName.ExperimentCreate:

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -121,6 +121,13 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(5),
+  LANGFUSE_EVAL_EXECUTION_SECONDARY_QUEUE_PROCESSING_CONCURRENCY: z.coerce
+    .number()
+    .positive()
+    .default(5),
+  LANGFUSE_SECONDARY_EVAL_EXECUTION_QUEUE_ENABLED_PROJECT_IDS: z
+    .string()
+    .optional(),
   LANGFUSE_EXPERIMENT_CREATOR_WORKER_CONCURRENCY: z.coerce
     .number()
     .positive()
@@ -179,6 +186,9 @@ const EnvSchema = z.object({
     .enum(["true", "false"])
     .default("true"),
   QUEUE_CONSUMER_EVAL_EXECUTION_QUEUE_IS_ENABLED: z
+    .enum(["true", "false"])
+    .default("true"),
+  QUEUE_CONSUMER_EVAL_EXECUTION_SECONDARY_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])
     .default("true"),
   QUEUE_CONSUMER_TRACE_UPSERT_QUEUE_IS_ENABLED: z

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -1,4 +1,4 @@
-import { Job } from "bullmq";
+import { Job, Processor } from "bullmq";
 import { JobExecutionStatus } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 import {
@@ -6,11 +6,11 @@ import {
   TQueueJobTypes,
   logger,
   traceException,
-  EvalExecutionQueue,
   LLMAsJudgeExecutionQueue,
   QueueJobs,
   getCurrentSpan,
   isLLMCompletionError,
+  getQueue,
 } from "@langfuse/shared/src/server";
 import { createEvalJobs, evaluate } from "../features/evaluation/evalService";
 import { processObservationEval } from "../features/evaluation/observationEval";
@@ -19,6 +19,7 @@ import { createW3CTraceId, retryLLMRateLimitError } from "../features/utils";
 import { isUnrecoverableError } from "../errors/UnrecoverableError";
 import { retryObservationNotFound } from "../features/evaluation/retryObservationNotFound";
 import { isObservationNotFoundError } from "../errors/ObservationNotFoundError";
+import { env } from "../env";
 
 export const evalJobTraceCreatorQueueProcessor = async (
   job: Job<TQueueJobTypes[QueueName.TraceUpsert]>,
@@ -113,113 +114,150 @@ export const evalJobCreatorQueueProcessor = async (
   }
 };
 
-export const evalJobExecutorQueueProcessor = async (
-  job: Job<TQueueJobTypes[QueueName.EvaluationExecution]>,
-) => {
-  try {
-    logger.info("Executing Evaluation Execution Job", job.data);
+type EvalExecutionQueueName =
+  | QueueName.EvaluationExecution
+  | QueueName.EvaluationExecutionSecondaryQueue;
 
-    const span = getCurrentSpan();
+export const evalJobExecutorQueueProcessorBuilder = (
+  enableRedirectToSecondaryQueue: boolean,
+  queueName: EvalExecutionQueueName,
+): Processor => {
+  const projectIdsToRedirectToSecondaryQueue =
+    env.LANGFUSE_SECONDARY_EVAL_EXECUTION_QUEUE_ENABLED_PROJECT_IDS?.split(
+      ",",
+    ) ?? [];
 
-    if (span) {
-      span.setAttribute(
-        "messaging.bullmq.job.input.jobExecutionId",
+  return async (job: Job<TQueueJobTypes[QueueName.EvaluationExecution]>) => {
+    try {
+      logger.info("Executing Evaluation Execution Job", job.data);
+
+      // Redirect selected projects to the secondary queue from the primary consumer.
+      if (enableRedirectToSecondaryQueue) {
+        const projectId = job.data.payload.projectId;
+        const shouldRedirectToSecondaryQueue =
+          projectIdsToRedirectToSecondaryQueue.includes(projectId);
+
+        if (shouldRedirectToSecondaryQueue) {
+          logger.debug(
+            `Redirecting evaluation execution job to secondary queue for project ${projectId}`,
+          );
+          const secondaryQueue = getQueue(
+            QueueName.EvaluationExecutionSecondaryQueue,
+          );
+          if (secondaryQueue) {
+            await secondaryQueue.add(
+              QueueName.EvaluationExecutionSecondaryQueue,
+              job.data,
+            );
+            return;
+          }
+        }
+      }
+
+      const span = getCurrentSpan();
+
+      if (span) {
+        span.setAttribute(
+          "messaging.bullmq.job.input.jobExecutionId",
+          job.data.payload.jobExecutionId,
+        );
+        span.setAttribute(
+          "messaging.bullmq.job.input.projectId",
+          job.data.payload.projectId,
+        );
+        span.setAttribute(
+          "messaging.bullmq.job.input.retryBaggage.attempt",
+          job.data.retryBaggage?.attempt ?? 0,
+        );
+      }
+
+      await evaluate({ event: job.data.payload });
+      return true;
+    } catch (e) {
+      // ┌─────────────────────────┐
+      // │   Job Fails with Error  │
+      // └───────────┬─────────────┘
+      //             │
+      //             ▼
+      // ┌────────────────────────────────────────┐
+      // │ Is it LLMCompletionError with          │
+      // │ isRetryable=true (429/5xx)?            │
+      // └─────┬──────────────────────────────┬───┘
+      //       │ Yes                          │ No
+      //       ▼                              ▼
+      // ┌──────────────────┐       ┌───────────────────────┐
+      // │ Is job < 24h old?│       │ Is it retryable?      │
+      // └─────┬──────┬─────┘       │ (shouldRetryJob)      │
+      //   Yes │      │ No          └─────┬─────────────┬───┘
+      //       ▼      ▼                Yes│             │No
+      // ┌─────────┐ ┌────────┐          ▼             ▼
+      // │Set:     │ │Set:    │    ┌─────────┐  ┌──────────┐
+      // │DELAYED  │ │ERROR   │    │BullMQ   │  │Set:      │
+      // │Retry in │ │Stop    │    │retry    │  │ERROR     │
+      // │1-25 min │ │        │    │w/ exp.  │  │Done      │
+      // └─────────┘ └────────┘    │backoff  │  └──────────┘
+      //                           └─────────┘
+
+      const executionTraceId = createW3CTraceId(
         job.data.payload.jobExecutionId,
       );
-      span.setAttribute(
-        "messaging.bullmq.job.input.projectId",
-        job.data.payload.projectId,
-      );
-      span.setAttribute(
-        "messaging.bullmq.job.input.retryBaggage.attempt",
-        job.data.retryBaggage?.attempt ?? 0,
-      );
-    }
 
-    await evaluate({ event: job.data.payload });
-    return true;
-  } catch (e) {
-    // ┌─────────────────────────┐
-    // │   Job Fails with Error  │
-    // └───────────┬─────────────┘
-    //             │
-    //             ▼
-    // ┌────────────────────────────────────────┐
-    // │ Is it LLMCompletionError with          │
-    // │ isRetryable=true (429/5xx)?            │
-    // └─────┬──────────────────────────────┬───┘
-    //       │ Yes                          │ No
-    //       ▼                              ▼
-    // ┌──────────────────┐       ┌───────────────────────┐
-    // │ Is job < 24h old?│       │ Is it retryable?      │
-    // └─────┬──────┬─────┘       │ (shouldRetryJob)      │
-    //   Yes │      │ No          └─────┬─────────────┬───┘
-    //       ▼      ▼                Yes│             │No
-    // ┌─────────┐ ┌────────┐          ▼             ▼
-    // │Set:     │ │Set:    │    ┌─────────┐  ┌──────────┐
-    // │DELAYED  │ │ERROR   │    │BullMQ   │  │Set:      │
-    // │Retry in │ │Stop    │    │retry    │  │ERROR     │
-    // │1-25 min │ │        │    │w/ exp.  │  │Done      │
-    // └─────────┘ └────────┘    │backoff  │  └──────────┘
-    //                           └─────────┘
+      if (isLLMCompletionError(e) && e.isRetryable) {
+        await retryLLMRateLimitError(job, {
+          table: "job_executions",
+          idField: "jobExecutionId",
+          queue: getQueue(queueName),
+          queueName,
+          jobName: QueueJobs.EvaluationExecution,
+          delayFn: delayInMs,
+        });
 
-    const executionTraceId = createW3CTraceId(job.data.payload.jobExecutionId);
+        // Use the deterministic execution trace ID to update the job execution
+        await prisma.jobExecution.update({
+          where: {
+            id: job.data.payload.jobExecutionId,
+            projectId: job.data.payload.projectId,
+          },
+          data: {
+            status: JobExecutionStatus.DELAYED,
+            executionTraceId,
+          },
+        });
 
-    if (isLLMCompletionError(e) && e.isRetryable) {
-      await retryLLMRateLimitError(job, {
-        table: "job_executions",
-        idField: "jobExecutionId",
-        queue: EvalExecutionQueue.getInstance(),
-        queueName: QueueName.EvaluationExecution,
-        jobName: QueueJobs.EvaluationExecution,
-        delayFn: delayInMs,
-      });
+        // Return early as we have already scheduled a delayed retry
+        return;
+      }
 
-      // Use the deterministic execution trace ID to update the job execution
+      // At this point there will be only 4xx LLMCompletionErrors that are not retryable and application errors
       await prisma.jobExecution.update({
         where: {
           id: job.data.payload.jobExecutionId,
           projectId: job.data.payload.projectId,
         },
         data: {
-          status: JobExecutionStatus.DELAYED,
+          status: JobExecutionStatus.ERROR,
+          endTime: new Date(),
+          // Show user-facing error messages (LLM and config errors)
+          error:
+            isLLMCompletionError(e) || isUnrecoverableError(e)
+              ? e.message
+              : "An internal error occurred",
           executionTraceId,
         },
       });
 
-      // Return early as we have already scheduled a delayed retry
-      return;
+      if (isLLMCompletionError(e) || isUnrecoverableError(e)) return;
+
+      traceException(e);
+      logger.error(
+        `Failed ${queueName} job for id ${job.data.payload.jobExecutionId}`,
+        e,
+      );
+
+      // Retry job by rethrowing error
+      throw e;
     }
-
-    // At this point there will be only 4xx LLMCompletionErrors that are not retryable and application errors
-    await prisma.jobExecution.update({
-      where: {
-        id: job.data.payload.jobExecutionId,
-        projectId: job.data.payload.projectId,
-      },
-      data: {
-        status: JobExecutionStatus.ERROR,
-        endTime: new Date(),
-        // Show user-facing error messages (LLM and config errors)
-        error:
-          isLLMCompletionError(e) || isUnrecoverableError(e)
-            ? e.message
-            : "An internal error occurred",
-        executionTraceId,
-      },
-    });
-
-    if (isLLMCompletionError(e) || isUnrecoverableError(e)) return;
-
-    traceException(e);
-    logger.error(
-      `Failed Evaluation_Execution job for id ${job.data.payload.jobExecutionId}`,
-      e,
-    );
-
-    // Retry job by rethrowing error
-    throw e;
-  }
+  };
 };
 
 /**

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -144,13 +144,17 @@ export const evalJobExecutorQueueProcessorBuilder = (
           const secondaryQueue = getQueue(
             QueueName.EvaluationExecutionSecondaryQueue,
           );
-          if (secondaryQueue) {
-            await secondaryQueue.add(
-              QueueName.EvaluationExecutionSecondaryQueue,
-              job.data,
+          if (!secondaryQueue) {
+            throw new Error(
+              "Secondary evaluation execution queue is not available",
             );
-            return;
           }
+
+          await secondaryQueue.add(
+            QueueName.EvaluationExecutionSecondaryQueue,
+            job.data,
+          );
+          return;
         }
       }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduce a secondary evaluation execution queue to separate high-throughput projects, with changes in queue definitions, environment settings, and worker registration.
> 
>   - **Queues**:
>     - Add `EvaluationExecutionSecondaryQueue` to `QueueName` in `queues.ts`.
>     - Define `SecondaryEvalExecutionQueue` class in `evalExecutionQueue.ts`.
>     - Update `getQueue()` in `getQueue.ts` to handle `EvaluationExecutionSecondaryQueue`.
>   - **Environment**:
>     - Add `LANGFUSE_EVAL_EXECUTION_SECONDARY_QUEUE_PROCESSING_CONCURRENCY` and `LANGFUSE_SECONDARY_EVAL_EXECUTION_QUEUE_ENABLED_PROJECT_IDS` to `env.ts`.
>   - **Workers**:
>     - Register `EvaluationExecutionSecondaryQueue` in `app.ts` with `evalJobExecutorQueueProcessorBuilder`.
>     - Modify `evalJobExecutorQueueProcessorBuilder` in `evalQueue.ts` to redirect jobs to secondary queue based on project IDs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6c3058b1e7e5d6d724718af4ee8fd33860c2edfb. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->