### PR TITLE
docs: add correct clickhouse installation in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Requirements
 
 1. Install development dependencies:
    - [golang-migrate](https://github.com/golang-migrate/migrate/tree/master/cmd/migrate#migrate-cli) as CLI
-   - [clickhouse binary](https://clickhouse.com/docs/install) on macOS with brew: `brew install --cask clickhouse`
+   - [clickhouse client](https://clickhouse.com/docs/interfaces/cli) or `curl https://clickhouse.com/ | sh && sudo ./clickhouse install`
 
 2. Fork the repository and clone it locally
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Installation using homebrew is deprecated

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

<img width="1326" height="265" alt="image" src="https://github.com/user-attachments/assets/0790b2d6-5b5e-4ea8-bc16-fea545a926d2" />


## Type of change

<!-- Please delete bullets that are not relevant. -->


- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Clickhouse installation instructions in `CONTRIBUTING.md` to replace deprecated homebrew method.
> 
>   - **Documentation**:
>     - Update Clickhouse installation instructions in `CONTRIBUTING.md` to use `clickhouse client` or `curl` method instead of deprecated homebrew method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for f7557b58318b6ed64bb3bb75b962a3602652e123. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->