### PR TITLE
fix(evals): add missing observation columns to checkTraceExistsAndGetTimestamp CTE

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -107,6 +107,9 @@ export const checkTraceExistsAndGetTimestamp = async ({
         countIf(level = 'WARNING') as warning_count,
         countIf(level = 'DEFAULT') as default_count,
         countIf(level = 'DEBUG') as debug_count,
+        date_diff('millisecond', least(min(start_time), min(end_time)), greatest(max(start_time), max(end_time))) as latency_milliseconds,
+        sumMap(usage_details) as usage_details,
+        sumMap(cost_details) as cost_details,
         trace_id,
         project_id
       FROM observations o FINAL


### PR DESCRIPTION
The observations_agg CTE only included level-related columns, causing ClickHouse errors when eval automations filtered on latency, cost, or token columns (e.g. "Identifier 'o.latency_milliseconds' cannot be resolved"). Add latency_milliseconds, usage_details, and cost_details aggregations to the CTE.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add missing columns to `observations_agg` CTE in `checkTraceExistsAndGetTimestamp` to fix filtering errors on latency, cost, or token columns.
> 
>   - **Behavior**:
>     - Add `latency_milliseconds`, `usage_details`, and `cost_details` to `observations_agg` CTE in `checkTraceExistsAndGetTimestamp` in `traces.ts`.
>     - Fixes ClickHouse errors when filtering on latency, cost, or token columns.
>   - **Tests**:
>     - Add tests in `trace-repository.servertest.ts` to verify filtering on `latency` and `totalCost` columns.
>     - Ensure tests cover both matching and non-matching scenarios for new columns.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 4c9859df01a344240d676cf16b26a5b1a0540ed3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->