### PR TITLE
feat(api): type ObservationsV2Response data field instead of map<string, unknown>

### DIFF
--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -195,6 +195,134 @@ types:
         type: nullable<double>
         docs: The time to the first token in seconds
 
+  # Source: web/src/features/public-api/types/observations.ts - APIObservationV2
+  ObservationV2:
+    docs: |
+      An observation from the v2 API with field-group-based selection.
+      Core fields are always present. Other fields are included only when their field group is requested.
+    properties:
+      # Core fields (always present)
+      id:
+        type: string
+        docs: The unique identifier of the observation
+      traceId:
+        type: nullable<string>
+        docs: The trace ID associated with the observation
+      startTime:
+        type: datetime
+        docs: The start time of the observation
+      endTime:
+        type: nullable<datetime>
+        docs: The end time of the observation
+      projectId:
+        type: string
+        docs: The project ID this observation belongs to
+      parentObservationId:
+        type: nullable<string>
+        docs: The parent observation ID
+      type:
+        type: string
+        docs: The type of the observation (e.g. GENERATION, SPAN, EVENT)
+
+      # Basic fields (field group: basic)
+      name:
+        type: optional<nullable<string>>
+        docs: The name of the observation
+      level:
+        type: optional<ObservationLevel>
+        docs: The level of the observation
+      statusMessage:
+        type: optional<nullable<string>>
+        docs: The status message of the observation
+      version:
+        type: optional<nullable<string>>
+        docs: The version of the observation
+      environment:
+        type: optional<nullable<string>>
+        docs: The environment from which this observation originated
+      bookmarked:
+        type: optional<boolean>
+        docs: Whether the observation is bookmarked
+      public:
+        type: optional<boolean>
+        docs: Whether the observation is public
+      userId:
+        type: optional<nullable<string>>
+        docs: The user ID associated with the observation
+      sessionId:
+        type: optional<nullable<string>>
+        docs: The session ID associated with the observation
+
+      # Time fields (field group: time)
+      completionStartTime:
+        type: optional<nullable<datetime>>
+        docs: The completion start time of the observation
+      createdAt:
+        type: optional<datetime>
+        docs: The creation timestamp of the observation
+      updatedAt:
+        type: optional<datetime>
+        docs: The last update timestamp of the observation
+
+      # IO fields (field group: io)
+      input:
+        type: optional<unknown>
+        docs: The input data of the observation
+      output:
+        type: optional<unknown>
+        docs: The output data of the observation
+
+      # Metadata fields (field group: metadata)
+      metadata:
+        type: optional<unknown>
+        docs: Additional metadata of the observation
+
+      # Model fields (field group: model)
+      providedModelName:
+        type: optional<nullable<string>>
+        docs: The model name as provided by the user
+      internalModelId:
+        type: optional<nullable<string>>
+        docs: The internal model ID matched by Langfuse
+      modelParameters:
+        type: optional<unknown>
+        docs: The parameters of the model used for the observation
+
+      # Usage fields (field group: usage)
+      usageDetails:
+        type: optional<map<string, integer>>
+        docs: The usage details of the observation. Key is the usage metric name, value is the number of units consumed.
+      costDetails:
+        type: optional<map<string, double>>
+        docs: The cost details of the observation. Key is the cost metric name, value is the cost in USD.
+      totalCost:
+        type: optional<nullable<double>>
+        docs: The total cost of the observation in USD
+
+      # Prompt fields (field group: prompt)
+      promptId:
+        type: optional<nullable<string>>
+        docs: The prompt ID associated with the observation
+      promptName:
+        type: optional<nullable<string>>
+        docs: The prompt name associated with the observation
+      promptVersion:
+        type: optional<nullable<integer>>
+        docs: The prompt version associated with the observation
+
+      # Metrics fields (field group: metrics)
+      latency:
+        type: optional<nullable<double>>
+        docs: The latency in seconds
+      timeToFirstToken:
+        type: optional<nullable<double>>
+        docs: The time to first token in seconds
+
+      # Enrichment fields (added by server-side enrichment)
+      modelId:
+        type: optional<nullable<string>>
+        docs: The matched model ID
+
   Usage:
     docs: (Deprecated. Use usageDetails and costDetails instead.) Standard interface for usage and cost
     properties:

--- a/fern/apis/server/definition/observations-v2.yml
+++ b/fern/apis/server/definition/observations-v2.yml
@@ -193,7 +193,7 @@ types:
       Use the `cursor` in `meta` to retrieve the next page of results.
     properties:
       data:
-        type: list<map<string, unknown>>
+        type: list<commons.ObservationV2>
         docs: Array of observation objects. Fields included depend on the `fields` parameter in the request.
       meta: ObservationsV2Meta
 

--- a/packages/shared/src/domain/observations.ts
+++ b/packages/shared/src/domain/observations.ts
@@ -103,7 +103,13 @@ export type Observation = z.infer<typeof ObservationSchema>;
 
 export type ObservationCoreFields = Pick<
   Observation,
-  "id" | "traceId" | "startTime" | "projectId" | "parentObservationId"
+  | "id"
+  | "traceId"
+  | "startTime"
+  | "endTime"
+  | "projectId"
+  | "parentObservationId"
+  | "type"
 >;
 
 export const EventsObservationSchema = ObservationSchema.extend({

--- a/packages/shared/src/server/repositories/observations_converters.ts
+++ b/packages/shared/src/server/repositories/observations_converters.ts
@@ -59,6 +59,7 @@ function ensureObservationCoreFields(
   if (record.trace_id === undefined) missingFields.push("trace_id");
   if (record.start_time === undefined) missingFields.push("start_time");
   if (record.project_id === undefined) missingFields.push("project_id");
+  if (record.type === undefined) missingFields.push("type");
 
   if (missingFields.length > 0) {
     const errorMessage = `Missing required ObservationCoreFields: ${missingFields.join(", ")}${record.id ? ` (record: ${record.id})` : ""}`;
@@ -70,8 +71,12 @@ function ensureObservationCoreFields(
     id: record.id!,
     traceId: record.trace_id ?? null,
     startTime: parseClickhouseUTCDateTimeFormat(record.start_time!),
+    endTime: record.end_time
+      ? parseClickhouseUTCDateTimeFormat(record.end_time)
+      : null,
     projectId: record.project_id!,
     parentObservationId: record.parent_observation_id ?? null,
+    type: record.type! as ObservationType,
   };
 }
 

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -9258,6 +9258,165 @@ components:
       required:
         - modelName
         - matchPattern
+    ObservationV2:
+      title: ObservationV2
+      type: object
+      description: >-
+        An observation from the v2 API with field-group-based selection.
+
+        Core fields are always present. Other fields are included only when
+        their field group is requested.
+      properties:
+        id:
+          type: string
+          description: The unique identifier of the observation
+        traceId:
+          type: string
+          nullable: true
+          description: The trace ID associated with the observation
+        startTime:
+          type: string
+          format: date-time
+          description: The start time of the observation
+        endTime:
+          type: string
+          format: date-time
+          nullable: true
+          description: The end time of the observation
+        projectId:
+          type: string
+          description: The project ID this observation belongs to
+        parentObservationId:
+          type: string
+          nullable: true
+          description: The parent observation ID
+        type:
+          type: string
+          description: The type of the observation (e.g. GENERATION, SPAN, EVENT)
+        name:
+          type: string
+          nullable: true
+          description: The name of the observation
+        level:
+          $ref: '#/components/schemas/ObservationLevel'
+          nullable: true
+          description: The level of the observation
+        statusMessage:
+          type: string
+          nullable: true
+          description: The status message of the observation
+        version:
+          type: string
+          nullable: true
+          description: The version of the observation
+        environment:
+          type: string
+          nullable: true
+          description: The environment from which this observation originated
+        bookmarked:
+          type: boolean
+          nullable: true
+          description: Whether the observation is bookmarked
+        public:
+          type: boolean
+          nullable: true
+          description: Whether the observation is public
+        userId:
+          type: string
+          nullable: true
+          description: The user ID associated with the observation
+        sessionId:
+          type: string
+          nullable: true
+          description: The session ID associated with the observation
+        completionStartTime:
+          type: string
+          format: date-time
+          nullable: true
+          description: The completion start time of the observation
+        createdAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: The creation timestamp of the observation
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: The last update timestamp of the observation
+        input:
+          nullable: true
+          description: The input data of the observation
+        output:
+          nullable: true
+          description: The output data of the observation
+        metadata:
+          nullable: true
+          description: Additional metadata of the observation
+        providedModelName:
+          type: string
+          nullable: true
+          description: The model name as provided by the user
+        internalModelId:
+          type: string
+          nullable: true
+          description: The internal model ID matched by Langfuse
+        modelParameters:
+          nullable: true
+          description: The parameters of the model used for the observation
+        usageDetails:
+          type: object
+          additionalProperties:
+            type: integer
+          nullable: true
+          description: >-
+            The usage details of the observation. Key is the usage metric name,
+            value is the number of units consumed.
+        costDetails:
+          type: object
+          additionalProperties:
+            type: number
+            format: double
+          nullable: true
+          description: >-
+            The cost details of the observation. Key is the cost metric name,
+            value is the cost in USD.
+        totalCost:
+          type: number
+          format: double
+          nullable: true
+          description: The total cost of the observation in USD
+        promptId:
+          type: string
+          nullable: true
+          description: The prompt ID associated with the observation
+        promptName:
+          type: string
+          nullable: true
+          description: The prompt name associated with the observation
+        promptVersion:
+          type: integer
+          nullable: true
+          description: The prompt version associated with the observation
+        latency:
+          type: number
+          format: double
+          nullable: true
+          description: The latency in seconds
+        timeToFirstToken:
+          type: number
+          format: double
+          nullable: true
+          description: The time to first token in seconds
+        modelId:
+          type: string
+          nullable: true
+          description: The matched model ID
+      required:
+        - id
+        - startTime
+        - projectId
+        - type
     ObservationsV2Response:
       title: ObservationsV2Response
       type: object
@@ -9274,8 +9433,7 @@ components:
         data:
           type: array
           items:
-            type: object
-            additionalProperties: true
+            $ref: '#/components/schemas/ObservationV2'
           description: >-
             Array of observation objects. Fields included depend on the `fields`
             parameter in the request.

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -353,9 +353,72 @@ export const GetObservationsV2Query = z.object({
     .pipe(z.array(singleFilter).optional()),
 });
 
+/**
+ * Typed observation schema for v2 API responses.
+ * Core fields are always present; other fields are optional depending on requested field groups.
+ * Uses .passthrough() to allow server enrichment fields not explicitly listed.
+ */
+const APIObservationV2 = z
+  .object({
+    // Core fields (always present)
+    id: z.string(),
+    traceId: z.string().nullable(),
+    startTime: z.coerce.date(),
+    endTime: z.coerce.date().nullable(),
+    projectId: z.string(),
+    parentObservationId: z.string().nullable(),
+    type: z.string(),
+
+    // Basic fields (field group: basic)
+    name: z.string().nullable().optional(),
+    level: z.enum(["DEBUG", "DEFAULT", "WARNING", "ERROR"]).optional(),
+    statusMessage: z.string().nullable().optional(),
+    version: z.string().nullable().optional(),
+    environment: z.string().nullable().optional(),
+    bookmarked: z.boolean().optional(),
+    public: z.boolean().optional(),
+    userId: z.string().nullable().optional(),
+    sessionId: z.string().nullable().optional(),
+
+    // Time fields (field group: time)
+    completionStartTime: z.coerce.date().nullable().optional(),
+    createdAt: z.coerce.date().optional(),
+    updatedAt: z.coerce.date().optional(),
+
+    // IO fields (field group: io)
+    input: z.any().optional(),
+    output: z.any().optional(),
+
+    // Metadata fields (field group: metadata)
+    metadata: z.any().optional(),
+
+    // Model fields (field group: model)
+    providedModelName: z.string().nullable().optional(),
+    internalModelId: z.string().nullable().optional(),
+    modelParameters: z.any().optional(),
+
+    // Usage fields (field group: usage)
+    usageDetails: z.record(z.string(), z.number().nonnegative()).optional(),
+    costDetails: z.record(z.string(), z.number().nonnegative()).optional(),
+    totalCost: z.number().nullable().optional(),
+
+    // Prompt fields (field group: prompt)
+    promptId: z.string().nullable().optional(),
+    promptName: z.string().nullable().optional(),
+    promptVersion: z.number().int().positive().nullable().optional(),
+
+    // Metrics fields (field group: metrics)
+    latency: z.number().nullable().optional(),
+    timeToFirstToken: z.number().nullable().optional(),
+
+    // Enrichment fields
+    modelId: z.string().nullable().optional(),
+  })
+  .passthrough();
+
 export const GetObservationsV2Response = z
   .object({
-    data: z.array(z.record(z.string(), z.any())), // Field-group-filtered observations
+    data: z.array(APIObservationV2),
     meta: z.object({
       cursor: EncodedObservationsCursorV2String.optional(),
     }),


### PR DESCRIPTION
Define ObservationV2 type in Fern with core fields required and field-group fields optional, so SDK users get autocomplete and type safety instead of Record<string, unknown>.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduce `ObservationV2` type for `ObservationsV2Response` data field, enhancing type safety and autocomplete for SDK users.
> 
>   - **Behavior**:
>     - Replace `map<string, unknown>` with `ObservationV2` in `ObservationsV2Response` data field in `observations-v2.yml`.
>     - `ObservationV2` type includes core fields (always present) and optional field groups.
>   - **Schema**:
>     - Define `ObservationV2` type in `observations-v2.yml` with core and optional fields.
>     - Update `APIObservationV2` schema in `observations.ts` to match `ObservationV2` structure.
>   - **Functions**:
>     - Update `ensureObservationCoreFields` in `observations_converters.ts` to require `type` field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 709ab4288e7efb774bac7a548a629216b41a03a3. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->