### PR TITLE
fix(otel): subtract cache tokens from pydantic-ai input usage

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2071,13 +2071,21 @@ export class OtelIngestionProcessor {
       const outputTokens = attributes["gen_ai.usage.output_tokens"];
       const cacheReadTokens =
         attributes["gen_ai.usage.cache_read_tokens"] ??
-        attributes["gen_ai.usage.details.cache_read_input_tokens"];
+        attributes["gen_ai.usage.details.cache_read_input_tokens"] ??
+        attributes["gen_ai.usage.details.cache_read_tokens"];
       const cacheWriteTokens =
         attributes["gen_ai.usage.cache_write_tokens"] ??
-        attributes["gen_ai.usage.details.cache_creation_input_tokens"];
+        attributes["gen_ai.usage.details.cache_creation_input_tokens"] ??
+        attributes["gen_ai.usage.details.cache_write_tokens"];
 
+      // Per OTel semantic conventions, gen_ai.usage.input_tokens is the TOTAL
+      // input token count (cached + uncached). Subtract cache tokens to avoid
+      // double-counting, matching the "ai" SDK branch above.
       return {
-        input: inputTokens,
+        input: Math.max(
+          (inputTokens ?? 0) - (cacheReadTokens ?? 0) - (cacheWriteTokens ?? 0),
+          0,
+        ),
         output: outputTokens,
         input_cache_read: cacheReadTokens,
         input_cache_creation: cacheWriteTokens,

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -1714,6 +1714,110 @@ describe("OTel Resource Span Mapping", () => {
       expect(metadataAttributes).not.toHaveProperty("pydantic_ai.all_messages");
     });
 
+    it("should not double-count cache tokens in pydantic-ai input usage (#12306)", async () => {
+      // Per OTel semantic conventions, gen_ai.usage.input_tokens is the TOTAL
+      // input token count (cached + uncached). genai-prices (used by pydantic-ai)
+      // sums Anthropic's input_tokens + cache_read + cache_creation into
+      // gen_ai.usage.input_tokens. Langfuse must subtract cache tokens to avoid
+      // double-counting.
+      const traceId = "abcdef1234567890abcdef1234567891";
+
+      const pydanticAiCacheSpan = {
+        resource: {
+          attributes: [
+            {
+              key: "telemetry.sdk.language",
+              value: { stringValue: "python" },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: {
+              name: "pydantic-ai",
+              version: "1.61.0",
+              attributes: [],
+            },
+            spans: [
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from("1234567890abcdef", "hex"),
+                parentSpanId: Buffer.from("fedcba0987654321", "hex"),
+                name: "anthropic cached call",
+                kind: 3,
+                startTimeUnixNano: {
+                  low: 1000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                endTimeUnixNano: {
+                  low: 2000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                attributes: [
+                  {
+                    key: "gen_ai.system",
+                    value: { stringValue: "anthropic" },
+                  },
+                  {
+                    key: "gen_ai.request.model",
+                    value: { stringValue: "claude-sonnet-4-5-20250929" },
+                  },
+                  {
+                    // genai-prices sets this to total = 5 + 128955 + 1253
+                    key: "gen_ai.usage.input_tokens",
+                    value: {
+                      intValue: { low: 130213, high: 0, unsigned: false },
+                    },
+                  },
+                  {
+                    key: "gen_ai.usage.output_tokens",
+                    value: {
+                      intValue: { low: 1769, high: 0, unsigned: false },
+                    },
+                  },
+                  {
+                    key: "gen_ai.usage.cache_read_tokens",
+                    value: {
+                      intValue: { low: 128955, high: 0, unsigned: false },
+                    },
+                  },
+                  {
+                    key: "gen_ai.usage.cache_write_tokens",
+                    value: {
+                      intValue: { low: 1253, high: 0, unsigned: false },
+                    },
+                  },
+                ],
+                events: [],
+                status: { code: 1 },
+              },
+            ],
+          },
+        ],
+      };
+
+      const events = await convertOtelSpanToIngestionEvent(
+        pydanticAiCacheSpan,
+        new Set([traceId]),
+      );
+
+      const observationEvent = events.find(
+        (e) => e.type === "generation-create",
+      );
+
+      expect(observationEvent).toBeDefined();
+
+      // input should be total MINUS cache tokens = 130213 - 128955 - 1253 = 5
+      expect(observationEvent?.body.usageDetails.input).toBe(5);
+      expect(observationEvent?.body.usageDetails.output).toBe(1769);
+      expect(observationEvent?.body.usageDetails.input_cache_read).toBe(128955);
+      expect(observationEvent?.body.usageDetails.input_cache_creation).toBe(
+        1253,
+      );
+    });
+
     it("should prioritize OpenInference over OTel GenAI and model detection", async () => {
       const resourceSpan = {
         scopeSpans: [


### PR DESCRIPTION
## Summary

Fixes double-counting of Anthropic prompt cache tokens in the pydantic-ai OTel ingestion branch.

Per OTel semantic conventions, `gen_ai.usage.input_tokens` is the **total** input token count (cached + uncached). `genai-prices` (used by pydantic-ai for token accounting) correctly sums Anthropic's `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` into this total. However, the pydantic-ai branch in `OtelIngestionProcessor` returned `input_tokens` as-is alongside cache breakdown fields (`input_cache_read`, `input_cache_creation`), so Langfuse added cache on top of an already-inclusive total.

### What changed

- Apply the same `input = total - cache_read - cache_write` subtraction already used by the `"ai"` SDK branch (line 2048-2054)
- Add forward-compat fallback keys (`gen_ai.usage.details.cache_read_tokens`, `gen_ai.usage.details.cache_write_tokens`) alongside the existing ones
- Add regression test covering the exact scenario (130213 total = 5 uncached + 128955 read + 1253 write)

### Before / After

| Field | Before | After |
|-------|--------|-------|
| `input` | 130213 (total, includes cache) | 5 (uncached only) |
| `input_cache_read` | 128955 | 128955 |
| `input_cache_creation` | 1253 | 1253 |
| **Effective total shown** | 130213 + 128955 + 1253 = **260421** (2x) | 5 + 128955 + 1253 = **130213** (correct) |

### No-cache case

When no cache attributes are present, `cacheReadTokens` and `cacheWriteTokens` are `undefined`, so `(undefined ?? 0) = 0` — subtraction is a no-op and behavior is unchanged.

Closes #12306
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes double-counting of cache tokens in `OtelIngestionProcessor.ts` by subtracting them from total input tokens and adds regression test in `otelMapping.servertest.ts`.
> 
>   - **Behavior**:
>     - Fixes double-counting of cache tokens in `OtelIngestionProcessor.ts` by subtracting cache tokens from `gen_ai.usage.input_tokens`.
>     - Adds forward-compatibility with fallback keys `gen_ai.usage.details.cache_read_tokens` and `gen_ai.usage.details.cache_write_tokens`.
>   - **Testing**:
>     - Adds regression test in `otelMapping.servertest.ts` to verify correct input token calculation (130213 total = 5 uncached + 128955 read + 1253 write).
>     - Ensures no double-counting occurs when cache tokens are present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 73bea947b2cb40ea1dd79367ed179fc596ab2059. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->