### PR TITLE
perf(env-filter): make envs cached again

### DIFF
--- a/web/src/hooks/use-environment-filter-options-cache.tsx
+++ b/web/src/hooks/use-environment-filter-options-cache.tsx
@@ -114,7 +114,6 @@ export function useEnvironmentFilterOptionsCache({
             skipBatch: true,
           },
         },
-        refetchOnMount: true,
         refetchOnWindowFocus: false,
         refetchOnReconnect: false,
         staleTime: ttlMs,

--- a/web/src/hooks/use-environment-filter-options-cache.tsx
+++ b/web/src/hooks/use-environment-filter-options-cache.tsx
@@ -1,0 +1,183 @@
+import useLocalStorage from "@/src/components/useLocalStorage";
+import {
+  type TimeRange,
+  toAbsoluteTimeRange,
+} from "@/src/utils/date-range-utils";
+import { api } from "@/src/utils/api";
+import { useMemo, useEffect } from "react";
+
+const ENVIRONMENT_OPTIONS_CACHE_STORAGE_KEY =
+  "langfuse-environment-options-cache-v1";
+
+const MINUTE_MS = 60 * 1000;
+const HALF_HOUR_MS = 30 * MINUTE_MS;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const TTL_30_MINUTES_MS = 0;
+const TTL_1_DAY_MS = 5 * MINUTE_MS;
+const TTL_7_DAYS_MS = 10 * MINUTE_MS;
+const TTL_30_DAYS_MS = 30 * MINUTE_MS;
+const TTL_LONG_MS = 60 * MINUTE_MS;
+
+type EnvironmentOptionsCacheEntry = {
+  options: string[];
+  fetchedAt: number;
+  expiresAt: number;
+};
+
+type EnvironmentOptionsCacheStore = Record<
+  string,
+  EnvironmentOptionsCacheEntry
+>;
+
+const getCacheBucketFromTimeRange = (timeRange: TimeRange) => {
+  if ("range" in timeRange) return `relative:${timeRange.range}`;
+
+  const durationMs = timeRange.to.getTime() - timeRange.from.getTime();
+
+  if (durationMs <= DAY_MS) return "absolute:<=1d";
+  if (durationMs <= 7 * DAY_MS) return "absolute:<=7d";
+  if (durationMs <= 30 * DAY_MS) return "absolute:<=30d";
+  return "absolute:>30d";
+};
+
+const getTtlMsFromTimeRange = (timeRange: TimeRange) => {
+  const absoluteTimeRange = toAbsoluteTimeRange(timeRange);
+  if (!absoluteTimeRange) return TTL_LONG_MS;
+
+  const durationMs =
+    absoluteTimeRange.to.getTime() - absoluteTimeRange.from.getTime();
+
+  if (durationMs <= HALF_HOUR_MS) return TTL_30_MINUTES_MS;
+  if (durationMs <= DAY_MS) return TTL_1_DAY_MS;
+  if (durationMs <= 7 * DAY_MS) return TTL_7_DAYS_MS;
+  if (durationMs <= 30 * DAY_MS) return TTL_30_DAYS_MS;
+  return TTL_LONG_MS;
+};
+
+const pruneExpiredEntries = (
+  store: EnvironmentOptionsCacheStore,
+  now: number,
+) => {
+  return Object.fromEntries(
+    Object.entries(store).filter(([, value]) => value.expiresAt > now),
+  ) as EnvironmentOptionsCacheStore;
+};
+
+const dedupeOptions = (options: string[]) => Array.from(new Set(options));
+
+export function useEnvironmentFilterOptionsCache({
+  projectId,
+  timeRange,
+}: {
+  projectId: string;
+  timeRange: TimeRange;
+}) {
+  const absoluteTimeRange = useMemo(
+    () => toAbsoluteTimeRange(timeRange) ?? undefined,
+    [timeRange],
+  );
+  const cacheBucket = useMemo(
+    () => getCacheBucketFromTimeRange(timeRange),
+    [timeRange],
+  );
+  const ttlMs = useMemo(() => getTtlMsFromTimeRange(timeRange), [timeRange]);
+
+  const cacheEntryKey = `${projectId}:${cacheBucket}`;
+  const [cacheStore, setCacheStore] =
+    useLocalStorage<EnvironmentOptionsCacheStore>(
+      ENVIRONMENT_OPTIONS_CACHE_STORAGE_KEY,
+      {},
+    );
+
+  const prunedCacheStore = useMemo(
+    () => pruneExpiredEntries(cacheStore, Date.now()),
+    [cacheStore],
+  );
+  const cacheEntry = prunedCacheStore[cacheEntryKey];
+  const shouldUseCache = ttlMs > 0;
+  const hasValidCache = Boolean(
+    shouldUseCache && cacheEntry && cacheEntry.expiresAt > Date.now(),
+  );
+
+  // Persist cache cleanup to localStorage when needed.
+  useEffect(() => {
+    if (
+      Object.keys(prunedCacheStore).length !== Object.keys(cacheStore).length
+    ) {
+      setCacheStore(prunedCacheStore);
+    }
+  }, [cacheStore, prunedCacheStore, setCacheStore]);
+
+  const environmentFilterOptions =
+    api.projects.environmentFilterOptions.useQuery(
+      {
+        projectId,
+        fromTimestamp: absoluteTimeRange?.from,
+      },
+      {
+        enabled: Boolean(projectId) && !hasValidCache,
+        trpc: {
+          context: {
+            skipBatch: true,
+          },
+        },
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+        staleTime: Infinity,
+      },
+    );
+
+  useEffect(() => {
+    if (!projectId || !environmentFilterOptions.data) return;
+
+    if (!shouldUseCache) {
+      setCacheStore((previousStore) => {
+        if (!previousStore[cacheEntryKey]) return previousStore;
+        const nextStore = { ...previousStore };
+        delete nextStore[cacheEntryKey];
+        return nextStore;
+      });
+      return;
+    }
+
+    const options = dedupeOptions(
+      environmentFilterOptions.data.map((value) => value.environment),
+    );
+    const nextEntry: EnvironmentOptionsCacheEntry = {
+      options,
+      fetchedAt: Date.now(),
+      expiresAt: Date.now() + ttlMs,
+    };
+
+    setCacheStore((previousStore) => {
+      const nextStore = pruneExpiredEntries(previousStore, Date.now());
+      nextStore[cacheEntryKey] = nextEntry;
+      return nextStore;
+    });
+  }, [
+    projectId,
+    shouldUseCache,
+    cacheEntryKey,
+    environmentFilterOptions.data,
+    ttlMs,
+    setCacheStore,
+  ]);
+
+  const environmentOptions = useMemo(() => {
+    if (hasValidCache && cacheEntry) return cacheEntry.options;
+    return dedupeOptions(
+      environmentFilterOptions.data?.map((value) => value.environment) ?? [],
+    );
+  }, [hasValidCache, cacheEntry, environmentFilterOptions.data]);
+
+  return {
+    environmentOptions,
+    isPending: !hasValidCache && environmentFilterOptions.isPending,
+    isReady:
+      hasValidCache ||
+      environmentFilterOptions.isSuccess ||
+      environmentFilterOptions.isError,
+  };
+}

--- a/web/src/hooks/use-environment-filter-options-cache.tsx
+++ b/web/src/hooks/use-environment-filter-options-cache.tsx
@@ -9,11 +9,12 @@ import { useMemo, useEffect } from "react";
 const ENVIRONMENT_OPTIONS_CACHE_STORAGE_KEY =
   "langfuse-environment-options-cache-v1";
 
+const SECOND_MS = 1000;
 const MINUTE_MS = 60 * 1000;
 const HALF_HOUR_MS = 30 * MINUTE_MS;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-const TTL_30_MINUTES_MS = 0;
+const TTL_30_MINUTES_MS = 30 * SECOND_MS;
 const TTL_1_DAY_MS = 5 * MINUTE_MS;
 const TTL_7_DAYS_MS = 10 * MINUTE_MS;
 const TTL_30_DAYS_MS = 30 * MINUTE_MS;
@@ -33,12 +34,7 @@ type EnvironmentOptionsCacheStore = Record<
 const getCacheBucketFromTimeRange = (timeRange: TimeRange) => {
   if ("range" in timeRange) return `relative:${timeRange.range}`;
 
-  const durationMs = timeRange.to.getTime() - timeRange.from.getTime();
-
-  if (durationMs <= DAY_MS) return "absolute:<=1d";
-  if (durationMs <= 7 * DAY_MS) return "absolute:<=7d";
-  if (durationMs <= 30 * DAY_MS) return "absolute:<=30d";
-  return "absolute:>30d";
+  return `absolute:${timeRange.from.getTime()}:${timeRange.to.getTime()}`;
 };
 
 const getTtlMsFromTimeRange = (timeRange: TimeRange) => {
@@ -77,11 +73,8 @@ export function useEnvironmentFilterOptionsCache({
     () => toAbsoluteTimeRange(timeRange) ?? undefined,
     [timeRange],
   );
-  const cacheBucket = useMemo(
-    () => getCacheBucketFromTimeRange(timeRange),
-    [timeRange],
-  );
-  const ttlMs = useMemo(() => getTtlMsFromTimeRange(timeRange), [timeRange]);
+  const cacheBucket = getCacheBucketFromTimeRange(timeRange);
+  const ttlMs = getTtlMsFromTimeRange(timeRange);
 
   const cacheEntryKey = `${projectId}:${cacheBucket}`;
   const [cacheStore, setCacheStore] =
@@ -95,9 +88,8 @@ export function useEnvironmentFilterOptionsCache({
     [cacheStore],
   );
   const cacheEntry = prunedCacheStore[cacheEntryKey];
-  const shouldUseCache = ttlMs > 0;
   const hasValidCache = Boolean(
-    shouldUseCache && cacheEntry && cacheEntry.expiresAt > Date.now(),
+    cacheEntry && cacheEntry.expiresAt > Date.now(),
   );
 
   // Persist cache cleanup to localStorage when needed.
@@ -122,25 +114,15 @@ export function useEnvironmentFilterOptionsCache({
             skipBatch: true,
           },
         },
-        refetchOnMount: false,
+        refetchOnMount: true,
         refetchOnWindowFocus: false,
         refetchOnReconnect: false,
-        staleTime: Infinity,
+        staleTime: ttlMs,
       },
     );
 
   useEffect(() => {
     if (!projectId || !environmentFilterOptions.data) return;
-
-    if (!shouldUseCache) {
-      setCacheStore((previousStore) => {
-        if (!previousStore[cacheEntryKey]) return previousStore;
-        const nextStore = { ...previousStore };
-        delete nextStore[cacheEntryKey];
-        return nextStore;
-      });
-      return;
-    }
 
     const options = dedupeOptions(
       environmentFilterOptions.data.map((value) => value.environment),
@@ -158,7 +140,6 @@ export function useEnvironmentFilterOptionsCache({
     });
   }, [
     projectId,
-    shouldUseCache,
     cacheEntryKey,
     environmentFilterOptions.data,
     ttlMs,
@@ -167,6 +148,7 @@ export function useEnvironmentFilterOptionsCache({
 
   const environmentOptions = useMemo(() => {
     if (hasValidCache && cacheEntry) return cacheEntry.options;
+
     return dedupeOptions(
       environmentFilterOptions.data?.map((value) => value.environment) ?? [],
     );

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -25,6 +25,7 @@ import {
   toAbsoluteTimeRange,
 } from "@/src/utils/date-range-utils";
 import { useEntitlementLimit } from "@/src/features/entitlements/hooks";
+import { useEnvironmentFilterOptionsCache } from "@/src/hooks/use-environment-filter-options-cache";
 
 interface WidgetPlacement {
   id: string;
@@ -206,28 +207,15 @@ export default function DashboardDetail() {
     },
   );
 
-  const environmentFilterOptions =
-    api.projects.environmentFilterOptions.useQuery(
-      {
-        projectId,
-        fromTimestamp: absoluteTimeRange?.from,
-      },
-      {
-        trpc: {
-          context: {
-            skipBatch: true,
-          },
-        },
-        refetchOnMount: false,
-        refetchOnWindowFocus: false,
-        refetchOnReconnect: false,
-        staleTime: Infinity,
-      },
-    );
-  const environmentOptions =
-    environmentFilterOptions.data?.map((value) => ({
-      value: value.environment,
-    })) || [];
+  const environmentOptionsState = useEnvironmentFilterOptionsCache({
+    projectId,
+    timeRange,
+  });
+  const environmentOptions = environmentOptionsState.environmentOptions.map(
+    (value) => ({
+      value,
+    }),
+  );
   const nameOptions = traceFilterOptions.data?.name || [];
   const tagsOptions = traceFilterOptions.data?.tags || [];
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduce caching for environment filter options to optimize data fetching in dashboard components.
> 
>   - **Caching**:
>     - Introduce `useEnvironmentFilterOptionsCache` in `use-environment-filter-options-cache.tsx` to cache environment filter options.
>     - Cache entries are keyed by `projectId` and time range bucket, with TTLs based on time range duration.
>     - Prunes expired cache entries and deduplicates options.
>   - **Integration**:
>     - Replace direct API calls with `useEnvironmentFilterOptionsCache` in `index.tsx` of both `dashboards/[dashboardId]` and `project/[projectId]`.
>     - Use cached environment options for filter components and loading states.
>   - **UI Changes**:
>     - Add `NoDataOrLoading` component to handle loading states in `project/[projectId]/index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e2faec18870ca1eb524db21696755345819a9a48. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->