### PR TITLE
fix(api-scores): return executionTraceId

### DIFF
--- a/fern/apis/server/definition/score-v2.yml
+++ b/fern/apis/server/definition/score-v2.yml
@@ -74,7 +74,7 @@ service:
             docs: Only scores linked to traces that include all of these tags will be returned.
           fields:
             type: optional<string>
-            docs: "Comma-separated list of field groups to include in the response. Available field groups: 'score' (core score fields), 'trace' (trace properties: userId, tags, environment). If not specified, both 'score' and 'trace' are returned by default. Example: 'score' to exclude trace data, 'score,trace' to include both. Note: When filtering by trace properties (using userId or traceTags parameters), the 'trace' field group must be included, otherwise a 400 error will be returned."
+            docs: "Comma-separated list of field groups to include in the response. Available field groups: 'score' (core score fields), 'trace' (trace properties: userId, tags, environment, sessionId). If not specified, both 'score' and 'trace' are returned by default. Example: 'score' to exclude trace data, 'score,trace' to include both. Note: When filtering by trace properties (using userId or traceTags parameters), the 'trace' field group must be included, otherwise a 400 error will be returned."
           filter:
             type: optional<string>
             docs: >
@@ -106,6 +106,9 @@ types:
       environment:
         type: optional<string>
         docs: The environment of the trace referenced by score
+      sessionId:
+        type: optional<string>
+        docs: The session ID associated with the trace referenced by score
 
   GetScoresResponseDataNumeric:
     extends: commons.NumericScore

--- a/packages/shared/src/features/scores/interfaces/api/v2/endpoints.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v2/endpoints.ts
@@ -29,6 +29,7 @@ export const GetScoreResponseDataV2 = z
           userId: z.string().nullish(),
           tags: z.array(z.string()).nullish(),
           environment: z.string().nullish(),
+          sessionId: z.string().nullish(),
         })
         .nullish(),
     }),

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -2669,11 +2669,10 @@ paths:
             nullable: true
         - name: parseIoAsJson
           in: query
-          description: >-
-            Set to `true` to parse input/output fields as JSON, or `false` to
-            return raw strings.
-
-            Defaults to `false` if not provided.
+          description: |-
+            **Deprecated.** Setting this to `true` will return a 400 error.
+            Input/output fields are always returned as raw strings.
+            Remove this parameter or set it to `false`.
           required: false
           schema:
             type: boolean
@@ -5235,9 +5234,9 @@ paths:
           description: >-
             Comma-separated list of field groups to include in the response.
             Available field groups: 'score' (core score fields), 'trace' (trace
-            properties: userId, tags, environment). If not specified, both
-            'score' and 'trace' are returned by default. Example: 'score' to
-            exclude trace data, 'score,trace' to include both. Note: When
+            properties: userId, tags, environment, sessionId). If not specified,
+            both 'score' and 'trace' are returned by default. Example: 'score'
+            to exclude trace data, 'score,trace' to include both. Note: When
             filtering by trace properties (using userId or traceTags
             parameters), the 'trace' field group must be included, otherwise a
             400 error will be returned.
@@ -10405,6 +10404,10 @@ components:
           type: string
           nullable: true
           description: The environment of the trace referenced by score
+        sessionId:
+          type: string
+          nullable: true
+          description: The session ID associated with the trace referenced by score
     GetScoresResponseDataNumeric:
       title: GetScoresResponseDataNumeric
       type: object

--- a/web/src/__tests__/server/scores-api-v2.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v2.servertest.ts
@@ -1366,11 +1366,13 @@ describe("/api/public/v2/scores API Endpoint", () => {
       it("should include both when fields=score,trace", async () => {
         const { projectId, auth } = await createOrgProjectAndApiKey();
         const traceId = v4();
+        const traceSessionId = v4();
         const scoreId = v4();
 
         const trace = createTrace({
           id: traceId,
           project_id: projectId,
+          session_id: traceSessionId,
           user_id: "test-user",
           tags: ["tag1"],
         });
@@ -1403,6 +1405,7 @@ describe("/api/public/v2/scores API Endpoint", () => {
           trace: {
             userId: "test-user",
             tags: ["tag1"],
+            sessionId: traceSessionId,
           },
         });
       });

--- a/web/src/__tests__/server/scores-api-v2.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v2.servertest.ts
@@ -219,11 +219,13 @@ describe("/api/public/v2/scores API Endpoint", () => {
       const correctionScoreId_2 = v4();
       let authentication: string;
       let newProjectId: string;
+      let executionTraceId: string;
 
       beforeEach(async () => {
         const { projectId, auth } = await createOrgProjectAndApiKey();
         authentication = auth;
         newProjectId = projectId;
+        executionTraceId = v4();
 
         const trace = createTrace({
           id: traceId,
@@ -278,6 +280,7 @@ describe("/api/public/v2/scores API Endpoint", () => {
           observation_id: generationId,
           config_id: config.id,
           comment: "comment",
+          execution_trace_id: executionTraceId,
         });
 
         const score2 = createTraceScore({
@@ -432,6 +435,13 @@ describe("/api/public/v2/scores API Endpoint", () => {
             ).toBeTruthy();
           }
         }
+
+        const scoreWithExecutionTraceId = getAllScore.body.data.find(
+          (score) => score.id === scoreId_1,
+        );
+        expect(scoreWithExecutionTraceId?.executionTraceId).toBe(
+          executionTraceId,
+        );
       });
 
       it("get all scores for config", async () => {

--- a/web/src/features/public-api/server/scores.ts
+++ b/web/src/features/public-api/server/scores.ts
@@ -91,7 +91,7 @@ export const _handleGenerateScoresForPublicApi = async ({
 
   const query = `
       SELECT
-          ${needsTraceJoin ? "t.user_id as user_id, t.tags as tags, t.environment as trace_environment," : ""}
+          ${needsTraceJoin ? "t.user_id as user_id, t.tags as tags, t.environment as trace_environment, t.session_id as trace_session_id," : ""}
           s.id as id,
           s.project_id as project_id,
           s.timestamp as timestamp,
@@ -174,6 +174,7 @@ export const _handleGenerateScoresForPublicApi = async ({
           tags?: string[];
           user_id?: string;
           trace_environment?: string;
+          trace_session_id?: string | null;
         }
       >({
         query: query.replace("__TRACE_TABLE__", "traces"),
@@ -193,6 +194,7 @@ export const _handleGenerateScoresForPublicApi = async ({
                   userId: record.user_id,
                   tags: record.tags,
                   environment: record.trace_environment,
+                  sessionId: record.trace_session_id,
                 }
               : null,
         };

--- a/web/src/features/public-api/server/scores.ts
+++ b/web/src/features/public-api/server/scores.ts
@@ -109,6 +109,7 @@ export const _handleGenerateScoresForPublicApi = async ({
           s.data_type as data_type,
           s.config_id as config_id,
           s.queue_id as queue_id,
+          s.execution_trace_id as execution_trace_id,
           s.trace_id as trace_id,
           s.observation_id as observation_id,
           s.session_id as session_id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `execution_trace_id` to scores API response and update tests accordingly.
> 
>   - **Behavior**:
>     - Add `execution_trace_id` to the response of `/api/public/v2/scores` in `scores.ts`.
>     - Update test in `scores-api-v2.servertest.ts` to check for `execution_trace_id` in the response.
>   - **Query**:
>     - Modify SQL query in `_handleGenerateScoresForPublicApi` in `scores.ts` to include `s.execution_trace_id`.
>   - **Tests**:
>     - Add `executionTraceId` to test setup and assertions in `scores-api-v2.servertest.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 776552af920775857c24160f2857726fa21a970d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->