### PR TITLE
feat(datasets): add batch export button to dataset runs table

### DIFF
--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -27,6 +27,8 @@ import {
 import { Button } from "@/src/components/ui/button";
 import { DeleteDatasetRunButton } from "@/src/features/datasets/components/DeleteDatasetRunButton";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
+import { BatchExportTableButton } from "@/src/components/BatchExportTableButton";
+import { BatchExportTableName } from "@langfuse/shared";
 import { Checkbox } from "@/src/components/ui/checkbox";
 import { type RowSelectionState } from "@tanstack/react-table";
 import Link from "next/link";
@@ -594,6 +596,23 @@ export function DatasetRunsTable(props: {
     columns,
   );
 
+  const batchExportButton = (
+    <BatchExportTableButton
+      key="batchExport"
+      projectId={props.projectId}
+      tableName={BatchExportTableName.DatasetRunItems}
+      orderByState={{ column: "createdAt", order: "DESC" }}
+      filterState={[
+        {
+          type: "string",
+          operator: "=",
+          column: "datasetId",
+          value: props.datasetId,
+        },
+      ]}
+    />
+  );
+
   // Check if we have charts to display
   const hasCharts = Boolean(props.selectedMetrics.length);
 
@@ -741,6 +760,7 @@ export function DatasetRunsTable(props: {
                     setRowSelection={setSelectedRows}
                   />
                 ) : null,
+                batchExportButton,
               ]}
             />
             <DataTable
@@ -805,6 +825,7 @@ export function DatasetRunsTable(props: {
                   setRowSelection={setSelectedRows}
                 />
               ) : null,
+              batchExportButton,
             ]}
           />
           <DataTable


### PR DESCRIPTION
## Summary

Adds a `BatchExportTableButton` to the dataset detail page (runs tab), allowing users to export dataset run items as CSV, JSON, or JSONL directly from the UI.

Closes #11945

## Problem

Users navigating to an individual dataset's detail page (runs tab at `/project/{id}/datasets/{datasetId}`) had no way to export data from the UI. The export button only existed on the dataset items tab. Users had to fall back to the API/SDK for exports, which was confusing given the [changelog](https://langfuse.com/changelog/2025-06-23-exports-datasets-audit-logs) suggested export was available.

## Solution

Added `BatchExportTableButton` to `DatasetRunsTable.tsx`, following the exact same pattern already used in `DatasetItemsTable.tsx`:

- Uses `BatchExportTableName.DatasetRunItems` (enum already existed, backend handler already supported)
- Filters by `datasetId` to scope the export
- Orders by `createdAt DESC`
- Added to **both** toolbar rendering paths (with-charts resizable panel and without-charts simple layout)

## Changes

- **`web/src/features/datasets/components/DatasetRunsTable.tsx`** — Added `BatchExportTableButton` import, created the button element, and added it to both `DataTableToolbar` `actionButtons` arrays

## How to Test

1. Navigate to any dataset detail page (runs tab)
2. Verify the export button appears in the toolbar
3. Click it → select CSV/JSON/JSONL → confirm export job is created
4. Switch to Items tab → verify existing export button still works
5. Toggle chart metrics on/off → verify export button appears in both modes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `BatchExportTableButton` to `DatasetRunsTable.tsx` for exporting dataset run items as CSV, JSON, or JSONL, filtered by `datasetId` and ordered by `createdAt DESC`.
> 
>   - **Behavior**:
>     - Adds `BatchExportTableButton` to `DatasetRunsTable.tsx` for exporting dataset run items as CSV, JSON, or JSONL.
>     - Filters exports by `datasetId` and orders by `createdAt DESC`.
>     - Button added to both toolbar rendering paths (with and without charts).
>   - **Components**:
>     - Imports `BatchExportTableButton` and `BatchExportTableName` in `DatasetRunsTable.tsx`.
>     - Adds `batchExportButton` to `DataTableToolbar` `actionButtons` arrays in `DatasetRunsTable.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 734763bf2a2a2c17d748e8fdac24f00662a8e72b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->