### PR TITLE
fix(web): align v4 beta banner sparkles icon with sidebar icons

### DIFF
--- a/web/src/features/events/components/V4BetaEnabledBanner.tsx
+++ b/web/src/features/events/components/V4BetaEnabledBanner.tsx
@@ -60,7 +60,7 @@ export function V4BetaEnabledBanner() {
       role="status"
       aria-live="polite"
     >
-      <div className="flex items-center gap-3 px-4 py-1.5">
+      <div className="flex items-center gap-3 py-1.5 pl-2 pr-4">
         <Sparkles className="h-4 w-4 shrink-0" />
         <p className="flex-1 text-sm">
           <span className="font-semibold">v4 Beta is enabled.</span> You&apos;re


### PR DESCRIPTION
### Motivation
- Left-align the sparkles icon in the v4 beta banner so it visually lines up with the Langfuse logo and main menu icon column in the sidebar.

### Description
- Adjusted horizontal padding on the banner container in `web/src/features/events/components/V4BetaEnabledBanner.tsx` from `px-4` to `pl-2 pr-4` to shift the `Sparkles` icon left.

### Testing
- Ran `pnpm --filter web run lint` which completed successfully. 
- Ran `pnpm --filter web run test-client -- --passWithNoTests --testPathPatterns="features/events"` which failed in this environment due to missing required environment variables (`DATABASE_URL`, `NEXTAUTH_URL`, `SALT`, `CLICKHOUSE_URL`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`).
- Attempted a Playwright screenshot run to validate the visual change but the local site at `http://127.0.0.1:3000` was not reachable in this environment (network error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0487439c48329a1a4beee2296ead3)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Aligns `Sparkles` icon in `V4BetaEnabledBanner.tsx` with sidebar elements by adjusting padding.
> 
>   - **UI Adjustment**:
>     - In `V4BetaEnabledBanner.tsx`, adjusted padding from `px-4` to `pl-2 pr-4` to align `Sparkles` icon with sidebar elements.
>   - **Testing**:
>     - Linting passed with `pnpm --filter web run lint`.
>     - Testing failed due to missing environment variables.
>     - Playwright screenshot validation was attempted but failed due to network error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 65fe026dee332b4dae1e36e42c52966cffef8df4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->