### PR TITLE
fix: make traces view slightly more useful on projects with rootless traces

### DIFF
--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -238,7 +238,7 @@ export const eventsTracesView: ViewDeclarationType = {
   },
   measures: {
     count: {
-      sql: "countIf(events_traces.parent_span_id = '')",
+      sql: "uniq(events_traces.trace_id)",
       alias: "count",
       type: "integer",
       description: "Total number of traces.",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve trace handling in projects with rootless traces by updating `eventsTracesView` measure and `QueryBuilder` logic for time bucketing and filtering.
> 
>   - **Behavior**:
>     - Change `count` measure in `eventsTracesView` in `dataModel.ts` to use `uniq(events_traces.trace_id)` instead of `countIf(events_traces.parent_span_id = '')`.
>     - Modify `QueryBuilder` in `queryBuilder.ts` to prefer root event's timestamp for time bucketing, falling back to `min(start_time)` if no root event exists.
>     - Add logic to skip subquery filter if no root events exist in the window, using `NOT EXISTS`.
>   - **Misc**:
>     - Minor refactoring in `queryBuilder.ts` for clarity and efficiency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c2c29615301845cf0a290c0ae63b5346f232f2d5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->