### PR TITLE
fix(dashboard): add fallback when  is empty in v2 queries

### DIFF
--- a/packages/shared/scripts/seeder/seed-postgres.ts
+++ b/packages/shared/scripts/seeder/seed-postgres.ts
@@ -745,6 +745,7 @@ async function generateEvalJobExecutions(
             jobConfiguration.evalTemplateId!,
             i,
             project.id,
+            0,
           ),
         },
       });

--- a/packages/shared/scripts/seeder/utils/data-generators.ts
+++ b/packages/shared/scripts/seeder/utils/data-generators.ts
@@ -332,6 +332,7 @@ export class DataGenerator {
               evalJobConfiguration.evalTemplateId,
               traceIndex,
               projectId,
+              i,
             ),
             trace_id: trace.id,
             project_id: projectId,

--- a/packages/shared/scripts/seeder/utils/seed-helpers.ts
+++ b/packages/shared/scripts/seeder/utils/seed-helpers.ts
@@ -36,8 +36,10 @@ export const generateEvalObservationId = (
   evalTemplateId: string,
   index: number,
   projectId: string,
+  observationIndex?: number,
 ) => {
-  return `observation-eval-${evalTemplateId}-${projectId.slice(-8)}-${index}`;
+  const suffix = observationIndex != null ? `-${observationIndex}` : "";
+  return `observation-eval-${evalTemplateId}-${projectId.slice(-8)}-${index}${suffix}`;
 };
 
 export const generateEvalScoreId = (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add fallback for empty `trace_name` in v2 queries to use root event's name, with updates to data model and tests.
> 
>   - **Behavior**:
>     - Implement fallback for empty `trace_name` in v2 queries to use root event's name in `dataModel.ts`.
>     - Update `eventsTracesView` and `eventsObservationsView` to use `COALESCE` for `trace_name` fallback.
>   - **Tests**:
>     - Add test cases in `dashboard-v1-v2-consistency.servertest.ts` to verify fallback behavior for empty `trace_name`.
>     - Ensure tests cover traces, observations, and scores views with the new fallback logic.
>   - **Misc**:
>     - Update `generateEvalObservationId` in `seed-helpers.ts` to include `observationIndex` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for b9878e210d0cdf3cdc0c500d88210fe281a552c6. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->