### PR TITLE
fix(api): add explicit type to nullable fields in CreateDatasetItemRequest

### DIFF
--- a/fern/apis/server/definition/dataset-items.yml
+++ b/fern/apis/server/definition/dataset-items.yml
@@ -63,9 +63,9 @@ types:
   CreateDatasetItemRequest:
     properties:
       datasetName: string
-      input: optional<unknown>
-      expectedOutput: optional<unknown>
-      metadata: optional<unknown>
+      input: optional<map<string, unknown>>
+      expectedOutput: optional<map<string, unknown>>
+      metadata: optional<map<string, unknown>>
       sourceTraceId: optional<string>
       sourceObservationId: optional<string>
       id:


### PR DESCRIPTION
## Summary

Fixes #12203

The `langfuse-cli dataset-items create` command fails because the CLI's option parser ([specli](https://github.com/vercel-labs/specli)) requires an explicit `type` when `nullable` is present. The `input`, `expectedOutput`, and `metadata` fields in `CreateDatasetItemRequest` were defined as `optional<unknown>` in the Fern spec, which compiles to `nullable: true` **without** an explicit `type` in the OpenAPI output — causing specli to silently drop these flags.

## Changes

In `fern/apis/server/definition/dataset-items.yml`, change the three fields from `optional<unknown>` to `optional<map<string, unknown>>`:

```diff
  CreateDatasetItemRequest:
    properties:
      datasetName: string
-      input: optional<unknown>
-      expectedOutput: optional<unknown>
-      metadata: optional<unknown>
+      input: optional<map<string, unknown>>
+      expectedOutput: optional<map<string, unknown>>
+      metadata: optional<map<string, unknown>>
```

### Why `map<string, unknown>`

In Fern's type system, `map<string, unknown>` compiles to `type: object` with `additionalProperties: true` in the OpenAPI spec. This gives the CLI parser the explicit `type` it needs while still accepting arbitrary JSON objects as input.

### Scope

Only `CreateDatasetItemRequest` is changed (the request type for `POST /api/public/dataset-items`). The response type `DatasetItem` in `commons.yml` uses `unknown` (not `optional<unknown>`) and is not affected by this issue.

## Verification

- 1 file changed, 3 insertions, 3 deletions
- No other types or endpoints affected
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes CLI parsing issue by specifying explicit types for nullable fields in `CreateDatasetItemRequest`.
> 
>   - **Behavior**:
>     - Fixes `langfuse-cli dataset-items create` command by specifying explicit types for nullable fields in `CreateDatasetItemRequest`.
>     - Changes `input`, `expectedOutput`, and `metadata` from `optional<unknown>` to `optional<map<string, unknown>>` in `dataset-items.yml`.
>   - **Scope**:
>     - Only affects `CreateDatasetItemRequest` for `POST /api/public/dataset-items`.
>     - Does not affect `DatasetItem` response type in `commons.yml`.
>   - **Verification**:
>     - 1 file changed, 3 insertions, 3 deletions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 12cde66efc9c644421d2ec9bba8772662842ab7d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->