### PR TITLE
fix(dashboard): add filterSql for correct Trace Name filtering on events_traces view

### DIFF
--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -5,6 +5,7 @@ export {
   type ObservationPriceFields,
 } from "./createGenerationsQuery";
 export {
+  type Filter,
   FilterList,
   StringFilter,
   DateTimeFilter,

--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -176,7 +176,8 @@ export const eventsTracesView: ViewDeclarationType = {
       // First try most-recent non-empty trace_name, then fall back to root event's name
       aggregationFunction:
         "COALESCE(nullIf(argMaxIf(events_traces.trace_name, events_traces.event_ts, events_traces.trace_name <> ''), ''), argMaxIf(events_traces.name, events_traces.event_ts, events_traces.parent_span_id = '' AND events_traces.name <> ''))",
-      // having defaults to aggregationFunction above
+      // Pruning columns for WHERE: OR'd together to help ClickHouse skip blocks,
+      // then dimension.sql is AND'd for exact row-level match.
       filterSql: {
         where: ["events_traces.trace_name", "events_traces.name"],
       },

--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -176,6 +176,10 @@ export const eventsTracesView: ViewDeclarationType = {
       // First try most-recent non-empty trace_name, then fall back to root event's name
       aggregationFunction:
         "COALESCE(nullIf(argMaxIf(events_traces.trace_name, events_traces.event_ts, events_traces.trace_name <> ''), ''), argMaxIf(events_traces.name, events_traces.event_ts, events_traces.parent_span_id = '' AND events_traces.name <> ''))",
+      // having defaults to aggregationFunction above
+      filterSql: {
+        where: ["events_traces.trace_name", "events_traces.name"],
+      },
     },
     tags: {
       sql: "events_traces.tags",

--- a/web/src/features/query/server/queryBuilder.ts
+++ b/web/src/features/query/server/queryBuilder.ts
@@ -281,7 +281,10 @@ export class QueryBuilder {
       return filters[0].apply();
     });
     const pruneQuery = `(${pruneApplied.map((p) => p.query).join(" OR ")})`;
-    const pruneParams = Object.assign({}, ...pruneApplied.map((p) => p.params));
+    const pruneParams = pruneApplied.reduce<Record<string, unknown>>(
+      (acc, p) => ({ ...acc, ...p.params }),
+      {},
+    );
 
     // Exact match: filter on the dimension's row-level sql expression
     const exactFilters = createFilterFromFilterState(
@@ -349,6 +352,14 @@ export class QueryBuilder {
         if (dimension.relationTable) {
           clickhouseTableName = dimension.relationTable;
         }
+        // Filters on measures are underdefined and not allowed in the initial version
+        // } else if (filter.column in view.measures) {
+        //   const measure = view.measures[filter.column];
+        //   clickhouseSelect = measure.sql;
+        //   type = measure.type;
+        //   if (measure.relationTable) {
+        //     clickhouseTableName = measure.relationTable;
+        //   }
       } else if (filter.column === view.timeDimension) {
         clickhouseSelect = view.timeDimension;
         queryPrefix = clickhouseTableName;
@@ -358,7 +369,9 @@ export class QueryBuilder {
         queryPrefix = clickhouseTableName;
         type = "stringObject";
       } else if (filter.column.endsWith("Name")) {
-        // Fallback for *Name columns when no "name" dimension exists (LFE-4838)
+        // Sometimes, the filter does not update correctly and sends us scoreName instead of name for scores, etc.
+        // If this happens, none of the conditions above apply, and we use this fallback to avoid raising an error.
+        // As this is hard to catch, we include this workaround. (LFE-4838).
         clickhouseSelect = "name";
         queryPrefix = clickhouseTableName;
         type = "string";
@@ -812,20 +825,13 @@ export class QueryBuilder {
       .join(",\n");
   }
 
-  private buildInnerSelect(params: {
-    view: ViewDeclarationType;
-    innerDimensionsPart: string;
-    innerMetricsPart: string;
-    fromClause: string;
-    appliedDimensions: AppliedDimensionType[];
-  }) {
-    const {
-      view,
-      innerDimensionsPart,
-      innerMetricsPart,
-      fromClause,
-      appliedDimensions,
-    } = params;
+  private buildInnerSelect(
+    view: ViewDeclarationType,
+    innerDimensionsPart: string,
+    innerMetricsPart: string,
+    fromClause: string,
+    appliedDimensions: AppliedDimensionType[],
+  ) {
     const actualTableName = this.actualTableName(view);
     // Use actual SQL from view definition for id column (handles events.span_id -> id mapping)
     const idSql = view.dimensions.id?.sql || `${actualTableName}.id`;
@@ -1405,13 +1411,13 @@ export class QueryBuilder {
       const innerMetricsPart = this.buildInnerMetricsPart(appliedMetrics);
 
       // Build inner SELECT
-      const innerQuery = this.buildInnerSelect({
+      const innerQuery = this.buildInnerSelect(
         view,
         innerDimensionsPart,
         innerMetricsPart,
         fromClause,
         appliedDimensions,
-      });
+      );
 
       // Build outer SELECT parts
       const outerDimensionsPart = this.buildOuterDimensionsPart(

--- a/web/src/features/query/server/queryBuilder.ts
+++ b/web/src/features/query/server/queryBuilder.ts
@@ -48,7 +48,6 @@ type RawSqlPart = { query: string; params: Record<string, unknown> };
 type MappedFilters = {
   whereFilters: Filter[];
   whereRawParts: RawSqlPart[];
-  havingParts: RawSqlPart[];
 };
 
 export class QueryBuilder {
@@ -248,60 +247,53 @@ export class QueryBuilder {
   }
 
   /**
-   * Builds an OR'd WHERE clause for pre-aggregation row pruning.
-   * Creates one filter per column via createFilterFromFilterState, applies each,
-   * and joins the SQL with OR.
+   * Builds a WHERE condition for a filterSql dimension:
+   *   (col1 OP X OR col2 OP X) AND dimensionSql OP X
+   *
+   * The OR'd part is pruning-friendly (helps ClickHouse skip blocks).
+   * The exact part uses the dimension's row-level sql expression for correctness.
+   * Both delegate to createFilterFromFilterState for full operator/type support.
    */
-  private buildFilterSqlWherePrune(params: {
+  private buildFilterSqlWhereCondition(params: {
     filter: z.infer<typeof queryModel>["filters"][number];
     whereCols: string[];
+    dimensionSql: string;
     tableName: string;
   }): RawSqlPart {
-    const { filter, whereCols, tableName } = params;
+    const { filter, whereCols, dimensionSql, tableName } = params;
+
+    const syntheticMapping = (clickhouseSelect: string) => [
+      {
+        uiTableName: filter.column,
+        uiTableId: filter.column,
+        clickhouseTableName: tableName,
+        clickhouseSelect,
+        queryPrefix: "",
+      },
+    ];
+
+    // Pruning: one filter per where column, OR'd together
     const pruneApplied = whereCols.map((col) => {
       const filters = createFilterFromFilterState(
         [filter],
-        [
-          {
-            uiTableName: filter.column,
-            uiTableId: filter.column,
-            clickhouseTableName: tableName,
-            clickhouseSelect: col,
-            queryPrefix: "",
-          },
-        ],
+        syntheticMapping(col),
       );
       return filters[0].apply();
     });
-    return {
-      query: `(${pruneApplied.map((p) => p.query).join(" OR ")})`,
-      params: Object.assign({}, ...pruneApplied.map((p) => p.params)),
-    };
-  }
+    const pruneQuery = `(${pruneApplied.map((p) => p.query).join(" OR ")})`;
+    const pruneParams = Object.assign({}, ...pruneApplied.map((p) => p.params));
 
-  /**
-   * Builds a HAVING clause for post-aggregation exact matching.
-   * Creates a filter via createFilterFromFilterState using the aggregation expression.
-   */
-  private buildFilterSqlHaving(params: {
-    filter: z.infer<typeof queryModel>["filters"][number];
-    havingExpression: string;
-    tableName: string;
-  }): RawSqlPart {
-    const { filter, havingExpression, tableName } = params;
-    const filters = createFilterFromFilterState(
+    // Exact match: filter on the dimension's row-level sql expression
+    const exactFilters = createFilterFromFilterState(
       [filter],
-      [
-        {
-          uiTableName: filter.column,
-          uiTableId: filter.column,
-          clickhouseTableName: tableName,
-          clickhouseSelect: havingExpression,
-          queryPrefix: "",
-        },
-      ],
+      syntheticMapping(dimensionSql),
     );
-    return filters[0].apply();
+    const exactApplied = exactFilters[0].apply();
+
+    return {
+      query: `${pruneQuery} AND ${exactApplied.query}`,
+      params: { ...pruneParams, ...exactApplied.params },
+    };
   }
 
   private mapFilters(
@@ -316,7 +308,6 @@ export class QueryBuilder {
     const result: MappedFilters = {
       whereFilters: [],
       whereRawParts: [],
-      havingParts: [],
     };
 
     // Separate filters into normal (createFilterFromFilterState) and filterSql-aware
@@ -333,27 +324,13 @@ export class QueryBuilder {
     for (const filter of filters) {
       const dimension = this.resolveDimension(filter.column, view);
 
-      // Dimension with filterSql: delegate to existing filter infrastructure
+      // Dimension with filterSql: pruning OR + exact match, both in WHERE
       if (dimension?.filterSql) {
-        const having =
-          dimension.filterSql.having ?? dimension.aggregationFunction;
-        if (!having) {
-          throw new InvalidRequestError(
-            `Dimension '${filter.column}' has filterSql.where but no having expression and no aggregationFunction to fall back to.`,
-          );
-        }
-
         result.whereRawParts.push(
-          this.buildFilterSqlWherePrune({
+          this.buildFilterSqlWhereCondition({
             filter,
             whereCols: dimension.filterSql.where,
-            tableName: actualTableName,
-          }),
-        );
-        result.havingParts.push(
-          this.buildFilterSqlHaving({
-            filter,
-            havingExpression: having,
+            dimensionSql: dimension.sql,
             tableName: actualTableName,
           }),
         );
@@ -841,7 +818,6 @@ export class QueryBuilder {
     innerMetricsPart: string;
     fromClause: string;
     appliedDimensions: AppliedDimensionType[];
-    havingClause?: string;
   }) {
     const {
       view,
@@ -849,7 +825,6 @@ export class QueryBuilder {
       innerMetricsPart,
       fromClause,
       appliedDimensions,
-      havingClause = "",
     } = params;
     const actualTableName = this.actualTableName(view);
     // Use actual SQL from view definition for id column (handles events.span_id -> id mapping)
@@ -872,8 +847,7 @@ export class QueryBuilder {
         ${innerDimensionsPart}
         ${innerMetricsPart}
         ${fromClause}
-      GROUP BY ${groupByParts.join(", ")}
-      ${havingClause}`;
+      GROUP BY ${groupByParts.join(", ")}`;
   }
 
   private buildOuterDimensionsPart(
@@ -1296,8 +1270,8 @@ export class QueryBuilder {
       }
     }
 
-    // Create filters: WHERE (normal + raw pruning) and HAVING (post-aggregation)
-    const { whereFilters, whereRawParts, havingParts } = this.mapFilters(
+    // Create filters: normal WHERE filters + raw WHERE parts (filterSql pruning + exact match)
+    const { whereFilters, whereRawParts } = this.mapFilters(
       query.filters,
       view,
     );
@@ -1372,10 +1346,8 @@ export class QueryBuilder {
 
     // Check if single-level optimization is applicable
     // Note: Relation tables are OK as long as measures have aggs configuration
-    // HAVING filters require the two-level path (inner GROUP BY + HAVING)
     const canOptimize =
       enableSingleLevelOptimization &&
-      havingParts.length === 0 &&
       this.canUseSingleLevelQuery(appliedDimensions, appliedMetrics);
 
     // Build GROUP BY clause (used by both single-level and two-level queries)
@@ -1407,16 +1379,6 @@ export class QueryBuilder {
     // Build LIMIT clause for row limiting
     const limitClause = this.buildLimitClause();
 
-    // Build HAVING clause from filterSql having expressions (post-aggregation filters)
-    let havingClause = "";
-    if (havingParts.length > 0) {
-      const havingQueries = havingParts.map((p) => p.query);
-      havingClause = `HAVING ${havingQueries.join(" AND ")}`;
-      for (const part of havingParts) {
-        Object.assign(parameters, part.params);
-      }
-    }
-
     // Build final query - branch based on optimization
     let sql: string;
     if (canOptimize) {
@@ -1442,14 +1404,13 @@ export class QueryBuilder {
       );
       const innerMetricsPart = this.buildInnerMetricsPart(appliedMetrics);
 
-      // Build inner SELECT with HAVING for filterSql post-aggregation filters
+      // Build inner SELECT
       const innerQuery = this.buildInnerSelect({
         view,
         innerDimensionsPart,
         innerMetricsPart,
         fromClause,
         appliedDimensions,
-        havingClause,
       });
 
       // Build outer SELECT parts

--- a/web/src/features/query/server/queryBuilder.ts
+++ b/web/src/features/query/server/queryBuilder.ts
@@ -19,6 +19,7 @@ import { getViewDeclaration } from "@/src/features/query/dataModel";
 import {
   FilterList,
   createFilterFromFilterState,
+  type Filter,
 } from "@langfuse/shared/src/server";
 import { InvalidRequestError } from "@langfuse/shared";
 
@@ -40,6 +41,14 @@ type AppliedMetricType = {
   aggs?: Record<string, string>;
   measureName: string; // Original measure name for lookups
   requiresDimension?: string;
+};
+
+type RawSqlPart = { query: string; params: Record<string, unknown> };
+
+type MappedFilters = {
+  whereFilters: Filter[];
+  whereRawParts: RawSqlPart[];
+  havingParts: RawSqlPart[];
 };
 
 export class QueryBuilder {
@@ -221,37 +230,148 @@ export class QueryBuilder {
     return parts[0];
   }
 
+  /**
+   * Resolves a filter column to a dimension, with fallback for *Name columns.
+   */
+  private resolveDimension(
+    filterColumn: string,
+    view: ViewDeclarationType,
+  ): ViewDeclarationType["dimensions"][string] | undefined {
+    if (filterColumn in view.dimensions) {
+      return view.dimensions[filterColumn];
+    }
+    // Fallback: scoreName/traceName → "name" dimension (LFE-4838)
+    if (filterColumn.endsWith("Name") && "name" in view.dimensions) {
+      return view.dimensions["name"];
+    }
+    return undefined;
+  }
+
+  /**
+   * Builds an OR'd WHERE clause for pre-aggregation row pruning.
+   * Creates one filter per column via createFilterFromFilterState, applies each,
+   * and joins the SQL with OR.
+   */
+  private buildFilterSqlWherePrune(params: {
+    filter: z.infer<typeof queryModel>["filters"][number];
+    whereCols: string[];
+    tableName: string;
+  }): RawSqlPart {
+    const { filter, whereCols, tableName } = params;
+    const pruneApplied = whereCols.map((col) => {
+      const filters = createFilterFromFilterState(
+        [filter],
+        [
+          {
+            uiTableName: filter.column,
+            uiTableId: filter.column,
+            clickhouseTableName: tableName,
+            clickhouseSelect: col,
+            queryPrefix: "",
+          },
+        ],
+      );
+      return filters[0].apply();
+    });
+    return {
+      query: `(${pruneApplied.map((p) => p.query).join(" OR ")})`,
+      params: Object.assign({}, ...pruneApplied.map((p) => p.params)),
+    };
+  }
+
+  /**
+   * Builds a HAVING clause for post-aggregation exact matching.
+   * Creates a filter via createFilterFromFilterState using the aggregation expression.
+   */
+  private buildFilterSqlHaving(params: {
+    filter: z.infer<typeof queryModel>["filters"][number];
+    havingExpression: string;
+    tableName: string;
+  }): RawSqlPart {
+    const { filter, havingExpression, tableName } = params;
+    const filters = createFilterFromFilterState(
+      [filter],
+      [
+        {
+          uiTableName: filter.column,
+          uiTableId: filter.column,
+          clickhouseTableName: tableName,
+          clickhouseSelect: havingExpression,
+          queryPrefix: "",
+        },
+      ],
+    );
+    return filters[0].apply();
+  }
+
   private mapFilters(
     filters: z.infer<typeof queryModel>["filters"],
     view: ViewDeclarationType,
-  ) {
+  ): MappedFilters {
     // Validate all filters before processing
     this.validateFilters(filters, view);
 
     const actualTableName = this.actualTableName(view);
 
-    // Transform our filters to match the column mapping format expected by createFilterFromFilterState
-    const columnMappings = filters.map((filter) => {
+    const result: MappedFilters = {
+      whereFilters: [],
+      whereRawParts: [],
+      havingParts: [],
+    };
+
+    // Separate filters into normal (createFilterFromFilterState) and filterSql-aware
+    const normalFilters: z.infer<typeof queryModel>["filters"] = [];
+    const normalMappings: Array<{
+      uiTableName: string;
+      uiTableId: string;
+      clickhouseTableName: string;
+      clickhouseSelect: string;
+      queryPrefix: string;
+      type: string;
+    }> = [];
+
+    for (const filter of filters) {
+      const dimension = this.resolveDimension(filter.column, view);
+
+      // Dimension with filterSql: delegate to existing filter infrastructure
+      if (dimension?.filterSql) {
+        const having =
+          dimension.filterSql.having ?? dimension.aggregationFunction;
+        if (!having) {
+          throw new InvalidRequestError(
+            `Dimension '${filter.column}' has filterSql.where but no having expression and no aggregationFunction to fall back to.`,
+          );
+        }
+
+        result.whereRawParts.push(
+          this.buildFilterSqlWherePrune({
+            filter,
+            whereCols: dimension.filterSql.where,
+            tableName: actualTableName,
+          }),
+        );
+        result.havingParts.push(
+          this.buildFilterSqlHaving({
+            filter,
+            havingExpression: having,
+            tableName: actualTableName,
+          }),
+        );
+        continue;
+      }
+
+      // Normal dimension or special-case filter: build column mapping
       let clickhouseSelect: string;
       let queryPrefix: string = "";
       let clickhouseTableName: string = actualTableName;
       let type: string;
 
-      if (filter.column in view.dimensions) {
-        const dimension = view.dimensions[filter.column];
+      if (dimension) {
         clickhouseSelect = dimension.sql;
         type = "string";
         if (dimension.relationTable) {
           clickhouseTableName = dimension.relationTable;
         }
-        // Filters on measures are underdefined and not allowed in the initial version
-        // } else if (filter.column in view.measures) {
-        //   const measure = view.measures[filter.column];
-        //   clickhouseSelect = measure.sql;
-        //   type = measure.type;
-        //   if (measure.relationTable) {
-        //     clickhouseTableName = measure.relationTable;
-        //   }
       } else if (filter.column === view.timeDimension) {
         clickhouseSelect = view.timeDimension;
         queryPrefix = clickhouseTableName;
@@ -261,9 +381,7 @@ export class QueryBuilder {
         queryPrefix = clickhouseTableName;
         type = "stringObject";
       } else if (filter.column.endsWith("Name")) {
-        // Sometimes, the filter does not update correctly and sends us scoreName instead of name for scores, etc.
-        // If this happens, none of the conditions above apply, and we use this fallback to avoid raising an error.
-        // As this is hard to catch, we include this workaround. (LFE-4838).
+        // Fallback for *Name columns when no "name" dimension exists (LFE-4838)
         clickhouseSelect = "name";
         queryPrefix = clickhouseTableName;
         type = "string";
@@ -273,18 +391,23 @@ export class QueryBuilder {
         );
       }
 
-      return {
+      normalFilters.push(filter);
+      normalMappings.push({
         uiTableName: filter.column,
         uiTableId: filter.column,
         clickhouseTableName,
         clickhouseSelect,
         queryPrefix,
         type,
-      };
-    });
+      });
+    }
 
-    // Use the createFilterFromFilterState function to create proper Clickhouse filters
-    return createFilterFromFilterState(filters, columnMappings);
+    // Create filters for non-filterSql dimensions using existing infrastructure
+    result.whereFilters = createFilterFromFilterState(
+      normalFilters,
+      normalMappings,
+    );
+    return result;
   }
 
   private addStandardFilters(
@@ -712,13 +835,22 @@ export class QueryBuilder {
       .join(",\n");
   }
 
-  private buildInnerSelect(
-    view: ViewDeclarationType,
-    innerDimensionsPart: string,
-    innerMetricsPart: string,
-    fromClause: string,
-    appliedDimensions: AppliedDimensionType[],
-  ) {
+  private buildInnerSelect(params: {
+    view: ViewDeclarationType;
+    innerDimensionsPart: string;
+    innerMetricsPart: string;
+    fromClause: string;
+    appliedDimensions: AppliedDimensionType[];
+    havingClause?: string;
+  }) {
+    const {
+      view,
+      innerDimensionsPart,
+      innerMetricsPart,
+      fromClause,
+      appliedDimensions,
+      havingClause = "",
+    } = params;
     const actualTableName = this.actualTableName(view);
     // Use actual SQL from view definition for id column (handles events.span_id -> id mapping)
     const idSql = view.dimensions.id?.sql || `${actualTableName}.id`;
@@ -740,7 +872,8 @@ export class QueryBuilder {
         ${innerDimensionsPart}
         ${innerMetricsPart}
         ${fromClause}
-      GROUP BY ${groupByParts.join(", ")}`;
+      GROUP BY ${groupByParts.join(", ")}
+      ${havingClause}`;
   }
 
   private buildOuterDimensionsPart(
@@ -1163,8 +1296,12 @@ export class QueryBuilder {
       }
     }
 
-    // Create a new FilterList with the mapped filters
-    let filterList = new FilterList(this.mapFilters(query.filters, view));
+    // Create filters: WHERE (normal + raw pruning) and HAVING (post-aggregation)
+    const { whereFilters, whereRawParts, havingParts } = this.mapFilters(
+      query.filters,
+      view,
+    );
+    let filterList = new FilterList(whereFilters);
 
     // Add standard filters (project_id, timestamps)
     filterList = this.addStandardFilters(
@@ -1205,6 +1342,12 @@ export class QueryBuilder {
     // Build WHERE clause with parameters
     fromClause += this.buildWhereClause(filterList, parameters);
 
+    // Append raw WHERE pruning parts (OR'd conditions from filterSql.where)
+    for (const part of whereRawParts) {
+      fromClause += ` AND ${part.query}`;
+      Object.assign(parameters, part.params);
+    }
+
     // When rootEventCondition is set, add a subquery filter to restrict rows
     // to traces whose root event has timeDimension in the query window.
     // The existing start_time filter above is kept for ClickHouse partition pruning.
@@ -1229,8 +1372,10 @@ export class QueryBuilder {
 
     // Check if single-level optimization is applicable
     // Note: Relation tables are OK as long as measures have aggs configuration
+    // HAVING filters require the two-level path (inner GROUP BY + HAVING)
     const canOptimize =
       enableSingleLevelOptimization &&
+      havingParts.length === 0 &&
       this.canUseSingleLevelQuery(appliedDimensions, appliedMetrics);
 
     // Build GROUP BY clause (used by both single-level and two-level queries)
@@ -1262,6 +1407,16 @@ export class QueryBuilder {
     // Build LIMIT clause for row limiting
     const limitClause = this.buildLimitClause();
 
+    // Build HAVING clause from filterSql having expressions (post-aggregation filters)
+    let havingClause = "";
+    if (havingParts.length > 0) {
+      const havingQueries = havingParts.map((p) => p.query);
+      havingClause = `HAVING ${havingQueries.join(" AND ")}`;
+      for (const part of havingParts) {
+        Object.assign(parameters, part.params);
+      }
+    }
+
     // Build final query - branch based on optimization
     let sql: string;
     if (canOptimize) {
@@ -1287,14 +1442,15 @@ export class QueryBuilder {
       );
       const innerMetricsPart = this.buildInnerMetricsPart(appliedMetrics);
 
-      // Build inner SELECT
-      const innerQuery = this.buildInnerSelect(
+      // Build inner SELECT with HAVING for filterSql post-aggregation filters
+      const innerQuery = this.buildInnerSelect({
         view,
         innerDimensionsPart,
         innerMetricsPart,
         fromClause,
         appliedDimensions,
-      );
+        havingClause,
+      });
 
       // Build outer SELECT parts
       const outerDimensionsPart = this.buildOuterDimensionsPart(

--- a/web/src/features/query/types.ts
+++ b/web/src/features/query/types.ts
@@ -22,13 +22,11 @@ export const viewDeclaration = z.object({
       unit: z.string().optional(),
       aggregationFunction: z.string().optional(),
       // Override for filter generation when the dimension uses complex SQL/aggregation.
-      // - where: column expressions OR'd together for pre-aggregation row pruning
-      // - having: aggregate expression applied after GROUP BY for exact match;
-      //   defaults to aggregationFunction when omitted
+      // where: column expressions OR'd together for pre-aggregation row pruning.
+      // The exact match uses dimension.sql (the row-level expression).
       filterSql: z
         .object({
           where: z.array(z.string()),
-          having: z.string().optional(),
         })
         .optional(),
       highCardinality: z.boolean().optional(),

--- a/web/src/features/query/types.ts
+++ b/web/src/features/query/types.ts
@@ -21,6 +21,16 @@ export const viewDeclaration = z.object({
       type: z.string().optional(),
       unit: z.string().optional(),
       aggregationFunction: z.string().optional(),
+      // Override for filter generation when the dimension uses complex SQL/aggregation.
+      // - where: column expressions OR'd together for pre-aggregation row pruning
+      // - having: aggregate expression applied after GROUP BY for exact match;
+      //   defaults to aggregationFunction when omitted
+      filterSql: z
+        .object({
+          where: z.array(z.string()),
+          having: z.string().optional(),
+        })
+        .optional(),
       highCardinality: z.boolean().optional(),
       explodeArray: z.boolean().optional(),
       pairExpand: z


### PR DESCRIPTION
The events_traces view reconstructs trace names via aggregation (argMaxIf), but filters on "Trace Name" were hitting the endsWith("Name") fallback and generating `events_core.name IN (..)` — matching observation names instead of trace names.

Introduces filterSql on view dimensions to support two-phase filtering:
- WHERE pruning: OR'd filters across raw columns for pre-aggregation row reduction
- HAVING: exact match on the aggregated expression after GROUP BY

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds two-phase filtering for trace names in `events_traces` view using `filterSql` for accurate pre- and post-aggregation filtering.
> 
>   - **Behavior**:
>     - Adds `filterSql` to `name` dimension in `eventsTracesView` in `dataModel.ts` for two-phase filtering.
>     - Implements pre-aggregation row pruning and post-aggregation exact matching in `queryBuilder.ts`.
>     - Filters trace names correctly in `events_traces` view using WHERE and HAVING clauses.
>   - **Tests**:
>     - Adds tests in `queryBuilder.servertest.ts` to verify correct filtering of trace names in `events_traces` view.
>     - Tests cover scenarios for filtering by `traceName` and combining with other filters.
>   - **Misc**:
>     - Introduces `type Filter` in `index.ts` for better type management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 1ae0fa9ab73f76f93b6fae625215db7b7d14ac4b. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->