### PR TITLE
docs(evals): position observation-level evals as recommended approach

### DIFF
--- a/web/src/components/ui/callout.tsx
+++ b/web/src/components/ui/callout.tsx
@@ -1,7 +1,7 @@
 import { Alert, AlertDescription } from "@/src/components/ui/alert";
 import { Button } from "@/src/components/ui/button";
 import useLocalStorage from "@/src/components/useLocalStorage";
-import { Info, AlertTriangle, X } from "lucide-react";
+import { X } from "lucide-react";
 import { useEffect, useState } from "react";
 
 const DEFAULT_STORAGE_KEY = "dismissed-callouts";
@@ -75,7 +75,6 @@ export function Callout({
 
   if (!isVisible) return null;
 
-  const Icon = variant === "warning" ? AlertTriangle : Info;
   const variantClass =
     variant === "warning"
       ? "border-light-yellow bg-light-yellow dark:border-light-yellow dark:bg-light-yellow"
@@ -89,13 +88,6 @@ export function Callout({
 
   return (
     <Alert className={`${variantClass} ${alignmentOverrides}`}>
-      <Icon
-        className={`h-4 w-4 ${
-          variant === "warning"
-            ? "text-dark-yellow dark:text-dark-yellow"
-            : "text-dark-blue dark:text-dark-blue"
-        }`}
-      />
       <AlertDescription
         className={`flex ${alignmentClass} ml-1 justify-between`}
       >

--- a/web/src/features/evals/components/eval-version-callout.tsx
+++ b/web/src/features/evals/components/eval-version-callout.tsx
@@ -1,5 +1,5 @@
 import { Alert, AlertDescription } from "@/src/components/ui/alert";
-import { Info } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import { type EvalCapabilities } from "@/src/features/evals/hooks/useEvalCapabilities";
 import {
   isTraceTarget,
@@ -145,9 +145,9 @@ export function EvalVersionCallout({
   return (
     <Alert
       variant="default"
-      className="mt-2 max-w-4xl border-light-blue bg-light-blue"
+      className="mt-2 max-w-4xl border-dark-yellow bg-light-yellow"
     >
-      <Info className="h-4 w-4 text-dark-blue dark:text-dark-blue" />
+      <AlertTriangle className="h-4 w-4 text-dark-yellow" />
       <AlertDescription>
         <div className="flex flex-col gap-2">
           <div className="flex flex-col gap-1">

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -69,7 +69,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
-import { useIsObservationEvalsFullyReleased } from "@/src/features/events/hooks/useObservationEvals";
 
 export type EvaluatorDataRow = {
   id: string;
@@ -135,7 +134,6 @@ function LegacyBadgeCell({ status }: { status: string }) {
 }
 
 export default function EvaluatorTable({ projectId }: { projectId: string }) {
-  const isFullyReleased = useIsObservationEvalsFullyReleased();
   const router = useRouter();
   const { setDetailPageList } = useDetailPageLists();
   const [paginationState, setPaginationState] = usePaginationState(0, 50, {
@@ -329,25 +327,21 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       enableSorting: true,
       size: 150,
     }),
-    ...(isFullyReleased
-      ? [
-          columnHelper.accessor("isLegacy", {
-            id: "isLegacy",
-            header: "Eval Version",
-            size: 180,
-            enableHiding: true,
-            cell: (row) => {
-              const targetObject = row.row.original.target;
-              const status = row.row.original.status;
-              const isDeprecated = isLegacyEvalTarget(targetObject);
+    columnHelper.accessor("isLegacy", {
+      id: "isLegacy",
+      header: "Eval Version",
+      size: 180,
+      enableHiding: true,
+      cell: (row) => {
+        const targetObject = row.row.original.target;
+        const status = row.row.original.status;
+        const isDeprecated = isLegacyEvalTarget(targetObject);
 
-              if (!isDeprecated) return null;
+        if (!isDeprecated) return null;
 
-              return <LegacyBadgeCell status={status} />;
-            },
-          }),
-        ]
-      : []),
+        return <LegacyBadgeCell status={status} />;
+      },
+    }),
     columnHelper.accessor("target", {
       id: "target",
       header: "Runs on",
@@ -512,11 +506,11 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       defaultSidebarCollapsed={evaluatorFilterConfig.defaultSidebarCollapsed}
     >
       <div className="flex h-full w-full flex-col">
-        {isFullyReleased && hasLegacyEvals && (
+        {hasLegacyEvals && (
           <div className="p-2 pb-0">
             <Callout
               id="eval-remapping-table"
-              variant="info"
+              variant="warning"
               key="dismissed-eval-remapping-callouts"
             >
               <span>New LLM-as-a-Judge functionality has landed. </span>

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -122,7 +122,9 @@ function LegacyBadgeCell({ status }: { status: string }) {
                   >
                     this guide
                   </Link>{" "}
-                  to upgrade to the new version.
+                  to upgrade to the new version. <br /> <br /> If you do not
+                  upgrade, your evaluator will continue to run, but you will not
+                  benefit from improvements.
                 </p>
               </div>
             </TooltipContent>
@@ -513,12 +515,12 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
               variant="warning"
               key="dismissed-eval-remapping-callouts"
             >
-              <span>New LLM-as-a-Judge functionality has landed. </span>
+              <span>New functionality has landed. </span>
               <span className="font-semibold">
                 Some of your evaluators (marked &quot;Legacy&quot;) require
                 changes{" "}
               </span>
-              <span>for new features and improvements. </span>
+              <span>to benefit from new features and improvements. </span>
               <Link
                 href="https://langfuse.com/faq/all/llm-as-a-judge-migration"
                 target="_blank"
@@ -528,6 +530,15 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
                 Learn what is changing and how to upgrade
               </Link>
               <span>.</span>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Info className="ml-1 inline h-4 w-4 cursor-help" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  Your evaluator will continue to work without upgrading, but
+                  you will not benefit from performance improvements.
+                </TooltipContent>
+              </Tooltip>
             </Callout>
           </div>
         )}

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -61,6 +61,7 @@ import {
 import { type PartialConfig } from "@/src/features/evals/types";
 import { type EvalCapabilities } from "@/src/features/evals/hooks/useEvalCapabilities";
 import { EvalVersionCallout } from "@/src/features/evals/components/eval-version-callout";
+import { Callout } from "@/src/components/ui/callout";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import {
   Dialog,
@@ -101,7 +102,6 @@ import {
 } from "@/src/features/evals/utils/evaluator-constants";
 import { useEvalConfigFilterOptions } from "@/src/features/evals/hooks/useEvalConfigFilterOptions";
 import { VariableMappingCard } from "@/src/features/evals/components/variable-mapping-card";
-import { useIsObservationEvalsFullyReleased } from "@/src/features/events/hooks/useObservationEvals";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 
 /**
@@ -278,7 +278,6 @@ export const InnerEvaluatorForm = (props: {
   oldConfigId?: string;
 }) => {
   const [formError, setFormError] = useState<string | null>(null);
-  const isFullyReleased = useIsObservationEvalsFullyReleased();
   const capture = usePostHogClientCapture();
   const router = useRouter();
   const [showTraceConfirmDialog, setShowTraceConfirmDialog] = useState(false);
@@ -391,12 +390,32 @@ export const InnerEvaluatorForm = (props: {
     ),
   );
 
+  const hasObservationTargetsInTraceEval = useMemo(() => {
+    if (props.mode === "edit") return false;
+
+    const target = form.watch("target");
+    if (!isTraceTarget(target)) return false;
+
+    const mapping = form.watch("mapping");
+    return mapping.some(
+      (m) => m.langfuseObject && m.langfuseObject !== "trace",
+    );
+  }, [form.watch("target"), form.watch("mapping"), props.mode]);
+
   function onSubmit(values: z.infer<typeof evalConfigFormSchema>) {
     capture(
       props.mode === "edit"
         ? "eval_config:update"
         : "eval_config:new_form_submit",
     );
+
+    // Block NEW trace-level evals that target observations
+    if (hasObservationTargetsInTraceEval) {
+      setFormError(
+        "Trace-level evaluators targeting observations are no longer supported. Please use observation-level evaluators instead.",
+      );
+      return;
+    }
 
     // Apply preprocessFormValues if it exists
     if (props.preprocessFormValues) {
@@ -624,13 +643,6 @@ export const InnerEvaluatorForm = (props: {
                           >
                             <CircleDot className="h-3.5 w-3.5" />
                             Observations
-                            <Badge
-                              variant="secondary"
-                              size="sm"
-                              className="border border-border font-normal"
-                            >
-                              Beta
-                            </Badge>
                           </TabsTrigger>
                           {allowLegacy && (
                             <TabsTrigger
@@ -640,15 +652,13 @@ export const InnerEvaluatorForm = (props: {
                             >
                               <ListTree className="h-3.5 w-3.5" />
                               Traces
-                              {isFullyReleased && (
-                                <Badge
-                                  variant="secondary"
-                                  size="sm"
-                                  className="border border-border font-normal"
-                                >
-                                  Legacy
-                                </Badge>
-                              )}
+                              <Badge
+                                variant="secondary"
+                                size="sm"
+                                className="border border-border font-normal"
+                              >
+                                Legacy
+                              </Badge>
                             </TabsTrigger>
                           )}
                           <TabsTrigger
@@ -714,13 +724,6 @@ export const InnerEvaluatorForm = (props: {
                       >
                         <FlaskConical className="h-3.5 w-3.5" />
                         Experiment Runner SDK
-                        <Badge
-                          variant="secondary"
-                          size="sm"
-                          className="border border-border font-normal"
-                        >
-                          Beta
-                        </Badge>
                       </TabsTrigger>
                       <TabsTrigger
                         value="non-otel"
@@ -729,15 +732,13 @@ export const InnerEvaluatorForm = (props: {
                       >
                         <BetweenHorizonalStart className="h-3.5 w-3.5" />
                         Low-level SDK methods
-                        {isFullyReleased && (
-                          <Badge
-                            variant="secondary"
-                            size="sm"
-                            className="border border-border font-normal"
-                          >
-                            Legacy
-                          </Badge>
-                        )}
+                        <Badge
+                          variant="secondary"
+                          size="sm"
+                          className="border border-border font-normal"
+                        >
+                          Legacy
+                        </Badge>
                       </TabsTrigger>
                     </TabsList>
                   </Tabs>
@@ -1063,6 +1064,24 @@ export const InnerEvaluatorForm = (props: {
             )}
           </div>
         </Card>
+      )}
+      {hasObservationTargetsInTraceEval && (
+        <Callout variant="warning" id="trace-observation-eval-warning">
+          <span className="font-semibold">
+            Trace-level evaluators targeting observations are no longer
+            supported.
+          </span>{" "}
+          Please use observation-level evaluators instead for improved
+          performance and functionality.{" "}
+          <a
+            href="https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline hover:opacity-80"
+          >
+            Learn more
+          </a>
+        </Callout>
       )}
       <VariableMappingCard
         projectId={props.projectId}

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -391,17 +391,16 @@ export const InnerEvaluatorForm = (props: {
   );
 
   const watchedTarget = form.watch("target");
-  const watchedMapping = form.watch("mapping");
 
-  const hasObservationTargetsInTraceEval = useMemo(() => {
-    if (props.mode === "edit") return false;
-
-    if (!isTraceTarget(watchedTarget)) return false;
-
-    return watchedMapping.some(
-      (m) => m.langfuseObject && m.langfuseObject !== "trace",
-    );
-  }, [watchedTarget, watchedMapping, props.mode]);
+  // Clear mapping error if user switches away from trace target
+  useEffect(() => {
+    if (
+      !isTraceTarget(watchedTarget) &&
+      form.formState.errors.mapping?.type === "manual"
+    ) {
+      form.clearErrors("mapping");
+    }
+  }, [watchedTarget, form]);
 
   function onSubmit(values: z.infer<typeof evalConfigFormSchema>) {
     capture(
@@ -409,14 +408,6 @@ export const InnerEvaluatorForm = (props: {
         ? "eval_config:update"
         : "eval_config:new_form_submit",
     );
-
-    // Block NEW trace-level evals that target observations
-    if (hasObservationTargetsInTraceEval) {
-      setFormError(
-        "Trace-level evaluators targeting observations are no longer supported. Please use observation-level evaluators instead.",
-      );
-      return;
-    }
 
     // Apply preprocessFormValues if it exists
     if (props.preprocessFormValues) {
@@ -449,6 +440,22 @@ export const InnerEvaluatorForm = (props: {
       form.setError("filter", {
         type: "manual",
         message: "Please fill out all filter fields",
+      });
+      return;
+    }
+
+    // Block NEW trace-level evals that target observations
+    if (
+      props.mode !== "edit" &&
+      isTraceTarget(values.target) &&
+      values.mapping.some(
+        (m) => m.langfuseObject && m.langfuseObject !== "trace",
+      )
+    ) {
+      form.setError("mapping", {
+        type: "manual",
+        message:
+          "Trace-level evaluators targeting observations are no longer supported. Please use observation-level evaluators or target trace IO instead.",
       });
       return;
     }
@@ -1065,24 +1072,6 @@ export const InnerEvaluatorForm = (props: {
             )}
           </div>
         </Card>
-      )}
-      {hasObservationTargetsInTraceEval && (
-        <Callout variant="warning" id="trace-observation-eval-warning">
-          <span className="font-semibold">
-            Trace-level evaluators targeting observations are no longer
-            supported.
-          </span>{" "}
-          Please use observation-level evaluators instead for improved
-          performance and functionality.{" "}
-          <a
-            href="https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="font-medium underline hover:opacity-80"
-          >
-            Learn more
-          </a>
-        </Callout>
       )}
       <VariableMappingCard
         projectId={props.projectId}

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -61,7 +61,6 @@ import {
 import { type PartialConfig } from "@/src/features/evals/types";
 import { type EvalCapabilities } from "@/src/features/evals/hooks/useEvalCapabilities";
 import { EvalVersionCallout } from "@/src/features/evals/components/eval-version-callout";
-import { Callout } from "@/src/components/ui/callout";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import {
   Dialog,

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -390,17 +390,18 @@ export const InnerEvaluatorForm = (props: {
     ),
   );
 
+  const watchedTarget = form.watch("target");
+  const watchedMapping = form.watch("mapping");
+
   const hasObservationTargetsInTraceEval = useMemo(() => {
     if (props.mode === "edit") return false;
 
-    const target = form.watch("target");
-    if (!isTraceTarget(target)) return false;
+    if (!isTraceTarget(watchedTarget)) return false;
 
-    const mapping = form.watch("mapping");
-    return mapping.some(
+    return watchedMapping.some(
       (m) => m.langfuseObject && m.langfuseObject !== "trace",
     );
-  }, [form.watch("target"), form.watch("mapping"), props.mode]);
+  }, [watchedTarget, watchedMapping, props.mode]);
 
   function onSubmit(values: z.infer<typeof evalConfigFormSchema>) {
     capture(

--- a/web/src/features/evals/components/legacy-eval-callout.tsx
+++ b/web/src/features/evals/components/legacy-eval-callout.tsx
@@ -23,7 +23,7 @@ export function LegacyEvalCallout({
   return (
     <Callout
       id={`eval-remapping-peek-${evalConfigId}`}
-      variant="info"
+      variant="warning"
       key="dismissed-eval-remapping-callouts"
       actions={() => (
         <>

--- a/web/src/features/evals/components/legacy-eval-callout.tsx
+++ b/web/src/features/evals/components/legacy-eval-callout.tsx
@@ -1,7 +1,13 @@
 import { Callout } from "@/src/components/ui/callout";
 import { Button } from "@/src/components/ui/button";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/src/components/ui/tooltip";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { Info } from "lucide-react";
 import { isLegacyEvalTarget } from "@/src/features/evals/utils/typeHelpers";
 
 interface LegacyEvalCalloutProps {
@@ -52,10 +58,16 @@ export function LegacyEvalCallout({
           requires changes{" "}
         </Link>
       </span>
-      <span>
-        to benefit from new features and performance improvements. Upgrade for
-        full compatibility.
-      </span>
+      <span>to benefit from new features and performance improvements.</span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Info className="ml-1 inline h-4 w-4 cursor-help" />
+        </TooltipTrigger>
+        <TooltipContent>
+          Your evaluator will continue to work without upgrading, but you will
+          not benefit from improvements.
+        </TooltipContent>
+      </Tooltip>
     </Callout>
   );
 }

--- a/web/src/features/evals/components/template-selector.tsx
+++ b/web/src/features/evals/components/template-selector.tsx
@@ -37,7 +37,6 @@ import {
 import { useSingleTemplateValidation } from "@/src/features/evals/hooks/useSingleTemplateValidation";
 import { getMaintainer } from "@/src/features/evals/utils/typeHelpers";
 import { MaintainerTooltip } from "@/src/features/evals/components/maintainer-tooltip";
-import { useIsObservationEvalsFullyReleased } from "@/src/features/events/hooks/useObservationEvals";
 
 type TemplateSelectorProps = {
   projectId: string;
@@ -68,7 +67,6 @@ export const TemplateSelector = ({
 }: TemplateSelectorProps) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [search, setSearch] = useState("");
-  const isFullyReleased = useIsObservationEvalsFullyReleased();
   const {
     activeTemplates,
     isTemplateActive,
@@ -224,7 +222,7 @@ export const TemplateSelector = ({
                               <div className="mr-2 h-4 w-4" />
                             )}
                             {name}
-                            {isFullyReleased && isLegacy && (
+                            {isLegacy && (
                               <Badge variant="outline" className="ml-2 text-xs">
                                 legacy
                               </Badge>
@@ -316,7 +314,7 @@ export const TemplateSelector = ({
                           <MaintainerTooltip
                             maintainer={getMaintainer(latestTemplate)}
                           />
-                          {isFullyReleased && isLegacy && (
+                          {isLegacy && (
                             <Badge variant="outline" className="ml-2 text-xs">
                               legacy
                             </Badge>

--- a/web/src/features/events/hooks/useObservationEvals.ts
+++ b/web/src/features/events/hooks/useObservationEvals.ts
@@ -1,3 +1,0 @@
-export function useIsObservationEvalsFullyReleased() {
-  return false;
-}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Promotes observation-level evaluations as the recommended approach, deprecating trace-level evaluations and updating UI components accordingly.
> 
>   - **Behavior**:
>     - Deprecates trace-level evaluators targeting observations in `inner-evaluator-form.tsx`, blocking new configurations and displaying warnings.
>     - Updates `EvalVersionCallout` in `eval-version-callout.tsx` to recommend observation evaluators over trace evaluators.
>   - **UI Components**:
>     - Changes alert icon from `Info` to `AlertTriangle` in `eval-version-callout.tsx`.
>     - Updates callout variants from `info` to `warning` in `evaluator-table.tsx` and `legacy-eval-callout.tsx`.
>     - Removes `Beta` badge from `inner-evaluator-form.tsx` and `template-selector.tsx`.
>   - **Code Cleanup**:
>     - Removes `useIsObservationEvalsFullyReleased` hook from `evaluator-table.tsx`, `inner-evaluator-form.tsx`, and `template-selector.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for ef1dca1e2dce2aff5d889c6011243ac349d266c4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->