### PR TITLE
feat(llm-connections): allow extraHeaders for anthropic adapter

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -1,6 +1,6 @@
 import { type ZodSchema, z } from "zod/v4";
 
-import { ChatAnthropic } from "@langchain/anthropic";
+import { ChatAnthropic, ChatAnthropicInput } from "@langchain/anthropic";
 import { ChatVertexAI } from "@langchain/google-vertexai";
 import { ChatBedrockConverse } from "@langchain/aws";
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
@@ -260,7 +260,7 @@ export async function fetchLLMCompletion(
       modelParams.model?.includes("claude-opus-4-6") ||
       modelParams.model?.includes("claude-haiku-4-5");
 
-    const chatOptions: Record<string, any> = {
+    const chatOptions: ChatAnthropicInput = {
       anthropicApiKey: apiKey,
       anthropicApiUrl: baseURL ?? undefined,
       model: modelParams.model,
@@ -268,6 +268,7 @@ export async function fetchLLMCompletion(
       callbacks: finalCallbacks,
       clientOptions: {
         maxRetries,
+        defaultHeaders: extraHeaders,
         timeout: timeoutMs,
         ...(proxyDispatcher && {
           fetchOptions: { dispatcher: proxyDispatcher },
@@ -276,7 +277,6 @@ export async function fetchLLMCompletion(
       temperature: modelParams.temperature,
       topP: modelParams.top_p,
       invocationKwargs: modelParams.providerOptions,
-      timeout: timeoutMs,
     };
 
     chatModel = new ChatAnthropic(chatOptions);

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -1027,8 +1027,9 @@ export function CreateLLMApiKeyForm({
               )}
 
               {/* Extra Headers */}
-              {currentAdapter === LLMAdapter.OpenAI &&
-                renderExtraHeadersField()}
+              {[LLMAdapter.OpenAI, LLMAdapter.Anthropic].includes(
+                currentAdapter,
+              ) && renderExtraHeadersField()}
 
               {/* With default models */}
               <FormField


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Support for extra headers added to the Anthropics adapter in both backend and frontend components.
> 
>   - **Behavior**:
>     - `fetchLLMCompletion` in `fetchLLMCompletion.ts` now supports `extraHeaders` for the Anthropics adapter by adding `defaultHeaders` to `ChatAnthropicInput`.
>     - `CreateLLMApiKeyForm` in `CreateLLMApiKeyForm.tsx` now renders extra headers for the Anthropics adapter, similar to OpenAI.
>   - **Misc**:
>     - Minor refactor in `fetchLLMCompletion.ts` to remove redundant `timeout` property in `chatOptions`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d7e96eb6d2974c1298a2f411c9b41962cb53f80a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->