### PR TITLE
fix(model-price-editor): use stable React keys in TierPriceEditor to prevent focus loss

### DIFF
--- a/web/src/features/models/components/pricing-tiers/TierPriceEditor.tsx
+++ b/web/src/features/models/components/pricing-tiers/TierPriceEditor.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { MinusCircle, PlusCircle } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import { Input } from "@/src/components/ui/input";
@@ -21,6 +22,22 @@ export function TierPriceEditor({
 }: TierPriceEditorProps) {
   const prices = form.watch(`pricingTiers.${tierIndex}.prices`) || {};
 
+  const nextIdRef = useRef(0);
+  const keyToIdRef = useRef<Record<string, number>>({});
+
+  // Assign stable IDs to any new keys
+  for (const k of Object.keys(prices)) {
+    if (!(k in keyToIdRef.current)) {
+      keyToIdRef.current[k] = nextIdRef.current++;
+    }
+  }
+  // Clean up removed keys
+  for (const k of Object.keys(keyToIdRef.current)) {
+    if (!(k in prices)) {
+      delete keyToIdRef.current[k];
+    }
+  }
+
   return (
     <div className="space-y-3">
       <FormLabel>Prices</FormLabel>
@@ -29,7 +46,7 @@ export function TierPriceEditor({
         <span>Price</span>
       </div>
       {Object.entries(prices).map(([key, value]) => (
-        <div key={key} className="grid grid-cols-2 gap-1">
+        <div key={keyToIdRef.current[key]} className="grid grid-cols-2 gap-1">
           <Input
             placeholder="Key (e.g. input, output)"
             value={key}
@@ -42,10 +59,20 @@ export function TierPriceEditor({
                 return; // Don't allow the change
               }
 
-              const newPrices = { ...prices };
-              const oldValue = newPrices[key];
-              delete newPrices[key];
-              newPrices[newKey] = oldValue;
+              // Transfer stable ID from old key to new key
+              const stableId = keyToIdRef.current[key];
+              delete keyToIdRef.current[key];
+              keyToIdRef.current[newKey] = stableId;
+
+              // Rebuild prices preserving insertion order
+              const newPrices: Record<string, number> = {};
+              for (const [k, v] of Object.entries(prices)) {
+                if (k === key) {
+                  newPrices[newKey] = v as number;
+                } else {
+                  newPrices[k] = v as number;
+                }
+              }
               form.setValue(`pricingTiers.${tierIndex}.prices`, newPrices);
             }}
             className={!isDefault ? "cursor-not-allowed bg-muted" : ""}


### PR DESCRIPTION
## Summary

Fixes the input focus loss bug in the model pricing editor where typing a usage type name causes the input to lose focus after every keystroke.

- Uses stable numeric IDs via `useRef` as React keys instead of the mutable key name
- Transfers the stable ID when a key is renamed, so React preserves the DOM element
- Preserves insertion order during renames by rebuilding the object instead of delete + re-add

Closes #12185

## Root Cause

PR #11939 changed the React `key` prop from array index to the price key name (`key={key}`) to fix an overwrite bug. However, since the key name is the value the user types into, every keystroke changes the React key. React interprets this as "old component removed, new component added" — unmounting and remounting the `<Input>`, which destroys focus.

## Solution

Maintain a `useRef`-based mapping of price key names → stable numeric IDs:

1. **On first render**: each existing key gets a unique incrementing ID
2. **On rename**: the stable ID transfers from the old key name to the new key name
3. **On delete**: the stale ID is cleaned up
4. **On add**: the new key gets the next available ID

The React `key` is now `keyToIdRef.current[key]` — a number that stays constant across renames, preventing unmount/remount.

Additionally, the rename handler now rebuilds the prices object by iterating entries (preserving insertion order) instead of `delete` + re-add (which moved the entry to the end).

## What changed

| File | Change |
|------|--------|
| `web/src/features/models/components/pricing-tiers/TierPriceEditor.tsx` | Stable ID refs + order-preserving rename |

## Verification

- `pnpm --filter web run lint` ✅
- `pnpm run typecheck` — no new errors (pre-existing errors in unrelated `react-resizable-panels` files)
- `lsp_diagnostics` — 0 errors in changed file
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes input focus loss in `TierPriceEditor` by using stable numeric IDs for React keys and preserving insertion order during renames.
> 
>   - **Behavior**:
>     - Fixes input focus loss in `TierPriceEditor` by using stable numeric IDs as React keys.
>     - Maintains stable IDs across renames using `useRef` for key-to-ID mapping.
>     - Preserves insertion order during renames by rebuilding the prices object.
>   - **Implementation**:
>     - Adds `useRef` for `nextIdRef` and `keyToIdRef` in `TierPriceEditor.tsx`.
>     - Updates key assignment logic to use `keyToIdRef.current[key]`.
>     - Modifies rename handler to transfer stable IDs and rebuild prices object.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 9d6b038e490f5a649c72826bcc1073eb9ccce9d4. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->